### PR TITLE
GH#713: fix(tests): neutralize header warnings in SseStreamerTest capture() helper

### DIFF
--- a/tests/GratisAiAgent/REST/SseStreamerTest.php
+++ b/tests/GratisAiAgent/REST/SseStreamerTest.php
@@ -44,12 +44,29 @@ class SseStreamerTest extends WP_UnitTestCase {
 	/**
 	 * Capture output produced by a callable.
 	 *
+	 * Installs a temporary error handler that silences PHP warnings about
+	 * headers already being sent (e.g. from SseStreamer::start() in CLI mode)
+	 * so that assertions can run without the test suite failing on those
+	 * warnings. All other errors are passed through to the previous handler.
+	 *
 	 * @param callable $fn The callable to execute.
 	 * @return string Captured output.
 	 */
 	private function capture( callable $fn ): string {
 		ob_start();
-		$fn();
+		set_error_handler(
+			static function ( int $severity, string $message ): bool {
+				return E_WARNING === $severity
+					&& str_contains( $message, 'Cannot modify header information' );
+			}
+		);
+
+		try {
+			$fn();
+		} finally {
+			restore_error_handler();
+		}
+
 		return (string) ob_get_clean();
 	}
 


### PR DESCRIPTION
## Summary

Addresses the critical CodeRabbit review finding from PR #702 on `tests/GratisAiAgent/REST/SseStreamerTest.php`.

The `capture()` helper only buffered output but did not suppress PHP warnings from `SseStreamer::start()` about headers already being sent. In a CLI/PHPUnit environment this caused all tests to fail with `Cannot modify header information — headers already sent`.

**Fix:** Install a narrowly-scoped temporary error handler around the callable invocation that silences only `E_WARNING` messages containing `"Cannot modify header information"`, then restore the previous handler in a `finally` block so no other errors are hidden.

## Changes

- `tests/GratisAiAgent/REST/SseStreamerTest.php` — updated `capture()` to wrap `$fn()` in `set_error_handler()` / `try-finally` / `restore_error_handler()` pattern

## Runtime Testing

**Risk level:** Low (test file only, no production code changed)
**Verification:** `self-assessed` — PHP syntax check passes (`php -l`). The fix exactly matches the proposed diff from the CodeRabbit review comment.

## Key Decisions

- Error handler is narrowly scoped: only silences `E_WARNING` with `"Cannot modify header information"` substring — all other errors pass through
- `restore_error_handler()` in `finally` guarantees cleanup even if `$fn()` throws
- `ob_get_clean()` called after `finally` so output buffer is always flushed

Closes #713

---
[aidevops.sh](https://aidevops.sh) v3.5.747 plugin for [OpenCode](https://opencode.ai) v1.3.0 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test stability by improving error handling in the test suite to reliably suppress header-related warnings during test execution while preserving other error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->