### PR TITLE
chore: bump version to 1.2.0 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,112 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.2.0] - 2026-03-19
+
+### Added
+- Support all three official AI providers: OpenAI, Anthropic, and Google Gemini
+- Image and file upload support in chat messages
+- Spending limits and budget caps to control AI costs
+- Live streaming token counter and cost display during responses
+- Tiered model pricing display in the Settings model selector
+- GPT-4.1 family models (GPT-4.1, GPT-4.1-mini, GPT-4.1-nano); GPT-4.1-nano is now the default OpenAI model
+- Graceful fallback when tool calls exhaust max iterations
+- Visible scroll affordance for settings tabs on touch devices
+- Suggestion cards on chat empty state
+- Search, category grouping, and collapsible sections in the Abilities settings tab
+- Auto-title sessions from the first message using AI
+- Settings tab bar horizontal scroll with fade indicators
+- Shared conversations — multiple admins can view and continue the same session
+- Text-to-speech for AI responses (optional)
+- White-label branding support — custom agent name, colors, and logo
+- Google Search Console SEO insights abilities
+- Google Analytics 4 traffic analysis ability
+- Resale API proxy endpoint with usage tracking
+- YOLO mode toggle to skip all confirmations
+- Abilities Explorer admin page
+- Screen-meta Help tab chat panel
+- Editorial and image AI abilities ported from WordPress/ai experiments
+- AI image generation ability (DALL-E 3)
+- Agent builder UI — create specialized agents with custom prompts, tools, and models
+- Role-based AI permissions — restrict abilities by WordPress user role
+- Floating widget shown on frontend for logged-in admins
+- Resizable floating widget panel with keyboard shortcut
+- WooCommerce onboarding — detect store and offer AI product creation
+- WooCommerce abilities — product CRUD, order queries, and store stats
+- Slack and Discord notification forwarding for automation results
+- Sortable, filterable DataTable rendering for tabular chat responses
+- Chart.js chart rendering in chat responses
+- Per-tool WordPress capabilities (`gratis_ai_agent_tool_{name}`)
+- Site builder conversation flow — interview user then generate a full site
+- Site builder mode triggered on fresh WordPress installs
+- Onboarding interview — ask user about site goals after site scan
+- Provider setup integrated into the onboarding wizard
+- Changes Admin page — view diffs, revert changes, and export patches
+- Plugin download links for AI-modified plugins
+- CodeMirror 6 syntax highlighting in chat code blocks
+- Output schema on all abilities
+- Conversation templates — pre-built prompts for common tasks
+- Webhook API — trigger AI conversations from external systems
+- Push-to-talk speech-to-text via browser Web Speech API
+- Daily site health automation (SiteHealthAbilities)
+- Proactive alerts with notification badge on the floating action button
+- Action cards for confirmable operations
+- MCP server — expose abilities as MCP tools for external AI clients
+- Playwright E2E tests for chat UI with wp-env
+- E2E tests for auto-title sessions and abilities search/filter
+- PHPUnit integration tests for McpController, RestController, AgentLoop, Database, and all 13 Abilities classes
+- JS unit tests with @wordpress/scripts
+- PHPUnit coverage reporting with pcov and Codecov
+- Integration tests for the Automations system
+- TypeScript types and JSDoc annotations across the JavaScript codebase
+- WordPress Playground blueprint for instant demo
+- Comprehensive CONTRIBUTING.md
+- Husky + lint-staged pre-commit hooks for PHP, JS, and CSS
+- Consolidate duplicate save buttons on Permissions and Integrations tabs
+- Mobile slide-out drawer replacing stacked sidebar layout
+
+### Changed
+- PHPStan level raised from 6 to 7 with all new errors resolved
+- Improved multi-step agentic workflows
+- Model benchmark suite added
+- Plugin renamed to Gratis AI Agent across all JS sources
+- Configurable default model (replaces hardcoded fallback)
+- Constructor injection for Settings and Database dependencies
+- Credential management extracted to dedicated `CredentialResolver` class
+- `send_prompt_direct()` extracted to dedicated `OpenAIProxy` class
+- Error handling standardised — return `WP_Error` instead of arrays with `error` key
+- Event/hook system added for ability execution (before/after hooks)
+- PHPDoc blocks added to all classes and methods
+- PHPCS rules tightened — EscapeOutput and NonceVerification re-enabled
+- GitHub Actions workflows updated to Node.js 24 with standardised action refs
+- wp-env Docker replaced with direct MariaDB for PHPUnit CI
+- ESLint and Stylelint violations resolved; CI steps no longer use `continue-on-error`
+- `meta.show_in_rest = true` added to all `wp_register_ability()` calls
+- `meta.annotations` completed on all abilities
+- AbilityDiscoveryAbilities registered at priority 999
+- ChangeLogger wraps `execute_abilities()` in try/finally to guarantee `end()` is always called
+- Secrets and PII redacted in ChangeLogger `before_value`/`after_value`
+- `allSelected` header checkbox logic corrected for cross-page selections
+- Object-level permission check added in `permission_edit_posts`
+- Stream error handling, timeout, and retry added
+- Site builder overlay restricted to main AI Agent page
+- `@wordpress/components` Badge replaced with custom inline Badge component
+- `$instance` creation moved before `/stream` route to fix non-static permission callback
+- Discovery mode confusion resolved in ToolDiscovery
+- Double `/wp-admin/` URL in screen meta context fixed; discovery abilities gated correctly
+- Empty args array normalised; follow-up injected on empty AI response
+- Chat bubble max-width increased on large screens
+- Focus keyword fields added to `analyze_post_seo` output schema
+- `handle_delete_change` checks delete result before returning success
+- `ChangesLog::record()` return type fixed to `int|false`
+- Hard-coded versioned Chrome path replaced with env var fallback
+- `sanitize_textarea_field()` used to preserve line breaks in summary output
+- WP_Error return from `get_the_terms()` handled in WooCommerceAbilities
+- ShellCheck violations resolved across all shell scripts (SC2015, SC1091, SC2086, SC2046, SC2148)
+- npm audit vulnerabilities fixed (26 issues: 12 moderate, 14 high)
+- Compat layer class check updated; dual WP version testing (6.9 + trunk)
+- wp-env override JSON passed via env var to avoid shell quote stripping
+- PHPUnit (WP trunk) fatal resolved — `ClientWithOptionsInterface` namespace mismatch
+
+[1.2.0]: https://github.com/Ultimate-Multisite/gratis-ai-agent/compare/v1.1.0...v1.2.0

--- a/gratis-ai-agent.php
+++ b/gratis-ai-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name: Gratis AI Agent
  * Plugin URI:  https://developer.wordpress.org/
  * Description: Agentic AI loop for WordPress — chat with an AI that can call WordPress abilities (tools) autonomously.
- * Version:     1.1.0
+ * Version:     1.2.0
  * Author:      Dave
  * License:     GPL-2.0-or-later
  * Requires at least: 6.9

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: ai, chatbot, assistant, automation, tools
 Requires at least: 6.9
 Tested up to: 6.9
 Requires PHP: 8.2
-Stable tag: 1.1.0
+Stable tag: 1.2.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -158,6 +158,58 @@ Yes, the plugin works on both single-site and multisite WordPress installations.
 
 == Changelog ==
 
+= 1.2.0 =
+* New: Support all three official AI providers — OpenAI, Anthropic, and Google Gemini
+* New: Image and file upload support in chat messages
+* New: Spending limits and budget caps to control AI costs
+* New: Live streaming token counter and cost display during responses
+* New: Tiered model pricing display in the Settings model selector
+* New: GPT-4.1 family models (GPT-4.1, GPT-4.1-mini, GPT-4.1-nano); GPT-4.1-nano is now the default OpenAI model
+* New: Graceful fallback when tool calls exhaust max iterations
+* New: Suggestion cards on chat empty state
+* New: Search, category grouping, and collapsible sections in the Abilities settings tab
+* New: Auto-title sessions from the first message using AI
+* New: Shared conversations — multiple admins can view and continue the same session
+* New: Text-to-speech for AI responses (optional)
+* New: White-label branding support — custom agent name, colors, and logo
+* New: Google Search Console SEO insights abilities
+* New: Google Analytics 4 traffic analysis ability
+* New: Resale API proxy endpoint with usage tracking
+* New: YOLO mode toggle to skip all confirmations
+* New: Abilities Explorer admin page
+* New: AI image generation ability (DALL-E 3)
+* New: Agent builder UI — create specialized agents with custom prompts, tools, and models
+* New: Role-based AI permissions — restrict abilities by WordPress user role
+* New: Floating widget shown on frontend for logged-in admins
+* New: Resizable floating widget panel with keyboard shortcut
+* New: WooCommerce abilities — product CRUD, order queries, and store stats
+* New: Slack and Discord notification forwarding for automation results
+* New: Sortable, filterable DataTable rendering for tabular chat responses
+* New: Chart.js chart rendering in chat responses
+* New: Per-tool WordPress capabilities (gratis_ai_agent_tool_{name})
+* New: Site builder conversation flow — interview user then generate a full site
+* New: Site builder mode triggered on fresh WordPress installs
+* New: Changes Admin page — view diffs, revert changes, and export patches
+* New: CodeMirror 6 syntax highlighting in chat code blocks
+* New: Webhook API — trigger AI conversations from external systems
+* New: Push-to-talk speech-to-text via browser Web Speech API
+* New: MCP server — expose abilities as MCP tools for external AI clients
+* New: Mobile slide-out drawer replacing stacked sidebar layout
+* New: Visible scroll affordance for settings tabs on touch devices
+* Enhancement: PHPStan level raised from 6 to 7
+* Enhancement: Improved multi-step agentic workflows
+* Enhancement: Configurable default model (replaces hardcoded fallback)
+* Enhancement: Secrets and PII redacted in change log before/after values
+* Enhancement: Stream error handling, timeout, and retry
+* Enhancement: Object-level permission check in post editing
+* Fix: Double /wp-admin/ URL in screen meta context
+* Fix: Discovery mode confusion in ToolDiscovery
+* Fix: Site builder overlay restricted to main AI Agent page
+* Fix: Non-static permission callback on /stream route
+* Fix: WP_Error return from get_the_terms() in WooCommerceAbilities
+* Fix: ShellCheck violations across all shell scripts
+* Fix: npm audit vulnerabilities (26 issues: 12 moderate, 14 high)
+
 = 1.1.0 =
 * New: Gutenberg block content generation — markdown-to-blocks converter, block discovery, and structured block creation
 * New: 7 block abilities — markdown-to-blocks, list-block-types, get-block-type, list-block-patterns, list-block-templates, create-block-content, parse-block-content
@@ -198,6 +250,9 @@ Yes, the plugin works on both single-site and multisite WordPress installations.
 * WordPress 6.9 compatibility layer (bundles AI Client SDK)
 
 == Upgrade Notice ==
+
+= 1.2.0 =
+Major feature release: adds Google/Anthropic provider support, image uploads, spending limits, white-label branding, agent builder, role-based permissions, WooCommerce abilities, MCP server, and many more features. Database will upgrade automatically.
 
 = 1.1.0 =
 Adds Gutenberg block content generation, SEO/content/marketing abilities, WP-CLI command, and improved agent behavior. Database will upgrade automatically.


### PR DESCRIPTION
## Summary

- Bumps plugin version from 1.1.0 to 1.2.0
- Updates `Version` header in `gratis-ai-agent.php`
- Updates `Stable tag` in `readme.txt` to 1.2.0
- Adds comprehensive 1.2.0 changelog entry to `CHANGELOG.md` and `readme.txt` covering all changes since v1.1.0
- Adds 1.2.0 upgrade notice to `readme.txt`

## Changes documented in 1.2.0

**New features (selected highlights):**
- Support for all three official AI providers (OpenAI, Anthropic, Google Gemini)
- Image and file upload support in chat messages
- Spending limits and budget caps
- Live streaming token counter and cost display
- GPT-4.1 family models; GPT-4.1-nano as new default
- White-label branding support
- Agent builder UI
- Role-based AI permissions
- WooCommerce abilities
- MCP server (expose abilities as MCP tools)
- Mobile slide-out drawer
- Google Search Console and GA4 abilities
- DALL-E 3 image generation
- CodeMirror 6 syntax highlighting
- Shared conversations
- Text-to-speech
- Webhook API
- Push-to-talk speech-to-text
- Changes Admin page (diffs, revert, export)
- Playwright E2E and PHPUnit integration test suites

**Quality:**
- PHPStan raised to level 7
- ShellCheck violations resolved
- npm audit vulnerabilities fixed

Closes #583