### PR TITLE
fix: double /wp-admin/ URL in screen meta context and gate discovery abilities

### DIFF
--- a/includes/Abilities/AbilityDiscoveryAbilities.php
+++ b/includes/Abilities/AbilityDiscoveryAbilities.php
@@ -93,6 +93,13 @@ class AbilityDiscoveryAbilities {
 			return;
 		}
 
+		// Skip registration when discovery mode is not active.
+		// When all tools are loaded directly (priority categories cover everything),
+		// these meta-tools confuse the AI into searching instead of using tools directly.
+		if ( ! \GratisAiAgent\Tools\ToolDiscovery::should_use_discovery_mode() ) {
+			return;
+		}
+
 		wp_register_ability(
 			'gratis-ai-agent/discovery-list',
 			[

--- a/includes/Admin/ScreenMetaPanel.php
+++ b/includes/Admin/ScreenMetaPanel.php
@@ -148,11 +148,12 @@ class ScreenMetaPanel {
 		$context['taxonomy']  = $screen->taxonomy;
 
 		// Sanitize the request URI for context (no auth tokens).
+		// Use site_url() + REQUEST_URI to avoid double /wp-admin/ from admin_url().
 		$request_uri = isset( $_SERVER['REQUEST_URI'] )
 			? sanitize_url( wp_unslash( (string) $_SERVER['REQUEST_URI'] ) )
 			: '';
 
-		$context['url'] = admin_url( ltrim( $request_uri, '/' ) );
+		$context['url'] = $request_uri ? site_url( $request_uri ) : '';
 
 		// Page title from the screen's parent_title or a generic fallback.
 		$context['page_title'] = $screen->get_option( 'title' ) ?? '';


### PR DESCRIPTION
## Summary

- Fix double `/wp-admin/` in context URLs passed to the AI
- Remove remaining 3 discovery meta-tools when discovery mode is inactive

## Changes

### ScreenMetaPanel.php
`admin_url(ltrim($request_uri, '/'))` produced `http://site/wp-admin/wp-admin/edit.php` because `$_SERVER['REQUEST_URI']` already contains `/wp-admin/`. Changed to `site_url($request_uri)`.

### AbilityDiscoveryAbilities.php
Added `ToolDiscovery::should_use_discovery_mode()` guard before registering `discovery-list`, `discovery-get`, `discovery-execute`. PR #563 already removed `list-tools` and `execute-tool` from ToolDiscovery, but these 3 from AbilityDiscoveryAbilities were still registered — the AI was calling `discovery-list` with invalid args and getting errors.

With this fix, when all 83+ tools are in priority categories (loaded directly), zero discovery/meta-tools are registered. The AI sees only the tools it can call directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed discovery abilities to no longer register when discovery mode is disabled.
  * Corrected URL construction in the admin panel to properly handle request URIs without duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->