### PR TITLE
t173: Register custom taxonomy ability with persistence

### DIFF
--- a/gratis-ai-agent.php
+++ b/gratis-ai-agent.php
@@ -44,6 +44,7 @@ use GratisAiAgent\Abilities\AiImageAbilities;
 use GratisAiAgent\Abilities\BlockAbilities;
 use GratisAiAgent\Abilities\ContentAbilities;
 use GratisAiAgent\Abilities\CustomPostTypeAbilities;
+use GratisAiAgent\Abilities\CustomTaxonomyAbilities;
 use GratisAiAgent\Abilities\DatabaseAbilities;
 use GratisAiAgent\Abilities\EditorialAbilities;
 use GratisAiAgent\Abilities\FileAbilities;
@@ -366,6 +367,9 @@ PostAbilities::register();
 
 // Custom post type abilities (register, list, delete CPTs with persistence).
 CustomPostTypeAbilities::register();
+
+// Custom taxonomy abilities (register, list, delete taxonomies with persistence).
+CustomTaxonomyAbilities::register();
 
 // User management abilities (list, create, update role).
 UserAbilities::register();

--- a/includes/Abilities/CustomTaxonomyAbilities.php
+++ b/includes/Abilities/CustomTaxonomyAbilities.php
@@ -1,0 +1,422 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Custom taxonomy abilities for the AI agent.
+ *
+ * Provides abilities to register, list, and delete custom taxonomies
+ * with persistence via WordPress options (stored in the database so
+ * taxonomies survive page reloads and are re-registered on every init).
+ *
+ * @package GratisAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace GratisAiAgent\Abilities;
+
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Custom taxonomy abilities.
+ *
+ * Persists taxonomy definitions in the `gratis_ai_agent_custom_taxonomies` option
+ * (an array keyed by taxonomy slug) and re-registers them on every `init`
+ * hook so they survive page reloads.
+ *
+ * @since 1.3.4
+ */
+class CustomTaxonomyAbilities {
+
+	/**
+	 * WordPress option key used to persist taxonomy definitions.
+	 */
+	const OPTION_KEY = 'gratis_ai_agent_custom_taxonomies';
+
+	/**
+	 * Register the abilities and the persistent taxonomy re-registration hook.
+	 */
+	public static function register(): void {
+		// Re-register persisted taxonomies on every init so they survive page reloads.
+		add_action( 'init', [ __CLASS__, 'restore_persisted_taxonomies' ], 5 );
+
+		// Register the AI abilities.
+		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
+	}
+
+	/**
+	 * Re-register all taxonomies that were previously persisted via the register ability.
+	 *
+	 * Runs on `init` with priority 5 (before most plugins) so the taxonomies are
+	 * available to the rest of WordPress on every request.
+	 */
+	public static function restore_persisted_taxonomies(): void {
+		$stored = get_option( self::OPTION_KEY, [] );
+		if ( ! is_array( $stored ) || empty( $stored ) ) {
+			return;
+		}
+
+		foreach ( $stored as $taxonomy => $entry ) {
+			if ( ! is_string( $taxonomy ) || '' === $taxonomy || taxonomy_exists( $taxonomy ) ) {
+				continue;
+			}
+			if ( ! is_array( $entry ) || empty( $entry['object_type'] ) || ! is_array( $entry['object_type'] ) ) {
+				continue;
+			}
+			$object_type = $entry['object_type'];
+			$args        = $entry['args'] ?? [];
+			if ( ! is_array( $args ) ) {
+				continue;
+			}
+			// @phpstan-ignore-next-line
+			register_taxonomy( $taxonomy, $object_type, $args );
+		}
+	}
+
+	/**
+	 * Register all custom taxonomy abilities.
+	 */
+	public static function register_abilities(): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			'gratis-ai-agent/register-taxonomy',
+			[
+				'label'               => __( 'Register Custom Taxonomy', 'gratis-ai-agent' ),
+				'description'         => __( 'Register a new custom taxonomy and persist it in the database so it survives page reloads. Supports labels, public visibility, REST API support, hierarchical settings, and association with one or more post types.', 'gratis-ai-agent' ),
+				'category'            => 'gratis-ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'taxonomy'     => [
+							'type'        => 'string',
+							'description' => 'The taxonomy slug (max 32 characters, lowercase letters, numbers, and hyphens only). Example: "genre", "location", "product-tag".',
+						],
+						'object_type'  => [
+							'type'        => 'array',
+							'description' => 'One or more post type slugs to associate this taxonomy with (e.g. ["post", "page", "portfolio"]). Use an empty array to register without association.',
+							'items'       => [ 'type' => 'string' ],
+						],
+						'singular'     => [
+							'type'        => 'string',
+							'description' => 'Singular label for the taxonomy (e.g. "Genre").',
+						],
+						'plural'       => [
+							'type'        => 'string',
+							'description' => 'Plural label for the taxonomy (e.g. "Genres").',
+						],
+						'public'       => [
+							'type'        => 'boolean',
+							'description' => 'Whether the taxonomy is publicly accessible (default: true).',
+						],
+						'show_in_rest' => [
+							'type'        => 'boolean',
+							'description' => 'Whether to expose the taxonomy in the REST API / block editor (default: true).',
+						],
+						'hierarchical' => [
+							'type'        => 'boolean',
+							'description' => 'Whether the taxonomy is hierarchical like categories (default: false — tag-like).',
+						],
+						'description'  => [
+							'type'        => 'string',
+							'description' => 'A short descriptive summary of what the taxonomy is.',
+						],
+					],
+					'required'   => [ 'taxonomy', 'object_type', 'singular', 'plural' ],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'taxonomy'     => [ 'type' => 'string' ],
+						'object_type'  => [ 'type' => 'array' ],
+						'singular'     => [ 'type' => 'string' ],
+						'plural'       => [ 'type' => 'string' ],
+						'public'       => [ 'type' => 'boolean' ],
+						'show_in_rest' => [ 'type' => 'boolean' ],
+						'hierarchical' => [ 'type' => 'boolean' ],
+						'persisted'    => [ 'type' => 'boolean' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'    => false,
+						'destructive' => false,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_register_taxonomy' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+			]
+		);
+
+		wp_register_ability(
+			'gratis-ai-agent/list-taxonomies',
+			[
+				'label'               => __( 'List Custom Taxonomies', 'gratis-ai-agent' ),
+				'description'         => __( 'List all registered taxonomies, including those persisted by the AI agent. Returns slug, labels, public status, associated post types, and whether the taxonomy was registered by the AI agent.', 'gratis-ai-agent' ),
+				'category'            => 'gratis-ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'include_builtin' => [
+							'type'        => 'boolean',
+							'description' => 'Whether to include built-in WordPress taxonomies (category, post_tag, etc.). Default: false.',
+						],
+					],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'taxonomies' => [ 'type' => 'array' ],
+						'total'      => [ 'type' => 'integer' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'   => true,
+						'idempotent' => true,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_list_taxonomies' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'edit_posts' );
+				},
+			]
+		);
+
+		wp_register_ability(
+			'gratis-ai-agent/delete-taxonomy',
+			[
+				'label'               => __( 'Delete Custom Taxonomy', 'gratis-ai-agent' ),
+				'description'         => __( 'Remove a custom taxonomy that was registered by the AI agent. This unregisters the taxonomy and removes it from the database so it will not be re-registered on future page loads. Only AI-registered taxonomies can be deleted via this ability.', 'gratis-ai-agent' ),
+				'category'            => 'gratis-ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'taxonomy' => [
+							'type'        => 'string',
+							'description' => 'The taxonomy slug to delete.',
+						],
+					],
+					'required'   => [ 'taxonomy' ],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'taxonomy' => [ 'type' => 'string' ],
+						'deleted'  => [ 'type' => 'boolean' ],
+					],
+				],
+				'meta'                => [
+					'annotations'  => [
+						'readonly'    => false,
+						'destructive' => true,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_delete_taxonomy' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'manage_options' );
+				},
+			]
+		);
+	}
+
+	/**
+	 * Handle the register-taxonomy ability.
+	 *
+	 * @param array<string, mixed> $input Input with taxonomy, object_type, singular, plural, and optional settings.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function handle_register_taxonomy( array $input ) {
+		$taxonomy     = sanitize_key( $input['taxonomy'] ?? '' );
+		$singular     = sanitize_text_field( $input['singular'] ?? '' );
+		$plural       = sanitize_text_field( $input['plural'] ?? '' );
+		$public       = isset( $input['public'] ) ? (bool) $input['public'] : true;
+		$show_in_rest = isset( $input['show_in_rest'] ) ? (bool) $input['show_in_rest'] : true;
+		$hierarchical = isset( $input['hierarchical'] ) ? (bool) $input['hierarchical'] : false;
+		$description  = sanitize_text_field( $input['description'] ?? '' );
+
+		$object_type = isset( $input['object_type'] ) && is_array( $input['object_type'] )
+			? array_map(
+				static function ( $item ): string {
+					return sanitize_key( (string) $item );
+				},
+				$input['object_type']
+			)
+			: [];
+
+		if ( empty( $taxonomy ) ) {
+			return new WP_Error( 'gratis_ai_agent_empty_taxonomy', __( 'taxonomy is required.', 'gratis-ai-agent' ) );
+		}
+
+		if ( strlen( $taxonomy ) > 32 ) {
+			return new WP_Error(
+				'gratis_ai_agent_taxonomy_too_long',
+				__( 'taxonomy slug must be 32 characters or fewer.', 'gratis-ai-agent' )
+			);
+		}
+
+		if ( empty( $singular ) || empty( $plural ) ) {
+			return new WP_Error( 'gratis_ai_agent_empty_labels', __( 'singular and plural labels are required.', 'gratis-ai-agent' ) );
+		}
+
+		// Prevent overwriting built-in taxonomies.
+		$builtin_taxonomies = [ 'category', 'post_tag', 'nav_menu', 'link_category', 'post_format', 'wp_theme', 'wp_template_part_area', 'wp_pattern_category' ];
+		if ( in_array( $taxonomy, $builtin_taxonomies, true ) ) {
+			return new WP_Error(
+				'gratis_ai_agent_builtin_taxonomy',
+				/* translators: %s: taxonomy slug */
+				sprintf( __( '"%s" is a built-in WordPress taxonomy and cannot be overwritten.', 'gratis-ai-agent' ), $taxonomy )
+			);
+		}
+
+		$labels = [
+			'name'                  => $plural,
+			'singular_name'         => $singular,
+			/* translators: %s: singular label */
+			'search_items'          => sprintf( __( 'Search %s', 'gratis-ai-agent' ), $plural ),
+			/* translators: %s: plural label */
+			'all_items'             => sprintf( __( 'All %s', 'gratis-ai-agent' ), $plural ),
+			/* translators: %s: singular label */
+			'edit_item'             => sprintf( __( 'Edit %s', 'gratis-ai-agent' ), $singular ),
+			/* translators: %s: singular label */
+			'view_item'             => sprintf( __( 'View %s', 'gratis-ai-agent' ), $singular ),
+			/* translators: %s: singular label */
+			'update_item'           => sprintf( __( 'Update %s', 'gratis-ai-agent' ), $singular ),
+			/* translators: %s: singular label */
+			'add_new_item'          => sprintf( __( 'Add New %s', 'gratis-ai-agent' ), $singular ),
+			/* translators: %s: singular label */
+			'new_item_name'         => sprintf( __( 'New %s Name', 'gratis-ai-agent' ), $singular ),
+			'menu_name'             => $plural,
+			/* translators: %s: plural label */
+			'not_found'             => sprintf( __( 'No %s found.', 'gratis-ai-agent' ), strtolower( $plural ) ),
+			/* translators: %s: plural label */
+			'no_terms'              => sprintf( __( 'No %s', 'gratis-ai-agent' ), strtolower( $plural ) ),
+			/* translators: %s: plural label */
+			'items_list'            => sprintf( __( '%s list', 'gratis-ai-agent' ), $plural ),
+			/* translators: %s: plural label */
+			'items_list_navigation' => sprintf( __( '%s list navigation', 'gratis-ai-agent' ), $plural ),
+		];
+
+		$args = [
+			'labels'       => $labels,
+			'description'  => $description,
+			'public'       => $public,
+			'show_in_rest' => $show_in_rest,
+			'hierarchical' => $hierarchical,
+			'rewrite'      => [ 'slug' => $taxonomy ],
+		];
+
+		// @phpstan-ignore-next-line
+		$result = register_taxonomy( $taxonomy, $object_type, $args );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		// Persist the taxonomy definition so it survives page reloads.
+		$stored              = get_option( self::OPTION_KEY, [] );
+		$stored[ $taxonomy ] = [
+			'object_type' => $object_type,
+			'args'        => $args,
+		];
+		update_option( self::OPTION_KEY, $stored, false );
+
+		return [
+			'taxonomy'     => $taxonomy,
+			'object_type'  => $object_type,
+			'singular'     => $singular,
+			'plural'       => $plural,
+			'public'       => $public,
+			'show_in_rest' => $show_in_rest,
+			'hierarchical' => $hierarchical,
+			'persisted'    => true,
+		];
+	}
+
+	/**
+	 * Handle the list-taxonomies ability.
+	 *
+	 * @param array<string, mixed> $input Input with optional include_builtin flag.
+	 * @return array<string, mixed>
+	 */
+	public static function handle_list_taxonomies( array $input ) {
+		$include_builtin = (bool) ( $input['include_builtin'] ?? false );
+
+		$builtin_taxonomies = [ 'category', 'post_tag', 'nav_menu', 'link_category', 'post_format', 'wp_theme', 'wp_template_part_area', 'wp_pattern_category' ];
+
+		$stored_taxonomies = array_keys( (array) get_option( self::OPTION_KEY, [] ) );
+
+		$all_taxonomies = get_taxonomies( [], 'objects' );
+		$result         = [];
+
+		foreach ( $all_taxonomies as $taxonomy_obj ) {
+			$slug = $taxonomy_obj->name;
+
+			if ( ! $include_builtin && in_array( $slug, $builtin_taxonomies, true ) ) {
+				continue;
+			}
+
+			$result[] = [
+				'slug'           => $slug,
+				'label'          => $taxonomy_obj->label,
+				'singular_label' => $taxonomy_obj->labels->singular_name ?? $slug,
+				'public'         => (bool) $taxonomy_obj->public,
+				'show_in_rest'   => (bool) $taxonomy_obj->show_in_rest,
+				'hierarchical'   => (bool) $taxonomy_obj->hierarchical,
+				'object_type'    => $taxonomy_obj->object_type,
+				'ai_registered'  => in_array( $slug, $stored_taxonomies, true ),
+			];
+		}
+
+		return [
+			'taxonomies' => $result,
+			'total'      => count( $result ),
+		];
+	}
+
+	/**
+	 * Handle the delete-taxonomy ability.
+	 *
+	 * @param array<string, mixed> $input Input with taxonomy slug.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function handle_delete_taxonomy( array $input ) {
+		$taxonomy = sanitize_key( $input['taxonomy'] ?? '' );
+
+		if ( empty( $taxonomy ) ) {
+			return new WP_Error( 'gratis_ai_agent_empty_taxonomy', __( 'taxonomy is required.', 'gratis-ai-agent' ) );
+		}
+
+		$stored = get_option( self::OPTION_KEY, [] );
+
+		if ( ! is_array( $stored ) || ! array_key_exists( $taxonomy, $stored ) ) {
+			return new WP_Error(
+				'gratis_ai_agent_taxonomy_not_found',
+				/* translators: %s: taxonomy slug */
+				sprintf( __( 'Taxonomy "%s" was not registered by the AI agent and cannot be deleted via this ability.', 'gratis-ai-agent' ), $taxonomy )
+			);
+		}
+
+		// Unregister from the current request.
+		unregister_taxonomy( $taxonomy );
+
+		// Remove from persistent storage.
+		unset( $stored[ $taxonomy ] );
+		update_option( self::OPTION_KEY, $stored, false );
+
+		return [
+			'taxonomy' => $taxonomy,
+			'deleted'  => true,
+		];
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `CustomTaxonomyAbilities` class (`includes/Abilities/CustomTaxonomyAbilities.php`) modeled on `CustomPostTypeAbilities`
- Registers three abilities: `register-taxonomy`, `list-taxonomies`, `delete-taxonomy`
- Persists taxonomy definitions in the `gratis_ai_agent_custom_taxonomies` option and re-registers on `init:5` so they survive page reloads
- Registers the class in `gratis-ai-agent.php` alongside `CustomPostTypeAbilities`

## Abilities

| Ability | Permission | Description |
|---|---|---|
| `gratis-ai-agent/register-taxonomy` | `manage_options` | Register a taxonomy with labels, public/REST/hierarchical settings, and post type associations |
| `gratis-ai-agent/list-taxonomies` | `edit_posts` | List all registered taxonomies; optionally include built-ins |
| `gratis-ai-agent/delete-taxonomy` | `manage_options` | Unregister and remove from persistent storage (AI-registered only) |

## Verification

- PHPCS: zero errors/warnings
- PHPStan: no errors

Resolves #851

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI agent can now register, list, and delete custom taxonomies with validation and sanitization built-in
  * Custom taxonomies persist across site requests and are automatically restored on each load
  * Built-in taxonomy protection prevents accidental overwrites of core WordPress taxonomies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->