### PR TITLE
GH#776: chore: document vendor/ gitignore entry (quality-debt close)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+# Composer dependencies — managed locally, not committed (see PR #770)
 vendor/
 .agents/loop-state/
 .phpunit.result.cache


### PR DESCRIPTION
## Summary

- Adds a clarifying comment to `.gitignore` documenting why `vendor/` is excluded
- The underlying vendor path artifact (CodeRabbit finding from PR #747) was already removed from git tracking in PR #770 (`git rm --cached vendor`)
- This commit provides an explicit audit trail closing the quality-debt issue

## What was the problem

CodeRabbit flagged in PR #747 review that a `vendor` path artifact (developer-machine absolute path) was accidentally included in the commit, potentially shadowing the real `vendor/` directory. Two remediation steps were required:
1. Remove the artifact from git tracking — **done in PR #770**
2. Ensure `.gitignore` prevents future commits of such artifacts — **`vendor/` was already in `.gitignore`**

## Verification

```
$ git ls-files vendor
(empty — vendor is not tracked)

$ grep vendor .gitignore
# Composer dependencies — managed locally, not committed (see PR #770)
vendor/
```

## Runtime Testing

**Risk level**: Low — documentation/comment change only, no functional code modified.
**Assessment**: self-assessed

Closes #776

---
[aidevops.sh](https://aidevops.sh) v3.6.93 plugin for [OpenCode](https://opencode.ai) v1.3.0 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration documentation to clarify dependency management approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->