### PR TITLE
fix(ci): restore E2E job timeout to 60 min — 202 tests need more time

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
   e2e:
     name: Playwright E2E (WP ${{ matrix.wp }})
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     # WP trunk may fail due to PSR namespace conflicts between our compat
     # layer and core's native AI Client SDK (see tests.yml for details).
     continue-on-error: ${{ matrix.wp == 'trunk' }}


### PR DESCRIPTION
## Problem

PR #669 reduced `timeout-minutes` from 60 to 30 to prevent indefinite stalls. However, the logs from the first run after that merge show the tests are **not stalling** — they are actively running:

```
Running 202 tests using 1 worker
[13:37:03] → [14:04:03] ##[error]The operation was canceled.
```

202 tests × 1 worker (forced by `playwright.config.js` on CI) × up to 30s each = up to ~100 min worst case. In practice they take ~27-33 min on the GitHub runner. The 30-minute job timeout is too tight.

## Fix

Restore `timeout-minutes: 60` on the job. The other improvements from #669 are kept:
- `concurrency: cancel-in-progress: true` — kills stale runs on new push
- `timeout-minutes: 10` on the `Start wp-env` step — guards against Docker startup hangs
- Explicit `exit 1` in the readiness check loop

## Root cause of original stalls

The original "indefinite stalls" in issue #668 were likely caused by multiple concurrent runs piling up (no `cancel-in-progress`), each consuming a runner slot and appearing stuck. With `cancel-in-progress: true` now in place, new pushes cancel old runs immediately, so the 60-minute timeout is only hit by genuinely slow test runs — not by orphaned runners.

Closes #668

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated E2E testing workflow timeout to provide sufficient execution time for comprehensive test completion and improve test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->