### PR TITLE
t048: Replace hardcoded model fallback with configurable default

### DIFF
--- a/ai-agent.php
+++ b/ai-agent.php
@@ -22,6 +22,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 define( 'AI_AGENT_DIR', __DIR__ );
 define( 'AI_AGENT_URL', plugin_dir_url( __FILE__ ) );
 
+/**
+ * Built-in fallback model ID used when no model is configured in settings
+ * and no connector default is available.
+ *
+ * Developers can override the effective default at runtime via the
+ * `ai_agent_default_model` filter rather than changing this constant.
+ */
+define( 'AI_AGENT_DEFAULT_MODEL', 'claude-sonnet-4' );
+
 // Load Jetpack Autoloader for PSR-4 autoloading with version conflict resolution.
 // Jetpack Autoloader ensures the newest version of shared packages (like php-ai-client) is used.
 if ( file_exists( AI_AGENT_DIR . '/vendor/autoload_packages.php' ) ) {

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -343,13 +343,13 @@ class AgentLoop {
 		}
 
 		// Resolve model for the OpenAI-compatible endpoint.
-		// Priority: explicit selection → connector default → hardcoded fallback.
+		// Priority: explicit selection → connector default → configurable plugin default.
 		$model_id = $this->model_id;
 		if ( empty( $model_id ) && function_exists( 'OpenAiCompatibleConnector\\get_default_model' ) ) {
 			$model_id = \OpenAiCompatibleConnector\get_default_model();
 		}
 		if ( empty( $model_id ) ) {
-			$model_id = 'claude-sonnet-4';
+			$model_id = Settings::get_default_model();
 		}
 
 		// Resolve abilities and convert to OpenAI tools format.

--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -93,6 +93,41 @@ class Settings {
 	}
 
 	/**
+	 * Resolve the effective default model ID.
+	 *
+	 * Resolution order (first non-empty value wins):
+	 *   1. `default_model` setting saved by the site administrator.
+	 *   2. Value returned by the `ai_agent_default_model` filter (allows
+	 *      developers to override the default programmatically).
+	 *   3. The `AI_AGENT_DEFAULT_MODEL` constant defined in the plugin root.
+	 *
+	 * Example — override the default model from a theme or mu-plugin:
+	 *
+	 *   add_filter( 'ai_agent_default_model', function ( string $model ): string {
+	 *       return 'gpt-4o';
+	 *   } );
+	 *
+	 * @return string Non-empty model ID.
+	 */
+	public static function get_default_model(): string {
+		$settings = self::get();
+		$model    = (string) ( $settings['default_model'] ?? '' );
+
+		if ( '' === $model ) {
+			$builtin = defined( 'AI_AGENT_DEFAULT_MODEL' ) ? (string) AI_AGENT_DEFAULT_MODEL : 'claude-sonnet-4';
+
+			/**
+			 * Filter the default model ID used when no model is configured in settings.
+			 *
+			 * @param string $model The built-in fallback model ID (AI_AGENT_DEFAULT_MODEL).
+			 */
+			$model = (string) apply_filters( 'ai_agent_default_model', $builtin );
+		}
+
+		return $model;
+	}
+
+	/**
 	 * Get a single setting or all settings merged with defaults.
 	 *
 	 * @param string|null $key Optional key to retrieve.


### PR DESCRIPTION
## Summary

- Adds `AI_AGENT_DEFAULT_MODEL` constant (`'claude-sonnet-4'`) in `ai-agent.php` as the single source of truth for the built-in fallback model ID
- Adds `Settings::get_default_model()` with a three-tier resolution: saved `default_model` setting → `ai_agent_default_model` filter → `AI_AGENT_DEFAULT_MODEL` constant
- Replaces the hardcoded `'claude-sonnet-4'` string in `AgentLoop::call_openai_compat()` with `Settings::get_default_model()`

## Developer override

Developers can override the default model without touching plugin settings:

```php
add_filter( 'ai_agent_default_model', function ( string $model ): string {
    return 'gpt-4o';
} );
```

## Verification

- PHPStan: no errors
- PHPCS: no violations

Closes #141