### PR TITLE
t178: add navigation menu management ability

### DIFF
--- a/gratis-ai-agent.php
+++ b/gratis-ai-agent.php
@@ -55,6 +55,7 @@ use GratisAiAgent\Abilities\PluginDownloadAbilities;
 use GratisAiAgent\Abilities\MarketingAbilities;
 use GratisAiAgent\Abilities\MediaAbilities;
 use GratisAiAgent\Abilities\MemoryAbilities;
+use GratisAiAgent\Abilities\MenuAbilities;
 use GratisAiAgent\Abilities\NavigationAbilities;
 use GratisAiAgent\Abilities\PostAbilities;
 use GratisAiAgent\Abilities\UserAbilities;
@@ -355,6 +356,9 @@ SiteHealthAbilities::register();
 
 // Navigation abilities (navigate, get page HTML).
 NavigationAbilities::register();
+
+// Navigation menu management abilities (list, create, delete menus; add/remove items; assign locations).
+MenuAbilities::register();
 
 // Post management abilities (get, create, update, delete posts).
 PostAbilities::register();

--- a/includes/Abilities/MenuAbilities.php
+++ b/includes/Abilities/MenuAbilities.php
@@ -1,0 +1,685 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Navigation menu management abilities for the AI agent.
+ *
+ * Provides WordPress nav menu listing, creation, item management, and deletion.
+ *
+ * @package GratisAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace GratisAiAgent\Abilities;
+
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class MenuAbilities {
+
+	/**
+	 * Register menu abilities on init.
+	 */
+	public static function register(): void {
+		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
+	}
+
+	/**
+	 * Register all navigation menu management abilities.
+	 */
+	public static function register_abilities(): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			'ai-agent/list-menus',
+			[
+				'label'               => __( 'List Menus', 'gratis-ai-agent' ),
+				'description'         => __( 'List all registered WordPress navigation menus. Returns menu ID, name, slug, and the theme locations it is assigned to.', 'gratis-ai-agent' ),
+				'category'            => 'gratis-ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [],
+					'required'   => [],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'menus' => [ 'type' => 'array' ],
+						'total' => [ 'type' => 'integer' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'   => true,
+						'idempotent' => true,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_list_menus' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'edit_theme_options' );
+				},
+			]
+		);
+
+		wp_register_ability(
+			'ai-agent/get-menu',
+			[
+				'label'               => __( 'Get Menu', 'gratis-ai-agent' ),
+				'description'         => __( 'Retrieve a WordPress navigation menu by ID or slug, including all its items with labels, URLs, and hierarchy.', 'gratis-ai-agent' ),
+				'category'            => 'gratis-ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'menu_id'   => [
+							'type'        => 'integer',
+							'description' => 'The term ID of the menu to retrieve.',
+						],
+						'menu_slug' => [
+							'type'        => 'string',
+							'description' => 'The slug of the menu to retrieve (alternative to menu_id).',
+						],
+					],
+					'required'   => [],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'id'    => [ 'type' => 'integer' ],
+						'name'  => [ 'type' => 'string' ],
+						'slug'  => [ 'type' => 'string' ],
+						'items' => [ 'type' => 'array' ],
+						'count' => [ 'type' => 'integer' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'   => true,
+						'idempotent' => true,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_get_menu' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'edit_theme_options' );
+				},
+			]
+		);
+
+		wp_register_ability(
+			'ai-agent/create-menu',
+			[
+				'label'               => __( 'Create Menu', 'gratis-ai-agent' ),
+				'description'         => __( 'Create a new WordPress navigation menu with the given name. Optionally assign it to a theme location.', 'gratis-ai-agent' ),
+				'category'            => 'gratis-ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'name'     => [
+							'type'        => 'string',
+							'description' => 'The display name for the new menu.',
+						],
+						'location' => [
+							'type'        => 'string',
+							'description' => 'Optional theme location slug to assign this menu to (e.g. "primary", "footer").',
+						],
+					],
+					'required'   => [ 'name' ],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'menu_id' => [ 'type' => 'integer' ],
+						'name'    => [ 'type' => 'string' ],
+						'slug'    => [ 'type' => 'string' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'    => false,
+						'destructive' => false,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_create_menu' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'edit_theme_options' );
+				},
+			]
+		);
+
+		wp_register_ability(
+			'ai-agent/delete-menu',
+			[
+				'label'               => __( 'Delete Menu', 'gratis-ai-agent' ),
+				'description'         => __( 'Delete a WordPress navigation menu and all its items by menu ID or slug.', 'gratis-ai-agent' ),
+				'category'            => 'gratis-ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'menu_id'   => [
+							'type'        => 'integer',
+							'description' => 'The term ID of the menu to delete.',
+						],
+						'menu_slug' => [
+							'type'        => 'string',
+							'description' => 'The slug of the menu to delete (alternative to menu_id).',
+						],
+					],
+					'required'   => [],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'menu_id' => [ 'type' => 'integer' ],
+						'name'    => [ 'type' => 'string' ],
+						'deleted' => [ 'type' => 'boolean' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'    => false,
+						'destructive' => true,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_delete_menu' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'edit_theme_options' );
+				},
+			]
+		);
+
+		wp_register_ability(
+			'ai-agent/add-menu-item',
+			[
+				'label'               => __( 'Add Menu Item', 'gratis-ai-agent' ),
+				'description'         => __( 'Add an item to a WordPress navigation menu. Supports custom URLs, pages, posts, categories, and tags.', 'gratis-ai-agent' ),
+				'category'            => 'gratis-ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'menu_id'     => [
+							'type'        => 'integer',
+							'description' => 'The term ID of the menu to add the item to.',
+						],
+						'menu_slug'   => [
+							'type'        => 'string',
+							'description' => 'The slug of the menu (alternative to menu_id).',
+						],
+						'title'       => [
+							'type'        => 'string',
+							'description' => 'The display label for the menu item.',
+						],
+						'url'         => [
+							'type'        => 'string',
+							'description' => 'The URL for a custom link menu item.',
+						],
+						'object_type' => [
+							'type'        => 'string',
+							'description' => 'Type of object: "custom", "post_type", or "taxonomy". Defaults to "custom".',
+							'enum'        => [ 'custom', 'post_type', 'taxonomy' ],
+						],
+						'object'      => [
+							'type'        => 'string',
+							'description' => 'For post_type: the post type slug (e.g. "page", "post"). For taxonomy: the taxonomy slug (e.g. "category", "post_tag").',
+						],
+						'object_id'   => [
+							'type'        => 'integer',
+							'description' => 'For post_type or taxonomy items: the ID of the post, page, or term.',
+						],
+						'parent_id'   => [
+							'type'        => 'integer',
+							'description' => 'Menu item ID of the parent item (for nested/dropdown menus).',
+						],
+						'position'    => [
+							'type'        => 'integer',
+							'description' => 'Menu order position (1-based). Defaults to last.',
+						],
+						'attr_title'  => [
+							'type'        => 'string',
+							'description' => 'Title attribute (tooltip) for the menu item.',
+						],
+						'css_classes' => [
+							'type'        => 'string',
+							'description' => 'Space-separated CSS classes to add to the menu item.',
+						],
+						'target'      => [
+							'type'        => 'string',
+							'description' => 'Link target attribute (e.g. "_blank" to open in new tab).',
+						],
+					],
+					'required'   => [ 'title' ],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'item_id' => [ 'type' => 'integer' ],
+						'title'   => [ 'type' => 'string' ],
+						'url'     => [ 'type' => 'string' ],
+						'menu_id' => [ 'type' => 'integer' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'    => false,
+						'destructive' => false,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_add_menu_item' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'edit_theme_options' );
+				},
+			]
+		);
+
+		wp_register_ability(
+			'ai-agent/remove-menu-item',
+			[
+				'label'               => __( 'Remove Menu Item', 'gratis-ai-agent' ),
+				'description'         => __( 'Remove an item from a WordPress navigation menu by its menu item ID.', 'gratis-ai-agent' ),
+				'category'            => 'gratis-ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'item_id' => [
+							'type'        => 'integer',
+							'description' => 'The post ID of the menu item to remove.',
+						],
+					],
+					'required'   => [ 'item_id' ],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'item_id' => [ 'type' => 'integer' ],
+						'title'   => [ 'type' => 'string' ],
+						'deleted' => [ 'type' => 'boolean' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'    => false,
+						'destructive' => true,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_remove_menu_item' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'edit_theme_options' );
+				},
+			]
+		);
+
+		wp_register_ability(
+			'ai-agent/assign-menu-location',
+			[
+				'label'               => __( 'Assign Menu to Location', 'gratis-ai-agent' ),
+				'description'         => __( 'Assign a WordPress navigation menu to a registered theme location (e.g. "primary", "footer"). Use list-menus to see available menus and their current locations.', 'gratis-ai-agent' ),
+				'category'            => 'gratis-ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'menu_id'   => [
+							'type'        => 'integer',
+							'description' => 'The term ID of the menu to assign.',
+						],
+						'menu_slug' => [
+							'type'        => 'string',
+							'description' => 'The slug of the menu (alternative to menu_id).',
+						],
+						'location'  => [
+							'type'        => 'string',
+							'description' => 'The theme location slug to assign the menu to.',
+						],
+					],
+					'required'   => [ 'location' ],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'menu_id'  => [ 'type' => 'integer' ],
+						'name'     => [ 'type' => 'string' ],
+						'location' => [ 'type' => 'string' ],
+						'assigned' => [ 'type' => 'boolean' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'    => false,
+						'destructive' => false,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_assign_menu_location' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'edit_theme_options' );
+				},
+			]
+		);
+	}
+
+	/**
+	 * Handle the list-menus ability.
+	 *
+	 * @param array<string, mixed> $input Input (unused).
+	 * @return array<string, mixed>
+	 */
+	public static function handle_list_menus( array $input ): array {
+		$nav_menus = wp_get_nav_menus();
+		$locations = get_nav_menu_locations();
+
+		// Build a reverse map: menu_id => [ location_slugs ].
+		$menu_locations = [];
+		foreach ( $locations as $location => $menu_id ) {
+			if ( ! isset( $menu_locations[ $menu_id ] ) ) {
+				$menu_locations[ $menu_id ] = [];
+			}
+			$menu_locations[ $menu_id ][] = $location;
+		}
+
+		$menus = [];
+		foreach ( $nav_menus as $menu ) {
+			$menus[] = [
+				'id'        => $menu->term_id,
+				'name'      => $menu->name,
+				'slug'      => $menu->slug,
+				'count'     => $menu->count,
+				'locations' => $menu_locations[ $menu->term_id ] ?? [],
+			];
+		}
+
+		return [
+			'menus' => $menus,
+			'total' => count( $menus ),
+		];
+	}
+
+	/**
+	 * Handle the get-menu ability.
+	 *
+	 * @param array<string, mixed> $input Input with menu_id or menu_slug.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function handle_get_menu( array $input ) {
+		$menu = self::resolve_menu( $input );
+
+		if ( is_wp_error( $menu ) ) {
+			return $menu;
+		}
+
+		$menu_items = wp_get_nav_menu_items( $menu->term_id );
+
+		$items = [];
+		if ( is_array( $menu_items ) ) {
+			foreach ( $menu_items as $item ) {
+				if ( ! ( $item instanceof \WP_Post ) ) {
+					continue;
+				}
+				$raw_classes = get_post_meta( $item->ID, '_menu_item_classes', true );
+				$classes     = is_array( $raw_classes ) ? implode( ' ', array_filter( $raw_classes, 'is_string' ) ) : '';
+				$items[]     = [
+					'id'         => $item->ID,
+					'title'      => $item->post_title,
+					'url'        => (string) get_post_meta( $item->ID, '_menu_item_url', true ),
+					'type'       => (string) get_post_meta( $item->ID, '_menu_item_type', true ),
+					'object'     => (string) get_post_meta( $item->ID, '_menu_item_object', true ),
+					'object_id'  => (int) get_post_meta( $item->ID, '_menu_item_object_id', true ),
+					'parent_id'  => (int) get_post_meta( $item->ID, '_menu_item_menu_item_parent', true ),
+					'position'   => (int) $item->menu_order,
+					'target'     => (string) get_post_meta( $item->ID, '_menu_item_target', true ),
+					'classes'    => $classes,
+					'attr_title' => (string) get_post_meta( $item->ID, '_menu_item_attr_title', true ),
+				];
+			}
+		}
+
+		return [
+			'id'    => $menu->term_id,
+			'name'  => $menu->name,
+			'slug'  => $menu->slug,
+			'items' => $items,
+			'count' => count( $items ),
+		];
+	}
+
+	/**
+	 * Handle the create-menu ability.
+	 *
+	 * @param array<string, mixed> $input Input with name and optional location.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function handle_create_menu( array $input ) {
+		// @phpstan-ignore-next-line
+		$name = sanitize_text_field( $input['name'] ?? '' );
+		// @phpstan-ignore-next-line
+		$location = sanitize_text_field( $input['location'] ?? '' );
+
+		if ( empty( $name ) ) {
+			return new WP_Error( 'ai_agent_empty_menu_name', __( 'Menu name is required.', 'gratis-ai-agent' ) );
+		}
+
+		$menu_id = wp_create_nav_menu( $name );
+
+		if ( is_wp_error( $menu_id ) ) {
+			return $menu_id;
+		}
+
+		// Assign to theme location if provided.
+		if ( ! empty( $location ) ) {
+			$locations              = get_nav_menu_locations();
+			$locations[ $location ] = $menu_id;
+			set_theme_mod( 'nav_menu_locations', $locations );
+		}
+
+		$menu = wp_get_nav_menu_object( $menu_id );
+
+		return [
+			'menu_id' => $menu_id,
+			'name'    => $menu ? $menu->name : $name,
+			'slug'    => $menu ? $menu->slug : sanitize_title( $name ),
+		];
+	}
+
+	/**
+	 * Handle the delete-menu ability.
+	 *
+	 * @param array<string, mixed> $input Input with menu_id or menu_slug.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function handle_delete_menu( array $input ) {
+		$menu = self::resolve_menu( $input );
+
+		if ( is_wp_error( $menu ) ) {
+			return $menu;
+		}
+
+		$menu_id   = $menu->term_id;
+		$menu_name = $menu->name;
+
+		$result = wp_delete_nav_menu( $menu_id );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return [
+			'menu_id' => $menu_id,
+			'name'    => $menu_name,
+			'deleted' => (bool) $result,
+		];
+	}
+
+	/**
+	 * Handle the add-menu-item ability.
+	 *
+	 * @param array<string, mixed> $input Input with menu_id/slug, title, url, etc.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function handle_add_menu_item( array $input ) {
+		$menu = self::resolve_menu( $input );
+
+		if ( is_wp_error( $menu ) ) {
+			return $menu;
+		}
+
+		// @phpstan-ignore-next-line
+		$title = sanitize_text_field( $input['title'] ?? '' );
+		// @phpstan-ignore-next-line
+		$url = esc_url_raw( $input['url'] ?? '' );
+		// @phpstan-ignore-next-line
+		$object_type = sanitize_text_field( $input['object_type'] ?? 'custom' );
+		// @phpstan-ignore-next-line
+		$object = sanitize_text_field( $input['object'] ?? '' );
+		// @phpstan-ignore-next-line
+		$object_id = (int) ( $input['object_id'] ?? 0 );
+		// @phpstan-ignore-next-line
+		$parent_id = (int) ( $input['parent_id'] ?? 0 );
+		// @phpstan-ignore-next-line
+		$position = (int) ( $input['position'] ?? 0 );
+		// @phpstan-ignore-next-line
+		$attr_title = sanitize_text_field( $input['attr_title'] ?? '' );
+		// @phpstan-ignore-next-line
+		$css_classes = sanitize_text_field( $input['css_classes'] ?? '' );
+		// @phpstan-ignore-next-line
+		$target = sanitize_text_field( $input['target'] ?? '' );
+
+		if ( empty( $title ) ) {
+			return new WP_Error( 'ai_agent_empty_item_title', __( 'Menu item title is required.', 'gratis-ai-agent' ) );
+		}
+
+		$allowed_types = [ 'custom', 'post_type', 'taxonomy' ];
+		if ( ! in_array( $object_type, $allowed_types, true ) ) {
+			$object_type = 'custom';
+		}
+
+		$item_data = [
+			'menu-item-title'      => $title,
+			'menu-item-url'        => $url,
+			'menu-item-type'       => $object_type,
+			'menu-item-object'     => $object,
+			'menu-item-object-id'  => $object_id,
+			'menu-item-parent-id'  => $parent_id,
+			'menu-item-position'   => $position,
+			'menu-item-attr-title' => $attr_title,
+			'menu-item-classes'    => $css_classes,
+			'menu-item-target'     => $target,
+			'menu-item-status'     => 'publish',
+		];
+
+		$item_id = wp_update_nav_menu_item( $menu->term_id, 0, $item_data );
+
+		if ( is_wp_error( $item_id ) ) {
+			return $item_id;
+		}
+
+		return [
+			'item_id' => $item_id,
+			'title'   => $title,
+			'url'     => $url,
+			'menu_id' => $menu->term_id,
+		];
+	}
+
+	/**
+	 * Handle the remove-menu-item ability.
+	 *
+	 * @param array<string, mixed> $input Input with item_id.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function handle_remove_menu_item( array $input ) {
+		// @phpstan-ignore-next-line
+		$item_id = (int) ( $input['item_id'] ?? 0 );
+
+		if ( ! $item_id ) {
+			return new WP_Error( 'ai_agent_empty_item_id', __( 'item_id is required.', 'gratis-ai-agent' ) );
+		}
+
+		$item = get_post( $item_id );
+
+		if ( ! $item || $item->post_type !== 'nav_menu_item' ) {
+			return new WP_Error(
+				'ai_agent_menu_item_not_found',
+				/* translators: %d: menu item ID */
+				sprintf( __( 'Menu item %d not found.', 'gratis-ai-agent' ), $item_id )
+			);
+		}
+
+		$title  = $item->post_title;
+		$result = wp_delete_post( $item_id, true );
+
+		return [
+			'item_id' => $item_id,
+			'title'   => $title,
+			'deleted' => (bool) $result,
+		];
+	}
+
+	/**
+	 * Handle the assign-menu-location ability.
+	 *
+	 * @param array<string, mixed> $input Input with menu_id/slug and location.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function handle_assign_menu_location( array $input ) {
+		$menu = self::resolve_menu( $input );
+
+		if ( is_wp_error( $menu ) ) {
+			return $menu;
+		}
+
+		// @phpstan-ignore-next-line
+		$location = sanitize_text_field( $input['location'] ?? '' );
+
+		if ( empty( $location ) ) {
+			return new WP_Error( 'ai_agent_empty_location', __( 'location is required.', 'gratis-ai-agent' ) );
+		}
+
+		$locations              = get_nav_menu_locations();
+		$locations[ $location ] = $menu->term_id;
+		set_theme_mod( 'nav_menu_locations', $locations );
+
+		return [
+			'menu_id'  => $menu->term_id,
+			'name'     => $menu->name,
+			'location' => $location,
+			'assigned' => true,
+		];
+	}
+
+	/**
+	 * Resolve a menu object from input containing menu_id or menu_slug.
+	 *
+	 * @param array<string, mixed> $input Input array.
+	 * @return \WP_Term|WP_Error
+	 */
+	private static function resolve_menu( array $input ) {
+		// @phpstan-ignore-next-line
+		$menu_id = (int) ( $input['menu_id'] ?? 0 );
+		// @phpstan-ignore-next-line
+		$menu_slug = sanitize_text_field( $input['menu_slug'] ?? '' );
+
+		if ( $menu_id > 0 ) {
+			$menu = wp_get_nav_menu_object( $menu_id );
+		} elseif ( ! empty( $menu_slug ) ) {
+			$menu = wp_get_nav_menu_object( $menu_slug );
+		} else {
+			return new WP_Error( 'ai_agent_missing_menu_identifier', __( 'Provide menu_id or menu_slug.', 'gratis-ai-agent' ) );
+		}
+
+		if ( ! $menu || is_wp_error( $menu ) ) {
+			return new WP_Error(
+				'ai_agent_menu_not_found',
+				__( 'Menu not found.', 'gratis-ai-agent' )
+			);
+		}
+
+		return $menu;
+	}
+}

--- a/tests/GratisAiAgent/Abilities/MenuAbilitiesTest.php
+++ b/tests/GratisAiAgent/Abilities/MenuAbilitiesTest.php
@@ -1,0 +1,346 @@
+<?php
+/**
+ * Test case for MenuAbilities class.
+ *
+ * @package GratisAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace GratisAiAgent\Tests\Abilities;
+
+use GratisAiAgent\Abilities\MenuAbilities;
+use WP_UnitTestCase;
+
+/**
+ * Test MenuAbilities handler methods.
+ */
+class MenuAbilitiesTest extends WP_UnitTestCase {
+
+	// ─── handle_list_menus ────────────────────────────────────────
+
+	/**
+	 * Test handle_list_menus returns expected structure when no menus exist.
+	 */
+	public function test_handle_list_menus_returns_structure() {
+		$result = MenuAbilities::handle_list_menus( [] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'menus', $result );
+		$this->assertArrayHasKey( 'total', $result );
+		$this->assertIsArray( $result['menus'] );
+		$this->assertIsInt( $result['total'] );
+	}
+
+	/**
+	 * Test handle_list_menus total matches menus array count.
+	 */
+	public function test_handle_list_menus_total_matches_count() {
+		wp_create_nav_menu( 'Test Menu A' );
+		wp_create_nav_menu( 'Test Menu B' );
+
+		$result = MenuAbilities::handle_list_menus( [] );
+
+		$this->assertSame( count( $result['menus'] ), $result['total'] );
+	}
+
+	/**
+	 * Test handle_list_menus each menu has required fields.
+	 */
+	public function test_handle_list_menus_menu_structure() {
+		wp_create_nav_menu( 'Structure Test Menu' );
+
+		$result = MenuAbilities::handle_list_menus( [] );
+
+		$this->assertNotEmpty( $result['menus'] );
+		$menu = $result['menus'][0];
+		$this->assertArrayHasKey( 'id', $menu );
+		$this->assertArrayHasKey( 'name', $menu );
+		$this->assertArrayHasKey( 'slug', $menu );
+		$this->assertArrayHasKey( 'count', $menu );
+		$this->assertArrayHasKey( 'locations', $menu );
+		$this->assertIsArray( $menu['locations'] );
+	}
+
+	// ─── handle_get_menu ─────────────────────────────────────────
+
+	/**
+	 * Test handle_get_menu returns error when no identifier provided.
+	 */
+	public function test_handle_get_menu_missing_identifier() {
+		$result = MenuAbilities::handle_get_menu( [] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_missing_menu_identifier', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_get_menu returns error for non-existent menu.
+	 */
+	public function test_handle_get_menu_not_found() {
+		$result = MenuAbilities::handle_get_menu( [ 'menu_id' => 999999 ] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_menu_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_get_menu returns menu by ID.
+	 */
+	public function test_handle_get_menu_by_id() {
+		$menu_id = wp_create_nav_menu( 'Get By ID Menu' );
+		$this->assertIsInt( $menu_id );
+
+		$result = MenuAbilities::handle_get_menu( [ 'menu_id' => $menu_id ] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $menu_id, $result['id'] );
+		$this->assertSame( 'Get By ID Menu', $result['name'] );
+		$this->assertArrayHasKey( 'items', $result );
+		$this->assertArrayHasKey( 'count', $result );
+	}
+
+	/**
+	 * Test handle_get_menu returns menu by slug.
+	 */
+	public function test_handle_get_menu_by_slug() {
+		$menu_id = wp_create_nav_menu( 'Get By Slug Menu' );
+		$this->assertIsInt( $menu_id );
+
+		$menu = wp_get_nav_menu_object( $menu_id );
+		$this->assertNotFalse( $menu );
+
+		$result = MenuAbilities::handle_get_menu( [ 'menu_slug' => $menu->slug ] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $menu_id, $result['id'] );
+	}
+
+	// ─── handle_create_menu ───────────────────────────────────────
+
+	/**
+	 * Test handle_create_menu returns error when name is empty.
+	 */
+	public function test_handle_create_menu_empty_name() {
+		$result = MenuAbilities::handle_create_menu( [ 'name' => '' ] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_empty_menu_name', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_create_menu creates a menu and returns expected structure.
+	 */
+	public function test_handle_create_menu_success() {
+		$result = MenuAbilities::handle_create_menu( [ 'name' => 'New Test Menu' ] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'menu_id', $result );
+		$this->assertArrayHasKey( 'name', $result );
+		$this->assertArrayHasKey( 'slug', $result );
+		$this->assertIsInt( $result['menu_id'] );
+		$this->assertSame( 'New Test Menu', $result['name'] );
+	}
+
+	/**
+	 * Test handle_create_menu creates a menu that can be retrieved.
+	 */
+	public function test_handle_create_menu_persisted() {
+		$result = MenuAbilities::handle_create_menu( [ 'name' => 'Persisted Menu' ] );
+
+		$this->assertIsArray( $result );
+		$menu = wp_get_nav_menu_object( $result['menu_id'] );
+		$this->assertNotFalse( $menu );
+		$this->assertSame( 'Persisted Menu', $menu->name );
+	}
+
+	// ─── handle_delete_menu ───────────────────────────────────────
+
+	/**
+	 * Test handle_delete_menu returns error when no identifier provided.
+	 */
+	public function test_handle_delete_menu_missing_identifier() {
+		$result = MenuAbilities::handle_delete_menu( [] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_missing_menu_identifier', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_delete_menu deletes a menu by ID.
+	 */
+	public function test_handle_delete_menu_success() {
+		$menu_id = wp_create_nav_menu( 'Menu To Delete' );
+		$this->assertIsInt( $menu_id );
+
+		$result = MenuAbilities::handle_delete_menu( [ 'menu_id' => $menu_id ] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $menu_id, $result['menu_id'] );
+		$this->assertTrue( $result['deleted'] );
+
+		// Verify it's gone.
+		$menu = wp_get_nav_menu_object( $menu_id );
+		$this->assertFalse( $menu );
+	}
+
+	// ─── handle_add_menu_item ─────────────────────────────────────
+
+	/**
+	 * Test handle_add_menu_item returns error when title is empty.
+	 */
+	public function test_handle_add_menu_item_empty_title() {
+		$menu_id = wp_create_nav_menu( 'Add Item Menu' );
+		$this->assertIsInt( $menu_id );
+
+		$result = MenuAbilities::handle_add_menu_item(
+			[
+				'menu_id' => $menu_id,
+				'title'   => '',
+				'url'     => 'https://example.com',
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_empty_item_title', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_add_menu_item adds a custom link item.
+	 */
+	public function test_handle_add_menu_item_custom_link() {
+		$menu_id = wp_create_nav_menu( 'Custom Link Menu' );
+		$this->assertIsInt( $menu_id );
+
+		$result = MenuAbilities::handle_add_menu_item(
+			[
+				'menu_id' => $menu_id,
+				'title'   => 'Home',
+				'url'     => 'https://example.com',
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'item_id', $result );
+		$this->assertArrayHasKey( 'title', $result );
+		$this->assertArrayHasKey( 'url', $result );
+		$this->assertArrayHasKey( 'menu_id', $result );
+		$this->assertIsInt( $result['item_id'] );
+		$this->assertSame( 'Home', $result['title'] );
+		$this->assertSame( $menu_id, $result['menu_id'] );
+	}
+
+	/**
+	 * Test handle_add_menu_item item appears in menu after adding.
+	 */
+	public function test_handle_add_menu_item_persisted() {
+		$menu_id = wp_create_nav_menu( 'Persist Item Menu' );
+		$this->assertIsInt( $menu_id );
+
+		MenuAbilities::handle_add_menu_item(
+			[
+				'menu_id' => $menu_id,
+				'title'   => 'About',
+				'url'     => 'https://example.com/about',
+			]
+		);
+
+		$items = wp_get_nav_menu_items( $menu_id );
+		$this->assertIsArray( $items );
+		$this->assertCount( 1, $items );
+		$this->assertSame( 'About', $items[0]->title );
+	}
+
+	// ─── handle_remove_menu_item ──────────────────────────────────
+
+	/**
+	 * Test handle_remove_menu_item returns error when item_id is missing.
+	 */
+	public function test_handle_remove_menu_item_missing_id() {
+		$result = MenuAbilities::handle_remove_menu_item( [] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_empty_item_id', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_remove_menu_item returns error for non-existent item.
+	 */
+	public function test_handle_remove_menu_item_not_found() {
+		$result = MenuAbilities::handle_remove_menu_item( [ 'item_id' => 999999 ] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_menu_item_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_remove_menu_item removes an item successfully.
+	 */
+	public function test_handle_remove_menu_item_success() {
+		$menu_id = wp_create_nav_menu( 'Remove Item Menu' );
+		$this->assertIsInt( $menu_id );
+
+		$item_id = wp_update_nav_menu_item(
+			$menu_id,
+			0,
+			[
+				'menu-item-title'  => 'Contact',
+				'menu-item-url'    => 'https://example.com/contact',
+				'menu-item-type'   => 'custom',
+				'menu-item-status' => 'publish',
+			]
+		);
+		$this->assertIsInt( $item_id );
+
+		$result = MenuAbilities::handle_remove_menu_item( [ 'item_id' => $item_id ] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $item_id, $result['item_id'] );
+		$this->assertTrue( $result['deleted'] );
+	}
+
+	// ─── handle_assign_menu_location ─────────────────────────────
+
+	/**
+	 * Test handle_assign_menu_location returns error when location is empty.
+	 */
+	public function test_handle_assign_menu_location_empty_location() {
+		$menu_id = wp_create_nav_menu( 'Location Menu' );
+		$this->assertIsInt( $menu_id );
+
+		$result = MenuAbilities::handle_assign_menu_location(
+			[
+				'menu_id'  => $menu_id,
+				'location' => '',
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ai_agent_empty_location', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_assign_menu_location assigns menu to location.
+	 */
+	public function test_handle_assign_menu_location_success() {
+		$menu_id = wp_create_nav_menu( 'Assign Location Menu' );
+		$this->assertIsInt( $menu_id );
+
+		$result = MenuAbilities::handle_assign_menu_location(
+			[
+				'menu_id'  => $menu_id,
+				'location' => 'primary',
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $menu_id, $result['menu_id'] );
+		$this->assertSame( 'primary', $result['location'] );
+		$this->assertTrue( $result['assigned'] );
+
+		// Verify the location was set.
+		$locations = get_nav_menu_locations();
+		$this->assertArrayHasKey( 'primary', $locations );
+		$this->assertSame( $menu_id, $locations['primary'] );
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `MenuAbilities` class with 7 WordPress nav menu management abilities: `list-menus`, `get-menu`, `create-menu`, `delete-menu`, `add-menu-item`, `remove-menu-item`, `assign-menu-location`
- Registers `MenuAbilities` in the main plugin file alongside `NavigationAbilities`
- Adds `MenuAbilitiesTest` with 20 unit tests covering all handlers including error cases

## Files Changed

- NEW: `includes/Abilities/MenuAbilities.php` — full CRUD for WordPress nav menus via `wp_create_nav_menu`, `wp_delete_nav_menu`, `wp_update_nav_menu_item`, `wp_delete_post`, and `set_theme_mod`
- NEW: `tests/GratisAiAgent/Abilities/MenuAbilitiesTest.php` — 20 unit tests
- EDIT: `gratis-ai-agent.php` — added `use` import and `MenuAbilities::register()` call

## Verification

PHPCS: 0 errors, 0 warnings on `includes/Abilities/MenuAbilities.php`
PHPStan: No errors on `includes/Abilities/MenuAbilities.php`

Resolves #844