### PR TITLE
GH#887: fix: update OnboardingWizard test for Connectors-page-link refactor

### DIFF
--- a/src/components/__tests__/OnboardingWizard.test.js
+++ b/src/components/__tests__/OnboardingWizard.test.js
@@ -628,7 +628,7 @@ describe( 'OnboardingProviderRow rendering', () => {
 		expect( html ).toContain( 'gratis-ai-agent-wizard' );
 	} );
 
-	test( 'provider row shows Configured badge when hasKey is true via settings', async () => {
+	test( 'step 1 renders Connectors page link instead of provider badge after refactor', async () => {
 		setupMocks( {
 			settings: { _provider_keys: { openai: true } },
 		} );
@@ -651,7 +651,16 @@ describe( 'OnboardingProviderRow rendering', () => {
 			nextBtn.click();
 		} );
 
-		expect( localContainer.innerHTML ).toContain( 'Configured' );
+		// Step 1 now directs users to the Connectors page instead of showing
+		// inline provider rows with Configured badges. Assert the link renders.
+		const connectorsLink = localContainer.querySelector(
+			'.gratis-ai-agent-wizard-connectors-link'
+		);
+		expect( connectorsLink ).not.toBeNull();
+		expect( connectorsLink.href ).toContain( 'options-connectors.php' );
+		expect( connectorsLink.textContent ).toContain(
+			'Open Connectors page to configure a provider'
+		);
 
 		await act( async () => {
 			localRoot.unmount();


### PR DESCRIPTION
## Summary

Fixes failing test introduced when commit `15b0168` refactored step 1 of the onboarding wizard to redirect to the WordPress Connectors page instead of rendering inline provider rows with API key inputs and status badges.

The test "provider row shows Configured badge when hasKey is true via settings" asserted `'Configured'` appeared in the HTML, which is no longer true after the refactor.

## Changes

**EDIT: `src/components/__tests__/OnboardingWizard.test.js`** (lines 631–669)

- Renamed test: `'provider row shows Configured badge when hasKey is true via settings'` → `'step 1 renders Connectors page link instead of provider badge after refactor'`
- Replaced `expect(html).toContain('Configured')` with three precise DOM assertions:
  1. `.gratis-ai-agent-wizard-connectors-link` element is present
  2. its `href` contains `options-connectors.php`
  3. its text contains `'Open Connectors page to configure a provider'`

## Verification

```
Tests: 244 passed, 244 total
Test Suites: 8 passed, 8 total
```

Resolves #887

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the onboarding wizard's Step 1 interface to display a link to the Connectors page, streamlining the provider configuration workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->