### PR TITLE
t009: Tighten PHPCS — re-enable EscapeOutput, add NonceVerification rules

### DIFF
--- a/includes/Abilities/FileAbilities.php
+++ b/includes/Abilities/FileAbilities.php
@@ -399,6 +399,7 @@ class FileAbilities {
 
 		set_error_handler(
 			function ( $severity, $message, $file, $line ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- ErrorException constructor arguments are not output; PHPCS false positive.
 				throw new \ErrorException( $message, 0, $severity, $file, $line );
 			}
 		);

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -42,9 +42,6 @@
         <exclude name="WordPress.DB.DirectDatabaseQuery.DirectQuery"/>
         <exclude name="WordPress.DB.DirectDatabaseQuery.NoCaching"/>
 
-        <!-- Allow file includes with variables (autoloader) -->
-        <exclude name="WordPress.Security.EscapeOutput.OutputNotEscaped"/>
-
         <!-- Allow short ternary (null coalescing style) - modern PHP -->
         <exclude name="Universal.Operators.DisallowShortTernary.Found"/>
 
@@ -59,9 +56,6 @@
 
         <!-- Allow unused function parameters (interface compliance) -->
         <exclude name="Generic.CodeAnalysis.UnusedFunctionParameter.Found"/>
-
-        <!-- Allow exception messages without escaping (internal use) -->
-        <exclude name="WordPress.Security.EscapeOutput.ExceptionNotEscaped"/>
 
         <!-- Relax commenting requirements for now -->
         <exclude name="Squiz.Commenting.FileComment.Missing"/>
@@ -88,6 +82,19 @@
         <!-- Allow property names from external APIs -->
         <exclude name="WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase"/>
     </rule>
+
+    <!-- Enforce output escaping: all dynamic output must pass through an escaping function.
+         Use esc_html(), esc_attr(), esc_url(), wp_kses_post(), etc. as appropriate.
+         Inline phpcs:ignore is permitted only for false positives (e.g. ErrorException
+         constructor arguments, which are not output). -->
+    <rule ref="WordPress.Security.EscapeOutput"/>
+
+    <!-- Enforce nonce verification: any handler that reads $_POST, $_GET, $_REQUEST, or
+         $_COOKIE must verify a nonce via wp_verify_nonce(), check_admin_referer(), or
+         check_ajax_referer() before accessing those values.
+         REST API endpoints are exempt — WP_REST_Request enforces authentication and
+         permission callbacks at the framework level. -->
+    <rule ref="WordPress.Security.NonceVerification"/>
 
     <!-- Verify text domain usage -->
     <rule ref="WordPress.WP.I18n">


### PR DESCRIPTION
## Summary

- Re-enables `WordPress.Security.EscapeOutput` (both `OutputNotEscaped` and `ExceptionNotEscaped` sub-sniffs) by removing the two blanket exclusions that were added as temporary scaffolding
- Adds an explicit `WordPress.Security.NonceVerification` rule so future superglobal access without nonce checks is caught at lint time
- Adds one targeted `phpcs:ignore` on `FileAbilities.php:403` for a PHPCS false positive (ErrorException constructor arguments flagged as unescaped output)

## Verification

```
vendor/bin/phpcs --standard=phpcs.xml --report=full
# 7/7 files, 0 errors, 0 warnings
```

## Why the blanket exclusions were wrong

`EscapeOutput.OutputNotEscaped` was excluded with the comment "Allow file includes with variables (autoloader)" — but file includes are not output. The exclusion was silencing a real security sniff across the entire codebase. `EscapeOutput.ExceptionNotEscaped` was excluded with "Allow exception messages without escaping (internal use)" — also too broad; exception messages can contain user-controlled data.

The only legitimate false positive in the codebase is `FileAbilities.php:403` where `ErrorException` constructor arguments are misidentified as output. That is now suppressed with a targeted inline ignore and a clear rationale comment.

Closes #28