### PR TITLE
t029: Standardize error handling — return WP_Error not arrays with 'error' key

### DIFF
--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace AiAgent\Abilities;
 
 use AiAgent\Models\MarkdownToBlocks;
+use WP_Error;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -235,13 +236,13 @@ class BlockAbilities {
 	 * Handle markdown-to-blocks conversion.
 	 *
 	 * @param array $input Input with 'markdown' key.
-	 * @return array Result with block_content and block_count.
+	 * @return array|\WP_Error Result with block_content and block_count or WP_Error on failure.
 	 */
-	public static function handle_markdown_to_blocks( array $input ): array {
+	public static function handle_markdown_to_blocks( array $input ): array|\WP_Error {
 		$markdown = $input['markdown'] ?? '';
 
 		if ( empty( $markdown ) ) {
-			return [ 'error' => 'markdown is required.' ];
+			return new WP_Error( 'missing_param', __( 'markdown is required.', 'ai-agent' ) );
 		}
 
 		$blocks        = MarkdownToBlocks::parse( $markdown );
@@ -330,20 +331,27 @@ class BlockAbilities {
 	 * Handle getting a single block type's full metadata.
 	 *
 	 * @param array $input Input with 'name' key.
-	 * @return array Full block type metadata.
+	 * @return array|\WP_Error Full block type metadata or WP_Error on failure.
 	 */
-	public static function handle_get_block_type( array $input ): array {
+	public static function handle_get_block_type( array $input ): array|\WP_Error {
 		$name = $input['name'] ?? '';
 
 		if ( empty( $name ) ) {
-			return [ 'error' => 'name is required.' ];
+			return new WP_Error( 'missing_param', __( 'name is required.', 'ai-agent' ) );
 		}
 
 		$registry = \WP_Block_Type_Registry::get_instance();
 		$block    = $registry->get_registered( $name );
 
 		if ( ! $block ) {
-			return [ 'error' => "Block type '{$name}' not found." ];
+			return new WP_Error(
+				'not_found',
+				sprintf(
+					/* translators: %s: block type name */
+					__( "Block type '%s' not found.", 'ai-agent' ),
+					$name
+				)
+			);
 		}
 
 		$result = [
@@ -502,13 +510,13 @@ class BlockAbilities {
 	 * Handle creating block content from a structured array.
 	 *
 	 * @param array $input Input with 'blocks' array.
-	 * @return array Result with block_content and block_count.
+	 * @return array|\WP_Error Result with block_content and block_count or WP_Error on failure.
 	 */
-	public static function handle_create_block_content( array $input ): array {
+	public static function handle_create_block_content( array $input ): array|\WP_Error {
 		$blocks = $input['blocks'] ?? [];
 
 		if ( empty( $blocks ) || ! is_array( $blocks ) ) {
-			return [ 'error' => 'blocks array is required.' ];
+			return new WP_Error( 'missing_param', __( 'blocks array is required.', 'ai-agent' ) );
 		}
 
 		$output      = '';
@@ -531,15 +539,15 @@ class BlockAbilities {
 	 * Handle parsing existing block content.
 	 *
 	 * @param array $input Input with post_id or content, optional site_url.
-	 * @return array Result with blocks and block_count.
+	 * @return array|\WP_Error Result with blocks and block_count or WP_Error on failure.
 	 */
-	public static function handle_parse_block_content( array $input ): array {
+	public static function handle_parse_block_content( array $input ): array|\WP_Error {
 		$post_id  = (int) ( $input['post_id'] ?? 0 );
 		$content  = $input['content'] ?? '';
 		$site_url = $input['site_url'] ?? '';
 
 		if ( ! $post_id && empty( $content ) ) {
-			return [ 'error' => 'Either post_id or content is required.' ];
+			return new WP_Error( 'missing_param', __( 'Either post_id or content is required.', 'ai-agent' ) );
 		}
 
 		$switched = false;
@@ -554,7 +562,14 @@ class BlockAbilities {
 				switch_to_blog( $blog_id );
 				$switched = true;
 			} elseif ( ! $blog_id ) {
-				return [ 'error' => "Could not find a site matching URL: {$site_url}" ];
+				return new WP_Error(
+					'site_not_found',
+					sprintf(
+						/* translators: %s: site URL */
+						__( 'Could not find a site matching URL: %s', 'ai-agent' ),
+						$site_url
+					)
+				);
 			}
 		}
 
@@ -564,7 +579,14 @@ class BlockAbilities {
 				if ( $switched ) {
 					restore_current_blog();
 				}
-				return [ 'error' => "Post {$post_id} not found." ];
+				return new WP_Error(
+					'not_found',
+					sprintf(
+						/* translators: %d: post ID */
+						__( 'Post %d not found.', 'ai-agent' ),
+						$post_id
+					)
+				);
 			}
 			$content = $post->post_content;
 		}

--- a/includes/Abilities/KnowledgeAbilities.php
+++ b/includes/Abilities/KnowledgeAbilities.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace AiAgent\Abilities;
 
 use AiAgent\Knowledge\Knowledge;
+use WP_Error;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -63,13 +64,13 @@ class KnowledgeAbilities {
 	 * Handle the knowledge-search ability call.
 	 *
 	 * @param array $input Input with query and optional collection.
-	 * @return array Result.
+	 * @return array|\WP_Error Result or WP_Error on failure.
 	 */
-	public static function handle_knowledge_search( array $input ): array {
+	public static function handle_knowledge_search( array $input ): array|\WP_Error {
 		$query = $input['query'] ?? '';
 
 		if ( empty( $query ) ) {
-			return [ 'error' => 'Search query is required.' ];
+			return new WP_Error( 'missing_param', __( 'Search query is required.', 'ai-agent' ) );
 		}
 
 		$options = [ 'limit' => 8 ];

--- a/includes/Abilities/MarketingAbilities.php
+++ b/includes/Abilities/MarketingAbilities.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace AiAgent\Abilities;
 
+use WP_Error;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -81,13 +83,13 @@ class MarketingAbilities {
 	 * Handle the fetch-url ability call.
 	 *
 	 * @param array $input Input with url.
-	 * @return array Fetch results.
+	 * @return array|\WP_Error Fetch results or WP_Error on failure.
 	 */
-	public static function handle_fetch_url( array $input ): array {
+	public static function handle_fetch_url( array $input ): array|\WP_Error {
 		$url = esc_url_raw( $input['url'] ?? '' );
 
 		if ( empty( $url ) ) {
-			return [ 'error' => 'url is required.' ];
+			return new WP_Error( 'missing_param', __( 'url is required.', 'ai-agent' ) );
 		}
 
 		$response = wp_remote_get(
@@ -100,7 +102,14 @@ class MarketingAbilities {
 		);
 
 		if ( is_wp_error( $response ) ) {
-			return [ 'error' => 'Failed to fetch URL: ' . $response->get_error_message() ];
+			return new WP_Error(
+				'fetch_failed',
+				sprintf(
+					/* translators: %s: error message */
+					__( 'Failed to fetch URL: %s', 'ai-agent' ),
+					$response->get_error_message()
+				)
+			);
 		}
 
 		$status_code = wp_remote_retrieve_response_code( $response );
@@ -159,13 +168,13 @@ class MarketingAbilities {
 	 * Handle the analyze-headers ability call.
 	 *
 	 * @param array $input Input with url.
-	 * @return array Header analysis results.
+	 * @return array|\WP_Error Header analysis results or WP_Error on failure.
 	 */
-	public static function handle_analyze_headers( array $input ): array {
+	public static function handle_analyze_headers( array $input ): array|\WP_Error {
 		$url = esc_url_raw( $input['url'] ?? '' );
 
 		if ( empty( $url ) ) {
-			return [ 'error' => 'url is required.' ];
+			return new WP_Error( 'missing_param', __( 'url is required.', 'ai-agent' ) );
 		}
 
 		$response = wp_remote_head(
@@ -178,7 +187,14 @@ class MarketingAbilities {
 		);
 
 		if ( is_wp_error( $response ) ) {
-			return [ 'error' => 'Failed to fetch headers: ' . $response->get_error_message() ];
+			return new WP_Error(
+				'fetch_failed',
+				sprintf(
+					/* translators: %s: error message */
+					__( 'Failed to fetch headers: %s', 'ai-agent' ),
+					$response->get_error_message()
+				)
+			);
 		}
 
 		$status_code = wp_remote_retrieve_response_code( $response );

--- a/includes/Abilities/MemoryAbilities.php
+++ b/includes/Abilities/MemoryAbilities.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace AiAgent\Abilities;
 
 use AiAgent\Models\Memory;
+use WP_Error;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -102,20 +103,20 @@ class MemoryAbilities {
 	 * Handle the memory-save ability call.
 	 *
 	 * @param array $input Input with category and content.
-	 * @return array Result.
+	 * @return array|\WP_Error Result or WP_Error on failure.
 	 */
-	public static function handle_memory_save( array $input ): array {
+	public static function handle_memory_save( array $input ): array|\WP_Error {
 		$category = $input['category'] ?? 'general';
 		$content  = $input['content'] ?? '';
 
 		if ( empty( $content ) ) {
-			return [ 'error' => 'Content is required.' ];
+			return new WP_Error( 'missing_param', __( 'Content is required.', 'ai-agent' ) );
 		}
 
 		$id = Memory::create( $category, $content );
 
 		if ( false === $id ) {
-			return [ 'error' => 'Failed to save memory.' ];
+			return new WP_Error( 'save_failed', __( 'Failed to save memory.', 'ai-agent' ) );
 		}
 
 		return [
@@ -153,19 +154,19 @@ class MemoryAbilities {
 	 * Handle the memory-delete ability call.
 	 *
 	 * @param array $input Input with id.
-	 * @return array Result.
+	 * @return array|\WP_Error Result or WP_Error on failure.
 	 */
-	public static function handle_memory_delete( array $input ): array {
+	public static function handle_memory_delete( array $input ): array|\WP_Error {
 		$id = $input['id'] ?? 0;
 
 		if ( empty( $id ) ) {
-			return [ 'error' => 'Memory ID is required.' ];
+			return new WP_Error( 'missing_param', __( 'Memory ID is required.', 'ai-agent' ) );
 		}
 
 		$deleted = Memory::delete( (int) $id );
 
 		if ( ! $deleted ) {
-			return [ 'error' => 'Failed to delete memory or memory not found.' ];
+			return new WP_Error( 'delete_failed', __( 'Failed to delete memory or memory not found.', 'ai-agent' ) );
 		}
 
 		return [

--- a/includes/Abilities/SeoAbilities.php
+++ b/includes/Abilities/SeoAbilities.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace AiAgent\Abilities;
 
+use WP_Error;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -93,13 +95,13 @@ class SeoAbilities {
 	 * Handle the seo-audit-url ability call.
 	 *
 	 * @param array $input Input with url and optional site_url.
-	 * @return array Audit results.
+	 * @return array|\WP_Error Audit results or WP_Error on failure.
 	 */
-	public static function handle_audit_url( array $input ): array {
+	public static function handle_audit_url( array $input ): array|\WP_Error {
 		$url = esc_url_raw( $input['url'] ?? '' );
 
 		if ( empty( $url ) ) {
-			return [ 'error' => 'url is required.' ];
+			return new WP_Error( 'missing_param', __( 'url is required.', 'ai-agent' ) );
 		}
 
 		$response = wp_remote_get(
@@ -111,18 +113,28 @@ class SeoAbilities {
 		);
 
 		if ( is_wp_error( $response ) ) {
-			return [ 'error' => 'Failed to fetch URL: ' . $response->get_error_message() ];
+			return new WP_Error(
+				'fetch_failed',
+				sprintf(
+					/* translators: %s: error message */
+					__( 'Failed to fetch URL: %s', 'ai-agent' ),
+					$response->get_error_message()
+				)
+			);
 		}
 
 		$status_code = wp_remote_retrieve_response_code( $response );
 		$body        = wp_remote_retrieve_body( $response );
 
 		if ( empty( $body ) ) {
-			return [
-				'url'         => $url,
-				'status_code' => $status_code,
-				'error'       => 'Empty response body.',
-			];
+			return new WP_Error(
+				'empty_response',
+				__( 'Empty response body.', 'ai-agent' ),
+				[
+					'url'         => $url,
+					'status_code' => $status_code,
+				]
+			);
 		}
 
 		return self::parse_seo_elements( $url, $status_code, $body );
@@ -272,15 +284,15 @@ class SeoAbilities {
 	 * Handle the seo-analyze-content ability call.
 	 *
 	 * @param array $input Input with post_id, optional focus_keyword, site_url.
-	 * @return array Analysis results.
+	 * @return array|\WP_Error Analysis results or WP_Error on failure.
 	 */
-	public static function handle_analyze_content( array $input ): array {
+	public static function handle_analyze_content( array $input ): array|\WP_Error {
 		$post_id       = (int) ( $input['post_id'] ?? 0 );
 		$focus_keyword = sanitize_text_field( $input['focus_keyword'] ?? '' );
 		$site_url      = $input['site_url'] ?? '';
 
 		if ( ! $post_id ) {
-			return [ 'error' => 'post_id is required.' ];
+			return new WP_Error( 'missing_param', __( 'post_id is required.', 'ai-agent' ) );
 		}
 
 		$switched = false;
@@ -303,7 +315,14 @@ class SeoAbilities {
 			if ( $switched ) {
 				restore_current_blog();
 			}
-			return [ 'error' => "Post {$post_id} not found." ];
+			return new WP_Error(
+				'not_found',
+				sprintf(
+					/* translators: %d: post ID */
+					__( 'Post %d not found.', 'ai-agent' ),
+					$post_id
+				)
+			);
 		}
 
 		$result = self::analyze_post_seo( $post, $focus_keyword );

--- a/includes/Abilities/SkillAbilities.php
+++ b/includes/Abilities/SkillAbilities.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace AiAgent\Abilities;
 
 use AiAgent\Models\Skill;
+use WP_Error;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -75,23 +76,37 @@ class SkillAbilities {
 	 * Handle the skill-load ability call.
 	 *
 	 * @param array $input Input with slug.
-	 * @return array Result with skill content.
+	 * @return array|\WP_Error Result with skill content or WP_Error on failure.
 	 */
-	public static function handle_skill_load( array $input ): array {
+	public static function handle_skill_load( array $input ): array|\WP_Error {
 		$slug = $input['slug'] ?? '';
 
 		if ( empty( $slug ) ) {
-			return [ 'error' => 'Skill slug is required.' ];
+			return new WP_Error( 'missing_param', __( 'Skill slug is required.', 'ai-agent' ) );
 		}
 
 		$skill = Skill::get_by_slug( $slug );
 
 		if ( ! $skill ) {
-			return [ 'error' => "Skill '$slug' not found." ];
+			return new WP_Error(
+				'not_found',
+				sprintf(
+					/* translators: %s: skill slug */
+					__( "Skill '%s' not found.", 'ai-agent' ),
+					$slug
+				)
+			);
 		}
 
 		if ( ! (int) $skill->enabled ) {
-			return [ 'error' => "Skill '$slug' is disabled." ];
+			return new WP_Error(
+				'skill_disabled',
+				sprintf(
+					/* translators: %s: skill slug */
+					__( "Skill '%s' is disabled.", 'ai-agent' ),
+					$slug
+				)
+			);
 		}
 
 		return [

--- a/includes/Abilities/StockImageAbilities.php
+++ b/includes/Abilities/StockImageAbilities.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace AiAgent\Abilities;
 
+use WP_Error;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -73,16 +75,16 @@ class StockImageAbilities {
 	 * Handle the import-stock-image ability call.
 	 *
 	 * @param array $input Input with keyword, optional site_url, width, height.
-	 * @return array Result with attachment_id, url, alt, title or error.
+	 * @return array|\WP_Error Result with attachment_id, url, alt, title or WP_Error on failure.
 	 */
-	public static function handle_import( array $input ): array {
+	public static function handle_import( array $input ): array|\WP_Error {
 		$keyword  = sanitize_text_field( $input['keyword'] ?? '' );
 		$site_url = $input['site_url'] ?? '';
 		$width    = (int) ( $input['width'] ?? 1200 );
 		$height   = (int) ( $input['height'] ?? 800 );
 
 		if ( empty( $keyword ) ) {
-			return [ 'error' => 'keyword is required.' ];
+			return new WP_Error( 'missing_param', __( 'keyword is required.', 'ai-agent' ) );
 		}
 
 		// Clamp dimensions to reasonable range.
@@ -102,7 +104,14 @@ class StockImageAbilities {
 				switch_to_blog( $blog_id );
 				$switched = true;
 			} elseif ( ! $blog_id ) {
-				return [ 'error' => "Could not find a site matching URL: {$site_url}" ];
+				return new WP_Error(
+					'site_not_found',
+					sprintf(
+						/* translators: %s: site URL */
+						__( 'Could not find a site matching URL: %s', 'ai-agent' ),
+						$site_url
+					)
+				);
 			}
 		}
 
@@ -121,9 +130,9 @@ class StockImageAbilities {
 	 * @param string $keyword Search keyword.
 	 * @param int    $width   Image width.
 	 * @param int    $height  Image height.
-	 * @return array Result array.
+	 * @return array|\WP_Error Result array or WP_Error on failure.
 	 */
-	private static function download_and_import( string $keyword, int $width, int $height ): array {
+	private static function download_and_import( string $keyword, int $width, int $height ): array|\WP_Error {
 		// Build a deterministic-ish lock so the same keyword doesn't always
 		// return the exact same image, but retries in the same request do.
 		$lock = crc32( $keyword . gmdate( 'Y-m-d-H' ) );
@@ -152,7 +161,14 @@ class StockImageAbilities {
 			$tmp_file     = download_url( $fallback_url, 30 );
 
 			if ( is_wp_error( $tmp_file ) ) {
-				return [ 'error' => 'Failed to download image: ' . $tmp_file->get_error_message() ];
+				return new WP_Error(
+					'download_failed',
+					sprintf(
+						/* translators: %s: error message */
+						__( 'Failed to download image: %s', 'ai-agent' ),
+						$tmp_file->get_error_message()
+					)
+				);
 			}
 		}
 
@@ -174,7 +190,14 @@ class StockImageAbilities {
 			if ( file_exists( $tmp_file ) ) {
 				unlink( $tmp_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
 			}
-			return [ 'error' => 'Failed to import image: ' . $attachment_id->get_error_message() ];
+			return new WP_Error(
+				'import_failed',
+				sprintf(
+					/* translators: %s: error message */
+					__( 'Failed to import image: %s', 'ai-agent' ),
+					$attachment_id->get_error_message()
+				)
+			);
 		}
 
 		// Set alt text from keyword.

--- a/includes/Tools/CustomToolExecutor.php
+++ b/includes/Tools/CustomToolExecutor.php
@@ -69,9 +69,9 @@ class CustomToolExecutor {
 	 *
 	 * @param array $tool  The tool definition.
 	 * @param array $input Input parameters from the AI.
-	 * @return array Result array.
+	 * @return array|\WP_Error Result array or WP_Error on failure.
 	 */
-	public static function execute( array $tool, array $input ): array {
+	public static function execute( array $tool, array $input ): array|\WP_Error {
 		switch ( $tool['type'] ) {
 			case CustomTools::TYPE_HTTP:
 				return self::execute_http( $tool, $input );
@@ -83,7 +83,14 @@ class CustomToolExecutor {
 				return self::execute_cli( $tool, $input );
 
 			default:
-				return [ 'error' => sprintf( 'Unknown tool type: %s', $tool['type'] ) ];
+				return new WP_Error(
+					'unknown_tool_type',
+					sprintf(
+						/* translators: %s: tool type */
+						__( 'Unknown tool type: %s', 'ai-agent' ),
+						$tool['type']
+					)
+				);
 		}
 	}
 
@@ -92,9 +99,9 @@ class CustomToolExecutor {
 	 *
 	 * @param array $tool  Tool definition.
 	 * @param array $input Input parameters.
-	 * @return array
+	 * @return array|\WP_Error
 	 */
-	private static function execute_http( array $tool, array $input ): array {
+	private static function execute_http( array $tool, array $input ): array|\WP_Error {
 		$config = $tool['config'];
 		$url    = $config['url'] ?? '';
 		$method = strtoupper( $config['method'] ?? 'GET' );
@@ -141,10 +148,7 @@ class CustomToolExecutor {
 		$response = wp_remote_request( $url, $args );
 
 		if ( is_wp_error( $response ) ) {
-			return [
-				'success' => false,
-				'error'   => $response->get_error_message(),
-			];
+			return new WP_Error( 'http_request_failed', $response->get_error_message() );
 		}
 
 		$code          = wp_remote_retrieve_response_code( $response );
@@ -165,19 +169,19 @@ class CustomToolExecutor {
 	 *
 	 * @param array $tool  Tool definition.
 	 * @param array $input Input parameters.
-	 * @return array
+	 * @return array|\WP_Error
 	 */
-	private static function execute_action( array $tool, array $input ): array {
+	private static function execute_action( array $tool, array $input ): array|\WP_Error {
 		$config    = $tool['config'];
 		$hook_name = $config['hook_name'] ?? '';
 
 		if ( empty( $hook_name ) ) {
-			return [ 'error' => 'No hook_name configured.' ];
+			return new WP_Error( 'missing_config', __( 'No hook_name configured.', 'ai-agent' ) );
 		}
 
 		// Sanitize hook name — only allow valid hook characters.
 		if ( ! preg_match( '/^[a-zA-Z0-9_]+$/', $hook_name ) ) {
-			return [ 'error' => 'Invalid hook name.' ];
+			return new WP_Error( 'invalid_hook_name', __( 'Invalid hook name.', 'ai-agent' ) );
 		}
 
 		// Build arguments from config defaults + input.
@@ -211,10 +215,7 @@ class CustomToolExecutor {
 		} catch ( \Throwable $e ) {
 			ob_end_clean();
 
-			return [
-				'success' => false,
-				'error'   => $e->getMessage(),
-			];
+			return new WP_Error( 'action_exception', $e->getMessage() );
 		}
 	}
 
@@ -223,14 +224,14 @@ class CustomToolExecutor {
 	 *
 	 * @param array $tool  Tool definition.
 	 * @param array $input Input parameters.
-	 * @return array
+	 * @return array|\WP_Error
 	 */
-	private static function execute_cli( array $tool, array $input ): array {
+	private static function execute_cli( array $tool, array $input ): array|\WP_Error {
 		$config  = $tool['config'];
 		$command = $config['command'] ?? '';
 
 		if ( empty( $command ) ) {
-			return [ 'error' => 'No command configured.' ];
+			return new WP_Error( 'missing_config', __( 'No command configured.', 'ai-agent' ) );
 		}
 
 		// Replace {{placeholders}} in the command.

--- a/includes/Tools/ToolDiscovery.php
+++ b/includes/Tools/ToolDiscovery.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace AiAgent\Tools;
 
 use AiAgent\Core\Settings;
+use WP_Error;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -138,11 +139,11 @@ class ToolDiscovery {
 	 * Handle the list-tools ability call.
 	 *
 	 * @param array $input The input parameters.
-	 * @return array The result.
+	 * @return array|\WP_Error The result or WP_Error on failure.
 	 */
-	public static function handle_list_tools( array $input ): array {
+	public static function handle_list_tools( array $input ): array|\WP_Error {
 		if ( ! function_exists( 'wp_get_abilities' ) ) {
-			return [ 'error' => 'Abilities API not available.' ];
+			return new WP_Error( 'api_unavailable', __( 'Abilities API not available.', 'ai-agent' ) );
 		}
 
 		$query    = $input['query'] ?? '';
@@ -287,25 +288,32 @@ class ToolDiscovery {
 	 * Handle the execute-tool ability call.
 	 *
 	 * @param array $input The input parameters.
-	 * @return array The result.
+	 * @return array|\WP_Error The result or WP_Error on failure.
 	 */
-	public static function handle_execute_tool( array $input ): array {
+	public static function handle_execute_tool( array $input ): array|\WP_Error {
 		$tool_name  = $input['tool_name'] ?? '';
 		$parameters = $input['parameters'] ?? null;
 		$confirmed  = $input['confirmed'] ?? false;
 
 		if ( '' === $tool_name ) {
-			return [ 'error' => 'tool_name is required.' ];
+			return new WP_Error( 'missing_param', __( 'tool_name is required.', 'ai-agent' ) );
 		}
 
 		if ( ! function_exists( 'wp_get_ability' ) ) {
-			return [ 'error' => 'Abilities API not available.' ];
+			return new WP_Error( 'api_unavailable', __( 'Abilities API not available.', 'ai-agent' ) );
 		}
 
 		$ability = wp_get_ability( $tool_name );
 
 		if ( ! $ability instanceof \WP_Ability ) {
-			return [ 'error' => sprintf( 'Tool "%s" not found.', $tool_name ) ];
+			return new WP_Error(
+				'not_found',
+				sprintf(
+					/* translators: %s: tool name */
+					__( 'Tool "%s" not found.', 'ai-agent' ),
+					$tool_name
+				)
+			);
 		}
 
 		// Check tool permissions.
@@ -313,7 +321,14 @@ class ToolDiscovery {
 		$permission = $perms[ $tool_name ] ?? 'auto';
 
 		if ( 'disabled' === $permission ) {
-			return [ 'error' => sprintf( 'Tool "%s" is disabled.', $tool_name ) ];
+			return new WP_Error(
+				'tool_disabled',
+				sprintf(
+					/* translators: %s: tool name */
+					__( 'Tool "%s" is disabled.', 'ai-agent' ),
+					$tool_name
+				)
+			);
 		}
 
 		if ( 'confirm' === $permission && ! $confirmed ) {


### PR DESCRIPTION
## Summary

- Replaces all `return ['error' => '...']` patterns in ability handlers and tool executors with `new WP_Error(...)` objects
- Updates return type hints from `array` to `array|\WP_Error` on all affected handler methods
- Adds `/* translators: */` comments for all `sprintf(__())` calls with placeholders (PHPCS compliance)

## Why

The WordPress Abilities API resolver (`class-wp-ai-client-ability-function-resolver.php`) already converts `WP_Error` returns to `['error' => ...]` for the AI model, so this change is transparent to the model. Returning `WP_Error` is the idiomatic WordPress pattern per the project's own AGENTS.md rule: _"Return `WP_Error` objects; never throw exceptions in hooks"_.

## Files changed

**Abilities** (7 files):
- `KnowledgeAbilities` — `handle_knowledge_search`
- `MemoryAbilities` — `handle_memory_save`, `handle_memory_delete`
- `SkillAbilities` — `handle_skill_load`
- `StockImageAbilities` — `handle_import`, `download_and_import`
- `MarketingAbilities` — `handle_fetch_url`, `handle_analyze_headers`
- `SeoAbilities` — `handle_audit_url`, `handle_analyze_content`
- `BlockAbilities` — `handle_markdown_to_blocks`, `handle_get_block_type`, `handle_create_block_content`, `handle_parse_block_content`

**Tools** (2 files):
- `ToolDiscovery` — `handle_list_tools`, `handle_execute_tool`
- `CustomToolExecutor` — `execute`, `execute_http`, `execute_action`, `execute_cli`

## Verification

- PHPCS: zero violations across `includes/`
- Build: `npx wp-scripts build` compiles successfully

Closes #40