### PR TITLE
t101: Fix Disconnect button red text styling on Integrations tab

### DIFF
--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -1245,7 +1245,6 @@ export default function SettingsApp() {
 										{ gaStatus?.has_credentials && (
 											<Button
 												variant="secondary"
-												isDestructive
 												onClick={ handleGaClear }
 												isBusy={ gaSaving }
 												disabled={ gaSaving }


### PR DESCRIPTION
## Summary

- Removes `isDestructive` prop from the "Disconnect" button in the GA4 credentials section of the Integrations tab
- The `isDestructive` prop caused the button to render with red text, which is inconsistent with standard WordPress button styling
- The button now uses standard `variant="secondary"` styling (no red text)

## Change

`src/settings-page/settings-app.js` — removed `isDestructive` from the Disconnect `<Button>` component (line 1248).

Closes #523