### PR TITLE
fix: replace wp-env Docker with direct MariaDB for PHPUnit CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,18 +8,26 @@ on:
 
 jobs:
   phpunit:
-    name: PHPUnit (wp-env)
+    name: PHPUnit
     runs-on: ubuntu-latest
+
+    services:
+      mariadb:
+        image: mariadb:lts
+        env:
+          MARIADB_ROOT_PASSWORD: root
+          MARIADB_DATABASE: wordpress_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -43,18 +51,14 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --prefer-dist --no-progress
 
-      - name: Install npm dependencies
-        run: npm ci
+      - name: Install subversion
+        run: sudo apt-get update && sudo apt-get install -y subversion
 
-      - name: Start wp-env
-        run: npm run wp-env:start
+      - name: Install WordPress test suite
+        run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 latest true
 
-      - name: Run PHPUnit via wp-env
-        run: npm run test:php
-
-      - name: Stop wp-env
-        if: always()
-        run: npm run wp-env:stop
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit
 
   phpcs:
     name: PHPCS


### PR DESCRIPTION
## Summary

- Fixes the `PHPUnit (wp-env)` CI job that has never successfully run since wp-env was introduced in PR #88
- Root cause: `wp core multisite-install` fails inside the `wordpress:cli-php8.2` Docker container with an empty `Error:` message — the PHP 8.2 deprecation notice (trim() null) is a red herring; the real failure is multisite-install itself
- Fix: replace wp-env/Docker entirely with the standard WordPress plugin CI pattern (MariaDB service + `install-wp-tests.sh` + `vendor/bin/phpunit` directly on the runner)

## How it works

The new CI job:
1. Spins up a `mariadb:lts` service container
2. Runs `bin/install-wp-tests.sh` to download the WordPress test library to `/tmp/wordpress-tests-lib`
3. Runs `vendor/bin/phpunit` directly on the runner — no Docker, no wp-env, no WP-CLI

The `tests/bootstrap.php` already handles the `/tmp/wordpress-tests-lib` fallback path (it checks `/wordpress-phpunit` first for wp-env, then falls back to `sys_get_temp_dir()/wordpress-tests-lib`), so no bootstrap changes are needed.

## Why not the WP_CLI_PHP_ARGS approach (previous PR description)

The previous description was wrong. `WP_CLI_PHP_ARGS` set on the GitHub Actions host runner is never forwarded into the Docker container where WP-CLI runs. Even if it were, the actual failure is `wp core multisite-install` returning an empty error — not the deprecation notice. The deprecation notice is a red herring.

## Why not fix multisite-install inside Docker

The `.wp-env.json` has `MULTISITE: true` which triggers `wp core multisite-install` instead of `wp core install`. Multisite install is significantly more complex and fragile inside Docker. The tests themselves do not require multisite to run — `phpunit.xml.dist` sets `WP_TESTS_MULTISITE=1` as a constant, which is handled by the WordPress test library independently of how WordPress was installed.

## Trade-offs

- **Removed**: `npm ci`, `wp-env start`, `wp-env stop` steps (saves ~2-3 minutes per CI run)
- **Added**: `apt-get install subversion` (required by `install-wp-tests.sh` to download the test suite via SVN)
- **Unchanged**: `phpunit.xml.dist`, `tests/bootstrap.php`, `.wp-env.json` (wp-env still works for local development)

Closes #265