### PR TITLE
t037: Add per-tool WordPress capabilities (gratis_ai_agent_tool_{name})

### DIFF
--- a/gratis-ai-agent.php
+++ b/gratis-ai-agent.php
@@ -56,6 +56,7 @@ use GratisAiAgent\Abilities\SeoAbilities;
 use GratisAiAgent\Abilities\SiteHealthAbilities;
 use GratisAiAgent\Abilities\SkillAbilities;
 use GratisAiAgent\Abilities\StockImageAbilities;
+use GratisAiAgent\Abilities\ToolCapabilities;
 use GratisAiAgent\Abilities\WooCommerceAbilities;
 use GratisAiAgent\Abilities\WordPressAbilities;
 use GratisAiAgent\Admin\AdminPage;
@@ -76,10 +77,24 @@ use GratisAiAgent\Tools\ToolDiscovery;
 register_activation_hook( __FILE__, [ Database::class, 'install' ] );
 register_activation_hook( __FILE__, [ AutomationRunner::class, 'reschedule_all' ] );
 register_activation_hook( __FILE__, [ OnboardingManager::class, 'on_activation' ] );
+register_activation_hook(
+	__FILE__,
+	function () {
+		ToolCapabilities::register_capabilities( ToolCapabilities::all_ability_ids() );
+	}
+);
 register_deactivation_hook( __FILE__, [ KnowledgeHooks::class, 'deactivate' ] );
 register_deactivation_hook( __FILE__, [ AutomationRunner::class, 'unschedule_all' ] );
 register_deactivation_hook( __FILE__, [ SiteScanner::class, 'unschedule' ] );
 add_action( 'admin_init', [ Database::class, 'install' ] );
+
+// Register per-tool capabilities on admin_init so role-management plugins can discover them.
+add_action(
+	'admin_init',
+	function () {
+		ToolCapabilities::register_capabilities( ToolCapabilities::all_ability_ids() );
+	}
+);
 
 add_action( 'rest_api_init', [ RestController::class, 'register_routes' ] );
 add_action( 'admin_menu', [ AdminPage::class, 'register' ] );

--- a/includes/Abilities/AbilityDiscoveryAbilities.php
+++ b/includes/Abilities/AbilityDiscoveryAbilities.php
@@ -210,7 +210,7 @@ class DiscoveryListAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'manage_options' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -311,7 +311,7 @@ class DiscoveryGetAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'manage_options' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -423,7 +423,7 @@ class DiscoveryExecuteAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'manage_options' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {

--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -514,7 +514,7 @@ class MarkdownToBlocksAbility extends AbstractBlockAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'edit_posts' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -648,7 +648,7 @@ class ListBlockTypesAbility extends AbstractBlockAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'edit_posts' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -768,7 +768,7 @@ class GetBlockTypeAbility extends AbstractBlockAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'edit_posts' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -900,7 +900,7 @@ class ListBlockPatternsAbility extends AbstractBlockAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'edit_posts' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -986,7 +986,7 @@ class ListBlockTemplatesAbility extends AbstractBlockAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'edit_posts' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -1063,7 +1063,7 @@ class CreateBlockContentAbility extends AbstractBlockAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'edit_posts' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -1188,7 +1188,7 @@ class ParseBlockContentAbility extends AbstractBlockAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'edit_posts' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {

--- a/includes/Abilities/ContentAbilities.php
+++ b/includes/Abilities/ContentAbilities.php
@@ -171,7 +171,7 @@ class ContentAnalyzeAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'edit_posts' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -356,7 +356,7 @@ class ContentPerformanceReportAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'edit_posts' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {

--- a/includes/Abilities/DatabaseAbilities.php
+++ b/includes/Abilities/DatabaseAbilities.php
@@ -139,7 +139,7 @@ class DatabaseQueryAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'manage_options' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {

--- a/includes/Abilities/FileAbilities.php
+++ b/includes/Abilities/FileAbilities.php
@@ -409,7 +409,7 @@ class FileReadAbility extends AbstractFileAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'manage_options' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -525,7 +525,7 @@ class FileWriteAbility extends AbstractFileAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'manage_options' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -707,7 +707,7 @@ class FileEditAbility extends AbstractFileAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'manage_options' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -795,7 +795,7 @@ class FileDeleteAbility extends AbstractFileAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'manage_options' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -888,7 +888,7 @@ class FileListAbility extends AbstractFileAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'manage_options' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -968,7 +968,7 @@ class FileSearchAbility extends AbstractFileAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'manage_options' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -1060,7 +1060,7 @@ class ContentSearchAbility extends AbstractFileAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'manage_options' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {

--- a/includes/Abilities/GitAbilities.php
+++ b/includes/Abilities/GitAbilities.php
@@ -165,7 +165,7 @@ class GitSnapshotAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'manage_options' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -260,7 +260,7 @@ class GitDiffAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'manage_options' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -359,7 +359,7 @@ class GitRestoreAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'manage_options' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -439,7 +439,7 @@ class GitListAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'manage_options' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -519,7 +519,7 @@ class GitPackageSummaryAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'manage_options' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -603,7 +603,7 @@ class GitRevertPackageAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'manage_options' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {

--- a/includes/Abilities/KnowledgeAbilities.php
+++ b/includes/Abilities/KnowledgeAbilities.php
@@ -147,7 +147,7 @@ class KnowledgeSearchAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'manage_options' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {

--- a/includes/Abilities/MarketingAbilities.php
+++ b/includes/Abilities/MarketingAbilities.php
@@ -211,7 +211,7 @@ class FetchUrlAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'edit_posts' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -307,7 +307,7 @@ class AnalyzeHeadersAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'edit_posts' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {

--- a/includes/Abilities/MemoryAbilities.php
+++ b/includes/Abilities/MemoryAbilities.php
@@ -181,7 +181,7 @@ class MemorySaveAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'manage_options' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -245,7 +245,7 @@ class MemoryListAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input = null ): bool {
-		return current_user_can( 'manage_options' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -318,7 +318,7 @@ class MemoryDeleteAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'manage_options' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {

--- a/includes/Abilities/NavigationAbilities.php
+++ b/includes/Abilities/NavigationAbilities.php
@@ -171,7 +171,7 @@ class NavigateAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'read' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -249,7 +249,7 @@ class GetPageHtmlAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'read' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {

--- a/includes/Abilities/SeoAbilities.php
+++ b/includes/Abilities/SeoAbilities.php
@@ -180,7 +180,7 @@ class SeoAuditUrlAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'edit_posts' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -433,7 +433,7 @@ class SeoAnalyzeContentAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'edit_posts' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {

--- a/includes/Abilities/SiteHealthAbilities.php
+++ b/includes/Abilities/SiteHealthAbilities.php
@@ -88,7 +88,7 @@ class SiteHealthAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_check_plugin_updates' ],
 				'permission_callback' => function () {
-					return current_user_can( 'update_plugins' );
+					return ToolCapabilities::current_user_can( 'gratis-ai-agent/check-plugin-updates' );
 				},
 			]
 		);
@@ -144,7 +144,7 @@ class SiteHealthAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_scan_php_error_log' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					return ToolCapabilities::current_user_can( 'gratis-ai-agent/scan-php-error-log' );
 				},
 			]
 		);
@@ -185,7 +185,7 @@ class SiteHealthAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_check_disk_space' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					return ToolCapabilities::current_user_can( 'gratis-ai-agent/check-disk-space' );
 				},
 			]
 		);
@@ -223,7 +223,7 @@ class SiteHealthAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_check_security' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					return ToolCapabilities::current_user_can( 'gratis-ai-agent/check-security' );
 				},
 			]
 		);
@@ -264,7 +264,7 @@ class SiteHealthAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_check_performance' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					return ToolCapabilities::current_user_can( 'gratis-ai-agent/check-performance' );
 				},
 			]
 		);
@@ -311,7 +311,7 @@ class SiteHealthAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_site_health_summary' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					return ToolCapabilities::current_user_can( 'gratis-ai-agent/site-health-summary' );
 				},
 			]
 		);

--- a/includes/Abilities/SkillAbilities.php
+++ b/includes/Abilities/SkillAbilities.php
@@ -167,7 +167,7 @@ class SkillLoadAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'manage_options' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -231,7 +231,7 @@ class SkillListAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input = null ): bool {
-		return current_user_can( 'manage_options' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {

--- a/includes/Abilities/StockImageAbilities.php
+++ b/includes/Abilities/StockImageAbilities.php
@@ -335,7 +335,7 @@ class ImportStockImageAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'upload_files' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {

--- a/includes/Abilities/ToolCapabilities.php
+++ b/includes/Abilities/ToolCapabilities.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Per-tool WordPress capability checks for Gratis AI Agent abilities.
+ *
+ * Provides granular capability checks so each ability can be granted
+ * independently via user roles. Capability names follow the pattern
+ * `gratis_ai_agent_tool_{name}` where `{name}` is derived from the ability ID
+ * (e.g. `gratis-ai-agent/memory-save` → `gratis_ai_agent_tool_memory_save`).
+ *
+ * Fallback: if the capability has not been granted to any role, the check
+ * falls back to `manage_options` (admin only) so the default behaviour is
+ * unchanged until an administrator explicitly delegates a capability.
+ *
+ * Filter: `gratis_ai_agent_tool_capability` allows overriding the resolved
+ * capability name per tool.
+ *
+ * @package GratisAiAgent
+ */
+
+namespace GratisAiAgent\Abilities;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * ToolCapabilities
+ *
+ * Static helper that resolves and checks per-tool WordPress capabilities.
+ */
+class ToolCapabilities {
+
+	/**
+	 * Fallback capability used when a tool-specific capability has not been
+	 * granted to any role.
+	 */
+	public const FALLBACK_CAP = 'manage_options';
+
+	/**
+	 * Derive the tool-specific capability name from an ability ID.
+	 *
+	 * Examples:
+	 *   gratis-ai-agent/memory-save  → gratis_ai_agent_tool_memory_save
+	 *   gratis-ai-agent/db-query     → gratis_ai_agent_tool_db_query
+	 *   gratis-ai-agent/run-php      → gratis_ai_agent_tool_run_php
+	 *
+	 * @param string $ability_id The ability ID (e.g. "gratis-ai-agent/memory-save").
+	 * @return string The derived capability name.
+	 */
+	public static function cap_name( string $ability_id ): string {
+		// Strip the "gratis-ai-agent/" namespace prefix.
+		$name = str_replace( 'gratis-ai-agent/', '', $ability_id );
+
+		// Replace hyphens and slashes with underscores.
+		$name = str_replace( [ '-', '/' ], '_', $name );
+
+		return 'gratis_ai_agent_tool_' . $name;
+	}
+
+	/**
+	 * Check whether the current user can execute a given ability.
+	 *
+	 * Resolution order:
+	 * 1. Apply the `gratis_ai_agent_tool_capability` filter to allow overrides.
+	 * 2. If the resolved capability exists in any role, use it.
+	 * 3. Otherwise fall back to `manage_options`.
+	 *
+	 * @param string $ability_id The ability ID (e.g. "gratis-ai-agent/memory-save").
+	 * @return bool True if the current user has permission.
+	 */
+	public static function current_user_can( string $ability_id ): bool {
+		$tool_cap = self::cap_name( $ability_id );
+
+		/**
+		 * Filter the capability name used to gate a specific Gratis AI Agent tool.
+		 *
+		 * @param string $tool_cap   The derived capability name (e.g. "gratis_ai_agent_tool_memory_save").
+		 * @param string $ability_id The full ability ID (e.g. "gratis-ai-agent/memory-save").
+		 */
+		$resolved_cap = (string) apply_filters( 'gratis_ai_agent_tool_capability', $tool_cap, $ability_id );
+
+		// If the capability has been granted to at least one role, use it.
+		// Otherwise fall back to manage_options so the default is admin-only.
+		if ( self::capability_exists( $resolved_cap ) ) {
+			return current_user_can( $resolved_cap );
+		}
+
+		return current_user_can( self::FALLBACK_CAP );
+	}
+
+	/**
+	 * Check whether a capability has been granted to at least one role.
+	 *
+	 * This is used to distinguish between "capability exists but user lacks it"
+	 * and "capability has never been registered/granted", so we can fall back
+	 * to manage_options in the latter case.
+	 *
+	 * @param string $cap Capability name.
+	 * @return bool True if the capability is present in at least one role.
+	 */
+	public static function capability_exists( string $cap ): bool {
+		global $wp_roles;
+
+		if ( ! isset( $wp_roles ) ) {
+			return false;
+		}
+
+		foreach ( $wp_roles->roles as $role ) {
+			if ( ! empty( $role['capabilities'][ $cap ] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Register all Gratis AI Agent tool capabilities on the Administrator role.
+	 *
+	 * Called on plugin activation and `admin_init` so that the capabilities
+	 * are available for role-management plugins (e.g. Members, User Role Editor)
+	 * to discover and assign.
+	 *
+	 * The capabilities are added to the Administrator role with `true` so that
+	 * admins retain full access. Other roles start with no access and must be
+	 * explicitly granted capabilities.
+	 *
+	 * @param string[] $ability_ids List of all ability IDs to register.
+	 */
+	public static function register_capabilities( array $ability_ids ): void {
+		$admin_role = get_role( 'administrator' );
+
+		if ( ! $admin_role instanceof \WP_Role ) {
+			return;
+		}
+
+		foreach ( $ability_ids as $ability_id ) {
+			$cap = self::cap_name( $ability_id );
+
+			/**
+			 * Allow overriding the capability name at registration time.
+			 *
+			 * @param string $cap        The derived capability name.
+			 * @param string $ability_id The full ability ID.
+			 */
+			$cap = (string) apply_filters( 'gratis_ai_agent_tool_capability', $cap, $ability_id );
+
+			if ( ! isset( $admin_role->capabilities[ $cap ] ) ) {
+				$admin_role->add_cap( $cap, true );
+			}
+		}
+	}
+
+	/**
+	 * Return the list of all Gratis AI Agent ability IDs that have tool capabilities.
+	 *
+	 * This list is used both for capability registration and for documentation.
+	 *
+	 * @return string[]
+	 */
+	public static function all_ability_ids(): array {
+		return [
+			// Memory.
+			'gratis-ai-agent/memory-save',
+			'gratis-ai-agent/memory-list',
+			'gratis-ai-agent/memory-delete',
+			// Skills.
+			'gratis-ai-agent/skill-load',
+			'gratis-ai-agent/skill-list',
+			// Knowledge.
+			'gratis-ai-agent/knowledge-search',
+			// Ability discovery.
+			'gratis-ai-agent/discovery-list',
+			'gratis-ai-agent/discovery-get',
+			'gratis-ai-agent/discovery-execute',
+			// Stock images.
+			'gratis-ai-agent/import-stock-image',
+			// SEO.
+			'gratis-ai-agent/seo-audit-url',
+			'gratis-ai-agent/seo-analyze-content',
+			// Content.
+			'gratis-ai-agent/content-analyze',
+			'gratis-ai-agent/content-performance-report',
+			// Marketing.
+			'gratis-ai-agent/fetch-url',
+			'gratis-ai-agent/analyze-headers',
+			// Blocks.
+			'gratis-ai-agent/markdown-to-blocks',
+			'gratis-ai-agent/list-block-types',
+			'gratis-ai-agent/get-block-type',
+			'gratis-ai-agent/list-block-patterns',
+			'gratis-ai-agent/list-block-templates',
+			'gratis-ai-agent/create-block-content',
+			'gratis-ai-agent/parse-block-content',
+			// Files.
+			'gratis-ai-agent/file-read',
+			'gratis-ai-agent/file-write',
+			'gratis-ai-agent/file-edit',
+			'gratis-ai-agent/file-delete',
+			'gratis-ai-agent/file-list',
+			'gratis-ai-agent/file-search',
+			'gratis-ai-agent/content-search',
+			// Database.
+			'gratis-ai-agent/db-query',
+			// WordPress management.
+			'gratis-ai-agent/get-plugins',
+			'gratis-ai-agent/get-themes',
+			'gratis-ai-agent/install-plugin',
+			'gratis-ai-agent/run-php',
+			// Navigation.
+			'gratis-ai-agent/navigate',
+			'gratis-ai-agent/get-page-html',
+			// Git.
+			'gratis-ai-agent/git-list',
+			'gratis-ai-agent/git-diff',
+			'gratis-ai-agent/git-snapshot',
+			'gratis-ai-agent/git-restore',
+			'gratis-ai-agent/git-revert-package',
+			'gratis-ai-agent/git-package-summary',
+			// Site health.
+			'gratis-ai-agent/site-health-summary',
+			'gratis-ai-agent/check-plugin-updates',
+			'gratis-ai-agent/check-security',
+			'gratis-ai-agent/check-performance',
+			'gratis-ai-agent/check-disk-space',
+			'gratis-ai-agent/scan-php-error-log',
+		];
+	}
+}

--- a/includes/Abilities/WordPressAbilities.php
+++ b/includes/Abilities/WordPressAbilities.php
@@ -200,7 +200,7 @@ class GetPluginsAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input = null ): bool {
-		return current_user_can( 'activate_plugins' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -269,7 +269,7 @@ class GetThemesAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input = null ): bool {
-		return current_user_can( 'switch_themes' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -432,7 +432,7 @@ class InstallPluginAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'install_plugins' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -516,7 +516,7 @@ class RunPhpAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'manage_options' );
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {

--- a/includes/Tools/CustomToolExecutor.php
+++ b/includes/Tools/CustomToolExecutor.php
@@ -15,6 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use GratisAiAgent\Abilities\ToolCapabilities;
 use WP_Error;
 
 class CustomToolExecutor {
@@ -59,8 +60,8 @@ class CustomToolExecutor {
 					'execute_callback'    => function ( array $input ) use ( $tool ) {
 						return self::execute( $tool, $input );
 					},
-					'permission_callback' => function () {
-						return current_user_can( 'manage_options' );
+					'permission_callback' => function () use ( $ability_name ) {
+						return ToolCapabilities::current_user_can( $ability_name );
 					},
 				]
 			);

--- a/tests/GratisAiAgent/Abilities/ToolCapabilitiesTest.php
+++ b/tests/GratisAiAgent/Abilities/ToolCapabilitiesTest.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Test case for ToolCapabilities class.
+ *
+ * @package GratisAiAgent
+ * @subpackage Tests
+ */
+
+namespace GratisAiAgent\Tests\Abilities;
+
+use GratisAiAgent\Abilities\ToolCapabilities;
+use WP_UnitTestCase;
+
+/**
+ * Test ToolCapabilities functionality.
+ */
+class ToolCapabilitiesTest extends WP_UnitTestCase {
+
+	/**
+	 * Test cap_name derives the correct capability name from an ability ID.
+	 *
+	 * @dataProvider provider_cap_name
+	 *
+	 * @param string $ability_id   Input ability ID.
+	 * @param string $expected_cap Expected capability name.
+	 */
+	public function test_cap_name( string $ability_id, string $expected_cap ): void {
+		$this->assertSame( $expected_cap, ToolCapabilities::cap_name( $ability_id ) );
+	}
+
+	/**
+	 * Data provider for test_cap_name.
+	 *
+	 * @return array<string, array{string, string}>
+	 */
+	public function provider_cap_name(): array {
+		return [
+			'memory-save'              => [ 'gratis-ai-agent/memory-save', 'gratis_ai_agent_tool_memory_save' ],
+			'memory-list'              => [ 'gratis-ai-agent/memory-list', 'gratis_ai_agent_tool_memory_list' ],
+			'memory-delete'            => [ 'gratis-ai-agent/memory-delete', 'gratis_ai_agent_tool_memory_delete' ],
+			'db-query'                 => [ 'gratis-ai-agent/db-query', 'gratis_ai_agent_tool_db_query' ],
+			'run-php'                  => [ 'gratis-ai-agent/run-php', 'gratis_ai_agent_tool_run_php' ],
+			'file-read'                => [ 'gratis-ai-agent/file-read', 'gratis_ai_agent_tool_file_read' ],
+			'get-plugins'              => [ 'gratis-ai-agent/get-plugins', 'gratis_ai_agent_tool_get_plugins' ],
+			'navigate'                 => [ 'gratis-ai-agent/navigate', 'gratis_ai_agent_tool_navigate' ],
+			'seo-audit-url'            => [ 'gratis-ai-agent/seo-audit-url', 'gratis_ai_agent_tool_seo_audit_url' ],
+			'content-analyze'          => [ 'gratis-ai-agent/content-analyze', 'gratis_ai_agent_tool_content_analyze' ],
+			'markdown-to-blocks'       => [ 'gratis-ai-agent/markdown-to-blocks', 'gratis_ai_agent_tool_markdown_to_blocks' ],
+			'import-stock-image'       => [ 'gratis-ai-agent/import-stock-image', 'gratis_ai_agent_tool_import_stock_image' ],
+			'custom-tool-with-slashes' => [ 'gratis-ai-agent-custom/my-tool', 'gratis_ai_agent_tool_gratis_ai_agent_custom_my_tool' ],
+		];
+	}
+
+	/**
+	 * Test capability_exists returns false when capability is not in any role.
+	 */
+	public function test_capability_exists_returns_false_for_unknown_cap(): void {
+		$this->assertFalse( ToolCapabilities::capability_exists( 'gratis_ai_agent_tool_nonexistent_xyz_12345' ) );
+	}
+
+	/**
+	 * Test capability_exists returns true after adding capability to a role.
+	 */
+	public function test_capability_exists_returns_true_after_adding_to_role(): void {
+		$cap  = 'gratis_ai_agent_tool_test_cap_' . uniqid();
+		$role = get_role( 'administrator' );
+		$this->assertNotNull( $role );
+
+		$role->add_cap( $cap, true );
+		$this->assertTrue( ToolCapabilities::capability_exists( $cap ) );
+
+		// Clean up.
+		$role->remove_cap( $cap );
+	}
+
+	/**
+	 * Test current_user_can falls back to manage_options when capability doesn't exist.
+	 */
+	public function test_current_user_can_falls_back_to_manage_options(): void {
+		// Create a user with manage_options.
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		// Use an ability ID whose capability has never been registered.
+		$this->assertTrue( ToolCapabilities::current_user_can( 'gratis-ai-agent/nonexistent-tool-xyz' ) );
+
+		// Create a subscriber (no manage_options).
+		$subscriber_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+
+		$this->assertFalse( ToolCapabilities::current_user_can( 'gratis-ai-agent/nonexistent-tool-xyz' ) );
+	}
+
+	/**
+	 * Test current_user_can uses the specific capability when it exists.
+	 */
+	public function test_current_user_can_uses_specific_cap_when_registered(): void {
+		$ability_id = 'gratis-ai-agent/test-specific-tool-' . uniqid();
+		$cap        = ToolCapabilities::cap_name( $ability_id );
+
+		// Grant the capability to the editor role.
+		$editor_role = get_role( 'editor' );
+		$this->assertNotNull( $editor_role );
+		$editor_role->add_cap( $cap, true );
+
+		// Editor should now have access.
+		$editor_id = $this->factory->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $editor_id );
+		$this->assertTrue( ToolCapabilities::current_user_can( $ability_id ) );
+
+		// Subscriber should not have access.
+		$subscriber_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+		$this->assertFalse( ToolCapabilities::current_user_can( $ability_id ) );
+
+		// Clean up.
+		$editor_role->remove_cap( $cap );
+	}
+
+	/**
+	 * Test the gratis_ai_agent_tool_capability filter overrides the capability name.
+	 */
+	public function test_filter_overrides_capability_name(): void {
+		$ability_id   = 'gratis-ai-agent/memory-save';
+		$override_cap = 'edit_posts';
+
+		add_filter(
+			'gratis_ai_agent_tool_capability',
+			function ( string $cap, string $id ) use ( $ability_id, $override_cap ): string {
+				if ( $id === $ability_id ) {
+					return $override_cap;
+				}
+				return $cap;
+			},
+			10,
+			2
+		);
+
+		// Grant edit_posts to editor role (it already has it by default).
+		$editor_id = $this->factory->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $editor_id );
+
+		// The capability 'edit_posts' exists in roles, so it should be used directly.
+		$this->assertTrue( ToolCapabilities::current_user_can( $ability_id ) );
+
+		remove_all_filters( 'gratis_ai_agent_tool_capability' );
+	}
+
+	/**
+	 * Test register_capabilities adds capabilities to the administrator role.
+	 */
+	public function test_register_capabilities_adds_to_admin_role(): void {
+		$test_ids = [
+			'gratis-ai-agent/test-reg-tool-a-' . uniqid(),
+			'gratis-ai-agent/test-reg-tool-b-' . uniqid(),
+		];
+
+		ToolCapabilities::register_capabilities( $test_ids );
+
+		$admin_role = get_role( 'administrator' );
+		$this->assertNotNull( $admin_role );
+
+		foreach ( $test_ids as $id ) {
+			$cap = ToolCapabilities::cap_name( $id );
+			$this->assertArrayHasKey( $cap, $admin_role->capabilities );
+			$this->assertTrue( $admin_role->capabilities[ $cap ] );
+
+			// Clean up.
+			$admin_role->remove_cap( $cap );
+		}
+	}
+
+	/**
+	 * Test all_ability_ids returns a non-empty array of strings.
+	 */
+	public function test_all_ability_ids_returns_non_empty_array(): void {
+		$ids = ToolCapabilities::all_ability_ids();
+		$this->assertIsArray( $ids );
+		$this->assertNotEmpty( $ids );
+
+		foreach ( $ids as $id ) {
+			$this->assertIsString( $id );
+			$this->assertStringStartsWith( 'gratis-ai-agent', $id );
+		}
+	}
+
+	/**
+	 * Test all_ability_ids contains expected core abilities.
+	 */
+	public function test_all_ability_ids_contains_core_abilities(): void {
+		$ids = ToolCapabilities::all_ability_ids();
+
+		$expected = [
+			'gratis-ai-agent/memory-save',
+			'gratis-ai-agent/memory-list',
+			'gratis-ai-agent/memory-delete',
+			'gratis-ai-agent/db-query',
+			'gratis-ai-agent/run-php',
+			'gratis-ai-agent/file-read',
+			'gratis-ai-agent/file-write',
+			'gratis-ai-agent/navigate',
+		];
+
+		foreach ( $expected as $id ) {
+			$this->assertContains( $id, $ids, "Expected ability ID '{$id}' not found in all_ability_ids()" );
+		}
+	}
+}


### PR DESCRIPTION
Each AI tool/ability now checks a corresponding WordPress capability before executing, allowing fine-grained permission control per tool.

Closes #435
Closes #371