### PR TITLE
GH#769: chore: remove stale vendor git tracking entry (gitignored)

### DIFF
--- a/vendor
+++ b/vendor
@@ -1,1 +1,0 @@
-/home/dave/tgc.church/site/web/app/plugins/ai-agent/vendor


### PR DESCRIPTION
## Summary

- Runs `git rm --cached vendor` to remove the stale vendor symlink from the git index
- The vendor directory is gitignored; it was left tracked after commit 7b10461 removed php-ai-client from composer.json/lock
- No files are deleted from disk — only the index entry is removed

Closes #769


---
[aidevops.sh](https://aidevops.sh) v3.6.88 plugin for [OpenCode](https://opencode.ai) v1.3.0 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused vendor reference from the AI agent plugin directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->