### PR TITLE
fix(husky): add shebang to .husky/_/husky.sh via postprepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 		"wp-env:stop": "wp-env stop",
 		"wp-env:clean": "wp-env clean all",
 		"prepare": "husky",
-		"postprepare": "[ -f .husky/_/husky.sh ] && grep -q '^#!' .husky/_/husky.sh || sed -i '1s|^|#!/usr/bin/env sh\\n|' .husky/_/husky.sh || true",
+		"postprepare": "node -e \"const f='.husky/_/husky.sh',fs=require('fs');if(fs.existsSync(f)){const c=fs.readFileSync(f,'utf8');if(!c.startsWith('#!'))fs.writeFileSync(f,'#!/usr/bin/env sh\\n'+c);}\"",
 		"size": "size-limit"
 	},
 	"devDependencies": {


### PR DESCRIPTION
## Summary

- Fixes ShellCheck SC2148 warning on `.husky/_/husky.sh` (auto-generated deprecation stub, no shebang)
- Adds a `postprepare` npm script that prepends `#!/usr/bin/env sh` to the generated file after `husky` runs
- Idempotent: skips patching if shebang already present; no-ops if file doesn't exist

## Root Cause

Husky v9 generates `.husky/_/husky.sh` as a deprecation warning stub during `npm install`. The file contains only an `echo` command with no shebang, causing ShellCheck SC2148. Since the file is gitignored and regenerated on every install, it cannot be committed with a shebang — the fix must be applied post-generation.

## Verification

```sh
# Simulate: create a file without shebang, run the postprepare logic
printf 'echo "husky - DEPRECATED"\n' > /tmp/test.sh
grep -q '^#!' /tmp/test.sh || sed -i '1s|^|#!/usr/bin/env sh\n|' /tmp/test.sh
shellcheck /tmp/test.sh  # no warnings
```

Closes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a post-prepare automation that ensures the project's git hook script has the expected script header, with any errors suppressed to avoid interrupting setup. This refines project setup and configuration scripts to improve development environment reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->