### PR TITLE
GH#886: fix wp-env port conflict — assign ports 8890/8893

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,6 +1,8 @@
 {
 	"core": "WordPress/WordPress#7.0-branch",
 	"phpVersion": "8.2",
+	"port": 8890,
+	"testsPort": 8893,
 	"plugins": [
 		"."
 	],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@
 - **Test PHP**: `npm run test:php` (PHPUnit via `@wordpress/env`)
 - **Test E2E**: `npm run test:e2e:playwright` (Playwright)
 - **Pre-commit**: Husky + lint-staged runs lint fixes on staged files
-- **Dev environment**: `npx wp-env start` (WordPress 7.0 via `.wp-env.json`)
+- **Dev environment**: `npx wp-env start` (WordPress 7.0 via `.wp-env.json`) — dev site at http://localhost:8890, test site at http://localhost:8893
 
 ## Code Style & Architecture
 


### PR DESCRIPTION
## Summary

- Adds `port: 8890` and `testsPort: 8893` to `.wp-env.json` so `npx wp-env start` no longer tries to bind to port 8888, which was already occupied by another project on this machine.
- Updates AGENTS.md to document the wp-env dev/test URLs.

## Verification

wp-env started successfully and all 1758 PHP unit tests executed:

```
Tests: 1758, Assertions: 4458, Errors: 2, Failures: 3, Skipped: 59
```

The 5 remaining failures are pre-existing issues (not caused by this change) and will be tracked in separate issues per the original issue spec.

Resolves #886