### PR TITLE
feat(e2e): add Playwright E2E tests for text-to-speech

### DIFF
--- a/tests/e2e/text-to-speech.spec.js
+++ b/tests/e2e/text-to-speech.spec.js
@@ -324,9 +324,19 @@ test.describe( 'TTS Auto-Speak on AI Responses', () => {
 			.waitFor( { state: 'visible', timeout: 15_000 } );
 
 		// Verify that speak() was called on the mock.
-		const calls = await page.evaluate( () => window.__ttsMockCalls );
-		const speakCalls = calls.filter( ( c ) => c.type === 'speak' );
-		expect( speakCalls.length ).toBeGreaterThanOrEqual( 1 );
+		// TTS fires asynchronously after the stream completes, so poll until
+		// the speak call appears rather than checking synchronously.
+		await expect
+			.poll(
+				async () => {
+					const calls = await page.evaluate(
+						() => window.__ttsMockCalls
+					);
+					return calls.filter( ( c ) => c.type === 'speak' ).length;
+				},
+				{ timeout: 10_000 }
+			)
+			.toBeGreaterThanOrEqual( 1 );
 	} );
 
 	test( 'speechSynthesis.speak is NOT called when TTS is disabled', async ( {


### PR DESCRIPTION
## Summary

- Creates `tests/e2e/text-to-speech.spec.js` with 9 test cases covering the TTS feature shipped in v1.2.0
- Injects a `SpeechSynthesis` mock via `page.addInitScript()` so tests run in headless Chromium (which has no Web Speech API) without real audio output
- Follows patterns from `tests/e2e/chat-interactions.spec.js` (SSE stream interception, `loginToWordPress`/`goToAgentPage`/`goToSettingsPage` helpers)

## Test cases

**TTS Toggle Button (chat header)**
1. TTS toggle button is visible in the chat header
2. Clicking the toggle enables TTS and adds `is-active` class
3. Clicking the toggle a second time disables TTS

**TTS Settings Tab**
4. Text-to-Speech tab is present in settings
5. TTS enable toggle is visible in the Text-to-Speech settings tab
6. Enabling TTS in settings persists the toggle state

**TTS Auto-Speak on AI Responses**
7. `speechSynthesis.speak()` is called when TTS is enabled and AI responds
8. `speechSynthesis.speak()` is NOT called when TTS is disabled
9. Disabling TTS mid-conversation calls `speechSynthesis.cancel()`

## How the mock works

`injectTtsMock()` runs before page navigation and defines `window.speechSynthesis` + `window.SpeechSynthesisUtterance`. The mock records every `speak()` and `cancel()` call in `window.__ttsMockCalls`, which tests read back via `page.evaluate()`. `speak()` fires `utterance.onstart` synchronously and `utterance.onend` after 50 ms, matching the real API's lifecycle so the React hook's `isSpeaking` state transitions correctly.

Closes #652

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end tests for Text-to-Speech feature covering toggle controls, settings configuration, and auto-speak behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->