### PR TITLE
fix: resolve all ShellCheck violations in shell scripts (SC2015, SC1091, SC2086, SC2046, SC2148)

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -30,8 +30,9 @@ _script_path="${BASH_SOURCE[0]%/*}"
 [[ "$_script_path" == "${BASH_SOURCE[0]}" ]] && _script_path="."
 SCRIPT_DIR="$(cd "$_script_path" && pwd)" || exit
 unset _script_path
+# shellcheck source=/dev/null
 source "${SCRIPT_DIR}/shared-constants.sh"
-# shellcheck source=issue-sync-lib.sh
+# shellcheck source=/dev/null
 source "${SCRIPT_DIR}/issue-sync-lib.sh"
 
 # =============================================================================
@@ -109,7 +110,7 @@ _gh_edit_labels() {
 	local IFS=','
 	for lbl in $labels; do [[ -n "$lbl" ]] && args+=("--${action}-label" "$lbl"); done
 	unset IFS
-	[[ ${#args[@]} -gt 0 ]] && gh issue edit "$num" --repo "$repo" "${args[@]}" 2>/dev/null || true
+	if [[ ${#args[@]} -gt 0 ]]; then gh issue edit "$num" --repo "$repo" "${args[@]}" 2>/dev/null; fi
 }
 
 gh_create_label() {
@@ -150,7 +151,7 @@ _mark_issue_done() {
 	done
 	gh_create_label "$repo" "status:done" "6F42C1" "Task is complete"
 	_gh_edit_labels "add" "$repo" "$num" "status:done"
-	[[ ${#remove_args[@]} -gt 0 ]] && gh issue edit "$num" --repo "$repo" "${remove_args[@]}" 2>/dev/null || true
+	if [[ ${#remove_args[@]} -gt 0 ]]; then gh issue edit "$num" --repo "$repo" "${remove_args[@]}" 2>/dev/null; fi
 }
 
 # =============================================================================

--- a/.agents/scripts/issue-sync-lib.sh
+++ b/.agents/scripts/issue-sync-lib.sh
@@ -37,6 +37,7 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	SCRIPT_DIR="$(cd "$_lib_path" && pwd)"
 	unset _lib_path
 fi
+# shellcheck source=/dev/null
 source "${SCRIPT_DIR}/shared-constants.sh"
 
 # =============================================================================

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -1064,8 +1064,8 @@ backup_sqlite_db() {
 	# Fallback to file copy if .backup fails
 	if cp "$db_path" "$backup_file" 2>/dev/null; then
 		# Also copy WAL/SHM if present for consistency
-		[[ -f "${db_path}-wal" ]] && cp "${db_path}-wal" "${backup_file}-wal" 2>/dev/null || true
-		[[ -f "${db_path}-shm" ]] && cp "${db_path}-shm" "${backup_file}-shm" 2>/dev/null || true
+		if [[ -f "${db_path}-wal" ]]; then cp "${db_path}-wal" "${backup_file}-wal" 2>/dev/null; fi
+		if [[ -f "${db_path}-shm" ]]; then cp "${db_path}-shm" "${backup_file}-shm" 2>/dev/null; fi
 		echo "$backup_file"
 		return 0
 	fi
@@ -1180,12 +1180,12 @@ rollback_sqlite_db() {
 	fi
 
 	cp "$backup_path" "$db_path"
-	[[ -f "${backup_path}-wal" ]] && cp "${backup_path}-wal" "${db_path}-wal" 2>/dev/null || true
-	[[ -f "${backup_path}-shm" ]] && cp "${backup_path}-shm" "${db_path}-shm" 2>/dev/null || true
+	if [[ -f "${backup_path}-wal" ]]; then cp "${backup_path}-wal" "${db_path}-wal" 2>/dev/null; fi
+	if [[ -f "${backup_path}-shm" ]]; then cp "${backup_path}-shm" "${db_path}-shm" 2>/dev/null; fi
 
 	# Remove stale WAL/SHM if backup didn't have them
-	[[ ! -f "${backup_path}-wal" && -f "${db_path}-wal" ]] && rm -f "${db_path}-wal" 2>/dev/null || true
-	[[ ! -f "${backup_path}-shm" && -f "${db_path}-shm" ]] && rm -f "${db_path}-shm" 2>/dev/null || true
+	if [[ ! -f "${backup_path}-wal" && -f "${db_path}-wal" ]]; then rm -f "${db_path}-wal" 2>/dev/null; fi
+	if [[ ! -f "${backup_path}-shm" && -f "${db_path}-shm" ]]; then rm -f "${db_path}-shm" 2>/dev/null; fi
 
 	echo "[backup] Database restored from: $backup_path" >&2
 	return 0

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+#!/bin/sh
 npx lint-staged

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -13,14 +13,14 @@ WP_VERSION=${5-latest}
 SKIP_DB_CREATE=${6-false}
 
 TMPDIR=${TMPDIR-/tmp}
-TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
+TMPDIR=$(echo "$TMPDIR" | sed -e "s/\/$//")
 WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
 WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress}
 
 download() {
-	if [ $(which curl) ]; then
+	if [ "$(which curl)" ]; then
 		curl -s "$1" >"$2"
-	elif [ $(which wget) ]; then
+	elif [ "$(which wget)" ]; then
 		wget -nv -O "$2" "$1"
 	fi
 }
@@ -55,30 +55,31 @@ set -e
 
 install_wp() {
 
-	if [ -d $WP_CORE_DIR ]; then
+	if [ -d "$WP_CORE_DIR" ]; then
 		return
 	fi
 
-	mkdir -p $WP_CORE_DIR
+	mkdir -p "$WP_CORE_DIR"
 
 	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
-		mkdir -p $TMPDIR/wordpress-trunk
-		rm -rf $TMPDIR/wordpress-trunk/*
-		svn export --quiet https://core.svn.wordpress.org/trunk $TMPDIR/wordpress-trunk/wordpress
-		mv $TMPDIR/wordpress-trunk/wordpress/* $WP_CORE_DIR
+		mkdir -p "$TMPDIR/wordpress-trunk"
+		rm -rf "$TMPDIR/wordpress-trunk/"*
+		svn export --quiet https://core.svn.wordpress.org/trunk "$TMPDIR/wordpress-trunk/wordpress"
+		mv "$TMPDIR/wordpress-trunk/wordpress/"* "$WP_CORE_DIR"
 	else
-		if [ $WP_VERSION == 'latest' ]; then
+		if [ "$WP_VERSION" == 'latest' ]; then
 			local ARCHIVE_NAME='latest'
 		elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+ ]]; then
 			# https serves a hierarchical list of all available tags
-			download https://api.wordpress.org/core/version-check/1.7/ $TMPDIR/wp-latest.json
+			download https://api.wordpress.org/core/version-check/1.7/ "$TMPDIR/wp-latest.json"
 			if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
 				# version x.x.0 means the first release of the major version, so strip off the .0 and download version x.x
 				LATEST_VERSION=${WP_VERSION%??}
 			else
 				# otherwise, scan the releases and get the most up to date minor version of the major release
-				local VERSION_ESCAPED=$(echo $WP_VERSION | sed 's/\./\\\\./g')
-				LATEST_VERSION=$(grep -o '"version":"'$VERSION_ESCAPED'[^"]*' $TMPDIR/wp-latest.json | sed 's/"version":"//' | head -1)
+				local VERSION_ESCAPED
+				VERSION_ESCAPED="${WP_VERSION//./'\\.'}"
+				LATEST_VERSION=$(grep -o '"version":"'"$VERSION_ESCAPED"'[^"]*' "$TMPDIR/wp-latest.json" | sed 's/"version":"//' | head -1)
 			fi
 			if [[ -z "$LATEST_VERSION" ]]; then
 				local ARCHIVE_NAME="wordpress-$WP_VERSION"
@@ -88,11 +89,11 @@ install_wp() {
 		else
 			local ARCHIVE_NAME="wordpress-$WP_VERSION"
 		fi
-		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz $TMPDIR/wordpress.tar.gz
-		tar --strip-components=1 -zxmf $TMPDIR/wordpress.tar.gz -C $WP_CORE_DIR
+		download "https://wordpress.org/${ARCHIVE_NAME}.tar.gz" "$TMPDIR/wordpress.tar.gz"
+		tar --strip-components=1 -zxmf "$TMPDIR/wordpress.tar.gz" -C "$WP_CORE_DIR"
 	fi
 
-	download https://raw.githubusercontent.com/marber/wp-config-github-actions/main/wp-config-ci.php $WP_CORE_DIR/wp-config.php
+	download https://raw.githubusercontent.com/marber/wp-config-github-actions/main/wp-config-ci.php "$WP_CORE_DIR/wp-config.php"
 }
 
 install_test_suite() {
@@ -104,24 +105,24 @@ install_test_suite() {
 	fi
 
 	# set up testing suite if it doesn't yet exist
-	if [ ! -d $WP_TESTS_DIR ]; then
+	if [ ! -d "$WP_TESTS_DIR" ]; then
 		# set up testing suite
-		mkdir -p $WP_TESTS_DIR
-		rm -rf $WP_TESTS_DIR/{includes,data}
-		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
-		svn export --quiet --ignore-externals https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+		mkdir -p "$WP_TESTS_DIR"
+		rm -rf "$WP_TESTS_DIR/{includes,data}"
+		svn export --quiet --ignore-externals "https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/" "$WP_TESTS_DIR/includes"
+		svn export --quiet --ignore-externals "https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/" "$WP_TESTS_DIR/data"
 	fi
 
 	if [ ! -f "$WP_TESTS_DIR/wp-tests-config.php" ]; then
-		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
-		# remove all forward slashes in the end
-		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
-		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
-		sed $ioption "s:__DIR__ . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
-		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
-		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
-		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
-		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+		download "https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php" "$WP_TESTS_DIR/wp-tests-config.php"
+		# remove all trailing forward slashes
+		while [[ "$WP_CORE_DIR" == */ ]]; do WP_CORE_DIR="${WP_CORE_DIR%/}"; done
+		sed "$ioption" "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR/wp-tests-config.php"
+		sed "$ioption" "s:__DIR__ . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR/wp-tests-config.php"
+		sed "$ioption" "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR/wp-tests-config.php"
+		sed "$ioption" "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR/wp-tests-config.php"
+		sed "$ioption" "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR/wp-tests-config.php"
+		sed "$ioption" "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR/wp-tests-config.php"
 	fi
 
 }
@@ -129,7 +130,7 @@ install_test_suite() {
 recreate_db() {
 	shopt -s nocasematch
 	if [[ $1 =~ ^(y|yes)$ ]]; then
-		mysqladmin drop $DB_NAME -f --user="$DB_USER" --password="$DB_PASS"$EXTRA
+		mysqladmin drop "$DB_NAME" -f --user="$DB_USER" --password="$DB_PASS""$EXTRA"
 		create_db
 		echo "Recreated the database ($DB_NAME)."
 	else
@@ -139,33 +140,32 @@ recreate_db() {
 }
 
 create_db() {
-	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+	mysqladmin create "$DB_NAME" --user="$DB_USER" --password="$DB_PASS""$EXTRA"
 }
 
 install_db() {
 
-	if [ ${SKIP_DB_CREATE} = "true" ]; then
+	if [ "${SKIP_DB_CREATE}" = "true" ]; then
 		return 0
 	fi
 
 	# parse DB_HOST for port or socket references
-	local PARTS=(${DB_HOST//\:/ })
-	local DB_HOSTNAME=${PARTS[0]}
-	local DB_SOCK_OR_PORT=${PARTS[1]}
+	local DB_HOSTNAME DB_SOCK_OR_PORT
+	IFS=':' read -r DB_HOSTNAME DB_SOCK_OR_PORT <<<"$DB_HOST"
 	local EXTRA=""
 
-	if ! [ -z $DB_HOSTNAME ]; then
-		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+	if [ -n "$DB_HOSTNAME" ]; then
+		if echo "$DB_SOCK_OR_PORT" | grep -qe '^[0-9]\{1,\}$'; then
 			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
-		elif ! [ -z $DB_SOCK_OR_PORT ]; then
+		elif [ -n "$DB_SOCK_OR_PORT" ]; then
 			EXTRA=" --socket=$DB_SOCK_OR_PORT"
-		elif ! [ -z $DB_HOSTNAME ]; then
+		elif [ -n "$DB_HOSTNAME" ]; then
 			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
 		fi
 	fi
 
 	# create database
-	if [ $(mysql --user="$DB_USER" --password="$DB_PASS"$EXTRA --execute='show databases;' | grep ^$DB_NAME$) ]; then
+	if mysql --user="$DB_USER" --password="$DB_PASS""$EXTRA" --execute='show databases;' | grep -q "^${DB_NAME}$"; then
 		echo "Reinitializing will delete the existing test database ($DB_NAME)"
 		recreate_db yes
 	else


### PR DESCRIPTION
## Summary

Fixes all ShellCheck violations identified in issue #540. Zero violations target achieved across all five files.

## Changes

### `.agents/scripts/shared-constants.sh` — SC2015 (6 violations)
Replaced `[[ cond ]] && cmd 2>/dev/null || true` patterns with explicit `if/then/fi` blocks. The `A && B || C` pattern is not if-then-else — `C` can run when `A` is true but `B` fails. Affects WAL/SHM copy and remove operations in `backup_sqlite_db` and `rollback_sqlite_db`.

### `.agents/scripts/issue-sync-lib.sh` — SC1091 (1 violation)
Added `# shellcheck source=/dev/null` before the dynamic `source "${SCRIPT_DIR}/shared-constants.sh"` call. ShellCheck cannot resolve `${SCRIPT_DIR}` at static analysis time; the directive suppresses the false positive. The sourced file is checked independently.

### `.agents/scripts/issue-sync-helper.sh` — SC1091 (2 violations) + SC2015 (2 violations)
- Added `# shellcheck source=/dev/null` for both dynamic source paths.
- Replaced `[[ ${#args[@]} -gt 0 ]] && gh ... || true` with `if/fi` in `_gh_edit_labels` and `_mark_issue_done`.

### `bin/install-wp-tests.sh` — SC2086, SC2046, SC2155, SC2206, SC2237, SC2143, SC2001
- Quoted all unquoted variable expansions (SC2086).
- Replaced `[ $(cmd) ]` with `"$(cmd)"` for `which` checks (SC2046).
- Replaced `[ $(grep ...) ]` with `grep -q` (SC2046, SC2143).
- Used `IFS=':' read -r` for `DB_HOST` parsing instead of unquoted array word-splitting (SC2206).
- Replaced `! [ -z $x ]` with `[ -n "$x" ]` (SC2237).
- Declared `VERSION_ESCAPED` separately before assignment (SC2155).
- Replaced `sed`-based trailing-slash removal with a pure-bash `while` loop (SC2001).

### `.husky/pre-commit` — SC2148
Added `#!/bin/sh` shebang so ShellCheck knows the target shell.

## Verification

```
shellcheck .agents/scripts/shared-constants.sh       # PASS
shellcheck -x .agents/scripts/issue-sync-lib.sh      # PASS
shellcheck -x .agents/scripts/issue-sync-helper.sh   # PASS
shellcheck bin/install-wp-tests.sh                   # PASS
shellcheck .husky/pre-commit                         # PASS
```

Closes #540