### PR TITLE
fix: resolve critical security and correctness issues in install-wp-tests.sh

### DIFF
--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -51,7 +51,7 @@ else
 	fi
 	WP_TESTS_TAG="tags/$LATEST_VERSION"
 fi
-set -ex
+set -e
 
 install_wp() {
 
@@ -112,7 +112,7 @@ install_test_suite() {
 		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
 	fi
 
-	if [ ! -f wp-tests-config.php ]; then
+	if [ ! -f "$WP_TESTS_DIR/wp-tests-config.php" ]; then
 		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
 		# remove all forward slashes in the end
 		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
@@ -167,7 +167,7 @@ install_db() {
 	# create database
 	if [ $(mysql --user="$DB_USER" --password="$DB_PASS"$EXTRA --execute='show databases;' | grep ^$DB_NAME$) ]; then
 		echo "Reinitializing will delete the existing test database ($DB_NAME)"
-		recreate_db no
+		recreate_db yes
 	else
 		create_db
 	fi


### PR DESCRIPTION
## Summary

- **Security (critical)**: Remove `set -x` xtrace to prevent `DB_PASS` credential exposure in CI logs — `mysqladmin` and `mysql` commands with `--password` were being echoed to stderr on every run
- **Correctness (high)**: Fix `wp-tests-config.php` existence check to use `$WP_TESTS_DIR/wp-tests-config.php` instead of `./wp-tests-config.php` — wrong path caused stale configs to block setup regeneration
- **Correctness (critical)**: Fix `recreate_db no` → `recreate_db yes` so the existing test DB is actually dropped when reinitializing — the previous code printed "Reinitializing will delete the existing test database" but then passed `no`, leaving stale tables and causing flaky tests

## Changes

`bin/install-wp-tests.sh`:
- Line 54: `set -ex` → `set -e`
- Line 115: `if [ ! -f wp-tests-config.php ]` → `if [ ! -f "$WP_TESTS_DIR/wp-tests-config.php" ]`
- Line 170: `recreate_db no` → `recreate_db yes`

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved test installation script reliability with enhanced error handling and updated file path verification.
  * Modified test database initialization to properly recreate the database during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->