### PR TITLE
t106: Update OpenAI default model to GPT-4.1-nano and add GPT-4.1 family

### DIFF
--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -51,8 +51,20 @@ class Settings {
 	const DIRECT_PROVIDERS = [
 		'openai'    => [
 			'name'          => 'OpenAI',
-			'default_model' => 'gpt-4o',
+			'default_model' => 'gpt-4.1-nano',
 			'models'        => [
+				[
+					'id'   => 'gpt-4.1-nano',
+					'name' => 'GPT-4.1 Nano',
+				],
+				[
+					'id'   => 'gpt-4.1-mini',
+					'name' => 'GPT-4.1 Mini',
+				],
+				[
+					'id'   => 'gpt-4.1',
+					'name' => 'GPT-4.1',
+				],
 				[
 					'id'   => 'gpt-4o',
 					'name' => 'GPT-4o',

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -43,6 +43,9 @@ const STORE_NAME = 'gratis-ai-agent';
 const MODEL_CONTEXT_WINDOWS = {
 	'claude-sonnet-4-20250514': 200000,
 	'claude-opus-4-20250115': 200000,
+	'gpt-4.1': 1000000,
+	'gpt-4.1-mini': 1000000,
+	'gpt-4.1-nano': 1000000,
 	'gpt-4o': 128000,
 	'gpt-4o-mini': 128000,
 };


### PR DESCRIPTION
## Summary

- Updates `Settings::DIRECT_PROVIDERS` OpenAI `default_model` from `gpt-4o` to `gpt-4.1-nano`
- Adds GPT-4.1 Nano, GPT-4.1 Mini, and GPT-4.1 to the OpenAI model list (prepended before existing models)
- Adds GPT-4.1 context window (1M tokens) to `MODEL_CONTEXT_WINDOWS` in the JS store

## Existing installs are not affected

`default_model` in `DIRECT_PROVIDERS` is only used when no model is saved in `wp_options`. Existing installs have a saved `default_model` value (or a saved per-provider selection in `localStorage`) that takes precedence — they will not be silently switched.

## Rationale (from ROADMAP.md)

GPT-4.1-nano: $0.10/M input, 1M context window — best value for the default tier. GPT-4.1-mini and GPT-4.1 are added as premium options for users who need more capability.

Closes #539

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for three new OpenAI model variants: GPT-4.1, GPT-4.1 Mini, and GPT-4.1 Nano
  * Set GPT-4.1 Nano as the new default model
  * Extended context window support for all new models (1M tokens)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->