### PR TITLE
fix: make Brave Search API URL a clickable link in settings UI

### DIFF
--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -1846,9 +1846,16 @@ export default function SettingsApp() {
 										</h4>
 										<p className="description">
 											{ __(
-												'Enable richer internet search results by connecting a Brave Search API key. Without a key, the agent uses DuckDuckGo instant answers (free, no setup required). Get a free Brave Search API key at brave.com/search/api/',
+												'Enable richer internet search results by connecting a Brave Search API key. Without a key, the agent uses DuckDuckGo instant answers (free, no setup required). Get a free Brave Search API key at',
 												'gratis-ai-agent'
-											) }
+											) }{ ' ' }
+											<a
+												href="https://brave.com/search/api/"
+												target="_blank"
+												rel="noopener noreferrer"
+											>
+												brave.com/search/api/
+											</a>
 										</p>
 										{ braveConfigured && (
 											<Notice


### PR DESCRIPTION
## Summary

Addresses unaddressed CodeRabbit review feedback from PR #880.

The Brave Search API URL `brave.com/search/api/` was rendered as plain text inside a translated string. This PR extracts the URL into a proper `<a>` anchor element with `target="_blank"` and `rel="noopener noreferrer"` for better UX.

## Changes

- **EDIT: `src/settings-page/settings-app.js`** — split the translated string at '...at' and add a clickable `<a>` element for `https://brave.com/search/api/`

## Verification

- ESLint: 0 errors (`npx eslint src/settings-page/settings-app.js`)
- Diff is minimal: 9 insertions, 2 deletions in a single file

Resolves #896