### PR TITLE
fix: move $instance creation before /stream route to fix non-static permission callback

### DIFF
--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -90,13 +90,14 @@ class RestController {
 		// Resale API endpoints.
 		ResaleApiController::register_routes();
 
+		$instance = new self();
 		register_rest_route(
 			self::NAMESPACE,
 			'/stream',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => [ __CLASS__, 'handle_stream' ],
-				'permission_callback' => [ __CLASS__, 'check_chat_permission' ],
+				'permission_callback' => [ $instance, 'check_chat_permission' ],
 				'args'                => [
 					'message'            => [
 						'required'          => true,
@@ -149,7 +150,6 @@ class RestController {
 			]
 		);
 
-		$instance = new self();
 		register_rest_route(
 			self::NAMESPACE,
 			'/run',


### PR DESCRIPTION
## Summary

- Moves `$instance = new self()` from after the `/stream` route registration to before it
- Changes `permission_callback` on `/stream` from `[ __CLASS__, 'check_chat_permission' ]` to `[ $instance, 'check_chat_permission' ]`
- The `/run` route reuses the same `$instance` (no duplicate instantiation)

## Root cause

`check_chat_permission()` is a non-static instance method. Registering it via `__CLASS__` caused PHP to attempt a static call, producing:

```
Fatal error: Uncaught TypeError: call_user_func(): Argument #1 ($callback) must be a valid callback,
non-static method GratisAiAgent\REST\RestController::check_chat_permission() cannot be called statically
```

This crashed 100% of chat requests — the frontend showed "Thinking..." indefinitely.

## Fix

Two-line change: move `$instance = new self()` up 60 lines, change `__CLASS__` to `$instance` for the permission callback. `handle_stream` remains `[ __CLASS__, 'handle_stream' ]` since it is correctly declared `static`.

Closes #509

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal route handling for REST API endpoints to optimize controller instance management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->