### PR TITLE
qd-712: fix(tests): prime quota via log_usage() in test_proxy_quota_exceeded_returns_429

### DIFF
--- a/tests/GratisAiAgent/REST/ResaleApiControllerTest.php
+++ b/tests/GratisAiAgent/REST/ResaleApiControllerTest.php
@@ -556,12 +556,15 @@ class ResaleApiControllerTest extends WP_UnitTestCase {
 
 		$api_key   = 'gaa_' . wp_generate_password( 32, false );
 		$client_id = $this->create_test_client( [
-			'api_key'                => $api_key,
-			'enabled'                => 1,
-			'monthly_token_quota'    => 100,
-			'tokens_used_this_month' => 100,
-			'quota_reset_at'         => gmdate( 'Y-m-d H:i:s', strtotime( '+1 month' ) ),
+			'api_key'             => $api_key,
+			'enabled'             => 1,
+			'monthly_token_quota' => 100,
 		] );
+
+		// Prime the quota: create_client() starts tokens_used_this_month at 0.
+		// Use log_usage() to record 100 tokens so the quota is fully exhausted
+		// before the proxy request, ensuring the controller returns 429.
+		ResaleApiDatabase::log_usage( $client_id, 'openai', 'gpt-4o', 50, 50, 0.0, 'success', '', 100 );
 
 		$response = $this->dispatch(
 			'POST',


### PR DESCRIPTION
## Summary

- Fixes the critical CodeRabbit finding from PR #702: `test_proxy_quota_exceeded_returns_429` was getting HTTP 502 instead of 429 because `ResaleApiDatabase::create_client()` always starts `tokens_used_this_month` at 0, ignoring the value passed in the input array.
- Removes `tokens_used_this_month` and `quota_reset_at` from the `create_test_client()` call and instead calls `ResaleApiDatabase::log_usage()` after creation to prime the quota to 100 tokens via the UPDATE path.
- Also resolves the PHPMD `UnusedLocalVariable` warning on `$client_id` (line 558) by using it in the `log_usage()` call.

## What changed

- `tests/GratisAiAgent/REST/ResaleApiControllerTest.php` — `test_proxy_quota_exceeded_returns_429()`: replaced direct `tokens_used_this_month` insert (which was silently ignored) with a `ResaleApiDatabase::log_usage()` call that correctly increments the counter via SQL UPDATE.

## Root cause

`create_client()` builds its insert array with `'tokens_used_this_month' => (int) ( $data['tokens_used_this_month'] ?? 0 )` but the DB column has `DEFAULT 0` and the insert was not persisting the value as expected in the test environment. Using `log_usage()` (which does `tokens_used_this_month = tokens_used_this_month + %d`) is the correct and reliable way to set usage.

## Runtime Testing

**Risk level**: Low — test file only, no production code changed.
**Verification**: PHP syntax check passed (`php -l`). CI will run PHPUnit.

## Closes

Closes #712

---
[aidevops.sh](https://aidevops.sh) v3.5.747 plugin for [OpenCode](https://opencode.ai) v1.3.0 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored quota validation test to use realistic test setup approach while maintaining the same validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->