### PR TITLE
feat: Add E2E tests for spending limits and budget caps (GH#651)

### DIFF
--- a/tests/e2e/spending-limits.spec.js
+++ b/tests/e2e/spending-limits.spec.js
@@ -272,8 +272,11 @@ test.describe( 'Spending Limits — Settings UI (GH#651)', () => {
 		).toBeVisible();
 
 		// Warning Threshold range control.
+		// WordPress RangeControl renders two inputs with the same aria-label
+		// (a range slider and a number spinbutton). Use the slider role to
+		// avoid a strict-mode violation from the ambiguous getByLabel match.
 		await expect(
-			page.getByLabel( /warning threshold/i )
+			page.getByRole( 'slider', { name: /warning threshold/i } )
 		).toBeVisible();
 
 		// Action When Budget Exceeded select.


### PR DESCRIPTION
## Summary

- Creates `tests/e2e/spending-limits.spec.js` with 11 test cases across 2 describe blocks
- Covers all 4 acceptance criteria from issue #651

## Test Cases

**Spending Limits — Settings UI (6 tests)**
- General tab renders the Spending Limits heading
- All 4 spending limit fields are visible with correct labels (daily cap, monthly cap, warning threshold, exceeded action)
- Budget exceeded action select has `pause` and `warn` options
- Saving a daily cap sends PATCH with `budget_daily_cap` value and shows success notice
- Saving a monthly cap sends PATCH with `budget_monthly_cap` value
- Resetting caps to zero sends PATCH with `budget_daily_cap: 0, budget_monthly_cap: 0`

**Spending Limits — Budget Indicator (5 tests)**
- Indicator is hidden when no caps are configured (BudgetIndicator returns null)
- Indicator shows `--ok` CSS class when spend is below warning threshold
- Indicator shows `--warning` CSS class when threshold is approached (with correct tooltip)
- Indicator shows `--exceeded` CSS class when cap is surpassed (with correct tooltip)
- Indicator uses monthly cap and "this month" label when no daily cap is set

## Patterns Followed

Follows `tests/e2e/automations.spec.js` exactly:
- `page.unrouteAll()` in mock setup to prevent handler stacking
- `'**'` catch-all route with decoded URL matching for plain/pretty permalink compat
- `X-HTTP-Method-Override` header resolution for WordPress apiFetch PATCH
- LIFO route override pattern for per-test PATCH capture
- `route.fallback()` (not `route.continue()`) for non-matching requests in stacked handlers
- Bootstrap mocks for `/settings`, `/providers`, `/abilities`, `/settings/google-analytics`

Closes #651

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test coverage for the spending limits and budget caps feature, including validation of daily/monthly cap configuration, warning thresholds, exceeded action handling, and budget indicator states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->