### PR TITLE
chore: remove deprecated husky v8 artifact .husky/_/husky.sh

### DIFF
--- a/.husky/_/husky.sh
+++ b/.husky/_/husky.sh
@@ -1,9 +1,0 @@
-echo "husky - DEPRECATED
-
-Please remove the following two lines from $0:
-
-#!/usr/bin/env sh
-. \"\$(dirname -- \"\$0\")/_/husky.sh\"
-
-They WILL FAIL in v10.0.0
-"


### PR DESCRIPTION
## Summary

- Deletes `.husky/_/husky.sh`, a husky v8 compatibility shim that is no longer needed and will fail in husky v10.0.0
- Verified no hook scripts in `.husky/` reference this file (`pre-commit` uses `npx lint-staged` directly)
- Removes the SC2148 ShellCheck false-positive in SonarCloud (file had no shebang because it is not a real hook script)

## Testing Evidence

- **Testing level:** `self-assessed`
- **Stability results:** N/A — file deletion only, no executable code changed
- **Smoke pages/endpoints checked:** N/A

## Risk Classification

Low — deleting a deprecated shim file that outputs a deprecation warning. No hook scripts source it.

Closes #666

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed deprecation notice from hook configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->