### PR TITLE
t047: Extract credential management to CredentialResolver class

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -19,6 +19,7 @@ use AiAgent\Tools\ToolDiscovery;
 use AiAgent\Tools\ToolProfiles;
 use WP_AI_Client_Ability_Function_Resolver;
 use WP_Error;
+use AiAgent\Core\CredentialResolver;
 use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\DTO\ModelMessage;
@@ -284,8 +285,7 @@ class AgentLoop {
 		try {
 			$registry = \WordPress\AiClient\AiClient::defaultRegistry();
 			if ( ! $registry->hasProvider( $provider_id ) ) {
-				$endpoint_url = get_option( 'openai_compat_endpoint_url', '' );
-				if ( ! empty( $endpoint_url ) ) {
+				if ( CredentialResolver::isOpenAiCompatConfigured() ) {
 					return $this->send_prompt_direct();
 				}
 				return new WP_Error(
@@ -337,8 +337,8 @@ class AgentLoop {
 	 * @return SimpleAiResult|WP_Error
 	 */
 	private function send_prompt_direct() {
-		$endpoint_url = rtrim( (string) get_option( 'openai_compat_endpoint_url', '' ), '/' );
-		if ( empty( $endpoint_url ) ) {
+		$endpoint_url = CredentialResolver::getOpenAiCompatEndpointUrl();
+		if ( '' === $endpoint_url ) {
 			return new WP_Error( 'ai_agent_no_endpoint', __( 'OpenAI-compatible endpoint URL is not configured.', 'ai-agent' ) );
 		}
 
@@ -520,8 +520,8 @@ class AgentLoop {
 			}
 		}
 
-		$api_key = (string) get_option( 'openai_compat_api_key', 'no-key' );
-		$timeout = (int) get_option( 'openai_compat_timeout', 600 );
+		$api_key = CredentialResolver::getOpenAiCompatApiKey();
+		$timeout = CredentialResolver::getOpenAiCompatTimeout();
 
 		$request_body = [
 			'model'       => $model_id,
@@ -735,9 +735,9 @@ class AgentLoop {
 		}
 
 		// Source 2: AI Experiments plugin credentials option.
-		$credentials = get_option( 'wp_ai_client_provider_credentials', [] );
+		$credentials = CredentialResolver::getAiExperimentsCredentials();
 
-		if ( is_array( $credentials ) && ! empty( $credentials ) ) {
+		if ( ! empty( $credentials ) ) {
 			foreach ( $credentials as $provider_id => $api_key ) {
 				if ( ! is_string( $api_key ) || '' === $api_key ) {
 					continue;
@@ -758,11 +758,7 @@ class AgentLoop {
 		$compat_provider = 'ai-provider-for-any-openai-compatible';
 
 		if ( $registry->hasProvider( $compat_provider ) && null === $registry->getProviderRequestAuthentication( $compat_provider ) ) {
-			$api_key = get_option( 'openai_compat_api_key', '' );
-
-			if ( empty( $api_key ) ) {
-				$api_key = 'no-key';
-			}
+			$api_key = CredentialResolver::getOpenAiCompatApiKey();
 
 			$registry->setProviderRequestAuthentication(
 				$compat_provider,

--- a/includes/Core/CredentialResolver.php
+++ b/includes/Core/CredentialResolver.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Credential resolution for AI provider API keys and connection settings.
+ *
+ * Centralises all reads and writes of credential-related WordPress options so
+ * that the rest of the plugin never calls get_option() / update_option()
+ * directly for secrets.  Handles:
+ *
+ *  - OpenAI-compatible connector (endpoint URL, API key, timeout)
+ *  - AI Experiments plugin provider credentials array
+ *  - Claude Max OAuth token
+ *  - WordPress 7.0 Connectors API (read-only, delegated to WP functions)
+ *
+ * @package AiAgent\Core
+ */
+
+namespace AiAgent\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class CredentialResolver {
+
+	// ── Option names ──────────────────────────────────────────────────────────
+
+	/**
+	 * WordPress option that stores the OpenAI-compatible endpoint URL.
+	 */
+	const OPENAI_COMPAT_ENDPOINT_OPTION = 'openai_compat_endpoint_url';
+
+	/**
+	 * WordPress option that stores the OpenAI-compatible API key.
+	 */
+	const OPENAI_COMPAT_API_KEY_OPTION = 'openai_compat_api_key';
+
+	/**
+	 * WordPress option that stores the OpenAI-compatible request timeout (seconds).
+	 */
+	const OPENAI_COMPAT_TIMEOUT_OPTION = 'openai_compat_timeout';
+
+	/**
+	 * WordPress option that stores the AI Experiments plugin provider credentials.
+	 * Shape: array<string, string>  (provider_id => api_key)
+	 */
+	const AI_EXPERIMENTS_CREDENTIALS_OPTION = 'wp_ai_client_provider_credentials';
+
+	/**
+	 * WordPress option that stores the Claude Max OAuth access token.
+	 */
+	const CLAUDE_MAX_TOKEN_OPTION = 'ai_agent_claude_max_token';
+
+	/**
+	 * Sentinel value used when no real API key is available but a non-empty
+	 * string is required by the HTTP client.
+	 */
+	const NO_KEY_SENTINEL = 'no-key';
+
+	// ── OpenAI-compatible connector ───────────────────────────────────────────
+
+	/**
+	 * Return the configured OpenAI-compatible endpoint URL, trailing slash stripped.
+	 *
+	 * @return string Empty string when not configured.
+	 */
+	public static function getOpenAiCompatEndpointUrl(): string {
+		return rtrim( (string) get_option( self::OPENAI_COMPAT_ENDPOINT_OPTION, '' ), '/' );
+	}
+
+	/**
+	 * Return the OpenAI-compatible API key.
+	 *
+	 * Falls back to {@see NO_KEY_SENTINEL} when the option is empty so that
+	 * callers can always pass a non-empty Authorization header.
+	 *
+	 * @param bool $allow_sentinel When true (default) returns the sentinel
+	 *                             instead of an empty string.  Pass false to
+	 *                             get the raw stored value (empty string when
+	 *                             not configured).
+	 * @return string
+	 */
+	public static function getOpenAiCompatApiKey( bool $allow_sentinel = true ): string {
+		$key = (string) get_option( self::OPENAI_COMPAT_API_KEY_OPTION, '' );
+
+		if ( '' === $key && $allow_sentinel ) {
+			return self::NO_KEY_SENTINEL;
+		}
+
+		return $key;
+	}
+
+	/**
+	 * Return the OpenAI-compatible request timeout in seconds.
+	 *
+	 * @return int Default 600 seconds.
+	 */
+	public static function getOpenAiCompatTimeout(): int {
+		return (int) get_option( self::OPENAI_COMPAT_TIMEOUT_OPTION, 600 );
+	}
+
+	// ── AI Experiments plugin credentials ─────────────────────────────────────
+
+	/**
+	 * Return the full provider-credentials array stored by the AI Experiments plugin.
+	 *
+	 * @return array<string, string>  Keys are provider IDs, values are API keys.
+	 */
+	public static function getAiExperimentsCredentials(): array {
+		$raw = get_option( self::AI_EXPERIMENTS_CREDENTIALS_OPTION, [] );
+		return is_array( $raw ) ? $raw : [];
+	}
+
+	/**
+	 * Return the API key for a specific provider from the AI Experiments store.
+	 *
+	 * @param string $provider_id The provider ID (e.g. 'openai', 'anthropic', 'google').
+	 * @return string Empty string when not configured.
+	 */
+	public static function getAiExperimentsApiKey( string $provider_id ): string {
+		$credentials = self::getAiExperimentsCredentials();
+		$key         = $credentials[ $provider_id ] ?? '';
+		return is_string( $key ) ? $key : '';
+	}
+
+	/**
+	 * Persist an API key for a specific provider in the AI Experiments store.
+	 *
+	 * Pass an empty string to remove the entry for that provider.
+	 *
+	 * @param string $provider_id The provider ID.
+	 * @param string $api_key     The API key value.
+	 * @return bool True on success.
+	 */
+	public static function setAiExperimentsApiKey( string $provider_id, string $api_key ): bool {
+		$credentials = self::getAiExperimentsCredentials();
+
+		if ( '' === $api_key ) {
+			unset( $credentials[ $provider_id ] );
+		} else {
+			$credentials[ $provider_id ] = $api_key;
+		}
+
+		return (bool) update_option( self::AI_EXPERIMENTS_CREDENTIALS_OPTION, $credentials );
+	}
+
+	// ── Claude Max OAuth token ────────────────────────────────────────────────
+
+	/**
+	 * Return the stored Claude Max OAuth access token.
+	 *
+	 * @return string Empty string when not configured.
+	 */
+	public static function getClaudeMaxToken(): string {
+		return (string) get_option( self::CLAUDE_MAX_TOKEN_OPTION, '' );
+	}
+
+	/**
+	 * Persist the Claude Max OAuth access token.
+	 *
+	 * Pass an empty string to clear the credential.
+	 *
+	 * @param string $token The OAuth access token (sk-ant-oat01-… or similar).
+	 * @return bool True on success.
+	 */
+	public static function setClaudeMaxToken( string $token ): bool {
+		if ( '' === $token ) {
+			return (bool) delete_option( self::CLAUDE_MAX_TOKEN_OPTION );
+		}
+		return (bool) update_option( self::CLAUDE_MAX_TOKEN_OPTION, $token );
+	}
+
+	// ── Validation helpers ────────────────────────────────────────────────────
+
+	/**
+	 * Return true when the OpenAI-compatible connector is fully configured
+	 * (endpoint URL is non-empty).
+	 *
+	 * @return bool
+	 */
+	public static function isOpenAiCompatConfigured(): bool {
+		return '' !== self::getOpenAiCompatEndpointUrl();
+	}
+
+	/**
+	 * Return true when a Claude Max token is stored.
+	 *
+	 * @return bool
+	 */
+	public static function hasClaudeMaxToken(): bool {
+		return '' !== self::getClaudeMaxToken();
+	}
+
+	/**
+	 * Return true when the given API key is a real key (not empty and not the
+	 * sentinel placeholder).
+	 *
+	 * @param string $api_key The key to test.
+	 * @return bool
+	 */
+	public static function isValidApiKey( string $api_key ): bool {
+		return '' !== $api_key && self::NO_KEY_SENTINEL !== $api_key;
+	}
+}

--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace AiAgent\Core;
 
+use AiAgent\Core\CredentialResolver;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -67,29 +69,26 @@ class Settings {
 	/**
 	 * Get the stored Claude Max OAuth access token.
 	 *
-	 * The token is stored in its own option rather than the general settings
-	 * blob so that it can be excluded from REST API exposure and treated as a
-	 * credential (not a preference).
+	 * Delegates to {@see CredentialResolver::getClaudeMaxToken()} so that all
+	 * credential reads are centralised in one place.
 	 *
 	 * @return string Empty string when not configured.
 	 */
 	public static function get_claude_max_token(): string {
-		return (string) get_option( self::CLAUDE_MAX_TOKEN_OPTION, '' );
+		return CredentialResolver::getClaudeMaxToken();
 	}
 
 	/**
 	 * Persist the Claude Max OAuth access token.
 	 *
+	 * Delegates to {@see CredentialResolver::setClaudeMaxToken()}.
 	 * Pass an empty string to clear the credential.
 	 *
 	 * @param string $token The OAuth access token (sk-ant-oat01-… or similar).
 	 * @return bool True on success.
 	 */
 	public static function set_claude_max_token( string $token ): bool {
-		if ( '' === $token ) {
-			return delete_option( self::CLAUDE_MAX_TOKEN_OPTION );
-		}
-		return update_option( self::CLAUDE_MAX_TOKEN_OPTION, $token );
+		return CredentialResolver::setClaudeMaxToken( $token );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Adds `AiAgent\Core\CredentialResolver` — a single class that owns all reads/writes of credential-related WordPress options (`openai_compat_api_key`, `openai_compat_endpoint_url`, `openai_compat_timeout`, `wp_ai_client_provider_credentials`, `ai_agent_claude_max_token`)
- Updates `AgentLoop.php` to replace 5 direct `get_option()` credential call sites with `CredentialResolver` static methods
- Updates `Settings.php` to delegate `get_claude_max_token()` / `set_claude_max_token()` to `CredentialResolver`, keeping the public API intact for backward compatibility

## Verification

- PHPStan level 5: **0 errors** (on changed files and full `includes/`)
- PHPCS (WordPress coding standards): **0 violations** (on changed files and full `includes/`)
- Pre-existing PHPStan ignored-pattern warning on `main` is unchanged (baseline issue in `phpstan.neon`, not introduced here)

## Credential sources covered

| Option key | Provider | Method |
|---|---|---|
| `openai_compat_endpoint_url` | OpenAI-compat connector | `getOpenAiCompatEndpointUrl()` |
| `openai_compat_api_key` | OpenAI-compat connector | `getOpenAiCompatApiKey()` |
| `openai_compat_timeout` | OpenAI-compat connector | `getOpenAiCompatTimeout()` |
| `wp_ai_client_provider_credentials` | AI Experiments plugin (all providers) | `getAiExperimentsCredentials()`, `getAiExperimentsApiKey()`, `setAiExperimentsApiKey()` |
| `ai_agent_claude_max_token` | Claude Max OAuth | `getClaudeMaxToken()`, `setClaudeMaxToken()` |

WordPress Connectors API (`_wp_connectors_get_provider_settings`) is already abstracted via WP core functions and is not duplicated here.

Closes #140