### PR TITLE
fix: add complementary assertNotContains for status filter in DatabaseTest

### DIFF
--- a/tests/GratisAiAgent/Core/DatabaseTest.php
+++ b/tests/GratisAiAgent/Core/DatabaseTest.php
@@ -230,9 +230,11 @@ class DatabaseTest extends WP_UnitTestCase {
 		$active = Database::list_sessions( $user_id, [ 'status' => 'active' ] );
 		$trashed = Database::list_sessions( $user_id, [ 'status' => 'trash' ] );
 
-		// The trashed session should appear in trash list.
-		$trashed_ids = array_column( $trashed, 'id' );
-		$this->assertContains( (int) $session_id, array_map( 'intval', $trashed_ids ) );
+		// The trashed session should appear in trash list but NOT in active list.
+		$active_ids  = array_map( 'intval', array_column( $active, 'id' ) );
+		$trashed_ids = array_map( 'intval', array_column( $trashed, 'id' ) );
+		$this->assertNotContains( (int) $session_id, $active_ids );
+		$this->assertContains( (int) $session_id, $trashed_ids );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Addresses CodeRabbit review feedback from PR #1 on `tests/AiAgent/Core/DatabaseTest.php:235`
- Adds `assertNotContains` to verify the trashed session does NOT appear in the active list, covering the status filter end-to-end
- Fixes PHPMD `UnusedLocalVariable` warning on `$active` (line 230) by actually using it in the assertion

## Changes

In `test_trash_session`, after moving a session to trash:
- `$active_ids` is now used in `assertNotContains( (int) $session_id, $active_ids )` — proves the trashed row doesn't leak into the active query
- `$trashed_ids` assertion unchanged — proves the row appears in the trash query

This validates the status filter bidirectionally rather than only checking the positive case.

Closes #6