### PR TITLE
fix: use sanitize_textarea_field() to preserve line breaks in summary output

### DIFF
--- a/includes/Abilities/EditorialAbilities.php
+++ b/includes/Abilities/EditorialAbilities.php
@@ -405,7 +405,7 @@ INSTRUCTION;
 			return new WP_Error( 'no_results', __( 'No summary was generated.', 'gratis-ai-agent' ) );
 		}
 
-		return sanitize_text_field( trim( $result ) );
+		return sanitize_textarea_field( trim( $result ) );
 	}
 
 	// ─── Block Review ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replaces `sanitize_text_field()` with `sanitize_textarea_field()` at `EditorialAbilities.php:408`
- `sanitize_text_field()` strips newlines, corrupting multi-paragraph AI-generated summaries
- `sanitize_textarea_field()` applies identical XSS sanitization while preserving line breaks

## Change

```diff
- return sanitize_text_field( trim( $result ) );
+ return sanitize_textarea_field( trim( $result ) );
```

One-line fix. No other files touched.

Closes #483