### PR TITLE
GH#792: fix(ci): PHPCS whitespace alignment violations in CliCommand and SessionController

### DIFF
--- a/includes/CLI/CliCommand.php
+++ b/includes/CLI/CliCommand.php
@@ -164,7 +164,7 @@ class CliCommand extends \WP_CLI_Command {
 			/** @var list<array<string, mixed>> $result_history */
 			$result_history = $result['history'] ?? [];
 			$history        = AgentLoop::deserialize_history( array_values( $result_history ) );
-			$remaining = $result['iterations_remaining'] ?? $max_iterations;
+			$remaining      = $result['iterations_remaining'] ?? $max_iterations;
 
 			$resume_options                  = $options;
 			$resume_options['tool_call_log'] = $result['tool_call_log'] ?? [];

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -1220,7 +1220,7 @@ class SessionController {
 			$state     = $job['confirmation_state'] ?? array();
 
 			/** @var list<array<string, mixed>> $state_history */
-			$state_history  = $state['history'] ?? array();
+			$state_history = $state['history'] ?? array();
 			try {
 				$resume_history = AgentLoop::deserialize_history( array_values( $state_history ) );
 			} catch ( \Exception $e ) {


### PR DESCRIPTION
## Summary

Fixes two PHPCS whitespace alignment warnings that were causing CI to fail on `main` with exit code 2.

## Changes

- `includes/CLI/CliCommand.php:167` — equals sign alignment corrected (expected 6 spaces, found 1)
- `includes/REST/SessionController.php:1223` — equals sign alignment corrected (expected 1 space, found 2)

Both violations were auto-fixed by `./vendor/bin/phpcbf`.

## Verification

`./vendor/bin/phpcs includes/CLI/CliCommand.php includes/REST/SessionController.php` exits 0 with no warnings.

## Runtime Testing

**Risk level:** Low — whitespace-only formatting changes, no logic modified.
**Testing:** `self-assessed` — ran `phpcs` locally, exits 0 with no violations.

Closes #792

---
[aidevops.sh](https://aidevops.sh) v3.6.114 plugin for [OpenCode](https://opencode.ai) v1.3.0 with claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Internal code formatting and whitespace adjustments for consistency across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->