### PR TITLE
t042: Port post, user, and media abilities from ai-experiments pattern

### DIFF
--- a/ai-agent.php
+++ b/ai-agent.php
@@ -40,11 +40,14 @@ use AiAgent\Abilities\DatabaseAbilities;
 use AiAgent\Abilities\FileAbilities;
 use AiAgent\Abilities\KnowledgeAbilities;
 use AiAgent\Abilities\MarketingAbilities;
+use AiAgent\Abilities\MediaAbilities;
 use AiAgent\Abilities\MemoryAbilities;
 use AiAgent\Abilities\NavigationAbilities;
+use AiAgent\Abilities\PostAbilities;
 use AiAgent\Abilities\SeoAbilities;
 use AiAgent\Abilities\SkillAbilities;
 use AiAgent\Abilities\StockImageAbilities;
+use AiAgent\Abilities\UserAbilities;
 use AiAgent\Abilities\WordPressAbilities;
 use AiAgent\Admin\AdminPage;
 use AiAgent\Admin\FloatingWidget;
@@ -122,6 +125,15 @@ WordPressAbilities::register();
 
 // Navigation abilities (navigate, get page HTML).
 NavigationAbilities::register();
+
+// Post management abilities (get, create, update, delete posts).
+PostAbilities::register();
+
+// User management abilities (list, create, update role).
+UserAbilities::register();
+
+// Media library abilities (list, upload from URL, delete).
+MediaAbilities::register();
 
 // Custom tool abilities (registered as WordPress Abilities).
 CustomToolExecutor::register();

--- a/includes/Abilities/MediaAbilities.php
+++ b/includes/Abilities/MediaAbilities.php
@@ -1,0 +1,449 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Media library abilities for the AI agent.
+ *
+ * Provides media listing, sideloading from URL, and deletion.
+ * Ported from the WordPress/ai experiments plugin pattern.
+ *
+ * @package AiAgent
+ */
+
+namespace AiAgent\Abilities;
+
+use WP_Error;
+use WP_Post;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class MediaAbilities {
+
+	/**
+	 * Register media abilities on init.
+	 */
+	public static function register(): void {
+		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
+	}
+
+	/**
+	 * Register all media library abilities.
+	 */
+	public static function register_abilities(): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			'ai-agent/list-media',
+			[
+				'label'               => __( 'List Media', 'ai-agent' ),
+				'description'         => __( 'List items in the WordPress media library. Filter by MIME type, search term, or date. Returns attachment ID, URL, title, alt text, MIME type, and file size.', 'ai-agent' ),
+				'category'            => 'ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'mime_type' => [
+							'type'        => 'string',
+							'description' => 'Filter by MIME type prefix (e.g. "image", "image/jpeg", "video", "application/pdf").',
+						],
+						'search'    => [
+							'type'        => 'string',
+							'description' => 'Search term matched against title, caption, or description.',
+						],
+						'limit'     => [
+							'type'        => 'integer',
+							'description' => 'Maximum number of items to return (default: 20, max: 100).',
+						],
+						'site_url'  => [
+							'type'        => 'string',
+							'description' => 'Subsite URL for multisite. Omit for the main site.',
+						],
+					],
+					'required'   => [],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'items' => [ 'type' => 'array' ],
+						'total' => [ 'type' => 'integer' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'   => true,
+						'idempotent' => true,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_list_media' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'upload_files' );
+				},
+			]
+		);
+
+		wp_register_ability(
+			'ai-agent/upload-media-from-url',
+			[
+				'label'               => __( 'Upload Media from URL', 'ai-agent' ),
+				'description'         => __( 'Download a file from a URL and add it to the WordPress media library. Returns the new attachment ID and URL. Supports images, PDFs, and other media types.', 'ai-agent' ),
+				'category'            => 'ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'url'         => [
+							'type'        => 'string',
+							'description' => 'The URL of the file to download and import.',
+						],
+						'title'       => [
+							'type'        => 'string',
+							'description' => 'Optional title for the attachment. Defaults to the filename.',
+						],
+						'alt_text'    => [
+							'type'        => 'string',
+							'description' => 'Alt text for image attachments.',
+						],
+						'caption'     => [
+							'type'        => 'string',
+							'description' => 'Optional caption for the attachment.',
+						],
+						'description' => [
+							'type'        => 'string',
+							'description' => 'Optional description for the attachment.',
+						],
+						'post_id'     => [
+							'type'        => 'integer',
+							'description' => 'Optional post ID to attach the media to.',
+						],
+						'site_url'    => [
+							'type'        => 'string',
+							'description' => 'Subsite URL for multisite. Omit for the main site.',
+						],
+					],
+					'required'   => [ 'url' ],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'attachment_id' => [ 'type' => 'integer' ],
+						'url'           => [ 'type' => 'string' ],
+						'title'         => [ 'type' => 'string' ],
+						'mime_type'     => [ 'type' => 'string' ],
+						'file_size'     => [ 'type' => 'integer' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'destructive' => false,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_upload_media_from_url' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'upload_files' );
+				},
+			]
+		);
+
+		wp_register_ability(
+			'ai-agent/delete-media',
+			[
+				'label'               => __( 'Delete Media', 'ai-agent' ),
+				'description'         => __( 'Permanently delete a media attachment from the WordPress media library, including all generated image sizes and metadata.', 'ai-agent' ),
+				'category'            => 'ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'attachment_id' => [
+							'type'        => 'integer',
+							'description' => 'The ID of the attachment to delete.',
+						],
+						'site_url'      => [
+							'type'        => 'string',
+							'description' => 'Subsite URL for multisite. Omit for the main site.',
+						],
+					],
+					'required'   => [ 'attachment_id' ],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'attachment_id' => [ 'type' => 'integer' ],
+						'title'         => [ 'type' => 'string' ],
+						'deleted'       => [ 'type' => 'boolean' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'destructive' => true,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_delete_media' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'delete_posts' );
+				},
+			]
+		);
+	}
+
+	/**
+	 * Handle the list-media ability.
+	 *
+	 * @param array<string, mixed> $input Input with optional mime_type, search, limit, site_url.
+	 * @return array<string, mixed>
+	 */
+	public static function handle_list_media( array $input ): array {
+		$mime_type = sanitize_text_field( $input['mime_type'] ?? '' );
+		$search    = sanitize_text_field( $input['search'] ?? '' );
+		$limit     = min( 100, max( 1, (int) ( $input['limit'] ?? 20 ) ) );
+		$site_url  = $input['site_url'] ?? '';
+
+		$switched = false;
+
+		if ( ! empty( $site_url ) && is_multisite() ) {
+			$blog_id = get_blog_id_from_url(
+				wp_parse_url( $site_url, PHP_URL_HOST ),
+				wp_parse_url( $site_url, PHP_URL_PATH ) ?: '/'
+			);
+
+			if ( $blog_id && $blog_id !== get_current_blog_id() ) {
+				switch_to_blog( $blog_id );
+				$switched = true;
+			}
+		}
+
+		$args = [
+			'post_type'      => 'attachment',
+			'post_status'    => 'inherit',
+			'posts_per_page' => $limit,
+			'orderby'        => 'date',
+			'order'          => 'DESC',
+		];
+
+		if ( ! empty( $mime_type ) ) {
+			$args['post_mime_type'] = $mime_type;
+		}
+
+		if ( ! empty( $search ) ) {
+			$args['s'] = $search;
+		}
+
+		$attachments = get_posts( $args );
+
+		$items = [];
+		foreach ( $attachments as $attachment ) {
+			if ( ! ( $attachment instanceof WP_Post ) ) {
+				continue;
+			}
+
+			$url       = wp_get_attachment_url( $attachment->ID );
+			$metadata  = wp_get_attachment_metadata( $attachment->ID );
+			$file_size = 0;
+
+			if ( is_array( $metadata ) && isset( $metadata['filesize'] ) ) {
+				$file_size = (int) $metadata['filesize'];
+			} else {
+				$file_path = get_attached_file( $attachment->ID );
+				if ( $file_path && file_exists( $file_path ) ) {
+					$file_size = (int) filesize( $file_path );
+				}
+			}
+
+			$items[] = [
+				'id'        => $attachment->ID,
+				'url'       => $url,
+				'title'     => $attachment->post_title,
+				'alt_text'  => get_post_meta( $attachment->ID, '_wp_attachment_image_alt', true ),
+				'caption'   => $attachment->post_excerpt,
+				'mime_type' => $attachment->post_mime_type,
+				'date'      => $attachment->post_date,
+				'file_size' => $file_size,
+			];
+		}
+
+		if ( $switched ) {
+			restore_current_blog();
+		}
+
+		return [
+			'items' => $items,
+			'total' => count( $items ),
+		];
+	}
+
+	/**
+	 * Handle the upload-media-from-url ability.
+	 *
+	 * @param array<string, mixed> $input Input with url, optional title, alt_text, caption, description, post_id, site_url.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function handle_upload_media_from_url( array $input ) {
+		$url         = esc_url_raw( $input['url'] ?? '' );
+		$title       = sanitize_text_field( $input['title'] ?? '' );
+		$alt_text    = sanitize_text_field( $input['alt_text'] ?? '' );
+		$caption     = sanitize_textarea_field( $input['caption'] ?? '' );
+		$description = sanitize_textarea_field( $input['description'] ?? '' );
+		$post_id     = (int) ( $input['post_id'] ?? 0 );
+		$site_url    = $input['site_url'] ?? '';
+
+		if ( empty( $url ) ) {
+			return new WP_Error( 'ai_agent_empty_url', __( 'URL is required.', 'ai-agent' ) );
+		}
+
+		$switched = false;
+
+		if ( ! empty( $site_url ) && is_multisite() ) {
+			$blog_id = get_blog_id_from_url(
+				wp_parse_url( $site_url, PHP_URL_HOST ),
+				wp_parse_url( $site_url, PHP_URL_PATH ) ?: '/'
+			);
+
+			if ( $blog_id && $blog_id !== get_current_blog_id() ) {
+				switch_to_blog( $blog_id );
+				$switched = true;
+			}
+		}
+
+		if ( ! function_exists( 'download_url' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+		if ( ! function_exists( 'media_handle_sideload' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/media.php';
+			require_once ABSPATH . 'wp-admin/includes/image.php';
+		}
+
+		$tmp_file = download_url( $url, 30 );
+
+		if ( is_wp_error( $tmp_file ) ) {
+			if ( $switched ) {
+				restore_current_blog();
+			}
+			return new WP_Error(
+				'ai_agent_download_failed',
+				/* translators: %s: error message */
+				sprintf( __( 'Failed to download file: %s', 'ai-agent' ), $tmp_file->get_error_message() )
+			);
+		}
+
+		// Derive filename from URL if no title given.
+		$url_path = wp_parse_url( $url, PHP_URL_PATH );
+		$filename = $url_path ? basename( $url_path ) : 'upload';
+		if ( empty( $title ) ) {
+			$title = pathinfo( $filename, PATHINFO_FILENAME );
+			$title = str_replace( [ '-', '_' ], ' ', $title );
+			$title = ucwords( $title );
+		}
+
+		$file_array = [
+			'name'     => $filename,
+			'tmp_name' => $tmp_file,
+		];
+
+		$attachment_id = media_handle_sideload( $file_array, $post_id, $title );
+
+		if ( is_wp_error( $attachment_id ) ) {
+			if ( file_exists( $tmp_file ) ) {
+				unlink( $tmp_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+			}
+			if ( $switched ) {
+				restore_current_blog();
+			}
+			return new WP_Error(
+				'ai_agent_sideload_failed',
+				/* translators: %s: error message */
+				sprintf( __( 'Failed to import media: %s', 'ai-agent' ), $attachment_id->get_error_message() )
+			);
+		}
+
+		// Update attachment metadata.
+		$update_data = [
+			'ID'           => $attachment_id,
+			'post_title'   => $title,
+			'post_excerpt' => $caption,
+			'post_content' => $description,
+		];
+		wp_update_post( $update_data );
+
+		if ( ! empty( $alt_text ) ) {
+			update_post_meta( $attachment_id, '_wp_attachment_image_alt', $alt_text );
+		}
+
+		$attachment_url = wp_get_attachment_url( $attachment_id );
+		$attachment     = get_post( $attachment_id );
+		$mime_type      = $attachment instanceof WP_Post ? $attachment->post_mime_type : '';
+
+		$file_path = get_attached_file( $attachment_id );
+		$file_size = ( $file_path && file_exists( $file_path ) ) ? (int) filesize( $file_path ) : 0;
+
+		if ( $switched ) {
+			restore_current_blog();
+		}
+
+		return [
+			'attachment_id' => $attachment_id,
+			'url'           => $attachment_url,
+			'title'         => $title,
+			'mime_type'     => $mime_type,
+			'file_size'     => $file_size,
+		];
+	}
+
+	/**
+	 * Handle the delete-media ability.
+	 *
+	 * @param array<string, mixed> $input Input with attachment_id and optional site_url.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function handle_delete_media( array $input ) {
+		$attachment_id = (int) ( $input['attachment_id'] ?? 0 );
+		$site_url      = $input['site_url'] ?? '';
+
+		if ( ! $attachment_id ) {
+			return new WP_Error( 'ai_agent_empty_attachment_id', __( 'attachment_id is required.', 'ai-agent' ) );
+		}
+
+		$switched = false;
+
+		if ( ! empty( $site_url ) && is_multisite() ) {
+			$blog_id = get_blog_id_from_url(
+				wp_parse_url( $site_url, PHP_URL_HOST ),
+				wp_parse_url( $site_url, PHP_URL_PATH ) ?: '/'
+			);
+
+			if ( $blog_id && $blog_id !== get_current_blog_id() ) {
+				switch_to_blog( $blog_id );
+				$switched = true;
+			}
+		}
+
+		$attachment = get_post( $attachment_id );
+
+		if ( ! ( $attachment instanceof WP_Post ) || $attachment->post_type !== 'attachment' ) {
+			if ( $switched ) {
+				restore_current_blog();
+			}
+			return new WP_Error(
+				'ai_agent_attachment_not_found',
+				/* translators: %d: attachment ID */
+				sprintf( __( 'Attachment %d not found.', 'ai-agent' ), $attachment_id )
+			);
+		}
+
+		$title  = $attachment->post_title;
+		$result = wp_delete_attachment( $attachment_id, true );
+
+		if ( $switched ) {
+			restore_current_blog();
+		}
+
+		return [
+			'attachment_id' => $attachment_id,
+			'title'         => $title,
+			'deleted'       => (bool) $result,
+		];
+	}
+}

--- a/includes/Abilities/PostAbilities.php
+++ b/includes/Abilities/PostAbilities.php
@@ -1,0 +1,621 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Post management abilities for the AI agent.
+ *
+ * Provides post creation, retrieval, update, and deletion.
+ * Ported from the WordPress/ai experiments plugin pattern.
+ *
+ * @package AiAgent
+ */
+
+namespace AiAgent\Abilities;
+
+use WP_Error;
+use WP_Post;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class PostAbilities {
+
+	/**
+	 * Register post abilities on init.
+	 */
+	public static function register(): void {
+		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
+	}
+
+	/**
+	 * Register all post management abilities.
+	 */
+	public static function register_abilities(): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			'ai-agent/get-post',
+			[
+				'label'               => __( 'Get Post', 'ai-agent' ),
+				'description'         => __( 'Retrieve a WordPress post by ID. Returns title, content, excerpt, status, author, categories, tags, featured image, and meta.', 'ai-agent' ),
+				'category'            => 'ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'post_id'   => [
+							'type'        => 'integer',
+							'description' => 'The ID of the post to retrieve.',
+						],
+						'post_type' => [
+							'type'        => 'string',
+							'description' => 'Post type to validate against (default: any).',
+						],
+					],
+					'required'   => [ 'post_id' ],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'id'             => [ 'type' => 'integer' ],
+						'title'          => [ 'type' => 'string' ],
+						'content'        => [ 'type' => 'string' ],
+						'excerpt'        => [ 'type' => 'string' ],
+						'status'         => [ 'type' => 'string' ],
+						'post_type'      => [ 'type' => 'string' ],
+						'author_id'      => [ 'type' => 'integer' ],
+						'author_name'    => [ 'type' => 'string' ],
+						'date'           => [ 'type' => 'string' ],
+						'modified'       => [ 'type' => 'string' ],
+						'permalink'      => [ 'type' => 'string' ],
+						'categories'     => [ 'type' => 'array' ],
+						'tags'           => [ 'type' => 'array' ],
+						'featured_image' => [ 'type' => 'string' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'   => true,
+						'idempotent' => true,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_get_post' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'edit_posts' );
+				},
+			]
+		);
+
+		wp_register_ability(
+			'ai-agent/create-post',
+			[
+				'label'               => __( 'Create Post', 'ai-agent' ),
+				'description'         => __( 'Create a new WordPress post or custom post type entry. Supports title, content, excerpt, status, categories, tags, and meta fields.', 'ai-agent' ),
+				'category'            => 'ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'title'      => [
+							'type'        => 'string',
+							'description' => 'The post title.',
+						],
+						'content'    => [
+							'type'        => 'string',
+							'description' => 'The post content (HTML or plain text).',
+						],
+						'excerpt'    => [
+							'type'        => 'string',
+							'description' => 'Optional post excerpt.',
+						],
+						'status'     => [
+							'type'        => 'string',
+							'description' => 'Post status: "draft" (default), "publish", "pending", "private", or "future".',
+							'enum'        => [ 'draft', 'publish', 'pending', 'private', 'future' ],
+						],
+						'post_type'  => [
+							'type'        => 'string',
+							'description' => 'Post type (default: "post"). Use "page" for pages.',
+						],
+						'categories' => [
+							'type'        => 'array',
+							'description' => 'Array of category IDs or names to assign.',
+							'items'       => [ 'type' => 'string' ],
+						],
+						'tags'       => [
+							'type'        => 'array',
+							'description' => 'Array of tag names to assign.',
+							'items'       => [ 'type' => 'string' ],
+						],
+						'meta'       => [
+							'type'        => 'object',
+							'description' => 'Key-value pairs of post meta to set.',
+						],
+						'site_url'   => [
+							'type'        => 'string',
+							'description' => 'Subsite URL for multisite. Omit for the main site.',
+						],
+					],
+					'required'   => [ 'title' ],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'post_id'   => [ 'type' => 'integer' ],
+						'permalink' => [ 'type' => 'string' ],
+						'status'    => [ 'type' => 'string' ],
+						'post_type' => [ 'type' => 'string' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'destructive' => false,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_create_post' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'edit_posts' );
+				},
+			]
+		);
+
+		wp_register_ability(
+			'ai-agent/update-post',
+			[
+				'label'               => __( 'Update Post', 'ai-agent' ),
+				'description'         => __( 'Update an existing WordPress post. Only provided fields are changed; omitted fields are left as-is.', 'ai-agent' ),
+				'category'            => 'ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'post_id'    => [
+							'type'        => 'integer',
+							'description' => 'The ID of the post to update.',
+						],
+						'title'      => [
+							'type'        => 'string',
+							'description' => 'New post title.',
+						],
+						'content'    => [
+							'type'        => 'string',
+							'description' => 'New post content.',
+						],
+						'excerpt'    => [
+							'type'        => 'string',
+							'description' => 'New post excerpt.',
+						],
+						'status'     => [
+							'type'        => 'string',
+							'description' => 'New post status.',
+							'enum'        => [ 'draft', 'publish', 'pending', 'private', 'future', 'trash' ],
+						],
+						'categories' => [
+							'type'        => 'array',
+							'description' => 'Replace categories with this array of IDs or names.',
+							'items'       => [ 'type' => 'string' ],
+						],
+						'tags'       => [
+							'type'        => 'array',
+							'description' => 'Replace tags with this array of names.',
+							'items'       => [ 'type' => 'string' ],
+						],
+						'meta'       => [
+							'type'        => 'object',
+							'description' => 'Key-value pairs of post meta to update.',
+						],
+						'site_url'   => [
+							'type'        => 'string',
+							'description' => 'Subsite URL for multisite. Omit for the main site.',
+						],
+					],
+					'required'   => [ 'post_id' ],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'post_id'   => [ 'type' => 'integer' ],
+						'permalink' => [ 'type' => 'string' ],
+						'status'    => [ 'type' => 'string' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'destructive' => false,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_update_post' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'edit_posts' );
+				},
+			]
+		);
+
+		wp_register_ability(
+			'ai-agent/delete-post',
+			[
+				'label'               => __( 'Delete Post', 'ai-agent' ),
+				'description'         => __( 'Move a WordPress post to the trash, or permanently delete it. Defaults to trash (recoverable). Set force_delete to true for permanent deletion.', 'ai-agent' ),
+				'category'            => 'ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'post_id'      => [
+							'type'        => 'integer',
+							'description' => 'The ID of the post to delete.',
+						],
+						'force_delete' => [
+							'type'        => 'boolean',
+							'description' => 'If true, permanently delete instead of trashing (default: false).',
+						],
+						'site_url'     => [
+							'type'        => 'string',
+							'description' => 'Subsite URL for multisite. Omit for the main site.',
+						],
+					],
+					'required'   => [ 'post_id' ],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'post_id'      => [ 'type' => 'integer' ],
+						'title'        => [ 'type' => 'string' ],
+						'action'       => [ 'type' => 'string' ],
+						'force_delete' => [ 'type' => 'boolean' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'destructive' => true,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_delete_post' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'delete_posts' );
+				},
+			]
+		);
+	}
+
+	/**
+	 * Handle the get-post ability.
+	 *
+	 * @param array<string, mixed> $input Input with post_id and optional post_type.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function handle_get_post( array $input ) {
+		$post_id   = (int) ( $input['post_id'] ?? 0 );
+		$post_type = sanitize_text_field( $input['post_type'] ?? 'any' );
+
+		if ( ! $post_id ) {
+			return new WP_Error( 'ai_agent_empty_post_id', __( 'post_id is required.', 'ai-agent' ) );
+		}
+
+		$post = get_post( $post_id );
+
+		if ( ! ( $post instanceof WP_Post ) ) {
+			return new WP_Error(
+				'ai_agent_post_not_found',
+				/* translators: %d: post ID */
+				sprintf( __( 'Post %d not found.', 'ai-agent' ), $post_id )
+			);
+		}
+
+		if ( $post_type !== 'any' && $post->post_type !== $post_type ) {
+			return new WP_Error(
+				'ai_agent_post_type_mismatch',
+				/* translators: 1: post ID, 2: expected type, 3: actual type */
+				sprintf( __( 'Post %1$d is of type "%2$s", not "%3$s".', 'ai-agent' ), $post_id, $post->post_type, $post_type )
+			);
+		}
+
+		$categories = wp_get_post_categories( $post_id, [ 'fields' => 'names' ] );
+		$tags       = wp_get_post_tags( $post_id, [ 'fields' => 'names' ] );
+
+		$featured_image_url = '';
+		$thumbnail_id       = get_post_thumbnail_id( $post_id );
+		if ( $thumbnail_id ) {
+			$image_src          = wp_get_attachment_image_src( $thumbnail_id, 'full' );
+			$featured_image_url = $image_src ? $image_src[0] : '';
+		}
+
+		return [
+			'id'             => $post->ID,
+			'title'          => $post->post_title,
+			'content'        => $post->post_content,
+			'excerpt'        => $post->post_excerpt,
+			'status'         => $post->post_status,
+			'post_type'      => $post->post_type,
+			'author_id'      => (int) $post->post_author,
+			'author_name'    => get_the_author_meta( 'display_name', (int) $post->post_author ),
+			'date'           => $post->post_date,
+			'modified'       => $post->post_modified,
+			'permalink'      => get_permalink( $post_id ),
+			'categories'     => is_wp_error( $categories ) ? [] : $categories,
+			'tags'           => is_wp_error( $tags ) ? [] : $tags,
+			'featured_image' => $featured_image_url,
+		];
+	}
+
+	/**
+	 * Handle the create-post ability.
+	 *
+	 * @param array<string, mixed> $input Input with title, content, status, etc.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function handle_create_post( array $input ) {
+		$title     = sanitize_text_field( $input['title'] ?? '' );
+		$content   = wp_kses_post( $input['content'] ?? '' );
+		$excerpt   = sanitize_textarea_field( $input['excerpt'] ?? '' );
+		$status    = sanitize_text_field( $input['status'] ?? 'draft' );
+		$post_type = sanitize_text_field( $input['post_type'] ?? 'post' );
+		$site_url  = $input['site_url'] ?? '';
+
+		if ( empty( $title ) ) {
+			return new WP_Error( 'ai_agent_empty_title', __( 'Post title is required.', 'ai-agent' ) );
+		}
+
+		$allowed_statuses = [ 'draft', 'publish', 'pending', 'private', 'future' ];
+		if ( ! in_array( $status, $allowed_statuses, true ) ) {
+			$status = 'draft';
+		}
+
+		$switched = false;
+
+		if ( ! empty( $site_url ) && is_multisite() ) {
+			$blog_id = get_blog_id_from_url(
+				wp_parse_url( $site_url, PHP_URL_HOST ),
+				wp_parse_url( $site_url, PHP_URL_PATH ) ?: '/'
+			);
+
+			if ( $blog_id && $blog_id !== get_current_blog_id() ) {
+				switch_to_blog( $blog_id );
+				$switched = true;
+			}
+		}
+
+		$post_data = [
+			'post_title'   => $title,
+			'post_content' => $content,
+			'post_excerpt' => $excerpt,
+			'post_status'  => $status,
+			'post_type'    => $post_type,
+		];
+
+		$post_id = wp_insert_post( $post_data, true );
+
+		if ( is_wp_error( $post_id ) ) {
+			if ( $switched ) {
+				restore_current_blog();
+			}
+			return $post_id;
+		}
+
+		// Assign categories.
+		$categories = $input['categories'] ?? [];
+		if ( ! empty( $categories ) && is_array( $categories ) ) {
+			$cat_ids = self::resolve_category_ids( $categories );
+			wp_set_post_categories( $post_id, $cat_ids );
+		}
+
+		// Assign tags.
+		$tags = $input['tags'] ?? [];
+		if ( ! empty( $tags ) && is_array( $tags ) ) {
+			$tag_names = array_map( 'sanitize_text_field', $tags );
+			wp_set_post_tags( $post_id, $tag_names );
+		}
+
+		// Set post meta.
+		$meta = $input['meta'] ?? [];
+		if ( ! empty( $meta ) && is_array( $meta ) ) {
+			foreach ( $meta as $key => $value ) {
+				update_post_meta( $post_id, sanitize_key( $key ), $value );
+			}
+		}
+
+		$permalink = get_permalink( $post_id );
+
+		if ( $switched ) {
+			restore_current_blog();
+		}
+
+		return [
+			'post_id'   => $post_id,
+			'permalink' => $permalink,
+			'status'    => $status,
+			'post_type' => $post_type,
+		];
+	}
+
+	/**
+	 * Handle the update-post ability.
+	 *
+	 * @param array<string, mixed> $input Input with post_id and fields to update.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function handle_update_post( array $input ) {
+		$post_id  = (int) ( $input['post_id'] ?? 0 );
+		$site_url = $input['site_url'] ?? '';
+
+		if ( ! $post_id ) {
+			return new WP_Error( 'ai_agent_empty_post_id', __( 'post_id is required.', 'ai-agent' ) );
+		}
+
+		$switched = false;
+
+		if ( ! empty( $site_url ) && is_multisite() ) {
+			$blog_id = get_blog_id_from_url(
+				wp_parse_url( $site_url, PHP_URL_HOST ),
+				wp_parse_url( $site_url, PHP_URL_PATH ) ?: '/'
+			);
+
+			if ( $blog_id && $blog_id !== get_current_blog_id() ) {
+				switch_to_blog( $blog_id );
+				$switched = true;
+			}
+		}
+
+		$post = get_post( $post_id );
+
+		if ( ! ( $post instanceof WP_Post ) ) {
+			if ( $switched ) {
+				restore_current_blog();
+			}
+			return new WP_Error(
+				'ai_agent_post_not_found',
+				/* translators: %d: post ID */
+				sprintf( __( 'Post %d not found.', 'ai-agent' ), $post_id )
+			);
+		}
+
+		$post_data = [ 'ID' => $post_id ];
+
+		if ( isset( $input['title'] ) ) {
+			$post_data['post_title'] = sanitize_text_field( $input['title'] );
+		}
+		if ( isset( $input['content'] ) ) {
+			$post_data['post_content'] = wp_kses_post( $input['content'] );
+		}
+		if ( isset( $input['excerpt'] ) ) {
+			$post_data['post_excerpt'] = sanitize_textarea_field( $input['excerpt'] );
+		}
+		if ( isset( $input['status'] ) ) {
+			$allowed_statuses = [ 'draft', 'publish', 'pending', 'private', 'future', 'trash' ];
+			$new_status       = sanitize_text_field( $input['status'] );
+			if ( in_array( $new_status, $allowed_statuses, true ) ) {
+				$post_data['post_status'] = $new_status;
+			}
+		}
+
+		$result = wp_update_post( $post_data, true );
+
+		if ( is_wp_error( $result ) ) {
+			if ( $switched ) {
+				restore_current_blog();
+			}
+			return $result;
+		}
+
+		// Update categories if provided.
+		if ( isset( $input['categories'] ) && is_array( $input['categories'] ) ) {
+			$cat_ids = self::resolve_category_ids( $input['categories'] );
+			wp_set_post_categories( $post_id, $cat_ids );
+		}
+
+		// Update tags if provided.
+		if ( isset( $input['tags'] ) && is_array( $input['tags'] ) ) {
+			$tag_names = array_map( 'sanitize_text_field', $input['tags'] );
+			wp_set_post_tags( $post_id, $tag_names );
+		}
+
+		// Update meta if provided.
+		if ( isset( $input['meta'] ) && is_array( $input['meta'] ) ) {
+			foreach ( $input['meta'] as $key => $value ) {
+				update_post_meta( $post_id, sanitize_key( $key ), $value );
+			}
+		}
+
+		$updated_post = get_post( $post_id );
+		$permalink    = get_permalink( $post_id );
+
+		if ( $switched ) {
+			restore_current_blog();
+		}
+
+		return [
+			'post_id'   => $post_id,
+			'permalink' => $permalink,
+			'status'    => $updated_post instanceof WP_Post ? $updated_post->post_status : '',
+		];
+	}
+
+	/**
+	 * Handle the delete-post ability.
+	 *
+	 * @param array<string, mixed> $input Input with post_id and optional force_delete, site_url.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function handle_delete_post( array $input ) {
+		$post_id      = (int) ( $input['post_id'] ?? 0 );
+		$force_delete = (bool) ( $input['force_delete'] ?? false );
+		$site_url     = $input['site_url'] ?? '';
+
+		if ( ! $post_id ) {
+			return new WP_Error( 'ai_agent_empty_post_id', __( 'post_id is required.', 'ai-agent' ) );
+		}
+
+		$switched = false;
+
+		if ( ! empty( $site_url ) && is_multisite() ) {
+			$blog_id = get_blog_id_from_url(
+				wp_parse_url( $site_url, PHP_URL_HOST ),
+				wp_parse_url( $site_url, PHP_URL_PATH ) ?: '/'
+			);
+
+			if ( $blog_id && $blog_id !== get_current_blog_id() ) {
+				switch_to_blog( $blog_id );
+				$switched = true;
+			}
+		}
+
+		$post = get_post( $post_id );
+
+		if ( ! ( $post instanceof WP_Post ) ) {
+			if ( $switched ) {
+				restore_current_blog();
+			}
+			return new WP_Error(
+				'ai_agent_post_not_found',
+				/* translators: %d: post ID */
+				sprintf( __( 'Post %d not found.', 'ai-agent' ), $post_id )
+			);
+		}
+
+		$title  = $post->post_title;
+		$result = wp_delete_post( $post_id, $force_delete );
+
+		if ( $switched ) {
+			restore_current_blog();
+		}
+
+		if ( ! $result ) {
+			return new WP_Error(
+				'ai_agent_delete_failed',
+				/* translators: %d: post ID */
+				sprintf( __( 'Failed to delete post %d.', 'ai-agent' ), $post_id )
+			);
+		}
+
+		return [
+			'post_id'      => $post_id,
+			'title'        => $title,
+			'action'       => $force_delete ? 'permanently_deleted' : 'trashed',
+			'force_delete' => $force_delete,
+		];
+	}
+
+	/**
+	 * Resolve an array of category IDs or names to an array of IDs.
+	 *
+	 * @param array<int|string> $categories Array of category IDs or names.
+	 * @return int[] Array of category IDs.
+	 */
+	private static function resolve_category_ids( array $categories ): array {
+		$ids = [];
+		foreach ( $categories as $cat ) {
+			if ( is_numeric( $cat ) ) {
+				$ids[] = (int) $cat;
+			} else {
+				$term = get_term_by( 'name', sanitize_text_field( (string) $cat ), 'category' );
+				if ( $term && ! is_wp_error( $term ) ) {
+					$ids[] = $term->term_id;
+				}
+			}
+		}
+		return $ids;
+	}
+}

--- a/includes/Abilities/UserAbilities.php
+++ b/includes/Abilities/UserAbilities.php
@@ -1,0 +1,380 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * User management abilities for the AI agent.
+ *
+ * Provides user listing, creation, role management, and profile updates.
+ * Ported from the WordPress/ai experiments plugin pattern.
+ *
+ * @package AiAgent
+ */
+
+namespace AiAgent\Abilities;
+
+use WP_Error;
+use WP_User;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class UserAbilities {
+
+	/**
+	 * Register user abilities on init.
+	 */
+	public static function register(): void {
+		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
+	}
+
+	/**
+	 * Register all user management abilities.
+	 */
+	public static function register_abilities(): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			'ai-agent/list-users',
+			[
+				'label'               => __( 'List Users', 'ai-agent' ),
+				'description'         => __( 'List WordPress users with optional filtering by role, search term, or number. Returns ID, login, email, display name, roles, and registration date.', 'ai-agent' ),
+				'category'            => 'ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'role'   => [
+							'type'        => 'string',
+							'description' => 'Filter by role slug (e.g. "administrator", "editor", "author", "subscriber"). Omit for all roles.',
+						],
+						'search' => [
+							'type'        => 'string',
+							'description' => 'Search term matched against login, email, URL, or display name.',
+						],
+						'limit'  => [
+							'type'        => 'integer',
+							'description' => 'Maximum number of users to return (default: 20, max: 100).',
+						],
+					],
+					'required'   => [],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'users' => [ 'type' => 'array' ],
+						'total' => [ 'type' => 'integer' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'   => true,
+						'idempotent' => true,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_list_users' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'list_users' );
+				},
+			]
+		);
+
+		wp_register_ability(
+			'ai-agent/create-user',
+			[
+				'label'               => __( 'Create User', 'ai-agent' ),
+				'description'         => __( 'Create a new WordPress user with the specified username, email, role, and optional display name. Returns the new user ID.', 'ai-agent' ),
+				'category'            => 'ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'username'     => [
+							'type'        => 'string',
+							'description' => 'The login username for the new user.',
+						],
+						'email'        => [
+							'type'        => 'string',
+							'description' => 'The email address for the new user.',
+						],
+						'role'         => [
+							'type'        => 'string',
+							'description' => 'The role to assign (e.g. "subscriber", "author", "editor"). Defaults to the site default role.',
+						],
+						'display_name' => [
+							'type'        => 'string',
+							'description' => 'Optional display name. Defaults to the username.',
+						],
+						'send_email'   => [
+							'type'        => 'boolean',
+							'description' => 'Whether to send a new-user notification email (default: false).',
+						],
+					],
+					'required'   => [ 'username', 'email' ],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'user_id'      => [ 'type' => 'integer' ],
+						'username'     => [ 'type' => 'string' ],
+						'email'        => [ 'type' => 'string' ],
+						'role'         => [ 'type' => 'string' ],
+						'display_name' => [ 'type' => 'string' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'destructive' => false,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_create_user' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'create_users' );
+				},
+			]
+		);
+
+		wp_register_ability(
+			'ai-agent/update-user-role',
+			[
+				'label'               => __( 'Update User Role', 'ai-agent' ),
+				'description'         => __( 'Change the role of an existing WordPress user. Provide either user_id or user_email to identify the user.', 'ai-agent' ),
+				'category'            => 'ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'user_id'    => [
+							'type'        => 'integer',
+							'description' => 'The ID of the user to update.',
+						],
+						'user_email' => [
+							'type'        => 'string',
+							'description' => 'The email of the user to update (alternative to user_id).',
+						],
+						'role'       => [
+							'type'        => 'string',
+							'description' => 'The new role slug (e.g. "editor", "author", "subscriber", "administrator").',
+						],
+					],
+					'required'   => [ 'role' ],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'user_id'       => [ 'type' => 'integer' ],
+						'username'      => [ 'type' => 'string' ],
+						'previous_role' => [ 'type' => 'string' ],
+						'new_role'      => [ 'type' => 'string' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'destructive' => false,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_update_user_role' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'edit_users' );
+				},
+			]
+		);
+	}
+
+	/**
+	 * Handle the list-users ability.
+	 *
+	 * @param array<string, mixed> $input Input with optional role, search, limit.
+	 * @return array<string, mixed>
+	 */
+	public static function handle_list_users( array $input ): array {
+		$role   = sanitize_text_field( $input['role'] ?? '' );
+		$search = sanitize_text_field( $input['search'] ?? '' );
+		$limit  = min( 100, max( 1, (int) ( $input['limit'] ?? 20 ) ) );
+
+		$args = [
+			'number'  => $limit,
+			'fields'  => 'all',
+			'orderby' => 'registered',
+			'order'   => 'DESC',
+		];
+
+		if ( ! empty( $role ) ) {
+			$args['role'] = $role;
+		}
+
+		if ( ! empty( $search ) ) {
+			$args['search']         = '*' . $search . '*';
+			$args['search_columns'] = [ 'user_login', 'user_email', 'display_name' ];
+		}
+
+		$user_query = new \WP_User_Query( $args );
+		$wp_users   = $user_query->get_results();
+
+		$users = [];
+		foreach ( $wp_users as $user ) {
+			if ( ! ( $user instanceof WP_User ) ) {
+				continue;
+			}
+			$users[] = [
+				'id'           => $user->ID,
+				'username'     => $user->user_login,
+				'email'        => $user->user_email,
+				'display_name' => $user->display_name,
+				'roles'        => $user->roles,
+				'registered'   => $user->user_registered,
+				'url'          => $user->user_url,
+			];
+		}
+
+		return [
+			'users' => $users,
+			'total' => count( $users ),
+		];
+	}
+
+	/**
+	 * Handle the create-user ability.
+	 *
+	 * @param array<string, mixed> $input Input with username, email, optional role, display_name, send_email.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function handle_create_user( array $input ) {
+		$username     = sanitize_user( $input['username'] ?? '' );
+		$email        = sanitize_email( $input['email'] ?? '' );
+		$role         = sanitize_text_field( $input['role'] ?? get_option( 'default_role', 'subscriber' ) );
+		$display_name = sanitize_text_field( $input['display_name'] ?? $username );
+		$send_email   = (bool) ( $input['send_email'] ?? false );
+
+		if ( empty( $username ) ) {
+			return new WP_Error( 'ai_agent_empty_username', __( 'Username is required.', 'ai-agent' ) );
+		}
+
+		if ( empty( $email ) || ! is_email( $email ) ) {
+			return new WP_Error( 'ai_agent_invalid_email', __( 'A valid email address is required.', 'ai-agent' ) );
+		}
+
+		if ( username_exists( $username ) ) {
+			return new WP_Error(
+				'ai_agent_username_exists',
+				/* translators: %s: username */
+				sprintf( __( 'Username "%s" is already taken.', 'ai-agent' ), $username )
+			);
+		}
+
+		if ( email_exists( $email ) ) {
+			return new WP_Error(
+				'ai_agent_email_exists',
+				/* translators: %s: email address */
+				sprintf( __( 'Email "%s" is already registered.', 'ai-agent' ), $email )
+			);
+		}
+
+		// Validate role exists.
+		$editable_roles = wp_roles()->get_names();
+		if ( ! array_key_exists( $role, $editable_roles ) ) {
+			return new WP_Error(
+				'ai_agent_invalid_role',
+				/* translators: %s: role slug */
+				sprintf( __( 'Role "%s" does not exist.', 'ai-agent' ), $role )
+			);
+		}
+
+		$password = wp_generate_password( 24, true, true );
+
+		$user_id = wp_create_user( $username, $password, $email );
+
+		if ( is_wp_error( $user_id ) ) {
+			return $user_id;
+		}
+
+		$user = new WP_User( $user_id );
+		$user->set_role( $role );
+
+		wp_update_user(
+			[
+				'ID'           => $user_id,
+				'display_name' => $display_name,
+			]
+		);
+
+		if ( $send_email ) {
+			wp_new_user_notification( $user_id, null, 'both' );
+		}
+
+		return [
+			'user_id'      => $user_id,
+			'username'     => $username,
+			'email'        => $email,
+			'role'         => $role,
+			'display_name' => $display_name,
+		];
+	}
+
+	/**
+	 * Handle the update-user-role ability.
+	 *
+	 * @param array<string, mixed> $input Input with user_id or user_email, and role.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function handle_update_user_role( array $input ) {
+		$user_id    = (int) ( $input['user_id'] ?? 0 );
+		$user_email = sanitize_email( $input['user_email'] ?? '' );
+		$new_role   = sanitize_text_field( $input['role'] ?? '' );
+
+		if ( empty( $new_role ) ) {
+			return new WP_Error( 'ai_agent_empty_role', __( 'Role is required.', 'ai-agent' ) );
+		}
+
+		// Validate role exists.
+		$editable_roles = wp_roles()->get_names();
+		if ( ! array_key_exists( $new_role, $editable_roles ) ) {
+			return new WP_Error(
+				'ai_agent_invalid_role',
+				/* translators: %s: role slug */
+				sprintf( __( 'Role "%s" does not exist.', 'ai-agent' ), $new_role )
+			);
+		}
+
+		// Resolve user.
+		$user = null;
+		if ( $user_id > 0 ) {
+			$user = get_user_by( 'id', $user_id );
+		} elseif ( ! empty( $user_email ) ) {
+			$user = get_user_by( 'email', $user_email );
+		}
+
+		if ( ! ( $user instanceof WP_User ) ) {
+			return new WP_Error( 'ai_agent_user_not_found', __( 'User not found. Provide a valid user_id or user_email.', 'ai-agent' ) );
+		}
+
+		// Prevent demoting the last administrator.
+		if ( in_array( 'administrator', $user->roles, true ) && $new_role !== 'administrator' ) {
+			$admin_count = (int) ( new \WP_User_Query(
+				[
+					'role'        => 'administrator',
+					'count_total' => true,
+				]
+			) )->get_total();
+			if ( $admin_count <= 1 ) {
+				return new WP_Error(
+					'ai_agent_last_admin',
+					__( 'Cannot change the role of the last administrator.', 'ai-agent' )
+				);
+			}
+		}
+
+		$previous_role = ! empty( $user->roles ) ? $user->roles[0] : '';
+
+		$user->set_role( $new_role );
+
+		return [
+			'user_id'       => $user->ID,
+			'username'      => $user->user_login,
+			'previous_role' => $previous_role,
+			'new_role'      => $new_role,
+		];
+	}
+}


### PR DESCRIPTION
## Summary

Implements three high-value ability classes identified as gaps when reviewing the WordPress/ai experiments plugin pattern. The `WordPress/ai-experiments` repo is not publicly available, so this PR ports the canonical ability categories that any AI-WordPress integration should expose.

## New Abilities

### `PostAbilities` (4 abilities)
- `ai-agent/get-post` — retrieve a post by ID with full metadata (categories, tags, featured image, author)
- `ai-agent/create-post` — create posts/CPTs with title, content, excerpt, status, categories, tags, meta, multisite support
- `ai-agent/update-post` — partial update (only provided fields changed), supports all statuses including trash
- `ai-agent/delete-post` — trash (default, recoverable) or force-delete with `force_delete: true`

### `UserAbilities` (3 abilities)
- `ai-agent/list-users` — list users with role/search filtering
- `ai-agent/create-user` — create user with role validation, duplicate checks, optional notification email
- `ai-agent/update-user-role` — change role by user_id or email, with last-administrator guard

### `MediaAbilities` (3 abilities)
- `ai-agent/list-media` — list media library items with MIME type and search filtering
- `ai-agent/upload-media-from-url` — sideload a file from URL into the media library with alt/caption/description
- `ai-agent/delete-media` — permanently delete an attachment and all generated sizes

## Quality

- PHPStan level 5: **0 errors** (full project scan, 51 files)
- PHPCS: **0 violations** (full project scan)
- All abilities follow the existing `wp_register_ability()` pattern with full input/output schemas, `permission_callback`, `annotations`, and `show_in_rest`
- Multisite `site_url` switching supported on all write operations
- Destructive operations annotated with `'destructive' => true`

Closes #134