### PR TITLE
t031: Complete meta.annotations (readonly, destructive, idempotent) on all abilities

### DIFF
--- a/includes/Abilities/FileAbilities.php
+++ b/includes/Abilities/FileAbilities.php
@@ -415,8 +415,9 @@ class FileReadAbility extends AbstractFileAbility {
 	protected function meta(): array {
 		return [
 			'annotations'  => [
-				'readonly'   => true,
-				'idempotent' => true,
+				'readonly'    => true,
+				'destructive' => false,
+				'idempotent'  => true,
 			],
 			'show_in_rest' => true,
 		];
@@ -524,7 +525,9 @@ class FileWriteAbility extends AbstractFileAbility {
 	protected function meta(): array {
 		return [
 			'annotations'  => [
+				'readonly'    => false,
 				'destructive' => true,
+				'idempotent'  => false,
 			],
 			'show_in_rest' => true,
 		];
@@ -698,7 +701,9 @@ class FileEditAbility extends AbstractFileAbility {
 	protected function meta(): array {
 		return [
 			'annotations'  => [
+				'readonly'    => false,
 				'destructive' => true,
+				'idempotent'  => false,
 			],
 			'show_in_rest' => true,
 		];
@@ -784,7 +789,9 @@ class FileDeleteAbility extends AbstractFileAbility {
 	protected function meta(): array {
 		return [
 			'annotations'  => [
+				'readonly'    => false,
 				'destructive' => true,
+				'idempotent'  => false,
 			],
 			'show_in_rest' => true,
 		];
@@ -875,8 +882,9 @@ class FileListAbility extends AbstractFileAbility {
 	protected function meta(): array {
 		return [
 			'annotations'  => [
-				'readonly'   => true,
-				'idempotent' => true,
+				'readonly'    => true,
+				'destructive' => false,
+				'idempotent'  => true,
 			],
 			'show_in_rest' => true,
 		];
@@ -954,8 +962,9 @@ class FileSearchAbility extends AbstractFileAbility {
 	protected function meta(): array {
 		return [
 			'annotations'  => [
-				'readonly'   => true,
-				'idempotent' => true,
+				'readonly'    => true,
+				'destructive' => false,
+				'idempotent'  => true,
 			],
 			'show_in_rest' => true,
 		];
@@ -1045,8 +1054,9 @@ class ContentSearchAbility extends AbstractFileAbility {
 	protected function meta(): array {
 		return [
 			'annotations'  => [
-				'readonly'   => true,
-				'idempotent' => true,
+				'readonly'    => true,
+				'destructive' => false,
+				'idempotent'  => true,
 			],
 			'show_in_rest' => true,
 		];

--- a/includes/Abilities/WordPressAbilities.php
+++ b/includes/Abilities/WordPressAbilities.php
@@ -206,8 +206,9 @@ class GetPluginsAbility extends AbstractAbility {
 	protected function meta(): array {
 		return [
 			'annotations'  => [
-				'readonly'   => true,
-				'idempotent' => true,
+				'readonly'    => true,
+				'destructive' => false,
+				'idempotent'  => true,
 			],
 			'show_in_rest' => true,
 		];
@@ -274,8 +275,9 @@ class GetThemesAbility extends AbstractAbility {
 	protected function meta(): array {
 		return [
 			'annotations'  => [
-				'readonly'   => true,
-				'idempotent' => true,
+				'readonly'    => true,
+				'destructive' => false,
+				'idempotent'  => true,
 			],
 			'show_in_rest' => true,
 		];
@@ -436,7 +438,9 @@ class InstallPluginAbility extends AbstractAbility {
 	protected function meta(): array {
 		return [
 			'annotations'  => [
+				'readonly'    => false,
 				'destructive' => false,
+				'idempotent'  => false,
 			],
 			'show_in_rest' => true,
 		];
@@ -518,7 +522,9 @@ class RunPhpAbility extends AbstractAbility {
 	protected function meta(): array {
 		return [
 			'annotations'  => [
+				'readonly'    => false,
 				'destructive' => true,
+				'idempotent'  => false,
 			],
 			'show_in_rest' => true,
 		];


### PR DESCRIPTION
## Summary

Completes issue #430 — ensures every ability's `meta()` method returns all three annotation keys (`readonly`, `destructive`, `idempotent`) in the `annotations` array.

## Changes

**`FileAbilities.php`** (7 abilities fixed):
- `FileReadAbility`: added `destructive => false`
- `FileWriteAbility`: added `readonly => false`, `idempotent => false`
- `FileEditAbility`: added `readonly => false`, `idempotent => false`
- `FileDeleteAbility`: added `readonly => false`, `idempotent => false`
- `FileListAbility`: added `destructive => false`
- `FileSearchAbility`: added `destructive => false`
- `ContentSearchAbility`: added `destructive => false`

**`WordPressAbilities.php`** (4 abilities fixed):
- `GetPluginsAbility`: added `destructive => false`
- `GetThemesAbility`: added `destructive => false`
- `InstallPluginAbility`: added `readonly => false`, `idempotent => false`
- `RunPhpAbility`: added `readonly => false`, `idempotent => false`

## Already complete (no changes needed)

`BlockAbilities`, `ContentAbilities`, `DatabaseAbilities`, `KnowledgeAbilities`, `MarketingAbilities`, `MemoryAbilities`, `NavigationAbilities`, `SeoAbilities`, `SkillAbilities`, `StockImageAbilities`, `AbilityDiscoveryAbilities` — all had all three annotation keys.

## Verification

Python script confirmed all 14 ability files now have all three annotation keys in every `meta()` method. PHP syntax check passed on both modified files.

Closes #430