### PR TITLE
t089: MCP server — expose abilities as MCP tools for external AI clients

### DIFF
--- a/includes/REST/McpController.php
+++ b/includes/REST/McpController.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * MCP (Model Context Protocol) REST endpoint.
+ *
+ * Exposes all registered WordPress abilities as MCP tools so that external
+ * AI clients (Claude Desktop, Cursor, etc.) can discover and invoke them
+ * via the standard MCP protocol over HTTP.
+ *
+ * Endpoint: POST /wp-json/ai-agent/v1/mcp
+ *
+ * Supported methods:
+ *   - list_tools  — returns all registered abilities as MCP tool definitions
+ *   - call_tool   — executes a named ability with the provided arguments
+ *
+ * Authentication: WordPress nonce (X-WP-Nonce header) or Application Password
+ * (HTTP Basic Auth). Both are handled transparently by the WP REST API.
+ *
+ * @package AiAgent
+ */
+
+namespace AiAgent\REST;
+
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * McpController class
+ *
+ * Implements the MCP protocol over a single WordPress REST endpoint.
+ */
+class McpController {
+
+	/**
+	 * MCP protocol version advertised in responses.
+	 */
+	const MCP_PROTOCOL_VERSION = '2024-11-05';
+
+	/**
+	 * Register the /mcp REST route.
+	 */
+	public static function register_routes(): void {
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/mcp',
+			[
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => [ __CLASS__, 'handle_request' ],
+				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'args'                => [
+					'method' => [
+						'required'          => true,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+						'description'       => 'MCP method: list_tools or call_tool.',
+					],
+					'params' => [
+						'required' => false,
+						'type'     => 'object',
+						'default'  => [],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Permission check — requires manage_options capability.
+	 *
+	 * Satisfied by:
+	 *   - Cookie + nonce (browser / admin-ajax)
+	 *   - Application Password (HTTP Basic Auth)
+	 *   - Any other WP auth mechanism that sets the current user
+	 *
+	 * @return bool
+	 */
+	public static function check_permission(): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Dispatch an MCP request to the appropriate handler.
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public static function handle_request( WP_REST_Request $request ) {
+		$method = $request->get_param( 'method' );
+		$params = $request->get_param( 'params' );
+
+		if ( ! is_array( $params ) ) {
+			$params = [];
+		}
+
+		switch ( $method ) {
+			case 'list_tools':
+				return self::handle_list_tools();
+
+			case 'call_tool':
+				return self::handle_call_tool( $params );
+
+			default:
+				return new WP_Error(
+					'ai_agent_mcp_unknown_method',
+					sprintf(
+						/* translators: %s: MCP method name */
+						__( 'Unknown MCP method: %s. Supported methods: list_tools, call_tool.', 'ai-agent' ),
+						$method
+					),
+					[ 'status' => 400 ]
+				);
+		}
+	}
+
+	/**
+	 * Handle the list_tools MCP method.
+	 *
+	 * Returns all registered WordPress abilities as MCP tool definitions.
+	 * Each tool definition includes name, description, and inputSchema
+	 * following the JSON Schema / OpenAI function-calling format.
+	 *
+	 * @return WP_REST_Response
+	 */
+	private static function handle_list_tools(): WP_REST_Response {
+		$tools = self::get_mcp_tools();
+
+		return new WP_REST_Response(
+			[
+				'protocol_version' => self::MCP_PROTOCOL_VERSION,
+				'tools'            => $tools,
+			],
+			200
+		);
+	}
+
+	/**
+	 * Handle the call_tool MCP method.
+	 *
+	 * Executes a named ability with the provided arguments and returns
+	 * the result in MCP tool-result format.
+	 *
+	 * @param array $params MCP params: { name: string, arguments?: object }.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	private static function handle_call_tool( array $params ) {
+		$tool_name = isset( $params['name'] ) ? sanitize_text_field( (string) $params['name'] ) : '';
+		$arguments = isset( $params['arguments'] ) && is_array( $params['arguments'] )
+			? $params['arguments']
+			: [];
+
+		if ( '' === $tool_name ) {
+			return new WP_Error(
+				'ai_agent_mcp_missing_name',
+				__( 'call_tool requires a "name" parameter.', 'ai-agent' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			return new WP_Error(
+				'ai_agent_mcp_no_abilities_api',
+				__( 'WordPress Abilities API is not available. WordPress 6.9+ is required.', 'ai-agent' ),
+				[ 'status' => 503 ]
+			);
+		}
+
+		// MCP tool names use underscores; ability names use slashes and hyphens.
+		// Convert back: e.g. "ai_agent__memory_save" → "ai-agent/memory-save".
+		$ability_name = self::mcp_name_to_ability_name( $tool_name );
+		$ability      = wp_get_ability( $ability_name );
+
+		if ( null === $ability ) {
+			return new WP_Error(
+				'ai_agent_mcp_tool_not_found',
+				sprintf(
+					/* translators: %s: tool name */
+					__( 'Tool not found: %s', 'ai-agent' ),
+					$tool_name
+				),
+				[ 'status' => 404 ]
+			);
+		}
+
+		// execute() checks the ability's own permission_callback internally
+		// and returns WP_Error( 'ability_invalid_permissions', ... ) on failure.
+		$result = $ability->execute( ! empty( $arguments ) ? $arguments : null );
+
+		if ( is_wp_error( $result ) ) {
+			return new WP_REST_Response(
+				[
+					'protocol_version' => self::MCP_PROTOCOL_VERSION,
+					'tool'             => $tool_name,
+					'isError'          => true,
+					'content'          => [
+						[
+							'type' => 'text',
+							'text' => $result->get_error_message(),
+						],
+					],
+				],
+				200
+			);
+		}
+
+		// Normalise result to a scalar or JSON-serialisable value.
+		$text = is_string( $result ) ? $result : wp_json_encode( $result );
+
+		return new WP_REST_Response(
+			[
+				'protocol_version' => self::MCP_PROTOCOL_VERSION,
+				'tool'             => $tool_name,
+				'isError'          => false,
+				'content'          => [
+					[
+						'type' => 'text',
+						'text' => $text,
+					],
+				],
+			],
+			200
+		);
+	}
+
+	/**
+	 * Build the full list of MCP tool definitions from registered abilities.
+	 *
+	 * @return array<int, array{name: string, description: string, inputSchema: array}>
+	 */
+	private static function get_mcp_tools(): array {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			return [];
+		}
+
+		$abilities = wp_get_abilities();
+		$tools     = [];
+
+		foreach ( $abilities as $ability ) {
+			$name         = self::ability_name_to_mcp_name( $ability->get_name() );
+			$description  = $ability->get_description();
+			$input_schema = $ability->get_input_schema();
+
+			// Ensure inputSchema is a valid JSON Schema object.
+			if ( empty( $input_schema ) || ! is_array( $input_schema ) ) {
+				$input_schema = [
+					'type'       => 'object',
+					'properties' => new \stdClass(),
+				];
+			} else {
+				// Normalise empty properties arrays to objects (JSON Schema requires {}).
+				if ( isset( $input_schema['properties'] ) && $input_schema['properties'] === [] ) {
+					$input_schema['properties'] = new \stdClass();
+				}
+				// Remove empty required arrays (some clients reject them).
+				if ( isset( $input_schema['required'] ) && is_array( $input_schema['required'] ) && empty( $input_schema['required'] ) ) {
+					unset( $input_schema['required'] );
+				}
+			}
+
+			$tools[] = [
+				'name'        => $name,
+				'description' => $description,
+				'inputSchema' => $input_schema,
+			];
+		}
+
+		return $tools;
+	}
+
+	/**
+	 * Convert a WordPress ability name to an MCP-safe tool name.
+	 *
+	 * MCP tool names must match [a-zA-Z0-9_-]+.
+	 * Ability names use the format "namespace/tool-name" (slash + hyphens).
+	 *
+	 * Conversion: "ai-agent/memory-save" → "ai-agent__memory-save"
+	 * (slash replaced with double-underscore; hyphens preserved)
+	 *
+	 * @param string $ability_name WordPress ability name.
+	 * @return string MCP tool name.
+	 */
+	public static function ability_name_to_mcp_name( string $ability_name ): string {
+		return str_replace( '/', '__', $ability_name );
+	}
+
+	/**
+	 * Convert an MCP tool name back to a WordPress ability name.
+	 *
+	 * Reverses ability_name_to_mcp_name():
+	 * "ai-agent__memory-save" → "ai-agent/memory-save"
+	 *
+	 * @param string $mcp_name MCP tool name.
+	 * @return string WordPress ability name.
+	 */
+	public static function mcp_name_to_ability_name( string $mcp_name ): string {
+		return str_replace( '__', '/', $mcp_name );
+	}
+}

--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -52,6 +52,9 @@ class RestController {
 	 * Register REST routes.
 	 */
 	public static function register_routes(): void {
+		// MCP (Model Context Protocol) endpoint.
+		McpController::register_routes();
+
 		register_rest_route(
 			self::NAMESPACE,
 			'/run',


### PR DESCRIPTION
## Summary

Implements the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) over a single WordPress REST endpoint, allowing external AI clients (Claude Desktop, Cursor, Continue, etc.) to discover and invoke all registered WordPress abilities as MCP tools.

## Changes

- **New**: `includes/REST/McpController.php` — MCP protocol handler
- **Modified**: `includes/REST/RestController.php` — registers the `/mcp` route on boot

## Endpoint

```
POST /wp-json/ai-agent/v1/mcp
```

### Authentication

WordPress nonce (`X-WP-Nonce` header) or Application Password (HTTP Basic Auth). Requires `manage_options` capability.

### Methods

#### `list_tools`

Returns all abilities registered via `wp_register_ability()` as MCP tool definitions:

```json
{
  "method": "list_tools"
}
```

Response:
```json
{
  "protocol_version": "2024-11-05",
  "tools": [
    {
      "name": "ai-agent__memory-save",
      "description": "Save a piece of information to persistent memory...",
      "inputSchema": { "type": "object", "properties": { ... } }
    }
  ]
}
```

#### `call_tool`

Executes a named ability with provided arguments:

```json
{
  "method": "call_tool",
  "params": {
    "name": "ai-agent__memory-save",
    "arguments": { "category": "general", "content": "User prefers dark mode" }
  }
}
```

Response:
```json
{
  "protocol_version": "2024-11-05",
  "tool": "ai-agent__memory-save",
  "isError": false,
  "content": [{ "type": "text", "text": "{\"saved\":true,\"id\":42}" }]
}
```

### Name mapping

Ability names use `namespace/tool-name` format (slash + hyphens). MCP tool names must match `[a-zA-Z0-9_-]+`, so the slash is replaced with `__`:

- `ai-agent/memory-save` → `ai-agent__memory-save`
- `ai-agent/discovery-list` → `ai-agent__discovery-list`

## Quality

- PHPCS: 0 errors, 0 warnings (auto-fixed 2 alignment warnings via phpcbf)
- PHPStan: No errors
- `npm run build`: compiled successfully

Closes #160