### PR TITLE
fix(e2e): use evaluate() for ToggleControl click in automations toggle tests (closes #658)

### DIFF
--- a/tests/e2e/automations.spec.js
+++ b/tests/e2e/automations.spec.js
@@ -694,8 +694,10 @@ test.describe( 'Scheduled Automations (t080)', () => {
 
 		// WordPress ToggleControl renders an opacity:0 <input> that covers
 		// the entire .components-form-toggle area (position:absolute, z-index:1,
-		// width/height 100%). Click with { force: true } to bypass the
-		// opacity:0 visibility check and trigger React's onChange handler.
+		// width/height 100%). Use evaluate() to trigger the native click in the
+		// page's JS context — this properly fires React's synthetic onChange
+		// handler, unlike Playwright's click({ force: true }) which bypasses
+		// the browser's native event dispatch for opacity:0 elements.
 		const checkbox = card
 			.locator( 'input.components-form-toggle__input' )
 			.first();
@@ -703,8 +705,8 @@ test.describe( 'Scheduled Automations (t080)', () => {
 		// Verify the toggle starts in the checked/enabled state.
 		await expect( checkbox ).toBeChecked();
 
-		// Click the checkbox to toggle it off.
-		await checkbox.click( { force: true } );
+		// Trigger the click via evaluate() so React's onChange fires correctly.
+		await checkbox.evaluate( ( el ) => el.click() );
 
 		// PATCH should have been called with enabled: false.
 		await expect
@@ -1116,8 +1118,11 @@ test.describe( 'Event-Driven Automations (t081)', () => {
 		await expect( card ).toBeVisible( { timeout: 10_000 } );
 
 		// WordPress ToggleControl renders an opacity:0 <input> that covers
-		// the entire .components-form-toggle area. Click with { force: true }
-		// to bypass the opacity:0 visibility check.
+		// the entire .components-form-toggle area. Use evaluate() to trigger
+		// the native click in the page's JS context — this properly fires
+		// React's synthetic onChange handler, unlike click({ force: true })
+		// which bypasses the browser's native event dispatch for opacity:0
+		// elements.
 		const checkbox = card
 			.locator( 'input.components-form-toggle__input' )
 			.first();
@@ -1125,8 +1130,8 @@ test.describe( 'Event-Driven Automations (t081)', () => {
 		// Verify the toggle starts in the checked/enabled state.
 		await expect( checkbox ).toBeChecked();
 
-		// Click the checkbox to toggle it off.
-		await checkbox.click( { force: true } );
+		// Trigger the click via evaluate() so React's onChange fires correctly.
+		await checkbox.evaluate( ( el ) => el.click() );
 
 		// PATCH should have been called with enabled: false.
 		await expect


### PR DESCRIPTION
## Summary

Addresses the two CodeRabbit findings from PR #613 review (issue #658):

- **Finding 1 (MEDIUM — logs route mock):** The mock only matched `/automation-logs` but the REST route is `/automations/{id}/logs`. This was already fixed in the PR #613 merge — the handler now matches both patterns via `url.includes('/automation-logs') || /\/automations\/\d+\/logs/.test(url)`. No change needed.

- **Finding 2 (CRITICAL — toggle tests use wrong interaction):** Both toggle tests (scheduled and event automations) used `checkbox.click({ force: true })` which bypasses the browser's native event dispatch for opacity:0 elements, preventing React's synthetic `onChange` handler from firing. Fixed by replacing with `checkbox.evaluate( el => el.click() )` which triggers the native click in the page's JS context and properly fires `onChange`. Updated comments in both tests to explain the rationale.

## What was verified

- Confirmed the logs route mock at lines 321-331 already handles both `/automation-logs` and `/automations/{id}/logs`.
- Confirmed the toggle tests now use `evaluate()` instead of `click({ force: true })` in both the scheduled automations test (line ~709) and the event automations test (line ~1134).
- Both tests still verify `patchBody.enabled === false` and assert the checkbox is unchecked after `fetchAll()`.

## Files changed

- `tests/e2e/automations.spec.js` — replace `checkbox.click({ force: true })` with `checkbox.evaluate( el => el.click() )` in both toggle tests; improve comments

Closes #658