### PR TITLE
fix: deliver reply for SDK-routed providers

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -110,6 +110,24 @@ class AgentLoop {
 	/** @var SseStreamer|null Optional SSE streamer for token-by-token output. */
 	private ?SseStreamer $sse_streamer = null;
 
+	/**
+	 * Whether the current run has already pushed reply tokens to the SSE
+	 * streamer character-by-character. The direct streaming path sets this so
+	 * the REST controller knows it does not need to flush the final reply as
+	 * a single token at the end of the run.
+	 *
+	 * @var bool
+	 */
+	private bool $reply_streamed = false;
+
+	/**
+	 * Whether the final reply text has already been pushed to the SSE
+	 * streamer token-by-token by a streaming provider implementation.
+	 */
+	public function reply_was_streamed(): bool {
+		return $this->reply_streamed;
+	}
+
 	/** @var Settings Injected settings dependency. */
 	private $settings_service;
 
@@ -1362,6 +1380,7 @@ class AgentLoop {
 				$full_text .= $token;
 				if ( null !== $this->sse_streamer ) {
 					$this->sse_streamer->send_token( $token );
+					$this->reply_streamed = true;
 				}
 			}
 

--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -510,6 +510,18 @@ class RestController {
 			$done_payload['generated_title'] = $generated_title;
 		}
 
+		// Providers routed through the WP AI Client SDK do not stream tokens
+		// individually — the full reply is only available after run() returns.
+		// In that case, push the reply as a single token before sending `done`
+		// so the frontend (which only commits accumulated token text) can
+		// display the assistant message. Streaming providers (handled by
+		// send_prompt_direct_streaming) set reply_was_streamed() and skip this.
+		// @phpstan-ignore-next-line
+		$reply_text = (string) ( $result['reply'] ?? '' );
+		if ( '' !== $reply_text && ! $loop->reply_was_streamed() ) {
+			$streamer->send_token( $reply_text );
+		}
+
 		$streamer->send_done( $done_payload );
 
 		exit;


### PR DESCRIPTION
Providers routed through the WP AI Client SDK (everything except the hardcoded openai/anthropic/google/openai-compat direct paths) call generate_text_result() which is non-streaming. The REST controller's SSE response only commits text the frontend assembled from `token` events, so SDK provider replies were silently dropped on the wire — the user saw the loop complete with iterations_used=1 but no assistant message in the chat.

Track whether the streaming direct path already pushed tokens via a `reply_streamed` flag on AgentLoop, exposed via reply_was_streamed(). In handle_stream, after run() returns, push the reply text as a single token before sending `done` whenever streaming did not happen. This is a temporary bridge — see ai-agent#TBD for the full strip of the bespoke direct paths in favour of SDK-only routing.