### PR TITLE
t008: Make CI workflows non-continue-on-error

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -26,7 +26,6 @@ jobs:
 
       - name: Run ESLint
         run: npx eslint src/ --ext .js,.jsx --format stylish
-        continue-on-error: true
 
   stylelint:
     name: Stylelint
@@ -47,7 +46,6 @@ jobs:
 
       - name: Run Stylelint
         run: npx stylelint "src/**/*.css" --formatter verbose
-        continue-on-error: true
 
   build:
     name: Build Check


### PR DESCRIPTION
## Summary

- Removes `continue-on-error: true` from the **ESLint** step in `code-quality.yml`
- Removes `continue-on-error: true` from the **Stylelint** step in `code-quality.yml`

These flags caused linter failures to be silently swallowed — the workflow showed green even when ESLint or Stylelint found violations. Removing them means linter failures now correctly fail the CI check, enforcing code quality gates on every PR and push.

No other workflows were affected: `tests.yml` has no `continue-on-error` flags, `release.yml` has none, and the `|| true` patterns in `issue-sync.yml` are intentional operational resilience for sync steps (not quality gates).

Closes #27