### PR TITLE
fix: update integration and abilities tests to use instance-based PluginUpdater API

### DIFF
--- a/includes/Abilities/PluginBuilderAbilities.php
+++ b/includes/Abilities/PluginBuilderAbilities.php
@@ -415,20 +415,16 @@ class UpdatePluginSandboxedAbility extends AbstractAbility {
 		return [
 			'type'       => 'object',
 			'properties' => [
-				'slug'        => [
+				'slug'  => [
 					'type'        => 'string',
 					'description' => 'Plugin slug (directory name under wp-content/plugins/).',
 				],
-				'files'       => [
+				'files' => [
 					'type'        => 'object',
 					'description' => 'Map of relative file paths to new PHP source code.',
 				],
-				'plugin_file' => [
-					'type'        => 'string',
-					'description' => 'Main plugin file path relative to the plugins directory.',
-				],
 			],
-			'required'   => [ 'slug', 'files', 'plugin_file' ],
+			'required'   => [ 'slug', 'files' ],
 		];
 	}
 
@@ -436,16 +432,16 @@ class UpdatePluginSandboxedAbility extends AbstractAbility {
 		return [
 			'type'       => 'object',
 			'properties' => [
-				'updated'     => [ 'type' => 'boolean' ],
+				'swapped'     => [ 'type' => 'boolean' ],
 				'plugin_file' => [ 'type' => 'string' ],
+				'was_active'  => [ 'type' => 'boolean' ],
 				'backup_dir'  => [ 'type' => 'string' ],
 			],
 		];
 	}
 
 	protected function execute_callback( $input ): array|\WP_Error {
-		$slug        = (string) ( $input['slug'] ?? '' );
-		$plugin_file = (string) ( $input['plugin_file'] ?? '' );
+		$slug = (string) ( $input['slug'] ?? '' );
 
 		// Coerce to array<string,string>: PluginUpdater::update() requires that shape.
 		$raw_files = is_array( $input['files'] ?? null ) ? $input['files'] : [];
@@ -461,11 +457,8 @@ class UpdatePluginSandboxedAbility extends AbstractAbility {
 		if ( empty( $files ) ) {
 			return new WP_Error( 'gratis_ai_agent_no_files', __( 'files must not be empty.', 'gratis-ai-agent' ) );
 		}
-		if ( empty( $plugin_file ) ) {
-			return new WP_Error( 'gratis_ai_agent_invalid_plugin_file', __( 'plugin_file is required.', 'gratis-ai-agent' ) );
-		}
 
-		return PluginUpdater::update( $slug, $files, $plugin_file );
+		return ( new PluginUpdater() )->update( $slug, $files );
 	}
 
 	protected function permission_callback( $input ): bool {

--- a/includes/PluginBuilder/PluginUpdater.php
+++ b/includes/PluginBuilder/PluginUpdater.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 /**
  * Plugin Updater — sandboxed live updates for AI-generated plugins.
  *
- * Flow: backup current files → stage new files → run layers 1+2 → swap on
- * success, restore backup on failure.
+ * Flow: backup → stage → test → swap → verify → rollback on failure.
+ *
+ * Backups land in wp-content/gratis-ai-backups/{slug}-{timestamp}/.
+ * Staging uses    wp-content/gratis-ai-staging/{slug}/.
  *
  * @package GratisAiAgent\PluginBuilder
  * @license GPL-2.0-or-later
@@ -27,25 +29,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 class PluginUpdater {
 
 	/**
-	 * Update an installed AI-generated plugin with new file content.
+	 * Backup an installed plugin to wp-content/gratis-ai-backups/{slug}-{timestamp}/.
 	 *
-	 * Steps:
-	 *   1. Backup existing plugin directory.
-	 *   2. Stage new files to a temp directory.
-	 *   3. Run layers 1 + 2 of PluginSandbox against the staged files.
-	 *   4. If tests pass: swap staged directory in place of original.
-	 *   5. If tests fail: restore backup and return WP_Error.
-	 *
-	 * @param string               $slug        Plugin slug (directory name under wp-content/plugins/).
-	 * @param array<string,string> $new_files   Map of relative path → PHP source.
-	 * @param string               $plugin_file Main plugin file relative to plugins dir.
-	 * @return array{updated: bool, plugin_file: string, backup_dir: string}|\WP_Error
+	 * @param string $slug Plugin slug (directory name under wp-content/plugins/).
+	 * @return string|\WP_Error Absolute path to the backup directory on success.
 	 */
-	public static function update(
-		string $slug,
-		array $new_files,
-		string $plugin_file
-	): array|\WP_Error {
+	public function backup( string $slug ): string|\WP_Error {
 		$slug = sanitize_title( $slug );
 		if ( empty( $slug ) ) {
 			return new WP_Error(
@@ -54,9 +43,7 @@ class PluginUpdater {
 			);
 		}
 
-		$plugins_dir = WP_CONTENT_DIR . '/plugins/';
-		$plugin_dir  = $plugins_dir . $slug . '/';
-
+		$plugin_dir = WP_CONTENT_DIR . '/plugins/' . $slug . '/';
 		if ( ! is_dir( $plugin_dir ) ) {
 			return new WP_Error(
 				'gratis_ai_agent_plugin_not_found',
@@ -65,88 +52,336 @@ class PluginUpdater {
 			);
 		}
 
-		// Step 1: Backup existing plugin directory.
-		$backup_dir = $plugins_dir . $slug . '-backup-' . time() . '/';
-		$copied     = self::copy_directory( $plugin_dir, $backup_dir );
-		if ( is_wp_error( $copied ) ) {
-			return $copied;
+		$timestamp  = gmdate( 'Y-m-d-His' );
+		$backup_dir = WP_CONTENT_DIR . '/gratis-ai-backups/' . $slug . '-' . $timestamp . '/';
+
+		$result = $this->copy_directory( $plugin_dir, $backup_dir );
+		if ( is_wp_error( $result ) ) {
+			return $result;
 		}
 
-		// Step 2: Stage new files to temp directory.
-		$stage_dir = $plugins_dir . $slug . '-staging-' . time() . '/';
-		if ( ! wp_mkdir_p( $stage_dir ) ) {
+		return $backup_dir;
+	}
+
+	/**
+	 * Stage new file content for a plugin.
+	 *
+	 * Copies the live plugin directory to the staging location first so the
+	 * staged copy is always complete, then overlays the provided modified files.
+	 *
+	 * @param string               $slug           Plugin slug.
+	 * @param array<string,string> $modified_files Map of relative path → PHP source.
+	 * @return string|\WP_Error Absolute path to the staging directory on success.
+	 */
+	public function stage( string $slug, array $modified_files ): string|\WP_Error {
+		$slug = sanitize_title( $slug );
+		if ( empty( $slug ) ) {
 			return new WP_Error(
-				'gratis_ai_agent_staging_failed',
-				/* translators: %s: directory */
-				sprintf( __( 'Could not create staging directory: %s', 'gratis-ai-agent' ), $stage_dir )
+				'gratis_ai_agent_invalid_slug',
+				__( 'Plugin slug must not be empty.', 'gratis-ai-agent' )
 			);
 		}
 
-		foreach ( $new_files as $relative_path => $content ) {
-			$relative_path = ltrim( $relative_path, '/\\' );
-			$abs_path      = $stage_dir . $relative_path;
+		$plugin_dir = WP_CONTENT_DIR . '/plugins/' . $slug . '/';
+		if ( ! is_dir( $plugin_dir ) ) {
+			return new WP_Error(
+				'gratis_ai_agent_plugin_not_found',
+				/* translators: %s: plugin directory */
+				sprintf( __( 'Plugin directory not found: %s', 'gratis-ai-agent' ), $plugin_dir )
+			);
+		}
+
+		$staging_dir = WP_CONTENT_DIR . '/gratis-ai-staging/' . $slug . '/';
+
+		// Remove stale staging dir if it exists.
+		if ( is_dir( $staging_dir ) ) {
+			$this->remove_directory( $staging_dir );
+		}
+
+		// Copy live plugin to staging so the staged copy is always complete.
+		$result = $this->copy_directory( $plugin_dir, $staging_dir );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		// Overlay the modified files.
+		foreach ( $modified_files as $relative_path => $content ) {
+			$relative_path = ltrim( (string) $relative_path, '/\\' );
+			$abs_path      = $staging_dir . $relative_path;
 			wp_mkdir_p( dirname( $abs_path ) );
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Writing to staging temp dir; WP_Filesystem not available at this stage.
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Staging: WP_Filesystem not applicable when writing generated PHP source to a temp location.
 			if ( false === file_put_contents( $abs_path, $content ) ) {
-				self::remove_directory( $stage_dir );
+				$this->remove_directory( $staging_dir );
 				return new WP_Error(
 					'gratis_ai_agent_staging_write_failed',
-					/* translators: %s: file path */
+					/* translators: %s: relative file path */
 					sprintf( __( 'Could not write staging file: %s', 'gratis-ai-agent' ), $relative_path )
 				);
 			}
 		}
 
-		// Step 3: Run sandbox layers 1+2 on staged files.
-		$stage_plugin_file = ltrim( str_replace( $slug . '/', '', $plugin_file ), '/' );
-		$sandbox_result    = PluginSandbox::run_all( $stage_dir, $stage_plugin_file );
+		return $staging_dir;
+	}
+
+	/**
+	 * Run PluginSandbox checks on a staged plugin directory.
+	 *
+	 * @param string $slug        Plugin slug (used to derive the main plugin file name).
+	 * @param string $staging_dir Absolute path to the staging directory.
+	 * @return array<string,mixed> Sandbox result with at least `passed` (bool) and `errors` (string[]).
+	 */
+	public function test_staged( string $slug, string $staging_dir ): array {
+		$plugin_file    = $slug . '.php';
+		$sandbox_result = PluginSandbox::run_all( $staging_dir, $plugin_file );
 
 		if ( is_wp_error( $sandbox_result ) ) {
-			self::remove_directory( $stage_dir );
-			return $sandbox_result;
+			return [
+				'passed' => false,
+				'errors' => [ $sandbox_result->get_error_message() ],
+			];
 		}
 
-		if ( ! $sandbox_result['passed'] ) {
-			self::remove_directory( $stage_dir );
+		return $sandbox_result;
+	}
+
+	/**
+	 * Swap the staged plugin over the live plugin.
+	 *
+	 * Deactivates the plugin (if active), copies staging over the live directory,
+	 * then reactivates. If reactivation fails, restores from backup automatically.
+	 *
+	 * @param string $slug        Plugin slug.
+	 * @param string $staging_dir Absolute path to the staging directory.
+	 * @param string $backup_dir  Absolute path to the backup directory (used for rollback on failure).
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function swap( string $slug, string $staging_dir, string $backup_dir ): array|\WP_Error {
+		if ( ! is_dir( $staging_dir ) ) {
 			return new WP_Error(
-				'gratis_ai_agent_sandbox_failed',
-				implode( '; ', $sandbox_result['errors'] )
+				'gratis_ai_agent_staging_not_found',
+				/* translators: %s: staging directory */
+				sprintf( __( 'Staging directory not found: %s', 'gratis-ai-agent' ), $staging_dir )
 			);
 		}
 
-		// Step 4: Swap staged dir into original location.
-		self::remove_directory( $plugin_dir );
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- Atomic directory swap; WP_Filesystem::move() does not support directory rename.
-		$renamed = rename( $stage_dir, $plugin_dir );
-		if ( ! $renamed ) {
+		$plugin_file = $slug . '/' . $slug . '.php';
+		$plugin_dir  = WP_CONTENT_DIR . '/plugins/' . $slug . '/';
+
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+		$was_active = is_plugin_active( $plugin_file );
+		if ( $was_active ) {
+			deactivate_plugins( $plugin_file, true );
+		}
+
+		// Replace live directory with staged copy.
+		if ( is_dir( $plugin_dir ) ) {
+			$this->remove_directory( $plugin_dir );
+		}
+
+		$copy_result = $this->copy_directory( $staging_dir, $plugin_dir );
+		if ( is_wp_error( $copy_result ) ) {
 			// Restore backup.
-			self::copy_directory( $backup_dir, $plugin_dir );
-			self::remove_directory( $backup_dir );
+			$this->rollback( $slug, $backup_dir );
 			return new WP_Error(
-				'gratis_ai_agent_swap_failed',
-				__( 'Could not replace plugin directory. Backup restored.', 'gratis-ai-agent' )
+				'gratis_ai_agent_swap_copy_failed',
+				/* translators: %s: underlying error message */
+				sprintf( __( 'Swap failed, backup restored: %s', 'gratis-ai-agent' ), $copy_result->get_error_message() )
 			);
+		}
+
+		// Reactivate if the plugin was active before the swap.
+		if ( $was_active ) {
+			$activate_result = activate_plugin( $plugin_file );
+			if ( is_wp_error( $activate_result ) ) {
+				// Reactivation failed — restore from backup.
+				$this->remove_directory( $plugin_dir );
+				$this->rollback( $slug, $backup_dir );
+				return new WP_Error(
+					'gratis_ai_agent_reactivation_failed',
+					sprintf(
+						/* translators: 1: plugin file, 2: underlying error */
+						__( 'Reactivation of "%1$s" failed after swap, backup restored: %2$s', 'gratis-ai-agent' ),
+						$plugin_file,
+						$activate_result->get_error_message()
+					)
+				);
+			}
 		}
 
 		return [
-			'updated'     => true,
+			'swapped'     => true,
 			'plugin_file' => $plugin_file,
+			'was_active'  => $was_active,
+		];
+	}
+
+	/**
+	 * Roll back a plugin to a previously created backup.
+	 *
+	 * @param string $slug       Plugin slug.
+	 * @param string $backup_dir Absolute path to the backup directory.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function rollback( string $slug, string $backup_dir ): array|\WP_Error {
+		if ( ! is_dir( $backup_dir ) ) {
+			return new WP_Error(
+				'gratis_ai_agent_backup_not_found',
+				/* translators: %s: backup directory */
+				sprintf( __( 'Backup directory not found: %s', 'gratis-ai-agent' ), $backup_dir )
+			);
+		}
+
+		$plugin_dir = WP_CONTENT_DIR . '/plugins/' . sanitize_title( $slug ) . '/';
+
+		if ( is_dir( $plugin_dir ) ) {
+			$this->remove_directory( $plugin_dir );
+		}
+
+		$result = $this->copy_directory( $backup_dir, $plugin_dir );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return [
+			'rolled_back' => true,
+			'slug'        => $slug,
 			'backup_dir'  => $backup_dir,
 		];
 	}
 
 	/**
-	 * Copy a directory recursively.
+	 * Remove old plugin backups beyond the configured retention window.
 	 *
-	 * @param string $source      Source directory.
-	 * @param string $destination Destination directory.
+	 * Never deletes the most recent backup for any slug regardless of age.
+	 * Retention window is configurable via the `gratis_ai_agent_backup_retention_days` filter.
+	 *
+	 * @param int $max_age_days Maximum backup age in days. Default 7.
+	 * @return int Number of backup directories removed.
+	 */
+	public function cleanup_old_backups( int $max_age_days = 7 ): int {
+		/**
+		 * Filter the number of days to retain plugin backups.
+		 *
+		 * @param int $max_age_days Default retention in days.
+		 */
+		$max_age_days = (int) apply_filters( 'gratis_ai_agent_backup_retention_days', $max_age_days );
+		$backups_root = WP_CONTENT_DIR . '/gratis-ai-backups/';
+
+		if ( ! is_dir( $backups_root ) ) {
+			return 0;
+		}
+
+		$cutoff  = time() - ( $max_age_days * DAY_IN_SECONDS );
+		$removed = 0;
+
+		// Collect all backup directories grouped by slug.
+		$entries = glob( $backups_root . '*', GLOB_ONLYDIR );
+		if ( false === $entries || empty( $entries ) ) {
+			return 0;
+		}
+
+		/** @var array<string,list<array{dir:string,timestamp:string}>> $by_slug */
+		$by_slug = [];
+		foreach ( $entries as $entry ) {
+			$basename = basename( $entry );
+			// Expected format: {slug}-YYYY-MM-DD-HHiiss
+			if ( preg_match( '/^(.+)-(\d{4}-\d{2}-\d{2}-\d{6})$/', $basename, $m ) ) {
+				$by_slug[ $m[1] ][] = [
+					'dir'       => $entry,
+					'timestamp' => $m[2],
+				];
+			}
+		}
+
+		foreach ( $by_slug as $backups ) {
+			// Sort descending by timestamp so index 0 is the most recent.
+			usort(
+				$backups,
+				static function ( array $a, array $b ): int {
+					return strcmp( $b['timestamp'], $a['timestamp'] );
+				}
+			);
+
+			foreach ( $backups as $index => $backup ) {
+				// Always preserve the most recent backup.
+				if ( 0 === $index ) {
+					continue;
+				}
+
+				$mtime = filemtime( $backup['dir'] );
+				if ( false !== $mtime && $mtime < $cutoff ) {
+					$this->remove_directory( $backup['dir'] );
+					++$removed;
+				}
+			}
+		}
+
+		return $removed;
+	}
+
+	/**
+	 * Orchestrate the full update flow for an installed plugin.
+	 *
+	 * Steps: backup → stage → test → swap → cleanup staging.
+	 *
+	 * @param string               $slug           Plugin slug.
+	 * @param array<string,string> $modified_files Map of relative path → PHP source.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	public function update( string $slug, array $modified_files ): array|\WP_Error {
+		// Step 1: Backup.
+		$backup_dir = $this->backup( $slug );
+		if ( is_wp_error( $backup_dir ) ) {
+			return $backup_dir;
+		}
+
+		// Step 2: Stage.
+		$staging_dir = $this->stage( $slug, $modified_files );
+		if ( is_wp_error( $staging_dir ) ) {
+			return $staging_dir;
+		}
+
+		// Step 3: Test staged copy.
+		$test_result = $this->test_staged( $slug, $staging_dir );
+		if ( ! $test_result['passed'] ) {
+			$this->remove_directory( $staging_dir );
+			return new WP_Error(
+				'gratis_ai_agent_sandbox_failed',
+				implode( '; ', $test_result['errors'] )
+			);
+		}
+
+		// Step 4: Swap.
+		$swap_result = $this->swap( $slug, $staging_dir, $backup_dir );
+		if ( is_wp_error( $swap_result ) ) {
+			$this->remove_directory( $staging_dir );
+			return $swap_result;
+		}
+
+		// Step 5: Cleanup staging.
+		$this->remove_directory( $staging_dir );
+
+		return array_merge(
+			$swap_result,
+			[ 'backup_dir' => $backup_dir ]
+		);
+	}
+
+	// ─── Private helpers ──────────────────────────────────────────────────────
+
+	/**
+	 * Recursively copy a directory.
+	 *
+	 * @param string $source      Source directory (must exist).
+	 * @param string $destination Destination directory (will be created).
 	 * @return true|\WP_Error
 	 */
-	private static function copy_directory( string $source, string $destination ): bool|\WP_Error {
+	private function copy_directory( string $source, string $destination ): bool|\WP_Error {
 		if ( ! wp_mkdir_p( $destination ) ) {
 			return new WP_Error(
 				'gratis_ai_agent_mkdir_failed',
-				/* translators: %s: directory */
+				/* translators: %s: directory path */
 				sprintf( __( 'Could not create directory: %s', 'gratis-ai-agent' ), $destination )
 			);
 		}
@@ -157,11 +392,18 @@ class PluginUpdater {
 		);
 
 		foreach ( $iterator as $item ) {
-			$dest_path = $destination . str_replace( $source, '', $item->getRealPath() );
+			/** @var \SplFileInfo $item */
+			$real_path = $item->getRealPath();
+			if ( false === $real_path ) {
+				continue;
+			}
+
+			$dest_path = $destination . str_replace( $source, '', $real_path );
+
 			if ( $item->isDir() ) {
 				wp_mkdir_p( $dest_path );
 			} else {
-				copy( $item->getRealPath(), $dest_path );
+				copy( $real_path, $dest_path );
 			}
 		}
 
@@ -169,12 +411,12 @@ class PluginUpdater {
 	}
 
 	/**
-	 * Remove a directory and its contents recursively.
+	 * Recursively remove a directory using WP_Filesystem_Direct.
 	 *
-	 * @param string $dir Directory to remove.
+	 * @param string $dir Absolute path to the directory to remove.
 	 * @return void
 	 */
-	private static function remove_directory( string $dir ): void {
+	private function remove_directory( string $dir ): void {
 		if ( ! is_dir( $dir ) ) {
 			return;
 		}

--- a/tests/GratisAiAgent/Abilities/PluginBuilderAbilitiesTest.php
+++ b/tests/GratisAiAgent/Abilities/PluginBuilderAbilitiesTest.php
@@ -124,7 +124,7 @@ class PluginBuilderAbilitiesTest extends WP_UnitTestCase {
 	public function test_update_plugin_sandboxed_returns_wp_error_for_empty_slug(): void {
 		$ability = new UpdatePluginSandboxedAbility( 'gratis-ai-agent/update-plugin-sandboxed' );
 
-		$result = $ability->run( [ 'slug' => '', 'files' => [ 'my-plugin.php' => '<?php' ], 'plugin_file' => 'my-plugin.php' ] );
+		$result = $ability->run( [ 'slug' => '', 'files' => [ 'my-plugin.php' => '<?php' ] ] );
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'gratis_ai_agent_invalid_slug', $result->get_error_code() );
@@ -136,22 +136,25 @@ class PluginBuilderAbilitiesTest extends WP_UnitTestCase {
 	public function test_update_plugin_sandboxed_returns_wp_error_for_empty_files(): void {
 		$ability = new UpdatePluginSandboxedAbility( 'gratis-ai-agent/update-plugin-sandboxed' );
 
-		$result = $ability->run( [ 'slug' => 'my-plugin', 'files' => [], 'plugin_file' => 'my-plugin.php' ] );
+		$result = $ability->run( [ 'slug' => 'my-plugin', 'files' => [] ] );
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'gratis_ai_agent_no_files', $result->get_error_code() );
 	}
 
 	/**
-	 * UpdatePluginSandboxedAbility returns WP_Error when plugin_file is empty.
+	 * UpdatePluginSandboxedAbility returns WP_Error when plugin directory does not exist.
+	 *
+	 * Since plugin_file is no longer required (derived from slug), verify the
+	 * ability correctly propagates the plugin_not_found error from PluginUpdater.
 	 */
-	public function test_update_plugin_sandboxed_returns_wp_error_for_empty_plugin_file(): void {
+	public function test_update_plugin_sandboxed_returns_wp_error_for_nonexistent_plugin(): void {
 		$ability = new UpdatePluginSandboxedAbility( 'gratis-ai-agent/update-plugin-sandboxed' );
 
-		$result = $ability->run( [ 'slug' => 'my-plugin', 'files' => [ 'my-plugin.php' => '<?php' ], 'plugin_file' => '' ] );
+		$result = $ability->run( [ 'slug' => 'non-existent-plugin-phpunit', 'files' => [ 'main.php' => '<?php' ] ] );
 
 		$this->assertWPError( $result );
-		$this->assertSame( 'gratis_ai_agent_invalid_plugin_file', $result->get_error_code() );
+		$this->assertSame( 'gratis_ai_agent_plugin_not_found', $result->get_error_code() );
 	}
 
 	// ── ScanPluginHooksAbility ─────────────────────────────────────────────

--- a/tests/GratisAiAgent/PluginBuilder/PluginBuilderIntegrationTest.php
+++ b/tests/GratisAiAgent/PluginBuilder/PluginBuilderIntegrationTest.php
@@ -607,13 +607,12 @@ PHP
 			'<?php /* Plugin Name: Test Updater */ // v1'
 		);
 
-		$new_files   = [ $slug . '.php' => '<?php /* Plugin Name: Test Updater */ // v2' ];
-		$plugin_file = $slug . '/' . $slug . '.php';
+		$new_files = [ $slug . '.php' => '<?php /* Plugin Name: Test Updater */ // v2' ];
 
-		$result = PluginUpdater::update( $slug, $new_files, $plugin_file );
+		$result = ( new PluginUpdater() )->update( $slug, $new_files );
 
 		$this->assertIsArray( $result );
-		$this->assertTrue( $result['updated'] );
+		$this->assertTrue( (bool) ( $result['swapped'] ?? false ) );
 		$this->assertArrayHasKey( 'backup_dir', $result );
 
 		$written = file_get_contents( $dir . $slug . '.php' );
@@ -637,10 +636,9 @@ PHP
 			'<?php /* Plugin Name: Test Rollback */ // original'
 		);
 
-		$new_files   = [ $slug . '.php' => '<?php $broken = "unclosed string' . PHP_EOL ];
-		$plugin_file = $slug . '/' . $slug . '.php';
+		$new_files = [ $slug . '.php' => '<?php $broken = "unclosed string' . PHP_EOL ];
 
-		$result = PluginUpdater::update( $slug, $new_files, $plugin_file );
+		$result = ( new PluginUpdater() )->update( $slug, $new_files );
 
 		$this->assertWPError( $result );
 
@@ -648,8 +646,8 @@ PHP
 		$current = file_get_contents( $dir . $slug . '.php' );
 		$this->assertStringContainsString( '// original', (string) $current );
 
-		// Clean up any backup directory left by the updater.
-		$backup_glob = glob( WP_CONTENT_DIR . '/plugins/' . $slug . '-backup-*' );
+		// Clean up any backup directory left by the updater (new path: gratis-ai-backups/).
+		$backup_glob = glob( WP_CONTENT_DIR . '/gratis-ai-backups/' . $slug . '-*', GLOB_ONLYDIR );
 		if ( is_array( $backup_glob ) ) {
 			foreach ( $backup_glob as $backup_dir ) {
 				$this->rmdir_recursive( $backup_dir );
@@ -661,10 +659,9 @@ PHP
 	 * update() returns WP_Error when the plugin slug does not exist.
 	 */
 	public function test_updater_returns_wp_error_for_missing_slug(): void {
-		$result = PluginUpdater::update(
+		$result = ( new PluginUpdater() )->update(
 			'gratis-pb-test-missing-' . uniqid(),
-			[ 'file.php' => '<?php // code' ],
-			'gratis-pb-test-missing/file.php'
+			[ 'file.php' => '<?php // code' ]
 		);
 
 		$this->assertWPError( $result );

--- a/tests/GratisAiAgent/PluginBuilder/PluginUpdaterTest.php
+++ b/tests/GratisAiAgent/PluginBuilder/PluginUpdaterTest.php
@@ -1,0 +1,346 @@
+<?php
+/**
+ * Test case for PluginUpdater class.
+ *
+ * @package GratisAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace GratisAiAgent\Tests\PluginBuilder;
+
+use GratisAiAgent\PluginBuilder\PluginUpdater;
+use WP_UnitTestCase;
+
+/**
+ * Tests for PluginUpdater — sandboxed live update flow.
+ *
+ * Each test uses a unique slug prefixed with 'gratis-test-updater-phpunit' and
+ * cleans up all created directories in tearDown().
+ */
+class PluginUpdaterTest extends WP_UnitTestCase {
+
+	/**
+	 * Plugin slug used across tests.
+	 *
+	 * @var string
+	 */
+	private string $slug = 'gratis-test-updater-phpunit';
+
+	/**
+	 * Absolute path to the test plugin directory.
+	 *
+	 * @var string
+	 */
+	private string $plugin_dir;
+
+	/**
+	 * PluginUpdater instance under test.
+	 *
+	 * @var PluginUpdater
+	 */
+	private PluginUpdater $updater;
+
+	/**
+	 * Set up test directories and a minimal plugin before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->plugin_dir = WP_CONTENT_DIR . '/plugins/' . $this->slug . '/';
+		$this->updater    = new PluginUpdater();
+		$this->cleanup_all();
+		$this->create_minimal_plugin();
+	}
+
+	/**
+	 * Remove all created directories after each test.
+	 */
+	public function tearDown(): void {
+		$this->cleanup_all();
+		parent::tearDown();
+	}
+
+	// ─── backup() ────────────────────────────────────────────────────────────
+
+	/**
+	 * backup() should return a path to a new directory containing the plugin files.
+	 */
+	public function test_backup_creates_backup_dir(): void {
+		$result = $this->updater->backup( $this->slug );
+
+		$this->assertIsString( $result );
+		$this->assertDirectoryExists( $result );
+		$this->assertFileExists( $result . $this->slug . '.php' );
+	}
+
+	/**
+	 * backup() should return WP_Error for an empty slug.
+	 */
+	public function test_backup_empty_slug_returns_error(): void {
+		$result = $this->updater->backup( '' );
+		$this->assertWPError( $result );
+		$this->assertSame( 'gratis_ai_agent_invalid_slug', $result->get_error_code() );
+	}
+
+	/**
+	 * backup() should return WP_Error when the plugin directory does not exist.
+	 */
+	public function test_backup_missing_plugin_dir_returns_error(): void {
+		$result = $this->updater->backup( 'non-existent-plugin-phpunit' );
+		$this->assertWPError( $result );
+		$this->assertSame( 'gratis_ai_agent_plugin_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Backup directory name should follow the {slug}-YYYY-MM-DD-HHiiss pattern.
+	 */
+	public function test_backup_dir_name_format(): void {
+		$result = $this->updater->backup( $this->slug );
+
+		$this->assertIsString( $result );
+		$basename = basename( rtrim( $result, '/' ) );
+		$this->assertMatchesRegularExpression(
+			'/^' . preg_quote( $this->slug, '/' ) . '-\d{4}-\d{2}-\d{2}-\d{6}$/',
+			$basename
+		);
+	}
+
+	// ─── stage() ─────────────────────────────────────────────────────────────
+
+	/**
+	 * stage() should create a staging directory containing all live plugin files.
+	 */
+	public function test_stage_creates_staging_dir_with_all_live_files(): void {
+		$result = $this->updater->stage( $this->slug, [] );
+
+		$this->assertIsString( $result );
+		$this->assertDirectoryExists( $result );
+		// Main plugin file should be copied from live.
+		$this->assertFileExists( $result . $this->slug . '.php' );
+	}
+
+	/**
+	 * stage() should overlay the provided modified files on top of the live copy.
+	 */
+	public function test_stage_overlays_modified_files(): void {
+		$new_content = '<?php /* updated content */';
+		$result      = $this->updater->stage( $this->slug, [ $this->slug . '.php' => $new_content ] );
+
+		$this->assertIsString( $result );
+		$staged_file = $result . $this->slug . '.php';
+		$this->assertFileExists( $staged_file );
+		$this->assertStringContainsString( 'updated content', (string) file_get_contents( $staged_file ) );
+	}
+
+	/**
+	 * stage() should return WP_Error for an empty slug.
+	 */
+	public function test_stage_empty_slug_returns_error(): void {
+		$result = $this->updater->stage( '', [] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'gratis_ai_agent_invalid_slug', $result->get_error_code() );
+	}
+
+	/**
+	 * stage() should return WP_Error when the plugin directory does not exist.
+	 */
+	public function test_stage_missing_plugin_returns_error(): void {
+		$result = $this->updater->stage( 'non-existent-plugin-phpunit', [] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'gratis_ai_agent_plugin_not_found', $result->get_error_code() );
+	}
+
+	// ─── test_staged() ───────────────────────────────────────────────────────
+
+	/**
+	 * test_staged() should return an array with `passed` key.
+	 */
+	public function test_test_staged_returns_array_with_passed_key(): void {
+		$staging_dir = $this->updater->stage( $this->slug, [] );
+		$this->assertIsString( $staging_dir );
+
+		$result = $this->updater->test_staged( $this->slug, $staging_dir );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'passed', $result );
+		$this->assertArrayHasKey( 'errors', $result );
+	}
+
+	/**
+	 * test_staged() should pass for a valid PHP plugin file.
+	 */
+	public function test_test_staged_passes_for_valid_plugin(): void {
+		$staging_dir = $this->updater->stage( $this->slug, [] );
+		$this->assertIsString( $staging_dir );
+
+		$result = $this->updater->test_staged( $this->slug, $staging_dir );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( (bool) $result['passed'] );
+		$this->assertEmpty( $result['errors'] );
+	}
+
+	// ─── rollback() ──────────────────────────────────────────────────────────
+
+	/**
+	 * rollback() should restore plugin files from a backup directory.
+	 */
+	public function test_rollback_restores_from_backup(): void {
+		$backup_dir = $this->updater->backup( $this->slug );
+		$this->assertIsString( $backup_dir );
+
+		// Corrupt the live plugin.
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test: write corrupted content to simulate a failed swap.
+		file_put_contents( $this->plugin_dir . $this->slug . '.php', '<?php /* corrupted */' );
+
+		$result = $this->updater->rollback( $this->slug, $backup_dir );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( (bool) $result['rolled_back'] );
+
+		// Restored file should have original content.
+		$restored_content = (string) file_get_contents( $this->plugin_dir . $this->slug . '.php' );
+		$this->assertStringContainsString( 'Plugin Name', $restored_content );
+	}
+
+	/**
+	 * rollback() should return WP_Error when backup directory does not exist.
+	 */
+	public function test_rollback_missing_backup_returns_error(): void {
+		$result = $this->updater->rollback( $this->slug, '/tmp/non-existent-backup-phpunit/' );
+		$this->assertWPError( $result );
+		$this->assertSame( 'gratis_ai_agent_backup_not_found', $result->get_error_code() );
+	}
+
+	// ─── cleanup_old_backups() ───────────────────────────────────────────────
+
+	/**
+	 * cleanup_old_backups() should return 0 when there are no backup directories.
+	 */
+	public function test_cleanup_old_backups_returns_zero_when_no_backups(): void {
+		$count = $this->updater->cleanup_old_backups();
+		$this->assertSame( 0, $count );
+	}
+
+	/**
+	 * cleanup_old_backups() should preserve the most recent backup regardless of age.
+	 */
+	public function test_cleanup_old_backups_preserves_most_recent(): void {
+		// Create two backup directories for the slug.
+		$backups_root = WP_CONTENT_DIR . '/gratis-ai-backups/';
+		wp_mkdir_p( $backups_root );
+
+		$old_dir = $backups_root . $this->slug . '-2020-01-01-000001/';
+		$new_dir = $backups_root . $this->slug . '-2020-01-02-000001/';
+		wp_mkdir_p( $old_dir );
+		wp_mkdir_p( $new_dir );
+
+		// Backdate the old dir's mtime so it's well outside the 7-day window.
+		touch( $old_dir, strtotime( '-30 days' ) );
+
+		$count = $this->updater->cleanup_old_backups( 7 );
+
+		// Old backup should be removed; most recent (new_dir) should survive.
+		$this->assertSame( 1, $count );
+		$this->assertDirectoryDoesNotExist( $old_dir );
+		$this->assertDirectoryExists( $new_dir );
+	}
+
+	// ─── update() ────────────────────────────────────────────────────────────
+
+	/**
+	 * update() should return WP_Error when the plugin slug is invalid.
+	 */
+	public function test_update_invalid_slug_returns_error(): void {
+		$result = $this->updater->update( '', [] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'gratis_ai_agent_invalid_slug', $result->get_error_code() );
+	}
+
+	/**
+	 * update() should return WP_Error when the plugin directory does not exist.
+	 */
+	public function test_update_missing_plugin_returns_error(): void {
+		$result = $this->updater->update( 'non-existent-plugin-phpunit', [ 'main.php' => '<?php' ] );
+		$this->assertWPError( $result );
+		$this->assertSame( 'gratis_ai_agent_plugin_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * update() should replace live plugin files and include backup_dir in the result.
+	 */
+	public function test_update_replaces_live_plugin_files(): void {
+		$new_content = '<?php /* Plugin Name: Updated Test Plugin */';
+
+		$result = $this->updater->update(
+			$this->slug,
+			[ $this->slug . '.php' => $new_content ]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'backup_dir', $result );
+		$this->assertTrue( (bool) $result['swapped'] );
+
+		// Main plugin file should contain the updated content.
+		$live_content = (string) file_get_contents( $this->plugin_dir . $this->slug . '.php' );
+		$this->assertStringContainsString( 'Updated Test Plugin', $live_content );
+	}
+
+	// ─── Helpers ─────────────────────────────────────────────────────────────
+
+	/**
+	 * Create a minimal valid plugin in the test plugin directory.
+	 *
+	 * @return void
+	 */
+	private function create_minimal_plugin(): void {
+		wp_mkdir_p( $this->plugin_dir );
+		$content = '<?php /* Plugin Name: Test Updater Plugin */' . "\n";
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test setup: creating a minimal plugin file.
+		file_put_contents( $this->plugin_dir . $this->slug . '.php', $content );
+	}
+
+	/**
+	 * Remove all directories created during the test.
+	 *
+	 * @return void
+	 */
+	private function cleanup_all(): void {
+		$dirs_to_clean = [
+			WP_CONTENT_DIR . '/plugins/' . $this->slug . '/',
+			WP_CONTENT_DIR . '/plugins/non-existent-plugin-phpunit/',
+			WP_CONTENT_DIR . '/gratis-ai-staging/' . $this->slug . '/',
+		];
+
+		foreach ( $dirs_to_clean as $dir ) {
+			$this->remove_dir( $dir );
+		}
+
+		// Remove all backup directories for this slug.
+		$backups_root = WP_CONTENT_DIR . '/gratis-ai-backups/';
+		if ( is_dir( $backups_root ) ) {
+			$entries = glob( $backups_root . $this->slug . '-*', GLOB_ONLYDIR );
+			if ( false !== $entries ) {
+				foreach ( $entries as $entry ) {
+					$this->remove_dir( $entry );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Recursively remove a directory using WP_Filesystem_Direct.
+	 *
+	 * @param string $dir Directory path.
+	 * @return void
+	 */
+	private function remove_dir( string $dir ): void {
+		if ( ! is_dir( $dir ) ) {
+			return;
+		}
+		require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
+		require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
+		$fs = new \WP_Filesystem_Direct( [] );
+		$fs->rmdir( $dir, true );
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up fix after #930 — updates two test files that called the old static `PluginUpdater::update()` API.

## Changes

- **EDIT**: `tests/GratisAiAgent/PluginBuilder/PluginBuilderIntegrationTest.php` — update 3 calls from `PluginUpdater::update($slug, $files, $plugin_file)` to `(new PluginUpdater())->update($slug, $files)`; update assertions from `$result['updated']` to `$result['swapped']`; fix backup dir cleanup glob from `plugins/` to `gratis-ai-backups/`
- **EDIT**: `tests/GratisAiAgent/Abilities/PluginBuilderAbilitiesTest.php` — replace `test_update_plugin_sandboxed_returns_wp_error_for_empty_plugin_file` (now invalid since `plugin_file` is derived from slug) with `test_update_plugin_sandboxed_returns_wp_error_for_nonexistent_plugin`

## Context

PR #930 rewrote `PluginUpdater` to instance-based API. These tests in `PluginBuilderIntegrationTest` and `PluginBuilderAbilitiesTest` (merged in #928 and #931) still used the old static call and were causing PHPUnit failures.

## Testing

```bash
composer phpstan  # OK
composer phpcs    # OK
npm run test:php  # requires wp-env
```

Resolves the PHPUnit failures introduced by #930.