### PR TITLE
fix: raise AI Client SDK timeout to 120s for agentic workloads

### DIFF
--- a/gratis-ai-agent.php
+++ b/gratis-ai-agent.php
@@ -426,6 +426,19 @@ ChangeLogger::register();
 // Provider trace logger — captures LLM provider HTTP traffic when enabled.
 ProviderTraceLogger::register();
 
+// Raise the AI Client SDK request timeout to match the agent loop wall-clock
+// limit (120 s). The SDK default is 30 s, which is too short for agentic
+// workloads that involve research + long-form content generation (e.g.
+// "research AIDS and write a blog post" — the final generation call alone
+// can exceed 30 s). The filter is applied at construction time of the prompt
+// builder, so hooking it here (before any REST request is processed) is safe.
+add_filter(
+	'wp_ai_client_default_request_timeout',
+	static function (): int {
+		return AgentLoop::LOOP_TIMEOUT_SECONDS;
+	}
+);
+
 // Fresh install detection — registers cache-invalidation hooks.
 FreshInstallDetector::register();
 


### PR DESCRIPTION
## Problem

Prompts like _"research AIDS and write a current blog post article"_ fail with:

```
Error: Network error occurred while sending request to https://api.anthropic.com/v1/messages:
cURL error 28: Operation timed out after 30002 milliseconds with 0 bytes received
```

**Root cause:** The WordPress AI Client SDK applies a **30-second HTTP timeout** via the `wp_ai_client_default_request_timeout` filter (default: `30`, set in `class-wp-ai-client-prompt-builder.php:200`). The final generation call for a research + long-form article can take 30–60 seconds, hitting this limit before the response arrives.

The agent loop already enforces a 120-second wall-clock budget (`AgentLoop::LOOP_TIMEOUT_SECONDS`), but the HTTP layer was cutting the connection at 30s — well before the loop's own deadline.

## Fix

Hook `wp_ai_client_default_request_timeout` in `gratis-ai-agent.php` to return `AgentLoop::LOOP_TIMEOUT_SECONDS` (120s), aligning the HTTP timeout with the loop's own wall-clock budget:

```php
add_filter(
    'wp_ai_client_default_request_timeout',
    static function (): int {
        return AgentLoop::LOOP_TIMEOUT_SECONDS; // 120
    }
);
```

The background worker (`/process` endpoint) already calls `set_time_limit(600)`, so PHP execution time is not a constraint. This change only raises the cURL/HTTP layer timeout to match what the loop already allows.

## Testing

Reproduce with the prompt that was failing:
> "research AIDS and write a current blog post article about how well it is being treated"

Before this fix: times out at ~30s with cURL error 28.  
After this fix: completes and returns a full article (typically 40–90s depending on model and output length).