### PR TITLE
fix: wrap execute_abilities() in try/finally to guarantee ChangeLogger::end() is always called

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -187,8 +187,11 @@ class AgentLoop {
 			// The last message in history is the model's tool call message.
 			$assistant_message = end( $this->history );
 			ChangeLogger::begin( $this->session_id, 'confirmed-tool' );
-			$response_message = $this->get_ability_resolver()->execute_abilities( $assistant_message );
-			ChangeLogger::end();
+			try {
+				$response_message = $this->get_ability_resolver()->execute_abilities( $assistant_message );
+			} finally {
+				ChangeLogger::end();
+			}
 			$this->history[] = $response_message;
 			$this->log_tool_responses( $response_message );
 		} else {
@@ -287,8 +290,11 @@ class AgentLoop {
 
 			// Execute the ability calls and get the function response message.
 			ChangeLogger::begin( $this->session_id );
-			$response_message = $this->get_ability_resolver()->execute_abilities( $assistant_message );
-			ChangeLogger::end();
+			try {
+				$response_message = $this->get_ability_resolver()->execute_abilities( $assistant_message );
+			} finally {
+				ChangeLogger::end();
+			}
 			$this->history[] = $response_message;
 			$this->log_tool_responses( $response_message );
 


### PR DESCRIPTION
## Summary

- Wraps both `execute_abilities()` call sites in `AgentLoop.php` in `try/finally` blocks so `ChangeLogger::end()` is always called even if `execute_abilities()` throws an exception.
- Fixes a critical CodeRabbit finding: without the `finally` guard, an exception from `execute_abilities()` would leave the change-log in an open/inconsistent state.
- Only `includes/Core/AgentLoop.php` is touched; no logic changes beyond the safety wrapper.

Closes #486

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of change logging to ensure accurate tracking of modifications even when system operations encounter errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->