### PR TITLE
t488: fix: add int|false return type to ChangesLog::record()

### DIFF
--- a/includes/Models/ChangesLog.php
+++ b/includes/Models/ChangesLog.php
@@ -23,7 +23,7 @@ class ChangesLog {
 	 * @param array<string,mixed> $data Change data: session_id, user_id, object_type, object_id, object_title, ability_name, field_name, before_value, after_value.
 	 * @return int|false Inserted row ID or false on failure.
 	 */
-	public static function record( array $data ) {
+	public static function record( array $data ): int|false {
 		global $wpdb;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Custom table; caching not applicable.


### PR DESCRIPTION
## Summary

- Adds explicit `: int|false` return type declaration to `ChangesLog::record()` (line 26)
- Aligns the method signature with its existing `@return int|false` docblock
- Required per project coding guidelines: all methods must declare return types

## Change

```diff
-	public static function record( array $data ) {
+	public static function record( array $data ): int|false {
```

No logic changes — signature only.

Closes #488

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Internal code improvements for type safety and code quality.

No user-facing changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->