### PR TITLE
t049: Add proper dependency injection instead of static method calls

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -81,20 +81,25 @@ class AgentLoop {
 	/** @var SseStreamer|null Optional SSE streamer for token-by-token output. */
 	private ?SseStreamer $sse_streamer = null;
 
+	/** @var Settings Injected settings dependency. */
+	private $settings_service;
+
 	/**
-	 * @param string               $user_message The user's prompt.
-	 * @param string[]             $abilities    Ability names to enable (empty = all).
-	 * @param Message[]            $history     Prior messages for multi-turn.
-	 * @param array<string, mixed> $options      Optional overrides: system_instruction, max_iterations, provider_id, model_id, temperature, max_output_tokens, page_context.
+	 * @param string               $user_message     The user's prompt.
+	 * @param string[]             $abilities         Ability names to enable (empty = all).
+	 * @param Message[]            $history           Prior messages for multi-turn.
+	 * @param array<string, mixed> $options           Optional overrides: system_instruction, max_iterations, provider_id, model_id, temperature, max_output_tokens, page_context.
+	 * @param Settings|null        $settings_service  Injected Settings service (uses static Settings::get() when null).
 	 */
-	public function __construct( string $user_message, array $abilities = [], array $history = [], array $options = [] ) {
-		$this->user_message = $user_message;
-		$this->abilities    = $abilities;
-		$this->history      = $history;
-		$this->page_context = $options['page_context'] ?? [];
+	public function __construct( string $user_message, array $abilities = [], array $history = [], array $options = [], ?Settings $settings_service = null ) {
+		$this->user_message     = $user_message;
+		$this->abilities        = $abilities;
+		$this->history          = $history;
+		$this->page_context     = $options['page_context'] ?? [];
+		$this->settings_service = $settings_service ?? new Settings();
 
 		// Merge explicit options with saved settings as fallbacks.
-		$settings = Settings::get();
+		$settings = $this->settings_service->get();
 
 		$this->provider_id       = $options['provider_id'] ?? ( $settings['default_provider'] ?: '' );
 		$this->model_id          = $options['model_id'] ?? ( $settings['default_model'] ?: '' );
@@ -190,7 +195,7 @@ class AgentLoop {
 			++$this->iterations_used;
 
 			// Smart conversation trimming before each LLM call.
-			$max_turns = (int) Settings::get( 'max_history_turns' );
+			$max_turns = (int) $this->settings_service->get( 'max_history_turns' );
 			if ( $max_turns > 0 ) {
 				$this->history = ConversationTrimmer::trim( $this->history, $max_turns );
 			}
@@ -1338,7 +1343,7 @@ class AgentLoop {
 				}
 			);
 		} else {
-			$disabled = Settings::get( 'disabled_abilities' );
+			$disabled = $this->settings_service->get( 'disabled_abilities' );
 			if ( ! empty( $disabled ) && is_array( $disabled ) ) {
 				$all = array_filter(
 					$all,
@@ -1360,7 +1365,7 @@ class AgentLoop {
 		}
 
 		// Apply tool profile filter.
-		$active_profile = Settings::get( 'active_tool_profile' );
+		$active_profile = $this->settings_service->get( 'active_tool_profile' );
 		if ( ! empty( $active_profile ) && 'all' !== $active_profile ) {
 			$all = ToolProfiles::filter_abilities( $all, $active_profile );
 		}

--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -49,8 +49,28 @@ class RestController {
 	 */
 	const JOB_TTL = 600;
 
+	/** @var Settings Injected settings dependency. */
+	private Settings $settings;
+
+	/** @var Database Injected database dependency. */
+	private Database $database;
+
+	/**
+	 * Constructor — accepts injected dependencies for testability.
+	 *
+	 * @param Settings|null $settings  Settings service (defaults to new Settings()).
+	 * @param Database|null $database  Database service (defaults to new Database()).
+	 */
+	public function __construct( ?Settings $settings = null, ?Database $database = null ) {
+		$this->settings = $settings ?? new Settings();
+		$this->database = $database ?? new Database();
+	}
+
 	/**
 	 * Register REST routes.
+	 *
+	 * Creates a controller instance and registers instance methods as callbacks,
+	 * enabling constructor injection of dependencies.
 	 */
 	public static function register_routes(): void {
 		// MCP (Model Context Protocol) endpoint.
@@ -109,13 +129,14 @@ class RestController {
 			]
 		);
 
+		$instance = new self();
 		register_rest_route(
 			self::NAMESPACE,
 			'/run',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ __CLASS__, 'handle_run' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_run' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'message'            => [
 						'required'          => true,
@@ -172,8 +193,8 @@ class RestController {
 			'/job/(?P<id>[a-f0-9-]+)',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_job_status' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_job_status' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'id' => [
 						'required'          => true,
@@ -189,8 +210,8 @@ class RestController {
 			'/process',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ __CLASS__, 'handle_process' ],
-				'permission_callback' => [ __CLASS__, 'check_process_permission' ],
+				'callback'            => [ $instance, 'handle_process' ],
+				'permission_callback' => [ $instance, 'check_process_permission' ],
 				'args'                => [
 					'job_id' => [
 						'required'          => true,
@@ -211,8 +232,8 @@ class RestController {
 			'/abilities',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_abilities' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_abilities' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 			]
 		);
 
@@ -222,8 +243,8 @@ class RestController {
 			'/providers',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_providers' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_providers' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 			]
 		);
 
@@ -234,13 +255,13 @@ class RestController {
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ __CLASS__, 'handle_get_settings' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_get_settings' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 				],
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ __CLASS__, 'handle_update_settings' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_update_settings' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 				],
 			]
 		);
@@ -252,8 +273,8 @@ class RestController {
 			[
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ __CLASS__, 'handle_set_claude_max_token' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_set_claude_max_token' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'token' => [
 							'required'          => true,
@@ -322,13 +343,13 @@ class RestController {
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ __CLASS__, 'handle_list_memory' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_list_memory' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 				],
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ __CLASS__, 'handle_create_memory' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_create_memory' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'category' => [
 							'required'          => true,
@@ -351,8 +372,8 @@ class RestController {
 			[
 				[
 					'methods'             => 'PATCH',
-					'callback'            => [ __CLASS__, 'handle_update_memory' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_update_memory' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id'       => [
 							'required'          => true,
@@ -373,8 +394,8 @@ class RestController {
 				],
 				[
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => [ __CLASS__, 'handle_delete_memory' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_delete_memory' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -393,13 +414,13 @@ class RestController {
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ __CLASS__, 'handle_list_skills' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_list_skills' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 				],
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ __CLASS__, 'handle_create_skill' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_create_skill' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'slug'        => [
 							'required'          => true,
@@ -433,8 +454,8 @@ class RestController {
 			[
 				[
 					'methods'             => 'PATCH',
-					'callback'            => [ __CLASS__, 'handle_update_skill' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_update_skill' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id'          => [
 							'required'          => true,
@@ -464,8 +485,8 @@ class RestController {
 				],
 				[
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => [ __CLASS__, 'handle_delete_skill' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_delete_skill' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -483,8 +504,8 @@ class RestController {
 			[
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ __CLASS__, 'handle_reset_skill' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_reset_skill' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -503,8 +524,8 @@ class RestController {
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ __CLASS__, 'handle_list_sessions' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_list_sessions' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'status' => [
 							'required'          => false,
@@ -530,8 +551,8 @@ class RestController {
 				],
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ __CLASS__, 'handle_create_session' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_create_session' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'title'       => [
 							'required'          => false,
@@ -561,8 +582,8 @@ class RestController {
 			'/sessions/folders',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_list_folders' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_list_folders' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 			]
 		);
 
@@ -571,8 +592,8 @@ class RestController {
 			'/sessions/bulk',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ __CLASS__, 'handle_bulk_sessions' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_bulk_sessions' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'ids'    => [
 						'required' => true,
@@ -597,8 +618,8 @@ class RestController {
 			'/sessions/trash',
 			[
 				'methods'             => WP_REST_Server::DELETABLE,
-				'callback'            => [ __CLASS__, 'handle_empty_trash' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_empty_trash' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 			]
 		);
 
@@ -608,8 +629,8 @@ class RestController {
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ __CLASS__, 'handle_get_session' ],
-					'permission_callback' => [ __CLASS__, 'check_session_permission' ],
+					'callback'            => [ $instance, 'handle_get_session' ],
+					'permission_callback' => [ $instance, 'check_session_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -620,8 +641,8 @@ class RestController {
 				],
 				[
 					'methods'             => 'PATCH',
-					'callback'            => [ __CLASS__, 'handle_update_session' ],
-					'permission_callback' => [ __CLASS__, 'check_session_permission' ],
+					'callback'            => [ $instance, 'handle_update_session' ],
+					'permission_callback' => [ $instance, 'check_session_permission' ],
 					'args'                => [
 						'id'     => [
 							'required'          => true,
@@ -651,8 +672,8 @@ class RestController {
 				],
 				[
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => [ __CLASS__, 'handle_delete_session' ],
-					'permission_callback' => [ __CLASS__, 'check_session_permission' ],
+					'callback'            => [ $instance, 'handle_delete_session' ],
+					'permission_callback' => [ $instance, 'check_session_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -670,8 +691,8 @@ class RestController {
 			'/usage',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_get_usage' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_get_usage' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'period'     => [
 						'required'          => false,
@@ -698,8 +719,8 @@ class RestController {
 			'/sessions/(?P<id>\d+)/export',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_export_session' ],
-				'permission_callback' => [ __CLASS__, 'check_session_permission' ],
+				'callback'            => [ $instance, 'handle_export_session' ],
+				'permission_callback' => [ $instance, 'check_session_permission' ],
 				'args'                => [
 					'id'     => [
 						'required'          => true,
@@ -722,8 +743,8 @@ class RestController {
 			'/sessions/import',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ __CLASS__, 'handle_import_session' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_import_session' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 			]
 		);
 
@@ -733,8 +754,8 @@ class RestController {
 			'/memory/forget',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ __CLASS__, 'handle_forget_memory' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_forget_memory' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'topic' => [
 						'required'          => true,
@@ -752,13 +773,13 @@ class RestController {
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ __CLASS__, 'handle_list_collections' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_list_collections' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 				],
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ __CLASS__, 'handle_create_collection' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_create_collection' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'name'          => [
 							'required'          => true,
@@ -797,8 +818,8 @@ class RestController {
 			[
 				[
 					'methods'             => 'PATCH',
-					'callback'            => [ __CLASS__, 'handle_update_collection' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_update_collection' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id'            => [
 							'required'          => true,
@@ -827,8 +848,8 @@ class RestController {
 				],
 				[
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => [ __CLASS__, 'handle_delete_collection' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_delete_collection' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -845,8 +866,8 @@ class RestController {
 			'/knowledge/collections/(?P<id>\d+)/sources',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_list_sources' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_list_sources' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'id' => [
 						'required'          => true,
@@ -862,8 +883,8 @@ class RestController {
 			'/knowledge/collections/(?P<id>\d+)/index',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ __CLASS__, 'handle_index_collection' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_index_collection' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'id' => [
 						'required'          => true,
@@ -879,8 +900,8 @@ class RestController {
 			'/knowledge/upload',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ __CLASS__, 'handle_knowledge_upload' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_knowledge_upload' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 			]
 		);
 
@@ -889,8 +910,8 @@ class RestController {
 			'/knowledge/sources/(?P<id>\d+)',
 			[
 				'methods'             => WP_REST_Server::DELETABLE,
-				'callback'            => [ __CLASS__, 'handle_delete_source' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_delete_source' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'id' => [
 						'required'          => true,
@@ -906,8 +927,8 @@ class RestController {
 			'/knowledge/search',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_knowledge_search' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_knowledge_search' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'q'          => [
 						'required'          => true,
@@ -928,8 +949,8 @@ class RestController {
 			'/knowledge/stats',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_knowledge_stats' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_knowledge_stats' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 			]
 		);
 
@@ -939,8 +960,8 @@ class RestController {
 			'/job/(?P<id>[a-f0-9-]+)/confirm',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ __CLASS__, 'handle_confirm_tool' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_confirm_tool' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'id'           => [
 						'required'          => true,
@@ -961,8 +982,8 @@ class RestController {
 			'/job/(?P<id>[a-f0-9-]+)/reject',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ __CLASS__, 'handle_reject_tool' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_reject_tool' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'id' => [
 						'required'          => true,
@@ -980,13 +1001,13 @@ class RestController {
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ __CLASS__, 'handle_list_custom_tools' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_list_custom_tools' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 				],
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ __CLASS__, 'handle_create_custom_tool' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_create_custom_tool' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'name'         => [
 							'required'          => true,
@@ -1035,8 +1056,8 @@ class RestController {
 			[
 				[
 					'methods'             => 'PATCH',
-					'callback'            => [ __CLASS__, 'handle_update_custom_tool' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_update_custom_tool' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -1047,8 +1068,8 @@ class RestController {
 				],
 				[
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => [ __CLASS__, 'handle_delete_custom_tool' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_delete_custom_tool' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -1065,8 +1086,8 @@ class RestController {
 			'/custom-tools/(?P<id>\d+)/test',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ __CLASS__, 'handle_test_custom_tool' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_test_custom_tool' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'id'    => [
 						'required'          => true,
@@ -1089,13 +1110,13 @@ class RestController {
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ __CLASS__, 'handle_list_tool_profiles' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_list_tool_profiles' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 				],
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ __CLASS__, 'handle_save_tool_profile' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_save_tool_profile' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'slug'        => [
 							'required'          => true,
@@ -1128,8 +1149,8 @@ class RestController {
 			'/tool-profiles/(?P<slug>[a-z0-9-]+)',
 			[
 				'methods'             => WP_REST_Server::DELETABLE,
-				'callback'            => [ __CLASS__, 'handle_delete_tool_profile' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_delete_tool_profile' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'slug' => [
 						'required'          => true,
@@ -1147,13 +1168,13 @@ class RestController {
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ __CLASS__, 'handle_list_automations' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_list_automations' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 				],
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ __CLASS__, 'handle_create_automation' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_create_automation' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'name'     => [
 							'required'          => true,
@@ -1181,8 +1202,8 @@ class RestController {
 			[
 				[
 					'methods'             => 'PATCH',
-					'callback'            => [ __CLASS__, 'handle_update_automation' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_update_automation' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -1193,8 +1214,8 @@ class RestController {
 				],
 				[
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => [ __CLASS__, 'handle_delete_automation' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_delete_automation' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -1211,8 +1232,8 @@ class RestController {
 			'/automations/(?P<id>\d+)/run',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ __CLASS__, 'handle_run_automation' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_run_automation' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'id' => [
 						'required'          => true,
@@ -1228,8 +1249,8 @@ class RestController {
 			'/automations/(?P<id>\d+)/logs',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_automation_logs' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_automation_logs' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 				'args'                => [
 					'id' => [
 						'required'          => true,
@@ -1245,8 +1266,8 @@ class RestController {
 			'/automation-templates',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_automation_templates' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_automation_templates' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 			]
 		);
 
@@ -1257,13 +1278,13 @@ class RestController {
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ __CLASS__, 'handle_list_event_automations' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_list_event_automations' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 				],
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ __CLASS__, 'handle_create_event_automation' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_create_event_automation' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'name'            => [
 							'required'          => true,
@@ -1290,8 +1311,8 @@ class RestController {
 			[
 				[
 					'methods'             => 'PATCH',
-					'callback'            => [ __CLASS__, 'handle_update_event_automation' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_update_event_automation' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -1302,8 +1323,8 @@ class RestController {
 				],
 				[
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => [ __CLASS__, 'handle_delete_event_automation' ],
-					'permission_callback' => [ __CLASS__, 'check_permission' ],
+					'callback'            => [ $instance, 'handle_delete_event_automation' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -1320,8 +1341,8 @@ class RestController {
 			'/event-triggers',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_list_event_triggers' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_list_event_triggers' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 			]
 		);
 
@@ -1330,8 +1351,8 @@ class RestController {
 			'/automation-logs',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ __CLASS__, 'handle_list_all_logs' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'callback'            => [ $instance, 'handle_list_all_logs' ],
+				'permission_callback' => [ $instance, 'check_permission' ],
 			]
 		);
 	}
@@ -1339,7 +1360,7 @@ class RestController {
 	/**
 	 * Permission check — admin only.
 	 */
-	public static function check_permission(): bool {
+	public function check_permission(): bool {
 		return current_user_can( 'manage_options' );
 	}
 
@@ -1348,13 +1369,13 @@ class RestController {
 	 *
 	 * Verifies manage_options + session ownership.
 	 */
-	public static function check_session_permission( WP_REST_Request $request ): bool {
+	public function check_session_permission( WP_REST_Request $request ): bool {
 		if ( ! current_user_can( 'manage_options' ) ) {
 			return false;
 		}
 
 		$session_id = absint( $request->get_param( 'id' ) );
-		$session    = Database::get_session( $session_id );
+		$session    = $this->database->get_session( $session_id );
 
 		if ( ! $session ) {
 			return false;
@@ -1369,7 +1390,7 @@ class RestController {
 	 * Validates a one-time token stored in the job transient instead of
 	 * requiring cookie-based auth (the loopback request has no session).
 	 */
-	public static function check_process_permission( WP_REST_Request $request ): bool {
+	public function check_process_permission( WP_REST_Request $request ): bool {
 		$job_id = $request->get_param( 'job_id' );
 		$token  = $request->get_param( 'token' );
 
@@ -1394,7 +1415,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_run( WP_REST_Request $request ) {
+	public function handle_run( WP_REST_Request $request ) {
 		$job_id = wp_generate_uuid4();
 		$token  = wp_generate_password( 40, false );
 
@@ -1451,7 +1472,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_job_status( WP_REST_Request $request ) {
+	public function handle_job_status( WP_REST_Request $request ) {
 		$job_id = $request->get_param( 'id' );
 		$job    = get_transient( self::JOB_PREFIX . $job_id );
 
@@ -1511,7 +1532,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_confirm_tool( WP_REST_Request $request ) {
+	public function handle_confirm_tool( WP_REST_Request $request ) {
 		$job_id = $request->get_param( 'id' );
 		$job    = get_transient( self::JOB_PREFIX . $job_id );
 
@@ -1529,15 +1550,15 @@ class RestController {
 
 		// "Always allow" — update tool_permissions to auto.
 		if ( $request->get_param( 'always_allow' ) && ! empty( $job['pending_tools'] ) ) {
-			$settings = Settings::get();
+			$settings = $this->settings->get();
 			$perms    = $settings['tool_permissions'] ?? [];
 			foreach ( $job['pending_tools'] as $tool ) {
 				$perms[ $tool['name'] ] = 'auto';
 			}
-			Settings::update( [ 'tool_permissions' => $perms ] );
+			$this->settings->update( [ 'tool_permissions' => $perms ] );
 		}
 
-		return self::resume_job( $job_id, $job, 'confirm' );
+		return $this->resume_job( $job_id, $job, 'confirm' );
 	}
 
 	/**
@@ -1546,7 +1567,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_reject_tool( WP_REST_Request $request ) {
+	public function handle_reject_tool( WP_REST_Request $request ) {
 		$job_id = $request->get_param( 'id' );
 		$job    = get_transient( self::JOB_PREFIX . $job_id );
 
@@ -1562,7 +1583,7 @@ class RestController {
 			return new WP_Error( 'gratis_ai_agent_forbidden', __( 'Not authorized.', 'gratis-ai-agent' ), [ 'status' => 403 ] );
 		}
 
-		return self::resume_job( $job_id, $job, 'reject' );
+		return $this->resume_job( $job_id, $job, 'reject' );
 	}
 
 	/**
@@ -1618,7 +1639,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response
 	 */
-	public static function handle_process( WP_REST_Request $request ): WP_REST_Response {
+	public function handle_process( WP_REST_Request $request ): WP_REST_Response {
 		ignore_user_abort( true );
 		// phpcs:ignore Squiz.PHP.DiscouragedFunctions.Discouraged -- Agent loops need extended execution time.
 		set_time_limit( 600 );
@@ -1642,7 +1663,7 @@ class RestController {
 		// Load history from session if session_id is provided.
 		$history = [];
 		if ( $session_id ) {
-			$session = Database::get_session( $session_id );
+			$session = $this->database->get_session( $session_id );
 			if ( $session ) {
 				$session_messages = json_decode( $session->messages, true ) ?: [];
 				if ( ! empty( $session_messages ) ) {
@@ -1745,7 +1766,7 @@ class RestController {
 
 				// The full history from the loop includes existing + new messages.
 				// Slice off only the new ones to append.
-				$session        = Database::get_session( $session_id );
+				$session        = $this->database->get_session( $session_id );
 				$existing_count = 0;
 				if ( $session ) {
 					$existing_messages = json_decode( $session->messages, true ) ?: [];
@@ -1755,12 +1776,12 @@ class RestController {
 				$full_history = $result['history'] ?? [];
 				$appended     = array_slice( $full_history, $existing_count );
 
-				Database::append_to_session( $session_id, $appended, $result['tool_calls'] ?? [] );
+				$this->database->append_to_session( $session_id, $appended, $result['tool_calls'] ?? [] );
 
 				// Persist token usage.
 				$token_usage = $result['token_usage'] ?? [];
 				if ( ! empty( $token_usage ) ) {
-					Database::update_session_tokens(
+					$this->database->update_session_tokens(
 						$session_id,
 						$token_usage['prompt'] ?? 0,
 						$token_usage['completion'] ?? 0
@@ -1775,7 +1796,7 @@ class RestController {
 
 				if ( $prompt_t > 0 || $completion_t > 0 ) {
 					$cost = CostCalculator::calculate_cost( $model_id, $prompt_t, $completion_t );
-					Database::log_usage(
+					$this->database->log_usage(
 						[
 							'user_id'           => $job['user_id'] ?? 0,
 							'session_id'        => $session_id,
@@ -1794,7 +1815,7 @@ class RestController {
 					if ( mb_strlen( $params['message'] ) > 60 ) {
 						$title .= '...';
 					}
-					Database::update_session( $session_id, [ 'title' => $title ] );
+					$this->database->update_session( $session_id, [ 'title' => $title ] );
 				}
 			}
 		}
@@ -1996,7 +2017,7 @@ class RestController {
 	 *
 	 * @return WP_REST_Response
 	 */
-	public static function handle_abilities(): WP_REST_Response {
+	public function handle_abilities(): WP_REST_Response {
 		if ( ! function_exists( 'wp_get_abilities' ) ) {
 			return new WP_REST_Response( [], 200 );
 		}
@@ -2028,7 +2049,7 @@ class RestController {
 	 *
 	 * @return WP_REST_Response
 	 */
-	public static function handle_providers(): WP_REST_Response {
+	public function handle_providers(): WP_REST_Response {
 		$providers = [];
 
 		// Direct providers (OpenAI, Anthropic, Google) — listed first, no WP SDK required.
@@ -2137,7 +2158,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response
 	 */
-	public static function handle_list_sessions( WP_REST_Request $request ): WP_REST_Response {
+	public function handle_list_sessions( WP_REST_Request $request ): WP_REST_Response {
 		$filters = [];
 
 		if ( $request->has_param( 'status' ) ) {
@@ -2153,7 +2174,7 @@ class RestController {
 			$filters['pinned'] = $request->get_param( 'pinned' );
 		}
 
-		$sessions = Database::list_sessions( get_current_user_id(), $filters );
+		$sessions = $this->database->list_sessions( get_current_user_id(), $filters );
 
 		return new WP_REST_Response( $sessions, 200 );
 	}
@@ -2163,8 +2184,8 @@ class RestController {
 	 *
 	 * @return WP_REST_Response
 	 */
-	public static function handle_list_folders(): WP_REST_Response {
-		$folders = Database::list_folders( get_current_user_id() );
+	public function handle_list_folders(): WP_REST_Response {
+		$folders = $this->database->list_folders( get_current_user_id() );
 
 		return new WP_REST_Response( $folders, 200 );
 	}
@@ -2175,7 +2196,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_bulk_sessions( WP_REST_Request $request ) {
+	public function handle_bulk_sessions( WP_REST_Request $request ) {
 		$ids    = array_map( 'absint', $request->get_param( 'ids' ) );
 		$action = $request->get_param( 'action' );
 
@@ -2203,7 +2224,7 @@ class RestController {
 				return new WP_Error( 'gratis_ai_agent_invalid_action', __( 'Invalid bulk action.', 'gratis-ai-agent' ), [ 'status' => 400 ] );
 		}
 
-		$count = Database::bulk_update_sessions( $ids, get_current_user_id(), $data );
+		$count = $this->database->bulk_update_sessions( $ids, get_current_user_id(), $data );
 
 		return new WP_REST_Response( [ 'updated' => $count ], 200 );
 	}
@@ -2213,8 +2234,8 @@ class RestController {
 	 *
 	 * @return WP_REST_Response
 	 */
-	public static function handle_empty_trash(): WP_REST_Response {
-		$count = Database::empty_trash( get_current_user_id() );
+	public function handle_empty_trash(): WP_REST_Response {
+		$count = $this->database->empty_trash( get_current_user_id() );
 
 		return new WP_REST_Response( [ 'deleted' => $count ], 200 );
 	}
@@ -2225,9 +2246,9 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_get_session( WP_REST_Request $request ) {
+	public function handle_get_session( WP_REST_Request $request ) {
 		$session_id = absint( $request->get_param( 'id' ) );
-		$session    = Database::get_session( $session_id );
+		$session    = $this->database->get_session( $session_id );
 
 		if ( ! $session ) {
 			return new WP_Error(
@@ -2262,8 +2283,8 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_create_session( WP_REST_Request $request ) {
-		$session_id = Database::create_session(
+	public function handle_create_session( WP_REST_Request $request ) {
+		$session_id = $this->database->create_session(
 			[
 				'user_id'     => get_current_user_id(),
 				'title'       => $request->get_param( 'title' ),
@@ -2280,7 +2301,7 @@ class RestController {
 			);
 		}
 
-		$session = Database::get_session( $session_id );
+		$session = $this->database->get_session( $session_id );
 
 		return new WP_REST_Response(
 			[
@@ -2303,7 +2324,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_update_session( WP_REST_Request $request ) {
+	public function handle_update_session( WP_REST_Request $request ) {
 		$session_id = absint( $request->get_param( 'id' ) );
 
 		$data = [];
@@ -2327,7 +2348,7 @@ class RestController {
 			return new WP_Error( 'gratis_ai_agent_no_data', __( 'No fields to update.', 'gratis-ai-agent' ), [ 'status' => 400 ] );
 		}
 
-		$updated = Database::update_session( $session_id, $data );
+		$updated = $this->database->update_session( $session_id, $data );
 
 		if ( ! $updated ) {
 			return new WP_Error(
@@ -2337,7 +2358,7 @@ class RestController {
 			);
 		}
 
-		$session = Database::get_session( $session_id );
+		$session = $this->database->get_session( $session_id );
 
 		return new WP_REST_Response(
 			[
@@ -2361,10 +2382,10 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_delete_session( WP_REST_Request $request ) {
+	public function handle_delete_session( WP_REST_Request $request ) {
 		$session_id = absint( $request->get_param( 'id' ) );
 
-		$deleted = Database::delete_session( $session_id );
+		$deleted = $this->database->delete_session( $session_id );
 
 		if ( ! $deleted ) {
 			return new WP_Error(
@@ -2384,7 +2405,7 @@ class RestController {
 	 *
 	 * @return WP_REST_Response
 	 */
-	public static function handle_list_skills(): WP_REST_Response {
+	public function handle_list_skills(): WP_REST_Response {
 		$skills = Skill::get_all();
 
 		$list = array_map(
@@ -2414,7 +2435,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_create_skill( WP_REST_Request $request ) {
+	public function handle_create_skill( WP_REST_Request $request ) {
 		$slug = $request->get_param( 'slug' );
 
 		// Check for duplicate slug.
@@ -2471,7 +2492,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_update_skill( WP_REST_Request $request ) {
+	public function handle_update_skill( WP_REST_Request $request ) {
 		$id   = absint( $request->get_param( 'id' ) );
 		$data = [];
 
@@ -2523,7 +2544,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_delete_skill( WP_REST_Request $request ) {
+	public function handle_delete_skill( WP_REST_Request $request ) {
 		$id     = absint( $request->get_param( 'id' ) );
 		$result = Skill::delete( $id );
 
@@ -2552,7 +2573,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_reset_skill( WP_REST_Request $request ) {
+	public function handle_reset_skill( WP_REST_Request $request ) {
 		$id    = absint( $request->get_param( 'id' ) );
 		$reset = Skill::reset_builtin( $id );
 
@@ -2588,8 +2609,8 @@ class RestController {
 	/**
 	 * Handle GET /settings.
 	 */
-	public static function handle_get_settings(): WP_REST_Response {
-		$settings = Settings::get();
+	public function handle_get_settings(): WP_REST_Response {
+		$settings = $this->settings->get();
 
 		// Include built-in defaults so the UI can show them as placeholders.
 		$settings['_defaults'] = [
@@ -2615,16 +2636,16 @@ class RestController {
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 */
-	public static function handle_update_settings( WP_REST_Request $request ): WP_REST_Response {
+	public function handle_update_settings( WP_REST_Request $request ): WP_REST_Response {
 		$data = $request->get_json_params();
 
 		if ( empty( $data ) || ! is_array( $data ) ) {
 			return new WP_REST_Response( [ 'error' => 'No data provided.' ], 400 );
 		}
 
-		Settings::update( $data );
+		$this->settings->update( $data );
 
-		return new WP_REST_Response( Settings::get(), 200 );
+		return new WP_REST_Response( $this->settings->get(), 200 );
 	}
 
 	/**
@@ -2635,7 +2656,7 @@ class RestController {
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 */
-	public static function handle_set_claude_max_token( WP_REST_Request $request ): WP_REST_Response {
+	public function handle_set_claude_max_token( WP_REST_Request $request ): WP_REST_Response {
 		$token = $request->get_param( 'token' );
 
 		// Allow clearing the token by passing an empty string.
@@ -2844,7 +2865,7 @@ class RestController {
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 */
-	public static function handle_list_memory( WP_REST_Request $request ): WP_REST_Response {
+	public function handle_list_memory( WP_REST_Request $request ): WP_REST_Response {
 		$category = $request->get_param( 'category' );
 		$memories = Memory::get_all( $category ?: null );
 
@@ -2870,7 +2891,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_create_memory( WP_REST_Request $request ) {
+	public function handle_create_memory( WP_REST_Request $request ) {
 		$category = $request->get_param( 'category' );
 		$content  = $request->get_param( 'content' );
 
@@ -2896,7 +2917,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_update_memory( WP_REST_Request $request ) {
+	public function handle_update_memory( WP_REST_Request $request ) {
 		$id   = absint( $request->get_param( 'id' ) );
 		$data = [];
 
@@ -2928,7 +2949,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_delete_memory( WP_REST_Request $request ) {
+	public function handle_delete_memory( WP_REST_Request $request ) {
 		$id      = absint( $request->get_param( 'id' ) );
 		$deleted = Memory::delete( $id );
 
@@ -2947,7 +2968,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response
 	 */
-	public static function handle_get_usage( WP_REST_Request $request ): WP_REST_Response {
+	public function handle_get_usage( WP_REST_Request $request ): WP_REST_Response {
 		$filters = [
 			'user_id' => get_current_user_id(),
 		];
@@ -2962,7 +2983,7 @@ class RestController {
 			$filters['end_date'] = $request->get_param( 'end_date' );
 		}
 
-		$summary = Database::get_usage_summary( $filters );
+		$summary = $this->database->get_usage_summary( $filters );
 
 		return new WP_REST_Response( $summary, 200 );
 	}
@@ -2974,7 +2995,7 @@ class RestController {
 	 *
 	 * @return WP_REST_Response
 	 */
-	public static function handle_list_collections(): WP_REST_Response {
+	public function handle_list_collections(): WP_REST_Response {
 		$collections = KnowledgeDatabase::list_collections();
 
 		$list = array_map(
@@ -3005,7 +3026,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_create_collection( WP_REST_Request $request ) {
+	public function handle_create_collection( WP_REST_Request $request ) {
 		$slug = $request->get_param( 'slug' );
 
 		// Check for duplicate slug.
@@ -3062,7 +3083,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_update_collection( WP_REST_Request $request ) {
+	public function handle_update_collection( WP_REST_Request $request ) {
 		$id   = absint( $request->get_param( 'id' ) );
 		$data = [];
 
@@ -3115,7 +3136,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_delete_collection( WP_REST_Request $request ) {
+	public function handle_delete_collection( WP_REST_Request $request ) {
 		$id      = absint( $request->get_param( 'id' ) );
 		$deleted = KnowledgeDatabase::delete_collection( $id );
 
@@ -3136,7 +3157,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response
 	 */
-	public static function handle_list_sources( WP_REST_Request $request ): WP_REST_Response {
+	public function handle_list_sources( WP_REST_Request $request ): WP_REST_Response {
 		$id      = absint( $request->get_param( 'id' ) );
 		$sources = KnowledgeDatabase::get_sources_for_collection( $id );
 
@@ -3168,7 +3189,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_index_collection( WP_REST_Request $request ) {
+	public function handle_index_collection( WP_REST_Request $request ) {
 		$id     = absint( $request->get_param( 'id' ) );
 		$result = Knowledge::reindex_collection( $id );
 
@@ -3185,7 +3206,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_knowledge_upload( WP_REST_Request $request ) {
+	public function handle_knowledge_upload( WP_REST_Request $request ) {
 		$files = $request->get_file_params();
 
 		if ( empty( $files['file'] ) ) {
@@ -3243,7 +3264,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_delete_source( WP_REST_Request $request ) {
+	public function handle_delete_source( WP_REST_Request $request ) {
 		$id      = absint( $request->get_param( 'id' ) );
 		$deleted = Knowledge::delete_source( $id );
 
@@ -3264,7 +3285,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response
 	 */
-	public static function handle_knowledge_search( WP_REST_Request $request ): WP_REST_Response {
+	public function handle_knowledge_search( WP_REST_Request $request ): WP_REST_Response {
 		$query      = $request->get_param( 'q' );
 		$collection = $request->get_param( 'collection' );
 
@@ -3283,7 +3304,7 @@ class RestController {
 	 *
 	 * @return WP_REST_Response
 	 */
-	public static function handle_knowledge_stats(): WP_REST_Response {
+	public function handle_knowledge_stats(): WP_REST_Response {
 		$collections  = KnowledgeDatabase::list_collections();
 		$total_chunks = KnowledgeDatabase::get_total_chunk_count();
 
@@ -3314,7 +3335,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response
 	 */
-	public static function handle_forget_memory( WP_REST_Request $request ): WP_REST_Response {
+	public function handle_forget_memory( WP_REST_Request $request ): WP_REST_Response {
 		$topic   = $request->get_param( 'topic' );
 		$deleted = Memory::forget_by_topic( $topic );
 
@@ -3335,10 +3356,10 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_export_session( WP_REST_Request $request ) {
+	public function handle_export_session( WP_REST_Request $request ) {
 		$session_id = absint( $request->get_param( 'id' ) );
 		$format     = $request->get_param( 'format' ) ?: 'json';
-		$session    = Database::get_session( $session_id );
+		$session    = $this->database->get_session( $session_id );
 
 		if ( ! $session ) {
 			return new WP_Error( 'gratis_ai_agent_session_not_found', __( 'Session not found.', 'gratis-ai-agent' ), [ 'status' => 404 ] );
@@ -3355,7 +3376,7 @@ class RestController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_import_session( WP_REST_Request $request ) {
+	public function handle_import_session( WP_REST_Request $request ) {
 		$data = $request->get_json_params();
 
 		if ( empty( $data ) ) {
@@ -3368,7 +3389,7 @@ class RestController {
 			return $session_id;
 		}
 
-		$session = Database::get_session( $session_id );
+		$session = $this->database->get_session( $session_id );
 
 		return new WP_REST_Response(
 			[
@@ -3388,14 +3409,14 @@ class RestController {
 	/**
 	 * List custom tools.
 	 */
-	public static function handle_list_custom_tools(): WP_REST_Response {
+	public function handle_list_custom_tools(): WP_REST_Response {
 		return new WP_REST_Response( CustomTools::list(), 200 );
 	}
 
 	/**
 	 * Create a custom tool.
 	 */
-	public static function handle_create_custom_tool( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_create_custom_tool( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$data = $request->get_json_params();
 		$id   = CustomTools::create( $data );
 
@@ -3409,7 +3430,7 @@ class RestController {
 	/**
 	 * Update a custom tool.
 	 */
-	public static function handle_update_custom_tool( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_update_custom_tool( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$id   = absint( $request->get_param( 'id' ) );
 		$data = $request->get_json_params();
 
@@ -3423,7 +3444,7 @@ class RestController {
 	/**
 	 * Delete a custom tool.
 	 */
-	public static function handle_delete_custom_tool( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_delete_custom_tool( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$id = absint( $request->get_param( 'id' ) );
 
 		if ( ! CustomTools::delete( $id ) ) {
@@ -3436,7 +3457,7 @@ class RestController {
 	/**
 	 * Test-execute a custom tool with provided input.
 	 */
-	public static function handle_test_custom_tool( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_test_custom_tool( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$id    = absint( $request->get_param( 'id' ) );
 		$input = $request->get_param( 'input' ) ?: [];
 		$tool  = CustomTools::get( $id );
@@ -3455,14 +3476,14 @@ class RestController {
 	/**
 	 * List tool profiles.
 	 */
-	public static function handle_list_tool_profiles(): WP_REST_Response {
+	public function handle_list_tool_profiles(): WP_REST_Response {
 		return new WP_REST_Response( ToolProfiles::list(), 200 );
 	}
 
 	/**
 	 * Save (create or update) a tool profile.
 	 */
-	public static function handle_save_tool_profile( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_save_tool_profile( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$data = $request->get_json_params();
 
 		if ( ! ToolProfiles::save( $data ) ) {
@@ -3475,7 +3496,7 @@ class RestController {
 	/**
 	 * Delete a tool profile.
 	 */
-	public static function handle_delete_tool_profile( WP_REST_Request $request ): WP_REST_Response {
+	public function handle_delete_tool_profile( WP_REST_Request $request ): WP_REST_Response {
 		$slug = $request->get_param( 'slug' );
 		ToolProfiles::delete( $slug );
 
@@ -3487,14 +3508,14 @@ class RestController {
 	/**
 	 * List scheduled automations.
 	 */
-	public static function handle_list_automations(): WP_REST_Response {
+	public function handle_list_automations(): WP_REST_Response {
 		return new WP_REST_Response( Automations::list(), 200 );
 	}
 
 	/**
 	 * Create a scheduled automation.
 	 */
-	public static function handle_create_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_create_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$data = $request->get_json_params();
 		$id   = Automations::create( $data );
 
@@ -3508,7 +3529,7 @@ class RestController {
 	/**
 	 * Update a scheduled automation.
 	 */
-	public static function handle_update_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_update_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$id   = absint( $request->get_param( 'id' ) );
 		$data = $request->get_json_params();
 
@@ -3522,7 +3543,7 @@ class RestController {
 	/**
 	 * Delete a scheduled automation.
 	 */
-	public static function handle_delete_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_delete_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$id = absint( $request->get_param( 'id' ) );
 
 		if ( ! Automations::delete( $id ) ) {
@@ -3535,7 +3556,7 @@ class RestController {
 	/**
 	 * Manually run a scheduled automation.
 	 */
-	public static function handle_run_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_run_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$id     = absint( $request->get_param( 'id' ) );
 		$result = AutomationRunner::run( $id );
 
@@ -3549,7 +3570,7 @@ class RestController {
 	/**
 	 * Get logs for a specific automation.
 	 */
-	public static function handle_automation_logs( WP_REST_Request $request ): WP_REST_Response {
+	public function handle_automation_logs( WP_REST_Request $request ): WP_REST_Response {
 		$id   = absint( $request->get_param( 'id' ) );
 		$logs = AutomationLogs::list_for_automation( $id );
 
@@ -3559,7 +3580,7 @@ class RestController {
 	/**
 	 * Get automation templates.
 	 */
-	public static function handle_automation_templates(): WP_REST_Response {
+	public function handle_automation_templates(): WP_REST_Response {
 		return new WP_REST_Response( Automations::get_templates(), 200 );
 	}
 
@@ -3568,14 +3589,14 @@ class RestController {
 	/**
 	 * List event automations.
 	 */
-	public static function handle_list_event_automations(): WP_REST_Response {
+	public function handle_list_event_automations(): WP_REST_Response {
 		return new WP_REST_Response( EventAutomations::list(), 200 );
 	}
 
 	/**
 	 * Create an event automation.
 	 */
-	public static function handle_create_event_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_create_event_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$data = $request->get_json_params();
 		$id   = EventAutomations::create( $data );
 
@@ -3589,7 +3610,7 @@ class RestController {
 	/**
 	 * Update an event automation.
 	 */
-	public static function handle_update_event_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_update_event_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$id   = absint( $request->get_param( 'id' ) );
 		$data = $request->get_json_params();
 
@@ -3603,7 +3624,7 @@ class RestController {
 	/**
 	 * Delete an event automation.
 	 */
-	public static function handle_delete_event_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_delete_event_automation( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$id = absint( $request->get_param( 'id' ) );
 
 		if ( ! EventAutomations::delete( $id ) ) {
@@ -3616,14 +3637,14 @@ class RestController {
 	/**
 	 * List available event triggers from the registry.
 	 */
-	public static function handle_list_event_triggers(): WP_REST_Response {
+	public function handle_list_event_triggers(): WP_REST_Response {
 		return new WP_REST_Response( EventTriggerRegistry::get_all(), 200 );
 	}
 
 	/**
 	 * List recent automation logs across all automations.
 	 */
-	public static function handle_list_all_logs(): WP_REST_Response {
+	public function handle_list_all_logs(): WP_REST_Response {
 		return new WP_REST_Response( AutomationLogs::list_recent(), 200 );
 	}
 }


### PR DESCRIPTION
## Summary

- Converts `RestController` handler methods from `static` to instance methods, enabling constructor injection of `Settings` and `Database` dependencies
- Adds optional constructor parameters to `RestController` (`?Settings`, `?Database`) with sensible defaults, so existing call sites (`RestController::register_routes()`) require no changes
- Adds optional `?Settings` constructor parameter to `AgentLoop`, replacing `Settings::get()` static calls with `$this->settings_service->get()` for testability
- `register_routes()` now instantiates `new self()` and registers instance method callbacks, preserving the static entry point while enabling DI

## What changed

**`includes/REST/RestController.php`**
- Added `private Settings $settings` and `private Database $database` properties
- Added constructor with nullable injected dependencies (defaults to `new Settings()` / `new Database()`)
- Converted all `public static function handle_*` methods to `public function handle_*`
- Replaced `Database::get_session()`, `Database::create_session()`, etc. with `$this->database->*`
- Replaced `$this->settings->get()` / `$this->settings->update()` for settings access

**`includes/Core/AgentLoop.php`**
- Added `private $settings_service` property
- Added `?Settings $settings_service = null` constructor parameter
- Replaced `Settings::get()` calls with `$this->settings_service->get()`

## Verification

- PHPCS: zero violations on both changed files
- PHPStan level 5: no errors
- Backward compatible: `RestController::register_routes()` static entry point unchanged

Closes #320