### PR TITLE
t056: Add TypeScript types or JSDoc to JS codebase

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,6 +10,7 @@
 	},
 	"rules": {
 		"jsdoc/require-jsdoc": "off",
+		"jsdoc/no-undefined-types": [ "error", { "definedTypes": [ "JSX" ] } ],
 		"@wordpress/no-unsafe-wp-apis": "warn",
 		"no-console": "warn"
 	},

--- a/src/admin-page/index.js
+++ b/src/admin-page/index.js
@@ -16,9 +16,19 @@ import ShortcutsHelp from '../components/shortcuts-help';
 import { useKeyboardShortcuts } from '../utils/keyboard-shortcuts';
 import './style.css';
 
+/**
+ * Root admin page application component. Renders the session sidebar and chat panel,
+ * handles onboarding wizard display, keyboard shortcuts, and slash command routing.
+ *
+ * @return {JSX.Element|null} Admin page app element, or null while settings are loading.
+ */
 function AdminPageApp() {
-	const { fetchProviders, fetchSessions, fetchSettings, clearCurrentSession } =
-		useDispatch( STORE_NAME );
+	const {
+		fetchProviders,
+		fetchSessions,
+		fetchSettings,
+		clearCurrentSession,
+	} = useDispatch( STORE_NAME );
 	const { settings, settingsLoaded } = useSelect(
 		( select ) => ( {
 			settings: select( STORE_NAME ).getSettings(),
@@ -73,9 +83,7 @@ function AdminPageApp() {
 
 	if ( showOnboarding ) {
 		return (
-			<OnboardingWizard
-				onComplete={ () => setShowOnboarding( false ) }
-			/>
+			<OnboardingWizard onComplete={ () => setShowOnboarding( false ) } />
 		);
 	}
 
@@ -88,9 +96,7 @@ function AdminPageApp() {
 				</div>
 			</div>
 			{ showShortcuts && (
-				<ShortcutsHelp
-					onClose={ () => setShowShortcuts( false ) }
-				/>
+				<ShortcutsHelp onClose={ () => setShowShortcuts( false ) } />
 			) }
 		</>
 	);

--- a/src/components/chat-panel.js
+++ b/src/components/chat-panel.js
@@ -14,6 +14,17 @@ import MessageInput from './message-input';
 import ContextIndicator from './context-indicator';
 import ToolConfirmationDialog from './tool-confirmation-dialog';
 
+/**
+ * Main chat panel component. Renders the provider selector, message list,
+ * message input, and tool confirmation dialog.
+ *
+ * @param {Object}   props                  - Component props.
+ * @param {boolean}  [props.compact=false]  - Whether to render in compact mode
+ *                                          (used inside the floating widget).
+ * @param {Function} [props.onSlashCommand] - Callback for slash command actions.
+ *                                          Receives (action: string, data?: string).
+ * @return {JSX.Element} Chat panel element.
+ */
 export default function ChatPanel( { compact = false, onSlashCommand } ) {
 	const { confirmToolCall, rejectToolCall } = useDispatch( STORE_NAME );
 	const { pendingConfirmation, debugMode } = useSelect(

--- a/src/components/code-block.js
+++ b/src/components/code-block.js
@@ -10,6 +10,15 @@ import { __ } from '@wordpress/i18n';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 
+/**
+ * Syntax-highlighted code block with a copy-to-clipboard button.
+ * Used as a custom renderer inside MarkdownMessage.
+ *
+ * @param {Object} props            - Component props.
+ * @param {string} [props.language] - Language identifier for syntax highlighting.
+ * @param {*}      props.children   - Code content.
+ * @return {JSX.Element} Code block element.
+ */
 export default function CodeBlock( { language, children } ) {
 	const [ copied, setCopied ] = useState( false );
 	const code = String( children ).replace( /\n$/, '' );
@@ -25,9 +34,7 @@ export default function CodeBlock( { language, children } ) {
 		<div className="ai-agent-code-block">
 			<div className="ai-agent-code-header">
 				{ language && (
-					<span className="ai-agent-code-language">
-						{ language }
-					</span>
+					<span className="ai-agent-code-language">{ language }</span>
 				) }
 				<button
 					className="ai-agent-code-copy"

--- a/src/components/context-indicator.js
+++ b/src/components/context-indicator.js
@@ -10,6 +10,12 @@ import { __ } from '@wordpress/i18n';
  */
 import STORE_NAME from '../store';
 
+/**
+ * Format a token count as a human-readable string (e.g. '128K', '1.2M').
+ *
+ * @param {number} n - Token count.
+ * @return {string} Formatted string.
+ */
 function formatTokens( n ) {
 	if ( n >= 1_000_000 ) {
 		return ( n / 1_000_000 ).toFixed( 1 ) + 'M';
@@ -20,6 +26,13 @@ function formatTokens( n ) {
 	return n.toString();
 }
 
+/**
+ * Context window usage indicator showing token counts and a progress bar.
+ * Displays compact/expand actions when usage exceeds 80%.
+ * Returns null when no tokens have been used yet.
+ *
+ * @return {JSX.Element|null} Context indicator element, or null if no usage.
+ */
 export default function ContextIndicator() {
 	const { percentage, isWarning, tokenUsage } = useSelect(
 		( select ) => ( {
@@ -76,10 +89,7 @@ export default function ContextIndicator() {
 			{ isWarning && (
 				<div className="ai-agent-context-warning">
 					<span>
-						{ __(
-							'Context window is getting full.',
-							'ai-agent'
-						) }
+						{ __( 'Context window is getting full.', 'ai-agent' ) }
 					</span>
 					<div className="ai-agent-context-warning-actions">
 						<Button

--- a/src/components/debug-panel.js
+++ b/src/components/debug-panel.js
@@ -4,6 +4,12 @@
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Format a duration in milliseconds as a human-readable string.
+ *
+ * @param {number} ms - Duration in milliseconds.
+ * @return {string} Formatted string (e.g. '1.2s', '850ms').
+ */
 function formatTime( ms ) {
 	if ( ms < 1000 ) {
 		return ms + 'ms';
@@ -11,6 +17,12 @@ function formatTime( ms ) {
 	return ( ms / 1000 ).toFixed( 1 ) + 's';
 }
 
+/**
+ * Format a cost in USD as a human-readable string.
+ *
+ * @param {number} cost - Cost in USD.
+ * @return {string} Formatted string (e.g. '$0.0012', '$1.23').
+ */
 function formatCost( cost ) {
 	if ( ! cost || cost === 0 ) {
 		return '$0';
@@ -21,6 +33,14 @@ function formatCost( cost ) {
 	return '$' + cost.toFixed( 2 );
 }
 
+/**
+ * Collapsible debug panel showing per-response performance metrics.
+ * Only rendered when debug mode is active. Returns null when no debug data.
+ *
+ * @param {Object}                       props       - Component props.
+ * @param {import('../store').DebugInfo} props.debug - Debug metadata from the store.
+ * @return {JSX.Element|null} Debug panel element, or null if no debug data.
+ */
 export default function DebugPanel( { debug } ) {
 	const [ expanded, setExpanded ] = useState( false );
 
@@ -39,7 +59,8 @@ export default function DebugPanel( { debug } ) {
 		toolNames = [],
 	} = debug;
 
-	const totalTokens = ( tokenUsage.prompt || 0 ) + ( tokenUsage.completion || 0 );
+	const totalTokens =
+		( tokenUsage.prompt || 0 ) + ( tokenUsage.completion || 0 );
 
 	const summaryParts = [];
 	if ( responseTimeMs > 0 ) {
@@ -51,7 +72,8 @@ export default function DebugPanel( { debug } ) {
 	if ( costEstimate > 0 ) {
 		summaryParts.push( formatCost( costEstimate ) );
 	}
-	const summary = summaryParts.join( ' / ' ) || __( 'No metrics', 'ai-agent' );
+	const summary =
+		summaryParts.join( ' / ' ) || __( 'No metrics', 'ai-agent' );
 
 	return (
 		<div className="ai-agent-debug-panel">
@@ -60,9 +82,7 @@ export default function DebugPanel( { debug } ) {
 				onClick={ () => setExpanded( ! expanded ) }
 				type="button"
 			>
-				<span className="ai-agent-debug-summary">
-					{ summary }
-				</span>
+				<span className="ai-agent-debug-summary">{ summary }</span>
 				<span className="ai-agent-debug-caret">
 					{ expanded ? '\u25B4' : '\u25BE' }
 				</span>
@@ -94,7 +114,12 @@ export default function DebugPanel( { debug } ) {
 						<span className="ai-agent-debug-value">
 							{ totalTokens.toLocaleString() }
 							<span className="ai-agent-debug-detail">
-								({ ( tokenUsage.prompt || 0 ).toLocaleString() } in / { ( tokenUsage.completion || 0 ).toLocaleString() } out)
+								({ ( tokenUsage.prompt || 0 ).toLocaleString() }{ ' ' }
+								in /{ ' ' }
+								{ (
+									tokenUsage.completion || 0
+								).toLocaleString() }{ ' ' }
+								out)
 							</span>
 						</span>
 					</div>

--- a/src/components/export-dialog.js
+++ b/src/components/export-dialog.js
@@ -10,6 +10,15 @@ import { __ } from '@wordpress/i18n';
  */
 import STORE_NAME from '../store';
 
+/**
+ * Modal dialog for exporting a session in JSON or Markdown format.
+ * Closes on Escape key or click outside.
+ *
+ * @param {Object}   props           - Component props.
+ * @param {number}   props.sessionId - ID of the session to export.
+ * @param {Function} props.onClose   - Callback to close the dialog.
+ * @return {JSX.Element} Export dialog element.
+ */
 export default function ExportDialog( { sessionId, onClose } ) {
 	const [ format, setFormat ] = useState( 'json' );
 	const { exportSession } = useDispatch( STORE_NAME );

--- a/src/components/folder-picker.js
+++ b/src/components/folder-picker.js
@@ -10,6 +10,15 @@ import { __ } from '@wordpress/i18n';
  */
 import STORE_NAME from '../store';
 
+/**
+ * Folder picker for moving a session to an existing or new folder.
+ *
+ * @param {Object}   props               - Component props.
+ * @param {string}   props.currentFolder - The session's current folder name.
+ * @param {Function} props.onSelect      - Called with the selected folder name (empty = remove).
+ * @param {Function} props.onClose       - Called when the picker should close.
+ * @return {JSX.Element} Folder picker element.
+ */
 export default function FolderPicker( { currentFolder, onSelect, onClose } ) {
 	const [ newFolder, setNewFolder ] = useState( '' );
 	const { fetchFolders } = useDispatch( STORE_NAME );
@@ -57,7 +66,7 @@ export default function FolderPicker( { currentFolder, onSelect, onClose } ) {
 			<div className="ai-agent-folder-picker-new">
 				<input
 					type="text"
-					placeholder={ __( 'New folder...', 'ai-agent' ) }
+					placeholder={ __( 'New folder…', 'ai-agent' ) }
 					value={ newFolder }
 					onChange={ ( e ) => setNewFolder( e.target.value ) }
 					onKeyDown={ ( e ) => {

--- a/src/components/import-dialog.js
+++ b/src/components/import-dialog.js
@@ -10,6 +10,15 @@ import { __ } from '@wordpress/i18n';
  */
 import STORE_NAME from '../store';
 
+/**
+ * Modal dialog for importing a session from a JSON file.
+ * Supports drag-and-drop and click-to-browse. Validates the ai-agent-v1 format.
+ * Closes on Escape key.
+ *
+ * @param {Object}   props         - Component props.
+ * @param {Function} props.onClose - Callback to close the dialog.
+ * @return {JSX.Element} Import dialog element.
+ */
 export default function ImportDialog( { onClose } ) {
 	const [ fileData, setFileData ] = useState( null );
 	const [ fileName, setFileName ] = useState( '' );
@@ -28,6 +37,12 @@ export default function ImportDialog( { onClose } ) {
 		return () => document.removeEventListener( 'keydown', handler );
 	}, [ onClose ] );
 
+	/**
+	 * Read and validate a File object as an ai-agent-v1 JSON export.
+	 *
+	 * @param {File} file - The file to read.
+	 * @return {void}
+	 */
 	const handleFile = useCallback( ( file ) => {
 		setError( '' );
 		setFileName( file.name );
@@ -75,9 +90,7 @@ export default function ImportDialog( { onClose } ) {
 		<div className="ai-agent-shortcuts-overlay">
 			<div className="ai-agent-export-dialog" ref={ dialogRef }>
 				<div className="ai-agent-export-header">
-					<h3>
-						{ __( 'Import Conversation', 'ai-agent' ) }
-					</h3>
+					<h3>{ __( 'Import Conversation', 'ai-agent' ) }</h3>
 					<button type="button" onClick={ onClose }>
 						&times;
 					</button>
@@ -89,8 +102,7 @@ export default function ImportDialog( { onClose } ) {
 						onDragOver={ ( e ) => e.preventDefault() }
 						onDrop={ handleDrop }
 						onClick={ () => {
-							const input =
-								document.createElement( 'input' );
+							const input = document.createElement( 'input' );
 							input.type = 'file';
 							input.accept = '.json';
 							input.onchange = ( e ) => {
@@ -108,12 +120,12 @@ export default function ImportDialog( { onClose } ) {
 								{ fileData && (
 									<p>
 										{ fileData.title ||
-											__( 'Untitled', 'ai-agent' ) }{ ' ' }
-										({ ( fileData.messages?.length || 0 ) }{ ' ' }
-										{ __(
-											'messages',
-											'ai-agent'
-										) })
+											__(
+												'Untitled',
+												'ai-agent'
+											) }{ ' ' }
+										({ fileData.messages?.length || 0 }{ ' ' }
+										{ __( 'messages', 'ai-agent' ) })
 									</p>
 								) }
 							</div>

--- a/src/components/markdown-message.js
+++ b/src/components/markdown-message.js
@@ -21,9 +21,7 @@ const components = {
 	code( { inline, className, children, ...props } ) {
 		const match = /language-(\w+)/.exec( className || '' );
 		if ( ! inline && match ) {
-			return (
-				<CodeBlock language={ match[ 1 ] }>{ children }</CodeBlock>
-			);
+			return <CodeBlock language={ match[ 1 ] }>{ children }</CodeBlock>;
 		}
 		if ( ! inline && String( children ).includes( '\n' ) ) {
 			return <CodeBlock>{ children }</CodeBlock>;
@@ -55,12 +53,22 @@ const components = {
 	},
 	// Prevent wrapping image in paragraph.
 	img( { src, alt, ...props } ) {
-		return <img src={ src } alt={ alt || '' } loading="lazy" { ...props } />;
+		return (
+			<img src={ src } alt={ alt || '' } loading="lazy" { ...props } />
+		);
 	},
 };
 
 const remarkPlugins = [ remarkGfm ];
 
+/**
+ * Renders markdown content using ReactMarkdown with GFM support.
+ * Uses custom renderers for code blocks, links, tables, and images.
+ *
+ * @param {Object} props         - Component props.
+ * @param {string} props.content - Markdown string to render.
+ * @return {JSX.Element} Rendered markdown element.
+ */
 export default function MarkdownMessage( { content } ) {
 	const memoizedContent = useMemo( () => content, [ content ] );
 

--- a/src/components/message-actions.js
+++ b/src/components/message-actions.js
@@ -10,6 +10,15 @@ import { __ } from '@wordpress/i18n';
  */
 import STORE_NAME from '../store';
 
+/**
+ * Action buttons for a single message (copy, edit, regenerate).
+ * Shows edit for user messages and regenerate for model messages.
+ *
+ * @param {Object}                     props         - Component props.
+ * @param {import('../store').Message} props.message - The message to act on.
+ * @param {number}                     props.index   - Index of the message in the list.
+ * @return {JSX.Element} Message actions element.
+ */
 export default function MessageActions( { message, index } ) {
 	const [ copied, setCopied ] = useState( false );
 	const [ editing, setEditing ] = useState( false );
@@ -72,10 +81,7 @@ export default function MessageActions( { message, index } ) {
 					>
 						{ __( 'Send', 'ai-agent' ) }
 					</button>
-					<button
-						type="button"
-						onClick={ () => setEditing( false ) }
-					>
+					<button type="button" onClick={ () => setEditing( false ) }>
 						{ __( 'Cancel', 'ai-agent' ) }
 					</button>
 				</div>
@@ -94,7 +100,9 @@ export default function MessageActions( { message, index } ) {
 				onClick={ handleCopy }
 				title={ __( 'Copy', 'ai-agent' ) }
 			>
-				{ copied ? __( 'Copied', 'ai-agent' ) : __( 'Copy', 'ai-agent' ) }
+				{ copied
+					? __( 'Copied', 'ai-agent' )
+					: __( 'Copy', 'ai-agent' ) }
 			</button>
 			{ isUser && (
 				<button

--- a/src/components/message-input.js
+++ b/src/components/message-input.js
@@ -14,10 +14,16 @@ import apiFetch from '@wordpress/api-fetch';
 import STORE_NAME from '../store';
 import SlashCommandMenu from './slash-command-menu';
 
-export default function MessageInput( {
-	compact = false,
-	onSlashCommand,
-} ) {
+/**
+ * Message input area with auto-resize, slash command menu, and send/stop controls.
+ *
+ * @param {Object}   props                  - Component props.
+ * @param {boolean}  [props.compact=false]  - Whether to render in compact mode.
+ * @param {Function} [props.onSlashCommand] - Callback for slash command actions.
+ *                                          Receives (action: string, data?: string).
+ * @return {JSX.Element} Message input element.
+ */
+export default function MessageInput( { compact = false, onSlashCommand } ) {
 	const [ text, setText ] = useState( '' );
 	const [ showSlash, setShowSlash ] = useState( false );
 	const textareaRef = useRef( null );
@@ -76,15 +82,23 @@ export default function MessageInput( {
 					path: '/ai-agent/v1/memory',
 					method: 'POST',
 					data: { category: 'general', content: fact },
-				} ).then( () => {
-					if ( onSlashCommand ) {
-						onSlashCommand( 'notice', __( 'Memory saved.', 'ai-agent' ) );
-					}
-				} ).catch( () => {
-					if ( onSlashCommand ) {
-						onSlashCommand( 'notice', __( 'Failed to save memory.', 'ai-agent' ) );
-					}
-				} );
+				} )
+					.then( () => {
+						if ( onSlashCommand ) {
+							onSlashCommand(
+								'notice',
+								__( 'Memory saved.', 'ai-agent' )
+							);
+						}
+					} )
+					.catch( () => {
+						if ( onSlashCommand ) {
+							onSlashCommand(
+								'notice',
+								__( 'Failed to save memory.', 'ai-agent' )
+							);
+						}
+					} );
 			}
 			setText( '' );
 			return;
@@ -98,20 +112,33 @@ export default function MessageInput( {
 					path: '/ai-agent/v1/memory/forget',
 					method: 'POST',
 					data: { topic },
-				} ).then( ( result ) => {
-					if ( onSlashCommand ) {
-						const count = result?.deleted || 0;
-						onSlashCommand( 'notice',
-							count > 0
-								? `${ count } ${ count === 1 ? __( 'memory', 'ai-agent' ) : __( 'memories', 'ai-agent' ) } ${ __( 'deleted.', 'ai-agent' ) }`
-								: __( 'No matching memories found.', 'ai-agent' )
-						);
-					}
-				} ).catch( () => {
-					if ( onSlashCommand ) {
-						onSlashCommand( 'notice', __( 'Failed to forget memories.', 'ai-agent' ) );
-					}
-				} );
+				} )
+					.then( ( result ) => {
+						if ( onSlashCommand ) {
+							const count = result?.deleted || 0;
+							onSlashCommand(
+								'notice',
+								count > 0
+									? `${ count } ${
+											count === 1
+												? __( 'memory', 'ai-agent' )
+												: __( 'memories', 'ai-agent' )
+									  } ${ __( 'deleted.', 'ai-agent' ) }`
+									: __(
+											'No matching memories found.',
+											'ai-agent'
+									  )
+							);
+						}
+					} )
+					.catch( () => {
+						if ( onSlashCommand ) {
+							onSlashCommand(
+								'notice',
+								__( 'Failed to forget memories.', 'ai-agent' )
+							);
+						}
+					} );
 			}
 			setText( '' );
 			return;
@@ -220,9 +247,7 @@ export default function MessageInput( {
 
 	return (
 		<div
-			className={ `ai-agent-input-area ${
-				compact ? 'is-compact' : ''
-			}` }
+			className={ `ai-agent-input-area ${ compact ? 'is-compact' : '' }` }
 		>
 			{ showSlash && (
 				<SlashCommandMenu
@@ -236,7 +261,7 @@ export default function MessageInput( {
 				className="ai-agent-input"
 				rows={ 1 }
 				placeholder={ __(
-					'Type a message or / for commands...',
+					'Type a message or / for commands…',
 					'ai-agent'
 				) }
 				value={ text }

--- a/src/components/message-list.js
+++ b/src/components/message-list.js
@@ -20,7 +20,7 @@ import DebugPanel from './debug-panel';
  * Suggestions are lines starting with `[suggestion]`.
  *
  * @param {string} text The full response text.
- * @return {{ cleanText: string, suggestions: string[] }}
+ * @return {{ cleanText: string, suggestions: string[] }} Parsed text and suggestion strings.
  */
 function parseSuggestions( text ) {
 	const lines = text.split( '\n' );
@@ -41,10 +41,21 @@ function parseSuggestions( text ) {
 		}
 	}
 
-	const cleanText = lines.slice( 0, lastContentIdx + 1 ).join( '\n' ).trimEnd();
+	const cleanText = lines
+		.slice( 0, lastContentIdx + 1 )
+		.join( '\n' )
+		.trimEnd();
 	return { cleanText, suggestions };
 }
 
+/**
+ * Renders a single message bubble with role-appropriate styling.
+ *
+ * @param {Object} props      - Component props.
+ * @param {string} props.role - Message role: 'user' | 'model' | 'system'.
+ * @param {string} props.text - Message text content.
+ * @return {JSX.Element} Message bubble element.
+ */
 function MessageBubble( { role, text } ) {
 	const classMap = {
 		user: 'ai-agent-bubble ai-agent-user',
@@ -65,6 +76,15 @@ function MessageBubble( { role, text } ) {
 	);
 }
 
+/**
+ * Renders clickable suggestion chips below the last model message.
+ *
+ * @param {Object}   props             - Component props.
+ * @param {string[]} props.suggestions - Suggestion strings to display.
+ * @param {Function} props.onSelect    - Callback when a suggestion is clicked.
+ *                                     Receives the suggestion string.
+ * @return {JSX.Element|null} Suggestion chips, or null if none.
+ */
 function SuggestionChips( { suggestions, onSelect } ) {
 	if ( ! suggestions?.length ) {
 		return null;
@@ -86,6 +106,12 @@ function SuggestionChips( { suggestions, onSelect } ) {
 	);
 }
 
+/**
+ * Extract concatenated text from a message's parts array.
+ *
+ * @param {import('../store').Message} message - Message object.
+ * @return {string} Concatenated text content.
+ */
 function extractText( message ) {
 	if ( ! message.parts?.length ) {
 		return '';
@@ -96,6 +122,12 @@ function extractText( message ) {
 		.join( '' );
 }
 
+/**
+ * Renders the scrollable list of messages for the current session.
+ * Handles auto-scroll, suggestion chips, tool call details, and debug panels.
+ *
+ * @return {JSX.Element} Message list element.
+ */
 export default function MessageList() {
 	const { messages, sending, debugMode } = useSelect( ( select ) => {
 		const store = select( STORE_NAME );
@@ -141,7 +173,10 @@ export default function MessageList() {
 		<div className="ai-agent-messages" ref={ messagesRef }>
 			{ visibleMessages.length === 0 && ! sending && (
 				<div className="ai-agent-empty-state">
-					{ __( 'Send a message to start a conversation.', 'ai-agent' ) }
+					{ __(
+						'Send a message to start a conversation.',
+						'ai-agent'
+					) }
 				</div>
 			) }
 			{ visibleMessages.map( ( msg, i ) => {
@@ -156,9 +191,7 @@ export default function MessageList() {
 					: { cleanText: rawText, suggestions: [] };
 
 				const isLastModel =
-					isModel &&
-					! sending &&
-					i === visibleMessages.length - 1;
+					isModel && ! sending && i === visibleMessages.length - 1;
 
 				return (
 					<div key={ i } className="ai-agent-message-row">
@@ -166,10 +199,7 @@ export default function MessageList() {
 							<ToolCallDetails toolCalls={ msg.toolCalls } />
 						) }
 						<MessageBubble role={ msg.role } text={ cleanText } />
-						<MessageActions
-							message={ msg }
-							index={ i }
-						/>
+						<MessageActions message={ msg } index={ i } />
 						{ debugMode && isModel && msg.debug && (
 							<DebugPanel debug={ msg.debug } />
 						) }
@@ -185,7 +215,7 @@ export default function MessageList() {
 			{ sending && (
 				<div className="ai-agent-bubble ai-agent-assistant ai-agent-thinking">
 					<Spinner />
-					{ __( 'Thinking...', 'ai-agent' ) }
+					{ __( 'Thinking…', 'ai-agent' ) }
 				</div>
 			) }
 		</div>

--- a/src/components/onboarding-wizard.js
+++ b/src/components/onboarding-wizard.js
@@ -3,11 +3,7 @@
  */
 import { useState, useEffect, useCallback } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
-import {
-	Button,
-	ToggleControl,
-	Spinner,
-} from '@wordpress/components';
+import { Button, ToggleControl, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 
@@ -17,6 +13,14 @@ import apiFetch from '@wordpress/api-fetch';
 import STORE_NAME from '../store';
 import ProviderSelector from './provider-selector';
 
+/**
+ * Multi-step onboarding wizard shown on first use.
+ * Steps: Welcome → Provider selection → Abilities configuration → Done.
+ *
+ * @param {Object}   props            - Component props.
+ * @param {Function} props.onComplete - Callback invoked when the wizard is finished or skipped.
+ * @return {JSX.Element} Onboarding wizard element.
+ */
 export default function OnboardingWizard( { onComplete } ) {
 	const [ step, setStep ] = useState( 0 );
 	const [ abilities, setAbilities ] = useState( [] );

--- a/src/components/provider-selector.js
+++ b/src/components/provider-selector.js
@@ -10,6 +10,15 @@ import { __ } from '@wordpress/i18n';
  */
 import STORE_NAME from '../store';
 
+/**
+ * Provider and model selector dropdowns.
+ * Changing the provider auto-selects its first model.
+ *
+ * @param {Object}  props                 - Component props.
+ * @param {boolean} [props.compact=false] - Whether to render in compact mode
+ *                                        (hides labels, uses compact size).
+ * @return {JSX.Element} Provider selector element.
+ */
 export default function ProviderSelector( { compact = false } ) {
 	const { providers, selectedProviderId, selectedModelId, models } =
 		useSelect( ( select ) => {
@@ -22,8 +31,7 @@ export default function ProviderSelector( { compact = false } ) {
 			};
 		}, [] );
 
-	const { setSelectedProvider, setSelectedModel } =
-		useDispatch( STORE_NAME );
+	const { setSelectedProvider, setSelectedModel } = useDispatch( STORE_NAME );
 
 	const providerOptions = providers.map( ( p ) => ( {
 		label: p.name,
@@ -41,7 +49,7 @@ export default function ProviderSelector( { compact = false } ) {
 		? models.map( ( m ) => ( {
 				label: m.name || m.id,
 				value: m.id,
-			} ) )
+		  } ) )
 		: [ { label: __( '(default)', 'ai-agent' ), value: '' } ];
 
 	const onProviderChange = ( value ) => {

--- a/src/components/session-context-menu.js
+++ b/src/components/session-context-menu.js
@@ -11,6 +11,15 @@ import { __ } from '@wordpress/i18n';
 import STORE_NAME from '../store';
 import FolderPicker from './folder-picker';
 
+/**
+ * Context menu for a session item. Provides rename, pin, folder, export,
+ * archive, trash, and restore actions. Closes on click outside.
+ *
+ * @param {Object}                     props         - Component props.
+ * @param {import('../store').Session} props.session - Session data.
+ * @param {Function}                   props.onClose - Callback to close the menu.
+ * @return {JSX.Element} Context menu element.
+ */
 export default function SessionContextMenu( { session, onClose } ) {
 	const [ showFolderPicker, setShowFolderPicker ] = useState( false );
 	const [ isRenaming, setIsRenaming ] = useState( false );

--- a/src/components/session-sidebar.js
+++ b/src/components/session-sidebar.js
@@ -13,6 +13,12 @@ import { plus, upload } from '@wordpress/icons';
 import STORE_NAME from '../store';
 import SessionContextMenu from './session-context-menu';
 
+/**
+ * Format a date string as a relative time label (e.g. 'just now', '3h ago').
+ *
+ * @param {string} dateStr - ISO date string without timezone (UTC assumed).
+ * @return {string} Relative time label.
+ */
 function relativeTime( dateStr ) {
 	if ( ! dateStr ) {
 		return '';
@@ -36,6 +42,14 @@ function relativeTime( dateStr ) {
 	return date.toLocaleDateString();
 }
 
+/**
+ * A single session row in the sidebar list.
+ *
+ * @param {Object}                     props          - Component props.
+ * @param {import('../store').Session} props.session  - Session data.
+ * @param {boolean}                    props.isActive - Whether this session is currently open.
+ * @return {JSX.Element} Session item element.
+ */
 function SessionItem( { session, isActive } ) {
 	const [ showMenu, setShowMenu ] = useState( false );
 	const { openSession } = useDispatch( STORE_NAME );
@@ -96,6 +110,12 @@ function SessionItem( { session, isActive } ) {
 	);
 }
 
+/**
+ * Session sidebar with search, filter tabs, folder navigation, and session list.
+ * Handles session import via file picker.
+ *
+ * @return {JSX.Element} Session sidebar element.
+ */
 export default function SessionSidebar() {
 	const {
 		sessions,
@@ -164,9 +184,7 @@ export default function SessionSidebar() {
 					importSession( data );
 				} catch {
 					// eslint-disable-next-line no-alert
-					window.alert(
-						__( 'Invalid JSON file.', 'ai-agent' )
-					);
+					window.alert( __( 'Invalid JSON file.', 'ai-agent' ) );
 				}
 			};
 			reader.readAsText( file );
@@ -211,7 +229,7 @@ export default function SessionSidebar() {
 				<input
 					type="text"
 					className="ai-agent-sidebar-search"
-					placeholder={ __( 'Search conversations...', 'ai-agent' ) }
+					placeholder={ __( 'Search conversations…', 'ai-agent' ) }
 					onChange={ handleSearchChange }
 				/>
 			</div>
@@ -272,8 +290,7 @@ export default function SessionSidebar() {
 						key={ session.id }
 						session={ session }
 						isActive={
-							currentSessionId ===
-							parseInt( session.id, 10 )
+							currentSessionId === parseInt( session.id, 10 )
 						}
 					/>
 				) ) }

--- a/src/components/shortcuts-help.js
+++ b/src/components/shortcuts-help.js
@@ -9,6 +9,14 @@ import { useEffect, useRef } from '@wordpress/element';
  */
 import { SHORTCUTS } from '../utils/keyboard-shortcuts';
 
+/**
+ * Modal dialog listing all keyboard shortcuts and slash commands.
+ * Closes on Escape key or click outside.
+ *
+ * @param {Object}   props         - Component props.
+ * @param {Function} props.onClose - Callback to close the dialog.
+ * @return {JSX.Element} Shortcuts help dialog element.
+ */
 export default function ShortcutsHelp( { onClose } ) {
 	const dialogRef = useRef( null );
 
@@ -52,10 +60,7 @@ export default function ShortcutsHelp( { onClose } ) {
 				</div>
 				<div className="ai-agent-shortcuts-list">
 					{ SHORTCUTS.map( ( s ) => (
-						<div
-							key={ s.combo }
-							className="ai-agent-shortcut-row"
-						>
+						<div key={ s.combo } className="ai-agent-shortcut-row">
 							<span className="ai-agent-shortcut-label">
 								{ s.label }
 							</span>
@@ -75,21 +80,15 @@ export default function ShortcutsHelp( { onClose } ) {
 					</div>
 					<div className="ai-agent-shortcut-row">
 						<span>/model</span>
-						<span>
-							{ __( 'Switch model', 'ai-agent' ) }
-						</span>
+						<span>{ __( 'Switch model', 'ai-agent' ) }</span>
 					</div>
 					<div className="ai-agent-shortcut-row">
 						<span>/clear</span>
-						<span>
-							{ __( 'Clear conversation', 'ai-agent' ) }
-						</span>
+						<span>{ __( 'Clear conversation', 'ai-agent' ) }</span>
 					</div>
 					<div className="ai-agent-shortcut-row">
 						<span>/export</span>
-						<span>
-							{ __( 'Export conversation', 'ai-agent' ) }
-						</span>
+						<span>{ __( 'Export conversation', 'ai-agent' ) }</span>
 					</div>
 					<div className="ai-agent-shortcut-row">
 						<span>/compact</span>
@@ -99,9 +98,7 @@ export default function ShortcutsHelp( { onClose } ) {
 					</div>
 					<div className="ai-agent-shortcut-row">
 						<span>/help</span>
-						<span>
-							{ __( 'Show shortcuts', 'ai-agent' ) }
-						</span>
+						<span>{ __( 'Show shortcuts', 'ai-agent' ) }</span>
 					</div>
 				</div>
 			</div>

--- a/src/components/slash-command-menu.js
+++ b/src/components/slash-command-menu.js
@@ -17,7 +17,10 @@ const COMMANDS = [
 	},
 	{
 		name: '/remember',
-		description: __( 'Save a fact to memory (type fact after)', 'ai-agent' ),
+		description: __(
+			'Save a fact to memory (type fact after)',
+			'ai-agent'
+		),
 		action: 'remember',
 	},
 	{
@@ -47,11 +50,33 @@ const COMMANDS = [
 	},
 	{
 		name: '/debug',
-		description: __( 'Toggle debug mode (per-response metrics)', 'ai-agent' ),
+		description: __(
+			'Toggle debug mode (per-response metrics)',
+			'ai-agent'
+		),
 		action: 'debug',
 	},
 ];
 
+/**
+ * @typedef {Object} SlashCommand
+ * @property {string} name        - Command string (e.g. '/new').
+ * @property {string} description - Human-readable description.
+ * @property {string} action      - Action identifier passed to onSelect.
+ */
+
+/**
+ * Autocomplete menu for slash commands. Filters commands by the current input,
+ * supports keyboard navigation (arrow keys, Enter, Tab, Escape).
+ * Returns null when no commands match the filter.
+ *
+ * @param {Object}   props            - Component props.
+ * @param {string}   props.filter     - Current input text used to filter commands.
+ * @param {Function} props.onSelect   - Called with the selected SlashCommand object.
+ * @param {Function} props.onClose    - Called when the menu should close.
+ * @param {Object}   [props.position] - Optional position override (e.g. { bottom: '...' }).
+ * @return {JSX.Element|null} Slash command menu, or null if no matches.
+ */
 export default function SlashCommandMenu( {
 	filter,
 	onSelect,
@@ -116,9 +141,7 @@ export default function SlashCommandMenu( {
 					onClick={ () => onSelect( cmd ) }
 					onMouseEnter={ () => setSelectedIndex( i ) }
 				>
-					<span className="ai-agent-slash-name">
-						{ cmd.name }
-					</span>
+					<span className="ai-agent-slash-name">{ cmd.name }</span>
 					<span className="ai-agent-slash-desc">
 						{ cmd.description }
 					</span>

--- a/src/components/tool-call-details.js
+++ b/src/components/tool-call-details.js
@@ -3,6 +3,14 @@
  */
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Collapsible details panel showing tool calls and their results.
+ * Returns null when there are no tool calls.
+ *
+ * @param {Object}                        props           - Component props.
+ * @param {import('../store').ToolCall[]} props.toolCalls - Tool call entries to display.
+ * @return {JSX.Element|null} Tool call details element, or null if empty.
+ */
 export default function ToolCallDetails( { toolCalls } ) {
 	if ( ! toolCalls?.length ) {
 		return null;
@@ -51,7 +59,7 @@ export default function ToolCallDetails( { toolCalls } ) {
 														entry.response,
 														null,
 														2
-													),
+												  ),
 											500
 										) }
 									</pre>
@@ -65,6 +73,13 @@ export default function ToolCallDetails( { toolCalls } ) {
 	);
 }
 
+/**
+ * Truncate a string to a maximum length, appending '...' if truncated.
+ *
+ * @param {string} str - Input string.
+ * @param {number} max - Maximum character length.
+ * @return {string} Truncated string.
+ */
 function truncate( str, max ) {
 	if ( ! str ) {
 		return '';

--- a/src/components/tool-confirmation-dialog.js
+++ b/src/components/tool-confirmation-dialog.js
@@ -4,6 +4,16 @@
 import { useState, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Modal dialog asking the user to confirm or deny pending tool calls.
+ * Closes on Escape key. Returns null when there is no pending confirmation.
+ *
+ * @param {Object}                                 props              - Component props.
+ * @param {import('../store').PendingConfirmation} props.confirmation - Pending confirmation data.
+ * @param {Function}                               props.onConfirm    - Called with (alwaysAllow: boolean).
+ * @param {Function}                               props.onReject     - Called when the user denies.
+ * @return {JSX.Element|null} Confirmation dialog, or null if no confirmation pending.
+ */
 export default function ToolConfirmationDialog( {
 	confirmation,
 	onConfirm,
@@ -30,12 +40,7 @@ export default function ToolConfirmationDialog( {
 		<div className="ai-agent-shortcuts-overlay">
 			<div className="ai-agent-tool-confirm-dialog" ref={ dialogRef }>
 				<div className="ai-agent-tool-confirm-header">
-					<h3>
-						{ __(
-							'Tool Confirmation Required',
-							'ai-agent'
-						) }
-					</h3>
+					<h3>{ __( 'Tool Confirmation Required', 'ai-agent' ) }</h3>
 				</div>
 				<div className="ai-agent-tool-confirm-body">
 					<p className="ai-agent-tool-confirm-desc">

--- a/src/floating-widget/floating-button.js
+++ b/src/floating-widget/floating-button.js
@@ -11,6 +11,11 @@ import { Icon, comment } from '@wordpress/icons';
  */
 import STORE_NAME from '../store';
 
+/**
+ * Floating action button that opens the AI Agent chat panel.
+ *
+ * @return {JSX.Element} Floating button element.
+ */
 export default function FloatingButton() {
 	const { setFloatingOpen } = useDispatch( STORE_NAME );
 

--- a/src/floating-widget/floating-panel.js
+++ b/src/floating-widget/floating-panel.js
@@ -14,6 +14,12 @@ import ChatPanel from '../components/chat-panel';
 import SessionTabs from './session-tabs';
 import useDrag from './use-drag';
 
+/**
+ * Floating chat panel with draggable titlebar, minimize/close controls,
+ * session tabs, and the compact chat panel.
+ *
+ * @return {JSX.Element} Floating panel element.
+ */
 export default function FloatingPanel() {
 	const { setFloatingOpen, setFloatingMinimized, clearCurrentSession } =
 		useDispatch( STORE_NAME );
@@ -26,8 +32,7 @@ export default function FloatingPanel() {
 		[]
 	);
 
-	const { position, isDragging, handleMouseDown, resetPosition } =
-		useDrag();
+	const { position, isDragging, handleMouseDown, resetPosition } = useDrag();
 
 	// Build inline styles for custom position.
 	const panelStyle = {};
@@ -80,9 +85,7 @@ export default function FloatingPanel() {
 								? __( 'Expand', 'ai-agent' )
 								: __( 'Minimize', 'ai-agent' )
 						}
-						onClick={ () =>
-							setFloatingMinimized( ! isMinimized )
-						}
+						onClick={ () => setFloatingMinimized( ! isMinimized ) }
 					/>
 					<Button
 						icon={ close }

--- a/src/floating-widget/index.js
+++ b/src/floating-widget/index.js
@@ -13,6 +13,13 @@ import FloatingButton from './floating-button';
 import FloatingPanel from './floating-panel';
 import './style.css';
 
+/**
+ * Root floating widget component. Renders either the floating button or the
+ * floating panel depending on open state. Fetches providers and sessions on mount
+ * and gathers page context.
+ *
+ * @return {JSX.Element} Floating widget element.
+ */
 function FloatingWidget() {
 	const { fetchProviders, fetchSessions, setPageContext } =
 		useDispatch( STORE_NAME );
@@ -43,9 +50,10 @@ function FloatingWidget() {
 }
 
 /**
- * Gather structured context about the current admin page.
+ * Gather structured context about the current WordPress admin page.
  *
- * Returns an object with url, admin_page, screen_id, post_id.
+ * @return {{url: string, admin_page?: string, screen_id?: string, post_id?: number, page_title?: string}}
+ *   Page context object with available fields populated from the DOM and window globals.
  */
 function gatherPageContext() {
 	const context = {

--- a/src/floating-widget/session-tabs.js
+++ b/src/floating-widget/session-tabs.js
@@ -11,6 +11,12 @@ import { plus } from '@wordpress/icons';
  */
 import STORE_NAME from '../store';
 
+/**
+ * Horizontal tab bar showing up to 5 recent sessions in the floating panel.
+ * Returns null when there are no sessions.
+ *
+ * @return {JSX.Element|null} Session tabs element, or null if no sessions.
+ */
 export default function SessionTabs() {
 	const { sessions, currentSessionId } = useSelect(
 		( select ) => ( {

--- a/src/floating-widget/use-drag.js
+++ b/src/floating-widget/use-drag.js
@@ -6,10 +6,25 @@ import { useState, useRef, useCallback, useEffect } from '@wordpress/element';
 const STORAGE_KEY = 'aiAgentWidgetPosition';
 
 /**
+ * @typedef {Object} DragPosition
+ * @property {number} x - Left offset in pixels.
+ * @property {number} y - Top offset in pixels.
+ */
+
+/**
+ * @typedef {Object} UseDragReturn
+ * @property {DragPosition|null} position        - Current panel position, or null for CSS default.
+ * @property {boolean}           isDragging      - Whether the panel is currently being dragged.
+ * @property {Function}          handleMouseDown - mousedown handler to attach to the drag handle.
+ * @property {Function}          resetPosition   - Resets position to CSS default and clears localStorage.
+ */
+
+/**
  * Custom hook for making the floating panel draggable.
+ * Persists position to localStorage under 'aiAgentWidgetPosition'.
+ * Clamps position to the viewport on drag.
  *
- * Returns position, isDragging, handleMouseDown, and resetPosition.
- * Position is null when using CSS default (bottom-right).
+ * @return {UseDragReturn} Drag state and handlers.
  */
 export default function useDrag() {
 	const [ position, setPosition ] = useState( () => {
@@ -25,6 +40,13 @@ export default function useDrag() {
 	const dragOffset = useRef( { x: 0, y: 0 } );
 	const panelRef = useRef( null );
 
+	/**
+	 * Clamp a position to keep the panel fully within the viewport.
+	 *
+	 * @param {number} x - Desired left offset.
+	 * @param {number} y - Desired top offset.
+	 * @return {DragPosition} Clamped position.
+	 */
 	const clampToViewport = useCallback( ( x, y ) => {
 		const vw = window.innerWidth;
 		const vh = window.innerHeight;
@@ -37,31 +59,28 @@ export default function useDrag() {
 		};
 	}, [] );
 
-	const handleMouseDown = useCallback(
-		( e ) => {
-			// Only left button.
-			if ( e.button !== 0 ) {
-				return;
-			}
+	const handleMouseDown = useCallback( ( e ) => {
+		// Only left button.
+		if ( e.button !== 0 ) {
+			return;
+		}
 
-			const panel = e.target.closest( '.ai-agent-floating-panel' );
-			if ( ! panel ) {
-				return;
-			}
+		const panel = e.target.closest( '.ai-agent-floating-panel' );
+		if ( ! panel ) {
+			return;
+		}
 
-			panelRef.current = panel;
-			const rect = panel.getBoundingClientRect();
-			dragOffset.current = {
-				x: e.clientX - rect.left,
-				y: e.clientY - rect.top,
-			};
+		panelRef.current = panel;
+		const rect = panel.getBoundingClientRect();
+		dragOffset.current = {
+			x: e.clientX - rect.left,
+			y: e.clientY - rect.top,
+		};
 
-			setIsDragging( true );
-			document.body.style.userSelect = 'none';
-			e.preventDefault();
-		},
-		[]
-	);
+		setIsDragging( true );
+		document.body.style.userSelect = 'none';
+		e.preventDefault();
+	}, [] );
 
 	useEffect( () => {
 		if ( ! isDragging ) {

--- a/src/settings-page/automations-manager.js
+++ b/src/settings-page/automations-manager.js
@@ -34,6 +34,12 @@ function emptyForm() {
 	};
 }
 
+/**
+ * Automations management UI. Allows creating scheduled and trigger-based
+ * automations that run agent tasks automatically.
+ *
+ * @return {JSX.Element} Automations manager element.
+ */
 export default function AutomationsManager() {
 	const [ automations, setAutomations ] = useState( [] );
 	const [ loaded, setLoaded ] = useState( false );
@@ -52,7 +58,9 @@ export default function AutomationsManager() {
 			const [ result, tpl, prof ] = await Promise.all( [
 				apiFetch( { path: '/ai-agent/v1/automations' } ),
 				apiFetch( { path: '/ai-agent/v1/automation-templates' } ),
-				apiFetch( { path: '/ai-agent/v1/tool-profiles' } ).catch( () => [] ),
+				apiFetch( { path: '/ai-agent/v1/tool-profiles' } ).catch(
+					() => []
+				),
 			] );
 			setAutomations( result );
 			setTemplates( tpl );
@@ -98,9 +106,15 @@ export default function AutomationsManager() {
 			}
 			resetForm();
 			fetchAll();
-			setNotice( { status: 'success', message: __( 'Automation saved.', 'ai-agent' ) } );
+			setNotice( {
+				status: 'success',
+				message: __( 'Automation saved.', 'ai-agent' ),
+			} );
 		} catch ( err ) {
-			setNotice( { status: 'error', message: err.message || __( 'Failed to save.', 'ai-agent' ) } );
+			setNotice( {
+				status: 'error',
+				message: err.message || __( 'Failed to save.', 'ai-agent' ),
+			} );
 		}
 	}, [ form, editId, resetForm, fetchAll ] );
 
@@ -118,63 +132,78 @@ export default function AutomationsManager() {
 		setShowForm( true );
 	}, [] );
 
-	const handleDelete = useCallback( async ( id ) => {
-		// eslint-disable-next-line no-alert
-		if ( window.confirm( __( 'Delete this automation?', 'ai-agent' ) ) ) {
+	const handleDelete = useCallback(
+		async ( id ) => {
+			// eslint-disable-next-line no-alert
+			if (
+				window.confirm( __( 'Delete this automation?', 'ai-agent' ) )
+			) {
+				await apiFetch( {
+					path: `/ai-agent/v1/automations/${ id }`,
+					method: 'DELETE',
+				} );
+				fetchAll();
+			}
+		},
+		[ fetchAll ]
+	);
+
+	const handleToggle = useCallback(
+		async ( auto ) => {
 			await apiFetch( {
-				path: `/ai-agent/v1/automations/${ id }`,
-				method: 'DELETE',
+				path: `/ai-agent/v1/automations/${ auto.id }`,
+				method: 'PATCH',
+				data: { enabled: ! auto.enabled },
 			} );
 			fetchAll();
-		}
-	}, [ fetchAll ] );
+		},
+		[ fetchAll ]
+	);
 
-	const handleToggle = useCallback( async ( auto ) => {
-		await apiFetch( {
-			path: `/ai-agent/v1/automations/${ auto.id }`,
-			method: 'PATCH',
-			data: { enabled: ! auto.enabled },
-		} );
-		fetchAll();
-	}, [ fetchAll ] );
+	const handleRun = useCallback(
+		async ( id ) => {
+			setRunning( id );
+			setNotice( null );
+			try {
+				const result = await apiFetch( {
+					path: `/ai-agent/v1/automations/${ id }/run`,
+					method: 'POST',
+				} );
+				setNotice( {
+					status: result.success ? 'success' : 'warning',
+					message: result.success
+						? __( 'Automation ran successfully.', 'ai-agent' )
+						: result.error ||
+						  __( 'Automation completed with errors.', 'ai-agent' ),
+				} );
+				fetchAll();
+			} catch ( err ) {
+				setNotice( { status: 'error', message: err.message } );
+			}
+			setRunning( null );
+		},
+		[ fetchAll ]
+	);
 
-	const handleRun = useCallback( async ( id ) => {
-		setRunning( id );
-		setNotice( null );
-		try {
-			const result = await apiFetch( {
-				path: `/ai-agent/v1/automations/${ id }/run`,
-				method: 'POST',
-			} );
-			setNotice( {
-				status: result.success ? 'success' : 'warning',
-				message: result.success
-					? __( 'Automation ran successfully.', 'ai-agent' )
-					: ( result.error || __( 'Automation completed with errors.', 'ai-agent' ) ),
-			} );
-			fetchAll();
-		} catch ( err ) {
-			setNotice( { status: 'error', message: err.message } );
-		}
-		setRunning( null );
-	}, [ fetchAll ] );
-
-	const handleViewLogs = useCallback( async ( id ) => {
-		if ( viewLogsId === id ) {
-			setViewLogsId( null );
-			setLogs( [] );
-			return;
-		}
-		try {
-			const result = await apiFetch( {
-				path: `/ai-agent/v1/automations/${ id }/logs`,
-			} );
-			setLogs( result );
-			setViewLogsId( id );
-		} catch {
-			setLogs( [] );
-		}
-	}, [ viewLogsId ] );
+	const handleViewLogs = useCallback(
+		async ( id ) => {
+			if ( viewLogsId === id ) {
+				setViewLogsId( null );
+				setLogs( [] );
+				return;
+			}
+			try {
+				const result = await apiFetch( {
+					path: `/ai-agent/v1/automations/${ id }/logs`,
+				} );
+				setLogs( result );
+				setViewLogsId( id );
+			} catch {
+				setLogs( [] );
+			}
+		},
+		[ viewLogsId ]
+	);
 
 	const handleUseTemplate = useCallback( ( tpl ) => {
 		setForm( {
@@ -199,14 +228,20 @@ export default function AutomationsManager() {
 				<div>
 					<h3>{ __( 'Scheduled Automations', 'ai-agent' ) }</h3>
 					<p className="description">
-						{ __( 'Cron-based AI tasks that run on a schedule.', 'ai-agent' ) }
+						{ __(
+							'Cron-based AI tasks that run on a schedule.',
+							'ai-agent'
+						) }
 					</p>
 				</div>
 				{ ! showForm && (
 					<Button
 						variant="secondary"
 						icon={ plus }
-						onClick={ () => { resetForm(); setShowForm( true ); } }
+						onClick={ () => {
+							resetForm();
+							setShowForm( true );
+						} }
 						size="compact"
 					>
 						{ __( 'Add Automation', 'ai-agent' ) }
@@ -224,37 +259,44 @@ export default function AutomationsManager() {
 				</Notice>
 			) }
 
-			{ ! showForm && templates.length > 0 && automations.length === 0 && (
-				<div style={ { marginBottom: '16px' } }>
-					<h4>{ __( 'Quick Start Templates', 'ai-agent' ) }</h4>
-					<div className="ai-agent-skill-cards">
-						{ templates.map( ( tpl, idx ) => (
-							<div key={ idx } className="ai-agent-skill-card">
-								<div className="ai-agent-skill-card-header">
-									<div className="ai-agent-skill-card-title">
-										<strong>{ tpl.name }</strong>
+			{ ! showForm &&
+				templates.length > 0 &&
+				automations.length === 0 && (
+					<div style={ { marginBottom: '16px' } }>
+						<h4>{ __( 'Quick Start Templates', 'ai-agent' ) }</h4>
+						<div className="ai-agent-skill-cards">
+							{ templates.map( ( tpl, idx ) => (
+								<div
+									key={ idx }
+									className="ai-agent-skill-card"
+								>
+									<div className="ai-agent-skill-card-header">
+										<div className="ai-agent-skill-card-title">
+											<strong>{ tpl.name }</strong>
+										</div>
+									</div>
+									<p className="ai-agent-skill-card-description">
+										{ tpl.description }
+									</p>
+									<div className="ai-agent-skill-card-footer">
+										<span className="ai-agent-skill-word-count">
+											{ tpl.schedule }
+										</span>
+										<Button
+											variant="secondary"
+											size="compact"
+											onClick={ () =>
+												handleUseTemplate( tpl )
+											}
+										>
+											{ __( 'Use Template', 'ai-agent' ) }
+										</Button>
 									</div>
 								</div>
-								<p className="ai-agent-skill-card-description">
-									{ tpl.description }
-								</p>
-								<div className="ai-agent-skill-card-footer">
-									<span className="ai-agent-skill-word-count">
-										{ tpl.schedule }
-									</span>
-									<Button
-										variant="secondary"
-										size="compact"
-										onClick={ () => handleUseTemplate( tpl ) }
-									>
-										{ __( 'Use Template', 'ai-agent' ) }
-									</Button>
-								</div>
-							</div>
-						) ) }
+							) ) }
+						</div>
 					</div>
-				</div>
-			) }
+				) }
 
 			{ showForm && (
 				<div className="ai-agent-skill-form">
@@ -275,7 +317,10 @@ export default function AutomationsManager() {
 						value={ form.prompt }
 						onChange={ ( v ) => updateForm( 'prompt', v ) }
 						rows={ 6 }
-						help={ __( 'The instruction sent to the AI when this automation runs.', 'ai-agent' ) }
+						help={ __(
+							'The instruction sent to the AI when this automation runs.',
+							'ai-agent'
+						) }
 					/>
 					<SelectControl
 						label={ __( 'Schedule', 'ai-agent' ) }
@@ -289,7 +334,10 @@ export default function AutomationsManager() {
 						value={ form.tool_profile }
 						options={ profileOptions }
 						onChange={ ( v ) => updateForm( 'tool_profile', v ) }
-						help={ __( 'Restrict which tools this automation can use.', 'ai-agent' ) }
+						help={ __(
+							'Restrict which tools this automation can use.',
+							'ai-agent'
+						) }
 						__nextHasNoMarginBottom
 					/>
 					<TextControl
@@ -298,19 +346,32 @@ export default function AutomationsManager() {
 						min={ 1 }
 						max={ 50 }
 						value={ form.max_iterations }
-						onChange={ ( v ) => updateForm( 'max_iterations', parseInt( v, 10 ) || 10 ) }
+						onChange={ ( v ) =>
+							updateForm(
+								'max_iterations',
+								parseInt( v, 10 ) || 10
+							)
+						}
 						__nextHasNoMarginBottom
 					/>
 					<div className="ai-agent-skill-form-actions">
 						<Button
 							variant="primary"
 							onClick={ handleSubmit }
-							disabled={ ! form.name.trim() || ! form.prompt.trim() }
+							disabled={
+								! form.name.trim() || ! form.prompt.trim()
+							}
 							size="compact"
 						>
-							{ editId ? __( 'Update', 'ai-agent' ) : __( 'Create', 'ai-agent' ) }
+							{ editId
+								? __( 'Update', 'ai-agent' )
+								: __( 'Create', 'ai-agent' ) }
 						</Button>
-						<Button variant="tertiary" onClick={ resetForm } size="compact">
+						<Button
+							variant="tertiary"
+							onClick={ resetForm }
+							size="compact"
+						>
 							{ __( 'Cancel', 'ai-agent' ) }
 						</Button>
 					</div>
@@ -318,15 +379,22 @@ export default function AutomationsManager() {
 			) }
 
 			{ ! loaded && (
-				<p className="description">{ __( 'Loading...', 'ai-agent' ) }</p>
+				<p className="description">{ __( 'Loading…', 'ai-agent' ) }</p>
 			) }
 
 			{ loaded && automations.length > 0 && (
-				<div className="ai-agent-skill-cards" style={ { marginTop: '16px' } }>
+				<div
+					className="ai-agent-skill-cards"
+					style={ { marginTop: '16px' } }
+				>
 					{ automations.map( ( auto ) => (
 						<div
 							key={ auto.id }
-							className={ `ai-agent-skill-card ${ ! auto.enabled ? 'ai-agent-skill-card--disabled' : '' }` }
+							className={ `ai-agent-skill-card ${
+								! auto.enabled
+									? 'ai-agent-skill-card--disabled'
+									: ''
+							}` }
 						>
 							<div className="ai-agent-skill-card-header">
 								<ToggleControl
@@ -342,13 +410,20 @@ export default function AutomationsManager() {
 								</div>
 							</div>
 							<p className="ai-agent-skill-card-description">
-								{ auto.description || auto.prompt.slice( 0, 100 ) + '...' }
+								{ auto.description ||
+									auto.prompt.slice( 0, 100 ) + '...' }
 							</p>
 							<div className="ai-agent-skill-card-footer">
 								<span className="ai-agent-skill-word-count">
-									{ auto.run_count }{ ' ' }{ __( 'runs', 'ai-agent' ) }
+									{ auto.run_count }{ ' ' }
+									{ __( 'runs', 'ai-agent' ) }
 									{ auto.last_run_at && (
-										<> &middot; { __( 'Last:', 'ai-agent' ) } { auto.last_run_at }</>
+										<>
+											{ ' ' }
+											&middot;{ ' ' }
+											{ __( 'Last:', 'ai-agent' ) }{ ' ' }
+											{ auto.last_run_at }
+										</>
 									) }
 								</span>
 								<div className="ai-agent-skill-card-actions">
@@ -358,14 +433,22 @@ export default function AutomationsManager() {
 										onClick={ () => handleRun( auto.id ) }
 										disabled={ running === auto.id }
 									>
-										{ running === auto.id ? <Spinner /> : __( 'Run Now', 'ai-agent' ) }
+										{ running === auto.id ? (
+											<Spinner />
+										) : (
+											__( 'Run Now', 'ai-agent' )
+										) }
 									</Button>
 									<Button
 										variant="tertiary"
 										size="small"
-										onClick={ () => handleViewLogs( auto.id ) }
+										onClick={ () =>
+											handleViewLogs( auto.id )
+										}
 									>
-										{ viewLogsId === auto.id ? __( 'Hide Logs', 'ai-agent' ) : __( 'Logs', 'ai-agent' ) }
+										{ viewLogsId === auto.id
+											? __( 'Hide Logs', 'ai-agent' )
+											: __( 'Logs', 'ai-agent' ) }
 									</Button>
 									<Button
 										icon={ pencil }
@@ -378,7 +461,9 @@ export default function AutomationsManager() {
 										size="small"
 										label={ __( 'Delete', 'ai-agent' ) }
 										isDestructive
-										onClick={ () => handleDelete( auto.id ) }
+										onClick={ () =>
+											handleDelete( auto.id )
+										}
 									/>
 								</div>
 							</div>
@@ -386,27 +471,49 @@ export default function AutomationsManager() {
 							{ viewLogsId === auto.id && (
 								<div className="ai-agent-automation-logs">
 									{ logs.length === 0 && (
-										<p className="description">{ __( 'No logs yet.', 'ai-agent' ) }</p>
+										<p className="description">
+											{ __( 'No logs yet.', 'ai-agent' ) }
+										</p>
 									) }
 									{ logs.map( ( log ) => (
-										<div key={ log.id } className={ `ai-agent-log-entry ai-agent-log--${ log.status }` }>
+										<div
+											key={ log.id }
+											className={ `ai-agent-log-entry ai-agent-log--${ log.status }` }
+										>
 											<div className="ai-agent-log-meta">
-												<span className={ `ai-agent-log-status ai-agent-log-status--${ log.status }` }>
+												<span
+													className={ `ai-agent-log-status ai-agent-log-status--${ log.status }` }
+												>
 													{ log.status }
 												</span>
 												<span>{ log.created_at }</span>
-												<span>{ log.duration_ms }ms</span>
+												<span>
+													{ log.duration_ms }ms
+												</span>
 												{ log.prompt_tokens > 0 && (
-													<span>{ log.prompt_tokens + log.completion_tokens } tokens</span>
+													<span>
+														{ log.prompt_tokens +
+															log.completion_tokens }{ ' ' }
+														tokens
+													</span>
 												) }
 											</div>
 											{ log.error_message && (
-												<p className="ai-agent-log-error">{ log.error_message }</p>
+												<p className="ai-agent-log-error">
+													{ log.error_message }
+												</p>
 											) }
 											{ log.reply && (
 												<details>
-													<summary>{ __( 'Response', 'ai-agent' ) }</summary>
-													<pre className="ai-agent-log-reply">{ log.reply }</pre>
+													<summary>
+														{ __(
+															'Response',
+															'ai-agent'
+														) }
+													</summary>
+													<pre className="ai-agent-log-reply">
+														{ log.reply }
+													</pre>
 												</details>
 											) }
 										</div>

--- a/src/settings-page/custom-tools-manager.js
+++ b/src/settings-page/custom-tools-manager.js
@@ -40,6 +40,12 @@ function emptyForm() {
 	};
 }
 
+/**
+ * Custom tools management UI. Allows creating and editing custom tool definitions
+ * with JSON schema parameters.
+ *
+ * @return {JSX.Element} Custom tools manager element.
+ */
 export default function CustomToolsManager() {
 	const [ tools, setTools ] = useState( [] );
 	const [ loaded, setLoaded ] = useState( false );
@@ -51,7 +57,9 @@ export default function CustomToolsManager() {
 
 	const fetchTools = useCallback( async () => {
 		try {
-			const result = await apiFetch( { path: '/ai-agent/v1/custom-tools' } );
+			const result = await apiFetch( {
+				path: '/ai-agent/v1/custom-tools',
+			} );
 			setTools( result );
 		} catch {
 			setTools( [] );
@@ -89,8 +97,14 @@ export default function CustomToolsManager() {
 		try {
 			const data = {
 				...form,
-				config: typeof form.config === 'string' ? JSON.parse( form.config ) : form.config,
-				input_schema: typeof form.input_schema === 'string' ? JSON.parse( form.input_schema ) : form.input_schema,
+				config:
+					typeof form.config === 'string'
+						? JSON.parse( form.config )
+						: form.config,
+				input_schema:
+					typeof form.input_schema === 'string'
+						? JSON.parse( form.input_schema )
+						: form.input_schema,
 			};
 			if ( editId ) {
 				await apiFetch( {
@@ -107,9 +121,16 @@ export default function CustomToolsManager() {
 			}
 			resetForm();
 			fetchTools();
-			setNotice( { status: 'success', message: __( 'Tool saved.', 'ai-agent' ) } );
+			setNotice( {
+				status: 'success',
+				message: __( 'Tool saved.', 'ai-agent' ),
+			} );
 		} catch ( err ) {
-			setNotice( { status: 'error', message: err.message || __( 'Failed to save tool.', 'ai-agent' ) } );
+			setNotice( {
+				status: 'error',
+				message:
+					err.message || __( 'Failed to save tool.', 'ai-agent' ),
+			} );
 		}
 	}, [ form, editId, resetForm, fetchTools ] );
 
@@ -128,25 +149,33 @@ export default function CustomToolsManager() {
 		setTestResult( null );
 	}, [] );
 
-	const handleDelete = useCallback( async ( id ) => {
-		// eslint-disable-next-line no-alert
-		if ( window.confirm( __( 'Delete this custom tool?', 'ai-agent' ) ) ) {
+	const handleDelete = useCallback(
+		async ( id ) => {
+			// eslint-disable-next-line no-alert
+			if (
+				window.confirm( __( 'Delete this custom tool?', 'ai-agent' ) )
+			) {
+				await apiFetch( {
+					path: `/ai-agent/v1/custom-tools/${ id }`,
+					method: 'DELETE',
+				} );
+				fetchTools();
+			}
+		},
+		[ fetchTools ]
+	);
+
+	const handleToggle = useCallback(
+		async ( tool ) => {
 			await apiFetch( {
-				path: `/ai-agent/v1/custom-tools/${ id }`,
-				method: 'DELETE',
+				path: `/ai-agent/v1/custom-tools/${ tool.id }`,
+				method: 'PATCH',
+				data: { enabled: ! tool.enabled },
 			} );
 			fetchTools();
-		}
-	}, [ fetchTools ] );
-
-	const handleToggle = useCallback( async ( tool ) => {
-		await apiFetch( {
-			path: `/ai-agent/v1/custom-tools/${ tool.id }`,
-			method: 'PATCH',
-			data: { enabled: ! tool.enabled },
-		} );
-		fetchTools();
-	}, [ fetchTools ] );
+		},
+		[ fetchTools ]
+	);
 
 	const handleTest = useCallback( async () => {
 		if ( ! editId ) {
@@ -184,12 +213,19 @@ export default function CustomToolsManager() {
 							value={ cfg.url || '' }
 							onChange={ ( v ) => updateConfig( 'url', v ) }
 							placeholder="https://api.example.com/endpoint?q={{query}}"
-							help={ __( 'Use {{param}} placeholders for dynamic values.', 'ai-agent' ) }
+							help={ __(
+								'Use {{param}} placeholders for dynamic values.',
+								'ai-agent'
+							) }
 							__nextHasNoMarginBottom
 						/>
 						<TextareaControl
 							label={ __( 'Headers (JSON)', 'ai-agent' ) }
-							value={ typeof cfg.headers === 'object' ? JSON.stringify( cfg.headers, null, 2 ) : ( cfg.headers || '{}' ) }
+							value={
+								typeof cfg.headers === 'object'
+									? JSON.stringify( cfg.headers, null, 2 )
+									: cfg.headers || '{}'
+							}
 							onChange={ ( v ) => updateConfig( 'headers', v ) }
 							rows={ 3 }
 						/>
@@ -198,7 +234,10 @@ export default function CustomToolsManager() {
 							value={ cfg.body || '' }
 							onChange={ ( v ) => updateConfig( 'body', v ) }
 							rows={ 3 }
-							help={ __( 'Use {{param}} placeholders. Leave empty for GET requests.', 'ai-agent' ) }
+							help={ __(
+								'Use {{param}} placeholders. Leave empty for GET requests.',
+								'ai-agent'
+							) }
 						/>
 					</>
 				);
@@ -211,7 +250,10 @@ export default function CustomToolsManager() {
 							value={ cfg.hook_name || '' }
 							onChange={ ( v ) => updateConfig( 'hook_name', v ) }
 							placeholder="my_custom_action"
-							help={ __( 'The WordPress action hook to call via do_action().', 'ai-agent' ) }
+							help={ __(
+								'The WordPress action hook to call via do_action().',
+								'ai-agent'
+							) }
 							__nextHasNoMarginBottom
 						/>
 					</>
@@ -225,7 +267,10 @@ export default function CustomToolsManager() {
 							value={ cfg.command || '' }
 							onChange={ ( v ) => updateConfig( 'command', v ) }
 							placeholder="cache flush"
-							help={ __( 'Command to run (without the "wp" prefix). Use {{param}} placeholders.', 'ai-agent' ) }
+							help={ __(
+								'Command to run (without the "wp" prefix). Use {{param}} placeholders.',
+								'ai-agent'
+							) }
 							__nextHasNoMarginBottom
 						/>
 					</>
@@ -242,7 +287,10 @@ export default function CustomToolsManager() {
 				<div>
 					<h3>{ __( 'Custom Tools', 'ai-agent' ) }</h3>
 					<p className="description">
-						{ __( 'Create custom tools that the AI can use — HTTP APIs, WordPress actions, or WP-CLI commands.', 'ai-agent' ) }
+						{ __(
+							'Create custom tools that the AI can use — HTTP APIs, WordPress actions, or WP-CLI commands.',
+							'ai-agent'
+						) }
 					</p>
 				</div>
 				{ ! showForm && (
@@ -274,7 +322,10 @@ export default function CustomToolsManager() {
 							label={ __( 'Slug', 'ai-agent' ) }
 							value={ form.slug }
 							onChange={ ( v ) => updateForm( 'slug', v ) }
-							help={ __( 'Unique identifier (lowercase, hyphens).', 'ai-agent' ) }
+							help={ __(
+								'Unique identifier (lowercase, hyphens).',
+								'ai-agent'
+							) }
 							__nextHasNoMarginBottom
 						/>
 					) }
@@ -288,7 +339,10 @@ export default function CustomToolsManager() {
 						label={ __( 'Description', 'ai-agent' ) }
 						value={ form.description }
 						onChange={ ( v ) => updateForm( 'description', v ) }
-						help={ __( 'Explains to the AI when this tool should be used.', 'ai-agent' ) }
+						help={ __(
+							'Explains to the AI when this tool should be used.',
+							'ai-agent'
+						) }
 						__nextHasNoMarginBottom
 					/>
 					<SelectControl
@@ -299,7 +353,12 @@ export default function CustomToolsManager() {
 							updateForm( 'type', v );
 							// Reset config for new type.
 							if ( v === 'http' ) {
-								updateForm( 'config', { method: 'GET', url: '', headers: '{}', body: '' } );
+								updateForm( 'config', {
+									method: 'GET',
+									url: '',
+									headers: '{}',
+									body: '',
+								} );
 							} else if ( v === 'action' ) {
 								updateForm( 'config', { hook_name: '' } );
 							} else {
@@ -316,17 +375,25 @@ export default function CustomToolsManager() {
 						value={ form.input_schema }
 						onChange={ ( v ) => updateForm( 'input_schema', v ) }
 						rows={ 4 }
-						help={ __( 'JSON Schema describing the parameters the AI should provide.', 'ai-agent' ) }
+						help={ __(
+							'JSON Schema describing the parameters the AI should provide.',
+							'ai-agent'
+						) }
 					/>
 
 					<div className="ai-agent-skill-form-actions">
 						<Button
 							variant="primary"
 							onClick={ handleSubmit }
-							disabled={ ! form.name.trim() || ( ! editId && ! form.slug.trim() ) }
+							disabled={
+								! form.name.trim() ||
+								( ! editId && ! form.slug.trim() )
+							}
 							size="compact"
 						>
-							{ editId ? __( 'Update', 'ai-agent' ) : __( 'Create', 'ai-agent' ) }
+							{ editId
+								? __( 'Update', 'ai-agent' )
+								: __( 'Create', 'ai-agent' ) }
 						</Button>
 						{ editId && (
 							<Button
@@ -338,27 +405,50 @@ export default function CustomToolsManager() {
 								{ __( 'Test', 'ai-agent' ) }
 							</Button>
 						) }
-						<Button variant="tertiary" onClick={ resetForm } size="compact">
+						<Button
+							variant="tertiary"
+							onClick={ resetForm }
+							size="compact"
+						>
 							{ __( 'Cancel', 'ai-agent' ) }
 						</Button>
 					</div>
 
 					{ testResult && (
-						<div className={ `ai-agent-test-result ${ testResult.success ? 'is-success' : 'is-error' }` }>
-							<strong>{ testResult.success ? __( 'Success', 'ai-agent' ) : __( 'Error', 'ai-agent' ) }</strong>
-							<pre>{ typeof testResult.output === 'object' ? JSON.stringify( testResult.output, null, 2 ) : testResult.output }</pre>
+						<div
+							className={ `ai-agent-test-result ${
+								testResult.success ? 'is-success' : 'is-error'
+							}` }
+						>
+							<strong>
+								{ testResult.success
+									? __( 'Success', 'ai-agent' )
+									: __( 'Error', 'ai-agent' ) }
+							</strong>
+							<pre>
+								{ typeof testResult.output === 'object'
+									? JSON.stringify(
+											testResult.output,
+											null,
+											2
+									  )
+									: testResult.output }
+							</pre>
 						</div>
 					) }
 				</div>
 			) }
 
 			{ ! loaded && (
-				<p className="description">{ __( 'Loading...', 'ai-agent' ) }</p>
+				<p className="description">{ __( 'Loading…', 'ai-agent' ) }</p>
 			) }
 
 			{ loaded && tools.length === 0 && ! showForm && (
 				<p className="description">
-					{ __( 'No custom tools yet. Create one or deactivate/reactivate the plugin to seed examples.', 'ai-agent' ) }
+					{ __(
+						'No custom tools yet. Create one or deactivate/reactivate the plugin to seed examples.',
+						'ai-agent'
+					) }
 				</p>
 			) }
 
@@ -367,7 +457,11 @@ export default function CustomToolsManager() {
 					{ tools.map( ( tool ) => (
 						<div
 							key={ tool.id }
-							className={ `ai-agent-skill-card ${ ! tool.enabled ? 'ai-agent-skill-card--disabled' : '' }` }
+							className={ `ai-agent-skill-card ${
+								! tool.enabled
+									? 'ai-agent-skill-card--disabled'
+									: ''
+							}` }
 						>
 							<div className="ai-agent-skill-card-header">
 								<ToggleControl
@@ -401,7 +495,9 @@ export default function CustomToolsManager() {
 										size="small"
 										label={ __( 'Delete', 'ai-agent' ) }
 										isDestructive
-										onClick={ () => handleDelete( tool.id ) }
+										onClick={ () =>
+											handleDelete( tool.id )
+										}
 									/>
 								</div>
 							</div>

--- a/src/settings-page/events-manager.js
+++ b/src/settings-page/events-manager.js
@@ -27,6 +27,12 @@ function emptyForm() {
 	};
 }
 
+/**
+ * Events management UI. Allows configuring WordPress event hooks that
+ * trigger agent automations.
+ *
+ * @return {JSX.Element} Events manager element.
+ */
 export default function EventsManager() {
 	const [ events, setEvents ] = useState( [] );
 	const [ loaded, setLoaded ] = useState( false );
@@ -44,7 +50,9 @@ export default function EventsManager() {
 			const [ result, trigs, prof ] = await Promise.all( [
 				apiFetch( { path: '/ai-agent/v1/event-automations' } ),
 				apiFetch( { path: '/ai-agent/v1/event-triggers' } ),
-				apiFetch( { path: '/ai-agent/v1/tool-profiles' } ).catch( () => [] ),
+				apiFetch( { path: '/ai-agent/v1/tool-profiles' } ).catch(
+					() => []
+				),
 			] );
 			setEvents( result );
 			setTriggers( trigs );
@@ -70,14 +78,21 @@ export default function EventsManager() {
 	}, [] );
 
 	const handleSubmit = useCallback( async () => {
-		if ( ! form.name.trim() || ! form.hook_name || ! form.prompt_template.trim() ) {
+		if (
+			! form.name.trim() ||
+			! form.hook_name ||
+			! form.prompt_template.trim()
+		) {
 			return;
 		}
 		setNotice( null );
 		try {
 			const data = {
 				...form,
-				conditions: typeof form.conditions === 'string' ? JSON.parse( form.conditions ) : form.conditions,
+				conditions:
+					typeof form.conditions === 'string'
+						? JSON.parse( form.conditions )
+						: form.conditions,
 			};
 
 			if ( editId ) {
@@ -95,9 +110,15 @@ export default function EventsManager() {
 			}
 			resetForm();
 			fetchAll();
-			setNotice( { status: 'success', message: __( 'Event automation saved.', 'ai-agent' ) } );
+			setNotice( {
+				status: 'success',
+				message: __( 'Event automation saved.', 'ai-agent' ),
+			} );
 		} catch ( err ) {
-			setNotice( { status: 'error', message: err.message || __( 'Failed to save.', 'ai-agent' ) } );
+			setNotice( {
+				status: 'error',
+				message: err.message || __( 'Failed to save.', 'ai-agent' ),
+			} );
 		}
 	}, [ form, editId, resetForm, fetchAll ] );
 
@@ -116,42 +137,55 @@ export default function EventsManager() {
 		setShowForm( true );
 	}, [] );
 
-	const handleDelete = useCallback( async ( id ) => {
-		// eslint-disable-next-line no-alert
-		if ( window.confirm( __( 'Delete this event automation?', 'ai-agent' ) ) ) {
+	const handleDelete = useCallback(
+		async ( id ) => {
+			// eslint-disable-next-line no-alert
+			if (
+				window.confirm(
+					__( 'Delete this event automation?', 'ai-agent' )
+				)
+			) {
+				await apiFetch( {
+					path: `/ai-agent/v1/event-automations/${ id }`,
+					method: 'DELETE',
+				} );
+				fetchAll();
+			}
+		},
+		[ fetchAll ]
+	);
+
+	const handleToggle = useCallback(
+		async ( ev ) => {
 			await apiFetch( {
-				path: `/ai-agent/v1/event-automations/${ id }`,
-				method: 'DELETE',
+				path: `/ai-agent/v1/event-automations/${ ev.id }`,
+				method: 'PATCH',
+				data: { enabled: ! ev.enabled },
 			} );
 			fetchAll();
-		}
-	}, [ fetchAll ] );
+		},
+		[ fetchAll ]
+	);
 
-	const handleToggle = useCallback( async ( ev ) => {
-		await apiFetch( {
-			path: `/ai-agent/v1/event-automations/${ ev.id }`,
-			method: 'PATCH',
-			data: { enabled: ! ev.enabled },
-		} );
-		fetchAll();
-	}, [ fetchAll ] );
-
-	const handleViewLogs = useCallback( async ( id ) => {
-		if ( viewLogsId === id ) {
-			setViewLogsId( null );
-			setLogs( [] );
-			return;
-		}
-		try {
-			const result = await apiFetch( {
-				path: '/ai-agent/v1/automation-logs?trigger_type=event&limit=20',
-			} );
-			setLogs( result );
-			setViewLogsId( id );
-		} catch {
-			setLogs( [] );
-		}
-	}, [ viewLogsId ] );
+	const handleViewLogs = useCallback(
+		async ( id ) => {
+			if ( viewLogsId === id ) {
+				setViewLogsId( null );
+				setLogs( [] );
+				return;
+			}
+			try {
+				const result = await apiFetch( {
+					path: '/ai-agent/v1/automation-logs?trigger_type=event&limit=20',
+				} );
+				setLogs( result );
+				setViewLogsId( id );
+			} catch {
+				setLogs( [] );
+			}
+		},
+		[ viewLogsId ]
+	);
 
 	// Group triggers by category.
 	const triggersByCategory = triggers.reduce( ( acc, t ) => {
@@ -163,21 +197,27 @@ export default function EventsManager() {
 	}, {} );
 
 	const triggerOptions = [
-		{ label: __( 'Select a trigger...', 'ai-agent' ), value: '' },
-		...Object.entries( triggersByCategory ).flatMap( ( [ category, items ] ) => [
-			{
-				label: `--- ${ category.charAt( 0 ).toUpperCase() + category.slice( 1 ) } ---`,
-				value: `__group_${ category }`,
-				disabled: true,
-			},
-			...items.map( ( t ) => ( {
-				label: `${ t.label } (${ t.hook_name })`,
-				value: t.hook_name,
-			} ) ),
-		] ),
+		{ label: __( 'Select a trigger…', 'ai-agent' ), value: '' },
+		...Object.entries( triggersByCategory ).flatMap(
+			( [ category, items ] ) => [
+				{
+					label: `--- ${
+						category.charAt( 0 ).toUpperCase() + category.slice( 1 )
+					} ---`,
+					value: `__group_${ category }`,
+					disabled: true,
+				},
+				...items.map( ( t ) => ( {
+					label: `${ t.label } (${ t.hook_name })`,
+					value: t.hook_name,
+				} ) ),
+			]
+		),
 	];
 
-	const selectedTrigger = triggers.find( ( t ) => t.hook_name === form.hook_name );
+	const selectedTrigger = triggers.find(
+		( t ) => t.hook_name === form.hook_name
+	);
 
 	const profileOptions = [
 		{ label: __( 'None (all tools)', 'ai-agent' ), value: '' },
@@ -190,14 +230,20 @@ export default function EventsManager() {
 				<div>
 					<h3>{ __( 'Event-Driven Automations', 'ai-agent' ) }</h3>
 					<p className="description">
-						{ __( 'Trigger AI actions when WordPress hooks fire — post published, user registered, order placed, etc.', 'ai-agent' ) }
+						{ __(
+							'Trigger AI actions when WordPress hooks fire — post published, user registered, order placed, etc.',
+							'ai-agent'
+						) }
 					</p>
 				</div>
 				{ ! showForm && (
 					<Button
 						variant="secondary"
 						icon={ plus }
-						onClick={ () => { resetForm(); setShowForm( true ); } }
+						onClick={ () => {
+							resetForm();
+							setShowForm( true );
+						} }
 						size="compact"
 					>
 						{ __( 'Add Event', 'ai-agent' ) }
@@ -221,7 +267,10 @@ export default function EventsManager() {
 						label={ __( 'Name', 'ai-agent' ) }
 						value={ form.name }
 						onChange={ ( v ) => updateForm( 'name', v ) }
-						placeholder={ __( 'e.g., "Auto-tag new posts"', 'ai-agent' ) }
+						placeholder={ __(
+							'e.g., "Auto-tag new posts"',
+							'ai-agent'
+						) }
 						__nextHasNoMarginBottom
 					/>
 					<TextControl
@@ -245,17 +294,33 @@ export default function EventsManager() {
 
 					{ selectedTrigger && (
 						<div className="ai-agent-trigger-info">
-							<p className="description">{ selectedTrigger.description }</p>
+							<p className="description">
+								{ selectedTrigger.description }
+							</p>
 							{ selectedTrigger.placeholders?.length > 0 && (
 								<p className="description">
-									<strong>{ __( 'Available placeholders:', 'ai-agent' ) }</strong>{ ' ' }
-									{ selectedTrigger.placeholders.map( ( p ) => `{{${ p.key }}}` ).join( ', ' ) }
+									<strong>
+										{ __(
+											'Available placeholders:',
+											'ai-agent'
+										) }
+									</strong>{ ' ' }
+									{ selectedTrigger.placeholders
+										.map( ( p ) => `{{${ p.key }}}` )
+										.join( ', ' ) }
 								</p>
 							) }
 							{ selectedTrigger.conditions?.length > 0 && (
 								<p className="description">
-									<strong>{ __( 'Available conditions:', 'ai-agent' ) }</strong>{ ' ' }
-									{ selectedTrigger.conditions.map( ( c ) => c.key ).join( ', ' ) }
+									<strong>
+										{ __(
+											'Available conditions:',
+											'ai-agent'
+										) }
+									</strong>{ ' ' }
+									{ selectedTrigger.conditions
+										.map( ( c ) => c.key )
+										.join( ', ' ) }
 								</p>
 							) }
 						</div>
@@ -266,14 +331,20 @@ export default function EventsManager() {
 						value={ form.prompt_template }
 						onChange={ ( v ) => updateForm( 'prompt_template', v ) }
 						rows={ 6 }
-						help={ __( 'Use {{placeholders}} for dynamic data from the triggering event.', 'ai-agent' ) }
+						help={ __(
+							'Use {{placeholders}} for dynamic data from the triggering event.',
+							'ai-agent'
+						) }
 					/>
 					<TextareaControl
 						label={ __( 'Conditions (JSON)', 'ai-agent' ) }
 						value={ form.conditions }
 						onChange={ ( v ) => updateForm( 'conditions', v ) }
 						rows={ 3 }
-						help={ __( 'Optional. e.g., {"post_type":"post","new_status":"publish"}', 'ai-agent' ) }
+						help={ __(
+							'Optional. e.g., {"post_type":"post","new_status":"publish"}',
+							'ai-agent'
+						) }
 					/>
 					<SelectControl
 						label={ __( 'Tool Profile', 'ai-agent' ) }
@@ -288,19 +359,34 @@ export default function EventsManager() {
 						min={ 1 }
 						max={ 50 }
 						value={ form.max_iterations }
-						onChange={ ( v ) => updateForm( 'max_iterations', parseInt( v, 10 ) || 10 ) }
+						onChange={ ( v ) =>
+							updateForm(
+								'max_iterations',
+								parseInt( v, 10 ) || 10
+							)
+						}
 						__nextHasNoMarginBottom
 					/>
 					<div className="ai-agent-skill-form-actions">
 						<Button
 							variant="primary"
 							onClick={ handleSubmit }
-							disabled={ ! form.name.trim() || ! form.hook_name || ! form.prompt_template.trim() }
+							disabled={
+								! form.name.trim() ||
+								! form.hook_name ||
+								! form.prompt_template.trim()
+							}
 							size="compact"
 						>
-							{ editId ? __( 'Update', 'ai-agent' ) : __( 'Create', 'ai-agent' ) }
+							{ editId
+								? __( 'Update', 'ai-agent' )
+								: __( 'Create', 'ai-agent' ) }
 						</Button>
-						<Button variant="tertiary" onClick={ resetForm } size="compact">
+						<Button
+							variant="tertiary"
+							onClick={ resetForm }
+							size="compact"
+						>
 							{ __( 'Cancel', 'ai-agent' ) }
 						</Button>
 					</div>
@@ -308,7 +394,7 @@ export default function EventsManager() {
 			) }
 
 			{ ! loaded && (
-				<p className="description">{ __( 'Loading...', 'ai-agent' ) }</p>
+				<p className="description">{ __( 'Loading…', 'ai-agent' ) }</p>
 			) }
 
 			{ loaded && events.length === 0 && ! showForm && (
@@ -318,11 +404,18 @@ export default function EventsManager() {
 			) }
 
 			{ events.length > 0 && (
-				<div className="ai-agent-skill-cards" style={ { marginTop: '16px' } }>
+				<div
+					className="ai-agent-skill-cards"
+					style={ { marginTop: '16px' } }
+				>
 					{ events.map( ( ev ) => (
 						<div
 							key={ ev.id }
-							className={ `ai-agent-skill-card ${ ! ev.enabled ? 'ai-agent-skill-card--disabled' : '' }` }
+							className={ `ai-agent-skill-card ${
+								! ev.enabled
+									? 'ai-agent-skill-card--disabled'
+									: ''
+							}` }
 						>
 							<div className="ai-agent-skill-card-header">
 								<ToggleControl
@@ -338,22 +431,33 @@ export default function EventsManager() {
 								</div>
 							</div>
 							<p className="ai-agent-skill-card-description">
-								{ ev.description || ev.prompt_template.slice( 0, 100 ) + '...' }
+								{ ev.description ||
+									ev.prompt_template.slice( 0, 100 ) + '...' }
 							</p>
 							<div className="ai-agent-skill-card-footer">
 								<span className="ai-agent-skill-word-count">
-									{ ev.run_count }{ ' ' }{ __( 'runs', 'ai-agent' ) }
+									{ ev.run_count }{ ' ' }
+									{ __( 'runs', 'ai-agent' ) }
 									{ ev.last_run_at && (
-										<> &middot; { __( 'Last:', 'ai-agent' ) } { ev.last_run_at }</>
+										<>
+											{ ' ' }
+											&middot;{ ' ' }
+											{ __( 'Last:', 'ai-agent' ) }{ ' ' }
+											{ ev.last_run_at }
+										</>
 									) }
 								</span>
 								<div className="ai-agent-skill-card-actions">
 									<Button
 										variant="tertiary"
 										size="small"
-										onClick={ () => handleViewLogs( ev.id ) }
+										onClick={ () =>
+											handleViewLogs( ev.id )
+										}
 									>
-										{ viewLogsId === ev.id ? __( 'Hide Logs', 'ai-agent' ) : __( 'Logs', 'ai-agent' ) }
+										{ viewLogsId === ev.id
+											? __( 'Hide Logs', 'ai-agent' )
+											: __( 'Logs', 'ai-agent' ) }
 									</Button>
 									<Button
 										icon={ pencil }
@@ -374,25 +478,46 @@ export default function EventsManager() {
 							{ viewLogsId === ev.id && (
 								<div className="ai-agent-automation-logs">
 									{ logs.length === 0 && (
-										<p className="description">{ __( 'No logs yet.', 'ai-agent' ) }</p>
+										<p className="description">
+											{ __( 'No logs yet.', 'ai-agent' ) }
+										</p>
 									) }
 									{ logs.map( ( log ) => (
-										<div key={ log.id } className={ `ai-agent-log-entry ai-agent-log--${ log.status }` }>
+										<div
+											key={ log.id }
+											className={ `ai-agent-log-entry ai-agent-log--${ log.status }` }
+										>
 											<div className="ai-agent-log-meta">
-												<span className={ `ai-agent-log-status ai-agent-log-status--${ log.status }` }>
+												<span
+													className={ `ai-agent-log-status ai-agent-log-status--${ log.status }` }
+												>
 													{ log.status }
 												</span>
-												<span>{ log.trigger_name || log.hook_name }</span>
+												<span>
+													{ log.trigger_name ||
+														log.hook_name }
+												</span>
 												<span>{ log.created_at }</span>
-												<span>{ log.duration_ms }ms</span>
+												<span>
+													{ log.duration_ms }ms
+												</span>
 											</div>
 											{ log.error_message && (
-												<p className="ai-agent-log-error">{ log.error_message }</p>
+												<p className="ai-agent-log-error">
+													{ log.error_message }
+												</p>
 											) }
 											{ log.reply && (
 												<details>
-													<summary>{ __( 'Response', 'ai-agent' ) }</summary>
-													<pre className="ai-agent-log-reply">{ log.reply }</pre>
+													<summary>
+														{ __(
+															'Response',
+															'ai-agent'
+														) }
+													</summary>
+													<pre className="ai-agent-log-reply">
+														{ log.reply }
+													</pre>
 												</details>
 											) }
 										</div>

--- a/src/settings-page/knowledge-manager.js
+++ b/src/settings-page/knowledge-manager.js
@@ -21,6 +21,12 @@ import apiFetch from '@wordpress/api-fetch';
 
 const API_BASE = '/ai-agent/v1/knowledge';
 
+/**
+ * Knowledge base management UI. Lists indexed documents and provides
+ * index/re-index/delete actions. Also shows indexing status.
+ *
+ * @return {JSX.Element} Knowledge manager element.
+ */
 export default function KnowledgeManager() {
 	const [ collections, setCollections ] = useState( [] );
 	const [ loading, setLoading ] = useState( true );
@@ -50,7 +56,12 @@ export default function KnowledgeManager() {
 		setLoading( true );
 		apiFetch( { path: `${ API_BASE }/collections` } )
 			.then( setCollections )
-			.catch( () => setNotice( { status: 'error', message: __( 'Failed to load collections.', 'ai-agent' ) } ) )
+			.catch( () =>
+				setNotice( {
+					status: 'error',
+					message: __( 'Failed to load collections.', 'ai-agent' ),
+				} )
+			)
 			.finally( () => setLoading( false ) );
 	}, [] );
 
@@ -59,9 +70,14 @@ export default function KnowledgeManager() {
 	}, [ fetchCollections ] );
 
 	const fetchSources = useCallback( ( collectionId ) => {
-		apiFetch( { path: `${ API_BASE }/collections/${ collectionId }/sources` } )
+		apiFetch( {
+			path: `${ API_BASE }/collections/${ collectionId }/sources`,
+		} )
 			.then( ( data ) => {
-				setSources( ( prev ) => ( { ...prev, [ collectionId ]: data } ) );
+				setSources( ( prev ) => ( {
+					...prev,
+					[ collectionId ]: data,
+				} ) );
 			} )
 			.catch( () => {} );
 	}, [] );
@@ -74,98 +90,160 @@ export default function KnowledgeManager() {
 					method: 'PATCH',
 					data: form,
 				} );
-				setNotice( { status: 'success', message: __( 'Collection updated.', 'ai-agent' ) } );
+				setNotice( {
+					status: 'success',
+					message: __( 'Collection updated.', 'ai-agent' ),
+				} );
 			} else {
 				await apiFetch( {
 					path: `${ API_BASE }/collections`,
 					method: 'POST',
 					data: form,
 				} );
-				setNotice( { status: 'success', message: __( 'Collection created.', 'ai-agent' ) } );
+				setNotice( {
+					status: 'success',
+					message: __( 'Collection created.', 'ai-agent' ),
+				} );
 			}
 			setShowCreate( false );
 			setEditingId( null );
-			setForm( { name: '', slug: '', description: '', auto_index: false, source_config: { post_types: [ 'post', 'page' ] } } );
+			setForm( {
+				name: '',
+				slug: '',
+				description: '',
+				auto_index: false,
+				source_config: { post_types: [ 'post', 'page' ] },
+			} );
 			fetchCollections();
 		} catch ( err ) {
-			setNotice( { status: 'error', message: err.message || __( 'Operation failed.', 'ai-agent' ) } );
+			setNotice( {
+				status: 'error',
+				message: err.message || __( 'Operation failed.', 'ai-agent' ),
+			} );
 		}
 	}, [ form, editingId, fetchCollections ] );
 
-	const handleDelete = useCallback( async ( id ) => {
-		if ( ! window.confirm( __( 'Delete this collection and all its indexed data?', 'ai-agent' ) ) ) {
-			return;
-		}
-		try {
-			await apiFetch( { path: `${ API_BASE }/collections/${ id }`, method: 'DELETE' } );
-			setNotice( { status: 'success', message: __( 'Collection deleted.', 'ai-agent' ) } );
-			fetchCollections();
-		} catch {
-			setNotice( { status: 'error', message: __( 'Failed to delete collection.', 'ai-agent' ) } );
-		}
-	}, [ fetchCollections ] );
-
-	const handleIndex = useCallback( async ( id ) => {
-		setIndexing( ( prev ) => ( { ...prev, [ id ]: true } ) );
-		try {
-			const result = await apiFetch( {
-				path: `${ API_BASE }/collections/${ id }/index`,
-				method: 'POST',
-			} );
-			setNotice( {
-				status: 'success',
-				message: `${ __( 'Indexed:', 'ai-agent' ) } ${ result.indexed } | ${ __( 'Skipped:', 'ai-agent' ) } ${ result.skipped } | ${ __( 'Errors:', 'ai-agent' ) } ${ result.errors }`,
-			} );
-			fetchCollections();
-			if ( expandedId === id ) {
-				fetchSources( id );
+	const handleDelete = useCallback(
+		async ( id ) => {
+			if (
+				! window.confirm(
+					__(
+						'Delete this collection and all its indexed data?',
+						'ai-agent'
+					)
+				)
+			) {
+				return;
 			}
-		} catch {
-			setNotice( { status: 'error', message: __( 'Indexing failed.', 'ai-agent' ) } );
-		}
-		setIndexing( ( prev ) => ( { ...prev, [ id ]: false } ) );
-	}, [ fetchCollections, fetchSources, expandedId ] );
-
-	const handleUpload = useCallback( async ( id, event ) => {
-		const file = event.target?.files?.[ 0 ];
-		if ( ! file ) {
-			return;
-		}
-
-		setUploading( ( prev ) => ( { ...prev, [ id ]: true } ) );
-
-		const formData = new FormData();
-		formData.append( 'file', file );
-		formData.append( 'collection_id', id );
-
-		try {
-			await apiFetch( {
-				path: `${ API_BASE }/upload`,
-				method: 'POST',
-				body: formData,
-				// Don't set Content-Type — let browser set it with boundary.
-				headers: {},
-			} );
-			setNotice( { status: 'success', message: __( 'Document uploaded and indexed.', 'ai-agent' ) } );
-			fetchCollections();
-			if ( expandedId === id ) {
-				fetchSources( id );
+			try {
+				await apiFetch( {
+					path: `${ API_BASE }/collections/${ id }`,
+					method: 'DELETE',
+				} );
+				setNotice( {
+					status: 'success',
+					message: __( 'Collection deleted.', 'ai-agent' ),
+				} );
+				fetchCollections();
+			} catch {
+				setNotice( {
+					status: 'error',
+					message: __( 'Failed to delete collection.', 'ai-agent' ),
+				} );
 			}
-		} catch {
-			setNotice( { status: 'error', message: __( 'Upload failed.', 'ai-agent' ) } );
-		}
-		setUploading( ( prev ) => ( { ...prev, [ id ]: false } ) );
-	}, [ fetchCollections, fetchSources, expandedId ] );
+		},
+		[ fetchCollections ]
+	);
 
-	const handleDeleteSource = useCallback( async ( sourceId, collectionId ) => {
-		try {
-			await apiFetch( { path: `${ API_BASE }/sources/${ sourceId }`, method: 'DELETE' } );
-			fetchSources( collectionId );
-			fetchCollections();
-		} catch {
-			setNotice( { status: 'error', message: __( 'Failed to delete source.', 'ai-agent' ) } );
-		}
-	}, [ fetchSources, fetchCollections ] );
+	const handleIndex = useCallback(
+		async ( id ) => {
+			setIndexing( ( prev ) => ( { ...prev, [ id ]: true } ) );
+			try {
+				const result = await apiFetch( {
+					path: `${ API_BASE }/collections/${ id }/index`,
+					method: 'POST',
+				} );
+				setNotice( {
+					status: 'success',
+					message: `${ __( 'Indexed:', 'ai-agent' ) } ${
+						result.indexed
+					} | ${ __( 'Skipped:', 'ai-agent' ) } ${
+						result.skipped
+					} | ${ __( 'Errors:', 'ai-agent' ) } ${ result.errors }`,
+				} );
+				fetchCollections();
+				if ( expandedId === id ) {
+					fetchSources( id );
+				}
+			} catch {
+				setNotice( {
+					status: 'error',
+					message: __( 'Indexing failed.', 'ai-agent' ),
+				} );
+			}
+			setIndexing( ( prev ) => ( { ...prev, [ id ]: false } ) );
+		},
+		[ fetchCollections, fetchSources, expandedId ]
+	);
+
+	const handleUpload = useCallback(
+		async ( id, event ) => {
+			const file = event.target?.files?.[ 0 ];
+			if ( ! file ) {
+				return;
+			}
+
+			setUploading( ( prev ) => ( { ...prev, [ id ]: true } ) );
+
+			const formData = new FormData();
+			formData.append( 'file', file );
+			formData.append( 'collection_id', id );
+
+			try {
+				await apiFetch( {
+					path: `${ API_BASE }/upload`,
+					method: 'POST',
+					body: formData,
+					// Don't set Content-Type — let browser set it with boundary.
+					headers: {},
+				} );
+				setNotice( {
+					status: 'success',
+					message: __( 'Document uploaded and indexed.', 'ai-agent' ),
+				} );
+				fetchCollections();
+				if ( expandedId === id ) {
+					fetchSources( id );
+				}
+			} catch {
+				setNotice( {
+					status: 'error',
+					message: __( 'Upload failed.', 'ai-agent' ),
+				} );
+			}
+			setUploading( ( prev ) => ( { ...prev, [ id ]: false } ) );
+		},
+		[ fetchCollections, fetchSources, expandedId ]
+	);
+
+	const handleDeleteSource = useCallback(
+		async ( sourceId, collectionId ) => {
+			try {
+				await apiFetch( {
+					path: `${ API_BASE }/sources/${ sourceId }`,
+					method: 'DELETE',
+				} );
+				fetchSources( collectionId );
+				fetchCollections();
+			} catch {
+				setNotice( {
+					status: 'error',
+					message: __( 'Failed to delete source.', 'ai-agent' ),
+				} );
+			}
+		},
+		[ fetchSources, fetchCollections ]
+	);
 
 	const handleSearch = useCallback( async () => {
 		if ( ! searchQuery.trim() ) {
@@ -173,7 +251,11 @@ export default function KnowledgeManager() {
 		}
 		setSearching( true );
 		try {
-			const results = await apiFetch( { path: `${ API_BASE }/search?q=${ encodeURIComponent( searchQuery ) }` } );
+			const results = await apiFetch( {
+				path: `${ API_BASE }/search?q=${ encodeURIComponent(
+					searchQuery
+				) }`,
+			} );
 			setSearchResults( results );
 		} catch {
 			setSearchResults( [] );
@@ -187,22 +269,27 @@ export default function KnowledgeManager() {
 			slug: collection.slug,
 			description: collection.description || '',
 			auto_index: collection.auto_index,
-			source_config: collection.source_config || { post_types: [ 'post', 'page' ] },
+			source_config: collection.source_config || {
+				post_types: [ 'post', 'page' ],
+			},
 		} );
 		setEditingId( collection.id );
 		setShowCreate( true );
 	}, [] );
 
-	const toggleExpanded = useCallback( ( id ) => {
-		if ( expandedId === id ) {
-			setExpandedId( null );
-		} else {
-			setExpandedId( id );
-			if ( ! sources[ id ] ) {
-				fetchSources( id );
+	const toggleExpanded = useCallback(
+		( id ) => {
+			if ( expandedId === id ) {
+				setExpandedId( null );
+			} else {
+				setExpandedId( id );
+				if ( ! sources[ id ] ) {
+					fetchSources( id );
+				}
 			}
-		}
-	}, [ expandedId, sources, fetchSources ] );
+		},
+		[ expandedId, sources, fetchSources ]
+	);
 
 	if ( loading ) {
 		return <Spinner />;
@@ -220,12 +307,27 @@ export default function KnowledgeManager() {
 				</Notice>
 			) }
 
-			<div style={ { display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '16px' } }>
-				<h3 style={ { margin: 0 } }>{ __( 'Collections', 'ai-agent' ) }</h3>
+			<div
+				style={ {
+					display: 'flex',
+					justifyContent: 'space-between',
+					alignItems: 'center',
+					marginBottom: '16px',
+				} }
+			>
+				<h3 style={ { margin: 0 } }>
+					{ __( 'Collections', 'ai-agent' ) }
+				</h3>
 				<Button
 					variant="primary"
 					onClick={ () => {
-						setForm( { name: '', slug: '', description: '', auto_index: false, source_config: { post_types: [ 'post', 'page' ] } } );
+						setForm( {
+							name: '',
+							slug: '',
+							description: '',
+							auto_index: false,
+							source_config: { post_types: [ 'post', 'page' ] },
+						} );
 						setEditingId( null );
 						setShowCreate( true );
 					} }
@@ -235,44 +337,80 @@ export default function KnowledgeManager() {
 			</div>
 
 			{ collections.length === 0 && (
-				<p className="description">{ __( 'No collections yet. Create one to start indexing content.', 'ai-agent' ) }</p>
+				<p className="description">
+					{ __(
+						'No collections yet. Create one to start indexing content.',
+						'ai-agent'
+					) }
+				</p>
 			) }
 
 			{ collections.map( ( col ) => (
 				<Card key={ col.id } style={ { marginBottom: '12px' } }>
 					<CardHeader>
-						<div style={ { display: 'flex', justifyContent: 'space-between', alignItems: 'center', width: '100%' } }>
+						<div
+							style={ {
+								display: 'flex',
+								justifyContent: 'space-between',
+								alignItems: 'center',
+								width: '100%',
+							} }
+						>
 							<div>
 								<strong>{ col.name }</strong>
-								<Text variant="muted" style={ { marginLeft: '8px' } }>
+								<Text
+									variant="muted"
+									style={ { marginLeft: '8px' } }
+								>
 									{ col.slug }
 								</Text>
 							</div>
-							<div style={ { display: 'flex', gap: '8px', alignItems: 'center' } }>
+							<div
+								style={ {
+									display: 'flex',
+									gap: '8px',
+									alignItems: 'center',
+								} }
+							>
 								<Text variant="muted">
-									{ col.chunk_count } { __( 'chunks', 'ai-agent' ) }
+									{ col.chunk_count }{ ' ' }
+									{ __( 'chunks', 'ai-agent' ) }
 								</Text>
 								{ col.auto_index && (
-									<span className="ai-agent-badge">{ __( 'Auto', 'ai-agent' ) }</span>
+									<span className="ai-agent-badge">
+										{ __( 'Auto', 'ai-agent' ) }
+									</span>
 								) }
 							</div>
 						</div>
 					</CardHeader>
 					<CardBody>
-						{ col.description && <p className="description">{ col.description }</p> }
+						{ col.description && (
+							<p className="description">{ col.description }</p>
+						) }
 						{ col.last_indexed_at && (
 							<p className="description">
-								{ __( 'Last indexed:', 'ai-agent' ) } { col.last_indexed_at }
+								{ __( 'Last indexed:', 'ai-agent' ) }{ ' ' }
+								{ col.last_indexed_at }
 							</p>
 						) }
-						<div style={ { display: 'flex', gap: '8px', marginTop: '8px', flexWrap: 'wrap' } }>
+						<div
+							style={ {
+								display: 'flex',
+								gap: '8px',
+								marginTop: '8px',
+								flexWrap: 'wrap',
+							} }
+						>
 							<Button
 								variant="secondary"
 								onClick={ () => handleIndex( col.id ) }
 								isBusy={ indexing[ col.id ] }
 								disabled={ indexing[ col.id ] }
 							>
-								{ indexing[ col.id ] ? __( 'Indexing...', 'ai-agent' ) : __( 'Index Now', 'ai-agent' ) }
+								{ indexing[ col.id ]
+									? __( 'Indexing…', 'ai-agent' )
+									: __( 'Index Now', 'ai-agent' ) }
 							</Button>
 							<FormFileUpload
 								accept=".pdf,.docx,.txt,.md,.html"
@@ -292,7 +430,9 @@ export default function KnowledgeManager() {
 								variant="tertiary"
 								onClick={ () => toggleExpanded( col.id ) }
 							>
-								{ expandedId === col.id ? __( 'Hide Sources', 'ai-agent' ) : __( 'Show Sources', 'ai-agent' ) }
+								{ expandedId === col.id
+									? __( 'Hide Sources', 'ai-agent' )
+									: __( 'Show Sources', 'ai-agent' ) }
 							</Button>
 							<Button
 								variant="tertiary"
@@ -310,49 +450,115 @@ export default function KnowledgeManager() {
 						</div>
 
 						{ expandedId === col.id && (
-							<div style={ { marginTop: '12px', borderTop: '1px solid #ddd', paddingTop: '12px' } }>
-								<h4 style={ { margin: '0 0 8px 0' } }>{ __( 'Sources', 'ai-agent' ) }</h4>
+							<div
+								style={ {
+									marginTop: '12px',
+									borderTop: '1px solid #ddd',
+									paddingTop: '12px',
+								} }
+							>
+								<h4 style={ { margin: '0 0 8px 0' } }>
+									{ __( 'Sources', 'ai-agent' ) }
+								</h4>
 								{ ! sources[ col.id ] ? (
 									<Spinner />
 								) : sources[ col.id ].length === 0 ? (
-									<p className="description">{ __( 'No sources indexed yet.', 'ai-agent' ) }</p>
+									<p className="description">
+										{ __(
+											'No sources indexed yet.',
+											'ai-agent'
+										) }
+									</p>
 								) : (
-									<table className="widefat striped" style={ { marginTop: '4px' } }>
+									<table
+										className="widefat striped"
+										style={ { marginTop: '4px' } }
+									>
 										<thead>
 											<tr>
-												<th>{ __( 'Title', 'ai-agent' ) }</th>
-												<th>{ __( 'Type', 'ai-agent' ) }</th>
-												<th>{ __( 'Status', 'ai-agent' ) }</th>
-												<th>{ __( 'Chunks', 'ai-agent' ) }</th>
+												<th>
+													{ __(
+														'Title',
+														'ai-agent'
+													) }
+												</th>
+												<th>
+													{ __( 'Type', 'ai-agent' ) }
+												</th>
+												<th>
+													{ __(
+														'Status',
+														'ai-agent'
+													) }
+												</th>
+												<th>
+													{ __(
+														'Chunks',
+														'ai-agent'
+													) }
+												</th>
 												<th></th>
 											</tr>
 										</thead>
 										<tbody>
-											{ sources[ col.id ].map( ( src ) => (
-												<tr key={ src.id }>
-													<td>{ src.title || __( '(untitled)', 'ai-agent' ) }</td>
-													<td>{ src.source_type }</td>
-													<td>
-														<span className={ `ai-agent-status-badge is-${ src.status }` }>
-															{ src.status }
-														</span>
-														{ src.error_message && (
-															<span title={ src.error_message } style={ { cursor: 'help', marginLeft: '4px' } }>&#9888;</span>
-														) }
-													</td>
-													<td>{ src.chunk_count }</td>
-													<td>
-														<Button
-															variant="tertiary"
-															isDestructive
-															isSmall
-															onClick={ () => handleDeleteSource( src.id, col.id ) }
-														>
-															{ __( 'Remove', 'ai-agent' ) }
-														</Button>
-													</td>
-												</tr>
-											) ) }
+											{ sources[ col.id ].map(
+												( src ) => (
+													<tr key={ src.id }>
+														<td>
+															{ src.title ||
+																__(
+																	'(untitled)',
+																	'ai-agent'
+																) }
+														</td>
+														<td>
+															{ src.source_type }
+														</td>
+														<td>
+															<span
+																className={ `ai-agent-status-badge is-${ src.status }` }
+															>
+																{ src.status }
+															</span>
+															{ src.error_message && (
+																<span
+																	title={
+																		src.error_message
+																	}
+																	style={ {
+																		cursor: 'help',
+																		marginLeft:
+																			'4px',
+																	} }
+																>
+																	&#9888;
+																</span>
+															) }
+														</td>
+														<td>
+															{ src.chunk_count }
+														</td>
+														<td>
+															<Button
+																variant="tertiary"
+																isDestructive
+																isSmall
+																onClick={ () =>
+																	handleDeleteSource(
+																		src.id,
+																		col.id
+																	)
+																}
+															>
+																{ __(
+																	'Remove',
+																	'ai-agent'
+																) }
+															</Button>
+														</td>
+													</tr>
+												)
+											) }
 										</tbody>
 									</table>
 								) }
@@ -365,11 +571,20 @@ export default function KnowledgeManager() {
 			{ /* Search Preview */ }
 			<div style={ { marginTop: '24px' } }>
 				<h3>{ __( 'Search Preview', 'ai-agent' ) }</h3>
-				<div style={ { display: 'flex', gap: '8px', marginBottom: '12px' } }>
+				<div
+					style={ {
+						display: 'flex',
+						gap: '8px',
+						marginBottom: '12px',
+					} }
+				>
 					<TextControl
 						value={ searchQuery }
 						onChange={ setSearchQuery }
-						placeholder={ __( 'Search the knowledge base...', 'ai-agent' ) }
+						placeholder={ __(
+							'Search the knowledge base…',
+							'ai-agent'
+						) }
 						style={ { flex: 1 } }
 						onKeyDown={ ( e ) => {
 							if ( e.key === 'Enter' ) {
@@ -392,22 +607,40 @@ export default function KnowledgeManager() {
 						{ searchResults.map( ( result, i ) => (
 							<Card key={ i } style={ { marginBottom: '8px' } }>
 								<CardBody>
-									<div style={ { display: 'flex', justifyContent: 'space-between', marginBottom: '4px' } }>
+									<div
+										style={ {
+											display: 'flex',
+											justifyContent: 'space-between',
+											marginBottom: '4px',
+										} }
+									>
 										<Text variant="muted">
-											<strong>{ result.source_title }</strong>
-											{ result.collection_name && ` — ${ result.collection_name }` }
+											<strong>
+												{ result.source_title }
+											</strong>
+											{ result.collection_name &&
+												` — ${ result.collection_name }` }
 										</Text>
 										{ result.score && (
 											<Text variant="muted">
-												{ __( 'Score:', 'ai-agent' ) } { result.score.toFixed( 2 ) }
+												{ __( 'Score:', 'ai-agent' ) }{ ' ' }
+												{ result.score.toFixed( 2 ) }
 											</Text>
 										) }
 									</div>
-									<p style={ { margin: 0, fontSize: '13px', whiteSpace: 'pre-wrap' } }>
+									<p
+										style={ {
+											margin: 0,
+											fontSize: '13px',
+											whiteSpace: 'pre-wrap',
+										} }
+									>
 										{ result.chunk_text.length > 300
-											? result.chunk_text.substring( 0, 300 ) + '...'
-											: result.chunk_text
-										}
+											? result.chunk_text.substring(
+													0,
+													300
+											  ) + '...'
+											: result.chunk_text }
 									</p>
 								</CardBody>
 							</Card>
@@ -419,7 +652,11 @@ export default function KnowledgeManager() {
 			{ /* Create/Edit Modal */ }
 			{ showCreate && (
 				<Modal
-					title={ editingId ? __( 'Edit Collection', 'ai-agent' ) : __( 'Create Collection', 'ai-agent' ) }
+					title={
+						editingId
+							? __( 'Edit Collection', 'ai-agent' )
+							: __( 'Create Collection', 'ai-agent' )
+					}
 					onRequestClose={ () => {
 						setShowCreate( false );
 						setEditingId( null );
@@ -433,7 +670,14 @@ export default function KnowledgeManager() {
 								...prev,
 								name: v,
 								// Auto-generate slug from name if creating.
-								...( ! editingId ? { slug: v.toLowerCase().replace( /[^a-z0-9]+/g, '-' ).replace( /^-|-$/g, '' ) } : {} ),
+								...( ! editingId
+									? {
+											slug: v
+												.toLowerCase()
+												.replace( /[^a-z0-9]+/g, '-' )
+												.replace( /^-|-$/g, '' ),
+									  }
+									: {} ),
 							} ) );
 						} }
 						__nextHasNoMarginBottom
@@ -441,43 +685,93 @@ export default function KnowledgeManager() {
 					<TextControl
 						label={ __( 'Slug', 'ai-agent' ) }
 						value={ form.slug }
-						onChange={ ( v ) => setForm( ( prev ) => ( { ...prev, slug: v } ) ) }
-						help={ __( 'Unique identifier for this collection.', 'ai-agent' ) }
+						onChange={ ( v ) =>
+							setForm( ( prev ) => ( { ...prev, slug: v } ) )
+						}
+						help={ __(
+							'Unique identifier for this collection.',
+							'ai-agent'
+						) }
 						disabled={ !! editingId }
 						__nextHasNoMarginBottom
 					/>
 					<TextareaControl
 						label={ __( 'Description', 'ai-agent' ) }
 						value={ form.description }
-						onChange={ ( v ) => setForm( ( prev ) => ( { ...prev, description: v } ) ) }
+						onChange={ ( v ) =>
+							setForm( ( prev ) => ( {
+								...prev,
+								description: v,
+							} ) )
+						}
 						rows={ 2 }
 					/>
 					<TextControl
-						label={ __( 'Post Types (comma-separated)', 'ai-agent' ) }
-						value={ ( form.source_config?.post_types || [] ).join( ', ' ) }
-						onChange={ ( v ) => setForm( ( prev ) => ( {
-							...prev,
-							source_config: {
-								...prev.source_config,
-								post_types: v.split( ',' ).map( ( s ) => s.trim() ).filter( Boolean ),
-							},
-						} ) ) }
-						help={ __( 'Post types to include when indexing (e.g., post, page, product).', 'ai-agent' ) }
+						label={ __(
+							'Post Types (comma-separated)',
+							'ai-agent'
+						) }
+						value={ ( form.source_config?.post_types || [] ).join(
+							', '
+						) }
+						onChange={ ( v ) =>
+							setForm( ( prev ) => ( {
+								...prev,
+								source_config: {
+									...prev.source_config,
+									post_types: v
+										.split( ',' )
+										.map( ( s ) => s.trim() )
+										.filter( Boolean ),
+								},
+							} ) )
+						}
+						help={ __(
+							'Post types to include when indexing (e.g., post, page, product).',
+							'ai-agent'
+						) }
 						__nextHasNoMarginBottom
 					/>
 					<ToggleControl
 						label={ __( 'Auto-index', 'ai-agent' ) }
 						checked={ form.auto_index }
-						onChange={ ( v ) => setForm( ( prev ) => ( { ...prev, auto_index: v } ) ) }
-						help={ __( 'Automatically index new and updated posts matching this collection.', 'ai-agent' ) }
+						onChange={ ( v ) =>
+							setForm( ( prev ) => ( {
+								...prev,
+								auto_index: v,
+							} ) )
+						}
+						help={ __(
+							'Automatically index new and updated posts matching this collection.',
+							'ai-agent'
+						) }
 						__nextHasNoMarginBottom
 					/>
-					<div style={ { marginTop: '16px', display: 'flex', gap: '8px', justifyContent: 'flex-end' } }>
-						<Button variant="tertiary" onClick={ () => { setShowCreate( false ); setEditingId( null ); } }>
+					<div
+						style={ {
+							marginTop: '16px',
+							display: 'flex',
+							gap: '8px',
+							justifyContent: 'flex-end',
+						} }
+					>
+						<Button
+							variant="tertiary"
+							onClick={ () => {
+								setShowCreate( false );
+								setEditingId( null );
+							} }
+						>
 							{ __( 'Cancel', 'ai-agent' ) }
 						</Button>
-						<Button variant="primary" onClick={ handleCreateOrEdit } disabled={ ! form.name || ! form.slug }>
-							{ editingId ? __( 'Save', 'ai-agent' ) : __( 'Create', 'ai-agent' ) }
+						<Button
+							variant="primary"
+							onClick={ handleCreateOrEdit }
+							disabled={ ! form.name || ! form.slug }
+						>
+							{ editingId
+								? __( 'Save', 'ai-agent' )
+								: __( 'Create', 'ai-agent' ) }
 						</Button>
 					</div>
 				</Modal>

--- a/src/settings-page/memory-manager.js
+++ b/src/settings-page/memory-manager.js
@@ -31,6 +31,11 @@ const CATEGORIES = [
 	{ label: __( 'Workflows', 'ai-agent' ), value: 'workflows' },
 ];
 
+/**
+ * Memory management UI. Lists stored memories and provides create/edit/delete actions.
+ *
+ * @return {JSX.Element} Memory manager element.
+ */
 export default function MemoryManager() {
 	const { fetchMemories, createMemory, updateMemory, deleteMemory } =
 		useDispatch( STORE_NAME );
@@ -149,9 +154,7 @@ export default function MemoryManager() {
 			) }
 
 			{ ! memoriesLoaded && (
-				<p className="description">
-					{ __( 'Loading...', 'ai-agent' ) }
-				</p>
+				<p className="description">{ __( 'Loading…', 'ai-agent' ) }</p>
 			) }
 
 			{ memoriesLoaded && memories.length === 0 && (
@@ -186,10 +189,7 @@ export default function MemoryManager() {
 										<Button
 											icon={ pencil }
 											size="small"
-											label={ __(
-												'Edit',
-												'ai-agent'
-											) }
+											label={ __( 'Edit', 'ai-agent' ) }
 											onClick={ () =>
 												handleEdit( memory )
 											}
@@ -197,10 +197,7 @@ export default function MemoryManager() {
 										<Button
 											icon={ trash }
 											size="small"
-											label={ __(
-												'Delete',
-												'ai-agent'
-											) }
+											label={ __( 'Delete', 'ai-agent' ) }
 											isDestructive
 											onClick={ () =>
 												handleDelete( memory.id )

--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -30,6 +30,13 @@ import ToolProfilesManager from './tool-profiles-manager';
 import AutomationsManager from './automations-manager';
 import EventsManager from './events-manager';
 
+/**
+ * Root settings page component. Renders a tab panel with sections for
+ * general settings, system prompt, memory, skills, knowledge, custom tools,
+ * tool profiles, automations, events, abilities, usage, and advanced options.
+ *
+ * @return {JSX.Element} Settings app element.
+ */
 export default function SettingsApp() {
 	const { fetchSettings, fetchProviders, saveSettings } =
 		useDispatch( STORE_NAME );
@@ -62,21 +69,24 @@ export default function SettingsApp() {
 		}
 	}, [ settings, local ] );
 
-	const updateField = useCallback(
-		( key, value ) => {
-			setLocal( ( prev ) => ( { ...prev, [ key ]: value } ) );
-		},
-		[]
-	);
+	const updateField = useCallback( ( key, value ) => {
+		setLocal( ( prev ) => ( { ...prev, [ key ]: value } ) );
+	}, [] );
 
 	const handleSave = useCallback( async () => {
 		setSaving( true );
 		setNotice( null );
 		try {
 			await saveSettings( local );
-			setNotice( { status: 'success', message: __( 'Settings saved.', 'ai-agent' ) } );
+			setNotice( {
+				status: 'success',
+				message: __( 'Settings saved.', 'ai-agent' ),
+			} );
 		} catch {
-			setNotice( { status: 'error', message: __( 'Failed to save settings.', 'ai-agent' ) } );
+			setNotice( {
+				status: 'error',
+				message: __( 'Failed to save settings.', 'ai-agent' ),
+			} );
 		}
 		setSaving( false );
 	}, [ local, saveSettings ] );
@@ -194,10 +204,7 @@ export default function SettingsApp() {
 										value={ local.default_provider }
 										options={ providerOptions }
 										onChange={ ( v ) =>
-											updateField(
-												'default_provider',
-												v
-											)
+											updateField( 'default_provider', v )
 										}
 										__nextHasNoMarginBottom
 									/>
@@ -241,10 +248,7 @@ export default function SettingsApp() {
 										) }
 										value={ local.greeting_message }
 										onChange={ ( v ) =>
-											updateField(
-												'greeting_message',
-												v
-											)
+											updateField( 'greeting_message', v )
 										}
 										placeholder={
 											settings?._defaults
@@ -339,9 +343,7 @@ export default function SettingsApp() {
 											'Auto-Index on Post Save',
 											'ai-agent'
 										) }
-										checked={
-											local.knowledge_auto_index
-										}
+										checked={ local.knowledge_auto_index }
 										onChange={ ( v ) =>
 											updateField(
 												'knowledge_auto_index',
@@ -520,9 +522,7 @@ export default function SettingsApp() {
 										type="number"
 										min={ 4096 }
 										max={ 2000000 }
-										value={
-											local.context_window_default
-										}
+										value={ local.context_window_default }
 										onChange={ ( v ) =>
 											updateField(
 												'context_window_default',
@@ -541,8 +541,7 @@ export default function SettingsApp() {
 											'ai-agent'
 										) }
 										value={
-											local.tool_discovery_mode ||
-											'auto'
+											local.tool_discovery_mode || 'auto'
 										}
 										options={ [
 											{

--- a/src/settings-page/skill-manager.js
+++ b/src/settings-page/skill-manager.js
@@ -17,14 +17,15 @@ import { trash, pencil, plus, backup } from '@wordpress/icons';
  */
 import STORE_NAME from '../store';
 
+/**
+ * Skill management UI. Lists registered skills and provides create/edit/delete/reset actions.
+ * System skills can be edited but not deleted; they can be reset to defaults.
+ *
+ * @return {JSX.Element} Skill manager element.
+ */
 export default function SkillManager() {
-	const {
-		fetchSkills,
-		createSkill,
-		updateSkill,
-		deleteSkill,
-		resetSkill,
-	} = useDispatch( STORE_NAME );
+	const { fetchSkills, createSkill, updateSkill, deleteSkill, resetSkill } =
+		useDispatch( STORE_NAME );
 	const { skills, skillsLoaded } = useSelect(
 		( select ) => ( {
 			skills: select( STORE_NAME ).getSkills(),
@@ -100,11 +101,7 @@ export default function SkillManager() {
 	const handleDelete = useCallback(
 		async ( id ) => {
 			// eslint-disable-next-line no-alert
-			if (
-				window.confirm(
-					__( 'Delete this skill?', 'ai-agent' )
-				)
-			) {
+			if ( window.confirm( __( 'Delete this skill?', 'ai-agent' ) ) ) {
 				await deleteSkill( id );
 			}
 		},
@@ -116,10 +113,7 @@ export default function SkillManager() {
 			// eslint-disable-next-line no-alert
 			if (
 				window.confirm(
-					__(
-						'Reset this skill to its default content?',
-						'ai-agent'
-					)
+					__( 'Reset this skill to its default content?', 'ai-agent' )
 				)
 			) {
 				await resetSkill( id );
@@ -226,9 +220,7 @@ export default function SkillManager() {
 			) }
 
 			{ ! skillsLoaded && (
-				<p className="description">
-					{ __( 'Loading...', 'ai-agent' ) }
-				</p>
+				<p className="description">{ __( 'Loading…', 'ai-agent' ) }</p>
 			) }
 
 			{ skillsLoaded && skills.length === 0 && (
@@ -254,19 +246,14 @@ export default function SkillManager() {
 							<div className="ai-agent-skill-card-header">
 								<ToggleControl
 									checked={ skill.enabled }
-									onChange={ () =>
-										handleToggle( skill )
-									}
+									onChange={ () => handleToggle( skill ) }
 									__nextHasNoMarginBottom
 								/>
 								<div className="ai-agent-skill-card-title">
 									<strong>{ skill.name }</strong>
 									{ skill.is_builtin && (
 										<span className="ai-agent-skill-badge">
-											{ __(
-												'Built-in',
-												'ai-agent'
-											) }
+											{ __( 'Built-in', 'ai-agent' ) }
 										</span>
 									) }
 								</div>
@@ -283,13 +270,8 @@ export default function SkillManager() {
 									<Button
 										icon={ pencil }
 										size="small"
-										label={ __(
-											'Edit',
-											'ai-agent'
-										) }
-										onClick={ () =>
-											handleEdit( skill )
-										}
+										label={ __( 'Edit', 'ai-agent' ) }
+										onClick={ () => handleEdit( skill ) }
 									/>
 									{ skill.is_builtin ? (
 										<Button
@@ -307,10 +289,7 @@ export default function SkillManager() {
 										<Button
 											icon={ trash }
 											size="small"
-											label={ __(
-												'Delete',
-												'ai-agent'
-											) }
+											label={ __( 'Delete', 'ai-agent' ) }
 											isDestructive
 											onClick={ () =>
 												handleDelete( skill.id )

--- a/src/settings-page/tool-profiles-manager.js
+++ b/src/settings-page/tool-profiles-manager.js
@@ -19,6 +19,12 @@ import apiFetch from '@wordpress/api-fetch';
  */
 import STORE_NAME from '../store';
 
+/**
+ * Tool profiles management UI. Allows creating named profiles that group
+ * a subset of tools for specific use cases.
+ *
+ * @return {JSX.Element} Tool profiles manager element.
+ */
 export default function ToolProfilesManager() {
 	const { saveSettings } = useDispatch( STORE_NAME );
 	const { settings } = useSelect(
@@ -38,7 +44,9 @@ export default function ToolProfilesManager() {
 
 	const fetchProfiles = useCallback( async () => {
 		try {
-			const result = await apiFetch( { path: '/ai-agent/v1/tool-profiles' } );
+			const result = await apiFetch( {
+				path: '/ai-agent/v1/tool-profiles',
+			} );
 			setProfiles( result );
 		} catch {
 			setProfiles( [] );
@@ -93,11 +101,24 @@ export default function ToolProfilesManager() {
 			}
 			resetForm();
 			fetchProfiles();
-			setNotice( { status: 'success', message: __( 'Profile saved.', 'ai-agent' ) } );
+			setNotice( {
+				status: 'success',
+				message: __( 'Profile saved.', 'ai-agent' ),
+			} );
 		} catch ( err ) {
-			setNotice( { status: 'error', message: err.message || __( 'Failed to save.', 'ai-agent' ) } );
+			setNotice( {
+				status: 'error',
+				message: err.message || __( 'Failed to save.', 'ai-agent' ),
+			} );
 		}
-	}, [ formName, formDescription, formToolNames, editSlug, resetForm, fetchProfiles ] );
+	}, [
+		formName,
+		formDescription,
+		formToolNames,
+		editSlug,
+		resetForm,
+		fetchProfiles,
+	] );
 
 	const handleEdit = useCallback( ( profile ) => {
 		setEditSlug( profile.slug );
@@ -107,27 +128,36 @@ export default function ToolProfilesManager() {
 		setShowForm( true );
 	}, [] );
 
-	const handleDelete = useCallback( async ( slug ) => {
-		// eslint-disable-next-line no-alert
-		if ( window.confirm( __( 'Delete this profile?', 'ai-agent' ) ) ) {
-			await apiFetch( {
-				path: `/ai-agent/v1/tool-profiles/${ slug }`,
-				method: 'DELETE',
-			} );
-			fetchProfiles();
-		}
-	}, [ fetchProfiles ] );
+	const handleDelete = useCallback(
+		async ( slug ) => {
+			// eslint-disable-next-line no-alert
+			if ( window.confirm( __( 'Delete this profile?', 'ai-agent' ) ) ) {
+				await apiFetch( {
+					path: `/ai-agent/v1/tool-profiles/${ slug }`,
+					method: 'DELETE',
+				} );
+				fetchProfiles();
+			}
+		},
+		[ fetchProfiles ]
+	);
 
-	const handleActivate = useCallback( async ( slug ) => {
-		const newValue = settings?.active_tool_profile === slug ? '' : slug;
-		await saveSettings( { active_tool_profile: newValue } );
-		setNotice( {
-			status: 'success',
-			message: newValue
-				? __( 'Profile activated.', 'ai-agent' )
-				: __( 'Profile deactivated. All tools are now available.', 'ai-agent' ),
-		} );
-	}, [ settings, saveSettings ] );
+	const handleActivate = useCallback(
+		async ( slug ) => {
+			const newValue = settings?.active_tool_profile === slug ? '' : slug;
+			await saveSettings( { active_tool_profile: newValue } );
+			setNotice( {
+				status: 'success',
+				message: newValue
+					? __( 'Profile activated.', 'ai-agent' )
+					: __(
+							'Profile deactivated. All tools are now available.',
+							'ai-agent'
+					  ),
+			} );
+		},
+		[ settings, saveSettings ]
+	);
 
 	const activeProfile = settings?.active_tool_profile || '';
 
@@ -143,7 +173,10 @@ export default function ToolProfilesManager() {
 				<div>
 					<h3>{ __( 'Tool Profiles', 'ai-agent' ) }</h3>
 					<p className="description">
-						{ __( 'Profiles restrict which tools the AI can access. Useful for security (read-only mode) or token savings.', 'ai-agent' ) }
+						{ __(
+							'Profiles restrict which tools the AI can access. Useful for security (read-only mode) or token savings.',
+							'ai-agent'
+						) }
 					</p>
 				</div>
 				{ ! showForm && (
@@ -173,12 +206,18 @@ export default function ToolProfilesManager() {
 				value={ activeProfile }
 				options={ profileOptions }
 				onChange={ handleActivate }
-				help={ __( 'Select a profile to restrict the AI to a specific set of tools.', 'ai-agent' ) }
+				help={ __(
+					'Select a profile to restrict the AI to a specific set of tools.',
+					'ai-agent'
+				) }
 				__nextHasNoMarginBottom
 			/>
 
 			{ showForm && (
-				<div className="ai-agent-skill-form" style={ { marginTop: '16px' } }>
+				<div
+					className="ai-agent-skill-form"
+					style={ { marginTop: '16px' } }
+				>
 					<TextControl
 						label={ __( 'Name', 'ai-agent' ) }
 						value={ formName }
@@ -192,13 +231,16 @@ export default function ToolProfilesManager() {
 						__nextHasNoMarginBottom
 					/>
 					<TextareaControl
-						label={ __( 'Tool Name Prefixes (one per line)', 'ai-agent' ) }
+						label={ __(
+							'Tool Name Prefixes (one per line)',
+							'ai-agent'
+						) }
 						value={ formToolNames }
 						onChange={ setFormToolNames }
 						rows={ 8 }
 						help={ __(
 							'Enter tool name prefixes, one per line. Use partial names for matching (e.g., "wp_read" matches all read tools). Available tools: ' +
-							abilities.map( ( a ) => a.name ).join( ', ' ),
+								abilities.map( ( a ) => a.name ).join( ', ' ),
 							'ai-agent'
 						) }
 					/>
@@ -209,9 +251,15 @@ export default function ToolProfilesManager() {
 							disabled={ ! formName.trim() }
 							size="compact"
 						>
-							{ editSlug ? __( 'Update', 'ai-agent' ) : __( 'Create', 'ai-agent' ) }
+							{ editSlug
+								? __( 'Update', 'ai-agent' )
+								: __( 'Create', 'ai-agent' ) }
 						</Button>
-						<Button variant="tertiary" onClick={ resetForm } size="compact">
+						<Button
+							variant="tertiary"
+							onClick={ resetForm }
+							size="compact"
+						>
 							{ __( 'Cancel', 'ai-agent' ) }
 						</Button>
 					</div>
@@ -219,15 +267,22 @@ export default function ToolProfilesManager() {
 			) }
 
 			{ ! loaded && (
-				<p className="description">{ __( 'Loading...', 'ai-agent' ) }</p>
+				<p className="description">{ __( 'Loading…', 'ai-agent' ) }</p>
 			) }
 
 			{ loaded && profiles.length > 0 && (
-				<div className="ai-agent-skill-cards" style={ { marginTop: '16px' } }>
+				<div
+					className="ai-agent-skill-cards"
+					style={ { marginTop: '16px' } }
+				>
 					{ profiles.map( ( profile ) => (
 						<div
 							key={ profile.slug }
-							className={ `ai-agent-skill-card ${ activeProfile === profile.slug ? 'ai-agent-skill-card--active' : '' }` }
+							className={ `ai-agent-skill-card ${
+								activeProfile === profile.slug
+									? 'ai-agent-skill-card--active'
+									: ''
+							}` }
 						>
 							<div className="ai-agent-skill-card-header">
 								<div className="ai-agent-skill-card-title">
@@ -238,7 +293,13 @@ export default function ToolProfilesManager() {
 										</span>
 									) }
 									{ activeProfile === profile.slug && (
-										<span className="ai-agent-skill-badge" style={ { background: '#00a32a', color: '#fff' } }>
+										<span
+											className="ai-agent-skill-badge"
+											style={ {
+												background: '#00a32a',
+												color: '#fff',
+											} }
+										>
 											{ __( 'Active', 'ai-agent' ) }
 										</span>
 									) }
@@ -258,15 +319,25 @@ export default function ToolProfilesManager() {
 											<Button
 												icon={ pencil }
 												size="small"
-												label={ __( 'Edit', 'ai-agent' ) }
-												onClick={ () => handleEdit( profile ) }
+												label={ __(
+													'Edit',
+													'ai-agent'
+												) }
+												onClick={ () =>
+													handleEdit( profile )
+												}
 											/>
 											<Button
 												icon={ trash }
 												size="small"
-												label={ __( 'Delete', 'ai-agent' ) }
+												label={ __(
+													'Delete',
+													'ai-agent'
+												) }
 												isDestructive
-												onClick={ () => handleDelete( profile.slug ) }
+												onClick={ () =>
+													handleDelete( profile.slug )
+												}
 											/>
 										</>
 									) }

--- a/src/settings-page/usage-dashboard.js
+++ b/src/settings-page/usage-dashboard.js
@@ -6,6 +6,12 @@ import { Spinner, SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 
+/**
+ * Format a cost value in USD as a human-readable string.
+ *
+ * @param {number|string} cost - Cost value.
+ * @return {string} Formatted cost string (e.g. '$0.0012', '$1.23').
+ */
 function formatCost( cost ) {
 	const num = parseFloat( cost ) || 0;
 	if ( num < 0.01 ) {
@@ -14,6 +20,12 @@ function formatCost( cost ) {
 	return '$' + num.toFixed( 2 );
 }
 
+/**
+ * Format a token count as a human-readable string.
+ *
+ * @param {number|string} tokens - Token count.
+ * @return {string} Formatted string (e.g. '128K', '1.2M').
+ */
 function formatTokens( tokens ) {
 	const num = parseInt( tokens, 10 ) || 0;
 	if ( num >= 1_000_000 ) {
@@ -25,6 +37,11 @@ function formatTokens( tokens ) {
 	return num.toString();
 }
 
+/**
+ * Usage dashboard showing token consumption and cost statistics over a time period.
+ *
+ * @return {JSX.Element} Usage dashboard element.
+ */
 export default function UsageDashboard() {
 	const [ period, setPeriod ] = useState( '30d' );
 	const [ data, setData ] = useState( null );
@@ -56,9 +73,7 @@ export default function UsageDashboard() {
 	}
 
 	if ( ! data ) {
-		return (
-			<p>{ __( 'Failed to load usage data.', 'ai-agent' ) }</p>
-		);
+		return <p>{ __( 'Failed to load usage data.', 'ai-agent' ) }</p>;
 	}
 
 	const totals = data.totals || {};
@@ -141,24 +156,17 @@ export default function UsageDashboard() {
 							<tr>
 								<th>{ __( 'Model', 'ai-agent' ) }</th>
 								<th>{ __( 'Requests', 'ai-agent' ) }</th>
-								<th>
-									{ __( 'Input Tokens', 'ai-agent' ) }
-								</th>
-								<th>
-									{ __( 'Output Tokens', 'ai-agent' ) }
-								</th>
+								<th>{ __( 'Input Tokens', 'ai-agent' ) }</th>
+								<th>{ __( 'Output Tokens', 'ai-agent' ) }</th>
 								<th>{ __( 'Cost', 'ai-agent' ) }</th>
 								<th></th>
 							</tr>
 						</thead>
 						<tbody>
 							{ byModel.map( ( m, i ) => {
-								const cost =
-									parseFloat( m.cost_usd ) || 0;
+								const cost = parseFloat( m.cost_usd ) || 0;
 								const pct =
-									maxCost > 0
-										? ( cost / maxCost ) * 100
-										: 0;
+									maxCost > 0 ? ( cost / maxCost ) * 100 : 0;
 								return (
 									<tr key={ i }>
 										<td>
@@ -168,18 +176,14 @@ export default function UsageDashboard() {
 										</td>
 										<td>{ m.request_count }</td>
 										<td>
-											{ formatTokens(
-												m.prompt_tokens
-											) }
+											{ formatTokens( m.prompt_tokens ) }
 										</td>
 										<td>
 											{ formatTokens(
 												m.completion_tokens
 											) }
 										</td>
-										<td>
-											{ formatCost( m.cost_usd ) }
-										</td>
+										<td>{ formatCost( m.cost_usd ) }</td>
 										<td>
 											<div className="ai-agent-usage-bar">
 												<div

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -4,6 +4,125 @@
 import { createReduxStore, register } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 
+/**
+ * @typedef {Object} Provider
+ * @property {string}  id     - Provider identifier.
+ * @property {string}  name   - Display name.
+ * @property {Model[]} models - Available models for this provider.
+ */
+
+/**
+ * @typedef {Object} Model
+ * @property {string} id   - Model identifier.
+ * @property {string} name - Display name.
+ */
+
+/**
+ * @typedef {Object} MessagePart
+ * @property {string} [text] - Text content of the message part.
+ */
+
+/**
+ * @typedef {Object} DebugInfo
+ * @property {number}                               responseTimeMs  - Time from send to response in ms.
+ * @property {{prompt: number, completion: number}} tokenUsage      - Token counts.
+ * @property {number}                               tokensPerSecond - Output tokens per second.
+ * @property {string}                               modelId         - Model used for this response.
+ * @property {number}                               costEstimate    - Estimated cost in USD.
+ * @property {number}                               iterationsUsed  - Number of tool-call iterations.
+ * @property {number}                               toolCallCount   - Number of tool calls made.
+ * @property {string[]}                             toolNames       - Unique tool names used.
+ */
+
+/**
+ * @typedef {Object} Message
+ * @property {'user'|'model'|'system'|'function'} role        - Message role.
+ * @property {MessagePart[]}                      parts       - Message content parts.
+ * @property {ToolCall[]}                         [toolCalls] - Tool calls attached to this message.
+ * @property {DebugInfo}                          [debug]     - Debug metadata (debug mode only).
+ */
+
+/**
+ * @typedef {Object} ToolCall
+ * @property {'call'|'result'} type       - Whether this is a call or its result.
+ * @property {string}          name       - Tool name.
+ * @property {Object}          [args]     - Arguments passed to the tool.
+ * @property {*}               [response] - Tool response value.
+ */
+
+/**
+ * @typedef {Object} Session
+ * @property {number|string}                        id            - Session ID.
+ * @property {string}                               [title]       - Session title.
+ * @property {string}                               [status]      - 'active' | 'archived' | 'trash'.
+ * @property {string}                               [folder]      - Folder name.
+ * @property {number|string}                        [pinned]      - 1 if pinned, 0 otherwise.
+ * @property {string}                               [provider_id] - Provider used for this session.
+ * @property {string}                               [model_id]    - Model used for this session.
+ * @property {string}                               [updated_at]  - ISO date string (without Z).
+ * @property {{prompt: number, completion: number}} [token_usage] - Token counts.
+ */
+
+/**
+ * @typedef {Object} Memory
+ * @property {number} id       - Memory ID.
+ * @property {string} category - Memory category slug.
+ * @property {string} content  - Memory text content.
+ */
+
+/**
+ * @typedef {Object} Skill
+ * @property {number}  id           - Skill ID.
+ * @property {string}  name         - Skill name/slug.
+ * @property {string}  [content]    - Skill prompt content.
+ * @property {boolean} [isReadonly] - Whether the skill is system-defined.
+ */
+
+/**
+ * @typedef {Object} TokenUsage
+ * @property {number} prompt     - Input/prompt tokens used.
+ * @property {number} completion - Output/completion tokens used.
+ */
+
+/**
+ * @typedef {Object} PendingConfirmation
+ * @property {string}     jobId - Job ID awaiting confirmation.
+ * @property {ToolCall[]} tools - Tools pending user approval.
+ */
+
+/**
+ * @typedef {Object} StoreState
+ * @property {Provider[]}               providers               - Available AI providers.
+ * @property {boolean}                  providersLoaded         - Whether providers have been fetched.
+ * @property {Session[]}                sessions                - Session list.
+ * @property {boolean}                  sessionsLoaded          - Whether sessions have been fetched.
+ * @property {number|null}              currentSessionId        - Active session ID.
+ * @property {Message[]}                currentSessionMessages  - Messages in the active session.
+ * @property {ToolCall[]}               currentSessionToolCalls - Tool calls in the active session.
+ * @property {boolean}                  sending                 - Whether a message is in-flight.
+ * @property {string|null}              currentJobId            - Active job ID.
+ * @property {string}                   selectedProviderId      - Selected provider ID.
+ * @property {string}                   selectedModelId         - Selected model ID.
+ * @property {boolean}                  floatingOpen            - Whether the floating panel is open.
+ * @property {boolean}                  floatingMinimized       - Whether the floating panel is minimized.
+ * @property {Object}                   pageContext             - Structured page context for the agent.
+ * @property {string}                   sessionFilter           - Active session list filter.
+ * @property {string}                   sessionFolder           - Active folder filter.
+ * @property {string}                   sessionSearch           - Active search query.
+ * @property {string[]}                 folders                 - Available folder names.
+ * @property {boolean}                  foldersLoaded           - Whether folders have been fetched.
+ * @property {Object|null}              settings                - Plugin settings object.
+ * @property {boolean}                  settingsLoaded          - Whether settings have been fetched.
+ * @property {Memory[]}                 memories                - Stored memories.
+ * @property {boolean}                  memoriesLoaded          - Whether memories have been fetched.
+ * @property {Skill[]}                  skills                  - Registered skills.
+ * @property {boolean}                  skillsLoaded            - Whether skills have been fetched.
+ * @property {TokenUsage}               tokenUsage              - Cumulative token usage for the session.
+ * @property {PendingConfirmation|null} pendingConfirmation     - Tool call awaiting user confirmation.
+ * @property {boolean}                  debugMode               - Whether debug mode is active.
+ * @property {number}                   sendTimestamp           - Timestamp of the last send (ms).
+ */
+
 const STORE_NAME = 'ai-agent';
 
 /**
@@ -63,12 +182,32 @@ const DEFAULT_STATE = {
 };
 
 const actions = {
+	/**
+	 * Set the list of available AI providers.
+	 *
+	 * @param {Provider[]} providers - Provider objects from the API.
+	 * @return {Object} Redux action.
+	 */
 	setProviders( providers ) {
 		return { type: 'SET_PROVIDERS', providers };
 	},
+	/**
+	 * Set the list of sessions.
+	 *
+	 * @param {Session[]} sessions - Session objects from the API.
+	 * @return {Object} Redux action.
+	 */
 	setSessions( sessions ) {
 		return { type: 'SET_SESSIONS', sessions };
 	},
+	/**
+	 * Set the active session and its messages/tool calls.
+	 *
+	 * @param {number}     sessionId - Session ID.
+	 * @param {Message[]}  messages  - Messages for the session.
+	 * @param {ToolCall[]} toolCalls - Tool calls for the session.
+	 * @return {Object} Redux action.
+	 */
 	setCurrentSession( sessionId, messages, toolCalls ) {
 		return {
 			type: 'SET_CURRENT_SESSION',
@@ -77,78 +216,214 @@ const actions = {
 			toolCalls,
 		};
 	},
+	/**
+	 * Clear the active session (start a new chat).
+	 *
+	 * @return {Object} Redux action.
+	 */
 	clearCurrentSession() {
 		return { type: 'CLEAR_CURRENT_SESSION' };
 	},
+	/**
+	 * Set the sending state.
+	 *
+	 * @param {boolean} sending - Whether a message is in-flight.
+	 * @return {Object} Redux action.
+	 */
 	setSending( sending ) {
 		return { type: 'SET_SENDING', sending };
 	},
+	/**
+	 * Set the current background job ID.
+	 *
+	 * @param {string|null} jobId - Job ID, or null to clear.
+	 * @return {Object} Redux action.
+	 */
 	setCurrentJobId( jobId ) {
 		return { type: 'SET_CURRENT_JOB_ID', jobId };
 	},
+	/**
+	 * Set the selected provider and persist to localStorage.
+	 *
+	 * @param {string} providerId - Provider ID to select.
+	 * @return {Object} Redux action.
+	 */
 	setSelectedProvider( providerId ) {
 		localStorage.setItem( 'aiAgentProvider', providerId );
 		return { type: 'SET_SELECTED_PROVIDER', providerId };
 	},
+	/**
+	 * Set the selected model and persist to localStorage.
+	 *
+	 * @param {string} modelId - Model ID to select.
+	 * @return {Object} Redux action.
+	 */
 	setSelectedModel( modelId ) {
 		localStorage.setItem( 'aiAgentModel', modelId );
 		return { type: 'SET_SELECTED_MODEL', modelId };
 	},
+	/**
+	 * Open or close the floating chat panel.
+	 *
+	 * @param {boolean} open - Whether the panel should be open.
+	 * @return {Object} Redux action.
+	 */
 	setFloatingOpen( open ) {
 		return { type: 'SET_FLOATING_OPEN', open };
 	},
+	/**
+	 * Minimize or expand the floating chat panel.
+	 *
+	 * @param {boolean} minimized - Whether the panel should be minimized.
+	 * @return {Object} Redux action.
+	 */
 	setFloatingMinimized( minimized ) {
 		return { type: 'SET_FLOATING_MINIMIZED', minimized };
 	},
+	/**
+	 * Set structured page context for the agent.
+	 *
+	 * @param {Object} context - Page context object (url, admin_page, etc.).
+	 * @return {Object} Redux action.
+	 */
 	setPageContext( context ) {
 		return { type: 'SET_PAGE_CONTEXT', context };
 	},
+	/**
+	 * Append a message to the current session's message list.
+	 *
+	 * @param {Message} message - Message to append.
+	 * @return {Object} Redux action.
+	 */
 	appendMessage( message ) {
 		return { type: 'APPEND_MESSAGE', message };
 	},
+	/**
+	 * Remove the last message from the current session.
+	 *
+	 * @return {Object} Redux action.
+	 */
 	removeLastMessage() {
 		return { type: 'REMOVE_LAST_MESSAGE' };
 	},
+	/**
+	 * Set the plugin settings object.
+	 *
+	 * @param {Object} settings - Settings from the API.
+	 * @return {Object} Redux action.
+	 */
 	setSettings( settings ) {
 		return { type: 'SET_SETTINGS', settings };
 	},
+	/**
+	 * Set the list of stored memories.
+	 *
+	 * @param {Memory[]} memories - Memory objects from the API.
+	 * @return {Object} Redux action.
+	 */
 	setMemories( memories ) {
 		return { type: 'SET_MEMORIES', memories };
 	},
+	/**
+	 * Set the list of registered skills.
+	 *
+	 * @param {Skill[]} skills - Skill objects from the API.
+	 * @return {Object} Redux action.
+	 */
 	setSkills( skills ) {
 		return { type: 'SET_SKILLS', skills };
 	},
+	/**
+	 * Set the cumulative token usage for the current session.
+	 *
+	 * @param {TokenUsage} tokenUsage - Token usage counts.
+	 * @return {Object} Redux action.
+	 */
 	setTokenUsage( tokenUsage ) {
 		return { type: 'SET_TOKEN_USAGE', tokenUsage };
 	},
+	/**
+	 * Set the session list filter.
+	 *
+	 * @param {string} filter - Filter value: 'active' | 'archived' | 'trash'.
+	 * @return {Object} Redux action.
+	 */
 	setSessionFilter( filter ) {
 		return { type: 'SET_SESSION_FILTER', filter };
 	},
+	/**
+	 * Set the active folder filter for the session list.
+	 *
+	 * @param {string} folder - Folder name, or empty string for all.
+	 * @return {Object} Redux action.
+	 */
 	setSessionFolder( folder ) {
 		return { type: 'SET_SESSION_FOLDER', folder };
 	},
+	/**
+	 * Set the session search query.
+	 *
+	 * @param {string} search - Search string.
+	 * @return {Object} Redux action.
+	 */
 	setSessionSearch( search ) {
 		return { type: 'SET_SESSION_SEARCH', search };
 	},
+	/**
+	 * Set the list of available folder names.
+	 *
+	 * @param {string[]} folders - Folder names from the API.
+	 * @return {Object} Redux action.
+	 */
 	setFolders( folders ) {
 		return { type: 'SET_FOLDERS', folders };
 	},
+	/**
+	 * Set the pending tool confirmation state.
+	 *
+	 * @param {PendingConfirmation|null} confirmation - Confirmation data, or null to clear.
+	 * @return {Object} Redux action.
+	 */
 	setPendingConfirmation( confirmation ) {
 		return { type: 'SET_PENDING_CONFIRMATION', confirmation };
 	},
+	/**
+	 * Truncate the message list to the given index (exclusive).
+	 *
+	 * @param {number} index - Messages at or after this index are removed.
+	 * @return {Object} Redux action.
+	 */
 	truncateMessagesTo( index ) {
 		return { type: 'TRUNCATE_MESSAGES_TO', index };
 	},
+	/**
+	 * Enable or disable debug mode and persist to localStorage.
+	 *
+	 * @param {boolean} enabled - Whether debug mode should be active.
+	 * @return {Object} Redux action.
+	 */
 	setDebugMode( enabled ) {
 		localStorage.setItem( 'aiAgentDebugMode', enabled ? 'true' : 'false' );
 		return { type: 'SET_DEBUG_MODE', enabled };
 	},
+	/**
+	 * Record the timestamp when a message was sent.
+	 *
+	 * @param {number} ts - Unix timestamp in milliseconds.
+	 * @return {Object} Redux action.
+	 */
 	setSendTimestamp( ts ) {
 		return { type: 'SET_SEND_TIMESTAMP', ts };
 	},
 
 	// ─── Thunks ──────────────────────────────────────────────────
 
+	/**
+	 * Fetch available AI providers from the REST API.
+	 * Auto-selects the first provider/model if none is saved.
+	 *
+	 * @return {Function} Thunk.
+	 */
 	fetchProviders() {
 		return async ( { dispatch } ) => {
 			try {
@@ -179,6 +454,11 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Fetch sessions from the REST API, applying current filter/folder/search.
+	 *
+	 * @return {Function} Thunk.
+	 */
 	fetchSessions() {
 		return async ( { dispatch, select } ) => {
 			try {
@@ -208,6 +488,12 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Open a session by ID, loading its messages and restoring provider/model.
+	 *
+	 * @param {number} sessionId - Session ID to open.
+	 * @return {Function} Thunk.
+	 */
 	openSession( sessionId ) {
 		return async ( { dispatch, select } ) => {
 			try {
@@ -226,13 +512,9 @@ const actions = {
 						( p ) => p.id === session.provider_id
 					);
 					if ( providerExists ) {
-						dispatch.setSelectedProvider(
-							session.provider_id
-						);
+						dispatch.setSelectedProvider( session.provider_id );
 						if ( session.model_id ) {
-							dispatch.setSelectedModel(
-								session.model_id
-							);
+							dispatch.setSelectedModel( session.model_id );
 						}
 					}
 				}
@@ -245,6 +527,12 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Permanently delete a session.
+	 *
+	 * @param {number} sessionId - Session ID to delete.
+	 * @return {Function} Thunk.
+	 */
 	deleteSession( sessionId ) {
 		return async ( { dispatch, select } ) => {
 			try {
@@ -262,6 +550,13 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Pin or unpin a session.
+	 *
+	 * @param {number}  sessionId - Session ID.
+	 * @param {boolean} pinned    - Whether to pin the session.
+	 * @return {Function} Thunk.
+	 */
 	pinSession( sessionId, pinned ) {
 		return async ( { dispatch } ) => {
 			await apiFetch( {
@@ -273,6 +568,12 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Archive a session (move to archived status).
+	 *
+	 * @param {number} sessionId - Session ID to archive.
+	 * @return {Function} Thunk.
+	 */
 	archiveSession( sessionId ) {
 		return async ( { dispatch, select } ) => {
 			await apiFetch( {
@@ -287,6 +588,12 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Move a session to trash.
+	 *
+	 * @param {number} sessionId - Session ID to trash.
+	 * @return {Function} Thunk.
+	 */
 	trashSession( sessionId ) {
 		return async ( { dispatch, select } ) => {
 			await apiFetch( {
@@ -301,6 +608,12 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Restore a trashed or archived session to active status.
+	 *
+	 * @param {number} sessionId - Session ID to restore.
+	 * @return {Function} Thunk.
+	 */
 	restoreSession( sessionId ) {
 		return async ( { dispatch } ) => {
 			await apiFetch( {
@@ -312,6 +625,13 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Move a session to a folder.
+	 *
+	 * @param {number} sessionId - Session ID.
+	 * @param {string} folder    - Target folder name, or empty string to remove.
+	 * @return {Function} Thunk.
+	 */
 	moveSessionToFolder( sessionId, folder ) {
 		return async ( { dispatch } ) => {
 			await apiFetch( {
@@ -324,6 +644,13 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Rename a session.
+	 *
+	 * @param {number} sessionId - Session ID.
+	 * @param {string} title     - New title.
+	 * @return {Function} Thunk.
+	 */
 	renameSession( sessionId, title ) {
 		return async ( { dispatch } ) => {
 			await apiFetch( {
@@ -335,6 +662,11 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Fetch the list of session folder names from the REST API.
+	 *
+	 * @return {Function} Thunk.
+	 */
 	fetchFolders() {
 		return async ( { dispatch } ) => {
 			try {
@@ -348,6 +680,13 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Export a session and trigger a file download.
+	 *
+	 * @param {number}            sessionId       - Session ID to export.
+	 * @param {'json'|'markdown'} [format='json'] - Export format.
+	 * @return {Function} Thunk.
+	 */
 	exportSession( sessionId, format = 'json' ) {
 		return async () => {
 			const result = await apiFetch( {
@@ -358,10 +697,7 @@ const actions = {
 					? JSON.stringify( result.content, null, 2 )
 					: result.content;
 			const blob = new Blob( [ content ], {
-				type:
-					format === 'json'
-						? 'application/json'
-						: 'text/markdown',
+				type: format === 'json' ? 'application/json' : 'text/markdown',
 			} );
 			const url = URL.createObjectURL( blob );
 			const a = document.createElement( 'a' );
@@ -372,6 +708,12 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Import a session from exported JSON data.
+	 *
+	 * @param {Object} data - Parsed JSON export data (format: 'ai-agent-v1').
+	 * @return {Function} Thunk.
+	 */
 	importSession( data ) {
 		return async ( { dispatch } ) => {
 			const session = await apiFetch( {
@@ -384,6 +726,13 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Regenerate the AI response at the given message index.
+	 * Finds the preceding user message and re-sends it.
+	 *
+	 * @param {number} index - Index of the message to regenerate from.
+	 * @return {Function} Thunk.
+	 */
 	regenerateMessage( index ) {
 		return async ( { dispatch, select } ) => {
 			const messages = select.getCurrentSessionMessages();
@@ -408,6 +757,13 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Truncate messages to the given index and re-send with new text.
+	 *
+	 * @param {number} index   - Index to truncate at.
+	 * @param {string} newText - Replacement message text.
+	 * @return {Function} Thunk.
+	 */
 	editAndResend( index, newText ) {
 		return async ( { dispatch } ) => {
 			dispatch.truncateMessagesTo( index );
@@ -415,6 +771,11 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Cancel the current in-flight generation.
+	 *
+	 * @return {Function} Thunk.
+	 */
 	stopGeneration() {
 		return async ( { dispatch } ) => {
 			dispatch.setCurrentJobId( null );
@@ -422,6 +783,13 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Confirm a pending tool call and resume the job.
+	 *
+	 * @param {string}  jobId               - Job ID awaiting confirmation.
+	 * @param {boolean} [alwaysAllow=false] - If true, set tool permission to Auto.
+	 * @return {Function} Thunk.
+	 */
 	confirmToolCall( jobId, alwaysAllow = false ) {
 		return async ( { dispatch } ) => {
 			dispatch.setPendingConfirmation( null );
@@ -437,7 +805,9 @@ const actions = {
 					role: 'system',
 					parts: [
 						{
-							text: `Error: ${ err.message || 'Failed to confirm tool call' }`,
+							text: `Error: ${
+								err.message || 'Failed to confirm tool call'
+							}`,
 						},
 					],
 				} );
@@ -447,6 +817,12 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Reject a pending tool call and resume the job without executing it.
+	 *
+	 * @param {string} jobId - Job ID awaiting confirmation.
+	 * @return {Function} Thunk.
+	 */
 	rejectToolCall( jobId ) {
 		return async ( { dispatch } ) => {
 			dispatch.setPendingConfirmation( null );
@@ -461,7 +837,9 @@ const actions = {
 					role: 'system',
 					parts: [
 						{
-							text: `Error: ${ err.message || 'Failed to reject tool call' }`,
+							text: `Error: ${
+								err.message || 'Failed to reject tool call'
+							}`,
 						},
 					],
 				} );
@@ -471,6 +849,12 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Send a user message. Creates a session if none is active, then starts a job.
+	 *
+	 * @param {string} message - User message text.
+	 * @return {Function} Thunk.
+	 */
 	sendMessage( message ) {
 		return async ( { dispatch, select } ) => {
 			dispatch.setSending( true );
@@ -548,7 +932,9 @@ const actions = {
 					role: 'system',
 					parts: [
 						{
-							text: `Error: ${ err.message || 'Failed to start job' }`,
+							text: `Error: ${
+								err.message || 'Failed to start job'
+							}`,
 						},
 					],
 				} );
@@ -557,6 +943,13 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Poll a background job until it completes, errors, or requires confirmation.
+	 * Retries every 3 seconds up to 200 attempts (~10 minutes).
+	 *
+	 * @param {string} jobId - Job ID to poll.
+	 * @return {Function} Thunk.
+	 */
 	pollJob( jobId ) {
 		return async ( { dispatch, select } ) => {
 			let attempts = 0;
@@ -603,7 +996,9 @@ const actions = {
 							role: 'system',
 							parts: [
 								{
-									text: `Error: ${ result.message || 'Unknown error' }`,
+									text: `Error: ${
+										result.message || 'Unknown error'
+									}`,
 								},
 							],
 						} );
@@ -621,21 +1016,36 @@ const actions = {
 							// Attach debug metadata when debug mode is active.
 							if ( select.isDebugMode() ) {
 								const sendTs = select.getSendTimestamp();
-								const elapsed = sendTs ? Date.now() - sendTs : 0;
+								const elapsed = sendTs
+									? Date.now() - sendTs
+									: 0;
 								const tu = result.token_usage || {};
 								const completionTokens = tu.completion || 0;
 								const promptTokens = tu.prompt || 0;
-								const tokPerSec = elapsed > 0 ? ( completionTokens / ( elapsed / 1000 ) ) : 0;
+								const tokPerSec =
+									elapsed > 0
+										? completionTokens / ( elapsed / 1000 )
+										: 0;
 
 								// Derive tool call count and names.
 								const tc = result.tool_calls || [];
-								const toolCalls = tc.filter( ( t ) => t.type === 'call' );
-								const toolNames = [ ...new Set( toolCalls.map( ( t ) => t.name ) ) ];
+								const toolCalls = tc.filter(
+									( t ) => t.type === 'call'
+								);
+								const toolNames = [
+									...new Set(
+										toolCalls.map( ( t ) => t.name )
+									),
+								];
 
 								msg.debug = {
 									responseTimeMs: elapsed,
-									tokenUsage: { prompt: promptTokens, completion: completionTokens },
-									tokensPerSecond: Math.round( tokPerSec * 10 ) / 10,
+									tokenUsage: {
+										prompt: promptTokens,
+										completion: completionTokens,
+									},
+									tokensPerSecond:
+										Math.round( tokPerSec * 10 ) / 10,
 									modelId: result.model_id || '',
 									costEstimate: result.cost_estimate || 0,
 									iterationsUsed: result.iterations_used || 0,
@@ -686,6 +1096,11 @@ const actions = {
 
 	// ─── Settings thunks ─────────────────────────────────────────
 
+	/**
+	 * Fetch plugin settings from the REST API.
+	 *
+	 * @return {Function} Thunk.
+	 */
 	fetchSettings() {
 		return async ( { dispatch } ) => {
 			try {
@@ -699,6 +1114,12 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Save plugin settings via the REST API.
+	 *
+	 * @param {Object} data - Settings fields to update.
+	 * @return {Function} Thunk that resolves with the saved settings object.
+	 */
 	saveSettings( data ) {
 		return async ( { dispatch } ) => {
 			try {
@@ -717,6 +1138,11 @@ const actions = {
 
 	// ─── Memory thunks ───────────────────────────────────────────
 
+	/**
+	 * Fetch stored memories from the REST API.
+	 *
+	 * @return {Function} Thunk.
+	 */
 	fetchMemories() {
 		return async ( { dispatch } ) => {
 			try {
@@ -730,6 +1156,13 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Create a new memory entry.
+	 *
+	 * @param {string} category - Memory category slug.
+	 * @param {string} content  - Memory text content.
+	 * @return {Function} Thunk.
+	 */
 	createMemory( category, content ) {
 		return async ( { dispatch } ) => {
 			await apiFetch( {
@@ -741,6 +1174,13 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Update an existing memory entry.
+	 *
+	 * @param {number} id   - Memory ID.
+	 * @param {Object} data - Fields to update (category, content).
+	 * @return {Function} Thunk.
+	 */
 	updateMemory( id, data ) {
 		return async ( { dispatch } ) => {
 			await apiFetch( {
@@ -752,6 +1192,12 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Delete a memory entry.
+	 *
+	 * @param {number} id - Memory ID to delete.
+	 * @return {Function} Thunk.
+	 */
 	deleteMemory( id ) {
 		return async ( { dispatch } ) => {
 			await apiFetch( {
@@ -764,6 +1210,11 @@ const actions = {
 
 	// ─── Skills thunks ──────────────────────────────────────────
 
+	/**
+	 * Fetch registered skills from the REST API.
+	 *
+	 * @return {Function} Thunk.
+	 */
 	fetchSkills() {
 		return async ( { dispatch } ) => {
 			try {
@@ -777,6 +1228,12 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Create a new skill.
+	 *
+	 * @param {Object} data - Skill fields (name, content, etc.).
+	 * @return {Function} Thunk.
+	 */
 	createSkill( data ) {
 		return async ( { dispatch } ) => {
 			await apiFetch( {
@@ -788,6 +1245,13 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Update an existing skill.
+	 *
+	 * @param {number} id   - Skill ID.
+	 * @param {Object} data - Fields to update.
+	 * @return {Function} Thunk.
+	 */
 	updateSkill( id, data ) {
 		return async ( { dispatch } ) => {
 			await apiFetch( {
@@ -799,6 +1263,12 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Delete a skill.
+	 *
+	 * @param {number} id - Skill ID to delete.
+	 * @return {Function} Thunk.
+	 */
 	deleteSkill( id ) {
 		return async ( { dispatch } ) => {
 			await apiFetch( {
@@ -809,6 +1279,12 @@ const actions = {
 		};
 	},
 
+	/**
+	 * Reset a skill to its system default content.
+	 *
+	 * @param {number} id - Skill ID to reset.
+	 * @return {Function} Thunk.
+	 */
 	resetSkill( id ) {
 		return async ( { dispatch } ) => {
 			await apiFetch( {
@@ -821,6 +1297,12 @@ const actions = {
 
 	// ─── Compact thunk ───────────────────────────────────────────
 
+	/**
+	 * Compact the current conversation into a new session with a summary.
+	 * Creates a new session and sends the full conversation as context.
+	 *
+	 * @return {Function} Thunk.
+	 */
 	compactConversation() {
 		return async ( { dispatch, select } ) => {
 			const messages = select.getCurrentSessionMessages();
@@ -869,113 +1351,299 @@ const actions = {
 };
 
 const selectors = {
+	/**
+	 * Get the list of available AI providers.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {Provider[]} Providers.
+	 */
 	getProviders( state ) {
 		return state.providers;
 	},
+	/**
+	 * Whether providers have been fetched from the API.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {boolean} True if providers have loaded.
+	 */
 	getProvidersLoaded( state ) {
 		return state.providersLoaded;
 	},
+	/**
+	 * Get the list of sessions.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {Session[]} Sessions.
+	 */
 	getSessions( state ) {
 		return state.sessions;
 	},
+	/**
+	 * Whether sessions have been fetched from the API.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {boolean} True if sessions have loaded.
+	 */
 	getSessionsLoaded( state ) {
 		return state.sessionsLoaded;
 	},
+	/**
+	 * Get the active session ID.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {number|null} Session ID, or null if no session is open.
+	 */
 	getCurrentSessionId( state ) {
 		return state.currentSessionId;
 	},
+	/**
+	 * Get the messages for the active session.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {Message[]} Messages.
+	 */
 	getCurrentSessionMessages( state ) {
 		return state.currentSessionMessages;
 	},
+	/**
+	 * Get the tool calls for the active session.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {ToolCall[]} Tool calls.
+	 */
 	getCurrentSessionToolCalls( state ) {
 		return state.currentSessionToolCalls;
 	},
+	/**
+	 * Whether a message is currently being sent/processed.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {boolean} True if sending.
+	 */
 	isSending( state ) {
 		return state.sending;
 	},
+	/**
+	 * Get the current background job ID.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {string|null} Job ID, or null if no job is running.
+	 */
 	getCurrentJobId( state ) {
 		return state.currentJobId;
 	},
+	/**
+	 * Get the selected provider ID.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {string} Provider ID.
+	 */
 	getSelectedProviderId( state ) {
 		return state.selectedProviderId;
 	},
+	/**
+	 * Get the selected model ID.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {string} Model ID.
+	 */
 	getSelectedModelId( state ) {
 		return state.selectedModelId;
 	},
+	/**
+	 * Get the models available for the currently selected provider.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {Model[]} Models for the selected provider.
+	 */
 	getSelectedProviderModels( state ) {
 		const provider = state.providers.find(
 			( p ) => p.id === state.selectedProviderId
 		);
 		return provider?.models || [];
 	},
+	/**
+	 * Whether the floating chat panel is open.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {boolean} True if open.
+	 */
 	isFloatingOpen( state ) {
 		return state.floatingOpen;
 	},
+	/**
+	 * Whether the floating chat panel is minimized.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {boolean} True if minimized.
+	 */
 	isFloatingMinimized( state ) {
 		return state.floatingMinimized;
 	},
+	/**
+	 * Get the structured page context for the agent.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {Object} Page context object.
+	 */
 	getPageContext( state ) {
 		return state.pageContext;
 	},
 
 	// Settings
+	/**
+	 * Get the plugin settings object.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {Object|null} Settings, or null if not yet loaded.
+	 */
 	getSettings( state ) {
 		return state.settings;
 	},
+	/**
+	 * Whether settings have been fetched from the API.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {boolean} True if settings have loaded.
+	 */
 	getSettingsLoaded( state ) {
 		return state.settingsLoaded;
 	},
 
 	// Memory
+	/**
+	 * Get the list of stored memories.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {Memory[]} Memories.
+	 */
 	getMemories( state ) {
 		return state.memories;
 	},
+	/**
+	 * Whether memories have been fetched from the API.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {boolean} True if memories have loaded.
+	 */
 	getMemoriesLoaded( state ) {
 		return state.memoriesLoaded;
 	},
 
 	// Skills
+	/**
+	 * Get the list of registered skills.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {Skill[]} Skills.
+	 */
 	getSkills( state ) {
 		return state.skills;
 	},
+	/**
+	 * Whether skills have been fetched from the API.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {boolean} True if skills have loaded.
+	 */
 	getSkillsLoaded( state ) {
 		return state.skillsLoaded;
 	},
 
 	// Session filters
+	/**
+	 * Get the active session list filter.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {string} Filter value: 'active' | 'archived' | 'trash'.
+	 */
 	getSessionFilter( state ) {
 		return state.sessionFilter;
 	},
+	/**
+	 * Get the active folder filter for the session list.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {string} Folder name, or empty string for all.
+	 */
 	getSessionFolder( state ) {
 		return state.sessionFolder;
 	},
+	/**
+	 * Get the active session search query.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {string} Search string.
+	 */
 	getSessionSearch( state ) {
 		return state.sessionSearch;
 	},
+	/**
+	 * Get the list of available folder names.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {string[]} Folder names.
+	 */
 	getFolders( state ) {
 		return state.folders;
 	},
+	/**
+	 * Whether folders have been fetched from the API.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {boolean} True if folders have loaded.
+	 */
 	getFoldersLoaded( state ) {
 		return state.foldersLoaded;
 	},
 
 	// Pending confirmation
+	/**
+	 * Get the pending tool confirmation state.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {PendingConfirmation|null} Confirmation data, or null if none pending.
+	 */
 	getPendingConfirmation( state ) {
 		return state.pendingConfirmation;
 	},
 
 	// Debug mode
+	/**
+	 * Whether debug mode is active.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {boolean} True if debug mode is on.
+	 */
 	isDebugMode( state ) {
 		return state.debugMode;
 	},
+	/**
+	 * Get the timestamp of the last message send.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {number} Unix timestamp in milliseconds.
+	 */
 	getSendTimestamp( state ) {
 		return state.sendTimestamp;
 	},
 
 	// Token usage
+	/**
+	 * Get the cumulative token usage for the current session.
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {TokenUsage} Token usage counts.
+	 */
 	getTokenUsage( state ) {
 		return state.tokenUsage;
 	},
+	/**
+	 * Get the context window usage as a percentage (0–100+).
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {number} Percentage of context window used.
+	 */
 	getContextPercentage( state ) {
 		const contextLimit =
 			MODEL_CONTEXT_WINDOWS[ state.selectedModelId ] ||
@@ -983,6 +1651,12 @@ const selectors = {
 			128000;
 		return ( state.tokenUsage.prompt / contextLimit ) * 100;
 	},
+	/**
+	 * Whether the context window usage exceeds the warning threshold (80%).
+	 *
+	 * @param {StoreState} state - Store state.
+	 * @return {boolean} True if context usage is above 80%.
+	 */
 	isContextWarning( state ) {
 		const contextLimit =
 			MODEL_CONTEXT_WINDOWS[ state.selectedModelId ] ||
@@ -992,6 +1666,13 @@ const selectors = {
 	},
 };
 
+/**
+ * Redux reducer for the ai-agent store.
+ *
+ * @param {StoreState} state  - Current state.
+ * @param {Object}     action - Dispatched action.
+ * @return {StoreState} Next state.
+ */
 const reducer = ( state = DEFAULT_STATE, action ) => {
 	switch ( action.type ) {
 		case 'SET_PROVIDERS':

--- a/src/utils/keyboard-shortcuts.js
+++ b/src/utils/keyboard-shortcuts.js
@@ -4,11 +4,18 @@
 import { useEffect, useCallback } from '@wordpress/element';
 
 /**
+ * @typedef {Object} ShortcutEntry
+ * @property {string} combo - Key combo string (e.g. 'mod+k', 'Escape').
+ * @property {string} label - Human-readable label for the shortcut.
+ */
+
+/**
  * Hook to register keyboard shortcuts.
  *
- * @param {Object} shortcuts Map of shortcut key combos to handlers.
- *                           Keys use format: "mod+k", "mod+n", "escape", "mod+/"
- *                           "mod" maps to Cmd on Mac, Ctrl on others.
+ * @param {Object.<string, Function>} shortcuts - Map of key combo strings to
+ *                                              handler functions. Keys use format: "mod+k", "mod+n", "escape", "mod+/".
+ *                                              "mod" maps to Cmd on Mac, Ctrl on other platforms.
+ * @return {void}
  */
 export function useKeyboardShortcuts( shortcuts ) {
 	const isMac =
@@ -34,6 +41,14 @@ export function useKeyboardShortcuts( shortcuts ) {
 	}, [ handler ] );
 }
 
+/**
+ * Check whether a keyboard event matches a shortcut combo string.
+ *
+ * @param {KeyboardEvent} e     - The keyboard event to test.
+ * @param {string}        combo - Combo string (e.g. 'mod+k', 'escape').
+ * @param {boolean}       isMac - Whether the current platform is macOS.
+ * @return {boolean} True if the event matches the combo.
+ */
 function matchesCombo( e, combo, isMac ) {
 	const parts = combo.toLowerCase().split( '+' );
 	let needMod = false;
@@ -75,6 +90,8 @@ function matchesCombo( e, combo, isMac ) {
 
 /**
  * All available keyboard shortcuts for the help dialog.
+ *
+ * @type {ShortcutEntry[]}
  */
 export const SHORTCUTS = [
 	{ combo: 'mod+n', label: 'New chat' },


### PR DESCRIPTION
## Summary

- Adds JSDoc type annotations to all main React components and utility functions in `src/`
- Covers component prop types, function parameter/return types, API response shapes
- 37 files annotated across components, settings pages, store, and utilities

Closes #147

## Changes

- `src/components/` — JSDoc on all component props and callbacks
- `src/store/index.js` — action/selector type annotations
- `src/utils/` — parameter and return type docs
- `src/settings-page/` — prop and state types
- `.eslintrc.json` — minor config update