### PR TITLE
fix: increase chat bubble max-width on large screens

### DIFF
--- a/src/admin-page/style.css
+++ b/src/admin-page/style.css
@@ -1738,6 +1738,21 @@ body.tools_page_ai-agent #wpbody-content > .updated {
 	border-top: 1px solid #dcdcde;
 }
 
+/* Large-screen bubble width — prevent bubbles from stretching too wide */
+@media (min-width: 1200px) {
+
+	.ai-agent-bubble {
+		max-width: min(90%, 900px);
+	}
+}
+
+@media (min-width: 1600px) {
+
+	.ai-agent-bubble {
+		max-width: min(92%, 1100px);
+	}
+}
+
 /* Responsive */
 @media (max-width: 900px) {
 


### PR DESCRIPTION
## Summary

- Adds two `min-width` media queries to `src/admin-page/style.css` to cap `.ai-agent-bubble` width on large screens
- ≥1200px: `max-width: min(90%, 900px)` — prevents bubbles from spanning the full chat column on 1080p+ displays
- ≥1600px: `max-width: min(92%, 1100px)` — allows slightly wider bubbles on 4K/ultrawide while still capping at 1100px

## Floating widget

No change needed to `src/floating-widget/style.css`. The floating panel is a fixed-size overlay (420px wide) that already constrains bubble width — a max-width override inside it would have no visible effect.

Closes #572

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout for the AI agent bubble on larger screens, allowing it to expand appropriately on viewports 1200px and wider for better space utilization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->