### PR TITLE
t078: Role-based AI permissions — restrict abilities by WordPress user role

### DIFF
--- a/gratis-ai-agent.php
+++ b/gratis-ai-agent.php
@@ -68,6 +68,7 @@ use GratisAiAgent\Automations\EventTriggerHandler;
 use GratisAiAgent\CLI\CliCommand;
 use GratisAiAgent\Core\Database;
 use GratisAiAgent\Core\OnboardingManager;
+use GratisAiAgent\Core\RolePermissions;
 use GratisAiAgent\Core\Settings;
 use GratisAiAgent\Core\SiteScanner;
 use GratisAiAgent\Knowledge\KnowledgeHooks;

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -18,6 +18,7 @@ use GratisAiAgent\Models\Skill;
 use GratisAiAgent\REST\SseStreamer;
 use GratisAiAgent\Tools\ToolDiscovery;
 use GratisAiAgent\Tools\ToolProfiles;
+use GratisAiAgent\Core\RolePermissions;
 use WP_AI_Client_Ability_Function_Resolver;
 use WP_Error;
 use GratisAiAgent\Core\CredentialResolver;
@@ -1361,6 +1362,18 @@ class AgentLoop {
 					}
 				);
 			}
+		}
+
+		// Apply role-based ability restrictions for the current user.
+		// Administrators are unrestricted (get_allowed_abilities_for_current_user returns null).
+		$role_allowed = RolePermissions::get_allowed_abilities_for_current_user();
+		if ( null !== $role_allowed ) {
+			$all = array_filter(
+				$all,
+				function ( $ability ) use ( $role_allowed ) {
+					return in_array( $ability->get_name(), $role_allowed, true );
+				}
+			);
 		}
 
 		if ( ! empty( $this->abilities ) ) {

--- a/includes/Core/RolePermissions.php
+++ b/includes/Core/RolePermissions.php
@@ -1,0 +1,255 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Role-based AI permissions management.
+ *
+ * Stores per-role access configuration in a dedicated WordPress option and
+ * provides server-side enforcement helpers used by the REST controller and
+ * AgentLoop. Admins always retain full access regardless of configuration.
+ *
+ * Option schema (gratis_ai_agent_role_permissions):
+ * {
+ *   "editor": {
+ *     "chat_access": true,
+ *     "allowed_abilities": ["gratis-ai-agent/content-analyze", ...]
+ *                          // empty array = all abilities allowed for this role
+ *   },
+ *   "author": {
+ *     "chat_access": false,
+ *     "allowed_abilities": []
+ *   }
+ * }
+ *
+ * @package GratisAiAgent
+ */
+
+namespace GratisAiAgent\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class RolePermissions {
+
+	/**
+	 * Option name in the wp_options table.
+	 */
+	const OPTION_NAME = 'gratis_ai_agent_role_permissions';
+
+	/**
+	 * WordPress roles that always have full access (cannot be restricted).
+	 */
+	const ALWAYS_ALLOWED_ROLES = [ 'administrator' ];
+
+	/**
+	 * Get the default role permissions configuration.
+	 *
+	 * By default:
+	 *  - administrator: full access (enforced in code, not stored)
+	 *  - editor: chat access, all abilities
+	 *  - author: chat access, all abilities
+	 *  - contributor: no chat access
+	 *  - subscriber: no chat access
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public static function get_defaults(): array {
+		return [
+			'editor'      => [
+				'chat_access'       => true,
+				'allowed_abilities' => [],
+			],
+			'author'      => [
+				'chat_access'       => true,
+				'allowed_abilities' => [],
+			],
+			'contributor' => [
+				'chat_access'       => false,
+				'allowed_abilities' => [],
+			],
+			'subscriber'  => [
+				'chat_access'       => false,
+				'allowed_abilities' => [],
+			],
+		];
+	}
+
+	/**
+	 * Get all role permissions, merged with defaults.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public static function get(): array {
+		$saved    = get_option( self::OPTION_NAME, [] );
+		$defaults = self::get_defaults();
+
+		if ( ! is_array( $saved ) ) {
+			return $defaults;
+		}
+
+		// Merge saved values over defaults, preserving any extra roles.
+		$merged = $defaults;
+		foreach ( $saved as $role => $config ) {
+			if ( ! is_string( $role ) || ! is_array( $config ) ) {
+				continue;
+			}
+			$merged[ $role ] = [
+				'chat_access'       => (bool) ( $config['chat_access'] ?? false ),
+				'allowed_abilities' => array_values(
+					array_filter(
+						(array) ( $config['allowed_abilities'] ?? [] ),
+						'is_string'
+					)
+				),
+			];
+		}
+
+		return $merged;
+	}
+
+	/**
+	 * Persist role permissions.
+	 *
+	 * @param array<string, array<string, mixed>> $data Role slug => config map.
+	 * @return bool True on success.
+	 */
+	public static function update( array $data ): bool {
+		$sanitized = [];
+
+		foreach ( $data as $role => $config ) {
+			if ( ! is_string( $role ) || ! is_array( $config ) ) {
+				continue;
+			}
+
+			// Skip the always-allowed roles — they cannot be restricted.
+			if ( in_array( $role, self::ALWAYS_ALLOWED_ROLES, true ) ) {
+				continue;
+			}
+
+			$sanitized[ sanitize_key( $role ) ] = [
+				'chat_access'       => (bool) ( $config['chat_access'] ?? false ),
+				'allowed_abilities' => array_values(
+					array_filter(
+						array_map( 'sanitize_text_field', (array) ( $config['allowed_abilities'] ?? [] ) ),
+						'is_string'
+					)
+				),
+			];
+		}
+
+		return update_option( self::OPTION_NAME, $sanitized );
+	}
+
+	/**
+	 * Check whether the current user has chat access.
+	 *
+	 * Administrators always have access. For other roles, the first matching
+	 * role config with chat_access=true grants access.
+	 *
+	 * @return bool
+	 */
+	public static function current_user_has_chat_access(): bool {
+		// Must be logged in.
+		if ( ! is_user_logged_in() ) {
+			return false;
+		}
+
+		// Administrators always have full access.
+		if ( current_user_can( 'manage_options' ) ) {
+			return true;
+		}
+
+		$user        = wp_get_current_user();
+		$permissions = self::get();
+
+		foreach ( (array) $user->roles as $role ) {
+			if ( isset( $permissions[ $role ] ) && true === $permissions[ $role ]['chat_access'] ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get the set of ability names allowed for the current user.
+	 *
+	 * Returns null when there is no restriction (all abilities allowed).
+	 * Returns an array of ability name strings when restrictions apply.
+	 *
+	 * Administrators always receive null (unrestricted).
+	 *
+	 * @return string[]|null Null = unrestricted; array = allowed ability names.
+	 */
+	public static function get_allowed_abilities_for_current_user(): ?array {
+		// Administrators are unrestricted.
+		if ( current_user_can( 'manage_options' ) ) {
+			return null;
+		}
+
+		$user        = wp_get_current_user();
+		$permissions = self::get();
+
+		// Collect the union of allowed abilities across all user roles.
+		// An empty allowed_abilities array for a role means "all abilities".
+		$has_restriction = false;
+		$allowed         = [];
+
+		foreach ( (array) $user->roles as $role ) {
+			if ( ! isset( $permissions[ $role ] ) ) {
+				continue;
+			}
+
+			$role_config = $permissions[ $role ];
+
+			// If any role grants unrestricted abilities, the user is unrestricted.
+			if ( empty( $role_config['allowed_abilities'] ) ) {
+				return null;
+			}
+
+			$has_restriction = true;
+			$allowed         = array_merge( $allowed, $role_config['allowed_abilities'] );
+		}
+
+		if ( ! $has_restriction ) {
+			// No matching role config found — deny all abilities by default.
+			return [];
+		}
+
+		return array_values( array_unique( $allowed ) );
+	}
+
+	/**
+	 * Check whether the current user can invoke a specific ability.
+	 *
+	 * @param string $ability_name The ability name (e.g. 'gratis-ai-agent/memory-save').
+	 * @return bool
+	 */
+	public static function current_user_can_use_ability( string $ability_name ): bool {
+		$allowed = self::get_allowed_abilities_for_current_user();
+
+		// null = unrestricted.
+		if ( null === $allowed ) {
+			return true;
+		}
+
+		return in_array( $ability_name, $allowed, true );
+	}
+
+	/**
+	 * Get all registered WordPress roles with their display names.
+	 *
+	 * @return array<string, string> Role slug => display name.
+	 */
+	public static function get_all_roles(): array {
+		$wp_roles = wp_roles();
+		$roles    = [];
+
+		foreach ( $wp_roles->roles as $slug => $role_data ) {
+			$roles[ $slug ] = translate_user_role( $role_data['name'] );
+		}
+
+		return $roles;
+	}
+}

--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -22,6 +22,7 @@ use GratisAiAgent\Core\AgentLoop;
 use GratisAiAgent\Core\CostCalculator;
 use GratisAiAgent\Core\Database;
 use GratisAiAgent\Core\Export;
+use GratisAiAgent\Core\RolePermissions;
 use GratisAiAgent\Core\Settings;
 use GratisAiAgent\Knowledge\Knowledge;
 use GratisAiAgent\Knowledge\KnowledgeDatabase;
@@ -88,7 +89,7 @@ class RestController {
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => [ __CLASS__, 'handle_stream' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'permission_callback' => [ __CLASS__, 'check_chat_permission' ],
 				'args'                => [
 					'message'            => [
 						'required'          => true,
@@ -381,6 +382,43 @@ class RestController {
 							'sanitize_callback' => 'sanitize_text_field',
 						],
 					],
+				],
+			]
+		);
+
+		// Role permissions endpoints.
+		register_rest_route(
+			self::NAMESPACE,
+			'/role-permissions',
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $instance, 'handle_get_role_permissions' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
+				],
+				[
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => [ $instance, 'handle_update_role_permissions' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
+					'args'                => [
+						'permissions' => [
+							'required' => true,
+							'type'     => 'object',
+						],
+					],
+				],
+			]
+		);
+
+		// Role permissions — available roles list.
+		register_rest_route(
+			self::NAMESPACE,
+			'/role-permissions/roles',
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $instance, 'handle_get_roles' ],
+					'permission_callback' => [ $instance, 'check_permission' ],
 				],
 			]
 		);
@@ -1496,19 +1534,47 @@ class RestController {
 	}
 
 	/**
-	 * Permission check — admin only.
+	 * Permission check — admin only (for admin-only endpoints).
 	 */
 	public function check_permission(): bool {
 		return current_user_can( 'manage_options' );
 	}
 
 	/**
+	 * Permission check for chat endpoints (stream, run, process).
+	 *
+	 * Allows access based on role-based permissions configuration.
+	 * Administrators always have access.
+	 *
+	 * @return bool|WP_Error
+	 */
+	public function check_chat_permission() {
+		if ( ! is_user_logged_in() ) {
+			return new WP_Error(
+				'rest_not_logged_in',
+				__( 'You must be logged in to use the AI chat.', 'gratis-ai-agent' ),
+				[ 'status' => 401 ]
+			);
+		}
+
+		if ( ! RolePermissions::current_user_has_chat_access() ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'Your user role does not have permission to access the AI chat.', 'gratis-ai-agent' ),
+				[ 'status' => 403 ]
+			);
+		}
+
+		return true;
+	}
+
+	/**
 	 * Permission check for session-specific endpoints.
 	 *
-	 * Verifies manage_options + session ownership.
+	 * Verifies chat access + session ownership.
 	 */
 	public function check_session_permission( WP_REST_Request $request ): bool {
-		if ( ! current_user_can( 'manage_options' ) ) {
+		if ( ! RolePermissions::current_user_has_chat_access() ) {
 			return false;
 		}
 
@@ -2876,6 +2942,67 @@ class RestController {
 		$this->settings->update( $data );
 
 		return new WP_REST_Response( $this->settings->get(), 200 );
+	}
+
+
+	/**
+	 * Handle GET /role-permissions — return current role permissions config.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function handle_get_role_permissions(): WP_REST_Response {
+		return new WP_REST_Response(
+			[
+				'permissions'    => RolePermissions::get(),
+				'always_allowed' => RolePermissions::ALWAYS_ALLOWED_ROLES,
+			],
+			200
+		);
+	}
+
+	/**
+	 * Handle POST /role-permissions — update role permissions config.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function handle_update_role_permissions( WP_REST_Request $request ) {
+		$permissions = $request->get_param( 'permissions' );
+
+		if ( ! is_array( $permissions ) ) {
+			return new WP_Error(
+				'invalid_permissions',
+				__( 'Invalid permissions data.', 'gratis-ai-agent' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$success = RolePermissions::update( $permissions );
+
+		if ( ! $success ) {
+			return new WP_Error(
+				'update_failed',
+				__( 'Failed to save role permissions.', 'gratis-ai-agent' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		return new WP_REST_Response(
+			[
+				'permissions'    => RolePermissions::get(),
+				'always_allowed' => RolePermissions::ALWAYS_ALLOWED_ROLES,
+			],
+			200
+		);
+	}
+
+	/**
+	 * Handle GET /role-permissions/roles — return all registered WordPress roles.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function handle_get_roles(): WP_REST_Response {
+		return new WP_REST_Response( RolePermissions::get_all_roles(), 200 );
 	}
 
 	/**

--- a/src/settings-page/role-permissions-manager.js
+++ b/src/settings-page/role-permissions-manager.js
@@ -1,0 +1,283 @@
+/**
+ * Role Permissions Manager component.
+ *
+ * Allows administrators to configure which WordPress user roles can access
+ * the AI chat and which specific abilities are available per role.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState, useCallback, useMemo } from '@wordpress/element';
+import {
+	Button,
+	CheckboxControl,
+	Notice,
+	Spinner,
+	ToggleControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * A single role row showing chat access toggle and ability restrictions.
+ *
+ * @param {Object}   props
+ * @param {string}   props.roleSlug  WordPress role slug.
+ * @param {string}   props.roleLabel Human-readable role name.
+ * @param {Object}   props.config    Current config for this role.
+ * @param {Array}    props.abilities All registered abilities.
+ * @param {Function} props.onChange  Called with (roleSlug, newConfig).
+ * @return {JSX.Element} The role row element.
+ */
+function RoleRow( { roleSlug, roleLabel, config, abilities, onChange } ) {
+	const chatAccess = config?.chat_access ?? false;
+
+	const allowedAbilities = useMemo(
+		() => config?.allowed_abilities ?? [],
+		[ config ]
+	);
+
+	const allAllowed = allowedAbilities.length === 0;
+
+	const handleChatToggle = useCallback(
+		( value ) => {
+			onChange( roleSlug, {
+				...( config || {} ),
+				chat_access: value,
+				allowed_abilities: allowedAbilities,
+			} );
+		},
+		[ roleSlug, config, allowedAbilities, onChange ]
+	);
+
+	const handleAllAbilitiesToggle = useCallback(
+		( value ) => {
+			onChange( roleSlug, {
+				...( config || {} ),
+				chat_access: chatAccess,
+				// Empty array = all abilities allowed; populated = restricted list.
+				allowed_abilities: value
+					? []
+					: abilities.map( ( a ) => a.name ),
+			} );
+		},
+		[ roleSlug, config, chatAccess, abilities, onChange ]
+	);
+
+	const handleAbilityToggle = useCallback(
+		( abilityName, checked ) => {
+			const updated = checked
+				? [ ...allowedAbilities, abilityName ]
+				: allowedAbilities.filter( ( n ) => n !== abilityName );
+			onChange( roleSlug, {
+				...( config || {} ),
+				chat_access: chatAccess,
+				allowed_abilities: updated,
+			} );
+		},
+		[ roleSlug, config, chatAccess, allowedAbilities, onChange ]
+	);
+
+	return (
+		<div className="gratis-ai-agent-role-row">
+			<div className="gratis-ai-agent-role-header">
+				<h3 className="gratis-ai-agent-role-name">{ roleLabel }</h3>
+				<ToggleControl
+					label={ __( 'Chat Access', 'gratis-ai-agent' ) }
+					checked={ chatAccess }
+					onChange={ handleChatToggle }
+					help={ __(
+						'Allow this role to use the AI chat.',
+						'gratis-ai-agent'
+					) }
+					__nextHasNoMarginBottom
+				/>
+			</div>
+
+			{ chatAccess && (
+				<div className="gratis-ai-agent-role-abilities">
+					<ToggleControl
+						label={ __(
+							'All abilities (unrestricted)',
+							'gratis-ai-agent'
+						) }
+						checked={ allAllowed }
+						onChange={ handleAllAbilitiesToggle }
+						help={ __(
+							'When enabled, this role can use all available abilities. Disable to select specific abilities.',
+							'gratis-ai-agent'
+						) }
+						__nextHasNoMarginBottom
+					/>
+
+					{ ! allAllowed && abilities.length > 0 && (
+						<div className="gratis-ai-agent-ability-list">
+							<p className="description">
+								{ __(
+									'Select which abilities this role can use:',
+									'gratis-ai-agent'
+								) }
+							</p>
+							{ abilities.map( ( ability ) => (
+								<CheckboxControl
+									key={ ability.name }
+									label={ ability.label || ability.name }
+									help={ ability.description || '' }
+									checked={ allowedAbilities.includes(
+										ability.name
+									) }
+									onChange={ ( checked ) =>
+										handleAbilityToggle(
+											ability.name,
+											checked
+										)
+									}
+									__nextHasNoMarginBottom
+								/>
+							) ) }
+						</div>
+					) }
+				</div>
+			) }
+		</div>
+	);
+}
+
+/**
+ * Main Role Permissions Manager component.
+ *
+ * @return {JSX.Element} The role permissions manager element.
+ */
+export default function RolePermissionsManager() {
+	const [ loading, setLoading ] = useState( true );
+	const [ saving, setSaving ] = useState( false );
+	const [ notice, setNotice ] = useState( null );
+	const [ roles, setRoles ] = useState( {} );
+	const [ permissions, setPermissions ] = useState( {} );
+	const [ alwaysAllowed, setAlwaysAllowed ] = useState( [] );
+	const [ abilities, setAbilities ] = useState( [] );
+
+	useEffect( () => {
+		Promise.all( [
+			apiFetch( { path: '/gratis-ai-agent/v1/role-permissions' } ),
+			apiFetch( { path: '/gratis-ai-agent/v1/role-permissions/roles' } ),
+			apiFetch( { path: '/gratis-ai-agent/v1/abilities' } ).catch(
+				() => []
+			),
+		] )
+			.then( ( [ permData, rolesData, abilitiesData ] ) => {
+				setPermissions( permData.permissions || {} );
+				setAlwaysAllowed( permData.always_allowed || [] );
+				setRoles( rolesData || {} );
+				setAbilities( abilitiesData || [] );
+			} )
+			.catch( () => {
+				setNotice( {
+					status: 'error',
+					message: __(
+						'Failed to load role permissions.',
+						'gratis-ai-agent'
+					),
+				} );
+			} )
+			.finally( () => setLoading( false ) );
+	}, [] );
+
+	const handleRoleChange = useCallback( ( roleSlug, newConfig ) => {
+		setPermissions( ( prev ) => ( { ...prev, [ roleSlug ]: newConfig } ) );
+	}, [] );
+
+	const handleSave = useCallback( async () => {
+		setSaving( true );
+		setNotice( null );
+		try {
+			const result = await apiFetch( {
+				path: '/gratis-ai-agent/v1/role-permissions',
+				method: 'POST',
+				data: { permissions },
+			} );
+			setPermissions( result.permissions || {} );
+			setNotice( {
+				status: 'success',
+				message: __( 'Role permissions saved.', 'gratis-ai-agent' ),
+			} );
+		} catch {
+			setNotice( {
+				status: 'error',
+				message: __(
+					'Failed to save role permissions.',
+					'gratis-ai-agent'
+				),
+			} );
+		}
+		setSaving( false );
+	}, [ permissions ] );
+
+	if ( loading ) {
+		return (
+			<div className="gratis-ai-agent-role-permissions-loading">
+				<Spinner />
+			</div>
+		);
+	}
+
+	return (
+		<div className="gratis-ai-agent-role-permissions">
+			{ notice && (
+				<Notice
+					status={ notice.status }
+					isDismissible
+					onDismiss={ () => setNotice( null ) }
+				>
+					{ notice.message }
+				</Notice>
+			) }
+
+			<p className="description">
+				{ __(
+					'Configure which WordPress user roles can access the AI chat and which abilities are available per role. Administrators always have full access.',
+					'gratis-ai-agent'
+				) }
+			</p>
+
+			{ alwaysAllowed.length > 0 && (
+				<p className="description">
+					<em>
+						{ __(
+							'Always allowed (cannot be restricted):',
+							'gratis-ai-agent'
+						) }{ ' ' }
+						{ alwaysAllowed.join( ', ' ) }
+					</em>
+				</p>
+			) }
+
+			<div className="gratis-ai-agent-role-list">
+				{ Object.entries( roles )
+					.filter( ( [ slug ] ) => ! alwaysAllowed.includes( slug ) )
+					.map( ( [ slug, label ] ) => (
+						<RoleRow
+							key={ slug }
+							roleSlug={ slug }
+							roleLabel={ label }
+							config={ permissions[ slug ] }
+							abilities={ abilities }
+							onChange={ handleRoleChange }
+						/>
+					) ) }
+			</div>
+
+			<div className="gratis-ai-agent-role-permissions-actions">
+				<Button
+					variant="primary"
+					onClick={ handleSave }
+					isBusy={ saving }
+					disabled={ saving }
+				>
+					{ __( 'Save Permissions', 'gratis-ai-agent' ) }
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -31,6 +31,7 @@ import CustomToolsManager from './custom-tools-manager';
 import ToolProfilesManager from './tool-profiles-manager';
 import AutomationsManager from './automations-manager';
 import EventsManager from './events-manager';
+import RolePermissionsManager from './role-permissions-manager';
 
 /**
  *
@@ -168,6 +169,11 @@ export default function SettingsApp() {
 		{
 			name: 'abilities',
 			title: __( 'Abilities', 'gratis-ai-agent' ),
+			className: 'gratis-ai-agent-settings-tab',
+		},
+		{
+			name: 'permissions',
+			title: __( 'Permissions', 'gratis-ai-agent' ),
 			className: 'gratis-ai-agent-settings-tab',
 		},
 		{
@@ -569,6 +575,20 @@ export default function SettingsApp() {
 											/>
 										);
 									} ) }
+								</div>
+							);
+
+						case 'permissions':
+							return (
+								<div className="gratis-ai-agent-settings-section">
+									<ErrorBoundary
+										label={ __(
+											'Role permissions manager',
+											'gratis-ai-agent'
+										) }
+									>
+										<RolePermissionsManager />
+									</ErrorBoundary>
 								</div>
 							);
 


### PR DESCRIPTION
## Summary

Implements role-based access control for AI abilities in the WordPress admin.

- **RolePermissions class** (): stores per-role ability allow-lists in . Administrators are unrestricted (null = all abilities allowed).
- **REST endpoints**:  for reading and saving role permission settings.
- **Server-side enforcement** in : checks current user's role before invoking any ability. Non-admin users are filtered to their allowed set.
- **Settings UI** (): React component in the admin settings page showing a matrix of roles × abilities with checkboxes.

Closes #388