### PR TITLE
t049: Add constructor injection for Settings and Database dependencies

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -76,20 +76,25 @@ class AgentLoop {
 	/** @var WP_AI_Client_Ability_Function_Resolver|null */
 	private $ability_resolver = null;
 
+	/** @var Settings Injected settings dependency. */
+	private $settings_service;
+
 	/**
-	 * @param string    $user_message The user's prompt.
-	 * @param string[]  $abilities    Ability names to enable (empty = all).
-	 * @param Message[] $history     Prior messages for multi-turn.
-	 * @param array     $options      Optional overrides: system_instruction, max_iterations, provider_id, model_id, temperature, max_output_tokens, page_context.
+	 * @param string        $user_message      The user's prompt.
+	 * @param string[]      $abilities         Ability names to enable (empty = all).
+	 * @param Message[]     $history           Prior messages for multi-turn.
+	 * @param array         $options           Optional overrides: system_instruction, max_iterations, provider_id, model_id, temperature, max_output_tokens, page_context.
+	 * @param Settings|null $settings_service Injected Settings service (uses static Settings::get() when null).
 	 */
-	public function __construct( string $user_message, array $abilities = [], array $history = [], array $options = [] ) {
-		$this->user_message = $user_message;
-		$this->abilities    = $abilities;
-		$this->history      = $history;
-		$this->page_context = $options['page_context'] ?? [];
+	public function __construct( string $user_message, array $abilities = [], array $history = [], array $options = [], ?Settings $settings_service = null ) {
+		$this->user_message     = $user_message;
+		$this->abilities        = $abilities;
+		$this->history          = $history;
+		$this->page_context     = $options['page_context'] ?? [];
+		$this->settings_service = $settings_service ?? new Settings();
 
 		// Merge explicit options with saved settings as fallbacks.
-		$settings = Settings::get();
+		$settings = $this->settings_service->get();
 
 		$this->provider_id       = $options['provider_id'] ?? ( $settings['default_provider'] ?: '' );
 		$this->model_id          = $options['model_id'] ?? ( $settings['default_model'] ?: '' );
@@ -180,7 +185,7 @@ class AgentLoop {
 			++$this->iterations_used;
 
 			// Smart conversation trimming before each LLM call.
-			$max_turns = (int) Settings::get( 'max_history_turns' );
+			$max_turns = (int) $this->settings_service->get( 'max_history_turns' );
 			if ( $max_turns > 0 ) {
 				$this->history = ConversationTrimmer::trim( $this->history, $max_turns );
 			}
@@ -838,7 +843,7 @@ class AgentLoop {
 				}
 			);
 		} else {
-			$disabled = Settings::get( 'disabled_abilities' );
+			$disabled = $this->settings_service->get( 'disabled_abilities' );
 			if ( ! empty( $disabled ) && is_array( $disabled ) ) {
 				$all = array_filter(
 					$all,
@@ -860,7 +865,7 @@ class AgentLoop {
 		}
 
 		// Apply tool profile filter.
-		$active_profile = Settings::get( 'active_tool_profile' );
+		$active_profile = $this->settings_service->get( 'active_tool_profile' );
 		if ( ! empty( $active_profile ) && 'all' !== $active_profile ) {
 			$all = ToolProfiles::filter_abilities( $all, $active_profile );
 		}

--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -48,17 +48,38 @@ class RestController {
 	 */
 	const JOB_TTL = 600;
 
+	/** @var Settings Injected settings dependency. */
+	private Settings $settings;
+
+	/** @var Database Injected database dependency. */
+	private Database $database;
+
+	/**
+	 * Constructor — accepts injected dependencies for testability.
+	 *
+	 * @param Settings|null $settings  Settings service (defaults to new Settings()).
+	 * @param Database|null $database  Database service (defaults to new Database()).
+	 */
+	public function __construct( ?Settings $settings = null, ?Database $database = null ) {
+		$this->settings = $settings ?? new Settings();
+		$this->database = $database ?? new Database();
+	}
+
 	/**
 	 * Register REST routes.
+	 *
+	 * Creates a controller instance and registers instance methods as callbacks,
+	 * enabling constructor injection of dependencies.
 	 */
 	public static function register_routes(): void {
+		$instance = new self();
 		register_rest_route(
 			self::NAMESPACE,
 			'/run',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ __CLASS__, 'handle_run' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_run' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'message'            => [
 						'required'          => true,
@@ -115,8 +136,8 @@ class RestController {
 			'/job/(?P<id>[a-f0-9-]+)',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_job_status' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_job_status' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'id' => [
 						'required'          => true,
@@ -132,8 +153,8 @@ class RestController {
 			'/process',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ __CLASS__, 'handle_process' ],
-				'permission_callback' => [ __CLASS__, 'check_process_permission' ],
+				'callback'            => [ $instance, 'handle_process' ],
+				'permission_callback' => [ $instance, 'check_process_permission' ],
 				'args'                => [
 					'job_id' => [
 						'required'          => true,
@@ -154,8 +175,8 @@ class RestController {
 			'/abilities',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_abilities' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_abilities' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 			]
 		);
 
@@ -165,8 +186,8 @@ class RestController {
 			'/providers',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_providers' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_providers' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 			]
 		);
 
@@ -177,13 +198,13 @@ class RestController {
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ __CLASS__, 'handle_get_settings' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_get_settings' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 				],
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ __CLASS__, 'handle_update_settings' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_update_settings' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 				],
 			]
 		);
@@ -195,8 +216,8 @@ class RestController {
 			[
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ __CLASS__, 'handle_set_claude_max_token' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_set_claude_max_token' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'token' => [
 							'required'          => true,
@@ -215,13 +236,13 @@ class RestController {
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ __CLASS__, 'handle_list_memory' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_list_memory' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 				],
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ __CLASS__, 'handle_create_memory' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_create_memory' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'category' => [
 							'required'          => true,
@@ -244,8 +265,8 @@ class RestController {
 			[
 				[
 					'methods'             => 'PATCH',
-					'callback'            => [ __CLASS__, 'handle_update_memory' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_update_memory' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id'       => [
 							'required'          => true,
@@ -266,8 +287,8 @@ class RestController {
 				],
 				[
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => [ __CLASS__, 'handle_delete_memory' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_delete_memory' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -286,13 +307,13 @@ class RestController {
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ __CLASS__, 'handle_list_skills' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_list_skills' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 				],
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ __CLASS__, 'handle_create_skill' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_create_skill' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'slug'        => [
 							'required'          => true,
@@ -326,8 +347,8 @@ class RestController {
 			[
 				[
 					'methods'             => 'PATCH',
-					'callback'            => [ __CLASS__, 'handle_update_skill' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_update_skill' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id'          => [
 							'required'          => true,
@@ -357,8 +378,8 @@ class RestController {
 				],
 				[
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => [ __CLASS__, 'handle_delete_skill' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_delete_skill' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -376,8 +397,8 @@ class RestController {
 			[
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ __CLASS__, 'handle_reset_skill' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_reset_skill' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -396,8 +417,8 @@ class RestController {
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ __CLASS__, 'handle_list_sessions' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_list_sessions' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'status' => [
 							'required'          => false,
@@ -423,8 +444,8 @@ class RestController {
 				],
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ __CLASS__, 'handle_create_session' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_create_session' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'title'       => [
 							'required'          => false,
@@ -454,8 +475,8 @@ class RestController {
 			'/sessions/folders',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_list_folders' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_list_folders' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 			]
 		);
 
@@ -464,8 +485,8 @@ class RestController {
 			'/sessions/bulk',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ __CLASS__, 'handle_bulk_sessions' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_bulk_sessions' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'ids'    => [
 						'required' => true,
@@ -490,8 +511,8 @@ class RestController {
 			'/sessions/trash',
 			[
 				'methods'             => WP_REST_Server::DELETABLE,
-				'callback'            => [ __CLASS__, 'handle_empty_trash' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_empty_trash' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 			]
 		);
 
@@ -501,8 +522,8 @@ class RestController {
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ __CLASS__, 'handle_get_session' ],
-					'permission_callback' => [ __CLASS__, 'check_session_permission' ],
+					'callback'            => [ $instance, 'handle_get_session' ],
+					'permission_callback' => [ $instance, 'check_session_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -513,8 +534,8 @@ class RestController {
 				],
 				[
 					'methods'             => 'PATCH',
-					'callback'            => [ __CLASS__, 'handle_update_session' ],
-					'permission_callback' => [ __CLASS__, 'check_session_permission' ],
+					'callback'            => [ $instance, 'handle_update_session' ],
+					'permission_callback' => [ $instance, 'check_session_permission' ],
 					'args'                => [
 						'id'     => [
 							'required'          => true,
@@ -544,8 +565,8 @@ class RestController {
 				],
 				[
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => [ __CLASS__, 'handle_delete_session' ],
-					'permission_callback' => [ __CLASS__, 'check_session_permission' ],
+					'callback'            => [ $instance, 'handle_delete_session' ],
+					'permission_callback' => [ $instance, 'check_session_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -563,8 +584,8 @@ class RestController {
 			'/usage',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_get_usage' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_get_usage' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'period'     => [
 						'required'          => false,
@@ -591,8 +612,8 @@ class RestController {
 			'/sessions/(?P<id>\d+)/export',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_export_session' ],
-				'permission_callback' => [ __CLASS__, 'check_session_permission' ],
+				'callback'            => [ $instance, 'handle_export_session' ],
+				'permission_callback' => [ $instance, 'check_session_permission' ],
 				'args'                => [
 					'id'     => [
 						'required'          => true,
@@ -615,8 +636,8 @@ class RestController {
 			'/sessions/import',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ __CLASS__, 'handle_import_session' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_import_session' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 			]
 		);
 
@@ -626,8 +647,8 @@ class RestController {
 			'/memory/forget',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ __CLASS__, 'handle_forget_memory' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_forget_memory' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'topic' => [
 						'required'          => true,
@@ -645,13 +666,13 @@ class RestController {
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ __CLASS__, 'handle_list_collections' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_list_collections' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 				],
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ __CLASS__, 'handle_create_collection' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_create_collection' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'name'          => [
 							'required'          => true,
@@ -690,8 +711,8 @@ class RestController {
 			[
 				[
 					'methods'             => 'PATCH',
-					'callback'            => [ __CLASS__, 'handle_update_collection' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_update_collection' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id'            => [
 							'required'          => true,
@@ -720,8 +741,8 @@ class RestController {
 				],
 				[
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => [ __CLASS__, 'handle_delete_collection' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_delete_collection' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -738,8 +759,8 @@ class RestController {
 			'/knowledge/collections/(?P<id>\d+)/sources',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_list_sources' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_list_sources' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'id' => [
 						'required'          => true,
@@ -755,8 +776,8 @@ class RestController {
 			'/knowledge/collections/(?P<id>\d+)/index',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ __CLASS__, 'handle_index_collection' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_index_collection' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'id' => [
 						'required'          => true,
@@ -772,8 +793,8 @@ class RestController {
 			'/knowledge/upload',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ __CLASS__, 'handle_knowledge_upload' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_knowledge_upload' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 			]
 		);
 
@@ -782,8 +803,8 @@ class RestController {
 			'/knowledge/sources/(?P<id>\d+)',
 			[
 				'methods'             => WP_REST_Server::DELETABLE,
-				'callback'            => [ __CLASS__, 'handle_delete_source' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_delete_source' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'id' => [
 						'required'          => true,
@@ -799,8 +820,8 @@ class RestController {
 			'/knowledge/search',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_knowledge_search' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_knowledge_search' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'q'          => [
 						'required'          => true,
@@ -821,8 +842,8 @@ class RestController {
 			'/knowledge/stats',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_knowledge_stats' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_knowledge_stats' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 			]
 		);
 
@@ -832,8 +853,8 @@ class RestController {
 			'/job/(?P<id>[a-f0-9-]+)/confirm',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ __CLASS__, 'handle_confirm_tool' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_confirm_tool' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'id'           => [
 						'required'          => true,
@@ -854,8 +875,8 @@ class RestController {
 			'/job/(?P<id>[a-f0-9-]+)/reject',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ __CLASS__, 'handle_reject_tool' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_reject_tool' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'id' => [
 						'required'          => true,
@@ -873,13 +894,13 @@ class RestController {
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ __CLASS__, 'handle_list_custom_tools' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_list_custom_tools' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 				],
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ __CLASS__, 'handle_create_custom_tool' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_create_custom_tool' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'name'         => [
 							'required'          => true,
@@ -928,8 +949,8 @@ class RestController {
 			[
 				[
 					'methods'             => 'PATCH',
-					'callback'            => [ __CLASS__, 'handle_update_custom_tool' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_update_custom_tool' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -940,8 +961,8 @@ class RestController {
 				],
 				[
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => [ __CLASS__, 'handle_delete_custom_tool' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_delete_custom_tool' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -958,8 +979,8 @@ class RestController {
 			'/custom-tools/(?P<id>\d+)/test',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ __CLASS__, 'handle_test_custom_tool' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_test_custom_tool' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'id'    => [
 						'required'          => true,
@@ -982,13 +1003,13 @@ class RestController {
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ __CLASS__, 'handle_list_tool_profiles' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_list_tool_profiles' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 				],
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ __CLASS__, 'handle_save_tool_profile' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_save_tool_profile' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'slug'        => [
 							'required'          => true,
@@ -1021,8 +1042,8 @@ class RestController {
 			'/tool-profiles/(?P<slug>[a-z0-9-]+)',
 			[
 				'methods'             => WP_REST_Server::DELETABLE,
-				'callback'            => [ __CLASS__, 'handle_delete_tool_profile' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_delete_tool_profile' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'slug' => [
 						'required'          => true,
@@ -1040,13 +1061,13 @@ class RestController {
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ __CLASS__, 'handle_list_automations' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_list_automations' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 				],
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ __CLASS__, 'handle_create_automation' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_create_automation' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'name'     => [
 							'required'          => true,
@@ -1074,8 +1095,8 @@ class RestController {
 			[
 				[
 					'methods'             => 'PATCH',
-					'callback'            => [ __CLASS__, 'handle_update_automation' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_update_automation' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -1086,8 +1107,8 @@ class RestController {
 				],
 				[
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => [ __CLASS__, 'handle_delete_automation' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_delete_automation' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -1104,8 +1125,8 @@ class RestController {
 			'/automations/(?P<id>\d+)/run',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ __CLASS__, 'handle_run_automation' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_run_automation' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'id' => [
 						'required'          => true,
@@ -1121,8 +1142,8 @@ class RestController {
 			'/automations/(?P<id>\d+)/logs',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_automation_logs' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_automation_logs' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'id' => [
 						'required'          => true,
@@ -1138,8 +1159,8 @@ class RestController {
 			'/automation-templates',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_automation_templates' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_automation_templates' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 			]
 		);
 
@@ -1150,13 +1171,13 @@ class RestController {
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ __CLASS__, 'handle_list_event_automations' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_list_event_automations' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 				],
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ __CLASS__, 'handle_create_event_automation' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_create_event_automation' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'name'            => [
 							'required'          => true,
@@ -1183,8 +1204,8 @@ class RestController {
 			[
 				[
 					'methods'             => 'PATCH',
-					'callback'            => [ __CLASS__, 'handle_update_event_automation' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_update_event_automation' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -1195,8 +1216,8 @@ class RestController {
 				],
 				[
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => [ __CLASS__, 'handle_delete_event_automation' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_delete_event_automation' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -1213,8 +1234,8 @@ class RestController {
 			'/event-triggers',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_list_event_triggers' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_list_event_triggers' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 			]
 		);
 
@@ -1223,8 +1244,8 @@ class RestController {
 			'/automation-logs',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_list_all_logs' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_list_all_logs' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 			]
 		);
 	}
@@ -1232,7 +1253,7 @@ class RestController {
 	/**
 	 * Permission check — admin only.
 	 */
-	public static function check_permission(): bool {
+	public function check_permission(): bool {
 		return current_user_can( 'manage_options' );
 	}
 
@@ -1241,13 +1262,13 @@ class RestController {
 	 *
 	 * Verifies manage_options + session ownership.
 	 */
-	public static function check_session_permission( WP_REST_Request $request ): bool {
+	public function check_session_permission( WP_REST_Request $request ): bool {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return false;
 		}
 
 		$session_id = absint( $request->get_param( 'id' ) );
-		$session    = Database::get_session( $session_id );
+		$session    = $this->database->get_session( $session_id );
 
 		if ( ! $session ) {
 			return false;
@@ -1262,7 +1283,7 @@ class RestController {
 	 * Validates a one-time token stored in the job transient instead of
 	 * requiring cookie-based auth (the loopback request has no session).
 	 */
-	public static function check_process_permission( WP_REST_Request $request ): bool {
+	public function check_process_permission( WP_REST_Request $request ): bool {
 		$job_id = $request->get_param( 'job_id' );
 		$token  = $request->get_param( 'token' );
 
@@ -1287,7 +1308,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_run( WP_REST_Request $request ) {
+	public function handle_run( WP_REST_Request $request ) {
 		$job_id = wp_generate_uuid4();
 		$token  = wp_generate_password( 40, false );
 
@@ -1344,7 +1365,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_job_status( WP_REST_Request $request ) {
+	public function handle_job_status( WP_REST_Request $request ) {
 		$job_id = $request->get_param( 'id' );
 		$job    = get_transient( self::JOB_PREFIX . $job_id );
 
@@ -1404,7 +1425,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_confirm_tool( WP_REST_Request $request ) {
+	public function handle_confirm_tool( WP_REST_Request $request ) {
 		$job_id = $request->get_param( 'id' );
 		$job    = get_transient( self::JOB_PREFIX . $job_id );
 
@@ -1422,15 +1443,15 @@ class RestController {
 
 		// "Always allow" — update tool_permissions to auto.
 		if ( $request->get_param( 'always_allow' ) && ! empty( $job['pending_tools'] ) ) {
-			$settings = Settings::get();
+			$settings = $this->settings->get();
 			$perms    = $settings['tool_permissions'] ?? [];
 			foreach ( $job['pending_tools'] as $tool ) {
 				$perms[ $tool['name'] ] = 'auto';
 			}
-			Settings::update( [ 'tool_permissions' => $perms ] );
+			$this->settings->update( [ 'tool_permissions' => $perms ] );
 		}
 
-		return self::resume_job( $job_id, $job, 'confirm' );
+		return $this->resume_job( $job_id, $job, 'confirm' );
 	}
 
 	/**
@@ -1439,7 +1460,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_reject_tool( WP_REST_Request $request ) {
+	public function handle_reject_tool( WP_REST_Request $request ) {
 		$job_id = $request->get_param( 'id' );
 		$job    = get_transient( self::JOB_PREFIX . $job_id );
 
@@ -1455,7 +1476,7 @@ class RestController {
 			return new WP_Error( 'ai_agent_forbidden', __( 'Not authorized.', 'ai-agent' ), [ 'status' => 403 ] );
 		}
 
-		return self::resume_job( $job_id, $job, 'reject' );
+		return $this->resume_job( $job_id, $job, 'reject' );
 	}
 
 	/**
@@ -1511,7 +1532,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response
 	 */
-	public static function handle_process( WP_REST_Request $request ): WP_REST_Response {
+	public function handle_process( WP_REST_Request $request ): WP_REST_Response {
 		ignore_user_abort( true );
 		// phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- Agent loops need extended execution time.
 		set_time_limit( 600 );
@@ -1535,7 +1556,7 @@ class RestController {
 		// Load history from session if session_id is provided.
 		$history = [];
 		if ( $session_id ) {
-			$session = Database::get_session( $session_id );
+			$session = $this->database->get_session( $session_id );
 			if ( $session ) {
 				$session_messages = json_decode( $session->messages, true ) ?: [];
 				if ( ! empty( $session_messages ) ) {
@@ -1638,7 +1659,7 @@ class RestController {
 
 				// The full history from the loop includes existing + new messages.
 				// Slice off only the new ones to append.
-				$session        = Database::get_session( $session_id );
+				$session        = $this->database->get_session( $session_id );
 				$existing_count = 0;
 				if ( $session ) {
 					$existing_messages = json_decode( $session->messages, true ) ?: [];
@@ -1648,12 +1669,12 @@ class RestController {
 				$full_history = $result['history'] ?? [];
 				$appended     = array_slice( $full_history, $existing_count );
 
-				Database::append_to_session( $session_id, $appended, $result['tool_calls'] ?? [] );
+				$this->database->append_to_session( $session_id, $appended, $result['tool_calls'] ?? [] );
 
 				// Persist token usage.
 				$token_usage = $result['token_usage'] ?? [];
 				if ( ! empty( $token_usage ) ) {
-					Database::update_session_tokens(
+					$this->database->update_session_tokens(
 						$session_id,
 						$token_usage['prompt'] ?? 0,
 						$token_usage['completion'] ?? 0
@@ -1668,7 +1689,7 @@ class RestController {
 
 				if ( $prompt_t > 0 || $completion_t > 0 ) {
 					$cost = CostCalculator::calculate_cost( $model_id, $prompt_t, $completion_t );
-					Database::log_usage(
+					$this->database->log_usage(
 						[
 							'user_id'           => $job['user_id'] ?? 0,
 							'session_id'        => $session_id,
@@ -1687,7 +1708,7 @@ class RestController {
 					if ( mb_strlen( $params['message'] ) > 60 ) {
 						$title .= '...';
 					}
-					Database::update_session( $session_id, [ 'title' => $title ] );
+					$this->database->update_session( $session_id, [ 'title' => $title ] );
 				}
 			}
 		}
@@ -1704,7 +1725,7 @@ class RestController {
 	 *
 	 * @return WP_REST_Response
 	 */
-	public static function handle_abilities(): WP_REST_Response {
+	public function handle_abilities(): WP_REST_Response {
 		if ( ! function_exists( 'wp_get_abilities' ) ) {
 			return new WP_REST_Response( [], 200 );
 		}
@@ -1736,7 +1757,7 @@ class RestController {
 	 *
 	 * @return WP_REST_Response
 	 */
-	public static function handle_providers(): WP_REST_Response {
+	public function handle_providers(): WP_REST_Response {
 		if ( ! class_exists( '\\WordPress\\AiClient\\AiClient' ) ) {
 			return new WP_REST_Response( [], 200 );
 		}
@@ -1817,7 +1838,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response
 	 */
-	public static function handle_list_sessions( WP_REST_Request $request ): WP_REST_Response {
+	public function handle_list_sessions( WP_REST_Request $request ): WP_REST_Response {
 		$filters = [];
 
 		if ( $request->has_param( 'status' ) ) {
@@ -1833,7 +1854,7 @@ class RestController {
 			$filters['pinned'] = $request->get_param( 'pinned' );
 		}
 
-		$sessions = Database::list_sessions( get_current_user_id(), $filters );
+		$sessions = $this->database->list_sessions( get_current_user_id(), $filters );
 
 		return new WP_REST_Response( $sessions, 200 );
 	}
@@ -1843,8 +1864,8 @@ class RestController {
 	 *
 	 * @return WP_REST_Response
 	 */
-	public static function handle_list_folders(): WP_REST_Response {
-		$folders = Database::list_folders( get_current_user_id() );
+	public function handle_list_folders(): WP_REST_Response {
+		$folders = $this->database->list_folders( get_current_user_id() );
 
 		return new WP_REST_Response( $folders, 200 );
 	}
@@ -1855,7 +1876,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_bulk_sessions( WP_REST_Request $request ) {
+	public function handle_bulk_sessions( WP_REST_Request $request ) {
 		$ids    = array_map( 'absint', $request->get_param( 'ids' ) );
 		$action = $request->get_param( 'action' );
 
@@ -1883,7 +1904,7 @@ class RestController {
 				return new WP_Error( 'ai_agent_invalid_action', __( 'Invalid bulk action.', 'ai-agent' ), [ 'status' => 400 ] );
 		}
 
-		$count = Database::bulk_update_sessions( $ids, get_current_user_id(), $data );
+		$count = $this->database->bulk_update_sessions( $ids, get_current_user_id(), $data );
 
 		return new WP_REST_Response( [ 'updated' => $count ], 200 );
 	}
@@ -1893,8 +1914,8 @@ class RestController {
 	 *
 	 * @return WP_REST_Response
 	 */
-	public static function handle_empty_trash(): WP_REST_Response {
-		$count = Database::empty_trash( get_current_user_id() );
+	public function handle_empty_trash(): WP_REST_Response {
+		$count = $this->database->empty_trash( get_current_user_id() );
 
 		return new WP_REST_Response( [ 'deleted' => $count ], 200 );
 	}
@@ -1905,9 +1926,9 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_get_session( WP_REST_Request $request ) {
+	public function handle_get_session( WP_REST_Request $request ) {
 		$session_id = absint( $request->get_param( 'id' ) );
-		$session    = Database::get_session( $session_id );
+		$session    = $this->database->get_session( $session_id );
 
 		if ( ! $session ) {
 			return new WP_Error(
@@ -1942,8 +1963,8 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_create_session( WP_REST_Request $request ) {
-		$session_id = Database::create_session(
+	public function handle_create_session( WP_REST_Request $request ) {
+		$session_id = $this->database->create_session(
 			[
 				'user_id'     => get_current_user_id(),
 				'title'       => $request->get_param( 'title' ),
@@ -1960,7 +1981,7 @@ class RestController {
 			);
 		}
 
-		$session = Database::get_session( $session_id );
+		$session = $this->database->get_session( $session_id );
 
 		return new WP_REST_Response(
 			[
@@ -1983,7 +2004,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_update_session( WP_REST_Request $request ) {
+	public function handle_update_session( WP_REST_Request $request ) {
 		$session_id = absint( $request->get_param( 'id' ) );
 
 		$data = [];
@@ -2007,7 +2028,7 @@ class RestController {
 			return new WP_Error( 'ai_agent_no_data', __( 'No fields to update.', 'ai-agent' ), [ 'status' => 400 ] );
 		}
 
-		$updated = Database::update_session( $session_id, $data );
+		$updated = $this->database->update_session( $session_id, $data );
 
 		if ( ! $updated ) {
 			return new WP_Error(
@@ -2017,7 +2038,7 @@ class RestController {
 			);
 		}
 
-		$session = Database::get_session( $session_id );
+		$session = $this->database->get_session( $session_id );
 
 		return new WP_REST_Response(
 			[
@@ -2041,10 +2062,10 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_delete_session( WP_REST_Request $request ) {
+	public function handle_delete_session( WP_REST_Request $request ) {
 		$session_id = absint( $request->get_param( 'id' ) );
 
-		$deleted = Database::delete_session( $session_id );
+		$deleted = $this->database->delete_session( $session_id );
 
 		if ( ! $deleted ) {
 			return new WP_Error(
@@ -2064,7 +2085,7 @@ class RestController {
 	 *
 	 * @return WP_REST_Response
 	 */
-	public static function handle_list_skills(): WP_REST_Response {
+	public function handle_list_skills(): WP_REST_Response {
 		$skills = Skill::get_all();
 
 		$list = array_map(
@@ -2094,7 +2115,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_create_skill( WP_REST_Request $request ) {
+	public function handle_create_skill( WP_REST_Request $request ) {
 		$slug = $request->get_param( 'slug' );
 
 		// Check for duplicate slug.
@@ -2151,7 +2172,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_update_skill( WP_REST_Request $request ) {
+	public function handle_update_skill( WP_REST_Request $request ) {
 		$id   = absint( $request->get_param( 'id' ) );
 		$data = [];
 
@@ -2203,7 +2224,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_delete_skill( WP_REST_Request $request ) {
+	public function handle_delete_skill( WP_REST_Request $request ) {
 		$id     = absint( $request->get_param( 'id' ) );
 		$result = Skill::delete( $id );
 
@@ -2232,7 +2253,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_reset_skill( WP_REST_Request $request ) {
+	public function handle_reset_skill( WP_REST_Request $request ) {
 		$id    = absint( $request->get_param( 'id' ) );
 		$reset = Skill::reset_builtin( $id );
 
@@ -2268,8 +2289,8 @@ class RestController {
 	/**
 	 * Handle GET /settings.
 	 */
-	public static function handle_get_settings(): WP_REST_Response {
-		$settings = Settings::get();
+	public function handle_get_settings(): WP_REST_Response {
+		$settings = $this->settings->get();
 
 		// Include built-in defaults so the UI can show them as placeholders.
 		$settings['_defaults'] = [
@@ -2288,16 +2309,16 @@ class RestController {
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 */
-	public static function handle_update_settings( WP_REST_Request $request ): WP_REST_Response {
+	public function handle_update_settings( WP_REST_Request $request ): WP_REST_Response {
 		$data = $request->get_json_params();
 
 		if ( empty( $data ) || ! is_array( $data ) ) {
 			return new WP_REST_Response( [ 'error' => 'No data provided.' ], 400 );
 		}
 
-		Settings::update( $data );
+		$this->settings->update( $data );
 
-		return new WP_REST_Response( Settings::get(), 200 );
+		return new WP_REST_Response( $this->settings->get(), 200 );
 	}
 
 	/**
@@ -2308,7 +2329,7 @@ class RestController {
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 */
-	public static function handle_set_claude_max_token( WP_REST_Request $request ): WP_REST_Response {
+	public function handle_set_claude_max_token( WP_REST_Request $request ): WP_REST_Response {
 		$token = $request->get_param( 'token' );
 
 		// Allow clearing the token by passing an empty string.
@@ -2337,7 +2358,7 @@ class RestController {
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 */
-	public static function handle_list_memory( WP_REST_Request $request ): WP_REST_Response {
+	public function handle_list_memory( WP_REST_Request $request ): WP_REST_Response {
 		$category = $request->get_param( 'category' );
 		$memories = Memory::get_all( $category ?: null );
 
@@ -2362,7 +2383,7 @@ class RestController {
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 */
-	public static function handle_create_memory( WP_REST_Request $request ) {
+	public function handle_create_memory( WP_REST_Request $request ) {
 		$category = $request->get_param( 'category' );
 		$content  = $request->get_param( 'content' );
 
@@ -2387,7 +2408,7 @@ class RestController {
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 */
-	public static function handle_update_memory( WP_REST_Request $request ) {
+	public function handle_update_memory( WP_REST_Request $request ) {
 		$id   = absint( $request->get_param( 'id' ) );
 		$data = [];
 
@@ -2418,7 +2439,7 @@ class RestController {
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 */
-	public static function handle_delete_memory( WP_REST_Request $request ) {
+	public function handle_delete_memory( WP_REST_Request $request ) {
 		$id      = absint( $request->get_param( 'id' ) );
 		$deleted = Memory::delete( $id );
 
@@ -2437,7 +2458,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response
 	 */
-	public static function handle_get_usage( WP_REST_Request $request ): WP_REST_Response {
+	public function handle_get_usage( WP_REST_Request $request ): WP_REST_Response {
 		$filters = [
 			'user_id' => get_current_user_id(),
 		];
@@ -2452,7 +2473,7 @@ class RestController {
 			$filters['end_date'] = $request->get_param( 'end_date' );
 		}
 
-		$summary = Database::get_usage_summary( $filters );
+		$summary = $this->database->get_usage_summary( $filters );
 
 		return new WP_REST_Response( $summary, 200 );
 	}
@@ -2464,7 +2485,7 @@ class RestController {
 	 *
 	 * @return WP_REST_Response
 	 */
-	public static function handle_list_collections(): WP_REST_Response {
+	public function handle_list_collections(): WP_REST_Response {
 		$collections = KnowledgeDatabase::list_collections();
 
 		$list = array_map(
@@ -2495,7 +2516,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_create_collection( WP_REST_Request $request ) {
+	public function handle_create_collection( WP_REST_Request $request ) {
 		$slug = $request->get_param( 'slug' );
 
 		// Check for duplicate slug.
@@ -2552,7 +2573,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_update_collection( WP_REST_Request $request ) {
+	public function handle_update_collection( WP_REST_Request $request ) {
 		$id   = absint( $request->get_param( 'id' ) );
 		$data = [];
 
@@ -2605,7 +2626,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_delete_collection( WP_REST_Request $request ) {
+	public function handle_delete_collection( WP_REST_Request $request ) {
 		$id      = absint( $request->get_param( 'id' ) );
 		$deleted = KnowledgeDatabase::delete_collection( $id );
 
@@ -2626,7 +2647,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response
 	 */
-	public static function handle_list_sources( WP_REST_Request $request ): WP_REST_Response {
+	public function handle_list_sources( WP_REST_Request $request ): WP_REST_Response {
 		$id      = absint( $request->get_param( 'id' ) );
 		$sources = KnowledgeDatabase::get_sources_for_collection( $id );
 
@@ -2658,7 +2679,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_index_collection( WP_REST_Request $request ) {
+	public function handle_index_collection( WP_REST_Request $request ) {
 		$id     = absint( $request->get_param( 'id' ) );
 		$result = Knowledge::reindex_collection( $id );
 
@@ -2675,7 +2696,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_knowledge_upload( WP_REST_Request $request ) {
+	public function handle_knowledge_upload( WP_REST_Request $request ) {
 		$files = $request->get_file_params();
 
 		if ( empty( $files['file'] ) ) {
@@ -2733,7 +2754,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_delete_source( WP_REST_Request $request ) {
+	public function handle_delete_source( WP_REST_Request $request ) {
 		$id      = absint( $request->get_param( 'id' ) );
 		$deleted = Knowledge::delete_source( $id );
 
@@ -2754,7 +2775,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response
 	 */
-	public static function handle_knowledge_search( WP_REST_Request $request ): WP_REST_Response {
+	public function handle_knowledge_search( WP_REST_Request $request ): WP_REST_Response {
 		$query      = $request->get_param( 'q' );
 		$collection = $request->get_param( 'collection' );
 
@@ -2773,7 +2794,7 @@ class RestController {
 	 *
 	 * @return WP_REST_Response
 	 */
-	public static function handle_knowledge_stats(): WP_REST_Response {
+	public function handle_knowledge_stats(): WP_REST_Response {
 		$collections  = KnowledgeDatabase::list_collections();
 		$total_chunks = KnowledgeDatabase::get_total_chunk_count();
 
@@ -2804,7 +2825,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response
 	 */
-	public static function handle_forget_memory( WP_REST_Request $request ): WP_REST_Response {
+	public function handle_forget_memory( WP_REST_Request $request ): WP_REST_Response {
 		$topic   = $request->get_param( 'topic' );
 		$deleted = Memory::forget_by_topic( $topic );
 
@@ -2825,10 +2846,10 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_export_session( WP_REST_Request $request ) {
+	public function handle_export_session( WP_REST_Request $request ) {
 		$session_id = absint( $request->get_param( 'id' ) );
 		$format     = $request->get_param( 'format' ) ?: 'json';
-		$session    = Database::get_session( $session_id );
+		$session    = $this->database->get_session( $session_id );
 
 		if ( ! $session ) {
 			return new WP_Error( 'ai_agent_session_not_found', __( 'Session not found.', 'ai-agent' ), [ 'status' => 404 ] );
@@ -2845,7 +2866,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_import_session( WP_REST_Request $request ) {
+	public function handle_import_session( WP_REST_Request $request ) {
 		$data = $request->get_json_params();
 
 		if ( empty( $data ) ) {
@@ -2858,7 +2879,7 @@ class RestController {
 			return $session_id;
 		}
 
-		$session = Database::get_session( $session_id );
+		$session = $this->database->get_session( $session_id );
 
 		return new WP_REST_Response(
 			[
@@ -2878,14 +2899,14 @@ class RestController {
 	/**
 	 * List custom tools.
 	 */
-	public static function handle_list_custom_tools(): WP_REST_Response {
+	public function handle_list_custom_tools(): WP_REST_Response {
 		return new WP_REST_Response( CustomTools::list(), 200 );
 	}
 
 	/**
 	 * Create a custom tool.
 	 */
-	public static function handle_create_custom_tool( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_create_custom_tool( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$data = $request->get_json_params();
 		$id   = CustomTools::create( $data );
 
@@ -2899,7 +2920,7 @@ class RestController {
 	/**
 	 * Update a custom tool.
 	 */
-	public static function handle_update_custom_tool( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_update_custom_tool( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$id   = absint( $request->get_param( 'id' ) );
 		$data = $request->get_json_params();
 
@@ -2913,7 +2934,7 @@ class RestController {
 	/**
 	 * Delete a custom tool.
 	 */
-	public static function handle_delete_custom_tool( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_delete_custom_tool( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$id = absint( $request->get_param( 'id' ) );
 
 		if ( ! CustomTools::delete( $id ) ) {
@@ -2926,7 +2947,7 @@ class RestController {
 	/**
 	 * Test-execute a custom tool with provided input.
 	 */
-	public static function handle_test_custom_tool( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_test_custom_tool( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$id    = absint( $request->get_param( 'id' ) );
 		$input = $request->get_param( 'input' ) ?: [];
 		$tool  = CustomTools::get( $id );
@@ -2945,14 +2966,14 @@ class RestController {
 	/**
 	 * List tool profiles.
 	 */
-	public static function handle_list_tool_profiles(): WP_REST_Response {
+	public function handle_list_tool_profiles(): WP_REST_Response {
 		return new WP_REST_Response( ToolProfiles::list(), 200 );
 	}
 
 	/**
 	 * Save (create or update) a tool profile.
 	 */
-	public static function handle_save_tool_profile( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_save_tool_profile( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$data = $request->get_json_params();
 
 		if ( ! ToolProfiles::save( $data ) ) {
@@ -2965,7 +2986,7 @@ class RestController {
 	/**
 	 * Delete a tool profile.
 	 */
-	public static function handle_delete_tool_profile( WP_REST_Request $request ): WP_REST_Response {
+	public function handle_delete_tool_profile( WP_REST_Request $request ): WP_REST_Response {
 		$slug = $request->get_param( 'slug' );
 		ToolProfiles::delete( $slug );
 
@@ -2977,14 +2998,14 @@ class RestController {
 	/**
 	 * List scheduled automations.
 	 */
-	public static function handle_list_automations(): WP_REST_Response {
+	public function handle_list_automations(): WP_REST_Response {
 		return new WP_REST_Response( Automations::list(), 200 );
 	}
 
 	/**
 	 * Create a scheduled automation.
 	 */
-	public static function handle_create_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_create_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$data = $request->get_json_params();
 		$id   = Automations::create( $data );
 
@@ -2998,7 +3019,7 @@ class RestController {
 	/**
 	 * Update a scheduled automation.
 	 */
-	public static function handle_update_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_update_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$id   = absint( $request->get_param( 'id' ) );
 		$data = $request->get_json_params();
 
@@ -3012,7 +3033,7 @@ class RestController {
 	/**
 	 * Delete a scheduled automation.
 	 */
-	public static function handle_delete_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_delete_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$id = absint( $request->get_param( 'id' ) );
 
 		if ( ! Automations::delete( $id ) ) {
@@ -3025,7 +3046,7 @@ class RestController {
 	/**
 	 * Manually run a scheduled automation.
 	 */
-	public static function handle_run_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_run_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$id     = absint( $request->get_param( 'id' ) );
 		$result = AutomationRunner::run( $id );
 
@@ -3039,7 +3060,7 @@ class RestController {
 	/**
 	 * Get logs for a specific automation.
 	 */
-	public static function handle_automation_logs( WP_REST_Request $request ): WP_REST_Response {
+	public function handle_automation_logs( WP_REST_Request $request ): WP_REST_Response {
 		$id   = absint( $request->get_param( 'id' ) );
 		$logs = AutomationLogs::list_for_automation( $id );
 
@@ -3049,7 +3070,7 @@ class RestController {
 	/**
 	 * Get automation templates.
 	 */
-	public static function handle_automation_templates(): WP_REST_Response {
+	public function handle_automation_templates(): WP_REST_Response {
 		return new WP_REST_Response( Automations::get_templates(), 200 );
 	}
 
@@ -3058,14 +3079,14 @@ class RestController {
 	/**
 	 * List event automations.
 	 */
-	public static function handle_list_event_automations(): WP_REST_Response {
+	public function handle_list_event_automations(): WP_REST_Response {
 		return new WP_REST_Response( EventAutomations::list(), 200 );
 	}
 
 	/**
 	 * Create an event automation.
 	 */
-	public static function handle_create_event_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_create_event_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$data = $request->get_json_params();
 		$id   = EventAutomations::create( $data );
 
@@ -3079,7 +3100,7 @@ class RestController {
 	/**
 	 * Update an event automation.
 	 */
-	public static function handle_update_event_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_update_event_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$id   = absint( $request->get_param( 'id' ) );
 		$data = $request->get_json_params();
 
@@ -3093,7 +3114,7 @@ class RestController {
 	/**
 	 * Delete an event automation.
 	 */
-	public static function handle_delete_event_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_delete_event_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$id = absint( $request->get_param( 'id' ) );
 
 		if ( ! EventAutomations::delete( $id ) ) {
@@ -3106,14 +3127,14 @@ class RestController {
 	/**
 	 * List available event triggers from the registry.
 	 */
-	public static function handle_list_event_triggers(): WP_REST_Response {
+	public function handle_list_event_triggers(): WP_REST_Response {
 		return new WP_REST_Response( EventTriggerRegistry::get_all(), 200 );
 	}
 
 	/**
 	 * List recent automation logs across all automations.
 	 */
-	public static function handle_list_all_logs(): WP_REST_Response {
+	public function handle_list_all_logs(): WP_REST_Response {
 		return new WP_REST_Response( AutomationLogs::list_recent(), 200 );
 	}
 }


### PR DESCRIPTION
## Summary

- **AgentLoop**: Accept optional `Settings` instance via 5th constructor parameter. Replaces `Settings::get()` static calls in constructor, `run_loop()`, and `resolve_abilities()` with `$this->settings_service->get()`. Existing callers unchanged — `null` default falls back to `new Settings()`.

- **RestController**: Convert all 66 `public static function` handler methods to `public function` instance methods. Add constructor accepting optional `Settings` and `Database` instances. `register_routes()` (the only remaining static method) creates a `new self()` instance and registers `[$instance, 'method']` callbacks instead of `[__CLASS__, 'method']`. `Settings::get/update` and `Database::*` calls replaced with `$this->settings->` and `$this->database->` respectively.

- `KnowledgeDatabase::` calls remain static (separate service, out of scope for this task).
- `Settings::get_claude_max_token()` / `set_claude_max_token()` remain static (credential storage, separate concern).
- `ai-agent.php` unchanged — `RestController::register_routes()` is still called as a static hook, which internally creates the instance.

## Verification

- PHPStan level 5: **no errors**
- PHPCS (WordPress Coding Standards): **no violations**
- No changes to public API — all existing callers continue to work without modification

Closes #142