### PR TITLE
GH#904: fix: add Notice presence assertion to OnboardingWizard step-1 test

### DIFF
--- a/src/components/__tests__/OnboardingWizard.test.js
+++ b/src/components/__tests__/OnboardingWizard.test.js
@@ -652,7 +652,11 @@ describe( 'OnboardingProviderRow rendering', () => {
 		} );
 
 		// Step 1 now directs users to the Connectors page instead of showing
-		// inline provider rows with Configured badges. Assert the link renders.
+		// inline provider rows with Configured badges. Assert the notice
+		// wrapper and the link inside it both render.
+		const notice = localContainer.querySelector( '[data-testid="notice"]' );
+		expect( notice ).not.toBeNull();
+
 		const connectorsLink = localContainer.querySelector(
 			'.gratis-ai-agent-wizard-connectors-link'
 		);


### PR DESCRIPTION
## Summary

Adds the missing Notice wrapper assertion to the OnboardingWizard step-1 test, as flagged by CodeRabbit in PR #888.

## Problem

The test verified the connectors link rendered correctly but did not assert that the `<Notice>` wrapper component enclosing the link was also rendered. A regression removing the `<Notice>` wrapper would pass the existing test undetected.

## Fix

- **EDIT: `src/components/__tests__/OnboardingWizard.test.js`** — add `querySelector('[data-testid="notice"]')` assertion before the connectors link check, matching the `data-testid="notice"` rendered by the existing `Notice` mock (line 119-135 of the test file).

## Verification

All 27 tests pass:
```
PASS src/components/__tests__/OnboardingWizard.test.js
Tests: 27 passed, 27 total
```

Resolves #904