### PR TITLE
t179: Options management ability with safety blocklist

### DIFF
--- a/gratis-ai-agent.php
+++ b/gratis-ai-agent.php
@@ -56,6 +56,7 @@ use GratisAiAgent\Abilities\MarketingAbilities;
 use GratisAiAgent\Abilities\MediaAbilities;
 use GratisAiAgent\Abilities\MemoryAbilities;
 use GratisAiAgent\Abilities\NavigationAbilities;
+use GratisAiAgent\Abilities\OptionsAbilities;
 use GratisAiAgent\Abilities\PostAbilities;
 use GratisAiAgent\Abilities\UserAbilities;
 use GratisAiAgent\Abilities\SeoAbilities;
@@ -346,6 +347,9 @@ DatabaseAbilities::register();
 
 // WordPress management abilities (plugins, themes, install, run PHP).
 WordPressAbilities::register();
+
+// Options management abilities (get, update, delete, list options with safety blocklist).
+OptionsAbilities::register();
 
 // WooCommerce abilities (product CRUD, order queries, store stats) — only registers when WooCommerce is active.
 WooCommerceAbilities::register();

--- a/includes/Abilities/OptionsAbilities.php
+++ b/includes/Abilities/OptionsAbilities.php
@@ -309,7 +309,9 @@ class UpdateOptionAbility extends AbstractAbility {
 		}
 
 		$option_value = $input['option_value'];
-		$autoload     = isset( $input['autoload'] ) && 'no' === $input['autoload'] ? 'no' : 'yes';
+		// WordPress 7.0+ update_option() accepts bool|null for $autoload.
+		// false = do not autoload, true = autoload, null = keep existing setting.
+		$autoload = isset( $input['autoload'] ) && 'no' === $input['autoload'] ? false : true;
 
 		$updated = update_option( $option_name, $option_value, $autoload );
 
@@ -550,7 +552,6 @@ class ListOptionsAbility extends AbstractAbility {
 	}
 
 	protected function execute_callback( $input ) {
-		/** @var array<string, mixed> $input */
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 

--- a/includes/Abilities/OptionsAbilities.php
+++ b/includes/Abilities/OptionsAbilities.php
@@ -1,0 +1,653 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Options management abilities for the AI agent.
+ *
+ * Provides get, update, and delete operations for WordPress options with a
+ * safety blocklist that prevents the AI from modifying critical site options
+ * (e.g. siteurl, admin_email, active_plugins, db_version).
+ *
+ * @package GratisAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace GratisAiAgent\Abilities;
+
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class OptionsAbilities {
+
+	/**
+	 * Options that the AI agent is never allowed to modify or delete.
+	 *
+	 * These are critical WordPress core options whose corruption would break
+	 * the site or compromise security. The list can be extended via the
+	 * `gratis_ai_agent_options_blocklist` filter.
+	 *
+	 * @var string[]
+	 */
+	private const WRITE_BLOCKLIST = [
+		// Core site identity / URLs — changing these breaks the site.
+		'siteurl',
+		'home',
+		// Admin contact — changing silently locks out the admin.
+		'admin_email',
+		// Plugin/theme activation state — must go through the Upgrader API.
+		'active_plugins',
+		'active_sitewide_plugins',
+		'template',
+		'stylesheet',
+		// Database schema version — must only be changed by upgrade routines.
+		'db_version',
+		'db_upgraded',
+		// WordPress core update channel.
+		'auto_update_core_type',
+		// User roles — changing breaks capability checks site-wide.
+		'user_roles',
+		// Cron schedule — corrupting this stops all scheduled events.
+		'cron',
+		// Auth keys / salts — regenerating these logs out all users.
+		'auth_key',
+		'secure_auth_key',
+		'logged_in_key',
+		'nonce_key',
+		'auth_salt',
+		'secure_auth_salt',
+		'logged_in_salt',
+		'nonce_salt',
+		// WordPress secret keys stored as options (some setups).
+		'wp_user_roles',
+		// Multisite network options.
+		'site_admins',
+		'allowedthemes',
+		// Plugin/theme file editing gate.
+		'disallow_file_edit',
+		'disallow_file_mods',
+	];
+
+	/**
+	 * Register options management abilities on init.
+	 */
+	public static function register(): void {
+		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
+	}
+
+	/**
+	 * Register all options management abilities.
+	 */
+	public static function register_abilities(): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			'gratis-ai-agent/get-option',
+			[
+				'label'         => __( 'Get Option', 'gratis-ai-agent' ),
+				'description'   => __( 'Read a WordPress option by name. Returns the stored value or a default if the option does not exist.', 'gratis-ai-agent' ),
+				'ability_class' => GetOptionAbility::class,
+			]
+		);
+
+		wp_register_ability(
+			'gratis-ai-agent/update-option',
+			[
+				'label'         => __( 'Update Option', 'gratis-ai-agent' ),
+				'description'   => __( 'Create or update a WordPress option. Blocked for critical system options (siteurl, admin_email, active_plugins, etc.).', 'gratis-ai-agent' ),
+				'ability_class' => UpdateOptionAbility::class,
+			]
+		);
+
+		wp_register_ability(
+			'gratis-ai-agent/delete-option',
+			[
+				'label'         => __( 'Delete Option', 'gratis-ai-agent' ),
+				'description'   => __( 'Delete a WordPress option by name. Blocked for critical system options.', 'gratis-ai-agent' ),
+				'ability_class' => DeleteOptionAbility::class,
+			]
+		);
+
+		wp_register_ability(
+			'gratis-ai-agent/list-options',
+			[
+				'label'         => __( 'List Options', 'gratis-ai-agent' ),
+				'description'   => __( 'List WordPress options with optional prefix filtering. Returns option names and values (truncated for large values). Useful for discovering plugin/theme settings.', 'gratis-ai-agent' ),
+				'ability_class' => ListOptionsAbility::class,
+			]
+		);
+	}
+
+	/**
+	 * Get the runtime write blocklist (built-in + filtered).
+	 *
+	 * @return string[]
+	 */
+	public static function get_write_blocklist(): array {
+		/**
+		 * Filters the list of WordPress options the AI agent is blocked from writing.
+		 *
+		 * @since 1.2.0
+		 *
+		 * @param string[] $blocklist List of blocked option names.
+		 */
+		$blocklist = apply_filters( 'gratis_ai_agent_options_blocklist', self::WRITE_BLOCKLIST );
+
+		return array_values( array_filter( (array) $blocklist, 'is_string' ) );
+	}
+}
+
+/**
+ * Get Option ability.
+ *
+ * Reads a single WordPress option by name.
+ *
+ * @since 1.2.0
+ */
+class GetOptionAbility extends AbstractAbility {
+
+	protected function label(): string {
+		return __( 'Get Option', 'gratis-ai-agent' );
+	}
+
+	protected function description(): string {
+		return __( 'Read a WordPress option by name. Returns the stored value or a default if the option does not exist.', 'gratis-ai-agent' );
+	}
+
+	protected function input_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'option_name' => [
+					'type'        => 'string',
+					'description' => 'The option name to retrieve (e.g. "blogname", "blogdescription", "posts_per_page").',
+				],
+				'default'     => [
+					'description' => 'Value to return if the option does not exist. Defaults to false.',
+				],
+			],
+			'required'   => [ 'option_name' ],
+		];
+	}
+
+	protected function output_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'option_name' => [ 'type' => 'string' ],
+				'value'       => [],
+				'exists'      => [ 'type' => 'boolean' ],
+			],
+		];
+	}
+
+	protected function execute_callback( $input ) {
+		/** @var array<string, mixed> $input */
+		$option_name = isset( $input['option_name'] ) ? (string) $input['option_name'] : '';
+
+		if ( '' === $option_name ) {
+			return new WP_Error(
+				'gratis_ai_agent_empty_option_name',
+				__( 'The "option_name" parameter is required.', 'gratis-ai-agent' )
+			);
+		}
+
+		$default = $input['default'] ?? false;
+
+		// Check whether the option exists before fetching so we can report it.
+		$raw    = get_option( $option_name, null );
+		$exists = null !== $raw;
+
+		$value = $exists ? $raw : $default;
+
+		return [
+			'option_name' => $option_name,
+			'value'       => $value,
+			'exists'      => $exists,
+		];
+	}
+
+	protected function permission_callback( $input = null ): bool {
+		return ToolCapabilities::current_user_can( $this->name );
+	}
+
+	protected function meta(): array {
+		return [
+			'annotations'  => [
+				'readonly'    => true,
+				'destructive' => false,
+				'idempotent'  => true,
+			],
+			'show_in_rest' => true,
+		];
+	}
+}
+
+/**
+ * Update Option ability.
+ *
+ * Creates or updates a WordPress option with blocklist enforcement.
+ *
+ * @since 1.2.0
+ */
+class UpdateOptionAbility extends AbstractAbility {
+
+	protected function label(): string {
+		return __( 'Update Option', 'gratis-ai-agent' );
+	}
+
+	protected function description(): string {
+		return __( 'Create or update a WordPress option. Blocked for critical system options (siteurl, admin_email, active_plugins, etc.).', 'gratis-ai-agent' );
+	}
+
+	protected function input_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'option_name'  => [
+					'type'        => 'string',
+					'description' => 'The option name to create or update.',
+				],
+				'option_value' => [
+					'description' => 'The new value to store. Strings, numbers, booleans, arrays, and objects are all supported.',
+				],
+				'autoload'     => [
+					'type'        => 'string',
+					'enum'        => [ 'yes', 'no' ],
+					'description' => 'Whether to autoload this option on every page load. Use "no" for large or infrequently-accessed options. Defaults to "yes".',
+					'default'     => 'yes',
+				],
+			],
+			'required'   => [ 'option_name', 'option_value' ],
+		];
+	}
+
+	protected function output_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'option_name' => [ 'type' => 'string' ],
+				'status'      => [ 'type' => 'string' ],
+				'message'     => [ 'type' => 'string' ],
+			],
+		];
+	}
+
+	protected function execute_callback( $input ) {
+		/** @var array<string, mixed> $input */
+		$option_name = isset( $input['option_name'] ) ? (string) $input['option_name'] : '';
+
+		if ( '' === $option_name ) {
+			return new WP_Error(
+				'gratis_ai_agent_empty_option_name',
+				__( 'The "option_name" parameter is required.', 'gratis-ai-agent' )
+			);
+		}
+
+		// Blocklist check.
+		$blocklist = OptionsAbilities::get_write_blocklist();
+		if ( in_array( $option_name, $blocklist, true ) ) {
+			return new WP_Error(
+				'gratis_ai_agent_option_blocked',
+				sprintf(
+					/* translators: %s: option name */
+					__( 'The option "%s" is protected and cannot be modified by the AI agent.', 'gratis-ai-agent' ),
+					$option_name
+				)
+			);
+		}
+
+		if ( ! array_key_exists( 'option_value', $input ) ) {
+			return new WP_Error(
+				'gratis_ai_agent_missing_option_value',
+				__( 'The "option_value" parameter is required.', 'gratis-ai-agent' )
+			);
+		}
+
+		$option_value = $input['option_value'];
+		$autoload     = isset( $input['autoload'] ) && 'no' === $input['autoload'] ? 'no' : 'yes';
+
+		$updated = update_option( $option_name, $option_value, $autoload );
+
+		if ( $updated ) {
+			return [
+				'option_name' => $option_name,
+				'status'      => 'updated',
+				'message'     => sprintf(
+					/* translators: %s: option name */
+					__( 'Option "%s" updated successfully.', 'gratis-ai-agent' ),
+					$option_name
+				),
+			];
+		}
+
+		// update_option() returns false both when the value is unchanged and
+		// when the option does not exist yet (add_option path). Distinguish
+		// the two cases so the caller gets accurate feedback.
+		$exists = false !== get_option( $option_name, false );
+
+		if ( $exists ) {
+			return [
+				'option_name' => $option_name,
+				'status'      => 'unchanged',
+				'message'     => sprintf(
+					/* translators: %s: option name */
+					__( 'Option "%s" already has the requested value — no change made.', 'gratis-ai-agent' ),
+					$option_name
+				),
+			];
+		}
+
+		// Option did not exist and add_option (called internally by update_option) failed.
+		return new WP_Error(
+			'gratis_ai_agent_update_failed',
+			sprintf(
+				/* translators: %s: option name */
+				__( 'Failed to update option "%s".', 'gratis-ai-agent' ),
+				$option_name
+			)
+		);
+	}
+
+	protected function permission_callback( $input = null ): bool {
+		return ToolCapabilities::current_user_can( $this->name );
+	}
+
+	protected function meta(): array {
+		return [
+			'annotations'  => [
+				'readonly'    => false,
+				'destructive' => false,
+				'idempotent'  => true,
+			],
+			'show_in_rest' => true,
+		];
+	}
+}
+
+/**
+ * Delete Option ability.
+ *
+ * Removes a WordPress option with blocklist enforcement.
+ *
+ * @since 1.2.0
+ */
+class DeleteOptionAbility extends AbstractAbility {
+
+	protected function label(): string {
+		return __( 'Delete Option', 'gratis-ai-agent' );
+	}
+
+	protected function description(): string {
+		return __( 'Delete a WordPress option by name. Blocked for critical system options.', 'gratis-ai-agent' );
+	}
+
+	protected function input_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'option_name' => [
+					'type'        => 'string',
+					'description' => 'The option name to delete.',
+				],
+			],
+			'required'   => [ 'option_name' ],
+		];
+	}
+
+	protected function output_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'option_name' => [ 'type' => 'string' ],
+				'status'      => [ 'type' => 'string' ],
+				'message'     => [ 'type' => 'string' ],
+			],
+		];
+	}
+
+	protected function execute_callback( $input ) {
+		/** @var array<string, mixed> $input */
+		$option_name = isset( $input['option_name'] ) ? (string) $input['option_name'] : '';
+
+		if ( '' === $option_name ) {
+			return new WP_Error(
+				'gratis_ai_agent_empty_option_name',
+				__( 'The "option_name" parameter is required.', 'gratis-ai-agent' )
+			);
+		}
+
+		// Blocklist check.
+		$blocklist = OptionsAbilities::get_write_blocklist();
+		if ( in_array( $option_name, $blocklist, true ) ) {
+			return new WP_Error(
+				'gratis_ai_agent_option_blocked',
+				sprintf(
+					/* translators: %s: option name */
+					__( 'The option "%s" is protected and cannot be deleted by the AI agent.', 'gratis-ai-agent' ),
+					$option_name
+				)
+			);
+		}
+
+		// Check existence before deleting so we can report accurately.
+		$exists = false !== get_option( $option_name, false );
+
+		if ( ! $exists ) {
+			return [
+				'option_name' => $option_name,
+				'status'      => 'not_found',
+				'message'     => sprintf(
+					/* translators: %s: option name */
+					__( 'Option "%s" does not exist.', 'gratis-ai-agent' ),
+					$option_name
+				),
+			];
+		}
+
+		$deleted = delete_option( $option_name );
+
+		if ( $deleted ) {
+			return [
+				'option_name' => $option_name,
+				'status'      => 'deleted',
+				'message'     => sprintf(
+					/* translators: %s: option name */
+					__( 'Option "%s" deleted successfully.', 'gratis-ai-agent' ),
+					$option_name
+				),
+			];
+		}
+
+		return new WP_Error(
+			'gratis_ai_agent_delete_failed',
+			sprintf(
+				/* translators: %s: option name */
+				__( 'Failed to delete option "%s".', 'gratis-ai-agent' ),
+				$option_name
+			)
+		);
+	}
+
+	protected function permission_callback( $input = null ): bool {
+		return ToolCapabilities::current_user_can( $this->name );
+	}
+
+	protected function meta(): array {
+		return [
+			'annotations'  => [
+				'readonly'    => false,
+				'destructive' => true,
+				'idempotent'  => true,
+			],
+			'show_in_rest' => true,
+		];
+	}
+}
+
+/**
+ * List Options ability.
+ *
+ * Lists WordPress options with optional prefix filtering. Useful for
+ * discovering plugin/theme settings without knowing exact option names.
+ *
+ * @since 1.2.0
+ */
+class ListOptionsAbility extends AbstractAbility {
+
+	/**
+	 * Maximum number of characters to include per option value in the listing.
+	 * Large values (serialised arrays, HTML blobs) are truncated to keep the
+	 * response token-efficient.
+	 */
+	private const VALUE_TRUNCATE_LENGTH = 200;
+
+	protected function label(): string {
+		return __( 'List Options', 'gratis-ai-agent' );
+	}
+
+	protected function description(): string {
+		return __( 'List WordPress options with optional prefix filtering. Returns option names and values (truncated for large values). Useful for discovering plugin/theme settings.', 'gratis-ai-agent' );
+	}
+
+	protected function input_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'prefix'   => [
+					'type'        => 'string',
+					'description' => 'Filter options whose names start with this prefix (e.g. "woocommerce_", "elementor_"). Leave empty to list all options.',
+					'default'     => '',
+				],
+				'limit'    => [
+					'type'        => 'integer',
+					'description' => 'Maximum number of options to return (default: 50, max: 200).',
+					'default'     => 50,
+				],
+				'autoload' => [
+					'type'        => 'string',
+					'enum'        => [ 'all', 'yes', 'no' ],
+					'description' => 'Filter by autoload status: "yes" (autoloaded), "no" (not autoloaded), or "all" (default).',
+					'default'     => 'all',
+				],
+			],
+		];
+	}
+
+	protected function output_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'options' => [ 'type' => 'array' ],
+				'total'   => [ 'type' => 'integer' ],
+				'prefix'  => [ 'type' => 'string' ],
+			],
+		];
+	}
+
+	protected function execute_callback( $input ) {
+		/** @var array<string, mixed> $input */
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$prefix   = isset( $input['prefix'] ) ? (string) $input['prefix'] : '';
+		$limit    = min( 200, max( 1, (int) ( $input['limit'] ?? 50 ) ) );
+		$autoload = isset( $input['autoload'] ) ? (string) $input['autoload'] : 'all';
+
+		// Build query.
+		$where_clauses = [];
+		$query_args    = [];
+
+		if ( '' !== $prefix ) {
+			$where_clauses[] = 'option_name LIKE %s';
+			$query_args[]    = $wpdb->esc_like( $prefix ) . '%';
+		}
+
+		if ( 'yes' === $autoload ) {
+			$where_clauses[] = "autoload IN ('yes', 'on', '1', 'true')";
+		} elseif ( 'no' === $autoload ) {
+			$where_clauses[] = "autoload NOT IN ('yes', 'on', '1', 'true')";
+		}
+
+		$where_sql = '';
+		if ( ! empty( $where_clauses ) ) {
+			$where_sql = 'WHERE ' . implode( ' AND ', $where_clauses );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Dynamic prefix filter; caching not appropriate for discovery queries.
+		if ( ! empty( $query_args ) ) {
+			// @phpstan-ignore-next-line
+			$sql = $wpdb->prepare(
+				// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $where_sql contains only safe, pre-escaped clauses.
+				"SELECT option_name, option_value, autoload FROM {$wpdb->options} {$where_sql} ORDER BY option_name ASC LIMIT %d",
+				array_merge( $query_args, [ $limit ] )
+			);
+		} else {
+			// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- No user input; $limit is cast to int above.
+			$sql = $wpdb->prepare(
+				"SELECT option_name, option_value, autoload FROM {$wpdb->options} ORDER BY option_name ASC LIMIT %d",
+				$limit
+			);
+		}
+
+		// @phpstan-ignore-next-line
+		$rows = $wpdb->get_results( $sql, ARRAY_A ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is always the output of $wpdb->prepare() above; PHPCS cannot trace through the variable.
+
+		if ( null === $rows ) {
+			return new WP_Error(
+				'gratis_ai_agent_db_error',
+				__( 'Database query failed while listing options.', 'gratis-ai-agent' )
+			);
+		}
+
+		$options = [];
+		foreach ( $rows as $row ) {
+			$value = $row['option_value'];
+
+			// Attempt to unserialise so the caller sees the real data type.
+			$unserialized = maybe_unserialize( $value );
+
+			// Truncate large values to keep the response token-efficient.
+			if ( is_string( $unserialized ) && strlen( $unserialized ) > self::VALUE_TRUNCATE_LENGTH ) {
+				$unserialized = substr( $unserialized, 0, self::VALUE_TRUNCATE_LENGTH ) . '…';
+			} elseif ( ! is_scalar( $unserialized ) ) {
+				// For arrays/objects, encode to JSON and truncate if needed.
+				$encoded = wp_json_encode( $unserialized );
+				if ( false !== $encoded && strlen( $encoded ) > self::VALUE_TRUNCATE_LENGTH ) {
+					$unserialized = substr( $encoded, 0, self::VALUE_TRUNCATE_LENGTH ) . '…';
+				}
+			}
+
+			$options[] = [
+				'option_name'  => $row['option_name'],
+				'option_value' => $unserialized,
+				'autoload'     => $row['autoload'],
+			];
+		}
+
+		return [
+			'options' => $options,
+			'total'   => count( $options ),
+			'prefix'  => $prefix,
+		];
+	}
+
+	protected function permission_callback( $input = null ): bool {
+		return ToolCapabilities::current_user_can( $this->name );
+	}
+
+	protected function meta(): array {
+		return [
+			'annotations'  => [
+				'readonly'    => true,
+				'destructive' => false,
+				'idempotent'  => true,
+			],
+			'show_in_rest' => true,
+		];
+	}
+}

--- a/includes/Abilities/ToolCapabilities.php
+++ b/includes/Abilities/ToolCapabilities.php
@@ -210,6 +210,11 @@ class ToolCapabilities {
 			'gratis-ai-agent/get-themes',
 			'gratis-ai-agent/install-plugin',
 			'gratis-ai-agent/run-php',
+			// Options management.
+			'gratis-ai-agent/get-option',
+			'gratis-ai-agent/update-option',
+			'gratis-ai-agent/delete-option',
+			'gratis-ai-agent/list-options',
 			// Navigation.
 			'gratis-ai-agent/navigate',
 			'gratis-ai-agent/get-page-html',


### PR DESCRIPTION
## Summary

Implements `t179` — options management abilities with a safety blocklist that prevents the AI from modifying critical WordPress options.

## Changes

**New file:** `includes/Abilities/OptionsAbilities.php`

Four new abilities:

| Ability | Description | Annotations |
|---|---|---|
| `gratis-ai-agent/get-option` | Read a single option by name | readonly, idempotent |
| `gratis-ai-agent/update-option` | Create/update an option (blocklist enforced) | idempotent |
| `gratis-ai-agent/delete-option` | Delete an option (blocklist enforced) | destructive, idempotent |
| `gratis-ai-agent/list-options` | List options with prefix/autoload filtering | readonly, idempotent |

**Safety blocklist** (`WRITE_BLOCKLIST`) covers:
- Core site URLs: `siteurl`, `home`
- Admin contact: `admin_email`
- Plugin/theme activation: `active_plugins`, `active_sitewide_plugins`, `template`, `stylesheet`
- DB schema version: `db_version`, `db_upgraded`
- User roles: `user_roles`, `wp_user_roles`
- Cron schedule: `cron`
- Auth keys/salts (all 8 standard keys)
- Multisite network options: `site_admins`, `allowedthemes`
- File editing gates: `disallow_file_edit`, `disallow_file_mods`

The blocklist is extensible via the `gratis_ai_agent_options_blocklist` filter.

**Modified files:**
- `gratis-ai-agent.php`: added `use` statement + `OptionsAbilities::register()` call
- `includes/Abilities/ToolCapabilities.php`: added all 4 ability IDs to `all_ability_ids()`

## Verification

- `vendor/bin/phpcs --standard=phpcs.xml includes/Abilities/OptionsAbilities.php` — passes (0 errors)
- `vendor/bin/phpcs --standard=phpcs.xml includes/Abilities/ToolCapabilities.php gratis-ai-agent.php` — passes (0 errors)

Resolves #845

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI agent can now read, update, delete, and list WordPress options
  * Built-in safety blocklist protects critical options from unauthorized modification
  * User permission checks control access to option-management operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->