### PR TITLE
fix: add assertNotContains to verify trashed session absent from active list (closes #6)

### DIFF
--- a/tests/AiAgent/Core/DatabaseTest.php
+++ b/tests/AiAgent/Core/DatabaseTest.php
@@ -230,9 +230,11 @@ class DatabaseTest extends WP_UnitTestCase {
 		$active = Database::list_sessions( $user_id, [ 'status' => 'active' ] );
 		$trashed = Database::list_sessions( $user_id, [ 'status' => 'trash' ] );
 
-		// The trashed session should appear in trash list.
-		$trashed_ids = array_column( $trashed, 'id' );
-		$this->assertContains( (int) $session_id, array_map( 'intval', $trashed_ids ) );
+		// The trashed session should appear in trash list but NOT in active list.
+		$active_ids  = array_map( 'intval', array_column( $active, 'id' ) );
+		$trashed_ids = array_map( 'intval', array_column( $trashed, 'id' ) );
+		$this->assertNotContains( (int) $session_id, $active_ids );
+		$this->assertContains( (int) $session_id, $trashed_ids );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Adds a complementary `assertNotContains` assertion to `test_trash_session` so the status filter is verified end-to-end: the trashed session must appear in `$trashed` **and** must not appear in `$active`.
- Resolves the CodeRabbit medium finding from PR #1 (unused `$active` variable / incomplete negative assertion).

## Changes

`tests/AiAgent/Core/DatabaseTest.php` only — blast-radius-capped quality-debt fix.

```diff
-		// The trashed session should appear in trash list.
-		$trashed_ids = array_column( $trashed, 'id' );
-		$this->assertContains( (int) $session_id, array_map( 'intval', $trashed_ids ) );
+		// The trashed session should appear in trash list but NOT in active list.
+		$active_ids  = array_map( 'intval', array_column( $active, 'id' ) );
+		$trashed_ids = array_map( 'intval', array_column( $trashed, 'id' ) );
+		$this->assertNotContains( (int) $session_id, $active_ids );
+		$this->assertContains( (int) $session_id, $trashed_ids );
```

## Verification

- PHPCS: 0 violations
- PHPStan level 5: pre-existing errors only (all stem from `WP_UnitTestCase` not in PHPStan stubs — unchanged root cause, not introduced by this PR)

Closes #6