### PR TITLE
t103: Fix frontend floating widget not rendering for logged-in admins

### DIFF
--- a/includes/Admin/FloatingWidget.php
+++ b/includes/Admin/FloatingWidget.php
@@ -72,10 +72,9 @@ class FloatingWidget {
 			return;
 		}
 
-		// Require the AI client.
-		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
-			return;
-		}
+		// Note: wp_ai_client_prompt() availability is NOT checked here.
+		// The floating widget UI (FAB + panel) renders independently of the AI
+		// client. The REST API handles provider availability at message-send time.
 
 		self::enqueue_widget_assets();
 	}


### PR DESCRIPTION
## Summary

- Removes the `wp_ai_client_prompt()` availability guard from `enqueue_assets_frontend()` in `FloatingWidget.php`
- The admin enqueue path already omits this check (with an explanatory comment); the frontend path now matches
- The widget UI renders independently of the AI client — provider availability is checked by the REST API at message-send time, not at asset-enqueue time

## Root Cause

`enqueue_assets_frontend()` had an early-return guard:

```php
// Require the AI client.
if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
    return;
}
```

This silently blocked the floating widget from loading on the frontend for logged-in admins when:
- WordPress < 6.9 (AI Client SDK not available), or
- The SDK is not loaded at `wp_enqueue_scripts` time

The plugin supports direct providers (OpenAI, Anthropic, Google) that do not require `wp_ai_client_prompt` at all. The REST API (`/gratis-ai-agent/v1/`) handles provider availability when a message is actually sent.

## Testing

1. Enable **Show Widget on Frontend** in Tools → Gratis AI Agent Settings
2. Visit any frontend page while logged in as an admin
3. Widget FAB should appear in the bottom-right corner (previously absent)
4. Confirm widget still appears on admin pages (unchanged path)

Closes #525

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed floating widget display to properly load on the frontend when the display setting is enabled, with AI availability validation now occurring when messages are sent rather than during initial load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->