### PR TITLE
t048: Replace hardcoded model fallback with configurable default

### DIFF
--- a/gratis-ai-agent.php
+++ b/gratis-ai-agent.php
@@ -22,6 +22,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 define( 'GRATIS_AI_AGENT_DIR', __DIR__ );
 define( 'GRATIS_AI_AGENT_URL', plugin_dir_url( __FILE__ ) );
 
+/**
+ * Built-in fallback model ID used when no model is configured in settings
+ * and no connector default is available.
+ *
+ * Developers can override the effective default at runtime via the
+ * `gratis_ai_agent_default_model` filter rather than changing this constant.
+ */
+define( 'GRATIS_AI_AGENT_DEFAULT_MODEL', 'claude-sonnet-4' );
+
 // Load Jetpack Autoloader for PSR-4 autoloading with version conflict resolution.
 // Jetpack Autoloader ensures the newest version of shared packages (like php-ai-client) is used.
 if ( file_exists( GRATIS_AI_AGENT_DIR . '/vendor/autoload_packages.php' ) ) {

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -854,13 +854,13 @@ class AgentLoop {
 		}
 
 		// Resolve model for the OpenAI-compatible endpoint.
-		// Priority: explicit selection → connector default → hardcoded fallback.
+		// Priority: explicit selection → connector default → configurable plugin default.
 		$model_id = $this->model_id;
 		if ( empty( $model_id ) && function_exists( 'OpenAiCompatibleConnector\\get_default_model' ) ) {
 			$model_id = \OpenAiCompatibleConnector\get_default_model();
 		}
 		if ( empty( $model_id ) ) {
-			$model_id = 'claude-sonnet-4';
+			$model_id = Settings::get_default_model();
 		}
 
 		$messages = $this->build_openai_messages();

--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -254,6 +254,41 @@ class Settings {
 	}
 
 	/**
+	 * Resolve the effective default model ID.
+	 *
+	 * Resolution order (first non-empty value wins):
+	 *   1. `default_model` setting saved by the site administrator.
+	 *   2. Value returned by the `gratis_ai_agent_default_model` filter (allows
+	 *      developers to override the default programmatically).
+	 *   3. The `GRATIS_AI_AGENT_DEFAULT_MODEL` constant defined in the plugin root.
+	 *
+	 * Example — override the default model from a theme or mu-plugin:
+	 *
+	 *   add_filter( 'gratis_ai_agent_default_model', function ( string $model ): string {
+	 *       return 'gpt-4o';
+	 *   } );
+	 *
+	 * @return string Non-empty model ID.
+	 */
+	public static function get_default_model(): string {
+		$settings = self::get();
+		$model    = (string) ( $settings['default_model'] ?? '' );
+
+		if ( '' === $model ) {
+			$builtin = defined( 'GRATIS_AI_AGENT_DEFAULT_MODEL' ) ? (string) GRATIS_AI_AGENT_DEFAULT_MODEL : 'claude-sonnet-4';
+
+			/**
+			 * Filter the default model ID used when no model is configured in settings.
+			 *
+			 * @param string $model The built-in fallback model ID (GRATIS_AI_AGENT_DEFAULT_MODEL).
+			 */
+			$model = (string) apply_filters( 'gratis_ai_agent_default_model', $builtin );
+		}
+
+		return $model;
+	}
+
+	/**
 	 * Get a single setting or all settings merged with defaults.
 	 *
 	 * @param string|null $key Optional key to retrieve.


### PR DESCRIPTION
## Summary

- Adds `GRATIS_AI_AGENT_DEFAULT_MODEL` constant (`'claude-sonnet-4'`) in `gratis-ai-agent.php` as the single source of truth for the built-in fallback model ID
- Adds `Settings::get_default_model()` with a three-tier resolution: saved `default_model` setting → `gratis_ai_agent_default_model` filter → `GRATIS_AI_AGENT_DEFAULT_MODEL` constant
- Replaces the hardcoded `'claude-sonnet-4'` string in `AgentLoop::send_prompt_direct()` with `Settings::get_default_model()`

## Resolution order

1. `default_model` setting saved by the site administrator (Settings page)
2. `gratis_ai_agent_default_model` filter — allows developers to override programmatically
3. `GRATIS_AI_AGENT_DEFAULT_MODEL` constant — the built-in fallback

## Developer override

Developers can override the default model without touching plugin settings:

```php
add_filter( 'gratis_ai_agent_default_model', function ( string $model ): string {
    return 'gpt-4o';
} );
```

## Verification

- PHPStan: no errors
- PHPCS: no violations

Closes #241