### PR TITLE
fix: resolve PHPStan errors after RestController split

### DIFF
--- a/includes/REST/PermissionTrait.php
+++ b/includes/REST/PermissionTrait.php
@@ -15,9 +15,6 @@ use GratisAiAgent\Core\RolePermissions;
 use WP_Error;
 use WP_REST_Request;
 
-/**
- * @property Database $database Injected database dependency (required by session permission methods).
- */
 trait PermissionTrait {
 
 	/**
@@ -74,7 +71,7 @@ trait PermissionTrait {
 		}
 
 		$session_id = self::get_int_param( $request, 'id' );
-		$session    = $this->database->get_session( $session_id );
+		$session    = Database::get_session( $session_id );
 
 		if ( ! $session ) {
 			return false;
@@ -115,7 +112,7 @@ trait PermissionTrait {
 		}
 
 		$session_id = self::get_int_param( $request, 'id' );
-		$session    = $this->database->get_session( $session_id );
+		$session    = Database::get_session( $session_id );
 
 		if ( ! $session ) {
 			return false;

--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -54,22 +54,7 @@ class RestController {
 	 */
 	const JOB_TTL = 600;
 
-	/** @var Settings Injected settings dependency. */
-	private Settings $settings;
 
-	/** @var Database Injected database dependency. */
-	private Database $database;
-
-	/**
-	 * Constructor — accepts injected dependencies for testability.
-	 *
-	 * @param Settings|null $settings  Settings service (defaults to new Settings()).
-	 * @param Database|null $database  Database service (defaults to new Database()).
-	 */
-	public function __construct( ?Settings $settings = null, ?Database $database = null ) {
-		$this->settings = $settings ?? new Settings();
-		$this->database = $database ?? new Database();
-	}
 
 	/**
 	 * Register REST routes.

--- a/vendor
+++ b/vendor
@@ -1,0 +1,1 @@
+/home/dave/tgc.church/site/web/app/plugins/ai-agent/vendor


### PR DESCRIPTION
Fixes PHPStan failures introduced by the RestController split (t145).

- Remove @property Database docblock from PermissionTrait — caused PHPStan to flag all 7 trait-using controllers as missing the property
- Replace $this->database->get_session() with Database::get_session() in PermissionTrait (method is static)
- Remove unused $database property and constructor from RestController

PHPStan: 0 errors at level 10.

The WP trunk PHPUnit failure is a pre-existing WP 7.0 RC2 core bug (PSR interface mismatch in wp-includes/ai-client) — already marked continue-on-error in CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal session handling and dependency management architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->