### PR TITLE
GH#714: fix(tests): assert prompt-template interpolation in test_trigger_uses_prompt_template

### DIFF
--- a/tests/GratisAiAgent/REST/WebhookControllerTest.php
+++ b/tests/GratisAiAgent/REST/WebhookControllerTest.php
@@ -653,8 +653,9 @@ class WebhookControllerTest extends WP_UnitTestCase {
 	/**
 	 * POST /webhook/trigger with prompt template interpolates {{message}}.
 	 *
-	 * Verifies the async dispatch path is taken (202) when a prompt template
-	 * is configured and no raw message is provided.
+	 * Verifies that the stored job message equals the rendered template
+	 * (e.g. 'Summarise: some content') rather than the raw input, ensuring
+	 * {{message}} placeholder substitution actually occurs.
 	 */
 	public function test_trigger_uses_prompt_template(): void {
 		wp_set_current_user( 0 );
@@ -675,5 +676,11 @@ class WebhookControllerTest extends WP_UnitTestCase {
 			[ 'X-Webhook-Secret' => $webhook['secret'] ]
 		);
 		$this->assertStatus( 202, $response );
+
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'job_id', $data );
+		$job = get_transient( WebhookController::JOB_PREFIX . $data['job_id'] );
+		$this->assertIsArray( $job );
+		$this->assertSame( 'Summarise: some content', $job['params']['message'] );
 	}
 }


### PR DESCRIPTION
## Summary

- Fixes `test_trigger_uses_prompt_template` which previously only asserted the 202 async path — a regression where `{{message}}` is never rendered would still pass
- Now reads the queued job via `job_id` from the response and asserts `$job['params']['message'] === 'Summarise: some content'`, verifying actual template interpolation
- Implements the exact diff suggested by CodeRabbit in PR #702

## Changes

- `tests/GratisAiAgent/REST/WebhookControllerTest.php`: Added 3 assertions after the existing `assertStatus(202)` — extract `job_id`, fetch transient via `WebhookController::JOB_PREFIX`, assert rendered message

## Runtime Testing

Risk level: **Low** — test file only, no production code changed. `self-assessed`.

PHP syntax verified: `php -l` passes with no errors.

Closes #714

---
[aidevops.sh](https://aidevops.sh) v3.5.836 plugin for [OpenCode](https://opencode.ai) v1.3.0 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test validation for prompt template interpolation, ensuring correct message rendering in asynchronous job processing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->