### PR TITLE
fix: update readme.txt PHP requirement from 7.4 to 8.2

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: developer-dave
 Tags: ai, chatbot, assistant, automation, tools
 Requires at least: 6.9
 Tested up to: 6.9
-Requires PHP: 7.4
+Requires PHP: 8.2
 Stable tag: 1.1.0
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -111,7 +111,7 @@ The Gratis AI Agent discovers abilities at runtime from any plugin that register
 = Requirements =
 
 * WordPress 6.9 or higher
-* PHP 7.4 or higher
+* PHP 8.2 or higher
 * An AI provider connector plugin registered through the WordPress Connectors API
 * An API key from your chosen AI provider (OpenAI, Anthropic, etc.)
 


### PR DESCRIPTION
## Summary

- Updates `Requires PHP` header from `7.4` to `8.2` (line 6)
- Updates Requirements section text from `PHP 7.4 or higher` to `PHP 8.2 or higher` (line 114)

The plugin already requires PHP 8.2 features (enums, typed properties, `declare(strict_types=1)`) — the readme was simply out of date.

Closes #589