### PR TITLE
t011: Add PHPDoc blocks to all classes/methods

### DIFF
--- a/includes/Core/PlaceholderResolver.php
+++ b/includes/Core/PlaceholderResolver.php
@@ -93,6 +93,11 @@ class PlaceholderResolver {
 
 	/**
 	 * Enrich context with post data.
+	 *
+	 * @param array  $context   Current context map.
+	 * @param string $hook_name The WordPress hook that fired.
+	 * @param array  $hook_args Raw hook arguments.
+	 * @return array Enriched context map.
 	 */
 	private static function enrich_post_context( array $context, string $hook_name, array $hook_args ): array {
 		$post = null;
@@ -125,6 +130,11 @@ class PlaceholderResolver {
 
 	/**
 	 * Enrich context with user data.
+	 *
+	 * @param array  $context   Current context map.
+	 * @param string $hook_name The WordPress hook that fired.
+	 * @param array  $hook_args Raw hook arguments.
+	 * @return array Enriched context map.
 	 */
 	private static function enrich_user_context( array $context, string $hook_name, array $hook_args ): array {
 		$user = null;
@@ -161,6 +171,11 @@ class PlaceholderResolver {
 
 	/**
 	 * Enrich context with comment data.
+	 *
+	 * @param array  $context   Current context map.
+	 * @param string $hook_name The WordPress hook that fired.
+	 * @param array  $hook_args Raw hook arguments.
+	 * @return array Enriched context map.
 	 */
 	private static function enrich_comment_context( array $context, string $hook_name, array $hook_args ): array {
 		if ( 'comment_post' !== $hook_name || empty( $hook_args[0] ) ) {
@@ -184,6 +199,11 @@ class PlaceholderResolver {
 
 	/**
 	 * Enrich context with WooCommerce order data.
+	 *
+	 * @param array  $context   Current context map.
+	 * @param string $hook_name The WordPress hook that fired.
+	 * @param array  $hook_args Raw hook arguments.
+	 * @return array Enriched context map.
 	 */
 	private static function enrich_order_context( array $context, string $hook_name, array $hook_args ): array {
 		$order_hooks = [
@@ -216,6 +236,11 @@ class PlaceholderResolver {
 
 	/**
 	 * Enrich context with WooCommerce product data.
+	 *
+	 * @param array  $context   Current context map.
+	 * @param string $hook_name The WordPress hook that fired.
+	 * @param array  $hook_args Raw hook arguments.
+	 * @return array Enriched context map.
 	 */
 	private static function enrich_product_context( array $context, string $hook_name, array $hook_args ): array {
 		if ( 'woocommerce_low_stock' !== $hook_name || empty( $hook_args[0] ) ) {

--- a/includes/Core/SimpleAiResult.php
+++ b/includes/Core/SimpleAiResult.php
@@ -107,15 +107,29 @@ class SimpleAiResult {
 			private int $prompt;
 			private int $completion;
 
+			/**
+			 * @param int $prompt     Number of prompt tokens.
+			 * @param int $completion Number of completion tokens.
+			 */
 			public function __construct( int $prompt, int $completion ) {
 				$this->prompt     = $prompt;
 				$this->completion = $completion;
 			}
 
+			/**
+			 * Get the number of prompt (input) tokens used.
+			 *
+			 * @return int
+			 */
 			public function getPromptTokens(): int {
 				return $this->prompt;
 			}
 
+			/**
+			 * Get the number of completion (output) tokens used.
+			 *
+			 * @return int
+			 */
 			public function getCompletionTokens(): int {
 				return $this->completion;
 			}

--- a/includes/Enums/HttpMethod.php
+++ b/includes/Enums/HttpMethod.php
@@ -31,6 +31,9 @@ enum HttpMethod: string {
 
 	/**
 	 * Check if a value is a valid HTTP method.
+	 *
+	 * @param string $value The HTTP method string to validate.
+	 * @return bool True if valid, false otherwise.
 	 */
 	public static function isValid( string $value ): bool {
 		return in_array( strtoupper( $value ), self::values(), true );

--- a/includes/Enums/MemoryCategory.php
+++ b/includes/Enums/MemoryCategory.php
@@ -31,6 +31,9 @@ enum MemoryCategory: string {
 
 	/**
 	 * Check if a value is a valid category.
+	 *
+	 * @param string $value The category string to validate.
+	 * @return bool True if valid, false otherwise.
 	 */
 	public static function isValid( string $value ): bool {
 		return in_array( $value, self::values(), true );
@@ -38,6 +41,9 @@ enum MemoryCategory: string {
 
 	/**
 	 * Get a category from string, defaulting to General if invalid.
+	 *
+	 * @param string $value The category string to convert.
+	 * @return self The matching enum case, or General if the value is invalid.
 	 */
 	public static function fromStringOrDefault( string $value ): self {
 		return self::tryFrom( $value ) ?? self::General;

--- a/includes/Enums/Schedule.php
+++ b/includes/Enums/Schedule.php
@@ -30,6 +30,9 @@ enum Schedule: string {
 
 	/**
 	 * Check if a value is a valid schedule.
+	 *
+	 * @param string $value The schedule string to validate.
+	 * @return bool True if valid, false otherwise.
 	 */
 	public static function isValid( string $value ): bool {
 		return in_array( $value, self::values(), true );

--- a/includes/Enums/ToolType.php
+++ b/includes/Enums/ToolType.php
@@ -29,6 +29,9 @@ enum ToolType: string {
 
 	/**
 	 * Check if a value is a valid tool type.
+	 *
+	 * @param string $value The tool type string to validate.
+	 * @return bool True if valid, false otherwise.
 	 */
 	public static function isValid( string $value ): bool {
 		return in_array( $value, self::values(), true );

--- a/includes/Models/Skill.php
+++ b/includes/Models/Skill.php
@@ -352,6 +352,11 @@ class Skill {
 
 	// ─── Built-in skill content ─────────────────────────────────────
 
+	/**
+	 * Return the built-in WordPress Administration skill content.
+	 *
+	 * @return string Markdown skill content.
+	 */
 	private static function builtin_wordpress_admin(): string {
 		return <<<'MD'
 # WordPress Administration
@@ -401,6 +406,11 @@ After making changes, always verify:
 MD;
 	}
 
+	/**
+	 * Return the built-in Content Management skill content.
+	 *
+	 * @return string Markdown skill content.
+	 */
 	private static function builtin_content_management(): string {
 		return <<<'MD'
 # Content Management
@@ -448,6 +458,11 @@ After creating or updating content:
 MD;
 	}
 
+	/**
+	 * Return the built-in WooCommerce skill content.
+	 *
+	 * @return string Markdown skill content.
+	 */
 	private static function builtin_woocommerce(): string {
 		return <<<'MD'
 # WooCommerce Store Management
@@ -500,6 +515,11 @@ After making changes:
 MD;
 	}
 
+	/**
+	 * Return the built-in Site Troubleshooting skill content.
+	 *
+	 * @return string Markdown skill content.
+	 */
 	private static function builtin_site_troubleshooting(): string {
 		return <<<'MD'
 # Site Troubleshooting
@@ -568,6 +588,11 @@ After applying a fix:
 MD;
 	}
 
+	/**
+	 * Return the built-in Multisite Management skill content.
+	 *
+	 * @return string Markdown skill content.
+	 */
 	private static function builtin_multisite_management(): string {
 		return <<<'MD'
 # Multisite Network Management
@@ -616,6 +641,11 @@ After network changes:
 MD;
 	}
 
+	/**
+	 * Return the built-in SEO Optimization skill content.
+	 *
+	 * @return string Markdown skill content.
+	 */
 	private static function builtin_seo_optimization(): string {
 		return <<<'MD'
 # SEO Optimization
@@ -685,6 +715,11 @@ Use this skill for SEO audits, keyword optimization, meta tag management, and te
 MD;
 	}
 
+	/**
+	 * Return the built-in Content Marketing skill content.
+	 *
+	 * @return string Markdown skill content.
+	 */
 	private static function builtin_content_marketing(): string {
 		return <<<'MD'
 # Content Marketing
@@ -738,6 +773,11 @@ Use this skill for content strategy planning, editorial workflows, content audit
 MD;
 	}
 
+	/**
+	 * Return the built-in Competitive Analysis skill content.
+	 *
+	 * @return string Markdown skill content.
+	 */
 	private static function builtin_competitive_analysis(): string {
 		return <<<'MD'
 # Competitive Analysis
@@ -795,6 +835,11 @@ Use this skill for analyzing competitor websites, discovering their tech stack, 
 MD;
 	}
 
+	/**
+	 * Return the built-in Analytics & Reporting skill content.
+	 *
+	 * @return string Markdown skill content.
+	 */
 	private static function builtin_analytics_reporting(): string {
 		return <<<'MD'
 # Analytics & Reporting
@@ -857,6 +902,11 @@ Use this skill for generating content reports, tracking publishing activity, mea
 MD;
 	}
 
+	/**
+	 * Return the built-in Gutenberg Blocks skill content.
+	 *
+	 * @return string Markdown skill content.
+	 */
 	private static function builtin_gutenberg_blocks(): string {
 		return <<<'MD'
 # Gutenberg Blocks
@@ -935,6 +985,11 @@ Gutenberg blocks are stored as HTML comments in post_content:
 MD;
 	}
 
+	/**
+	 * Return the built-in Full Site Editing skill content.
+	 *
+	 * @return string Markdown skill content.
+	 */
 	private static function builtin_full_site_editing(): string {
 		return <<<'MD'
 # Full Site Editing


### PR DESCRIPTION
## Summary

- Add missing `@param`/`@return` PHPDoc tags to all methods across 7 files
- Zero methods without PHPDoc blocks (verified by automated check)

## Changes

| File | Methods documented |
|------|--------------------|
| `includes/Core/SimpleAiResult.php` | Anonymous class `__construct`, `getPromptTokens`, `getCompletionTokens` |
| `includes/Models/Skill.php` | 11 private `builtin_*` skill content methods |
| `includes/Enums/HttpMethod.php` | `isValid()` |
| `includes/Enums/MemoryCategory.php` | `isValid()`, `fromStringOrDefault()` |
| `includes/Enums/Schedule.php` | `isValid()` |
| `includes/Enums/ToolType.php` | `isValid()` |
| `includes/Core/PlaceholderResolver.php` | 5 private `enrich_*_context()` methods |

The rest of the codebase (41 other PHP files) already had complete PHPDoc coverage.

Closes #30