### PR TITLE
fix: remove incorrect EscapeOutput.OutputNotEscaped global exclusion from phpcs.xml

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -42,9 +42,6 @@
         <exclude name="WordPress.DB.DirectDatabaseQuery.DirectQuery"/>
         <exclude name="WordPress.DB.DirectDatabaseQuery.NoCaching"/>
 
-        <!-- Allow file includes with variables (autoloader) -->
-        <exclude name="WordPress.Security.EscapeOutput.OutputNotEscaped"/>
-
         <!-- Allow short ternary (null coalescing style) - modern PHP -->
         <exclude name="Universal.Operators.DisallowShortTernary.Found"/>
 


### PR DESCRIPTION
## Summary

- Removes the global `<exclude name="WordPress.Security.EscapeOutput.OutputNotEscaped"/>` from `phpcs.xml`
- The exclusion was mislabelled as "Allow file includes with variables (autoloader)" — `EscapeOutput.OutputNotEscaped` is the XSS/output-escaping sniff, entirely unrelated to file inclusion
- The `$asset = require $asset_file` pattern in `AdminPage.php`, `FloatingWidget.php`, and `Settings.php` does **not** trigger this sniff; the exclusion was never needed
- Re-enabling the sniff globally produces **zero new violations** (verified: `vendor/bin/phpcs --standard=phpcs.xml` passes clean)

## Verification

```
vendor/bin/phpcs --standard=phpcs.xml includes/ ai-agent.php
....... 7 / 7 (100%)
Time: 2.43 secs; Memory: 4MB
```

No violations with the XSS output-escaping check now active.

## Root cause

The original exclusion was added with an incorrect comment. `WordPress.Security.EscapeOutput.OutputNotEscaped` detects unescaped output in `echo`/`print`/`_e()` calls — it has no relationship to `include`/`require` file-inclusion patterns. Disabling it globally removed a high-signal XSS check for no benefit.

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code quality and security by enabling stricter output escaping validation checks in the development tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->