### PR TITLE
t136: Add JS bundle size budget to CI

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -76,3 +76,27 @@ jobs:
           fi
           echo "Build successful - artifacts found:"
           ls -la build/
+
+  bundle-size:
+    name: Bundle Size Budget
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Check bundle size budgets
+        run: npm run size

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,60 @@
+# Performance Baselines
+
+Bundle size baselines measured from the production build as of 2026-03-19.
+All sizes are **gzipped** (what the browser actually downloads).
+
+## JS Bundle Sizes
+
+| Bundle | Raw | Gzipped | Budget |
+|--------|-----|---------|--------|
+| `admin-page.js` | 1,139 KB | **370.6 KB** | 400 KB |
+| `floating-widget.js` | 1,124 KB | **367.5 KB** | 400 KB |
+| `screen-meta.js` | 1,111 KB | **363.9 KB** | 400 KB |
+| `settings-page.js` | 138 KB | **29.6 KB** | 50 KB |
+| `changes-page.js` | 11 KB | **3.4 KB** | 10 KB |
+| `abilities-explorer.js` | 8 KB | **2.9 KB** | 10 KB |
+
+## CSS Bundle Sizes
+
+| Bundle | Raw | Gzipped |
+|--------|-----|---------|
+| `style-admin-page.css` | 37 KB | 6.2 KB |
+| `style-floating-widget.css` | 19 KB | 3.8 KB |
+| `style-settings-page.css` | 10 KB | 2.2 KB |
+| `style-changes-page.css` | 2 KB | 0.6 KB |
+| `style-abilities-explorer.css` | 2 KB | 0.6 KB |
+| `style-screen-meta.css` | < 1 KB | 0.2 KB |
+
+## Why the Large Bundles
+
+The three large bundles (`admin-page`, `floating-widget`, `screen-meta`) share
+the same heavy dependencies because each is a separate webpack entry point that
+bundles its own copy of:
+
+- **CodeMirror 6** — syntax-highlighted code editor (~200 KB gzipped with all language packs)
+- **Chart.js** — analytics charts (~40 KB gzipped)
+- **highlight.js** — syntax highlighting for message rendering (~30 KB gzipped)
+- **@wordpress/components** — WordPress UI component library (~60 KB gzipped)
+
+## Budget Enforcement
+
+Bundle size budgets are enforced in CI via [size-limit](https://github.com/ai-tools/size-limit).
+
+```bash
+# Check locally after building
+npm run build
+npm run size
+```
+
+The `bundle-size` CI job runs on every PR and fails if any budget is breached.
+See `.github/workflows/code-quality.yml` and the `size-limit` config in `package.json`.
+
+## Reducing Bundle Size
+
+If a budget is breached, consider:
+
+1. **Shared chunks** — configure webpack `splitChunks` to extract common deps into a shared chunk loaded once
+2. **Dynamic imports** — lazy-load CodeMirror language packs only when the editor is opened
+3. **Tree-shaking** — audit which highlight.js languages are registered; import only those used
+4. **Chart.js tree-shaking** — import individual chart types instead of the full bundle
+5. **WordPress externals** — `@wordpress/*` packages are already externalised via `wp-scripts`; verify no accidental bundling

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,12 +38,14 @@
 			},
 			"devDependencies": {
 				"@playwright/test": "^1.58.2",
+				"@size-limit/file": "^12.0.1",
 				"@wordpress/e2e-test-utils-playwright": "^1.41.0",
 				"@wordpress/env": "^10.39.0",
 				"@wordpress/scripts": "^31.6.0",
 				"husky": "^9.1.7",
 				"lint-staged": "^16.4.0",
-				"react-dom": "^18.3.1"
+				"react-dom": "^18.3.1",
+				"size-limit": "^12.0.1"
 			}
 		},
 		"node_modules/@ampproject/remapping": {
@@ -6771,6 +6773,19 @@
 				"@sinonjs/commons": "^3.0.0"
 			}
 		},
+		"node_modules/@size-limit/file": {
+			"version": "12.0.1",
+			"resolved": "https://registry.npmjs.org/@size-limit/file/-/file-12.0.1.tgz",
+			"integrity": "sha512-Kvbnz46iV7WeHaANf1HmWjXBVMU2KkCU+0xJ78FzIjZwlVKKEqy+QCZprdBMfIWrzrvYeqP4cfuzKG8z6xVivg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"size-limit": "12.0.1"
+			}
+		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.1.0",
 			"dev": true,
@@ -11158,6 +11173,16 @@
 		},
 		"node_modules/bytes": {
 			"version": "3.1.2",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"node_modules/bytes-iec": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
+			"integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -20011,6 +20036,16 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
+		"node_modules/nanospinner": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
+			"integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"picocolors": "^1.1.1"
+			}
+		},
 		"node_modules/napi-postinstall": {
 			"version": "0.3.4",
 			"dev": true,
@@ -23452,6 +23487,34 @@
 			"version": "1.0.5",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/size-limit": {
+			"version": "12.0.1",
+			"resolved": "https://registry.npmjs.org/size-limit/-/size-limit-12.0.1.tgz",
+			"integrity": "sha512-vuFj+6lDOoBJQu6OLhcMQv7jnbXjuoEn4WsQHlSLOV/8EFfOka/tfjtLQ/rZig5Gagi3R0GnU/0kd4EY/y2etg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bytes-iec": "^3.1.1",
+				"lilconfig": "^3.1.3",
+				"nanospinner": "^1.2.2",
+				"picocolors": "^1.1.1",
+				"tinyglobby": "^0.2.15"
+			},
+			"bin": {
+				"size-limit": "bin.js"
+			},
+			"engines": {
+				"node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"jiti": "^2.0.0"
+			},
+			"peerDependenciesMeta": {
+				"jiti": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/slash": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -25,16 +25,19 @@
 		"wp-env:start": "wp-env start",
 		"wp-env:stop": "wp-env stop",
 		"wp-env:clean": "wp-env clean all",
-		"prepare": "husky"
+		"prepare": "husky",
+		"size": "size-limit"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.58.2",
+		"@size-limit/file": "^12.0.1",
 		"@wordpress/e2e-test-utils-playwright": "^1.41.0",
 		"@wordpress/env": "^10.39.0",
 		"@wordpress/scripts": "^31.6.0",
 		"husky": "^9.1.7",
 		"lint-staged": "^16.4.0",
-		"react-dom": "^18.3.1"
+		"react-dom": "^18.3.1",
+		"size-limit": "^12.0.1"
 	},
 	"dependencies": {
 		"@codemirror/commands": "^6.10.3",
@@ -102,5 +105,43 @@
 			"composer phpcbf --",
 			"composer phpcs --"
 		]
-	}
+	},
+	"size-limit": [
+		{
+			"name": "admin-page (main bundle)",
+			"path": "build/admin-page.js",
+			"limit": "400 KB",
+			"gzip": true
+		},
+		{
+			"name": "floating-widget",
+			"path": "build/floating-widget.js",
+			"limit": "400 KB",
+			"gzip": true
+		},
+		{
+			"name": "screen-meta",
+			"path": "build/screen-meta.js",
+			"limit": "400 KB",
+			"gzip": true
+		},
+		{
+			"name": "settings-page",
+			"path": "build/settings-page.js",
+			"limit": "50 KB",
+			"gzip": true
+		},
+		{
+			"name": "changes-page",
+			"path": "build/changes-page.js",
+			"limit": "10 KB",
+			"gzip": true
+		},
+		{
+			"name": "abilities-explorer",
+			"path": "build/abilities-explorer.js",
+			"limit": "10 KB",
+			"gzip": true
+		}
+	]
 }


### PR DESCRIPTION
## Summary

- Installs `size-limit@12` with `@size-limit/file` preset (gzip measurement, no headless browser required)
- Configures per-bundle budgets in `package.json` with `admin-page.js` < 400 KB gzipped as the primary constraint
- Adds `npm run size` script for local checks
- Adds `bundle-size` job to `code-quality.yml` (runs after `build` job, fails PR on budget breach)
- Documents current baseline sizes in `docs/performance.md` with notes on what drives the large bundles and how to reduce them

## Bundle Budgets

| Bundle | Gzipped | Budget |
|--------|---------|--------|
| `admin-page.js` | 383.8 KB | 400 KB |
| `floating-widget.js` | 380.7 KB | 400 KB |
| `screen-meta.js` | 377.1 KB | 400 KB |
| `settings-page.js` | 30.4 KB | 50 KB |
| `changes-page.js` | 3.5 KB | 10 KB |
| `abilities-explorer.js` | 3.0 KB | 10 KB |

All bundles currently pass. The three large bundles are close to the 400 KB ceiling due to shared CodeMirror 6, Chart.js, and highlight.js deps bundled separately per entry point — `docs/performance.md` documents the reduction path (shared chunks, dynamic imports).

## Verification

`npm run size` exits 0 locally against the current build.

Closes #611