### PR TITLE
GH#716: fix ineffective tautology assertion in deny-all test

### DIFF
--- a/tests/GratisAiAgent/Core/RolePermissionsTest.php
+++ b/tests/GratisAiAgent/Core/RolePermissionsTest.php
@@ -366,20 +366,22 @@ class RolePermissionsTest extends WP_UnitTestCase {
 	 * Test user with no matching role config gets empty array (deny all).
 	 */
 	public function test_user_with_no_role_config_gets_empty_array(): void {
-		// Clear all saved permissions so no role matches.
-		update_option( RolePermissions::OPTION_NAME, [] );
+		// Use a custom role that exists in neither defaults nor saved options.
+		// get_allowed_abilities_for_current_user() returns [] (deny all) when
+		// no role config is found for the current user's roles.
+		$custom_role = 'custom_no_config_role';
+		add_role( $custom_role, 'Custom No Config Role' );
 
-		// Create a user with a role that has no config.
-		$user_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		$user_id = $this->factory->user->create( [ 'role' => $custom_role ] );
 		wp_set_current_user( $user_id );
 
-		// Subscriber has no config in empty saved options, defaults give chat_access=false.
-		// get_allowed_abilities should return [] (deny all) since no role config found.
 		$allowed = RolePermissions::get_allowed_abilities_for_current_user();
 
-		// Either null (unrestricted via defaults) or empty array (deny all).
-		// With empty saved options, defaults apply: subscriber has empty allowed_abilities = unrestricted.
-		$this->assertTrue( null === $allowed || is_array( $allowed ) );
+		// No matching role config → deny-all: must return an empty array, not null.
+		$this->assertSame( [], $allowed );
+
+		// Clean up the custom role.
+		remove_role( $custom_role );
 	}
 
 	// ── current_user_can_use_ability ──────────────────────────────────────


### PR DESCRIPTION
## Summary

- Replaces `assertTrue(null === $allowed || is_array($allowed))` with `assertSame([], $allowed)` — the former is a near-tautology that never verified the deny-all behavior
- Fixes the test setup: was using `subscriber` (which exists in defaults with `allowed_abilities: []`, returning `null`/unrestricted), now uses a custom role absent from both defaults and saved options so the no-matching-role-config path is actually exercised
- The deny-all path in `get_allowed_abilities_for_current_user()` (line 218-220) returns `[]` when `$has_restriction` is false; the old test never reached this path

## Files Changed

- `tests/GratisAiAgent/Core/RolePermissionsTest.php` — `test_user_with_no_role_config_gets_empty_array`

## Runtime Testing

Risk: **Low** — test file only, no production code changed.
Verification: `self-assessed` — PHP syntax clean (`php -l`), logic verified against `RolePermissions::get_allowed_abilities_for_current_user()` implementation.

Closes #716

---
[aidevops.sh](https://aidevops.sh) v3.5.811 plugin for [OpenCode](https://opencode.ai) v1.3.0 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test strictness for role permissions behavior to explicitly verify that an empty array is returned when no matching role configuration exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->