### PR TITLE
GH#780: fix jsx-a11y/label-has-associated-control on 12 labels

### DIFF
--- a/src/components/model-pricing-selector.js
+++ b/src/components/model-pricing-selector.js
@@ -441,6 +441,7 @@ export function ModelPricingHint( { modelId } ) {
  * and renders a pricing badge below the selector for the selected model.
  *
  * @param {Object}   props              - Component props.
+ * @param {string}   props.id           - ID forwarded to the underlying SelectControl.
  * @param {string}   props.label        - SelectControl label.
  * @param {string}   props.value        - Currently selected model ID.
  * @param {Array}    props.models       - Models from the REST API.
@@ -449,6 +450,7 @@ export function ModelPricingHint( { modelId } ) {
  * @return {JSX.Element} Model selector with pricing hints.
  */
 export default function ModelPricingSelector( {
+	id,
 	label,
 	value,
 	models,
@@ -472,6 +474,7 @@ export default function ModelPricingSelector( {
 	return (
 		<div className="gratis-ai-agent-model-pricing-selector">
 			<SelectControl
+				id={ id }
 				label={ label }
 				value={ value }
 				options={ options }

--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -388,7 +388,7 @@ export default function SettingsApp() {
 											<tbody>
 												<tr>
 													<th scope="row">
-														<label>
+														<label htmlFor="gratis-default-provider">
 															{ __(
 																'Default Provider',
 																'gratis-ai-agent'
@@ -397,6 +397,7 @@ export default function SettingsApp() {
 													</th>
 													<td>
 														<SelectControl
+															id="gratis-default-provider"
 															value={
 																local.default_provider
 															}
@@ -415,7 +416,7 @@ export default function SettingsApp() {
 												</tr>
 												<tr>
 													<th scope="row">
-														<label>
+														<label htmlFor="gratis-default-model">
 															{ __(
 																'Default Model',
 																'gratis-ai-agent'
@@ -424,6 +425,7 @@ export default function SettingsApp() {
 													</th>
 													<td>
 														<ModelPricingSelector
+															id="gratis-default-model"
 															value={
 																local.default_model
 															}
@@ -724,7 +726,7 @@ export default function SettingsApp() {
 											<tbody>
 												<tr>
 													<th scope="row">
-														<label>
+														<label htmlFor="gratis-image-size">
 															{ __(
 																'Default Image Size',
 																'gratis-ai-agent'
@@ -733,6 +735,7 @@ export default function SettingsApp() {
 													</th>
 													<td>
 														<SelectControl
+															id="gratis-image-size"
 															value={
 																local.image_generation_size ||
 																'1024x1024'
@@ -776,7 +779,7 @@ export default function SettingsApp() {
 												</tr>
 												<tr>
 													<th scope="row">
-														<label>
+														<label htmlFor="gratis-image-quality">
 															{ __(
 																'Default Image Quality',
 																'gratis-ai-agent'
@@ -785,6 +788,7 @@ export default function SettingsApp() {
 													</th>
 													<td>
 														<SelectControl
+															id="gratis-image-quality"
 															value={
 																local.image_generation_quality ||
 																'standard'
@@ -821,7 +825,7 @@ export default function SettingsApp() {
 												</tr>
 												<tr>
 													<th scope="row">
-														<label>
+														<label htmlFor="gratis-image-style">
 															{ __(
 																'Default Image Style',
 																'gratis-ai-agent'
@@ -830,6 +834,7 @@ export default function SettingsApp() {
 													</th>
 													<td>
 														<SelectControl
+															id="gratis-image-style"
 															value={
 																local.image_generation_style ||
 																'vivid'
@@ -959,7 +964,7 @@ export default function SettingsApp() {
 												</tr>
 												<tr>
 													<th scope="row">
-														<label>
+														<label htmlFor="gratis-budget-warning-threshold">
 															{ __(
 																'Warning Threshold (%)',
 																'gratis-ai-agent'
@@ -968,6 +973,7 @@ export default function SettingsApp() {
 													</th>
 													<td>
 														<RangeControl
+															id="gratis-budget-warning-threshold"
 															value={
 																local.budget_warning_threshold ??
 																80
@@ -990,7 +996,7 @@ export default function SettingsApp() {
 												</tr>
 												<tr>
 													<th scope="row">
-														<label>
+														<label htmlFor="gratis-budget-exceeded-action">
 															{ __(
 																'Action When Budget Exceeded',
 																'gratis-ai-agent'
@@ -999,6 +1005,7 @@ export default function SettingsApp() {
 													</th>
 													<td>
 														<SelectControl
+															id="gratis-budget-exceeded-action"
 															value={
 																local.budget_exceeded_action ||
 																'pause'
@@ -1083,7 +1090,7 @@ export default function SettingsApp() {
 													{ ttsVoices.length > 0 && (
 														<tr>
 															<th scope="row">
-																<label>
+																<label htmlFor="gratis-tts-voice">
 																	{ __(
 																		'Voice',
 																		'gratis-ai-agent'
@@ -1092,6 +1099,7 @@ export default function SettingsApp() {
 															</th>
 															<td>
 																<SelectControl
+																	id="gratis-tts-voice"
 																	value={
 																		ttsVoiceURI
 																	}
@@ -1126,7 +1134,7 @@ export default function SettingsApp() {
 													) }
 													<tr>
 														<th scope="row">
-															<label>
+															<label htmlFor="gratis-tts-rate">
 																{ __(
 																	'Speech Rate',
 																	'gratis-ai-agent'
@@ -1135,6 +1143,7 @@ export default function SettingsApp() {
 														</th>
 														<td>
 															<RangeControl
+																id="gratis-tts-rate"
 																value={
 																	ttsRate
 																}
@@ -1153,7 +1162,7 @@ export default function SettingsApp() {
 													</tr>
 													<tr>
 														<th scope="row">
-															<label>
+															<label htmlFor="gratis-tts-pitch">
 																{ __(
 																	'Pitch',
 																	'gratis-ai-agent'
@@ -1162,6 +1171,7 @@ export default function SettingsApp() {
 														</th>
 														<td>
 															<RangeControl
+																id="gratis-tts-pitch"
 																value={
 																	ttsPitch
 																}
@@ -1513,7 +1523,7 @@ export default function SettingsApp() {
 											<tbody>
 												<tr>
 													<th scope="row">
-														<label>
+														<label htmlFor="gratis-temperature">
 															{ __(
 																'Temperature',
 																'gratis-ai-agent'
@@ -1522,6 +1532,7 @@ export default function SettingsApp() {
 													</th>
 													<td>
 														<RangeControl
+															id="gratis-temperature"
 															value={
 																local.temperature
 															}
@@ -1620,7 +1631,7 @@ export default function SettingsApp() {
 											<tbody>
 												<tr>
 													<th scope="row">
-														<label>
+														<label htmlFor="gratis-tool-discovery-mode">
 															{ __(
 																'Discovery Mode',
 																'gratis-ai-agent'
@@ -1629,6 +1640,7 @@ export default function SettingsApp() {
 													</th>
 													<td>
 														<SelectControl
+															id="gratis-tool-discovery-mode"
 															value={
 																local.tool_discovery_mode ||
 																'auto'


### PR DESCRIPTION
## Summary

- Adds `htmlFor` prop to 12 bare `<label>` elements in `src/settings-page/settings-app.js` that were missing association with their controls
- Adds matching `id` prop to each associated `SelectControl`, `RangeControl`, or `ModelPricingSelector`
- Adds `id` prop forwarding to `ModelPricingSelector` component so the underlying `SelectControl` receives it

## Controls fixed

| Label | Control type | ID |
|---|---|---|
| Default Provider | SelectControl | `gratis-default-provider` |
| Default Model | ModelPricingSelector → SelectControl | `gratis-default-model` |
| Default Image Size | SelectControl | `gratis-image-size` |
| Default Image Quality | SelectControl | `gratis-image-quality` |
| Default Image Style | SelectControl | `gratis-image-style` |
| Warning Threshold (%) | RangeControl | `gratis-budget-warning-threshold` |
| Action When Budget Exceeded | SelectControl | `gratis-budget-exceeded-action` |
| Voice | SelectControl | `gratis-tts-voice` |
| Speech Rate | RangeControl | `gratis-tts-rate` |
| Pitch | RangeControl | `gratis-tts-pitch` |
| Temperature | RangeControl | `gratis-temperature` |
| Discovery Mode | SelectControl | `gratis-tool-discovery-mode` |

## Verification

`npm run lint:js` exits 0 with no `jsx-a11y/label-has-associated-control` errors.

Closes #780


---
[aidevops.sh](https://aidevops.sh) v3.6.96 plugin for [OpenCode](https://opencode.ai) v1.3.0 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced accessibility throughout the settings interface by establishing proper connections between form labels and their corresponding controls.
  * Updated component structure to support improved accessibility features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->