### PR TITLE
GH#740: Fix systemic CI failures: remove deleted compat paths + drop WP 6.9 matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,15 +11,14 @@ jobs:
   phpunit:
     name: PHPUnit (WP ${{ matrix.wp }})
     runs-on: ubuntu-latest
-    # WP trunk may fail due to PSR namespace conflicts between our compat
-    # layer and core's native AI Client SDK. This is expected until WP 7.0
-    # stabilizes its API and we can align our Composer dependencies.
+    # Plugin requires WP 7.0+; trunk is the only pre-release target.
+    # Allow trunk failures since the API may still be in flux.
     continue-on-error: ${{ matrix.wp == 'trunk' }}
 
     strategy:
       fail-fast: false
       matrix:
-        wp: ['6.9', 'trunk']
+        wp: ['trunk']
 
     services:
       mariadb:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,16 +7,12 @@ parameters:
 		- includes
 		- gratis-ai-agent.php
 	excludePaths:
-		- compat
 		- includes/CLI
 	scanDirectories:
 		- vendor/wordpress/php-ai-client/src
 	bootstrapFiles:
 		- vendor/autoload.php
 	scanFiles:
-		- compat/abilities-api/class-abstract-ability.php
-		- compat/ai-client/class-wp-ai-client-prompt-builder.php
-		- compat/ai-client.php
 		- vendor/php-stubs/woocommerce-stubs/woocommerce-stubs.php
 	treatPhpDocTypesAsCertain: false
 	reportUnmatchedIgnoredErrors: false


### PR DESCRIPTION
## Summary

- **PHPStan fix**: Remove `compat/` from `excludePaths` and `scanFiles` in `phpstan.neon`. The directory was deleted in t144 work; PHPStan was exiting with `Invalid entry in excludePaths: Path ".../compat" is neither a directory, nor a file path, nor a fnmatch pattern.`
- **PHPUnit matrix fix**: Remove `'6.9'` from the test matrix in `.github/workflows/tests.yml`. The plugin now requires WP 7.0+; the AI Client SDK is unavailable on WP 6.9, causing `AgentLoopTest` and `ImageAbilitiesTest` to fail with `gratis_ai_agent_missing_client` WP_Error and undefined `Settings::PAGE_SLUG` constant.

## Files Changed

- `phpstan.neon` — removed `compat` excludePath and 3 `scanFiles` entries pointing to deleted compat files
- `.github/workflows/tests.yml` — matrix reduced from `['6.9', 'trunk']` to `['trunk']`; updated comment to reflect WP 7.0+ requirement

## Runtime Testing

**Risk level: Low** — CI config and PHPStan config only. No PHP code changes. Changes are self-assessed; CI will provide runtime verification on this PR.

## Key Decisions

- Removed `compat` entries entirely rather than marking optional with `(?)` — the directory is gone and won't return; optional markers would leave dead config.
- Kept `trunk` in the matrix with `continue-on-error: true` since WP trunk API may still be in flux.
- `reportUnmatchedIgnoredErrors: false` is already set in phpstan.neon, so the remaining `WP_AI_Client_Ability_Function_Resolver` ignoreErrors entries are harmless (they match nothing but don't cause failures).

Closes #740

---
[aidevops.sh](https://aidevops.sh) v3.6.19 plugin for [OpenCode](https://opencode.ai) v1.3.0 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI testing configuration to reflect WordPress compatibility requirements.
  * Refined static analysis configuration for improved code coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->