### PR TITLE
fix: resolve discovery mode confusion in ToolDiscovery

### DIFF
--- a/includes/Tools/ToolDiscovery.php
+++ b/includes/Tools/ToolDiscovery.php
@@ -60,9 +60,19 @@ class ToolDiscovery {
 
 	/**
 	 * Register the list-tools and execute-tool abilities.
+	 *
+	 * Skips registration entirely when there are no discoverable tools
+	 * (i.e. all registered abilities fall within priority categories/tools),
+	 * so the AI is never offered meta-tools that would return empty results.
 	 */
 	public static function register_abilities(): void {
 		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		// Count how many tools would be discoverable (not in priority categories).
+		$discoverable_count = array_sum( self::get_discoverable_category_counts() );
+		if ( 0 === $discoverable_count ) {
 			return;
 		}
 
@@ -150,6 +160,16 @@ class ToolDiscovery {
 	public static function handle_list_tools( array $input ): array|\WP_Error {
 		if ( ! function_exists( 'wp_get_abilities' ) ) {
 			return new WP_Error( 'api_unavailable', __( 'Abilities API not available.', 'gratis-ai-agent' ) );
+		}
+
+		// An empty JSON array ([]) is semantically equivalent to an empty object ({})
+		// here — both mean "no filters applied". When the AI sends [] instead of {},
+		// treat it as having no filter parameters (query='', category='', defaults apply).
+		// array_values() check: if $input is a non-empty sequential (list) array,
+		// it was likely passed incorrectly; ignore it and use defaults.
+		if ( ! empty( $input ) && array_values( $input ) === $input ) {
+			// Sequential array passed where associative object expected — treat as empty.
+			$input = [];
 		}
 
 		$query    = $input['query'] ?? '';
@@ -303,6 +323,14 @@ class ToolDiscovery {
 
 		if ( '' === $tool_name ) {
 			return new WP_Error( 'missing_param', __( 'tool_name is required.', 'gratis-ai-agent' ) );
+		}
+
+		// Normalize tool names that arrive in the Abilities API wire format
+		// (e.g. "wpab__gratis-ai-agent__check-security" → "gratis-ai-agent/check-security").
+		// The Abilities API encodes "/" as "__" and prefixes with "wpab__".
+		if ( str_starts_with( $tool_name, 'wpab__' ) ) {
+			$tool_name = substr( $tool_name, strlen( 'wpab__' ) );
+			$tool_name = str_replace( '__', '/', $tool_name );
 		}
 
 		if ( ! function_exists( 'wp_get_ability' ) ) {


### PR DESCRIPTION
## Summary

Three targeted fixes for discovery mode confusion:

1. **`register_abilities()` — skip when 0 discoverable tools**: Counts how many tools would be discoverable (not in priority categories/tools) before registering `list-tools` and `execute-tool`. If the count is 0, skips registration entirely so the AI is never offered meta-tools that would return empty results.

2. **`handle_execute_tool()` — normalize wire-format tool names**: Converts `wpab__gratis-ai-agent__check-security` → `gratis-ai-agent/check-security` by stripping the `wpab__` prefix and replacing `__` with `/`. This matches the Abilities API wire encoding used when the AI calls tools by their encoded names.

3. **`handle_list_tools()` — treat `[]` as `{}` (no filters)**: When the AI sends an empty JSON array `[]` instead of an empty object `{}`, the sequential array is now treated as having no filter parameters applied, falling through to the category overview response.

## Changes

- `includes/Tools/ToolDiscovery.php` — 28 lines added across three methods

Closes #561

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool discovery reliability when no tools are available
  * Enhanced input processing for more accurate tool filtering
  * Fixed tool name conversion for consistent tool execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->