### PR TITLE
fix: address review bot feedback from PR #876 (issue #897)

### DIFF
--- a/build/admin-page.asset.php
+++ b/build/admin-page.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'react-dom', 'react-jsx-runtime', 'wp-api-fetch', 'wp-components', 'wp-data', 'wp-element', 'wp-i18n', 'wp-primitives'), 'version' => '085e51ff014842cf661c');
+<?php declare(strict_types=1); return array('dependencies' => array('react', 'react-dom', 'react-jsx-runtime', 'wp-api-fetch', 'wp-components', 'wp-data', 'wp-element', 'wp-i18n', 'wp-primitives'), 'version' => '085e51ff014842cf661c');

--- a/build/benchmark-page.asset.php
+++ b/build/benchmark-page.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react-jsx-runtime', 'wp-api-fetch', 'wp-components', 'wp-element', 'wp-i18n', 'wp-primitives'), 'version' => 'cbe02c72a643418f33b4');
+<?php declare(strict_types=1); return array('dependencies' => array('react-jsx-runtime', 'wp-api-fetch', 'wp-components', 'wp-element', 'wp-i18n', 'wp-primitives'), 'version' => 'cbe02c72a643418f33b4');

--- a/build/floating-widget.asset.php
+++ b/build/floating-widget.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'react-dom', 'react-jsx-runtime', 'wp-api-fetch', 'wp-components', 'wp-data', 'wp-element', 'wp-i18n', 'wp-primitives'), 'version' => '2d91a55236b449ad5326');
+<?php declare(strict_types=1); return array('dependencies' => array('react', 'react-dom', 'react-jsx-runtime', 'wp-api-fetch', 'wp-components', 'wp-data', 'wp-element', 'wp-i18n', 'wp-primitives'), 'version' => '2d91a55236b449ad5326');

--- a/build/screen-meta.asset.php
+++ b/build/screen-meta.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react', 'react-dom', 'react-jsx-runtime', 'wp-api-fetch', 'wp-components', 'wp-data', 'wp-element', 'wp-i18n', 'wp-primitives'), 'version' => 'ca4e206b7700a894d7fa');
+<?php declare(strict_types=1); return array('dependencies' => array('react', 'react-dom', 'react-jsx-runtime', 'wp-api-fetch', 'wp-components', 'wp-data', 'wp-element', 'wp-i18n', 'wp-primitives'), 'version' => 'ca4e206b7700a894d7fa');

--- a/build/unified-admin.asset.php
+++ b/build/unified-admin.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array('react-jsx-runtime', 'wp-api-fetch', 'wp-components', 'wp-data', 'wp-element', 'wp-i18n', 'wp-primitives'), 'version' => 'e0a786efc0f1326e3286');
+<?php declare(strict_types=1); return array('dependencies' => array('react-jsx-runtime', 'wp-api-fetch', 'wp-components', 'wp-data', 'wp-element', 'wp-i18n', 'wp-primitives'), 'version' => 'e0a786efc0f1326e3286');

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -384,6 +384,10 @@ class AgentLoop {
 					'source'   => 'client',
 				);
 			}
+
+			// Fire progress so the UI reflects the client tool responses
+			// immediately, matching the behaviour of server-side tool calls.
+			$this->fire_progress();
 		}
 
 		return $this->run_loop( $remaining_iterations );
@@ -1243,10 +1247,19 @@ class AgentLoop {
 
 	/**
 	 * Fire the progress callback with the current tool call log.
+	 *
+	 * Progress reporting is best-effort: if the callback throws, the exception
+	 * is swallowed so a broken progress handler cannot abort the agent loop.
 	 */
 	private function fire_progress(): void {
-		if ( null !== $this->progress_callback ) {
+		if ( null === $this->progress_callback ) {
+			return;
+		}
+
+		try {
 			call_user_func( $this->progress_callback, $this->tool_call_log );
+		} catch ( \Throwable $e ) {
+			// Progress reporting is best-effort and must not interrupt the agent loop.
 		}
 	}
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"license": "GPL-2.0-or-later",
 	"scripts": {
 		"build": "wp-scripts build",
-		"postbuild": "npm run archive",
+		"postbuild": "node scripts/add-strict-types.js && npm run archive",
 		"prearchive": "composer install --no-dev -o",
 		"archive": "node scripts/archive.js",
 		"postarchive": "composer install",

--- a/scripts/add-strict-types.js
+++ b/scripts/add-strict-types.js
@@ -1,0 +1,54 @@
+/**
+ * Post-build script: inject `declare(strict_types=1);` into generated .asset.php files.
+ *
+ * wp-scripts generates .asset.php manifests that open with `<?php return array(...)`.
+ * These committed files must comply with the project-wide PHP coding standard that
+ * requires `declare(strict_types=1);` on every PHP file. This script rewrites each
+ * generated file to insert the declaration immediately after the opening `<?php` tag
+ * without altering the rest of the file content.
+ *
+ * Run automatically via the `postbuild` npm script.
+ */
+
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+const BUILD_DIR = path.join( __dirname, '..', 'build' );
+
+/**
+ * Inject `declare(strict_types=1);` after `<?php` if not already present.
+ *
+ * @param {string} filePath Absolute path to the .asset.php file.
+ */
+function addStrictTypes( filePath ) {
+	const content = fs.readFileSync( filePath, 'utf8' );
+
+	// Already compliant — skip to avoid double declaration.
+	if ( content.includes( 'declare(strict_types=1);' ) ) {
+		return;
+	}
+
+	if ( ! content.startsWith( '<?php' ) ) {
+		console.warn( `Skipping ${ filePath }: does not start with <?php` );
+		return;
+	}
+
+	// Insert the declaration immediately after `<?php`, preserving the rest.
+	const updated = content.replace( /^<\?php/, '<?php declare(strict_types=1);' );
+	fs.writeFileSync( filePath, updated, 'utf8' );
+	console.log( `Updated: ${ path.relative( process.cwd(), filePath ) }` );
+}
+
+// Process all .asset.php files in the build directory.
+const assetFiles = fs
+	.readdirSync( BUILD_DIR )
+	.filter( ( f ) => f.endsWith( '.asset.php' ) )
+	.map( ( f ) => path.join( BUILD_DIR, f ) );
+
+if ( assetFiles.length === 0 ) {
+	console.warn( 'No .asset.php files found in build/ — skipping.' );
+	process.exit( 0 );
+}
+
+assetFiles.forEach( addStrictTypes );
+console.log( `Processed ${ assetFiles.length } .asset.php file(s).` );

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'ultimate-multisite/ai-agent',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '4dc1acf62b3ef64a12b8699b5d9186e7263c6ca7',
+        'reference' => 'bd3312d7608b6e54bf49e65c79fe149e78eac673',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -409,7 +409,7 @@
         'ultimate-multisite/ai-agent' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '4dc1acf62b3ef64a12b8699b5d9186e7263c6ca7',
+            'reference' => 'bd3312d7608b6e54bf49e65c79fe149e78eac673',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Summary

Addresses all actionable review bot findings from PR #876 that were merged unresolved (issue #897).

### Changes

**`includes/Core/AgentLoop.php`** (2 fixes)
- `fire_progress()` — wrapped `call_user_func()` in `try/catch(\Throwable)` so a broken progress callback cannot abort the agent loop mid-run and leave jobs in a bad state. Progress reporting is now explicitly best-effort.
- `resume_after_client_tools()` — added `$this->fire_progress()` call after appending client tool responses to `$tool_call_log`. Previously the UI progress indicator was not updated when browser-executed (client-side) tools returned, making it appear stale until the next server-side tool fired.

**`scripts/add-strict-types.js`** + **`package.json`** (post-build script)
- New script that scans `build/*.asset.php` files generated by `wp-scripts build` and injects `declare(strict_types=1);` immediately after `<?php` if not already present. Idempotent — skips files that already have the declaration.
- `postbuild` npm script updated to invoke the script before the archive step: `node scripts/add-strict-types.js && npm run archive`.
- All five existing committed `.asset.php` files updated directly.

### Already resolved in prior PRs
- `includes/REST/SessionController.php` — TTL refresh in progress callback (fixed in #903).
- `src/components/session-sidebar.js` — `{boolean}` type for `hasActiveJob` (already present).
- `src/components/message-list.js` — `ToolCall` typedef (declared in file; ESLint passes).

### Verification
- PHPCS passes on modified PHP files.
- ESLint passes on JS files.
- All `.asset.php` files now contain `declare(strict_types=1);`.

Resolves #897