### PR TITLE
t117: Enhance chat empty state with suggestion cards

### DIFF
--- a/src/admin-page/style.css
+++ b/src/admin-page/style.css
@@ -414,6 +414,98 @@ body.tools_page_ai-agent #wpbody-content > .updated {
 	font-size: 14px;
 }
 
+/* Welcome screen — empty state with suggestion cards */
+.ai-agent-welcome {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 20px;
+	padding: 32px 24px;
+	max-width: 680px;
+	width: 100%;
+	text-align: center;
+}
+
+.ai-agent-welcome__greeting {
+	margin: 0;
+	font-size: 18px;
+	font-weight: 600;
+	color: #1d2327;
+	line-height: 1.4;
+}
+
+.ai-agent-welcome__grid {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: 12px;
+	width: 100%;
+}
+
+.ai-agent-welcome__card {
+	display: flex;
+	flex-direction: column;
+	align-items: flex-start;
+	gap: 4px;
+	padding: 14px 16px;
+	background: #f6f7f7;
+	border: 1px solid #dcdcde;
+	border-radius: 8px;
+	cursor: pointer;
+	text-align: left;
+	font-family: inherit;
+	transition: background 0.15s, border-color 0.15s, box-shadow 0.15s;
+}
+
+.ai-agent-welcome__card:hover {
+	background: #f0f0f1;
+	border-color: var(--wp-admin-theme-color, #2271b1);
+	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+}
+
+.ai-agent-welcome__card:focus-visible {
+	outline: 2px solid var(--wp-admin-theme-color, #2271b1);
+	outline-offset: 2px;
+}
+
+.ai-agent-welcome__card-title {
+	font-size: 13px;
+	font-weight: 600;
+	color: #1d2327;
+	line-height: 1.3;
+}
+
+.ai-agent-welcome__card-desc {
+	font-size: 12px;
+	color: #50575e;
+	line-height: 1.4;
+}
+
+.ai-agent-welcome__hint {
+	margin: 0;
+	font-size: 13px;
+	color: #a7aaad;
+}
+
+/* Responsive: 2 columns on medium screens */
+@media (max-width: 780px) {
+
+	.ai-agent-welcome__grid {
+		grid-template-columns: repeat(2, 1fr);
+	}
+}
+
+/* Responsive: 1 column on small screens */
+@media (max-width: 480px) {
+
+	.ai-agent-welcome__grid {
+		grid-template-columns: 1fr;
+	}
+
+	.ai-agent-welcome {
+		padding: 20px 16px;
+	}
+}
+
 /* Bubbles */
 .ai-agent-bubble {
 	padding: 10px 14px;

--- a/src/components/message-list.js
+++ b/src/components/message-list.js
@@ -7,6 +7,63 @@ import { __ } from '@wordpress/i18n';
 import { Button, Spinner } from '@wordpress/components';
 
 /**
+ * Suggestion cards shown in the empty state welcome screen.
+ * Each card has a title, description, and the prompt text to send on click.
+ *
+ * @type {Array<{title: string, description: string, prompt: string}>}
+ */
+const SUGGESTION_CARDS = [
+	{
+		title: __( 'Check site health', 'gratis-ai-agent' ),
+		description: __(
+			'Run a full health check and surface any issues.',
+			'gratis-ai-agent'
+		),
+		prompt: __( 'Check site health', 'gratis-ai-agent' ),
+	},
+	{
+		title: __( 'List plugins', 'gratis-ai-agent' ),
+		description: __(
+			'Show all installed plugins and their status.',
+			'gratis-ai-agent'
+		),
+		prompt: __( 'List installed plugins', 'gratis-ai-agent' ),
+	},
+	{
+		title: __( 'Create a blog post', 'gratis-ai-agent' ),
+		description: __(
+			'Draft a new post with a title, content, and tags.',
+			'gratis-ai-agent'
+		),
+		prompt: __( 'Create a blog post', 'gratis-ai-agent' ),
+	},
+	{
+		title: __( 'Run security check', 'gratis-ai-agent' ),
+		description: __(
+			'Scan for vulnerabilities and security misconfigurations.',
+			'gratis-ai-agent'
+		),
+		prompt: __( 'Run a security check', 'gratis-ai-agent' ),
+	},
+	{
+		title: __( 'Analyze SEO', 'gratis-ai-agent' ),
+		description: __(
+			'Review SEO settings and suggest improvements.',
+			'gratis-ai-agent'
+		),
+		prompt: __( 'Analyze SEO', 'gratis-ai-agent' ),
+	},
+	{
+		title: __( 'Check for updates', 'gratis-ai-agent' ),
+		description: __(
+			'List available plugin, theme, and core updates.',
+			'gratis-ai-agent'
+		),
+		prompt: __( 'Check for updates', 'gratis-ai-agent' ),
+	},
+];
+
+/**
  * Internal dependencies
  */
 import STORE_NAME from '../store';
@@ -105,6 +162,48 @@ function SuggestionChips( { suggestions, onSelect } ) {
 					{ suggestion }
 				</Button>
 			) ) }
+		</div>
+	);
+}
+
+/**
+ * Rich welcome screen shown when the chat has no messages yet.
+ * Displays a greeting and 6 clickable suggestion cards.
+ *
+ * @param {Object}   props          - Component props.
+ * @param {string}   props.greeting - Greeting text shown above the cards.
+ * @param {Function} props.onSelect - Called with the prompt text when a card is clicked.
+ * @return {JSX.Element} The empty state welcome element.
+ */
+function EmptyStateWelcome( { greeting, onSelect } ) {
+	return (
+		<div className="ai-agent-empty-state">
+			<div className="ai-agent-welcome">
+				<p className="ai-agent-welcome__greeting">{ greeting }</p>
+				<div className="ai-agent-welcome__grid">
+					{ SUGGESTION_CARDS.map( ( card, i ) => (
+						<button
+							key={ i }
+							type="button"
+							className="ai-agent-welcome__card"
+							onClick={ () => onSelect( card.prompt ) }
+						>
+							<span className="ai-agent-welcome__card-title">
+								{ card.title }
+							</span>
+							<span className="ai-agent-welcome__card-desc">
+								{ card.description }
+							</span>
+						</button>
+					) ) }
+				</div>
+				<p className="ai-agent-welcome__hint">
+					{ __(
+						'Or type a message below to ask anything.',
+						'gratis-ai-agent'
+					) }
+				</p>
+			</div>
 		</div>
 	);
 }
@@ -264,7 +363,10 @@ export default function MessageList() {
 	return (
 		<div className="ai-agent-messages" ref={ messagesRef }>
 			{ visibleMessages.length === 0 && ! sending && (
-				<div className="ai-agent-empty-state">{ greeting }</div>
+				<EmptyStateWelcome
+					greeting={ greeting }
+					onSelect={ sendMessage }
+				/>
 			) }
 			{ visibleMessages.map( ( { msg, originalIndex }, i ) => {
 				const rawText = extractText( msg );


### PR DESCRIPTION
## Summary

- Replaces the plain `Send a message to start a conversation.` text with a rich welcome screen
- Adds 6 clickable suggestion cards: Check site health, List plugins, Create a blog post, Run security check, Analyze SEO, Check for updates
- Each card has a title and brief description; clicking sends the prompt immediately via `sendMessage`
- Responsive grid: 3 columns on desktop (≥780px), 2 columns on medium, 1 column on mobile (≤480px)
- Greeting text still respects the admin settings / branding override

## Files changed

- `src/components/message-list.js` — adds `SUGGESTION_CARDS` constant and `EmptyStateWelcome` component; replaces the plain empty-state `<div>` with the new component
- `src/admin-page/style.css` — adds `.ai-agent-welcome` grid styles and responsive breakpoints

## Acceptance criteria

- [x] Empty state shows suggestion cards instead of plain text
- [x] Clicking a card sends the prompt
- [x] Cards are responsive (3 cols desktop → 2 cols medium → 1 col mobile)
- [x] Design follows WordPress admin conventions
- [x] `npm run build` succeeds (3 pre-existing bundle-size warnings only, no new errors)

Closes #570