### PR TITLE
fix: redact secrets/PII in ChangeLogger before_value/after_value

### DIFF
--- a/includes/Core/ChangeLogger.php
+++ b/includes/Core/ChangeLogger.php
@@ -160,6 +160,11 @@ class ChangeLogger {
 			return;
 		}
 
+		if ( self::is_sensitive_option( $option ) ) {
+			$before = self::redact_value();
+			$after  = self::redact_value();
+		}
+
 		ChangesLog::record(
 			[
 				'session_id'   => self::$session_id,
@@ -190,6 +195,10 @@ class ChangeLogger {
 		}
 
 		$after = is_scalar( $value ) ? (string) $value : wp_json_encode( $value );
+
+		if ( self::is_sensitive_option( $option ) ) {
+			$after = self::redact_value();
+		}
 
 		ChangesLog::record(
 			[
@@ -262,6 +271,12 @@ class ChangeLogger {
 				continue;
 			}
 
+			// Redact PII fields — log that the field changed without storing the value.
+			if ( 'user_email' === $field ) {
+				$before = self::redact_value();
+				$after  = self::redact_value();
+			}
+
 			ChangesLog::record(
 				[
 					'session_id'   => self::$session_id,
@@ -303,5 +318,34 @@ class ChangeLogger {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Whether an option name likely contains sensitive data (API keys, tokens, passwords, etc.).
+	 *
+	 * Matches common naming patterns used by WordPress core and plugins for
+	 * credential-like options to prevent secrets/PII from being stored in the
+	 * change log in plain text.
+	 *
+	 * @param string $option Option name.
+	 * @return bool
+	 */
+	private static function is_sensitive_option( string $option ): bool {
+		return (bool) preg_match(
+			'/(api[_-]?key|token|secret|password|pass|auth|client|authorization|cookie)/i',
+			$option
+		);
+	}
+
+	/**
+	 * Redact a value that should not be stored in plain text.
+	 *
+	 * Returns a constant placeholder so the change log records that a sensitive
+	 * field was modified without persisting the actual value.
+	 *
+	 * @return string
+	 */
+	private static function redact_value(): string {
+		return '[REDACTED]';
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `is_sensitive_option()` — keyword-pattern check (`api_key`, `token`, `secret`, `password`, `pass`, `auth`, `client`, `authorization`, `cookie`) to detect credential-like option names
- Adds `redact_value()` helper returning `[REDACTED]` constant
- Applies redaction in `on_updated_option()`, `on_added_option()`, and `on_profile_update()` (for `user_email` field)

The change log still records *that* a sensitive option was modified (field name, session, ability) — it just no longer stores the raw value in plain text.

## Motivation

CodeRabbit review on PR #447 flagged that `ChangeLogger` was persisting raw option values into `ChangesLog::record`, which could leak API keys, tokens, passwords, and user email addresses stored in WordPress options.

## Testing

- Non-sensitive options (e.g., `blogname`, `siteurl`) continue to log before/after values unchanged
- Options matching sensitive patterns (e.g., `my_plugin_api_key`, `oauth_token`, `admin_password`) log `[REDACTED]` for both before and after values
- `user_email` profile changes log `[REDACTED]` for both values; `display_name` and `user_url` continue to log normally

Closes #487