### PR TITLE
fix: use sentinel object for get_option existence checks in OptionsAbilities

### DIFF
--- a/includes/Abilities/OptionsAbilities.php
+++ b/includes/Abilities/OptionsAbilities.php
@@ -330,7 +330,10 @@ class UpdateOptionAbility extends AbstractAbility {
 		// update_option() returns false both when the value is unchanged and
 		// when the option does not exist yet (add_option path). Distinguish
 		// the two cases so the caller gets accurate feedback.
-		$exists = false !== get_option( $option_name, false );
+		// Use a sentinel object so options storing literal false are not
+		// misdetected as non-existent.
+		$sentinel = new \stdClass();
+		$exists   = get_option( $option_name, $sentinel ) !== $sentinel;
 
 		if ( $exists ) {
 			return [
@@ -437,7 +440,10 @@ class DeleteOptionAbility extends AbstractAbility {
 		}
 
 		// Check existence before deleting so we can report accurately.
-		$exists = false !== get_option( $option_name, false );
+		// Use a sentinel object so options storing literal false are not
+		// misdetected as non-existent.
+		$sentinel = new \stdClass();
+		$exists   = get_option( $option_name, $sentinel ) !== $sentinel;
 
 		if ( ! $exists ) {
 			return [


### PR DESCRIPTION
## Summary

Fixes the edge case where WordPress options storing a literal `false` value are misdetected as non-existent in `UpdateOptionAbility` and `DeleteOptionAbility`.

## Problem

Both classes used `false !== get_option( $option_name, false )` to check option existence. When an option's stored value is boolean `false`, `get_option()` returns `false` — identical to the default — making it impossible to distinguish "option exists with value false" from "option does not exist".

## Fix

Replace the `false` default with a unique `stdClass` sentinel object. Since no stored option value can ever be the same object instance, a strict `!==` comparison against the sentinel reliably detects non-existence:

```php
$sentinel = new \stdClass();
$exists   = get_option( $option_name, $sentinel ) !== $sentinel;
```

Applied to both:
- `UpdateOptionAbility::execute_callback()` (~line 333) — prevents false "unchanged" reports
- `DeleteOptionAbility::execute_callback()` (~line 443) — prevents false "not_found" reports

## Runtime Testing

Risk level: **Low** — logic-only fix, no API surface changes, no new dependencies.

Self-assessed: the sentinel pattern is a well-established PHP idiom for this exact WordPress API limitation. PHPCS passes with zero violations.

Resolves #866

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.6.234 plugin for [OpenCode](https://opencode.ai) v1.3.16 with claude-sonnet-4-6 spent 1m and 2,626 tokens on this as a headless worker.