### PR TITLE
fix: HookScanner empty-slug guard and test slug sanitization

### DIFF
--- a/includes/PluginBuilder/HookScanner.php
+++ b/includes/PluginBuilder/HookScanner.php
@@ -33,7 +33,15 @@ class HookScanner {
 	 */
 	public static function scan_plugin( string $plugin_slug ): array|\WP_Error {
 		$plugin_slug = sanitize_title( $plugin_slug );
-		$plugin_dir  = WP_CONTENT_DIR . '/plugins/' . $plugin_slug . '/';
+
+		if ( empty( $plugin_slug ) ) {
+			return new WP_Error(
+				'gratis_ai_agent_plugin_not_found',
+				__( 'Plugin slug must not be empty.', 'gratis-ai-agent' )
+			);
+		}
+
+		$plugin_dir = WP_CONTENT_DIR . '/plugins/' . $plugin_slug . '/';
 
 		if ( ! is_dir( $plugin_dir ) ) {
 			return new WP_Error(
@@ -54,7 +62,15 @@ class HookScanner {
 	 */
 	public static function scan_theme( string $theme_slug ): array|\WP_Error {
 		$theme_slug = sanitize_title( $theme_slug );
-		$theme_dir  = WP_CONTENT_DIR . '/themes/' . $theme_slug . '/';
+
+		if ( empty( $theme_slug ) ) {
+			return new WP_Error(
+				'gratis_ai_agent_theme_not_found',
+				__( 'Theme slug must not be empty.', 'gratis-ai-agent' )
+			);
+		}
+
+		$theme_dir = WP_CONTENT_DIR . '/themes/' . $theme_slug . '/';
 
 		if ( ! is_dir( $theme_dir ) ) {
 			return new WP_Error(

--- a/tests/GratisAiAgent/PluginBuilder/HookScannerTest.php
+++ b/tests/GratisAiAgent/PluginBuilder/HookScannerTest.php
@@ -375,7 +375,7 @@ class HookScannerTest extends WP_UnitTestCase {
 	 * Prevents third-party library hooks from polluting the results.
 	 */
 	public function test_scan_plugin_skips_vendor_directory(): void {
-		$slug = 'test-hook-scanner-vendor-' . uniqid( '', true );
+		$slug = 'test-hook-scanner-vendor-' . str_replace( '.', '', uniqid( '', true ) );
 		$dir  = $this->make_temp_plugin( $slug );
 
 		// Plugin-level hook — must appear.
@@ -405,7 +405,7 @@ class HookScannerTest extends WP_UnitTestCase {
 	 * Files inside a node_modules/ subdirectory are skipped during scan.
 	 */
 	public function test_scan_plugin_skips_node_modules_directory(): void {
-		$slug = 'test-hook-scanner-nm-' . uniqid( '', true );
+		$slug = 'test-hook-scanner-nm-' . str_replace( '.', '', uniqid( '', true ) );
 		$dir  = $this->make_temp_plugin( $slug );
 
 		$this->write_php_file(

--- a/tests/GratisAiAgent/PluginBuilder/HookScannerTest.php
+++ b/tests/GratisAiAgent/PluginBuilder/HookScannerTest.php
@@ -148,7 +148,7 @@ class HookScannerTest extends WP_UnitTestCase {
 	 * scan_plugin() extracts do_action() calls from a plugin PHP file.
 	 */
 	public function test_scan_plugin_extracts_do_action_hooks(): void {
-		$slug = 'test-hook-scanner-plugin-' . uniqid( '', true );
+		$slug = 'test-hook-scanner-plugin-' . str_replace( '.', '', uniqid( '', true ) );
 		$dir  = $this->make_temp_plugin( $slug );
 
 		$this->write_php_file(
@@ -175,7 +175,7 @@ class HookScannerTest extends WP_UnitTestCase {
 	 * scan_plugin() extracts apply_filters() calls.
 	 */
 	public function test_scan_plugin_extracts_apply_filters_hooks(): void {
-		$slug = 'test-hook-scanner-plugin-' . uniqid( '', true );
+		$slug = 'test-hook-scanner-plugin-' . str_replace( '.', '', uniqid( '', true ) );
 		$dir  = $this->make_temp_plugin( $slug );
 
 		$this->write_php_file(
@@ -199,7 +199,7 @@ class HookScannerTest extends WP_UnitTestCase {
 	 * scan_plugin() extracts add_action() and add_filter() calls.
 	 */
 	public function test_scan_plugin_extracts_add_action_and_add_filter(): void {
-		$slug = 'test-hook-scanner-plugin-' . uniqid( '', true );
+		$slug = 'test-hook-scanner-plugin-' . str_replace( '.', '', uniqid( '', true ) );
 		$dir  = $this->make_temp_plugin( $slug );
 
 		$this->write_php_file(
@@ -228,7 +228,7 @@ class HookScannerTest extends WP_UnitTestCase {
 	 * scan_plugin() does not match dynamic (variable) hook names.
 	 */
 	public function test_scan_plugin_skips_dynamic_hook_names(): void {
-		$slug = 'test-hook-scanner-plugin-' . uniqid( '', true );
+		$slug = 'test-hook-scanner-plugin-' . str_replace( '.', '', uniqid( '', true ) );
 		$dir  = $this->make_temp_plugin( $slug );
 
 		$this->write_php_file(
@@ -252,7 +252,7 @@ class HookScannerTest extends WP_UnitTestCase {
 	 * scan_plugin() scans PHP files in subdirectories.
 	 */
 	public function test_scan_plugin_scans_subdirectories(): void {
-		$slug = 'test-hook-scanner-plugin-' . uniqid( '', true );
+		$slug = 'test-hook-scanner-plugin-' . str_replace( '.', '', uniqid( '', true ) );
 		$dir  = $this->make_temp_plugin( $slug );
 
 		$this->write_php_file(
@@ -272,7 +272,7 @@ class HookScannerTest extends WP_UnitTestCase {
 	 * scan_plugin() aggregates hooks from multiple PHP files.
 	 */
 	public function test_scan_plugin_aggregates_hooks_from_multiple_files(): void {
-		$slug = 'test-hook-scanner-plugin-' . uniqid( '', true );
+		$slug = 'test-hook-scanner-plugin-' . str_replace( '.', '', uniqid( '', true ) );
 		$dir  = $this->make_temp_plugin( $slug );
 
 		$this->write_php_file( $dir, 'main.php', "<?php\ndo_action( 'hook_from_main' );\n" );
@@ -291,7 +291,7 @@ class HookScannerTest extends WP_UnitTestCase {
 	 * scan_plugin() returns empty hooks array for a plugin with no hook calls.
 	 */
 	public function test_scan_plugin_returns_empty_hooks_for_no_hook_calls(): void {
-		$slug = 'test-hook-scanner-plugin-' . uniqid( '', true );
+		$slug = 'test-hook-scanner-plugin-' . str_replace( '.', '', uniqid( '', true ) );
 		$dir  = $this->make_temp_plugin( $slug );
 
 		$this->write_php_file(
@@ -311,7 +311,7 @@ class HookScannerTest extends WP_UnitTestCase {
 	 * scan_plugin() result includes relative file path and line number.
 	 */
 	public function test_scan_plugin_result_includes_file_and_line(): void {
-		$slug = 'test-hook-scanner-plugin-' . uniqid( '', true );
+		$slug = 'test-hook-scanner-plugin-' . str_replace( '.', '', uniqid( '', true ) );
 		$dir  = $this->make_temp_plugin( $slug );
 
 		$this->write_php_file(
@@ -349,7 +349,7 @@ class HookScannerTest extends WP_UnitTestCase {
 	 * scan_theme() extracts hooks from theme PHP files.
 	 */
 	public function test_scan_theme_extracts_hooks(): void {
-		$slug = 'test-hook-scanner-theme-' . uniqid( '', true );
+		$slug = 'test-hook-scanner-theme-' . str_replace( '.', '', uniqid( '', true ) );
 		$dir  = $this->make_temp_theme( $slug );
 
 		$this->write_php_file(


### PR DESCRIPTION
## Summary

Two bugs exposed by the new unit tests added in #933 and #932:

**Bug 1 — empty slug bypasses WP_Error guard**  
`scan_plugin('')`/`scan_theme('')` called `sanitize_title('')` → `''` → checked `is_dir('/plugins//')` which resolved to the real `plugins/` directory and returned an array of all plugin hooks instead of `WP_Error`. Fix: add explicit `empty()` guard after `sanitize_title()`.

**Bug 2 — `uniqid('', true)` dot in test slugs causes path mismatch**  
`uniqid('', true)` includes a microsecond float like `abc.12345`. `sanitize_title()` converts `.` → `-`, so the directory created by `make_temp_plugin()` and the path looked up by `HookScanner::scan_plugin()` diverge. Fix: strip the dot suffix from slugs in test helpers so the directory name matches what `sanitize_title()` will produce.

## Changes

- `includes/PluginBuilder/HookScanner.php`: add `empty($plugin_slug)` guard in `scan_plugin()` and `scan_theme()` before `is_dir()` check
- `tests/GratisAiAgent/PluginBuilder/HookScannerTest.php`: strip `.` from `uniqid('', true)` results in `make_temp_plugin()` and `make_temp_theme()` helpers

## Verification

```bash
composer phpstan   # 0 errors
composer phpcs     # 0 errors
npm run test:php   # HookScannerTest passes (was 11 failures before this fix)
```

Resolves the 11 test failures in #933 CI and the pre-existing failures from #932.