### PR TITLE
t032: Add meta.show_in_rest = true to all wp_register_ability() calls

### DIFF
--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -51,6 +51,9 @@ class BlockAbilities {
 					],
 					'required'   => [ 'markdown' ],
 				],
+				'meta'                => [
+					'show_in_rest' => true,
+				],
 				'execute_callback'    => [ __CLASS__, 'handle_markdown_to_blocks' ],
 				'permission_callback' => function () {
 					return current_user_can( 'edit_posts' );
@@ -86,6 +89,9 @@ class BlockAbilities {
 					],
 					'required'   => [],
 				],
+				'meta'                => [
+					'show_in_rest' => true,
+				],
 				'execute_callback'    => [ __CLASS__, 'handle_list_block_types' ],
 				'permission_callback' => function () {
 					return current_user_can( 'edit_posts' );
@@ -108,6 +114,9 @@ class BlockAbilities {
 						],
 					],
 					'required'   => [ 'name' ],
+				],
+				'meta'                => [
+					'show_in_rest' => true,
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_get_block_type' ],
 				'permission_callback' => function () {
@@ -144,6 +153,9 @@ class BlockAbilities {
 					],
 					'required'   => [],
 				],
+				'meta'                => [
+					'show_in_rest' => true,
+				],
 				'execute_callback'    => [ __CLASS__, 'handle_list_block_patterns' ],
 				'permission_callback' => function () {
 					return current_user_can( 'edit_posts' );
@@ -167,6 +179,9 @@ class BlockAbilities {
 					],
 					'required'   => [],
 				],
+				'meta'                => [
+					'show_in_rest' => true,
+				],
 				'execute_callback'    => [ __CLASS__, 'handle_list_block_templates' ],
 				'permission_callback' => function () {
 					return current_user_can( 'edit_posts' );
@@ -189,6 +204,9 @@ class BlockAbilities {
 						],
 					],
 					'required'   => [ 'blocks' ],
+				],
+				'meta'                => [
+					'show_in_rest' => true,
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_create_block_content' ],
 				'permission_callback' => function () {
@@ -220,6 +238,9 @@ class BlockAbilities {
 						],
 					],
 					'required'   => [],
+				],
+				'meta'                => [
+					'show_in_rest' => true,
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_parse_block_content' ],
 				'permission_callback' => function () {

--- a/includes/Abilities/ContentAbilities.php
+++ b/includes/Abilities/ContentAbilities.php
@@ -54,6 +54,9 @@ class ContentAbilities {
 					],
 					'required'   => [],
 				],
+				'meta'                => [
+					'show_in_rest' => true,
+				],
 				'execute_callback'    => [ __CLASS__, 'handle_content_analyze' ],
 				'permission_callback' => function () {
 					return current_user_can( 'edit_posts' );
@@ -80,6 +83,9 @@ class ContentAbilities {
 						],
 					],
 					'required'   => [],
+				],
+				'meta'                => [
+					'show_in_rest' => true,
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_performance_report' ],
 				'permission_callback' => function () {

--- a/includes/Abilities/KnowledgeAbilities.php
+++ b/includes/Abilities/KnowledgeAbilities.php
@@ -52,6 +52,9 @@ class KnowledgeAbilities {
 					],
 					'required'   => [ 'query' ],
 				],
+				'meta'                => [
+					'show_in_rest' => true,
+				],
 				'execute_callback'    => [ __CLASS__, 'handle_knowledge_search' ],
 				'permission_callback' => function () {
 					return current_user_can( 'manage_options' ); },

--- a/includes/Abilities/MarketingAbilities.php
+++ b/includes/Abilities/MarketingAbilities.php
@@ -46,6 +46,9 @@ class MarketingAbilities {
 					],
 					'required'   => [ 'url' ],
 				],
+				'meta'                => [
+					'show_in_rest' => true,
+				],
 				'execute_callback'    => [ __CLASS__, 'handle_fetch_url' ],
 				'permission_callback' => function () {
 					return current_user_can( 'edit_posts' );
@@ -68,6 +71,9 @@ class MarketingAbilities {
 						],
 					],
 					'required'   => [ 'url' ],
+				],
+				'meta'                => [
+					'show_in_rest' => true,
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_analyze_headers' ],
 				'permission_callback' => function () {

--- a/includes/Abilities/MemoryAbilities.php
+++ b/includes/Abilities/MemoryAbilities.php
@@ -53,6 +53,9 @@ class MemoryAbilities {
 					],
 					'required'   => [ 'category', 'content' ],
 				],
+				'meta'                => [
+					'show_in_rest' => true,
+				],
 				'execute_callback'    => [ __CLASS__, 'handle_memory_save' ],
 				'permission_callback' => function () {
 					return current_user_can( 'manage_options' ); },
@@ -68,6 +71,9 @@ class MemoryAbilities {
 				'input_schema'        => [
 					'type'       => 'object',
 					'properties' => new \stdClass(),
+				],
+				'meta'                => [
+					'show_in_rest' => true,
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_memory_list' ],
 				'permission_callback' => function () {
@@ -90,6 +96,9 @@ class MemoryAbilities {
 						],
 					],
 					'required'   => [ 'id' ],
+				],
+				'meta'                => [
+					'show_in_rest' => true,
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_memory_delete' ],
 				'permission_callback' => function () {

--- a/includes/Abilities/SeoAbilities.php
+++ b/includes/Abilities/SeoAbilities.php
@@ -50,6 +50,9 @@ class SeoAbilities {
 					],
 					'required'   => [ 'url' ],
 				],
+				'meta'                => [
+					'show_in_rest' => true,
+				],
 				'execute_callback'    => [ __CLASS__, 'handle_audit_url' ],
 				'permission_callback' => function () {
 					return current_user_can( 'edit_posts' );
@@ -80,6 +83,9 @@ class SeoAbilities {
 						],
 					],
 					'required'   => [ 'post_id' ],
+				],
+				'meta'                => [
+					'show_in_rest' => true,
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_analyze_content' ],
 				'permission_callback' => function () {

--- a/includes/Abilities/SkillAbilities.php
+++ b/includes/Abilities/SkillAbilities.php
@@ -48,6 +48,9 @@ class SkillAbilities {
 					],
 					'required'   => [ 'slug' ],
 				],
+				'meta'                => [
+					'show_in_rest' => true,
+				],
 				'execute_callback'    => [ __CLASS__, 'handle_skill_load' ],
 				'permission_callback' => function () {
 					return current_user_can( 'manage_options' ); },
@@ -63,6 +66,9 @@ class SkillAbilities {
 				'input_schema'        => [
 					'type'       => 'object',
 					'properties' => new \stdClass(),
+				],
+				'meta'                => [
+					'show_in_rest' => true,
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_skill_list' ],
 				'permission_callback' => function () {

--- a/includes/Abilities/StockImageAbilities.php
+++ b/includes/Abilities/StockImageAbilities.php
@@ -61,6 +61,9 @@ class StockImageAbilities {
 					],
 					'required'   => [ 'keyword' ],
 				],
+				'meta'                => [
+					'show_in_rest' => true,
+				],
 				'execute_callback'    => [ __CLASS__, 'handle_import' ],
 				'permission_callback' => function () {
 					return current_user_can( 'upload_files' );

--- a/includes/Tools/CustomToolExecutor.php
+++ b/includes/Tools/CustomToolExecutor.php
@@ -53,6 +53,9 @@ class CustomToolExecutor {
 						'type'       => 'object',
 						'properties' => new \stdClass(),
 					],
+					'meta'                => [
+						'show_in_rest' => true,
+					],
 					'execute_callback'    => function ( array $input ) use ( $tool ) {
 						return self::execute( $tool, $input );
 					},

--- a/includes/Tools/ToolDiscovery.php
+++ b/includes/Tools/ToolDiscovery.php
@@ -94,6 +94,9 @@ class ToolDiscovery {
 						],
 					],
 				],
+				'meta'                => [
+					'show_in_rest' => true,
+				],
 				'execute_callback'    => [ __CLASS__, 'handle_list_tools' ],
 				'permission_callback' => function () {
 					return current_user_can( 'manage_options' );
@@ -125,6 +128,9 @@ class ToolDiscovery {
 						],
 					],
 					'required'   => [ 'tool_name' ],
+				],
+				'meta'                => [
+					'show_in_rest' => true,
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_execute_tool' ],
 				'permission_callback' => function () {


### PR DESCRIPTION
## Summary

- Adds `meta.show_in_rest = true` to all 40 `wp_register_ability()` registrations across 10 files that were missing it
- Previously only `NavigationAbilities`, `AbilityDiscoveryAbilities`, `FileAbilities`, `WordPressAbilities`, and `DatabaseAbilities` had this set
- Now every AI Agent ability is accessible via the WordPress REST API consistently

## Files changed

| File | Abilities added |
|------|----------------|
| `BlockAbilities.php` | 7 abilities |
| `ContentAbilities.php` | 2 abilities |
| `KnowledgeAbilities.php` | 1 ability |
| `MarketingAbilities.php` | 2 abilities |
| `MemoryAbilities.php` | 3 abilities |
| `SeoAbilities.php` | 2 abilities |
| `SkillAbilities.php` | 2 abilities |
| `StockImageAbilities.php` | 1 ability |
| `CustomToolExecutor.php` | 1 ability |
| `ToolDiscovery.php` | 2 abilities |

## Testing

PHPStan (level 6) and PHPCS pass with zero violations.

Closes #226