### PR TITLE
fix(e2e): correct stale JSDoc in setupMocks() — predicate not regex (closes #657)

### DIFF
--- a/tests/e2e/shared-conversations.spec.js
+++ b/tests/e2e/shared-conversations.spec.js
@@ -72,7 +72,7 @@ const MOCK_SESSION = {
 /**
  * Register per-endpoint route handlers for all plugin REST endpoints.
  *
- * Uses separate `page.route(/regex/, handler)` calls for each endpoint
+ * Uses separate `page.route(predicate, handler)` calls for each endpoint
  * instead of a single `page.route('**', handler)` catch-all. The catch-all
  * approach is unreliable in wp-env environments where REST routes live in
  * query parameters (`?rest_route=...`) rather than URL paths — the `**`
@@ -80,7 +80,7 @@ const MOCK_SESSION = {
  * (CSS, JS, images, HTML), and this high-volume pass-through can cause
  * timing issues that prevent mock responses from reaching the store.
  *
- * With per-endpoint regex handlers, each handler only fires for its own
+ * With per-endpoint predicate handlers, each handler only fires for its own
  * endpoint. Non-matching requests are never intercepted, so there is no
  * `route.continue()` overhead and no risk of interference.
  *


### PR DESCRIPTION
## Summary

- The two high-severity CodeRabbit findings from PR #614 (regex `unroute` mismatch at line 474, regex route for wp-env encoded URLs at line 773) were already resolved in the final merged state of that PR — no functional changes were needed.
- The only remaining quality debt was a stale JSDoc comment in `setupMocks()` that still described the implementation as using regex matchers (`page.route(/regex/, handler)`) when the actual code uses function predicates (`page.route(predicate, handler)`) with `decodeURIComponent()` for wp-env URL-encoding compatibility.
- Fixed two lines in the JSDoc to accurately reflect the predicate-based implementation.

## What was verified

- Searched the current file for any `page.unroute(regex)` or `page.route(/regex/)` calls — none found.
- All `unroute` calls use `unrouteAll({ behavior: 'ignoreErrors' })`.
- All `route` calls use function predicates with `decodeURIComponent()`.
- The file header (lines 26–40) already correctly described the predicate strategy; only the `setupMocks()` JSDoc was stale.

## Files changed

- `tests/e2e/shared-conversations.spec.js` — corrected two lines in the `setupMocks()` JSDoc (lines 75 and 83): `regex` → `predicate`

Closes #657

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test documentation for mock-registration helper to reflect improved routing approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->