### PR TITLE
fix: replace hard-coded versioned Chrome path with env var fallback

### DIFF
--- a/tests/e2e-docker-screenshots.js
+++ b/tests/e2e-docker-screenshots.js
@@ -3,7 +3,7 @@ const puppeteer = require( 'puppeteer-core' );
 const BASE_URL = 'http://localhost:8888';
 const SCREENSHOT_DIR = '/screenshots';
 const CHROME_PATH =
-	'/home/pptruser/.cache/puppeteer/chrome/linux-146.0.7680.76/chrome-linux64/chrome';
+	process.env.CHROME_PATH || '/usr/bin/chromium-browser';
 
 ( async () => {
 	const browser = await puppeteer.launch( {


### PR DESCRIPTION
## Summary

- Replaces the version-pinned `CHROME_PATH` constant (`linux-146.0.7680.76/...`) in `tests/e2e-docker-screenshots.js` with `process.env.CHROME_PATH || '/usr/bin/chromium-browser'`
- The hard-coded path breaks immediately when the Docker image's Chrome version updates; the env var allows Docker environments to override the path while the stable system fallback works for local runs

## Changes

- `tests/e2e-docker-screenshots.js:5-6` — one-line fix, no logic changes

Closes #491