### PR TITLE
fix: correct stub path reference in t162 TODO entry

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -205,7 +205,7 @@
 
 - [ ] t162 Fix systemic CI failures: PHPStan, PHPUnit, Playwright E2E #bug #auto-dispatch ~4h ref:GH#803 logged:2026-04-07
   - PHPStan: ~40 errors from WP 7.0 Abilities API stubs not matching actual API; PHPUnit: 7 errors + 20 failures in AgentLoopTest (WP_Error returned where array expected + WP_Ability category fixture); Playwright: 6 shards failing, likely /stream → /chat rename in #802
-  - Fix stubs in includes/stubs/, update AgentLoopTest fixtures, update frontend endpoint reference from /stream to /chat
+  - Fix stubs in stubs/, update AgentLoopTest fixtures, update frontend endpoint reference from /stream to /chat
 
 - [ ] t163 Seamless PHP+JS abilities — foundation slice (JsAbilityCatalog, client registry, entry wiring) #feature #interactive ~3h For #806 logged:2026-04-08 started:2026-04-08
   - PR 1 of 2 splitting #806. Adds includes/Abilities/Js/JsAbilityCatalog.php (pure metadata mirror), src/abilities/{registry,navigation,editor,index}.js, wires into 4 entry points, enqueues @wordpress/abilities script module on our admin hooks. No AgentLoop or REST changes in this slice.


### PR DESCRIPTION
## Summary

Fixes the stub path reference in the t162 TODO entry from `includes/stubs/` to `stubs/` (root-level), as flagged by CodeRabbit in PR #804.

The stub file lives at the root-level `stubs/` directory, not `includes/stubs/`. Keeping this path accurate prevents misdirected CI-fix work when a worker picks up t162.

## Changes

- **EDIT: `TODO.md:208`** — changed `includes/stubs/` to `stubs/` in the t162 implementation note

## Runtime Testing

**Risk level:** Low — documentation/planning file only, no code changes.
**Verification:** `grep "Fix stubs in stubs/" TODO.md` confirms the correct path.

Resolves #810

---
[aidevops.sh](https://aidevops.sh) v3.6.167 plugin for [OpenCode](https://opencode.ai) v1.3.16 with claude-sonnet-4-6 spent 59s and 1,596 tokens on this as a headless worker.