### PR TITLE
feat: add E2E tests for white-label branding (t140 / issue #653)

### DIFF
--- a/tests/e2e/white-label.spec.js
+++ b/tests/e2e/white-label.spec.js
@@ -312,8 +312,12 @@ test.describe( 'White-Label Branding - Live Preview', () => {
 		const fab = getPreviewFab( page );
 		await expect( fab ).toBeVisible();
 		// Verify the inline style contains the custom color.
+		// Browsers normalise hex colours to rgb() in computed/inline styles,
+		// so check for either the hex value or its rgb() equivalent.
 		const fabStyle = await fab.getAttribute( 'style' );
-		expect( fabStyle ).toContain( '#e63946' );
+		const hasHex = fabStyle && fabStyle.includes( '#e63946' );
+		const hasRgb = fabStyle && fabStyle.includes( 'rgb(230, 57, 70)' );
+		expect( hasHex || hasRgb ).toBe( true );
 	} );
 
 	test( 'entering a logo URL shows the logo image in the preview', async ( {


### PR DESCRIPTION
## Summary

- Creates `tests/e2e/white-label.spec.js` with 15 test cases across 4 suites covering the white-label branding feature shipped in v1.2.0
- Follows the exact patterns from `tests/e2e/agent-builder.spec.js` (REST mocking, `decodeUrl`, locator helpers, `beforeEach` mock-before-login ordering)
- All REST calls to `/gratis-ai-agent/v1/settings` are intercepted for deterministic, database-free test runs

## Test Suites

| Suite | Tests |
|-------|-------|
| Settings Fields | 6 — branding manager visible, agent name field, primary color field, logo URL field, greeting field, Save button |
| Live Preview | 5 — preview visible, name updates title bar, color updates FAB style, logo URL shows img, clearing name restores default |
| Save and Persist | 2 — save shows success notice, saved name persists after navigate-away-and-back |
| Color Picker | 2 — Pick/Close toggles picker, opening primary picker closes text picker |

## Acceptance Criteria

- [x] `white-label.spec.js` created with ≥4 test cases (15 total)
- [ ] All tests pass in `npm run test:e2e:playwright` (verified via CI — no local wp-env available)
- [ ] CI green

Closes #653