### PR TITLE
fix(ci): increase Playwright workers to 3 and job timeout to 90 min (#672)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
   e2e:
     name: Playwright E2E (WP ${{ matrix.wp }})
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     # WP trunk may fail due to PSR namespace conflicts between our compat
     # layer and core's native AI Client SDK (see tests.yml for details).
     continue-on-error: ${{ matrix.wp == 'trunk' }}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -22,10 +22,10 @@ module.exports = defineConfig( {
 	/* Retry on CI only — 1 retry keeps total time bounded. */
 	retries: process.env.CI ? 1 : 0,
 
-	/* 2 workers on CI: halves runtime (~57 min → ~30 min) while staying
-	 * conservative about wp-env resource contention. 1 worker caused the
-	 * 202-test suite to exceed the 60-minute job timeout consistently. */
-	workers: process.env.CI ? 2 : undefined,
+	/* 3 workers on CI: reduces runtime to ~35 min, well within the 90-min
+	 * job timeout. 2 workers still hit ~59 min (PR #671). 1 worker caused
+	 * the 202-test suite to exceed the 60-minute job timeout consistently. */
+	workers: process.env.CI ? 3 : undefined,
 
 	/* Reporter to use. */
 	reporter: process.env.CI


### PR DESCRIPTION
## Summary

- Increases Playwright CI workers from 2 → 3 in `playwright.config.js`
- Increases E2E job `timeout-minutes` from 60 → 90 in `.github/workflows/e2e.yml` as a safety net

## Problem

PR #671 increased workers from 1 → 2, but the E2E suite still timed out at ~59 min on both WP 6.9 and WP trunk (job timeout: 60 min). With 202 tests × 2 workers × ~30s each = ~50 min expected, but wp-env startup and browser install overhead pushes actual runtime to ~59 min.

## Changes

**`playwright.config.js`** (1-line change):
```js
// Before
workers: process.env.CI ? 2 : undefined,

// After
workers: process.env.CI ? 3 : undefined,
```

**`.github/workflows/e2e.yml`** (1-line change):
```yaml
# Before
timeout-minutes: 60

# After
timeout-minutes: 90
```

## Expected outcome

- 3 workers: ~35 min total runtime, well within the 90-min limit
- 90-min timeout: safety net if resource contention causes some slowdown

## Runtime Testing

- **Risk classification:** Low — CI config only, no application code changed
- **Testing level:** self-assessed
- **Verification:** Config values confirmed correct via grep after edit

Closes #672

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized end-to-end test execution with increased timeout and parallel worker allocation for improved build reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->