### PR TITLE
t031: Add meta.annotations (readonly, destructive, idempotent) to all abilities

### DIFF
--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -51,6 +51,14 @@ class BlockAbilities {
 					],
 					'required'   => [ 'markdown' ],
 				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'    => false,
+						'idempotent'  => true,
+						'destructive' => false,
+					],
+					'show_in_rest' => true,
+				],
 				'execute_callback'    => [ __CLASS__, 'handle_markdown_to_blocks' ],
 				'permission_callback' => function () {
 					return current_user_can( 'edit_posts' );
@@ -86,6 +94,13 @@ class BlockAbilities {
 					],
 					'required'   => [],
 				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'   => true,
+						'idempotent' => true,
+					],
+					'show_in_rest' => true,
+				],
 				'execute_callback'    => [ __CLASS__, 'handle_list_block_types' ],
 				'permission_callback' => function () {
 					return current_user_can( 'edit_posts' );
@@ -108,6 +123,13 @@ class BlockAbilities {
 						],
 					],
 					'required'   => [ 'name' ],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'   => true,
+						'idempotent' => true,
+					],
+					'show_in_rest' => true,
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_get_block_type' ],
 				'permission_callback' => function () {
@@ -144,6 +166,13 @@ class BlockAbilities {
 					],
 					'required'   => [],
 				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'   => true,
+						'idempotent' => true,
+					],
+					'show_in_rest' => true,
+				],
 				'execute_callback'    => [ __CLASS__, 'handle_list_block_patterns' ],
 				'permission_callback' => function () {
 					return current_user_can( 'edit_posts' );
@@ -167,6 +196,13 @@ class BlockAbilities {
 					],
 					'required'   => [],
 				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'   => true,
+						'idempotent' => true,
+					],
+					'show_in_rest' => true,
+				],
 				'execute_callback'    => [ __CLASS__, 'handle_list_block_templates' ],
 				'permission_callback' => function () {
 					return current_user_can( 'edit_posts' );
@@ -189,6 +225,14 @@ class BlockAbilities {
 						],
 					],
 					'required'   => [ 'blocks' ],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'    => false,
+						'idempotent'  => true,
+						'destructive' => false,
+					],
+					'show_in_rest' => true,
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_create_block_content' ],
 				'permission_callback' => function () {
@@ -220,6 +264,13 @@ class BlockAbilities {
 						],
 					],
 					'required'   => [],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'   => true,
+						'idempotent' => true,
+					],
+					'show_in_rest' => true,
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_parse_block_content' ],
 				'permission_callback' => function () {

--- a/includes/Abilities/ContentAbilities.php
+++ b/includes/Abilities/ContentAbilities.php
@@ -54,6 +54,13 @@ class ContentAbilities {
 					],
 					'required'   => [],
 				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'   => true,
+						'idempotent' => true,
+					],
+					'show_in_rest' => true,
+				],
 				'execute_callback'    => [ __CLASS__, 'handle_content_analyze' ],
 				'permission_callback' => function () {
 					return current_user_can( 'edit_posts' );
@@ -80,6 +87,13 @@ class ContentAbilities {
 						],
 					],
 					'required'   => [],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'   => true,
+						'idempotent' => true,
+					],
+					'show_in_rest' => true,
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_performance_report' ],
 				'permission_callback' => function () {

--- a/includes/Abilities/KnowledgeAbilities.php
+++ b/includes/Abilities/KnowledgeAbilities.php
@@ -52,6 +52,13 @@ class KnowledgeAbilities {
 					],
 					'required'   => [ 'query' ],
 				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'   => true,
+						'idempotent' => true,
+					],
+					'show_in_rest' => true,
+				],
 				'execute_callback'    => [ __CLASS__, 'handle_knowledge_search' ],
 				'permission_callback' => function () {
 					return current_user_can( 'manage_options' ); },

--- a/includes/Abilities/MarketingAbilities.php
+++ b/includes/Abilities/MarketingAbilities.php
@@ -46,6 +46,13 @@ class MarketingAbilities {
 					],
 					'required'   => [ 'url' ],
 				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'   => true,
+						'idempotent' => true,
+					],
+					'show_in_rest' => true,
+				],
 				'execute_callback'    => [ __CLASS__, 'handle_fetch_url' ],
 				'permission_callback' => function () {
 					return current_user_can( 'edit_posts' );
@@ -68,6 +75,13 @@ class MarketingAbilities {
 						],
 					],
 					'required'   => [ 'url' ],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'   => true,
+						'idempotent' => true,
+					],
+					'show_in_rest' => true,
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_analyze_headers' ],
 				'permission_callback' => function () {

--- a/includes/Abilities/MemoryAbilities.php
+++ b/includes/Abilities/MemoryAbilities.php
@@ -53,6 +53,14 @@ class MemoryAbilities {
 					],
 					'required'   => [ 'category', 'content' ],
 				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'    => false,
+						'idempotent'  => false,
+						'destructive' => false,
+					],
+					'show_in_rest' => true,
+				],
 				'execute_callback'    => [ __CLASS__, 'handle_memory_save' ],
 				'permission_callback' => function () {
 					return current_user_can( 'manage_options' ); },
@@ -68,6 +76,13 @@ class MemoryAbilities {
 				'input_schema'        => [
 					'type'       => 'object',
 					'properties' => new \stdClass(),
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'   => true,
+						'idempotent' => true,
+					],
+					'show_in_rest' => true,
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_memory_list' ],
 				'permission_callback' => function () {
@@ -90,6 +105,14 @@ class MemoryAbilities {
 						],
 					],
 					'required'   => [ 'id' ],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'    => false,
+						'idempotent'  => true,
+						'destructive' => true,
+					],
+					'show_in_rest' => true,
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_memory_delete' ],
 				'permission_callback' => function () {

--- a/includes/Abilities/SeoAbilities.php
+++ b/includes/Abilities/SeoAbilities.php
@@ -50,6 +50,13 @@ class SeoAbilities {
 					],
 					'required'   => [ 'url' ],
 				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'   => true,
+						'idempotent' => true,
+					],
+					'show_in_rest' => true,
+				],
 				'execute_callback'    => [ __CLASS__, 'handle_audit_url' ],
 				'permission_callback' => function () {
 					return current_user_can( 'edit_posts' );
@@ -80,6 +87,13 @@ class SeoAbilities {
 						],
 					],
 					'required'   => [ 'post_id' ],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'   => true,
+						'idempotent' => true,
+					],
+					'show_in_rest' => true,
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_analyze_content' ],
 				'permission_callback' => function () {

--- a/includes/Abilities/SkillAbilities.php
+++ b/includes/Abilities/SkillAbilities.php
@@ -48,6 +48,13 @@ class SkillAbilities {
 					],
 					'required'   => [ 'slug' ],
 				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'   => true,
+						'idempotent' => true,
+					],
+					'show_in_rest' => true,
+				],
 				'execute_callback'    => [ __CLASS__, 'handle_skill_load' ],
 				'permission_callback' => function () {
 					return current_user_can( 'manage_options' ); },
@@ -63,6 +70,13 @@ class SkillAbilities {
 				'input_schema'        => [
 					'type'       => 'object',
 					'properties' => new \stdClass(),
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'   => true,
+						'idempotent' => true,
+					],
+					'show_in_rest' => true,
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_skill_list' ],
 				'permission_callback' => function () {

--- a/includes/Abilities/StockImageAbilities.php
+++ b/includes/Abilities/StockImageAbilities.php
@@ -61,6 +61,14 @@ class StockImageAbilities {
 					],
 					'required'   => [ 'keyword' ],
 				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'    => false,
+						'idempotent'  => false,
+						'destructive' => false,
+					],
+					'show_in_rest' => true,
+				],
 				'execute_callback'    => [ __CLASS__, 'handle_import' ],
 				'permission_callback' => function () {
 					return current_user_can( 'upload_files' );


### PR DESCRIPTION
## Summary

- Adds `meta.annotations` with `readonly`, `destructive`, and `idempotent` flags to all 8 ability classes that were missing them
- Follows the same pattern already established in `FileAbilities`, `WordPressAbilities`, `NavigationAbilities`, `DatabaseAbilities`, and `AbilityDiscoveryAbilities`

## Abilities updated

| Class | Ability | readonly | destructive | idempotent |
|-------|---------|----------|-------------|------------|
| BlockAbilities | `markdown-to-blocks` | false | false | true |
| BlockAbilities | `list-block-types` | true | — | true |
| BlockAbilities | `get-block-type` | true | — | true |
| BlockAbilities | `list-block-patterns` | true | — | true |
| BlockAbilities | `list-block-templates` | true | — | true |
| BlockAbilities | `create-block-content` | false | false | true |
| BlockAbilities | `parse-block-content` | true | — | true |
| ContentAbilities | `content-analyze` | true | — | true |
| ContentAbilities | `content-performance-report` | true | — | true |
| KnowledgeAbilities | `knowledge-search` | true | — | true |
| MarketingAbilities | `fetch-url` | true | — | true |
| MarketingAbilities | `analyze-headers` | true | — | true |
| MemoryAbilities | `memory-save` | false | false | false |
| MemoryAbilities | `memory-list` | true | — | true |
| MemoryAbilities | `memory-delete` | false | true | true |
| SeoAbilities | `seo-audit-url` | true | — | true |
| SeoAbilities | `seo-analyze-content` | true | — | true |
| SkillAbilities | `skill-load` | true | — | true |
| SkillAbilities | `skill-list` | true | — | true |
| StockImageAbilities | `import-stock-image` | false | false | false |

## Verification

- PHPCS: clean (0 violations)
- PHPStan: same 11 pre-existing stale `ignoreErrors` pattern warnings as `main` — no new errors introduced

Closes #125