### PR TITLE
qd-715: fix test_create_webhook_defaults_enabled to exercise production default

### DIFF
--- a/tests/GratisAiAgent/REST/WebhookDatabaseTest.php
+++ b/tests/GratisAiAgent/REST/WebhookDatabaseTest.php
@@ -122,11 +122,18 @@ class WebhookDatabaseTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * create_webhook defaults enabled to 1.
+	 * create_webhook defaults enabled to 1 when not supplied.
+	 *
+	 * Calls WebhookDatabase::create_webhook() directly without an 'enabled'
+	 * key so the production default — not the test fixture — is exercised.
 	 */
 	public function test_create_webhook_defaults_enabled(): void {
-		$id      = $this->create_webhook();
-		$webhook = WebhookDatabase::get_webhook( $id );
+		$id = WebhookDatabase::create_webhook( [
+			'name'   => 'Stored Name Webhook',
+			'secret' => 'wh_' . wp_generate_password( 32, false ),
+		] );
+		$this->assertNotFalse( $id );
+		$webhook = WebhookDatabase::get_webhook( (int) $id );
 		$this->assertNotNull( $webhook );
 		$this->assertSame( '1', (string) $webhook->enabled );
 	}


### PR DESCRIPTION
## Summary

- `test_create_webhook_defaults_enabled()` previously called the `create_webhook()` helper which always passes `'enabled' => 1`, meaning the test never exercised the production default — it only verified that a value you explicitly set gets stored.
- Fix: call `WebhookDatabase::create_webhook()` directly without an `'enabled'` key so the DB-level `DEFAULT 1` is what sets the value, not the test fixture.
- Addresses CodeRabbit finding from PR #702 review.

## Files Changed

- `tests/GratisAiAgent/REST/WebhookDatabaseTest.php` — `test_create_webhook_defaults_enabled()` rewritten to bypass helper

## Testing

- PHPCS: passes with zero violations
- PHPStan: pre-existing errors only (WordPress stubs not fully configured); no new errors introduced by this change
- Risk level: Low (test-only change, no production code modified)

## Runtime Testing

**Risk: Low** — test file only, no production code changed. Self-assessed.

Closes #715

---
[aidevops.sh](https://aidevops.sh) v3.5.784 plugin for [OpenCode](https://opencode.ai) v1.3.0 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved webhook creation test to directly verify that the `enabled` field defaults to the expected value when not explicitly provided during webhook creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->