### PR TITLE
GH#711: fix(db): clamp tokens_used_this_month to non-negative before insert

### DIFF
--- a/includes/REST/ResaleApiDatabase.php
+++ b/includes/REST/ResaleApiDatabase.php
@@ -156,7 +156,7 @@ CREATE TABLE {$usage_table} (
 			// @phpstan-ignore-next-line
 			'monthly_token_quota'    => (int) ( $data['monthly_token_quota'] ?? 0 ),
 			// @phpstan-ignore-next-line
-			'tokens_used_this_month' => (int) ( $data['tokens_used_this_month'] ?? 0 ),
+			'tokens_used_this_month' => max( 0, (int) ( $data['tokens_used_this_month'] ?? 0 ) ),
 			'quota_reset_at'         => $data['quota_reset_at'] ?? null,
 			'allowed_models'         => wp_json_encode( $data['allowed_models'] ?? [] ),
 			// @phpstan-ignore-next-line


### PR DESCRIPTION
## Summary

- Clamps `tokens_used_this_month` to `max(0, ...)` before inserting into the usage table
- The column is `UNSIGNED` in schema; negative values cause DB-level failures or silent coercion depending on SQL mode
- One-line fix matching the CodeRabbit suggestion from PR #702

Closes #711

---
[aidevops.sh](https://aidevops.sh) v3.5.809 plugin for [OpenCode](https://opencode.ai) v1.3.0 with claude-sonnet-4-6 Overall, 4h 35m since this issue was created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved token usage data validation to prevent negative values from being recorded, ensuring accurate monthly token usage tracking and maintaining data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->