### PR TITLE
GH#890: fix: add missing AgentLoop use statement to resolve EditorialAbilitiesTest failures

### DIFF
--- a/gratis-ai-agent.php
+++ b/gratis-ai-agent.php
@@ -87,6 +87,7 @@ use GratisAiAgent\Automations\EventTriggerHandler;
 use GratisAiAgent\CLI\BenchmarkCommand;
 use GratisAiAgent\CLI\CliCommand;
 use GratisAiAgent\CLI\TraceCommand;
+use GratisAiAgent\Core\AgentLoop;
 use GratisAiAgent\Core\ChangeLogger;
 use GratisAiAgent\Core\Database;
 use GratisAiAgent\Core\FreshInstallDetector;


### PR DESCRIPTION
## Summary

- Adds the missing `use GratisAiAgent\Core\AgentLoop;` import to `gratis-ai-agent.php`
- This resolves `Error: Class "AgentLoop" not found` in the `wp_ai_client_default_request_timeout` filter callback at line 442

## Root Cause

`gratis-ai-agent.php` references `AgentLoop::LOOP_TIMEOUT_SECONDS` inside a static closure registered as a filter:

```php
add_filter(
    'wp_ai_client_default_request_timeout',
    static function (): int {
        return AgentLoop::LOOP_TIMEOUT_SECONDS;
    }
);
```

All other `GratisAiAgent\Core` classes are imported via `use` statements (lines 90–97), but `AgentLoop` was missing. PHP resolves unqualified class names in the global namespace, so `AgentLoop` fails with class-not-found.

## Fix

Single-line change: add `use GratisAiAgent\Core\AgentLoop;` alongside the existing Core imports.

## Verification

```
Tests: 15, Assertions: 18, Skipped: 4.
```

Both previously failing tests now pass:
- `test_handle_generate_title_candidates_clamped` ✅
- `test_handle_summarize_content_invalid_length_falls_back` ✅

Verified locally by running `php vendor/bin/phpunit --filter EditorialAbilitiesTest` against the wp-env test container.

Resolves #890

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced AI request timeout configuration handling to ensure proper timeout management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->