### PR TITLE
t484: fix object-level permission check in ImageAbilities::permission_edit_posts

### DIFF
--- a/includes/Abilities/ImageAbilities.php
+++ b/includes/Abilities/ImageAbilities.php
@@ -559,9 +559,13 @@ INSTRUCTION;
 	/**
 	 * Permission callback: requires edit_posts capability.
 	 *
+	 * When $input['context'] is a numeric post ID, also performs an object-level
+	 * check via current_user_can( 'edit_post', $post_id ) to prevent one author
+	 * from accessing another user's draft or private post content.
+	 *
 	 * @since 1.1.0
 	 *
-	 * @param mixed $input Input args (unused).
+	 * @param mixed $input Input args.
 	 * @return bool|\WP_Error
 	 */
 	public static function permission_edit_posts( $input ) {
@@ -571,6 +575,17 @@ INSTRUCTION;
 				__( 'You do not have permission to use AI image abilities.', 'gratis-ai-agent' )
 			);
 		}
+
+		if ( is_array( $input ) && isset( $input['context'] ) && is_numeric( $input['context'] ) ) {
+			$post_id = (int) $input['context'];
+			if ( $post_id > 0 && ! current_user_can( 'edit_post', $post_id ) ) {
+				return new WP_Error(
+					'insufficient_capabilities',
+					__( 'You do not have permission to use that post as AI image context.', 'gratis-ai-agent' )
+				);
+			}
+		}
+
 		return true;
 	}
 


### PR DESCRIPTION
## Summary

- Adds an object-level `current_user_can( 'edit_post', $post_id )` check inside `permission_edit_posts()` when `$input['context']` is a numeric post ID.
- Prevents one author from feeding another user's draft or private post content into the AI image prompt flow via the `context` parameter.
- Updates the method docblock to document the new behaviour; removes the stale `(unused)` annotation on `$input`.

## Security impact

Without this fix, any user with `edit_posts` capability could pass a numeric post ID they don't own as `context`, causing the handler to read that post's title, excerpt, and content and send it to the AI model. The fix closes the object-level authorisation gap identified by CodeRabbit.

## Changes

- `includes/Abilities/ImageAbilities.php` — `permission_edit_posts()` only (lines 559–590 after patch).

## Testing

1. Log in as Author A (owns post 42, draft).
2. Log in as Author B (does not own post 42).
3. Call the image ability with `context: 42` as Author B → expect `WP_Error` with `insufficient_capabilities`.
4. Call with `context: 42` as Author A → expect `true` (proceeds normally).
5. Call with non-numeric `context` (e.g. `"site"`) as any editor → expect `true` (existing path unchanged).

Closes #484