### PR TITLE
t489: fix: check delete result in handle_delete_change before returning success

### DIFF
--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -5298,7 +5298,11 @@ class RestController {
 			return new WP_Error( 'not_found', __( 'Change record not found.', 'gratis-ai-agent' ), [ 'status' => 404 ] );
 		}
 
-		ChangesLog::delete( $id );
+		$deleted = ChangesLog::delete( $id );
+
+		if ( ! $deleted ) {
+			return new WP_Error( 'delete_failed', __( 'Failed to delete change record.', 'gratis-ai-agent' ), [ 'status' => 500 ] );
+		}
 
 		return new WP_REST_Response(
 			[


### PR DESCRIPTION
## Summary

- `handle_delete_change` called `ChangesLog::delete($id)` without checking the return value, so the endpoint always returned HTTP 200 even when the database delete failed
- Capture the `bool` return value and return `WP_Error('delete_failed', ..., 500)` when deletion fails
- Success response is only returned when `$deleted` is truthy

## Changes

- `includes/REST/RestController.php`: capture `ChangesLog::delete()` result; add early-return `WP_Error` on failure

Closes #489

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for deletion operations, ensuring proper error responses are returned when deletions fail instead of proceeding unconditionally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->