### PR TITLE
GH#895: fix: use buffered TTL in progress callback recovery branch

### DIFF
--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -1271,13 +1271,16 @@ class SessionController {
 			} elseif ( false === $current ) {
 				// Transient expired mid-execution; re-create a minimal entry so
 				// the final job result can still be persisted after completion.
+				// Use the same buffered TTL (+60s) as the primary path to
+				// prevent the recreated transient from expiring again before
+				// the job finishes.
 				set_transient(
 					RestController::JOB_PREFIX . $progress_job_id,
 					array(
 						'status'     => 'processing',
 						'tool_calls' => $tool_call_log,
 					),
-					RestController::JOB_TTL
+					RestController::JOB_TTL + 60
 				);
 			}
 		};


### PR DESCRIPTION
## Summary

When the job transient expires mid-execution, the `elseif (false === $current)` recovery branch in the progress callback was using `RestController::JOB_TTL` (600s) instead of the buffered TTL (`JOB_TTL + 60`) used in the primary update path. This put the recreated transient back on the same short expiry, risking a second expiry before the job completes.

## Change

**File:** `includes/REST/SessionController.php` (~line 1280)

- Before: `RestController::JOB_TTL` (600s)
- After: `RestController::JOB_TTL + 60` (660s) — consistent with the primary path at line 1270

Added an explanatory comment to make the intent clear.

## Verification

- PHPCS lint clean for the changed lines (pre-existing errors at lines 1370+ are unrelated)
- Risk: **Low** — one-line value change in a TTL argument; no logic change

Resolves #895


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.5 plugin for [OpenCode](https://opencode.ai) v1.3.16 with claude-sonnet-4-6 spent 1m and 3,330 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved stability for long-running operations by enhancing session timeout handling. Sessions are now better maintained during extended processing, reducing the likelihood of unexpected interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->