### PR TITLE
GH#882: fix: replace vague {Array} JSDoc with inline ToolCall shape in LiveToolProgress

### DIFF
--- a/src/components/message-list.js
+++ b/src/components/message-list.js
@@ -189,8 +189,8 @@ function extractText( message ) {
  * background job is processing. Displays each tool call as it happens
  * so the user can see the agent is making progress.
  *
- * @param {Object} props           - Component props.
- * @param {Array}  props.toolCalls - Live tool call log from the job.
+ * @param {Object}     props           - Component props.
+ * @param {Array<{type: string, id?: string, name?: string, args?: Object, response?: unknown}>} props.toolCalls - Live tool call log from the job.
  * @return {JSX.Element} Progress indicator.
  */
 function LiveToolProgress( { toolCalls } ) {

--- a/src/components/message-list.js
+++ b/src/components/message-list.js
@@ -185,12 +185,21 @@ function extractText( message ) {
 }
 
 /**
+ * @typedef  {Object}  ToolCall
+ * @property {string}  type       - Entry kind: 'call' when invoked, 'response' when complete.
+ * @property {string}  [id]       - Optional unique identifier for the call.
+ * @property {string}  [name]     - Tool name.
+ * @property {Object}  [args]     - Arguments passed to the tool.
+ * @property {unknown} [response] - Value returned by the tool.
+ */
+
+/**
  * Live tool call progress shown inside the "Thinking" bubble while the
  * background job is processing. Displays each tool call as it happens
  * so the user can see the agent is making progress.
  *
  * @param {Object}     props           - Component props.
- * @param {Array<{type: string, id?: string, name?: string, args?: Object, response?: unknown}>} props.toolCalls - Live tool call log from the job.
+ * @param {ToolCall[]} props.toolCalls - Live tool call log from the job.
  * @return {JSX.Element} Progress indicator.
  */
 function LiveToolProgress( { toolCalls } ) {


### PR DESCRIPTION
## Summary

Replaces the generic `{Array}` JSDoc type for `props.toolCalls` in the `LiveToolProgress` component with the specific inline shape type as suggested by CodeRabbit during review of PR #876.

## Changes

- **EDIT: `src/components/message-list.js:192-193`** — Updated `@param {Array}` to `@param {Array<{type: string, id?: string, name?: string, args?: Object, response?: unknown}>}` for `props.toolCalls` in the `LiveToolProgress` JSDoc.

## Verification

ESLint passes: `npm run lint:js` — no errors.

The inline type accurately reflects the tool call object structure used throughout the component (see `calls.filter(t => t.type === 'call')` and similar).

Resolves #882