### PR TITLE
GH#891: fix: mock HTTP requests in MarketingAbilitiesTest and SeoAbilitiesTest

### DIFF
--- a/tests/GratisAiAgent/Abilities/MarketingAbilitiesTest.php
+++ b/tests/GratisAiAgent/Abilities/MarketingAbilitiesTest.php
@@ -17,6 +17,17 @@ use WP_UnitTestCase;
  */
 class MarketingAbilitiesTest extends WP_UnitTestCase {
 
+	/**
+	 * Tear down after each test.
+	 *
+	 * Remove any pre_http_request filters added by individual tests so they
+	 * do not bleed into the next test in the suite.
+	 */
+	public function tear_down(): void {
+		remove_all_filters( 'pre_http_request' );
+		parent::tear_down();
+	}
+
 	// ─── fetch-url ────────────────────────────────────────────────
 
 	/**
@@ -40,28 +51,46 @@ class MarketingAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test handle_fetch_url with valid URL returns array or WP_Error.
+	 * Test handle_fetch_url with valid URL returns expected array shape.
 	 *
-	 * In test environment, HTTP requests may fail, but the handler
-	 * should return an array or WP_Error (not throw an exception).
+	 * Uses a pre_http_request filter to intercept the outbound wp_remote_get()
+	 * call so the test is deterministic in environments without outbound HTTP
+	 * (e.g. wp-env Docker containers).
 	 */
 	public function test_handle_fetch_url_valid_url_returns_array() {
+		$mock_html = '<!DOCTYPE html><html><head>'
+			. '<title>Mock Page Title</title>'
+			. '<meta name="description" content="Mock meta description.">'
+			. '<meta name="generator" content="WordPress 7.0">'
+			. '</head><body><h1>Mock Heading</h1></body></html>';
+
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( $mock_html ) {
+				return [
+					'headers'  => [
+						'content-type' => 'text/html; charset=UTF-8',
+						'server'       => 'MockServer/1.0',
+					],
+					'body'     => $mock_html,
+					'response' => [ 'code' => 200, 'message' => 'OK' ],
+					'cookies'  => [],
+					'filename' => '',
+				];
+			},
+			10,
+			3
+		);
+
 		$result = MarketingAbilities::handle_fetch_url( [
 			'url' => home_url( '/' ),
 		] );
 
-		// Should return either fetch data (array) or a WP_Error on HTTP failure.
-		$this->assertTrue(
-			is_array( $result ) || is_wp_error( $result ),
-			'Result should be an array or WP_Error.'
-		);
-
-		if ( is_array( $result ) ) {
-			$this->assertTrue(
-				isset( $result['url'] ) || isset( $result['status_code'] ),
-				'Array result should have url or status_code key.'
-			);
-		}
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'url', $result );
+		$this->assertArrayHasKey( 'status_code', $result );
+		$this->assertSame( 200, $result['status_code'] );
+		$this->assertSame( 'Mock Page Title', $result['title'] );
 	}
 
 	// ─── analyze-headers ──────────────────────────────────────────
@@ -87,24 +116,42 @@ class MarketingAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test handle_analyze_headers with valid URL returns array or WP_Error.
+	 * Test handle_analyze_headers with valid URL returns expected array shape.
+	 *
+	 * Uses a pre_http_request filter to intercept the outbound wp_remote_head()
+	 * call so the test is deterministic in environments without outbound HTTP
+	 * (e.g. wp-env Docker containers).
 	 */
 	public function test_handle_analyze_headers_valid_url_returns_array() {
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) {
+				return [
+					'headers'  => [
+						'content-type'              => 'text/html; charset=UTF-8',
+						'cache-control'             => 'max-age=3600, public',
+						'strict-transport-security' => 'max-age=31536000; includeSubDomains',
+						'x-content-type-options'    => 'nosniff',
+					],
+					'body'     => '',
+					'response' => [ 'code' => 200, 'message' => 'OK' ],
+					'cookies'  => [],
+					'filename' => '',
+				];
+			},
+			10,
+			3
+		);
+
 		$result = MarketingAbilities::handle_analyze_headers( [
 			'url' => home_url( '/' ),
 		] );
 
-		// Should return either header analysis (array) or a WP_Error on HTTP failure.
-		$this->assertTrue(
-			is_array( $result ) || is_wp_error( $result ),
-			'Result should be an array or WP_Error.'
-		);
-
-		if ( is_array( $result ) ) {
-			$this->assertTrue(
-				isset( $result['url'] ) || isset( $result['headers'] ),
-				'Array result should have url or headers key.'
-			);
-		}
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'url', $result );
+		$this->assertArrayHasKey( 'status_code', $result );
+		$this->assertSame( 200, $result['status_code'] );
+		$this->assertArrayHasKey( 'security', $result );
+		$this->assertArrayHasKey( 'performance', $result );
 	}
 }

--- a/tests/GratisAiAgent/Abilities/SeoAbilitiesTest.php
+++ b/tests/GratisAiAgent/Abilities/SeoAbilitiesTest.php
@@ -17,6 +17,17 @@ use WP_UnitTestCase;
  */
 class SeoAbilitiesTest extends WP_UnitTestCase {
 
+	/**
+	 * Tear down after each test.
+	 *
+	 * Remove any pre_http_request filters added by individual tests so they
+	 * do not bleed into the next test in the suite.
+	 */
+	public function tear_down(): void {
+		remove_all_filters( 'pre_http_request' );
+		parent::tear_down();
+	}
+
 	// ─── seo-audit-url ────────────────────────────────────────────
 
 	/**
@@ -40,25 +51,51 @@ class SeoAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test handle_audit_url with valid URL returns array or WP_Error.
+	 * Test handle_audit_url with valid URL returns expected array shape.
 	 *
-	 * In test environment, the HTTP request may fail, but the handler
-	 * should return an array or WP_Error (not throw an exception).
+	 * Uses a pre_http_request filter to intercept the outbound wp_safe_remote_get()
+	 * call so the test is deterministic in environments without outbound HTTP
+	 * (e.g. wp-env Docker containers).
 	 */
 	public function test_handle_audit_url_valid_url_returns_array() {
+		$mock_html = '<!DOCTYPE html><html lang="en"><head>'
+			. '<title>SEO Mock Page Title Exactly Right Length</title>'
+			. '<meta name="description" content="This is a sufficiently long meta description for the SEO audit test page to avoid false positive length warnings.">'
+			. '<link rel="canonical" href="' . home_url( '/' ) . '">'
+			. '<meta property="og:title" content="SEO Mock Page">'
+			. '<meta property="og:type" content="website">'
+			. '</head><body>'
+			. '<h1>Main Heading</h1>'
+			. '<h2>Sub Heading</h2>'
+			. '<p>Page content for SEO analysis.</p>'
+			. '<img src="image.jpg" alt="A descriptive alt text">'
+			. '</body></html>';
+
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( $mock_html ) {
+				return [
+					'headers'  => [ 'content-type' => 'text/html; charset=UTF-8' ],
+					'body'     => $mock_html,
+					'response' => [ 'code' => 200, 'message' => 'OK' ],
+					'cookies'  => [],
+					'filename' => '',
+				];
+			},
+			10,
+			3
+		);
+
 		$result = SeoAbilities::handle_audit_url( [
 			'url' => home_url( '/' ),
 		] );
 
-		// Should return either audit data (array) or a WP_Error on HTTP failure.
-		$this->assertTrue(
-			is_array( $result ) || is_wp_error( $result ),
-			'Result should be an array or WP_Error.'
-		);
-
-		if ( is_array( $result ) ) {
-			$this->assertArrayHasKey( 'url', $result );
-		}
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'url', $result );
+		$this->assertArrayHasKey( 'status_code', $result );
+		$this->assertSame( 200, $result['status_code'] );
+		$this->assertArrayHasKey( 'title', $result );
+		$this->assertArrayHasKey( 'issues', $result );
 	}
 
 	// ─── seo-analyze-content ──────────────────────────────────────


### PR DESCRIPTION
## Summary

Mock outbound HTTP calls in the three URL-fetch tests that fail in wp-env due to blocked outbound network. Uses `add_filter('pre_http_request', ...)` — the established pattern in this codebase (see AgentLoopTest.php, NotificationDispatcherTest.php).

**Root cause:** `wp_remote_get`/`wp_remote_head`/`wp_safe_remote_get` fail with WP_Error in wp-env. The handlers return `['error' => '...']` — an array without `url`/`status_code` keys — but the tests assert those keys exist.

**Fix:** Return a 200 mock response with well-formed HTML/headers so the full handler logic is exercised deterministically, independent of network.

## Changes

- `tests/GratisAiAgent/Abilities/MarketingAbilitiesTest.php` — mock in `test_handle_fetch_url_valid_url_returns_array` and `test_handle_analyze_headers_valid_url_returns_array`; add `tear_down()`
- `tests/GratisAiAgent/Abilities/SeoAbilitiesTest.php` — mock in `test_handle_audit_url_valid_url_returns_array`; add `tear_down()`

## Testing

All 15 tests in both classes pass (verified in the running wp-env container):
```
OK (15 tests, 36 assertions)
```

Resolves #891


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.7.1 plugin for [OpenCode](https://opencode.ai) v1.3.16 with claude-sonnet-4-6 spent 6m and 18,760 tokens on this as a headless worker.