### PR TITLE
t037: Add per-tool WordPress capabilities (ai_agent_tool_{name})

### DIFF
--- a/ai-agent.php
+++ b/ai-agent.php
@@ -45,6 +45,7 @@ use AiAgent\Abilities\NavigationAbilities;
 use AiAgent\Abilities\SeoAbilities;
 use AiAgent\Abilities\SkillAbilities;
 use AiAgent\Abilities\StockImageAbilities;
+use AiAgent\Abilities\ToolCapabilities;
 use AiAgent\Abilities\WordPressAbilities;
 use AiAgent\Admin\AdminPage;
 use AiAgent\Admin\FloatingWidget;
@@ -60,9 +61,23 @@ use AiAgent\Tools\ToolDiscovery;
 
 register_activation_hook( __FILE__, [ Database::class, 'install' ] );
 register_activation_hook( __FILE__, [ AutomationRunner::class, 'reschedule_all' ] );
+register_activation_hook(
+	__FILE__,
+	function () {
+		ToolCapabilities::register_capabilities( ToolCapabilities::all_ability_ids() );
+	}
+);
 register_deactivation_hook( __FILE__, [ KnowledgeHooks::class, 'deactivate' ] );
 register_deactivation_hook( __FILE__, [ AutomationRunner::class, 'unschedule_all' ] );
 add_action( 'admin_init', [ Database::class, 'install' ] );
+
+// Register per-tool capabilities on admin_init so role-management plugins can discover them.
+add_action(
+	'admin_init',
+	function () {
+		ToolCapabilities::register_capabilities( ToolCapabilities::all_ability_ids() );
+	}
+);
 
 add_action( 'rest_api_init', [ RestController::class, 'register_routes' ] );
 add_action( 'admin_menu', [ AdminPage::class, 'register' ] );

--- a/includes/Abilities/AbilityDiscoveryAbilities.php
+++ b/includes/Abilities/AbilityDiscoveryAbilities.php
@@ -104,7 +104,7 @@ class AbilityDiscoveryAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_list_abilities' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					return ToolCapabilities::current_user_can( 'ai-agent/discovery-list' );
 				},
 			]
 		);
@@ -172,7 +172,7 @@ class AbilityDiscoveryAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_get_ability' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					return ToolCapabilities::current_user_can( 'ai-agent/discovery-get' );
 				},
 			]
 		);
@@ -227,7 +227,7 @@ class AbilityDiscoveryAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_execute_ability' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					return ToolCapabilities::current_user_can( 'ai-agent/discovery-execute' );
 				},
 			]
 		);

--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -53,7 +53,7 @@ class BlockAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_markdown_to_blocks' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					return ToolCapabilities::current_user_can( 'ai-agent/markdown-to-blocks' );
 				},
 			]
 		);
@@ -88,7 +88,7 @@ class BlockAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_list_block_types' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					return ToolCapabilities::current_user_can( 'ai-agent/list-block-types' );
 				},
 			]
 		);
@@ -111,7 +111,7 @@ class BlockAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_get_block_type' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					return ToolCapabilities::current_user_can( 'ai-agent/get-block-type' );
 				},
 			]
 		);
@@ -146,7 +146,7 @@ class BlockAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_list_block_patterns' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					return ToolCapabilities::current_user_can( 'ai-agent/list-block-patterns' );
 				},
 			]
 		);
@@ -169,7 +169,7 @@ class BlockAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_list_block_templates' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					return ToolCapabilities::current_user_can( 'ai-agent/list-block-templates' );
 				},
 			]
 		);
@@ -192,7 +192,7 @@ class BlockAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_create_block_content' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					return ToolCapabilities::current_user_can( 'ai-agent/create-block-content' );
 				},
 			]
 		);
@@ -223,7 +223,7 @@ class BlockAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_parse_block_content' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					return ToolCapabilities::current_user_can( 'ai-agent/parse-block-content' );
 				},
 			]
 		);

--- a/includes/Abilities/ContentAbilities.php
+++ b/includes/Abilities/ContentAbilities.php
@@ -56,7 +56,7 @@ class ContentAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_content_analyze' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					return ToolCapabilities::current_user_can( 'ai-agent/content-analyze' );
 				},
 			]
 		);
@@ -83,7 +83,7 @@ class ContentAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_performance_report' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					return ToolCapabilities::current_user_can( 'ai-agent/content-performance-report' );
 				},
 			]
 		);

--- a/includes/Abilities/DatabaseAbilities.php
+++ b/includes/Abilities/DatabaseAbilities.php
@@ -68,7 +68,7 @@ class DatabaseAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_db_query' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					return ToolCapabilities::current_user_can( 'ai-agent/db-query' );
 				},
 			]
 		);

--- a/includes/Abilities/FileAbilities.php
+++ b/includes/Abilities/FileAbilities.php
@@ -71,7 +71,7 @@ class FileAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_read_file' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					return ToolCapabilities::current_user_can( 'ai-agent/file-read' );
 				},
 			]
 		);
@@ -112,7 +112,7 @@ class FileAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_write_file' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					return ToolCapabilities::current_user_can( 'ai-agent/file-write' );
 				},
 			]
 		);
@@ -167,7 +167,7 @@ class FileAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_edit_file' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					return ToolCapabilities::current_user_can( 'ai-agent/file-edit' );
 				},
 			]
 		);
@@ -203,7 +203,7 @@ class FileAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_delete_file' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					return ToolCapabilities::current_user_can( 'ai-agent/file-delete' );
 				},
 			]
 		);
@@ -241,7 +241,7 @@ class FileAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_list_directory' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					return ToolCapabilities::current_user_can( 'ai-agent/file-list' );
 				},
 			]
 		);
@@ -279,7 +279,7 @@ class FileAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_search_files' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					return ToolCapabilities::current_user_can( 'ai-agent/file-search' );
 				},
 			]
 		);
@@ -325,7 +325,7 @@ class FileAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_search_content' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					return ToolCapabilities::current_user_can( 'ai-agent/content-search' );
 				},
 			]
 		);

--- a/includes/Abilities/KnowledgeAbilities.php
+++ b/includes/Abilities/KnowledgeAbilities.php
@@ -54,7 +54,8 @@ class KnowledgeAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_knowledge_search' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' ); },
+					return ToolCapabilities::current_user_can( 'ai-agent/knowledge-search' );
+				},
 			]
 		);
 	}

--- a/includes/Abilities/MarketingAbilities.php
+++ b/includes/Abilities/MarketingAbilities.php
@@ -48,7 +48,7 @@ class MarketingAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_fetch_url' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					return ToolCapabilities::current_user_can( 'ai-agent/fetch-url' );
 				},
 			]
 		);
@@ -71,7 +71,7 @@ class MarketingAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_analyze_headers' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					return ToolCapabilities::current_user_can( 'ai-agent/analyze-headers' );
 				},
 			]
 		);

--- a/includes/Abilities/MemoryAbilities.php
+++ b/includes/Abilities/MemoryAbilities.php
@@ -55,7 +55,8 @@ class MemoryAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_memory_save' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' ); },
+					return ToolCapabilities::current_user_can( 'ai-agent/memory-save' );
+				},
 			]
 		);
 
@@ -71,7 +72,8 @@ class MemoryAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_memory_list' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' ); },
+					return ToolCapabilities::current_user_can( 'ai-agent/memory-list' );
+				},
 			]
 		);
 
@@ -93,7 +95,8 @@ class MemoryAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_memory_delete' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' ); },
+					return ToolCapabilities::current_user_can( 'ai-agent/memory-delete' );
+				},
 			]
 		);
 	}

--- a/includes/Abilities/NavigationAbilities.php
+++ b/includes/Abilities/NavigationAbilities.php
@@ -66,7 +66,7 @@ class NavigationAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_navigate' ],
 				'permission_callback' => function () {
-					return current_user_can( 'read' );
+					return ToolCapabilities::current_user_can( 'ai-agent/navigate' );
 				},
 			]
 		);
@@ -108,7 +108,7 @@ class NavigationAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_get_page_html' ],
 				'permission_callback' => function () {
-					return current_user_can( 'read' );
+					return ToolCapabilities::current_user_can( 'ai-agent/get-page-html' );
 				},
 			]
 		);

--- a/includes/Abilities/SeoAbilities.php
+++ b/includes/Abilities/SeoAbilities.php
@@ -52,7 +52,7 @@ class SeoAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_audit_url' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					return ToolCapabilities::current_user_can( 'ai-agent/seo-audit-url' );
 				},
 			]
 		);
@@ -83,7 +83,7 @@ class SeoAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_analyze_content' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					return ToolCapabilities::current_user_can( 'ai-agent/seo-analyze-content' );
 				},
 			]
 		);

--- a/includes/Abilities/SkillAbilities.php
+++ b/includes/Abilities/SkillAbilities.php
@@ -50,7 +50,8 @@ class SkillAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_skill_load' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' ); },
+					return ToolCapabilities::current_user_can( 'ai-agent/skill-load' );
+				},
 			]
 		);
 
@@ -66,7 +67,8 @@ class SkillAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_skill_list' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' ); },
+					return ToolCapabilities::current_user_can( 'ai-agent/skill-list' );
+				},
 			]
 		);
 	}

--- a/includes/Abilities/StockImageAbilities.php
+++ b/includes/Abilities/StockImageAbilities.php
@@ -63,7 +63,7 @@ class StockImageAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_import' ],
 				'permission_callback' => function () {
-					return current_user_can( 'upload_files' );
+					return ToolCapabilities::current_user_can( 'ai-agent/import-stock-image' );
 				},
 			]
 		);

--- a/includes/Abilities/ToolCapabilities.php
+++ b/includes/Abilities/ToolCapabilities.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Per-tool WordPress capability checks for AI Agent abilities.
+ *
+ * Provides granular capability checks so each ability can be granted
+ * independently via user roles. Capability names follow the pattern
+ * `ai_agent_tool_{name}` where `{name}` is derived from the ability ID
+ * (e.g. `ai-agent/memory-save` → `ai_agent_tool_memory_save`).
+ *
+ * Fallback: if the capability has not been granted to any role, the check
+ * falls back to `manage_options` (admin only) so the default behaviour is
+ * unchanged until an administrator explicitly delegates a capability.
+ *
+ * Filter: `ai_agent_tool_capability` allows overriding the resolved
+ * capability name per tool.
+ *
+ * @package AiAgent
+ */
+
+namespace AiAgent\Abilities;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * ToolCapabilities
+ *
+ * Static helper that resolves and checks per-tool WordPress capabilities.
+ */
+class ToolCapabilities {
+
+	/**
+	 * Fallback capability used when a tool-specific capability has not been
+	 * granted to any role.
+	 */
+	public const FALLBACK_CAP = 'manage_options';
+
+	/**
+	 * Derive the tool-specific capability name from an ability ID.
+	 *
+	 * Examples:
+	 *   ai-agent/memory-save  → ai_agent_tool_memory_save
+	 *   ai-agent/db-query     → ai_agent_tool_db_query
+	 *   ai-agent/run-php      → ai_agent_tool_run_php
+	 *
+	 * @param string $ability_id The ability ID (e.g. "ai-agent/memory-save").
+	 * @return string The derived capability name.
+	 */
+	public static function cap_name( string $ability_id ): string {
+		// Strip the "ai-agent/" namespace prefix.
+		$name = str_replace( 'ai-agent/', '', $ability_id );
+
+		// Replace hyphens and slashes with underscores.
+		$name = str_replace( [ '-', '/' ], '_', $name );
+
+		return 'ai_agent_tool_' . $name;
+	}
+
+	/**
+	 * Check whether the current user can execute a given ability.
+	 *
+	 * Resolution order:
+	 * 1. Apply the `ai_agent_tool_capability` filter to allow overrides.
+	 * 2. If the resolved capability exists in any role, use it.
+	 * 3. Otherwise fall back to `manage_options`.
+	 *
+	 * @param string $ability_id The ability ID (e.g. "ai-agent/memory-save").
+	 * @return bool True if the current user has permission.
+	 */
+	public static function current_user_can( string $ability_id ): bool {
+		$tool_cap = self::cap_name( $ability_id );
+
+		/**
+		 * Filter the capability name used to gate a specific AI Agent tool.
+		 *
+		 * @param string $tool_cap   The derived capability name (e.g. "ai_agent_tool_memory_save").
+		 * @param string $ability_id The full ability ID (e.g. "ai-agent/memory-save").
+		 */
+		$resolved_cap = (string) apply_filters( 'ai_agent_tool_capability', $tool_cap, $ability_id );
+
+		// If the capability has been granted to at least one role, use it.
+		// Otherwise fall back to manage_options so the default is admin-only.
+		if ( self::capability_exists( $resolved_cap ) ) {
+			return current_user_can( $resolved_cap );
+		}
+
+		return current_user_can( self::FALLBACK_CAP );
+	}
+
+	/**
+	 * Check whether a capability has been granted to at least one role.
+	 *
+	 * This is used to distinguish between "capability exists but user lacks it"
+	 * and "capability has never been registered/granted", so we can fall back
+	 * to manage_options in the latter case.
+	 *
+	 * @param string $cap Capability name.
+	 * @return bool True if the capability is present in at least one role.
+	 */
+	public static function capability_exists( string $cap ): bool {
+		global $wp_roles;
+
+		if ( ! isset( $wp_roles ) ) {
+			return false;
+		}
+
+		foreach ( $wp_roles->roles as $role ) {
+			if ( ! empty( $role['capabilities'][ $cap ] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Register all AI Agent tool capabilities on the Administrator role.
+	 *
+	 * Called on plugin activation and `admin_init` so that the capabilities
+	 * are available for role-management plugins (e.g. Members, User Role Editor)
+	 * to discover and assign.
+	 *
+	 * The capabilities are added to the Administrator role with `true` so that
+	 * admins retain full access. Other roles start with no access and must be
+	 * explicitly granted capabilities.
+	 *
+	 * @param string[] $ability_ids List of all ability IDs to register.
+	 */
+	public static function register_capabilities( array $ability_ids ): void {
+		$admin_role = get_role( 'administrator' );
+
+		if ( ! $admin_role instanceof \WP_Role ) {
+			return;
+		}
+
+		foreach ( $ability_ids as $ability_id ) {
+			$cap = self::cap_name( $ability_id );
+
+			/**
+			 * Allow overriding the capability name at registration time.
+			 *
+			 * @param string $cap        The derived capability name.
+			 * @param string $ability_id The full ability ID.
+			 */
+			$cap = (string) apply_filters( 'ai_agent_tool_capability', $cap, $ability_id );
+
+			if ( ! isset( $admin_role->capabilities[ $cap ] ) ) {
+				$admin_role->add_cap( $cap, true );
+			}
+		}
+	}
+
+	/**
+	 * Return the list of all AI Agent ability IDs that have tool capabilities.
+	 *
+	 * This list is used both for capability registration and for documentation.
+	 *
+	 * @return string[]
+	 */
+	public static function all_ability_ids(): array {
+		return [
+			// Memory.
+			'ai-agent/memory-save',
+			'ai-agent/memory-list',
+			'ai-agent/memory-delete',
+			// Skills.
+			'ai-agent/skill-load',
+			'ai-agent/skill-list',
+			// Knowledge.
+			'ai-agent/knowledge-search',
+			// Ability discovery.
+			'ai-agent/discovery-list',
+			'ai-agent/discovery-get',
+			'ai-agent/discovery-execute',
+			// Stock images.
+			'ai-agent/import-stock-image',
+			// SEO.
+			'ai-agent/seo-audit-url',
+			'ai-agent/seo-analyze-content',
+			// Content.
+			'ai-agent/content-analyze',
+			'ai-agent/content-performance-report',
+			// Marketing.
+			'ai-agent/fetch-url',
+			'ai-agent/analyze-headers',
+			// Blocks.
+			'ai-agent/markdown-to-blocks',
+			'ai-agent/list-block-types',
+			'ai-agent/get-block-type',
+			'ai-agent/list-block-patterns',
+			'ai-agent/list-block-templates',
+			'ai-agent/create-block-content',
+			'ai-agent/parse-block-content',
+			// Files.
+			'ai-agent/file-read',
+			'ai-agent/file-write',
+			'ai-agent/file-edit',
+			'ai-agent/file-delete',
+			'ai-agent/file-list',
+			'ai-agent/file-search',
+			'ai-agent/content-search',
+			// Database.
+			'ai-agent/db-query',
+			// WordPress management.
+			'ai-agent/get-plugins',
+			'ai-agent/get-themes',
+			'ai-agent/install-plugin',
+			'ai-agent/run-php',
+			// Navigation.
+			'ai-agent/navigate',
+			'ai-agent/get-page-html',
+		];
+	}
+}

--- a/includes/Abilities/WordPressAbilities.php
+++ b/includes/Abilities/WordPressAbilities.php
@@ -61,7 +61,7 @@ class WordPressAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_get_plugins' ],
 				'permission_callback' => function () {
-					return current_user_can( 'activate_plugins' );
+					return ToolCapabilities::current_user_can( 'ai-agent/get-plugins' );
 				},
 			]
 		);
@@ -93,7 +93,7 @@ class WordPressAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_get_themes' ],
 				'permission_callback' => function () {
-					return current_user_can( 'switch_themes' );
+					return ToolCapabilities::current_user_can( 'ai-agent/get-themes' );
 				},
 			]
 		);
@@ -135,7 +135,7 @@ class WordPressAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_install_plugin' ],
 				'permission_callback' => function () {
-					return current_user_can( 'install_plugins' );
+					return ToolCapabilities::current_user_can( 'ai-agent/install-plugin' );
 				},
 			]
 		);
@@ -171,7 +171,7 @@ class WordPressAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_run_php' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					return ToolCapabilities::current_user_can( 'ai-agent/run-php' );
 				},
 			]
 		);

--- a/includes/Tools/CustomToolExecutor.php
+++ b/includes/Tools/CustomToolExecutor.php
@@ -56,8 +56,8 @@ class CustomToolExecutor {
 					'execute_callback'    => function ( array $input ) use ( $tool ) {
 						return self::execute( $tool, $input );
 					},
-					'permission_callback' => function () {
-						return current_user_can( 'manage_options' );
+					'permission_callback' => function () use ( $ability_name ) {
+						return \AiAgent\Abilities\ToolCapabilities::current_user_can( $ability_name );
 					},
 				]
 			);

--- a/tests/AiAgent/Abilities/ToolCapabilitiesTest.php
+++ b/tests/AiAgent/Abilities/ToolCapabilitiesTest.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Test case for ToolCapabilities class.
+ *
+ * @package AiAgent
+ * @subpackage Tests
+ */
+
+namespace AiAgent\Tests\Abilities;
+
+use AiAgent\Abilities\ToolCapabilities;
+use WP_UnitTestCase;
+
+/**
+ * Test ToolCapabilities functionality.
+ */
+class ToolCapabilitiesTest extends WP_UnitTestCase {
+
+	/**
+	 * Test cap_name derives the correct capability name from an ability ID.
+	 *
+	 * @dataProvider provider_cap_name
+	 *
+	 * @param string $ability_id   Input ability ID.
+	 * @param string $expected_cap Expected capability name.
+	 */
+	public function test_cap_name( string $ability_id, string $expected_cap ): void {
+		$this->assertSame( $expected_cap, ToolCapabilities::cap_name( $ability_id ) );
+	}
+
+	/**
+	 * Data provider for test_cap_name.
+	 *
+	 * @return array<string, array{string, string}>
+	 */
+	public function provider_cap_name(): array {
+		return [
+			'memory-save'              => [ 'ai-agent/memory-save', 'ai_agent_tool_memory_save' ],
+			'memory-list'              => [ 'ai-agent/memory-list', 'ai_agent_tool_memory_list' ],
+			'memory-delete'            => [ 'ai-agent/memory-delete', 'ai_agent_tool_memory_delete' ],
+			'db-query'                 => [ 'ai-agent/db-query', 'ai_agent_tool_db_query' ],
+			'run-php'                  => [ 'ai-agent/run-php', 'ai_agent_tool_run_php' ],
+			'file-read'                => [ 'ai-agent/file-read', 'ai_agent_tool_file_read' ],
+			'get-plugins'              => [ 'ai-agent/get-plugins', 'ai_agent_tool_get_plugins' ],
+			'navigate'                 => [ 'ai-agent/navigate', 'ai_agent_tool_navigate' ],
+			'seo-audit-url'            => [ 'ai-agent/seo-audit-url', 'ai_agent_tool_seo_audit_url' ],
+			'content-analyze'          => [ 'ai-agent/content-analyze', 'ai_agent_tool_content_analyze' ],
+			'markdown-to-blocks'       => [ 'ai-agent/markdown-to-blocks', 'ai_agent_tool_markdown_to_blocks' ],
+			'import-stock-image'       => [ 'ai-agent/import-stock-image', 'ai_agent_tool_import_stock_image' ],
+			'custom-tool-with-slashes' => [ 'ai-agent-custom/my-tool', 'ai_agent_tool_my_tool' ],
+		];
+	}
+
+	/**
+	 * Test capability_exists returns false when capability is not in any role.
+	 */
+	public function test_capability_exists_returns_false_for_unknown_cap(): void {
+		$this->assertFalse( ToolCapabilities::capability_exists( 'ai_agent_tool_nonexistent_xyz_12345' ) );
+	}
+
+	/**
+	 * Test capability_exists returns true after adding capability to a role.
+	 */
+	public function test_capability_exists_returns_true_after_adding_to_role(): void {
+		$cap  = 'ai_agent_tool_test_cap_' . uniqid();
+		$role = get_role( 'administrator' );
+		$this->assertNotNull( $role );
+
+		$role->add_cap( $cap, true );
+		$this->assertTrue( ToolCapabilities::capability_exists( $cap ) );
+
+		// Clean up.
+		$role->remove_cap( $cap );
+	}
+
+	/**
+	 * Test current_user_can falls back to manage_options when capability doesn't exist.
+	 */
+	public function test_current_user_can_falls_back_to_manage_options(): void {
+		// Create a user with manage_options.
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		// Use an ability ID whose capability has never been registered.
+		$this->assertTrue( ToolCapabilities::current_user_can( 'ai-agent/nonexistent-tool-xyz' ) );
+
+		// Create a subscriber (no manage_options).
+		$subscriber_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+
+		$this->assertFalse( ToolCapabilities::current_user_can( 'ai-agent/nonexistent-tool-xyz' ) );
+	}
+
+	/**
+	 * Test current_user_can uses the specific capability when it exists.
+	 */
+	public function test_current_user_can_uses_specific_cap_when_registered(): void {
+		$ability_id = 'ai-agent/test-specific-tool-' . uniqid();
+		$cap        = ToolCapabilities::cap_name( $ability_id );
+
+		// Grant the capability to the editor role.
+		$editor_role = get_role( 'editor' );
+		$this->assertNotNull( $editor_role );
+		$editor_role->add_cap( $cap, true );
+
+		// Editor should now have access.
+		$editor_id = $this->factory->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $editor_id );
+		$this->assertTrue( ToolCapabilities::current_user_can( $ability_id ) );
+
+		// Subscriber should not have access.
+		$subscriber_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+		$this->assertFalse( ToolCapabilities::current_user_can( $ability_id ) );
+
+		// Clean up.
+		$editor_role->remove_cap( $cap );
+	}
+
+	/**
+	 * Test the ai_agent_tool_capability filter overrides the capability name.
+	 */
+	public function test_filter_overrides_capability_name(): void {
+		$ability_id   = 'ai-agent/memory-save';
+		$override_cap = 'edit_posts';
+
+		add_filter(
+			'ai_agent_tool_capability',
+			function ( string $cap, string $id ) use ( $ability_id, $override_cap ): string {
+				if ( $id === $ability_id ) {
+					return $override_cap;
+				}
+				return $cap;
+			},
+			10,
+			2
+		);
+
+		// Grant edit_posts to editor role (it already has it by default).
+		$editor_id = $this->factory->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $editor_id );
+
+		// The capability 'edit_posts' exists in roles, so it should be used directly.
+		$this->assertTrue( ToolCapabilities::current_user_can( $ability_id ) );
+
+		remove_all_filters( 'ai_agent_tool_capability' );
+	}
+
+	/**
+	 * Test register_capabilities adds capabilities to the administrator role.
+	 */
+	public function test_register_capabilities_adds_to_admin_role(): void {
+		$test_ids = [
+			'ai-agent/test-reg-tool-a-' . uniqid(),
+			'ai-agent/test-reg-tool-b-' . uniqid(),
+		];
+
+		ToolCapabilities::register_capabilities( $test_ids );
+
+		$admin_role = get_role( 'administrator' );
+		$this->assertNotNull( $admin_role );
+
+		foreach ( $test_ids as $id ) {
+			$cap = ToolCapabilities::cap_name( $id );
+			$this->assertArrayHasKey( $cap, $admin_role->capabilities );
+			$this->assertTrue( $admin_role->capabilities[ $cap ] );
+
+			// Clean up.
+			$admin_role->remove_cap( $cap );
+		}
+	}
+
+	/**
+	 * Test all_ability_ids returns a non-empty array of strings.
+	 */
+	public function test_all_ability_ids_returns_non_empty_array(): void {
+		$ids = ToolCapabilities::all_ability_ids();
+		$this->assertIsArray( $ids );
+		$this->assertNotEmpty( $ids );
+
+		foreach ( $ids as $id ) {
+			$this->assertIsString( $id );
+			$this->assertStringStartsWith( 'ai-agent/', $id );
+		}
+	}
+
+	/**
+	 * Test all_ability_ids contains expected core abilities.
+	 */
+	public function test_all_ability_ids_contains_core_abilities(): void {
+		$ids = ToolCapabilities::all_ability_ids();
+
+		$expected = [
+			'ai-agent/memory-save',
+			'ai-agent/memory-list',
+			'ai-agent/memory-delete',
+			'ai-agent/db-query',
+			'ai-agent/run-php',
+			'ai-agent/file-read',
+			'ai-agent/file-write',
+			'ai-agent/navigate',
+		];
+
+		foreach ( $expected as $id ) {
+			$this->assertContains( $id, $ids, "Expected ability ID '{$id}' not found in all_ability_ids()" );
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #48

Adds granular WordPress capability checks so each AI Agent ability (tool) can be granted independently to user roles, rather than all abilities being gated by a single hardcoded capability.

## Changes

### New: `ToolCapabilities` helper class (`includes/Abilities/ToolCapabilities.php`)

- **`cap_name(string $ability_id): string`** — derives `ai_agent_tool_{name}` from an ability ID (e.g. `ai-agent/memory-save` → `ai_agent_tool_memory_save`)
- **`current_user_can(string $ability_id): bool`** — checks the per-tool capability; falls back to `manage_options` if the capability hasn't been granted to any role yet (preserves existing admin-only default)
- **`capability_exists(string $cap): bool`** — checks whether a capability has been assigned to at least one role
- **`register_capabilities(array $ability_ids): void`** — adds all tool capabilities to the Administrator role so role-management plugins (Members, User Role Editor) can discover and assign them
- **`all_ability_ids(): array`** — canonical list of all 46 AI Agent ability IDs

### Filter: \`ai_agent_tool_capability\`

Allows overriding the resolved capability name per tool:

\`\`\`php
add_filter( 'ai_agent_tool_capability', function( string \$cap, string \$ability_id ): string {
    if ( \$ability_id === 'ai-agent/run-php' ) {
        return 'manage_network'; // Restrict to super admins on multisite.
    }
    return \$cap;
}, 10, 2 );
\`\`\`

### Updated: All 13 Abilities classes + CustomToolExecutor

Every `permission_callback` now delegates to `ToolCapabilities::current_user_can()` instead of hardcoded capability checks.

### Updated: `ai-agent.php`

Calls `ToolCapabilities::register_capabilities()` on plugin activation and `admin_init`.

### New: `tests/AiAgent/Abilities/ToolCapabilitiesTest.php`

8 test cases covering cap derivation, fallback logic, filter override, and registration.

## Behaviour

| Scenario | Result |
|---|---|
| Capability not granted to any role | Falls back to `manage_options` (admin only — unchanged) |
| Admin grants `ai_agent_tool_memory_save` to Editor role | Editors can use the memory-save tool |
| Filter overrides capability for `ai-agent/run-php` | Custom capability used instead |
| Plugin activated | All tool capabilities registered on Administrator role |

## Quality Gates

- ✅ PHPStan level 5: no errors
- ✅ PHPCS: no errors
- ✅ ESLint: no new errors (601 pre-existing prettier issues on `main`)
- ✅ Stylelint: no new errors (76 pre-existing issues on `main`)