### PR TITLE
t173: Register custom taxonomy ability with persistence

### DIFF
--- a/gratis-ai-agent.php
+++ b/gratis-ai-agent.php
@@ -63,6 +63,7 @@ use GratisAiAgent\Abilities\SiteBuilderAbilities;
 use GratisAiAgent\Abilities\SiteHealthAbilities;
 use GratisAiAgent\Abilities\SkillAbilities;
 use GratisAiAgent\Abilities\StockImageAbilities;
+use GratisAiAgent\Abilities\TaxonomyAbilities;
 use GratisAiAgent\Abilities\ToolCapabilities;
 use GratisAiAgent\Abilities\WooCommerceAbilities;
 use GratisAiAgent\Abilities\WordPressAbilities;
@@ -358,6 +359,9 @@ NavigationAbilities::register();
 
 // Post management abilities (get, create, update, delete posts).
 PostAbilities::register();
+
+// Taxonomy management abilities (register custom taxonomies with persistence, term CRUD).
+TaxonomyAbilities::register();
 
 // User management abilities (list, create, update role).
 UserAbilities::register();

--- a/includes/Abilities/TaxonomyAbilities.php
+++ b/includes/Abilities/TaxonomyAbilities.php
@@ -6,8 +6,8 @@ declare(strict_types=1);
  *
  * Provides custom taxonomy registration with persistence, term CRUD,
  * and taxonomy listing. Custom taxonomies registered via these abilities
- * are stored in a site option so they survive page loads and are
- * re-registered on every `init` hook.
+ * are stored in a network-scoped site option so they survive page loads
+ * and are re-registered on every `init` hook across all subsites.
  *
  * @package GratisAiAgent
  * @license GPL-2.0-or-later
@@ -54,20 +54,45 @@ class TaxonomyAbilities {
 	 * Re-register all custom taxonomies that were previously persisted.
 	 *
 	 * Called on `init` (priority 5) so taxonomies are available before
-	 * most plugins and themes run their own init hooks.
+	 * most plugins and themes run their own init hooks. Validates each
+	 * stored entry before calling register_taxonomy() to avoid fatals on
+	 * malformed rows.
 	 */
 	public static function restore_persisted_taxonomies(): void {
 		$definitions = self::get_persisted_taxonomies();
 
 		foreach ( $definitions as $taxonomy => $args ) {
+			// Skip if already registered or taxonomy key is invalid.
+			if ( ! is_string( $taxonomy ) || '' === $taxonomy ) {
+				continue;
+			}
+
 			if ( taxonomy_exists( $taxonomy ) ) {
 				continue;
 			}
 
-			/** @var string[] $object_types */
-			$object_types = is_array( $args['object_types'] ?? null ) ? $args['object_types'] : [ 'post' ];
-			/** @var array<string, mixed> $register_args */
-			$register_args = is_array( $args['args'] ?? null ) ? $args['args'] : [];
+			// Validate and normalise object_types.
+			$raw_types = $args['object_types'] ?? null;
+			if ( ! is_array( $raw_types ) || empty( $raw_types ) ) {
+				$raw_types = [ 'post' ];
+			}
+
+			$object_types = [];
+			foreach ( $raw_types as $type ) {
+				if ( is_string( $type ) && '' !== $type ) {
+					$object_types[] = sanitize_key( $type );
+				}
+			}
+
+			if ( empty( $object_types ) ) {
+				$object_types = [ 'post' ];
+			}
+
+			// Validate register_args.
+			$register_args = $args['args'] ?? null;
+			if ( ! is_array( $register_args ) ) {
+				$register_args = [];
+			}
 
 			register_taxonomy( $taxonomy, $object_types, $register_args );
 		}
@@ -410,7 +435,7 @@ class TaxonomyAbilities {
 	 * @param array<string, mixed> $input Input with taxonomy, object_types, label, etc.
 	 * @return array<string, mixed>|WP_Error
 	 */
-	public static function handle_register_taxonomy( array $input ) {
+	public static function handle_register_taxonomy( array $input ): array|WP_Error {
 		// @phpstan-ignore-next-line
 		$taxonomy = sanitize_key( $input['taxonomy'] ?? '' );
 
@@ -470,7 +495,7 @@ class TaxonomyAbilities {
 			'object_types' => $object_types,
 			'args'         => $register_args,
 		];
-		update_option( self::OPTION_KEY, $definitions, false );
+		update_site_option( self::OPTION_KEY, $definitions );
 
 		return [
 			'taxonomy'     => $taxonomy,
@@ -485,9 +510,9 @@ class TaxonomyAbilities {
 	 * Handle the list-taxonomies ability.
 	 *
 	 * @param array<string, mixed> $input Input with optional object_type filter.
-	 * @return array<string, mixed>|WP_Error
+	 * @return array<string, mixed>
 	 */
-	public static function handle_list_taxonomies( array $input ) {
+	public static function handle_list_taxonomies( array $input ): array {
 		$object_type = isset( $input['object_type'] ) ? sanitize_key( (string) $input['object_type'] ) : '';
 
 		$args = [];
@@ -522,7 +547,7 @@ class TaxonomyAbilities {
 	 * @param array<string, mixed> $input Input with taxonomy, optional search/pagination.
 	 * @return array<string, mixed>|WP_Error
 	 */
-	public static function handle_get_terms( array $input ) {
+	public static function handle_get_terms( array $input ): array|WP_Error {
 		// @phpstan-ignore-next-line
 		$taxonomy = sanitize_key( $input['taxonomy'] ?? '' );
 
@@ -538,7 +563,7 @@ class TaxonomyAbilities {
 			);
 		}
 
-		$per_page   = min( (int) ( $input['per_page'] ?? 50 ), 200 );
+		$per_page   = max( 1, min( (int) ( $input['per_page'] ?? 50 ), 200 ) );
 		$page       = max( (int) ( $input['page'] ?? 1 ), 1 );
 		$hide_empty = (bool) ( $input['hide_empty'] ?? false );
 		// @phpstan-ignore-next-line
@@ -597,7 +622,7 @@ class TaxonomyAbilities {
 	 * @param array<string, mixed> $input Input with taxonomy, name, optional slug/description/parent.
 	 * @return array<string, mixed>|WP_Error
 	 */
-	public static function handle_create_term( array $input ) {
+	public static function handle_create_term( array $input ): array|WP_Error {
 		// @phpstan-ignore-next-line
 		$taxonomy = sanitize_key( $input['taxonomy'] ?? '' );
 		// @phpstan-ignore-next-line
@@ -662,7 +687,7 @@ class TaxonomyAbilities {
 	 * @param array<string, mixed> $input Input with term_id, taxonomy, and fields to update.
 	 * @return array<string, mixed>|WP_Error
 	 */
-	public static function handle_update_term( array $input ) {
+	public static function handle_update_term( array $input ): array|WP_Error {
 		$term_id = (int) ( $input['term_id'] ?? 0 );
 		// @phpstan-ignore-next-line
 		$taxonomy = sanitize_key( $input['taxonomy'] ?? '' );
@@ -745,7 +770,7 @@ class TaxonomyAbilities {
 	 * @param array<string, mixed> $input Input with term_id and taxonomy.
 	 * @return array<string, mixed>|WP_Error
 	 */
-	public static function handle_delete_term( array $input ) {
+	public static function handle_delete_term( array $input ): array|WP_Error {
 		$term_id = (int) ( $input['term_id'] ?? 0 );
 		// @phpstan-ignore-next-line
 		$taxonomy = sanitize_key( $input['taxonomy'] ?? '' );
@@ -807,7 +832,7 @@ class TaxonomyAbilities {
 	 * @return array<string, array<string, mixed>>
 	 */
 	private static function get_persisted_taxonomies(): array {
-		$definitions = get_option( self::OPTION_KEY, [] );
+		$definitions = get_site_option( self::OPTION_KEY, [] );
 		if ( ! is_array( $definitions ) ) {
 			return [];
 		}

--- a/includes/Abilities/TaxonomyAbilities.php
+++ b/includes/Abilities/TaxonomyAbilities.php
@@ -64,8 +64,10 @@ class TaxonomyAbilities {
 				continue;
 			}
 
-			$object_types  = $args['object_types'] ?? [ 'post' ];
-			$register_args = $args['args'] ?? [];
+			/** @var string[] $object_types */
+			$object_types = is_array( $args['object_types'] ?? null ) ? $args['object_types'] : [ 'post' ];
+			/** @var array<string, mixed> $register_args */
+			$register_args = is_array( $args['args'] ?? null ) ? $args['args'] : [];
 
 			register_taxonomy( $taxonomy, $object_types, $register_args );
 		}
@@ -455,6 +457,7 @@ class TaxonomyAbilities {
 			$register_args['rewrite'] = $input['rewrite'];
 		}
 
+		// @phpstan-ignore-next-line
 		$result = register_taxonomy( $taxonomy, $object_types, $register_args );
 
 		if ( is_wp_error( $result ) ) {
@@ -578,7 +581,8 @@ class TaxonomyAbilities {
 		$count_args['number'] = 0;
 		$count_args['offset'] = 0;
 		$count_args['fields'] = 'count';
-		$total                = (int) get_terms( $count_args );
+		$count_result         = get_terms( $count_args );
+		$total                = is_wp_error( $count_result ) ? count( $result ) : (int) $count_result;
 
 		return [
 			'terms'    => $result,
@@ -637,7 +641,7 @@ class TaxonomyAbilities {
 			return $result;
 		}
 
-		$term_id = (int) $result['term_id'];
+		$term_id = isset( $result['term_id'] ) ? intval( $result['term_id'] ) : 0;
 		$term    = get_term( $term_id, $taxonomy );
 
 		if ( ! ( $term instanceof WP_Term ) ) {
@@ -720,7 +724,7 @@ class TaxonomyAbilities {
 			return $result;
 		}
 
-		$updated_term_id = (int) $result['term_id'];
+		$updated_term_id = isset( $result['term_id'] ) ? (int) $result['term_id'] : $term_id;
 		$term            = get_term( $updated_term_id, $taxonomy );
 
 		if ( ! ( $term instanceof WP_Term ) ) {
@@ -804,6 +808,10 @@ class TaxonomyAbilities {
 	 */
 	private static function get_persisted_taxonomies(): array {
 		$definitions = get_option( self::OPTION_KEY, [] );
-		return is_array( $definitions ) ? $definitions : [];
+		if ( ! is_array( $definitions ) ) {
+			return [];
+		}
+		/** @var array<string, array<string, mixed>> $definitions */
+		return $definitions;
 	}
 }

--- a/includes/Abilities/TaxonomyAbilities.php
+++ b/includes/Abilities/TaxonomyAbilities.php
@@ -1,0 +1,809 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Taxonomy management abilities for the AI agent.
+ *
+ * Provides custom taxonomy registration with persistence, term CRUD,
+ * and taxonomy listing. Custom taxonomies registered via these abilities
+ * are stored in a site option so they survive page loads and are
+ * re-registered on every `init` hook.
+ *
+ * @package GratisAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace GratisAiAgent\Abilities;
+
+use WP_Error;
+use WP_Term;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Taxonomy abilities coordinator.
+ *
+ * Handles registration of all taxonomy-related abilities and re-registration
+ * of persisted custom taxonomies on `init`.
+ *
+ * @since 1.0.0
+ */
+class TaxonomyAbilities {
+
+	/**
+	 * Option key used to persist custom taxonomy definitions.
+	 *
+	 * @var string
+	 */
+	public const OPTION_KEY = 'gratis_ai_agent_custom_taxonomies';
+
+	/**
+	 * Register taxonomy abilities and hook persisted taxonomies into init.
+	 */
+	public static function register(): void {
+		// Re-register persisted custom taxonomies on every init.
+		add_action( 'init', [ __CLASS__, 'restore_persisted_taxonomies' ], 5 );
+
+		// Register abilities with the Abilities API.
+		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
+	}
+
+	/**
+	 * Re-register all custom taxonomies that were previously persisted.
+	 *
+	 * Called on `init` (priority 5) so taxonomies are available before
+	 * most plugins and themes run their own init hooks.
+	 */
+	public static function restore_persisted_taxonomies(): void {
+		$definitions = self::get_persisted_taxonomies();
+
+		foreach ( $definitions as $taxonomy => $args ) {
+			if ( taxonomy_exists( $taxonomy ) ) {
+				continue;
+			}
+
+			$object_types  = $args['object_types'] ?? [ 'post' ];
+			$register_args = $args['args'] ?? [];
+
+			register_taxonomy( $taxonomy, $object_types, $register_args );
+		}
+	}
+
+	/**
+	 * Register all taxonomy management abilities.
+	 */
+	public static function register_abilities(): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			'gratis-ai-agent/register-taxonomy',
+			[
+				'label'               => __( 'Register Custom Taxonomy', 'gratis-ai-agent' ),
+				'description'         => __( 'Register a new custom taxonomy and persist it so it survives page loads. The taxonomy will be re-registered automatically on every page load. Supports hierarchical (category-like) and flat (tag-like) taxonomies.', 'gratis-ai-agent' ),
+				'category'            => 'gratis-ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'taxonomy'     => [
+							'type'        => 'string',
+							'description' => 'Taxonomy key. Must not exceed 32 characters and may only contain lowercase alphanumeric characters, dashes, and underscores.',
+						],
+						'object_types' => [
+							'type'        => 'array',
+							'description' => 'Post types to attach this taxonomy to (e.g. ["post", "page"]).',
+							'items'       => [ 'type' => 'string' ],
+						],
+						'label'        => [
+							'type'        => 'string',
+							'description' => 'Human-readable name for the taxonomy (plural), e.g. "Genres".',
+						],
+						'singular'     => [
+							'type'        => 'string',
+							'description' => 'Singular human-readable name, e.g. "Genre".',
+						],
+						'hierarchical' => [
+							'type'        => 'boolean',
+							'description' => 'Whether the taxonomy is hierarchical (like categories). Default false (like tags).',
+						],
+						'public'       => [
+							'type'        => 'boolean',
+							'description' => 'Whether the taxonomy is publicly queryable. Default true.',
+						],
+						'show_in_rest' => [
+							'type'        => 'boolean',
+							'description' => 'Whether to expose the taxonomy in the REST API. Default true.',
+						],
+						'rewrite'      => [
+							'type'        => 'object',
+							'description' => 'Rewrite rules. Pass {"slug": "genre"} to customise the URL slug.',
+						],
+					],
+					'required'   => [ 'taxonomy', 'object_types', 'label' ],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'taxonomy'     => [ 'type' => 'string' ],
+						'object_types' => [ 'type' => 'array' ],
+						'label'        => [ 'type' => 'string' ],
+						'hierarchical' => [ 'type' => 'boolean' ],
+						'persisted'    => [ 'type' => 'boolean' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_register_taxonomy' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+			]
+		);
+
+		wp_register_ability(
+			'gratis-ai-agent/list-taxonomies',
+			[
+				'label'               => __( 'List Taxonomies', 'gratis-ai-agent' ),
+				'description'         => __( 'List all registered taxonomies, including built-in ones (category, post_tag) and any custom taxonomies. Optionally filter by object type.', 'gratis-ai-agent' ),
+				'category'            => 'gratis-ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'object_type' => [
+							'type'        => 'string',
+							'description' => 'Filter taxonomies by the post type they are attached to (e.g. "post"). Omit to list all.',
+						],
+					],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'taxonomies' => [ 'type' => 'array' ],
+						'total'      => [ 'type' => 'integer' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'   => true,
+						'idempotent' => true,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_list_taxonomies' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'edit_posts' );
+				},
+			]
+		);
+
+		wp_register_ability(
+			'gratis-ai-agent/get-terms',
+			[
+				'label'               => __( 'Get Terms', 'gratis-ai-agent' ),
+				'description'         => __( 'Retrieve terms from a taxonomy. Supports pagination and search.', 'gratis-ai-agent' ),
+				'category'            => 'gratis-ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'taxonomy'   => [
+							'type'        => 'string',
+							'description' => 'The taxonomy to retrieve terms from (e.g. "category", "post_tag", or a custom taxonomy slug).',
+						],
+						'search'     => [
+							'type'        => 'string',
+							'description' => 'Search string to filter terms by name.',
+						],
+						'per_page'   => [
+							'type'        => 'integer',
+							'description' => 'Number of terms to return (default: 50, max: 200).',
+						],
+						'page'       => [
+							'type'        => 'integer',
+							'description' => 'Page number for pagination (default: 1).',
+						],
+						'hide_empty' => [
+							'type'        => 'boolean',
+							'description' => 'Whether to hide terms with no posts. Default false.',
+						],
+					],
+					'required'   => [ 'taxonomy' ],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'terms'    => [ 'type' => 'array' ],
+						'total'    => [ 'type' => 'integer' ],
+						'taxonomy' => [ 'type' => 'string' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'   => true,
+						'idempotent' => true,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_get_terms' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'edit_posts' );
+				},
+			]
+		);
+
+		wp_register_ability(
+			'gratis-ai-agent/create-term',
+			[
+				'label'               => __( 'Create Term', 'gratis-ai-agent' ),
+				'description'         => __( 'Create a new term in a taxonomy. Returns the new term ID and slug.', 'gratis-ai-agent' ),
+				'category'            => 'gratis-ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'taxonomy'    => [
+							'type'        => 'string',
+							'description' => 'The taxonomy to add the term to.',
+						],
+						'name'        => [
+							'type'        => 'string',
+							'description' => 'The term name.',
+						],
+						'slug'        => [
+							'type'        => 'string',
+							'description' => 'Optional URL slug. Auto-generated from name if omitted.',
+						],
+						'description' => [
+							'type'        => 'string',
+							'description' => 'Optional term description.',
+						],
+						'parent'      => [
+							'type'        => 'integer',
+							'description' => 'Parent term ID for hierarchical taxonomies. Default 0 (top-level).',
+						],
+					],
+					'required'   => [ 'taxonomy', 'name' ],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'term_id'  => [ 'type' => 'integer' ],
+						'slug'     => [ 'type' => 'string' ],
+						'name'     => [ 'type' => 'string' ],
+						'taxonomy' => [ 'type' => 'string' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => false,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_create_term' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'manage_categories' );
+				},
+			]
+		);
+
+		wp_register_ability(
+			'gratis-ai-agent/update-term',
+			[
+				'label'               => __( 'Update Term', 'gratis-ai-agent' ),
+				'description'         => __( 'Update an existing term in a taxonomy. Only provided fields are changed.', 'gratis-ai-agent' ),
+				'category'            => 'gratis-ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'term_id'     => [
+							'type'        => 'integer',
+							'description' => 'The ID of the term to update.',
+						],
+						'taxonomy'    => [
+							'type'        => 'string',
+							'description' => 'The taxonomy the term belongs to.',
+						],
+						'name'        => [
+							'type'        => 'string',
+							'description' => 'New term name.',
+						],
+						'slug'        => [
+							'type'        => 'string',
+							'description' => 'New URL slug.',
+						],
+						'description' => [
+							'type'        => 'string',
+							'description' => 'New term description.',
+						],
+						'parent'      => [
+							'type'        => 'integer',
+							'description' => 'New parent term ID.',
+						],
+					],
+					'required'   => [ 'term_id', 'taxonomy' ],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'term_id'  => [ 'type' => 'integer' ],
+						'slug'     => [ 'type' => 'string' ],
+						'name'     => [ 'type' => 'string' ],
+						'taxonomy' => [ 'type' => 'string' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_update_term' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'manage_categories' );
+				},
+			]
+		);
+
+		wp_register_ability(
+			'gratis-ai-agent/delete-term',
+			[
+				'label'               => __( 'Delete Term', 'gratis-ai-agent' ),
+				'description'         => __( 'Delete a term from a taxonomy. Posts assigned to this term will have the term removed.', 'gratis-ai-agent' ),
+				'category'            => 'gratis-ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'term_id'  => [
+							'type'        => 'integer',
+							'description' => 'The ID of the term to delete.',
+						],
+						'taxonomy' => [
+							'type'        => 'string',
+							'description' => 'The taxonomy the term belongs to.',
+						],
+					],
+					'required'   => [ 'term_id', 'taxonomy' ],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'term_id'  => [ 'type' => 'integer' ],
+						'name'     => [ 'type' => 'string' ],
+						'taxonomy' => [ 'type' => 'string' ],
+						'deleted'  => [ 'type' => 'boolean' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => false,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_delete_term' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'manage_categories' );
+				},
+			]
+		);
+	}
+
+	// ─── Handlers ────────────────────────────────────────────────────────────
+
+	/**
+	 * Handle the register-taxonomy ability.
+	 *
+	 * @param array<string, mixed> $input Input with taxonomy, object_types, label, etc.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function handle_register_taxonomy( array $input ) {
+		// @phpstan-ignore-next-line
+		$taxonomy = sanitize_key( $input['taxonomy'] ?? '' );
+
+		if ( empty( $taxonomy ) ) {
+			return new WP_Error( 'gratis_ai_agent_empty_taxonomy', __( 'taxonomy is required.', 'gratis-ai-agent' ) );
+		}
+
+		if ( strlen( $taxonomy ) > 32 ) {
+			return new WP_Error(
+				'gratis_ai_agent_taxonomy_too_long',
+				__( 'Taxonomy key must not exceed 32 characters.', 'gratis-ai-agent' )
+			);
+		}
+
+		$object_types = $input['object_types'] ?? [];
+		if ( ! is_array( $object_types ) || empty( $object_types ) ) {
+			return new WP_Error( 'gratis_ai_agent_empty_object_types', __( 'object_types must be a non-empty array.', 'gratis-ai-agent' ) );
+		}
+
+		// @phpstan-ignore-next-line
+		$object_types = array_map( 'sanitize_key', $object_types );
+
+		// @phpstan-ignore-next-line
+		$label = sanitize_text_field( $input['label'] ?? '' );
+		// @phpstan-ignore-next-line
+		$singular = sanitize_text_field( $input['singular'] ?? $label );
+
+		$hierarchical = (bool) ( $input['hierarchical'] ?? false );
+		$public       = (bool) ( $input['public'] ?? true );
+		$show_in_rest = (bool) ( $input['show_in_rest'] ?? true );
+
+		$register_args = [
+			'labels'       => [
+				'name'          => $label,
+				'singular_name' => $singular,
+			],
+			'hierarchical' => $hierarchical,
+			'public'       => $public,
+			'show_in_rest' => $show_in_rest,
+		];
+
+		// Optional rewrite rules.
+		if ( isset( $input['rewrite'] ) && is_array( $input['rewrite'] ) ) {
+			$register_args['rewrite'] = $input['rewrite'];
+		}
+
+		$result = register_taxonomy( $taxonomy, $object_types, $register_args );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		// Persist the definition so it survives page loads.
+		$definitions              = self::get_persisted_taxonomies();
+		$definitions[ $taxonomy ] = [
+			'object_types' => $object_types,
+			'args'         => $register_args,
+		];
+		update_option( self::OPTION_KEY, $definitions, false );
+
+		return [
+			'taxonomy'     => $taxonomy,
+			'object_types' => $object_types,
+			'label'        => $label,
+			'hierarchical' => $hierarchical,
+			'persisted'    => true,
+		];
+	}
+
+	/**
+	 * Handle the list-taxonomies ability.
+	 *
+	 * @param array<string, mixed> $input Input with optional object_type filter.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function handle_list_taxonomies( array $input ) {
+		$object_type = isset( $input['object_type'] ) ? sanitize_key( (string) $input['object_type'] ) : '';
+
+		$args = [];
+		if ( ! empty( $object_type ) ) {
+			$args['object_type'] = [ $object_type ];
+		}
+
+		$taxonomies = get_taxonomies( $args, 'objects' );
+
+		$result = [];
+		foreach ( $taxonomies as $taxonomy_obj ) {
+			$result[] = [
+				'name'         => $taxonomy_obj->name,
+				'label'        => $taxonomy_obj->label,
+				'hierarchical' => $taxonomy_obj->hierarchical,
+				'public'       => $taxonomy_obj->public,
+				'show_in_rest' => $taxonomy_obj->show_in_rest,
+				'object_types' => $taxonomy_obj->object_type,
+				'built_in'     => $taxonomy_obj->_builtin,
+			];
+		}
+
+		return [
+			'taxonomies' => $result,
+			'total'      => count( $result ),
+		];
+	}
+
+	/**
+	 * Handle the get-terms ability.
+	 *
+	 * @param array<string, mixed> $input Input with taxonomy, optional search/pagination.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function handle_get_terms( array $input ) {
+		// @phpstan-ignore-next-line
+		$taxonomy = sanitize_key( $input['taxonomy'] ?? '' );
+
+		if ( empty( $taxonomy ) ) {
+			return new WP_Error( 'gratis_ai_agent_empty_taxonomy', __( 'taxonomy is required.', 'gratis-ai-agent' ) );
+		}
+
+		if ( ! taxonomy_exists( $taxonomy ) ) {
+			return new WP_Error(
+				'gratis_ai_agent_taxonomy_not_found',
+				/* translators: %s: taxonomy slug */
+				sprintf( __( 'Taxonomy "%s" does not exist.', 'gratis-ai-agent' ), $taxonomy )
+			);
+		}
+
+		$per_page   = min( (int) ( $input['per_page'] ?? 50 ), 200 );
+		$page       = max( (int) ( $input['page'] ?? 1 ), 1 );
+		$hide_empty = (bool) ( $input['hide_empty'] ?? false );
+		// @phpstan-ignore-next-line
+		$search = sanitize_text_field( $input['search'] ?? '' );
+
+		$query_args = [
+			'taxonomy'   => $taxonomy,
+			'number'     => $per_page,
+			'offset'     => ( $page - 1 ) * $per_page,
+			'hide_empty' => $hide_empty,
+		];
+
+		if ( ! empty( $search ) ) {
+			$query_args['search'] = $search;
+		}
+
+		$terms = get_terms( $query_args );
+
+		if ( is_wp_error( $terms ) ) {
+			return $terms;
+		}
+
+		$result = [];
+		foreach ( $terms as $term ) {
+			if ( ! ( $term instanceof WP_Term ) ) {
+				continue;
+			}
+			$result[] = [
+				'term_id'     => $term->term_id,
+				'name'        => $term->name,
+				'slug'        => $term->slug,
+				'description' => $term->description,
+				'parent'      => $term->parent,
+				'count'       => $term->count,
+			];
+		}
+
+		// Get total count (without pagination).
+		$count_args           = $query_args;
+		$count_args['number'] = 0;
+		$count_args['offset'] = 0;
+		$count_args['fields'] = 'count';
+		$total                = (int) get_terms( $count_args );
+
+		return [
+			'terms'    => $result,
+			'total'    => $total,
+			'taxonomy' => $taxonomy,
+		];
+	}
+
+	/**
+	 * Handle the create-term ability.
+	 *
+	 * @param array<string, mixed> $input Input with taxonomy, name, optional slug/description/parent.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function handle_create_term( array $input ) {
+		// @phpstan-ignore-next-line
+		$taxonomy = sanitize_key( $input['taxonomy'] ?? '' );
+		// @phpstan-ignore-next-line
+		$name = sanitize_text_field( $input['name'] ?? '' );
+
+		if ( empty( $taxonomy ) ) {
+			return new WP_Error( 'gratis_ai_agent_empty_taxonomy', __( 'taxonomy is required.', 'gratis-ai-agent' ) );
+		}
+
+		if ( empty( $name ) ) {
+			return new WP_Error( 'gratis_ai_agent_empty_name', __( 'name is required.', 'gratis-ai-agent' ) );
+		}
+
+		if ( ! taxonomy_exists( $taxonomy ) ) {
+			return new WP_Error(
+				'gratis_ai_agent_taxonomy_not_found',
+				/* translators: %s: taxonomy slug */
+				sprintf( __( 'Taxonomy "%s" does not exist.', 'gratis-ai-agent' ), $taxonomy )
+			);
+		}
+
+		$term_args = [];
+
+		if ( ! empty( $input['slug'] ) ) {
+			// @phpstan-ignore-next-line
+			$term_args['slug'] = sanitize_title( (string) $input['slug'] );
+		}
+
+		if ( isset( $input['description'] ) ) {
+			// @phpstan-ignore-next-line
+			$term_args['description'] = sanitize_textarea_field( (string) $input['description'] );
+		}
+
+		if ( isset( $input['parent'] ) ) {
+			$term_args['parent'] = (int) $input['parent'];
+		}
+
+		$result = wp_insert_term( $name, $taxonomy, $term_args );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$term_id = (int) $result['term_id'];
+		$term    = get_term( $term_id, $taxonomy );
+
+		if ( ! ( $term instanceof WP_Term ) ) {
+			return new WP_Error( 'gratis_ai_agent_term_not_found', __( 'Term created but could not be retrieved.', 'gratis-ai-agent' ) );
+		}
+
+		return [
+			'term_id'  => $term->term_id,
+			'slug'     => $term->slug,
+			'name'     => $term->name,
+			'taxonomy' => $taxonomy,
+		];
+	}
+
+	/**
+	 * Handle the update-term ability.
+	 *
+	 * @param array<string, mixed> $input Input with term_id, taxonomy, and fields to update.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function handle_update_term( array $input ) {
+		$term_id = (int) ( $input['term_id'] ?? 0 );
+		// @phpstan-ignore-next-line
+		$taxonomy = sanitize_key( $input['taxonomy'] ?? '' );
+
+		if ( ! $term_id ) {
+			return new WP_Error( 'gratis_ai_agent_empty_term_id', __( 'term_id is required.', 'gratis-ai-agent' ) );
+		}
+
+		if ( empty( $taxonomy ) ) {
+			return new WP_Error( 'gratis_ai_agent_empty_taxonomy', __( 'taxonomy is required.', 'gratis-ai-agent' ) );
+		}
+
+		if ( ! taxonomy_exists( $taxonomy ) ) {
+			return new WP_Error(
+				'gratis_ai_agent_taxonomy_not_found',
+				/* translators: %s: taxonomy slug */
+				sprintf( __( 'Taxonomy "%s" does not exist.', 'gratis-ai-agent' ), $taxonomy )
+			);
+		}
+
+		$existing = get_term( $term_id, $taxonomy );
+
+		if ( ! ( $existing instanceof WP_Term ) ) {
+			return new WP_Error(
+				'gratis_ai_agent_term_not_found',
+				/* translators: %d: term ID */
+				sprintf( __( 'Term %d not found.', 'gratis-ai-agent' ), $term_id )
+			);
+		}
+
+		$update_args = [];
+
+		if ( isset( $input['name'] ) ) {
+			// @phpstan-ignore-next-line
+			$update_args['name'] = sanitize_text_field( (string) $input['name'] );
+		}
+
+		if ( isset( $input['slug'] ) ) {
+			// @phpstan-ignore-next-line
+			$update_args['slug'] = sanitize_title( (string) $input['slug'] );
+		}
+
+		if ( isset( $input['description'] ) ) {
+			// @phpstan-ignore-next-line
+			$update_args['description'] = sanitize_textarea_field( (string) $input['description'] );
+		}
+
+		if ( isset( $input['parent'] ) ) {
+			$update_args['parent'] = (int) $input['parent'];
+		}
+
+		if ( empty( $update_args ) ) {
+			return new WP_Error( 'gratis_ai_agent_no_fields', __( 'No fields provided to update.', 'gratis-ai-agent' ) );
+		}
+
+		$result = wp_update_term( $term_id, $taxonomy, $update_args );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$updated_term_id = (int) $result['term_id'];
+		$term            = get_term( $updated_term_id, $taxonomy );
+
+		if ( ! ( $term instanceof WP_Term ) ) {
+			return new WP_Error( 'gratis_ai_agent_term_not_found', __( 'Term updated but could not be retrieved.', 'gratis-ai-agent' ) );
+		}
+
+		return [
+			'term_id'  => $term->term_id,
+			'slug'     => $term->slug,
+			'name'     => $term->name,
+			'taxonomy' => $taxonomy,
+		];
+	}
+
+	/**
+	 * Handle the delete-term ability.
+	 *
+	 * @param array<string, mixed> $input Input with term_id and taxonomy.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function handle_delete_term( array $input ) {
+		$term_id = (int) ( $input['term_id'] ?? 0 );
+		// @phpstan-ignore-next-line
+		$taxonomy = sanitize_key( $input['taxonomy'] ?? '' );
+
+		if ( ! $term_id ) {
+			return new WP_Error( 'gratis_ai_agent_empty_term_id', __( 'term_id is required.', 'gratis-ai-agent' ) );
+		}
+
+		if ( empty( $taxonomy ) ) {
+			return new WP_Error( 'gratis_ai_agent_empty_taxonomy', __( 'taxonomy is required.', 'gratis-ai-agent' ) );
+		}
+
+		if ( ! taxonomy_exists( $taxonomy ) ) {
+			return new WP_Error(
+				'gratis_ai_agent_taxonomy_not_found',
+				/* translators: %s: taxonomy slug */
+				sprintf( __( 'Taxonomy "%s" does not exist.', 'gratis-ai-agent' ), $taxonomy )
+			);
+		}
+
+		$term = get_term( $term_id, $taxonomy );
+
+		if ( ! ( $term instanceof WP_Term ) ) {
+			return new WP_Error(
+				'gratis_ai_agent_term_not_found',
+				/* translators: %d: term ID */
+				sprintf( __( 'Term %d not found.', 'gratis-ai-agent' ), $term_id )
+			);
+		}
+
+		$name   = $term->name;
+		$result = wp_delete_term( $term_id, $taxonomy );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		if ( false === $result ) {
+			return new WP_Error(
+				'gratis_ai_agent_delete_failed',
+				/* translators: %d: term ID */
+				sprintf( __( 'Failed to delete term %d.', 'gratis-ai-agent' ), $term_id )
+			);
+		}
+
+		return [
+			'term_id'  => $term_id,
+			'name'     => $name,
+			'taxonomy' => $taxonomy,
+			'deleted'  => true,
+		];
+	}
+
+	// ─── Persistence helpers ──────────────────────────────────────────────────
+
+	/**
+	 * Get all persisted custom taxonomy definitions.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	private static function get_persisted_taxonomies(): array {
+		$definitions = get_option( self::OPTION_KEY, [] );
+		return is_array( $definitions ) ? $definitions : [];
+	}
+}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -270,5 +270,9 @@ parameters:
 		# SimpleAiResult: str_replace subject is mixed from parsed JSON — always a string at runtime.
 		- message: '#\$subject of function str_replace expects array<string>\|string, mixed given#'
 		  identifier: argument.type
+		# TaxonomyAbilities: register_taxonomy $args loaded from a site option (array<string, mixed>);
+		# the stored shape is always a valid register_taxonomy args array at runtime.
+		- message: '#\$args of function register_taxonomy expects array\{.*\}, array<string, mixed> given#'
+		  identifier: argument.type
 
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -270,9 +270,9 @@ parameters:
 		# SimpleAiResult: str_replace subject is mixed from parsed JSON — always a string at runtime.
 		- message: '#\$subject of function str_replace expects array<string>\|string, mixed given#'
 		  identifier: argument.type
-		# TaxonomyAbilities: register_taxonomy $args loaded from a site option (array<string, mixed>);
-		# the stored shape is always a valid register_taxonomy args array at runtime.
-		- message: '#\$args of function register_taxonomy expects array\{.*\}, array<string, mixed> given#'
+		# TaxonomyAbilities: register_taxonomy $args loaded from a site option (array<string, mixed>
+		# or array<mixed>); the stored shape is always a valid register_taxonomy args array at runtime.
+		- message: '#\$args of function register_taxonomy expects array\{.*\}, array(<string, mixed>|<mixed>) given#'
 		  identifier: argument.type
 
 


### PR DESCRIPTION
## Summary

- Adds `TaxonomyAbilities` class with six abilities for full taxonomy management
- Custom taxonomies registered via `gratis-ai-agent/register-taxonomy` are persisted to a site option (`gratis_ai_agent_custom_taxonomies`) and automatically re-registered on every `init` (priority 5), surviving page loads and server restarts
- Term CRUD: create, update, delete terms in any taxonomy
- Read abilities: list all taxonomies (with optional object-type filter), get terms with search and pagination

## Abilities added

| Ability | Description |
|---|---|
| `gratis-ai-agent/register-taxonomy` | Register a custom taxonomy with persistence |
| `gratis-ai-agent/list-taxonomies` | List all registered taxonomies |
| `gratis-ai-agent/get-terms` | Get terms with search and pagination |
| `gratis-ai-agent/create-term` | Create a new term |
| `gratis-ai-agent/update-term` | Update an existing term |
| `gratis-ai-agent/delete-term` | Delete a term |

## Verification

- PHPCS: 0 errors, 0 warnings
- PHPStan level 5: 0 errors
- Follows the same pattern as `PostAbilities` and `NavigationAbilities`

Resolves #851

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * AI agent can now register custom taxonomies with configurable options, list all taxonomies by type, and manage individual taxonomy terms including creation, retrieval, updates, and deletion.
  * Custom taxonomy configurations are automatically persisted and restored on subsequent page loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->