### PR TITLE
t180: add feedback endpoint URL and API key fields to Settings > Advanced

### DIFF
--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -47,6 +47,13 @@ class Settings {
 	const GSC_CREDENTIALS_OPTION = 'gratis_ai_agent_gsc_credentials';
 
 	/**
+	 * Option name for the feedback-report receiver API key.
+	 * Stored separately from general settings to avoid leaking the credential
+	 * through the GET /settings endpoint.
+	 */
+	const FEEDBACK_API_KEY_OPTION = 'gratis_ai_agent_feedback_api_key';
+
+	/**
 	 * Supported direct providers with their metadata.
 	 */
 	const DIRECT_PROVIDERS = array(
@@ -221,6 +228,9 @@ class Settings {
 			// Provider trace / debug mode (GH#830).
 			'provider_trace_enabled'   => false,
 			'provider_trace_max_rows'  => 200,
+			// Feedback report receiver settings (t180).
+			'feedback_enabled'         => false,
+			'feedback_endpoint_url'    => '',
 		);
 	}
 
@@ -433,5 +443,43 @@ class Settings {
 		$merged = array_merge( $current, $data );
 
 		return update_option( self::OPTION_NAME, $merged );
+	}
+
+	/**
+	 * Get the stored feedback-report receiver API key.
+	 *
+	 * The key is intentionally stored in a dedicated option so it is never
+	 * returned by GET /settings and cannot leak through the JSON response.
+	 *
+	 * @return string Empty string when not configured.
+	 */
+	public static function get_feedback_api_key(): string {
+		$key = get_option( self::FEEDBACK_API_KEY_OPTION, '' );
+		return is_string( $key ) ? $key : '';
+	}
+
+	/**
+	 * Persist the feedback-report receiver API key.
+	 *
+	 * Pass an empty string to clear the credential.
+	 *
+	 * @param string $api_key The API key value.
+	 * @return bool True on success.
+	 */
+	public static function set_feedback_api_key( string $api_key ): bool {
+		if ( '' === $api_key ) {
+			return delete_option( self::FEEDBACK_API_KEY_OPTION );
+		}
+
+		return update_option( self::FEEDBACK_API_KEY_OPTION, $api_key );
+	}
+
+	/**
+	 * Check whether a feedback-report receiver API key is configured.
+	 *
+	 * @return bool
+	 */
+	public static function has_feedback_api_key(): bool {
+		return '' !== self::get_feedback_api_key();
 	}
 }

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -301,6 +301,31 @@ class SettingsController {
 			)
 		);
 
+		// Feedback receiver API key endpoint (t180).
+		register_rest_route(
+			self::NAMESPACE,
+			'/settings/feedback-api-key',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( __CLASS__, 'handle_set_feedback_api_key' ),
+					'permission_callback' => array( __CLASS__, 'check_admin_permission' ),
+					'args'                => array(
+						'api_key' => array(
+							'required'          => true,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( __CLASS__, 'handle_delete_feedback_api_key' ),
+					'permission_callback' => array( __CLASS__, 'check_admin_permission' ),
+				),
+			)
+		);
+
 		// Usage endpoint.
 		register_rest_route(
 			self::NAMESPACE,
@@ -378,6 +403,10 @@ class SettingsController {
 		// Indicate whether a Brave Search API key is configured (boolean only, no key value).
 		// @phpstan-ignore-next-line
 		$settings['_brave_search_key_configured'] = '' !== InternetSearchAbilities::get_brave_api_key();
+
+		// Indicate whether a feedback-report receiver API key is configured (boolean only, no key value — t180).
+		// @phpstan-ignore-next-line
+		$settings['_feedback_api_key_configured'] = Settings::has_feedback_api_key();
 
 		return new WP_REST_Response( $settings, 200 );
 	}
@@ -887,6 +916,55 @@ class SettingsController {
 	 */
 	public static function handle_delete_brave_search_key( WP_REST_Request $request ): WP_REST_Response {
 		InternetSearchAbilities::set_brave_api_key( '' );
+
+		return new WP_REST_Response(
+			array(
+				'deleted'    => true,
+				'configured' => false,
+			),
+			200
+		);
+	}
+
+	/**
+	 * Handle POST /settings/feedback-api-key — save the feedback-report receiver API key (t180).
+	 *
+	 * The key is stored in a dedicated option (Settings::FEEDBACK_API_KEY_OPTION)
+	 * and is never returned through GET /settings — only a boolean presence flag
+	 * is exposed via the _feedback_api_key_configured field.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 */
+	public static function handle_set_feedback_api_key( WP_REST_Request $request ): WP_REST_Response {
+		// @phpstan-ignore-next-line
+		$api_key = sanitize_text_field( (string) $request->get_param( 'api_key' ) );
+
+		if ( '' === $api_key ) {
+			return new WP_REST_Response( array( 'error' => 'api_key is required.' ), 400 );
+		}
+
+		$success = Settings::set_feedback_api_key( $api_key );
+
+		if ( ! $success ) {
+			return new WP_REST_Response( array( 'error' => 'Failed to save feedback API key.' ), 500 );
+		}
+
+		return new WP_REST_Response(
+			array(
+				'saved'      => true,
+				'configured' => true,
+			),
+			200
+		);
+	}
+
+	/**
+	 * Handle DELETE /settings/feedback-api-key — remove the feedback-report receiver API key (t180).
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 */
+	public static function handle_delete_feedback_api_key( WP_REST_Request $request ): WP_REST_Response {
+		Settings::set_feedback_api_key( '' );
 
 		return new WP_REST_Response(
 			array(

--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -105,6 +105,13 @@ export default function SettingsApp() {
 	const [ braveSaving, setBraveSaving ] = useState( false );
 	const [ braveNotice, setBraveNotice ] = useState( null );
 
+	// Feedback report receiver API key state (t180).
+	const [ feedbackApiKey, setFeedbackApiKey ] = useState( '' );
+	const [ feedbackApiKeyConfigured, setFeedbackApiKeyConfigured ] =
+		useState( false );
+	const [ feedbackApiKeySaving, setFeedbackApiKeySaving ] = useState( false );
+	const [ feedbackNotice, setFeedbackNotice ] = useState( null );
+
 	useEffect( () => {
 		fetchSettings();
 		fetchProviders();
@@ -121,10 +128,14 @@ export default function SettingsApp() {
 				}
 			} )
 			.catch( () => {} );
-		// Fetch Brave Search key status from the general settings response.
+		// Fetch Brave Search key status and feedback API key status from the
+		// general settings response.
 		apiFetch( { path: '/gratis-ai-agent/v1/settings' } )
 			.then( ( data ) => {
 				setBraveConfigured( !! data?._brave_search_key_configured );
+				setFeedbackApiKeyConfigured(
+					!! data?._feedback_api_key_configured
+				);
 			} )
 			.catch( () => {} );
 	}, [ fetchSettings, fetchProviders ] );
@@ -259,6 +270,58 @@ export default function SettingsApp() {
 			} );
 		}
 		setBraveSaving( false );
+	}, [] );
+
+	// Feedback report receiver API key handlers (t180).
+	const handleFeedbackApiKeySave = useCallback( async () => {
+		setFeedbackApiKeySaving( true );
+		setFeedbackNotice( null );
+		try {
+			await apiFetch( {
+				path: '/gratis-ai-agent/v1/settings/feedback-api-key',
+				method: 'POST',
+				data: { api_key: feedbackApiKey },
+			} );
+			setFeedbackApiKeyConfigured( true );
+			setFeedbackApiKey( '' ); // Clear the field after saving.
+			setFeedbackNotice( {
+				status: 'success',
+				message: __( 'Feedback API key saved.', 'gratis-ai-agent' ),
+			} );
+		} catch ( err ) {
+			setFeedbackNotice( {
+				status: 'error',
+				message:
+					err?.message ||
+					__( 'Failed to save feedback API key.', 'gratis-ai-agent' ),
+			} );
+		}
+		setFeedbackApiKeySaving( false );
+	}, [ feedbackApiKey ] );
+
+	const handleFeedbackApiKeyRemove = useCallback( async () => {
+		setFeedbackApiKeySaving( true );
+		setFeedbackNotice( null );
+		try {
+			await apiFetch( {
+				path: '/gratis-ai-agent/v1/settings/feedback-api-key',
+				method: 'DELETE',
+			} );
+			setFeedbackApiKeyConfigured( false );
+			setFeedbackNotice( {
+				status: 'success',
+				message: __( 'Feedback API key removed.', 'gratis-ai-agent' ),
+			} );
+		} catch {
+			setFeedbackNotice( {
+				status: 'error',
+				message: __(
+					'Failed to remove feedback API key.',
+					'gratis-ai-agent'
+				),
+			} );
+		}
+		setFeedbackApiKeySaving( false );
 	}, [] );
 
 	useEffect( () => {
@@ -1949,6 +2012,179 @@ export default function SettingsApp() {
 													onClick={ handleBraveClear }
 													isBusy={ braveSaving }
 													disabled={ braveSaving }
+												>
+													{ __(
+														'Remove Key',
+														'gratis-ai-agent'
+													) }
+												</Button>
+											) }
+										</div>
+
+										<h4 className="gratis-ai-agent-settings-subsection-title">
+											{ __(
+												'Feedback Reports',
+												'gratis-ai-agent'
+											) }
+										</h4>
+										<p className="description">
+											{ __(
+												'Configure where feedback reports (errors, thumbs-down, user-reported issues) are sent. The receiving endpoint is the gratis-ai-feedback plugin. Leave blank to disable report submission.',
+												'gratis-ai-agent'
+											) }
+										</p>
+										{ feedbackNotice && (
+											<Notice
+												status={ feedbackNotice.status }
+												isDismissible
+												onDismiss={ () =>
+													setFeedbackNotice( null )
+												}
+											>
+												{ feedbackNotice.message }
+											</Notice>
+										) }
+										<table className="form-table gratis-ai-agent-form-table">
+											<tbody>
+												<tr>
+													<th scope="row">
+														{ __(
+															'Enable Feedback Submission',
+															'gratis-ai-agent'
+														) }
+													</th>
+													<td>
+														<ToggleControl
+															label={ __(
+																'Send feedback reports to the configured endpoint',
+																'gratis-ai-agent'
+															) }
+															checked={
+																!! local.feedback_enabled
+															}
+															onChange={ ( v ) =>
+																updateField(
+																	'feedback_enabled',
+																	v
+																)
+															}
+															help={ __(
+																'When enabled, the plugin can send feedback reports (with user consent) to the endpoint URL below.',
+																'gratis-ai-agent'
+															) }
+															__nextHasNoMarginBottom
+														/>
+													</td>
+												</tr>
+												<tr>
+													<th scope="row">
+														<label htmlFor="gratis-feedback-endpoint-url">
+															{ __(
+																'Endpoint URL',
+																'gratis-ai-agent'
+															) }
+														</label>
+													</th>
+													<td>
+														<TextControl
+															id="gratis-feedback-endpoint-url"
+															type="url"
+															value={
+																local.feedback_endpoint_url ||
+																''
+															}
+															onChange={ ( v ) =>
+																updateField(
+																	'feedback_endpoint_url',
+																	v
+																)
+															}
+															placeholder="https://example.com/wp-json/gratis-ai-feedback/v1/reports"
+															help={ __(
+																'REST API URL of the gratis-ai-feedback receiving plugin. Reports are sent as POST requests to this URL.',
+																'gratis-ai-agent'
+															) }
+															__nextHasNoMarginBottom
+														/>
+													</td>
+												</tr>
+												<tr>
+													<th scope="row">
+														<label htmlFor="gratis-feedback-api-key">
+															{ __(
+																'API Key',
+																'gratis-ai-agent'
+															) }
+														</label>
+													</th>
+													<td>
+														{ feedbackApiKeyConfigured && (
+															<p className="description">
+																{ __(
+																	'An API key is currently saved.',
+																	'gratis-ai-agent'
+																) }
+															</p>
+														) }
+														<TextControl
+															id="gratis-feedback-api-key"
+															type="password"
+															value={
+																feedbackApiKey
+															}
+															onChange={
+																setFeedbackApiKey
+															}
+															placeholder={
+																feedbackApiKeyConfigured
+																	? __(
+																			'Key saved — enter a new key to replace it',
+																			'gratis-ai-agent'
+																	  )
+																	: __(
+																			'Enter your feedback API key',
+																			'gratis-ai-agent'
+																	  )
+															}
+															help={ __(
+																'The API key is stored securely and never exposed via the settings API. Sent as the X-Feedback-Api-Key header with each report.',
+																'gratis-ai-agent'
+															) }
+															__nextHasNoMarginBottom
+														/>
+													</td>
+												</tr>
+											</tbody>
+										</table>
+										<div className="gratis-ai-agent-settings-row-actions">
+											<Button
+												variant="primary"
+												onClick={
+													handleFeedbackApiKeySave
+												}
+												isBusy={ feedbackApiKeySaving }
+												disabled={
+													feedbackApiKeySaving ||
+													! feedbackApiKey
+												}
+											>
+												{ __(
+													'Save API Key',
+													'gratis-ai-agent'
+												) }
+											</Button>
+											{ feedbackApiKeyConfigured && (
+												<Button
+													variant="secondary"
+													onClick={
+														handleFeedbackApiKeyRemove
+													}
+													isBusy={
+														feedbackApiKeySaving
+													}
+													disabled={
+														feedbackApiKeySaving
+													}
 												>
 													{ __(
 														'Remove Key',


### PR DESCRIPTION
## Summary

Adds a **Feedback Reports** section to the Settings > Advanced tab so administrators can configure where feedback reports are sent (as specified by the gratis-ai-feedback receiving plugin system).

### Changes

**`includes/Core/Settings.php`**
- New constant `FEEDBACK_API_KEY_OPTION` (`gratis_ai_agent_feedback_api_key`) — stored in a dedicated WP option, never returned by GET /settings to prevent key leakage.
- Two new defaults: `feedback_enabled` (bool, false) and `feedback_endpoint_url` (string, '').
- Three new static methods: `get_feedback_api_key()`, `set_feedback_api_key(string)`, `has_feedback_api_key()`.

**`includes/REST/SettingsController.php`**
- New `POST /gratis-ai-agent/v1/settings/feedback-api-key` — saves the API key securely.
- New `DELETE /gratis-ai-agent/v1/settings/feedback-api-key` — removes the API key.
- `handle_get_settings()` now includes `_feedback_api_key_configured` boolean (same pattern as `_brave_search_key_configured`).

**`src/settings-page/settings-app.js`**
- New state: `feedbackApiKey`, `feedbackApiKeyConfigured`, `feedbackApiKeySaving`, `feedbackNotice`.
- Handlers: `handleFeedbackApiKeySave`, `handleFeedbackApiKeyRemove` (model on `handleBraveSave`/`handleBraveClear`).
- New **Feedback Reports** section in the Advanced tab with:
  - Enable/disable toggle (`feedback_enabled`) — saved via global Save Settings.
  - Endpoint URL text field (`feedback_endpoint_url`) — saved via global Save Settings.
  - API key password field — saved/removed via dedicated endpoint buttons.

### Verification

- PHPCS: `composer phpcs -- includes/Core/Settings.php includes/REST/SettingsController.php` → clean
- PHPStan: `composer phpstan -- includes/Core/Settings.php includes/REST/SettingsController.php` → No errors
- ESLint: `npm run lint:js` → clean
- Settings save/load round-trip: `feedback_enabled` and `feedback_endpoint_url` flow through the standard settings GET/POST. API key stored separately — only boolean presence visible via GET.

Resolves #937