### PR TITLE
GH#687: test(abilities): add unit tests for 6 untested ability classes

### DIFF
--- a/tests/GratisAiAgent/Abilities/AiImageAbilitiesTest.php
+++ b/tests/GratisAiAgent/Abilities/AiImageAbilitiesTest.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Test case for AiImageAbilities class.
+ *
+ * @package GratisAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace GratisAiAgent\Tests\Abilities;
+
+use GratisAiAgent\Abilities\AiImageAbilities;
+use WP_UnitTestCase;
+
+/**
+ * Test AiImageAbilities handler methods.
+ */
+class AiImageAbilitiesTest extends WP_UnitTestCase {
+
+	// ─── handle_generate ──────────────────────────────────────────
+
+	/**
+	 * Test handle_generate with empty prompt returns WP_Error.
+	 */
+	public function test_handle_generate_empty_prompt() {
+		$result = AiImageAbilities::handle_generate( [ 'prompt' => '' ] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'missing_param', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_generate with missing prompt returns WP_Error.
+	 */
+	public function test_handle_generate_missing_prompt() {
+		$result = AiImageAbilities::handle_generate( [] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'missing_param', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_generate with valid prompt but no API key returns WP_Error.
+	 *
+	 * In the test environment, no OpenAI API key is configured, so the handler
+	 * should return a WP_Error with 'no_openai_key' code.
+	 */
+	public function test_handle_generate_no_api_key() {
+		// Ensure no OpenAI key is set.
+		delete_option( 'gratis_ai_agent_settings' );
+
+		$result = AiImageAbilities::handle_generate( [
+			'prompt' => 'A beautiful sunset over the ocean.',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'no_openai_key', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_generate with valid prompt returns array or WP_Error.
+	 *
+	 * In the test environment, the API call will fail (no key), but the handler
+	 * must not throw an exception.
+	 */
+	public function test_handle_generate_returns_array_or_wp_error() {
+		$result = AiImageAbilities::handle_generate( [
+			'prompt' => 'A mountain landscape at dawn.',
+		] );
+
+		$this->assertTrue(
+			is_array( $result ) || is_wp_error( $result ),
+			'Result should be an array or WP_Error.'
+		);
+	}
+
+	/**
+	 * Test handle_generate with invalid size falls back gracefully.
+	 *
+	 * The handler resolves invalid enum values to the site default or first allowed value.
+	 * It should not error on the size parameter itself.
+	 */
+	public function test_handle_generate_invalid_size_falls_back() {
+		$result = AiImageAbilities::handle_generate( [
+			'prompt' => 'A forest path.',
+			'size'   => 'invalid_size',
+		] );
+
+		// Should fail on API key, not on size validation.
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertNotSame( 'invalid_size', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_generate with invalid quality falls back gracefully.
+	 */
+	public function test_handle_generate_invalid_quality_falls_back() {
+		$result = AiImageAbilities::handle_generate( [
+			'prompt'  => 'A city skyline.',
+			'quality' => 'ultra',
+		] );
+
+		// Should fail on API key, not on quality validation.
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertNotSame( 'ultra', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_generate with invalid style falls back gracefully.
+	 */
+	public function test_handle_generate_invalid_style_falls_back() {
+		$result = AiImageAbilities::handle_generate( [
+			'prompt' => 'A beach at sunset.',
+			'style'  => 'cartoon',
+		] );
+
+		// Should fail on API key, not on style validation.
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertNotSame( 'cartoon', $result->get_error_code() );
+	}
+
+	// ─── register ────────────────────────────────────────────────
+
+	/**
+	 * Test register adds the wp_abilities_api_init action hook.
+	 *
+	 * Calling register() should attach register_abilities to the
+	 * wp_abilities_api_init action without throwing.
+	 */
+	public function test_register_adds_action_hook() {
+		AiImageAbilities::register();
+
+		$this->assertGreaterThan(
+			0,
+			has_action( 'wp_abilities_api_init', [ AiImageAbilities::class, 'register_abilities' ] ),
+			'register() should add register_abilities to wp_abilities_api_init.'
+		);
+	}
+}

--- a/tests/GratisAiAgent/Abilities/EditorialAbilitiesTest.php
+++ b/tests/GratisAiAgent/Abilities/EditorialAbilitiesTest.php
@@ -1,0 +1,292 @@
+<?php
+/**
+ * Test case for EditorialAbilities class.
+ *
+ * @package GratisAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace GratisAiAgent\Tests\Abilities;
+
+use GratisAiAgent\Abilities\EditorialAbilities;
+use WP_UnitTestCase;
+
+/**
+ * Test EditorialAbilities handler methods.
+ */
+class EditorialAbilitiesTest extends WP_UnitTestCase {
+
+	// ─── handle_generate_title ────────────────────────────────────
+
+	/**
+	 * Test handle_generate_title without wp_ai_client_prompt returns WP_Error.
+	 *
+	 * In the test environment, wp_ai_client_prompt() is not available.
+	 * The handler must return a WP_Error with 'ai_client_unavailable'.
+	 */
+	public function test_handle_generate_title_no_ai_client() {
+		if ( function_exists( 'wp_ai_client_prompt' ) ) {
+			$this->markTestSkipped( 'wp_ai_client_prompt() is available in this environment.' );
+		}
+
+		$result = EditorialAbilities::handle_generate_title( [
+			'content' => 'This is some test content for title generation.',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_client_unavailable', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_generate_title with empty content and no post_id returns WP_Error.
+	 *
+	 * When wp_ai_client_prompt is available, empty content should return an error.
+	 * When it is not available, the ai_client_unavailable error fires first.
+	 */
+	public function test_handle_generate_title_empty_content() {
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			$result = EditorialAbilities::handle_generate_title( [ 'content' => '' ] );
+			$this->assertInstanceOf( \WP_Error::class, $result );
+			return;
+		}
+
+		$result = EditorialAbilities::handle_generate_title( [ 'content' => '' ] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'content_not_provided', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_generate_title with invalid post_id returns WP_Error.
+	 *
+	 * When wp_ai_client_prompt is available, a non-existent post_id should
+	 * return a post_not_found error.
+	 */
+	public function test_handle_generate_title_invalid_post_id() {
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			$this->markTestSkipped( 'wp_ai_client_prompt() is not available.' );
+		}
+
+		$result = EditorialAbilities::handle_generate_title( [
+			'post_id' => 999999,
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'post_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_generate_title candidates is clamped to 1–10 range.
+	 *
+	 * The handler clamps candidates to [1, 10]. This is exercised by passing
+	 * extreme values — the handler should not error on the candidates param itself.
+	 */
+	public function test_handle_generate_title_candidates_clamped() {
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			$this->markTestSkipped( 'wp_ai_client_prompt() is not available.' );
+		}
+
+		// Passing 0 candidates should be clamped to 1 — no validation error.
+		$result = EditorialAbilities::handle_generate_title( [
+			'content'    => 'Some content.',
+			'candidates' => 0,
+		] );
+
+		// Should fail on AI call, not on candidates validation.
+		$this->assertTrue(
+			is_array( $result ) || is_wp_error( $result ),
+			'Result should be an array or WP_Error.'
+		);
+	}
+
+	// ─── handle_generate_excerpt ──────────────────────────────────
+
+	/**
+	 * Test handle_generate_excerpt without wp_ai_client_prompt returns WP_Error.
+	 */
+	public function test_handle_generate_excerpt_no_ai_client() {
+		if ( function_exists( 'wp_ai_client_prompt' ) ) {
+			$this->markTestSkipped( 'wp_ai_client_prompt() is available in this environment.' );
+		}
+
+		$result = EditorialAbilities::handle_generate_excerpt( [
+			'content' => 'Some content to excerpt.',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_client_unavailable', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_generate_excerpt with empty content returns WP_Error.
+	 */
+	public function test_handle_generate_excerpt_empty_content() {
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			$result = EditorialAbilities::handle_generate_excerpt( [ 'content' => '' ] );
+			$this->assertInstanceOf( \WP_Error::class, $result );
+			return;
+		}
+
+		$result = EditorialAbilities::handle_generate_excerpt( [ 'content' => '' ] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'content_not_provided', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_generate_excerpt with invalid post_id in context returns WP_Error.
+	 */
+	public function test_handle_generate_excerpt_invalid_post_id_context() {
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			$this->markTestSkipped( 'wp_ai_client_prompt() is not available.' );
+		}
+
+		$result = EditorialAbilities::handle_generate_excerpt( [
+			'content' => '',
+			'context' => '999999',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'post_not_found', $result->get_error_code() );
+	}
+
+	// ─── handle_summarize_content ─────────────────────────────────
+
+	/**
+	 * Test handle_summarize_content without wp_ai_client_prompt returns WP_Error.
+	 */
+	public function test_handle_summarize_content_no_ai_client() {
+		if ( function_exists( 'wp_ai_client_prompt' ) ) {
+			$this->markTestSkipped( 'wp_ai_client_prompt() is available in this environment.' );
+		}
+
+		$result = EditorialAbilities::handle_summarize_content( [
+			'content' => 'Some content to summarize.',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_client_unavailable', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_summarize_content with empty content returns WP_Error.
+	 */
+	public function test_handle_summarize_content_empty_content() {
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			$result = EditorialAbilities::handle_summarize_content( [
+				'content' => '',
+				'length'  => 'medium',
+			] );
+			$this->assertInstanceOf( \WP_Error::class, $result );
+			return;
+		}
+
+		$result = EditorialAbilities::handle_summarize_content( [
+			'content' => '',
+			'length'  => 'medium',
+		] );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'content_not_provided', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_summarize_content with invalid length falls back to medium.
+	 *
+	 * The handler normalises invalid length values to 'medium'. It should not
+	 * error on the length parameter itself.
+	 */
+	public function test_handle_summarize_content_invalid_length_falls_back() {
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			$this->markTestSkipped( 'wp_ai_client_prompt() is not available.' );
+		}
+
+		$result = EditorialAbilities::handle_summarize_content( [
+			'content' => 'Some content.',
+			'length'  => 'invalid_length',
+		] );
+
+		// Should fail on AI call, not on length validation.
+		$this->assertTrue(
+			is_array( $result ) || is_string( $result ) || is_wp_error( $result ),
+			'Result should be a string, array, or WP_Error.'
+		);
+	}
+
+	// ─── handle_review_block ──────────────────────────────────────
+
+	/**
+	 * Test handle_review_block without wp_ai_client_prompt returns WP_Error.
+	 */
+	public function test_handle_review_block_no_ai_client() {
+		if ( function_exists( 'wp_ai_client_prompt' ) ) {
+			$this->markTestSkipped( 'wp_ai_client_prompt() is available in this environment.' );
+		}
+
+		$result = EditorialAbilities::handle_review_block( [
+			'block_type'    => 'core/paragraph',
+			'block_content' => 'Some paragraph content.',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_client_unavailable', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_review_block with empty block_content returns WP_Error.
+	 */
+	public function test_handle_review_block_empty_block_content() {
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			$result = EditorialAbilities::handle_review_block( [
+				'block_type'    => 'core/paragraph',
+				'block_content' => '',
+			] );
+			$this->assertInstanceOf( \WP_Error::class, $result );
+			return;
+		}
+
+		$result = EditorialAbilities::handle_review_block( [
+			'block_type'    => 'core/paragraph',
+			'block_content' => '',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'block_content_required', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_review_block with missing block_content returns WP_Error.
+	 */
+	public function test_handle_review_block_missing_block_content() {
+		$result = EditorialAbilities::handle_review_block( [
+			'block_type' => 'core/paragraph',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+	}
+
+	// ─── permission_edit_posts ────────────────────────────────────
+
+	/**
+	 * Test permission_edit_posts returns true when user can edit posts.
+	 */
+	public function test_permission_edit_posts_with_capable_user() {
+		$user_id = $this->factory->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $user_id );
+
+		$result = EditorialAbilities::permission_edit_posts( [] );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test permission_edit_posts returns WP_Error when user cannot edit posts.
+	 */
+	public function test_permission_edit_posts_without_capability() {
+		$user_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $user_id );
+
+		$result = EditorialAbilities::permission_edit_posts( [] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'insufficient_capabilities', $result->get_error_code() );
+	}
+}

--- a/tests/GratisAiAgent/Abilities/MediaAbilitiesTest.php
+++ b/tests/GratisAiAgent/Abilities/MediaAbilitiesTest.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * Test case for MediaAbilities class.
+ *
+ * @package GratisAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace GratisAiAgent\Tests\Abilities;
+
+use GratisAiAgent\Abilities\MediaAbilities;
+use WP_UnitTestCase;
+
+/**
+ * Test MediaAbilities handler methods.
+ */
+class MediaAbilitiesTest extends WP_UnitTestCase {
+
+	// ─── handle_list_media ────────────────────────────────────────
+
+	/**
+	 * Test handle_list_media returns expected structure.
+	 */
+	public function test_handle_list_media_returns_structure() {
+		$result = MediaAbilities::handle_list_media( [] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'items', $result );
+		$this->assertArrayHasKey( 'total', $result );
+		$this->assertIsArray( $result['items'] );
+		$this->assertIsInt( $result['total'] );
+	}
+
+	/**
+	 * Test handle_list_media total matches items array count.
+	 */
+	public function test_handle_list_media_total_matches_count() {
+		$result = MediaAbilities::handle_list_media( [] );
+
+		$this->assertSame( count( $result['items'] ), $result['total'] );
+	}
+
+	/**
+	 * Test handle_list_media with attachment returns item structure.
+	 */
+	public function test_handle_list_media_item_structure() {
+		// Create a test attachment.
+		$attachment_id = $this->factory->attachment->create( [
+			'post_title'     => 'Test Image',
+			'post_mime_type' => 'image/jpeg',
+			'post_status'    => 'inherit',
+		] );
+
+		$result = MediaAbilities::handle_list_media( [] );
+
+		$this->assertNotEmpty( $result['items'] );
+		$item = $result['items'][0];
+		$this->assertArrayHasKey( 'id', $item );
+		$this->assertArrayHasKey( 'url', $item );
+		$this->assertArrayHasKey( 'title', $item );
+		$this->assertArrayHasKey( 'alt_text', $item );
+		$this->assertArrayHasKey( 'mime_type', $item );
+		$this->assertArrayHasKey( 'date', $item );
+		$this->assertArrayHasKey( 'file_size', $item );
+	}
+
+	/**
+	 * Test handle_list_media with mime_type filter returns only matching items.
+	 */
+	public function test_handle_list_media_mime_type_filter() {
+		$this->factory->attachment->create( [
+			'post_mime_type' => 'image/jpeg',
+			'post_status'    => 'inherit',
+		] );
+
+		$result = MediaAbilities::handle_list_media( [ 'mime_type' => 'image/jpeg' ] );
+
+		$this->assertIsArray( $result );
+		foreach ( $result['items'] as $item ) {
+			$this->assertSame( 'image/jpeg', $item['mime_type'] );
+		}
+	}
+
+	/**
+	 * Test handle_list_media limit is respected.
+	 */
+	public function test_handle_list_media_limit() {
+		$this->factory->attachment->create_many( 5, [
+			'post_mime_type' => 'image/jpeg',
+			'post_status'    => 'inherit',
+		] );
+
+		$result = MediaAbilities::handle_list_media( [ 'limit' => 2 ] );
+
+		$this->assertLessThanOrEqual( 2, $result['total'] );
+	}
+
+	/**
+	 * Test handle_list_media limit is clamped to 100 maximum.
+	 */
+	public function test_handle_list_media_limit_clamped_max() {
+		$result = MediaAbilities::handle_list_media( [ 'limit' => 9999 ] );
+
+		$this->assertIsArray( $result );
+		$this->assertLessThanOrEqual( 100, $result['total'] );
+	}
+
+	// ─── handle_upload_media_from_url ─────────────────────────────
+
+	/**
+	 * Test handle_upload_media_from_url with empty URL returns WP_Error.
+	 */
+	public function test_handle_upload_media_from_url_empty_url() {
+		$result = MediaAbilities::handle_upload_media_from_url( [ 'url' => '' ] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_empty_url', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_upload_media_from_url with missing URL returns WP_Error.
+	 */
+	public function test_handle_upload_media_from_url_missing_url() {
+		$result = MediaAbilities::handle_upload_media_from_url( [] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_empty_url', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_upload_media_from_url with unreachable URL returns WP_Error.
+	 *
+	 * In the test environment, HTTP requests to external URLs will fail.
+	 * The handler should return a WP_Error, not throw an exception.
+	 */
+	public function test_handle_upload_media_from_url_unreachable_url() {
+		$result = MediaAbilities::handle_upload_media_from_url( [
+			'url' => 'https://nonexistent-domain-xyz-12345.example.com/image.jpg',
+		] );
+
+		// Should return WP_Error on download failure.
+		$this->assertInstanceOf( \WP_Error::class, $result );
+	}
+
+	// ─── handle_delete_media ──────────────────────────────────────
+
+	/**
+	 * Test handle_delete_media with missing attachment_id returns WP_Error.
+	 */
+	public function test_handle_delete_media_missing_attachment_id() {
+		$result = MediaAbilities::handle_delete_media( [] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_empty_attachment_id', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_delete_media with zero attachment_id returns WP_Error.
+	 */
+	public function test_handle_delete_media_zero_attachment_id() {
+		$result = MediaAbilities::handle_delete_media( [ 'attachment_id' => 0 ] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_empty_attachment_id', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_delete_media with non-existent attachment_id returns WP_Error.
+	 */
+	public function test_handle_delete_media_not_found() {
+		$result = MediaAbilities::handle_delete_media( [ 'attachment_id' => 999999 ] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_attachment_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_delete_media with a regular post ID (not attachment) returns WP_Error.
+	 */
+	public function test_handle_delete_media_non_attachment_post() {
+		$post_id = $this->factory->post->create( [ 'post_status' => 'publish' ] );
+
+		$result = MediaAbilities::handle_delete_media( [ 'attachment_id' => $post_id ] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_attachment_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_delete_media with valid attachment deletes it and returns structure.
+	 */
+	public function test_handle_delete_media_deletes_attachment() {
+		$attachment_id = $this->factory->attachment->create( [
+			'post_title'     => 'Deletable Image',
+			'post_mime_type' => 'image/jpeg',
+			'post_status'    => 'inherit',
+		] );
+
+		$result = MediaAbilities::handle_delete_media( [ 'attachment_id' => $attachment_id ] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'attachment_id', $result );
+		$this->assertArrayHasKey( 'title', $result );
+		$this->assertArrayHasKey( 'deleted', $result );
+		$this->assertSame( $attachment_id, $result['attachment_id'] );
+		$this->assertTrue( $result['deleted'] );
+	}
+}

--- a/tests/GratisAiAgent/Abilities/PostAbilitiesTest.php
+++ b/tests/GratisAiAgent/Abilities/PostAbilitiesTest.php
@@ -1,0 +1,378 @@
+<?php
+/**
+ * Test case for PostAbilities class.
+ *
+ * @package GratisAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace GratisAiAgent\Tests\Abilities;
+
+use GratisAiAgent\Abilities\PostAbilities;
+use WP_UnitTestCase;
+
+/**
+ * Test PostAbilities handler methods.
+ */
+class PostAbilitiesTest extends WP_UnitTestCase {
+
+	// ─── handle_get_post ──────────────────────────────────────────
+
+	/**
+	 * Test handle_get_post with missing post_id returns WP_Error.
+	 */
+	public function test_handle_get_post_missing_post_id() {
+		$result = PostAbilities::handle_get_post( [] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_empty_post_id', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_get_post with zero post_id returns WP_Error.
+	 */
+	public function test_handle_get_post_zero_post_id() {
+		$result = PostAbilities::handle_get_post( [ 'post_id' => 0 ] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_empty_post_id', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_get_post with non-existent post_id returns WP_Error.
+	 */
+	public function test_handle_get_post_not_found() {
+		$result = PostAbilities::handle_get_post( [ 'post_id' => 999999 ] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_post_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_get_post with valid post_id returns expected structure.
+	 */
+	public function test_handle_get_post_returns_structure() {
+		$post_id = $this->factory->post->create( [
+			'post_title'   => 'Test Post',
+			'post_content' => 'Test content.',
+			'post_status'  => 'publish',
+		] );
+
+		$result = PostAbilities::handle_get_post( [ 'post_id' => $post_id ] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'id', $result );
+		$this->assertArrayHasKey( 'title', $result );
+		$this->assertArrayHasKey( 'content', $result );
+		$this->assertArrayHasKey( 'status', $result );
+		$this->assertArrayHasKey( 'post_type', $result );
+		$this->assertArrayHasKey( 'author_id', $result );
+		$this->assertArrayHasKey( 'categories', $result );
+		$this->assertArrayHasKey( 'tags', $result );
+		$this->assertArrayHasKey( 'featured_image', $result );
+		$this->assertSame( $post_id, $result['id'] );
+		$this->assertSame( 'Test Post', $result['title'] );
+	}
+
+	/**
+	 * Test handle_get_post with post_type mismatch returns WP_Error.
+	 */
+	public function test_handle_get_post_type_mismatch() {
+		$post_id = $this->factory->post->create( [
+			'post_type'   => 'post',
+			'post_status' => 'publish',
+		] );
+
+		$result = PostAbilities::handle_get_post( [
+			'post_id'   => $post_id,
+			'post_type' => 'page',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_post_type_mismatch', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_get_post with matching post_type succeeds.
+	 */
+	public function test_handle_get_post_type_match() {
+		$post_id = $this->factory->post->create( [
+			'post_type'   => 'post',
+			'post_status' => 'publish',
+		] );
+
+		$result = PostAbilities::handle_get_post( [
+			'post_id'   => $post_id,
+			'post_type' => 'post',
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $post_id, $result['id'] );
+	}
+
+	/**
+	 * Test handle_get_post categories and tags are arrays.
+	 */
+	public function test_handle_get_post_categories_tags_are_arrays() {
+		$post_id = $this->factory->post->create( [ 'post_status' => 'publish' ] );
+
+		$result = PostAbilities::handle_get_post( [ 'post_id' => $post_id ] );
+
+		$this->assertIsArray( $result );
+		$this->assertIsArray( $result['categories'] );
+		$this->assertIsArray( $result['tags'] );
+	}
+
+	// ─── handle_create_post ───────────────────────────────────────
+
+	/**
+	 * Test handle_create_post with empty title returns WP_Error.
+	 */
+	public function test_handle_create_post_empty_title() {
+		$result = PostAbilities::handle_create_post( [ 'title' => '' ] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_empty_title', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_create_post with missing title returns WP_Error.
+	 */
+	public function test_handle_create_post_missing_title() {
+		$result = PostAbilities::handle_create_post( [] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_empty_title', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_create_post with valid title creates post and returns structure.
+	 */
+	public function test_handle_create_post_returns_structure() {
+		$result = PostAbilities::handle_create_post( [
+			'title'   => 'New Test Post',
+			'content' => 'Some content.',
+			'status'  => 'draft',
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'post_id', $result );
+		$this->assertArrayHasKey( 'permalink', $result );
+		$this->assertArrayHasKey( 'status', $result );
+		$this->assertArrayHasKey( 'post_type', $result );
+		$this->assertIsInt( $result['post_id'] );
+		$this->assertGreaterThan( 0, $result['post_id'] );
+	}
+
+	/**
+	 * Test handle_create_post default status is draft.
+	 */
+	public function test_handle_create_post_default_status_is_draft() {
+		$result = PostAbilities::handle_create_post( [ 'title' => 'Draft Post' ] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'draft', $result['status'] );
+	}
+
+	/**
+	 * Test handle_create_post with publish status creates published post.
+	 */
+	public function test_handle_create_post_publish_status() {
+		$result = PostAbilities::handle_create_post( [
+			'title'  => 'Published Post',
+			'status' => 'publish',
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'publish', $result['status'] );
+	}
+
+	/**
+	 * Test handle_create_post with invalid status falls back to draft.
+	 */
+	public function test_handle_create_post_invalid_status_falls_back_to_draft() {
+		$result = PostAbilities::handle_create_post( [
+			'title'  => 'Post With Bad Status',
+			'status' => 'invalid_status',
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'draft', $result['status'] );
+	}
+
+	/**
+	 * Test handle_create_post with page post_type creates a page.
+	 */
+	public function test_handle_create_post_page_post_type() {
+		$result = PostAbilities::handle_create_post( [
+			'title'     => 'New Page',
+			'post_type' => 'page',
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'page', $result['post_type'] );
+	}
+
+	/**
+	 * Test handle_create_post with meta sets post meta.
+	 */
+	public function test_handle_create_post_sets_meta() {
+		$result = PostAbilities::handle_create_post( [
+			'title' => 'Post With Meta',
+			'meta'  => [ 'custom_key' => 'custom_value' ],
+		] );
+
+		$this->assertIsArray( $result );
+		$meta_value = get_post_meta( $result['post_id'], 'custom_key', true );
+		$this->assertSame( 'custom_value', $meta_value );
+	}
+
+	// ─── handle_update_post ───────────────────────────────────────
+
+	/**
+	 * Test handle_update_post with missing post_id returns WP_Error.
+	 */
+	public function test_handle_update_post_missing_post_id() {
+		$result = PostAbilities::handle_update_post( [] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_empty_post_id', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_update_post with non-existent post_id returns WP_Error.
+	 */
+	public function test_handle_update_post_not_found() {
+		$result = PostAbilities::handle_update_post( [ 'post_id' => 999999 ] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_post_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_update_post updates title.
+	 */
+	public function test_handle_update_post_updates_title() {
+		$post_id = $this->factory->post->create( [
+			'post_title'  => 'Original Title',
+			'post_status' => 'publish',
+		] );
+
+		$result = PostAbilities::handle_update_post( [
+			'post_id' => $post_id,
+			'title'   => 'Updated Title',
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $post_id, $result['post_id'] );
+
+		$updated_post = get_post( $post_id );
+		$this->assertSame( 'Updated Title', $updated_post->post_title );
+	}
+
+	/**
+	 * Test handle_update_post updates status.
+	 */
+	public function test_handle_update_post_updates_status() {
+		$post_id = $this->factory->post->create( [
+			'post_status' => 'draft',
+		] );
+
+		$result = PostAbilities::handle_update_post( [
+			'post_id' => $post_id,
+			'status'  => 'publish',
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'publish', $result['status'] );
+	}
+
+	/**
+	 * Test handle_update_post returns post_id, permalink, status.
+	 */
+	public function test_handle_update_post_returns_structure() {
+		$post_id = $this->factory->post->create( [ 'post_status' => 'draft' ] );
+
+		$result = PostAbilities::handle_update_post( [ 'post_id' => $post_id ] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'post_id', $result );
+		$this->assertArrayHasKey( 'permalink', $result );
+		$this->assertArrayHasKey( 'status', $result );
+	}
+
+	// ─── handle_delete_post ───────────────────────────────────────
+
+	/**
+	 * Test handle_delete_post with missing post_id returns WP_Error.
+	 */
+	public function test_handle_delete_post_missing_post_id() {
+		$result = PostAbilities::handle_delete_post( [] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_empty_post_id', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_delete_post with non-existent post_id returns WP_Error.
+	 */
+	public function test_handle_delete_post_not_found() {
+		$result = PostAbilities::handle_delete_post( [ 'post_id' => 999999 ] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_post_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_delete_post trashes post by default.
+	 */
+	public function test_handle_delete_post_trashes_by_default() {
+		$post_id = $this->factory->post->create( [
+			'post_title'  => 'Post To Trash',
+			'post_status' => 'publish',
+		] );
+
+		$result = PostAbilities::handle_delete_post( [ 'post_id' => $post_id ] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $post_id, $result['post_id'] );
+		$this->assertSame( 'trashed', $result['action'] );
+		$this->assertFalse( $result['force_delete'] );
+	}
+
+	/**
+	 * Test handle_delete_post with force_delete permanently deletes.
+	 */
+	public function test_handle_delete_post_force_delete() {
+		$post_id = $this->factory->post->create( [
+			'post_title'  => 'Post To Delete',
+			'post_status' => 'publish',
+		] );
+
+		$result = PostAbilities::handle_delete_post( [
+			'post_id'      => $post_id,
+			'force_delete' => true,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'permanently_deleted', $result['action'] );
+		$this->assertTrue( $result['force_delete'] );
+		$this->assertNull( get_post( $post_id ) );
+	}
+
+	/**
+	 * Test handle_delete_post returns title in result.
+	 */
+	public function test_handle_delete_post_returns_title() {
+		$post_id = $this->factory->post->create( [
+			'post_title'  => 'My Titled Post',
+			'post_status' => 'publish',
+		] );
+
+		$result = PostAbilities::handle_delete_post( [ 'post_id' => $post_id ] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'My Titled Post', $result['title'] );
+	}
+}

--- a/tests/GratisAiAgent/Abilities/SiteBuilderAbilitiesTest.php
+++ b/tests/GratisAiAgent/Abilities/SiteBuilderAbilitiesTest.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Test case for SiteBuilderAbilities class.
+ *
+ * @package GratisAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace GratisAiAgent\Tests\Abilities;
+
+use GratisAiAgent\Abilities\SiteBuilderAbilities;
+use WP_UnitTestCase;
+
+/**
+ * Test SiteBuilderAbilities handler methods.
+ */
+class SiteBuilderAbilitiesTest extends WP_UnitTestCase {
+
+	// ─── check_fresh_install ──────────────────────────────────────
+
+	/**
+	 * Test check_fresh_install returns expected structure.
+	 */
+	public function test_check_fresh_install_returns_structure() {
+		$result = SiteBuilderAbilities::check_fresh_install();
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'is_fresh', $result );
+		$this->assertArrayHasKey( 'post_count', $result );
+		$this->assertArrayHasKey( 'page_count', $result );
+		$this->assertArrayHasKey( 'has_custom_menu', $result );
+		$this->assertArrayHasKey( 'site_title', $result );
+		$this->assertArrayHasKey( 'has_default_title', $result );
+	}
+
+	/**
+	 * Test check_fresh_install is_fresh is boolean.
+	 */
+	public function test_check_fresh_install_is_fresh_is_bool() {
+		$result = SiteBuilderAbilities::check_fresh_install();
+
+		$this->assertIsBool( $result['is_fresh'] );
+	}
+
+	/**
+	 * Test check_fresh_install post_count and page_count are integers.
+	 */
+	public function test_check_fresh_install_counts_are_ints() {
+		$result = SiteBuilderAbilities::check_fresh_install();
+
+		$this->assertIsInt( $result['post_count'] );
+		$this->assertIsInt( $result['page_count'] );
+		$this->assertGreaterThanOrEqual( 0, $result['post_count'] );
+		$this->assertGreaterThanOrEqual( 0, $result['page_count'] );
+	}
+
+	/**
+	 * Test check_fresh_install with published posts marks site as not fresh.
+	 */
+	public function test_check_fresh_install_not_fresh_with_posts() {
+		// Create multiple published posts to exceed the "fresh" threshold.
+		$this->factory->post->create_many( 3, [ 'post_status' => 'publish' ] );
+
+		$result = SiteBuilderAbilities::check_fresh_install();
+
+		$this->assertFalse( $result['is_fresh'] );
+		$this->assertGreaterThanOrEqual( 3, $result['post_count'] );
+	}
+
+	/**
+	 * Test check_fresh_install has_custom_menu is boolean.
+	 */
+	public function test_check_fresh_install_has_custom_menu_is_bool() {
+		$result = SiteBuilderAbilities::check_fresh_install();
+
+		$this->assertIsBool( $result['has_custom_menu'] );
+	}
+
+	/**
+	 * Test check_fresh_install site_title is a string.
+	 */
+	public function test_check_fresh_install_site_title_is_string() {
+		$result = SiteBuilderAbilities::check_fresh_install();
+
+		$this->assertIsString( $result['site_title'] );
+	}
+
+	// ─── handle_detect_fresh_install ─────────────────────────────
+
+	/**
+	 * Test handle_detect_fresh_install returns expected structure.
+	 */
+	public function test_handle_detect_fresh_install_returns_structure() {
+		$result = SiteBuilderAbilities::handle_detect_fresh_install();
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'is_fresh', $result );
+		$this->assertArrayHasKey( 'post_count', $result );
+		$this->assertArrayHasKey( 'page_count', $result );
+		$this->assertArrayHasKey( 'has_custom_menu', $result );
+		$this->assertArrayHasKey( 'site_title', $result );
+		$this->assertArrayHasKey( 'message', $result );
+	}
+
+	/**
+	 * Test handle_detect_fresh_install message is a non-empty string.
+	 */
+	public function test_handle_detect_fresh_install_message_is_string() {
+		$result = SiteBuilderAbilities::handle_detect_fresh_install();
+
+		$this->assertIsString( $result['message'] );
+		$this->assertNotEmpty( $result['message'] );
+	}
+
+	// ─── handle_set_site_builder_mode ────────────────────────────
+
+	/**
+	 * Test handle_set_site_builder_mode enable returns success structure.
+	 */
+	public function test_handle_set_site_builder_mode_enable() {
+		$result = SiteBuilderAbilities::handle_set_site_builder_mode( [ 'enabled' => true ] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'success', $result );
+		$this->assertArrayHasKey( 'site_builder_mode', $result );
+		$this->assertArrayHasKey( 'message', $result );
+		$this->assertTrue( $result['success'] );
+		$this->assertTrue( $result['site_builder_mode'] );
+	}
+
+	/**
+	 * Test handle_set_site_builder_mode disable returns success structure.
+	 */
+	public function test_handle_set_site_builder_mode_disable() {
+		$result = SiteBuilderAbilities::handle_set_site_builder_mode( [ 'enabled' => false ] );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['success'] );
+		$this->assertFalse( $result['site_builder_mode'] );
+	}
+
+	/**
+	 * Test handle_set_site_builder_mode message is a non-empty string.
+	 */
+	public function test_handle_set_site_builder_mode_message_is_string() {
+		$result = SiteBuilderAbilities::handle_set_site_builder_mode( [ 'enabled' => true ] );
+
+		$this->assertIsString( $result['message'] );
+		$this->assertNotEmpty( $result['message'] );
+	}
+
+	// ─── handle_get_site_builder_status ──────────────────────────
+
+	/**
+	 * Test handle_get_site_builder_status returns expected structure.
+	 */
+	public function test_handle_get_site_builder_status_returns_structure() {
+		$result = SiteBuilderAbilities::handle_get_site_builder_status();
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'site_builder_mode', $result );
+		$this->assertArrayHasKey( 'onboarding_complete', $result );
+		$this->assertArrayHasKey( 'site_title', $result );
+		$this->assertArrayHasKey( 'site_url', $result );
+		$this->assertArrayHasKey( 'message', $result );
+	}
+
+	/**
+	 * Test handle_get_site_builder_status site_builder_mode is boolean.
+	 */
+	public function test_handle_get_site_builder_status_mode_is_bool() {
+		$result = SiteBuilderAbilities::handle_get_site_builder_status();
+
+		$this->assertIsBool( $result['site_builder_mode'] );
+		$this->assertIsBool( $result['onboarding_complete'] );
+	}
+
+	// ─── handle_complete_site_builder ────────────────────────────
+
+	/**
+	 * Test handle_complete_site_builder returns success structure.
+	 */
+	public function test_handle_complete_site_builder_returns_structure() {
+		$result = SiteBuilderAbilities::handle_complete_site_builder();
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'success', $result );
+		$this->assertArrayHasKey( 'message', $result );
+		$this->assertTrue( $result['success'] );
+	}
+
+	/**
+	 * Test handle_complete_site_builder disables site builder mode.
+	 */
+	public function test_handle_complete_site_builder_disables_mode() {
+		// First enable site builder mode.
+		SiteBuilderAbilities::handle_set_site_builder_mode( [ 'enabled' => true ] );
+
+		// Then complete it.
+		SiteBuilderAbilities::handle_complete_site_builder();
+
+		// Status should now show mode disabled and onboarding complete.
+		$status = SiteBuilderAbilities::handle_get_site_builder_status();
+		$this->assertFalse( $status['site_builder_mode'] );
+		$this->assertTrue( $status['onboarding_complete'] );
+	}
+}

--- a/tests/GratisAiAgent/Abilities/UserAbilitiesTest.php
+++ b/tests/GratisAiAgent/Abilities/UserAbilitiesTest.php
@@ -1,0 +1,299 @@
+<?php
+/**
+ * Test case for UserAbilities class.
+ *
+ * @package GratisAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace GratisAiAgent\Tests\Abilities;
+
+use GratisAiAgent\Abilities\UserAbilities;
+use WP_UnitTestCase;
+
+/**
+ * Test UserAbilities handler methods.
+ */
+class UserAbilitiesTest extends WP_UnitTestCase {
+
+	// ─── handle_list_users ────────────────────────────────────────
+
+	/**
+	 * Test handle_list_users returns expected structure.
+	 */
+	public function test_handle_list_users_returns_structure() {
+		$result = UserAbilities::handle_list_users( [] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'users', $result );
+		$this->assertArrayHasKey( 'total', $result );
+		$this->assertIsArray( $result['users'] );
+		$this->assertIsInt( $result['total'] );
+	}
+
+	/**
+	 * Test handle_list_users total matches users array count.
+	 */
+	public function test_handle_list_users_total_matches_count() {
+		$result = UserAbilities::handle_list_users( [] );
+
+		$this->assertSame( count( $result['users'] ), $result['total'] );
+	}
+
+	/**
+	 * Test handle_list_users each user has required fields.
+	 */
+	public function test_handle_list_users_user_structure() {
+		// Ensure at least one user exists.
+		$this->factory->user->create( [ 'role' => 'subscriber' ] );
+
+		$result = UserAbilities::handle_list_users( [] );
+
+		$this->assertNotEmpty( $result['users'] );
+		$user = $result['users'][0];
+		$this->assertArrayHasKey( 'id', $user );
+		$this->assertArrayHasKey( 'username', $user );
+		$this->assertArrayHasKey( 'email', $user );
+		$this->assertArrayHasKey( 'display_name', $user );
+		$this->assertArrayHasKey( 'roles', $user );
+		$this->assertArrayHasKey( 'registered', $user );
+	}
+
+	/**
+	 * Test handle_list_users with role filter returns only that role.
+	 */
+	public function test_handle_list_users_role_filter() {
+		$this->factory->user->create( [ 'role' => 'editor' ] );
+
+		$result = UserAbilities::handle_list_users( [ 'role' => 'editor' ] );
+
+		$this->assertIsArray( $result );
+		foreach ( $result['users'] as $user ) {
+			$this->assertContains( 'editor', $user['roles'] );
+		}
+	}
+
+	/**
+	 * Test handle_list_users limit is respected.
+	 */
+	public function test_handle_list_users_limit() {
+		$this->factory->user->create_many( 5 );
+
+		$result = UserAbilities::handle_list_users( [ 'limit' => 2 ] );
+
+		$this->assertLessThanOrEqual( 2, $result['total'] );
+	}
+
+	/**
+	 * Test handle_list_users limit is clamped to 100 maximum.
+	 */
+	public function test_handle_list_users_limit_clamped_max() {
+		$result = UserAbilities::handle_list_users( [ 'limit' => 9999 ] );
+
+		// Should not error — limit is clamped internally.
+		$this->assertIsArray( $result );
+		$this->assertLessThanOrEqual( 100, $result['total'] );
+	}
+
+	/**
+	 * Test handle_list_users with search term filters results.
+	 */
+	public function test_handle_list_users_search() {
+		$unique = 'uniqueuser_' . uniqid();
+		$this->factory->user->create( [
+			'user_login' => $unique,
+			'user_email' => $unique . '@example.com',
+		] );
+
+		$result = UserAbilities::handle_list_users( [ 'search' => $unique ] );
+
+		$this->assertGreaterThanOrEqual( 1, $result['total'] );
+	}
+
+	// ─── handle_create_user ───────────────────────────────────────
+
+	/**
+	 * Test handle_create_user with empty username returns WP_Error.
+	 */
+	public function test_handle_create_user_empty_username() {
+		$result = UserAbilities::handle_create_user( [
+			'username' => '',
+			'email'    => 'test@example.com',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_empty_username', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_create_user with invalid email returns WP_Error.
+	 */
+	public function test_handle_create_user_invalid_email() {
+		$result = UserAbilities::handle_create_user( [
+			'username' => 'testuser_' . uniqid(),
+			'email'    => 'not-an-email',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_invalid_email', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_create_user with duplicate username returns WP_Error.
+	 */
+	public function test_handle_create_user_duplicate_username() {
+		$username = 'dupuser_' . uniqid();
+		$this->factory->user->create( [
+			'user_login' => $username,
+			'user_email' => $username . '@example.com',
+		] );
+
+		$result = UserAbilities::handle_create_user( [
+			'username' => $username,
+			'email'    => 'other_' . uniqid() . '@example.com',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_username_exists', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_create_user with duplicate email returns WP_Error.
+	 */
+	public function test_handle_create_user_duplicate_email() {
+		$email = 'dupemail_' . uniqid() . '@example.com';
+		$this->factory->user->create( [
+			'user_login' => 'user_' . uniqid(),
+			'user_email' => $email,
+		] );
+
+		$result = UserAbilities::handle_create_user( [
+			'username' => 'newuser_' . uniqid(),
+			'email'    => $email,
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_email_exists', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_create_user with invalid role returns WP_Error.
+	 */
+	public function test_handle_create_user_invalid_role() {
+		$result = UserAbilities::handle_create_user( [
+			'username' => 'roleuser_' . uniqid(),
+			'email'    => 'roleuser_' . uniqid() . '@example.com',
+			'role'     => 'nonexistent_role',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_invalid_role', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_create_user with valid data creates user and returns structure.
+	 */
+	public function test_handle_create_user_returns_structure() {
+		$username = 'newuser_' . uniqid();
+		$email    = $username . '@example.com';
+
+		$result = UserAbilities::handle_create_user( [
+			'username' => $username,
+			'email'    => $email,
+			'role'     => 'subscriber',
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'user_id', $result );
+		$this->assertArrayHasKey( 'username', $result );
+		$this->assertArrayHasKey( 'email', $result );
+		$this->assertArrayHasKey( 'role', $result );
+		$this->assertArrayHasKey( 'display_name', $result );
+		$this->assertIsInt( $result['user_id'] );
+		$this->assertGreaterThan( 0, $result['user_id'] );
+		$this->assertSame( $username, $result['username'] );
+		$this->assertSame( $email, $result['email'] );
+		$this->assertSame( 'subscriber', $result['role'] );
+	}
+
+	// ─── handle_update_user_role ──────────────────────────────────
+
+	/**
+	 * Test handle_update_user_role with empty role returns WP_Error.
+	 */
+	public function test_handle_update_user_role_empty_role() {
+		$result = UserAbilities::handle_update_user_role( [ 'role' => '' ] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_empty_role', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_update_user_role with invalid role returns WP_Error.
+	 */
+	public function test_handle_update_user_role_invalid_role() {
+		$user_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+
+		$result = UserAbilities::handle_update_user_role( [
+			'user_id' => $user_id,
+			'role'    => 'nonexistent_role',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_invalid_role', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_update_user_role with no user identifier returns WP_Error.
+	 */
+	public function test_handle_update_user_role_user_not_found() {
+		$result = UserAbilities::handle_update_user_role( [
+			'role' => 'editor',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_user_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_update_user_role with valid user_id updates role.
+	 */
+	public function test_handle_update_user_role_by_user_id() {
+		$user_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+
+		$result = UserAbilities::handle_update_user_role( [
+			'user_id' => $user_id,
+			'role'    => 'editor',
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'user_id', $result );
+		$this->assertArrayHasKey( 'username', $result );
+		$this->assertArrayHasKey( 'previous_role', $result );
+		$this->assertArrayHasKey( 'new_role', $result );
+		$this->assertSame( $user_id, $result['user_id'] );
+		$this->assertSame( 'subscriber', $result['previous_role'] );
+		$this->assertSame( 'editor', $result['new_role'] );
+	}
+
+	/**
+	 * Test handle_update_user_role can resolve user by email.
+	 */
+	public function test_handle_update_user_role_by_email() {
+		$email   = 'rolebyemail_' . uniqid() . '@example.com';
+		$user_id = $this->factory->user->create( [
+			'user_email' => $email,
+			'role'       => 'author',
+		] );
+
+		$result = UserAbilities::handle_update_user_role( [
+			'user_email' => $email,
+			'role'       => 'editor',
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $user_id, $result['user_id'] );
+		$this->assertSame( 'editor', $result['new_role'] );
+	}
+}


### PR DESCRIPTION
## Summary

- Adds PHPUnit test coverage for 6 previously untested Ability classes: `PostAbilities`, `UserAbilities`, `MediaAbilities`, `AiImageAbilities`, `SiteBuilderAbilities`, and `EditorialAbilities`
- Each test file follows the existing pattern in `tests/GratisAiAgent/Abilities/` using `WP_UnitTestCase` with factory helpers
- Tests cover: input validation (WP_Error paths), handler return structure, key business logic, and edge cases

## Test Coverage

| Class | Tests | Assertions |
|-------|-------|-----------|
| PostAbilitiesTest | 25 | 73 |
| UserAbilitiesTest | 18 | 60 |
| MediaAbilitiesTest | 14 | 40 |
| AiImageAbilitiesTest | 8 | 14 |
| SiteBuilderAbilitiesTest | 15 | 53 |
| EditorialAbilitiesTest | 15 | 18 |
| **Total** | **95** | **258** |

4 tests skipped by design (guarded by `markTestSkipped` when `wp_ai_client_prompt` is available — the "no ai client" paths are tested in environments without the AI SDK).

## Runtime Testing

- **Level**: unit-tested
- **Risk**: low (test files only, no production code changes)
- **Smoke check**: All 95 tests pass in the wp-env Docker test container (PHPUnit 9.6.34, PHP 8.2)

## Files Changed

- `tests/GratisAiAgent/Abilities/PostAbilitiesTest.php` — 25 tests for post CRUD, validation, meta
- `tests/GratisAiAgent/Abilities/UserAbilitiesTest.php` — 18 tests for user listing, creation, role updates
- `tests/GratisAiAgent/Abilities/MediaAbilitiesTest.php` — 14 tests for media listing, upload, deletion
- `tests/GratisAiAgent/Abilities/AiImageAbilitiesTest.php` — 8 tests for AI image generation validation
- `tests/GratisAiAgent/Abilities/SiteBuilderAbilitiesTest.php` — 15 tests for fresh install detection, mode management
- `tests/GratisAiAgent/Abilities/EditorialAbilitiesTest.php` — 15 tests for title/excerpt/summary/review-block handlers

Closes #687


---
[aidevops.sh](https://aidevops.sh) v3.5.179 plugin for [OpenCode](https://opencode.ai) v1.3.0 with claude-sonnet-4-6 spent 11m and 30,345 tokens on this as a headless worker.