### PR TITLE
feat: only show table filter when row count exceeds 10

### DIFF
--- a/src/components/data-table.js
+++ b/src/components/data-table.js
@@ -161,8 +161,8 @@ export default function DataTable( { children } ) {
 
 	return (
 		<div className="gratis-ai-agent-data-table-wrap">
-			{ /* Filter bar — only shown when the table has data */ }
-			{ rawRows.length > 0 && (
+			{ /* Filter bar — only shown when the table has more than 10 rows */ }
+			{ rawRows.length > 10 && (
 				<div className="gratis-ai-agent-data-table-toolbar">
 					<div className="gratis-ai-agent-data-table-filter">
 						<input


### PR DESCRIPTION
## Summary

- The filter input was shown for all tables regardless of size, adding visual noise to small tables that don't need filtering.
- Changed the condition in `DataTable` from `rawRows.length > 0` to `rawRows.length > 10` so the filter bar only renders for tables with more than 10 rows.

## Files changed

- EDIT: `src/components/data-table.js:165` — threshold condition update

## Verification

Render a table with ≤10 rows → no filter input shown. Render a table with 11+ rows → filter input appears as before.