### PR TITLE
fix: add PHP-native fallback to pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,42 @@
 #!/bin/sh
-npx lint-staged
+# Pre-commit hook: lint-staged (JS+CSS+PHP) with PHP-native fallback.
+# If node_modules is missing, fall back to running phpcs/phpcbf directly
+# so PHP indentation errors are caught even without a full npm install.
+
+if command -v npx >/dev/null 2>&1 && [ -d "node_modules/.bin" ]; then
+	npx lint-staged
+else
+	# Fallback: run phpcs/phpcbf on staged PHP files without lint-staged
+	STAGED_PHP=$(git diff --cached --name-only --diff-filter=ACM | grep '\.php$' || true)
+	[ -z "$STAGED_PHP" ] && exit 0
+
+	if [ ! -x "vendor/bin/phpcs" ]; then
+		echo "pre-commit: vendor/bin/phpcs not found — run 'composer install' first."
+		exit 1
+	fi
+
+	# Detect partially staged files (unstaged changes exist for the same file)
+	PARTIALLY_STAGED=""
+	for file in $STAGED_PHP; do
+		if git diff --name-only -- "$file" | grep -q .; then
+			PARTIALLY_STAGED="$PARTIALLY_STAGED $file"
+		fi
+	done
+
+	if [ -n "$PARTIALLY_STAGED" ]; then
+		# Cannot safely auto-fix — phpcbf would modify the working copy
+		# and re-staging would include unstaged hunks. Just check.
+		echo "pre-commit: partially staged PHP files detected, skipping auto-fix:"
+		echo "$PARTIALLY_STAGED"
+		# shellcheck disable=SC2086
+		vendor/bin/phpcs $STAGED_PHP
+	else
+		# Auto-fix, re-stage, then verify
+		# shellcheck disable=SC2086
+		vendor/bin/phpcbf $STAGED_PHP 2>/dev/null || true
+		# shellcheck disable=SC2086
+		git add $STAGED_PHP
+		# shellcheck disable=SC2086
+		vendor/bin/phpcs $STAGED_PHP
+	fi
+fi


### PR DESCRIPTION
## Summary

- Adds a PHP-native fallback to the Husky pre-commit hook so PHPCS runs even when `node_modules` is not installed (e.g. in worktrees or CI environments)
- The fallback runs `phpcbf` (auto-fix) then `phpcs` (verify) directly via `vendor/bin` on staged `.php` files
- Handles partially staged files safely by skipping auto-fix to avoid staging unintended hunks

## Context

The indentation errors fixed in #592 / PR #595 got through because the pre-commit hook depended entirely on `npx lint-staged`, which silently does nothing when `node_modules` is missing. Worktrees typically only have `composer install` run, not `npm install`.

## How it works

1. **Primary path** (unchanged): when `node_modules` exists, runs `npx lint-staged` (JS + CSS + PHP)
2. **Fallback path** (new): when `node_modules` is missing, runs `phpcbf` → `git add` → `phpcs` on staged PHP files via `vendor/bin`

Closes #592

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pre-commit validation with conditional configuration logic to support diverse development environments
  * Added intelligent fallback mechanisms ensuring consistent code quality checks across all setup configurations
  * Improved edge case handling with detection and proper processing of partially staged file modifications
  * Strengthened error detection and validation tool availability checks for enhanced robustness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->