### PR TITLE
t184: /report-issue slash command opening FeedbackConsentModal

### DIFF
--- a/src/components/__tests__/MessageInput.test.js
+++ b/src/components/__tests__/MessageInput.test.js
@@ -154,6 +154,20 @@ jest.mock( '../use-speech-recognition', () =>
 	} ) )
 );
 
+jest.mock( '../feedback-consent-modal', () => {
+	const React = require( 'react' );
+	return ( { reportType, userDescription, onClose } ) =>
+		React.createElement(
+			'div',
+			{
+				'data-testid': 'feedback-consent-modal',
+				'data-report-type': reportType,
+				'data-user-description': userDescription,
+			},
+			React.createElement( 'button', { onClick: onClose }, 'close-modal' )
+		);
+} );
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
@@ -600,6 +614,176 @@ describe( 'MessageInput interactions', () => {
 			debugBtn.click();
 		} );
 		expect( setDebugMode ).toHaveBeenCalledWith( true );
+	} );
+
+	test( '/report-issue with description opens FeedbackConsentModal with pre-filled description', () => {
+		setupMocks();
+
+		act( () => {
+			root.render( createElement( MessageInput, {} ) );
+		} );
+
+		const textarea = container.querySelector(
+			'textarea.gratis-ai-agent-input'
+		);
+
+		// Simulate typing /report-issue something broke
+		act( () => {
+			const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+				window.HTMLTextAreaElement.prototype,
+				'value'
+			).set;
+			nativeInputValueSetter.call(
+				textarea,
+				'/report-issue something broke'
+			);
+			textarea.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		} );
+
+		// Press Enter to trigger handleSend.
+		act( () => {
+			const enterEvent = new KeyboardEvent( 'keydown', {
+				key: 'Enter',
+				bubbles: true,
+				cancelable: true,
+			} );
+			textarea.dispatchEvent( enterEvent );
+		} );
+
+		const modal = container.querySelector(
+			'[data-testid="feedback-consent-modal"]'
+		);
+		expect( modal ).not.toBeNull();
+		expect( modal.getAttribute( 'data-report-type' ) ).toBe(
+			'user_reported'
+		);
+		expect( modal.getAttribute( 'data-user-description' ) ).toBe(
+			'something broke'
+		);
+	} );
+
+	test( '/report-issue with trailing space (no description) opens FeedbackConsentModal with empty description', () => {
+		setupMocks();
+
+		act( () => {
+			root.render( createElement( MessageInput, {} ) );
+		} );
+
+		const textarea = container.querySelector(
+			'textarea.gratis-ai-agent-input'
+		);
+
+		// A trailing space hides the slash menu so Enter reaches handleSend.
+		// This matches the flow after selecting /report-issue from the menu
+		// (which sets the text to '/report-issue ') and pressing Enter immediately.
+		act( () => {
+			const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+				window.HTMLTextAreaElement.prototype,
+				'value'
+			).set;
+			nativeInputValueSetter.call( textarea, '/report-issue ' );
+			textarea.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		} );
+
+		act( () => {
+			const enterEvent = new KeyboardEvent( 'keydown', {
+				key: 'Enter',
+				bubbles: true,
+				cancelable: true,
+			} );
+			textarea.dispatchEvent( enterEvent );
+		} );
+
+		const modal = container.querySelector(
+			'[data-testid="feedback-consent-modal"]'
+		);
+		expect( modal ).not.toBeNull();
+		expect( modal.getAttribute( 'data-report-type' ) ).toBe(
+			'user_reported'
+		);
+		expect( modal.getAttribute( 'data-user-description' ) ).toBe( '' );
+	} );
+
+	test( '/report-issue clears the input text after opening modal', () => {
+		setupMocks();
+
+		act( () => {
+			root.render( createElement( MessageInput, {} ) );
+		} );
+
+		const textarea = container.querySelector(
+			'textarea.gratis-ai-agent-input'
+		);
+
+		act( () => {
+			const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+				window.HTMLTextAreaElement.prototype,
+				'value'
+			).set;
+			nativeInputValueSetter.call(
+				textarea,
+				'/report-issue test description'
+			);
+			textarea.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		} );
+
+		act( () => {
+			const enterEvent = new KeyboardEvent( 'keydown', {
+				key: 'Enter',
+				bubbles: true,
+				cancelable: true,
+			} );
+			textarea.dispatchEvent( enterEvent );
+		} );
+
+		expect( textarea.value ).toBe( '' );
+	} );
+
+	test( 'closing FeedbackConsentModal hides the modal', () => {
+		setupMocks();
+
+		act( () => {
+			root.render( createElement( MessageInput, {} ) );
+		} );
+
+		const textarea = container.querySelector(
+			'textarea.gratis-ai-agent-input'
+		);
+
+		act( () => {
+			const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+				window.HTMLTextAreaElement.prototype,
+				'value'
+			).set;
+			nativeInputValueSetter.call( textarea, '/report-issue test' );
+			textarea.dispatchEvent( new Event( 'change', { bubbles: true } ) );
+		} );
+
+		act( () => {
+			const enterEvent = new KeyboardEvent( 'keydown', {
+				key: 'Enter',
+				bubbles: true,
+				cancelable: true,
+			} );
+			textarea.dispatchEvent( enterEvent );
+		} );
+
+		// Modal should be visible.
+		expect(
+			container.querySelector( '[data-testid="feedback-consent-modal"]' )
+		).not.toBeNull();
+
+		// Click the close button inside the modal mock.
+		const closeBtn = container.querySelector(
+			'[data-testid="feedback-consent-modal"] button'
+		);
+		act( () => {
+			closeBtn.click();
+		} );
+
+		expect(
+			container.querySelector( '[data-testid="feedback-consent-modal"]' )
+		).toBeNull();
 	} );
 } );
 

--- a/src/components/feedback-consent-modal.js
+++ b/src/components/feedback-consent-modal.js
@@ -1,0 +1,184 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useCallback, useRef, useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Feedback consent modal.
+ *
+ * Shown when the user invokes /report-issue or other feedback triggers.
+ * Lets the user review and optionally edit a description before sending a
+ * report to the configured feedback endpoint via the server-side proxy.
+ *
+ * Extensibility note: this component is intentionally minimal for the
+ * initial implementation. The payload preview, environment summary, and
+ * "Strip tool results" checkbox described in t182 can be added as additional
+ * sections in the modal body without changing the props interface.
+ *
+ * @param {Object}   props                      - Component props.
+ * @param {string}   props.reportType           - Type of report sent in the
+ *                                              payload: 'user_reported',
+ *                                              'thumbs_down', 'self_reported', etc.
+ * @param {string}   [props.userDescription=''] - Pre-filled description text.
+ *                                              Editable by the user before sending.
+ * @param {Function} props.onClose              - Called when the modal should close.
+ * @return {JSX.Element} The feedback consent modal element.
+ */
+export default function FeedbackConsentModal( {
+	reportType,
+	userDescription = '',
+	onClose,
+} ) {
+	const [ description, setDescription ] = useState( userDescription );
+	const [ isSending, setIsSending ] = useState( false );
+	const [ isSent, setIsSent ] = useState( false );
+	const [ error, setError ] = useState( null );
+	const dialogRef = useRef( null );
+
+	// Close on Escape key.
+	useEffect( () => {
+		const handler = ( e ) => {
+			if ( e.key === 'Escape' ) {
+				onClose();
+			}
+		};
+		document.addEventListener( 'keydown', handler );
+		return () => document.removeEventListener( 'keydown', handler );
+	}, [ onClose ] );
+
+	// Close on click outside the dialog box.
+	useEffect( () => {
+		const handler = ( e ) => {
+			if (
+				dialogRef.current &&
+				! dialogRef.current.contains( e.target )
+			) {
+				onClose();
+			}
+		};
+		document.addEventListener( 'mousedown', handler );
+		return () => document.removeEventListener( 'mousedown', handler );
+	}, [ onClose ] );
+
+	const handleSend = useCallback( async () => {
+		setIsSending( true );
+		setError( null );
+		try {
+			await apiFetch( {
+				path: '/gratis-ai-agent/v1/feedback/send',
+				method: 'POST',
+				data: {
+					report_type: reportType,
+					user_description: description,
+				},
+			} );
+			setIsSent( true );
+			// Auto-close after a short confirmation delay.
+			setTimeout( onClose, 1500 );
+		} catch {
+			setError(
+				__(
+					'Failed to send report. Please try again.',
+					'gratis-ai-agent'
+				)
+			);
+			setIsSending( false );
+		}
+	}, [ reportType, description, onClose ] );
+
+	return (
+		<div className="gratis-ai-agent-shortcuts-overlay">
+			<div
+				className="gratis-ai-agent-feedback-modal"
+				ref={ dialogRef }
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="gratis-ai-agent-feedback-title"
+			>
+				<div className="gratis-ai-agent-feedback-modal__header">
+					<h3 id="gratis-ai-agent-feedback-title">
+						{ __( 'Send Feedback Report', 'gratis-ai-agent' ) }
+					</h3>
+					<button
+						type="button"
+						className="gratis-ai-agent-feedback-modal__close"
+						onClick={ onClose }
+						aria-label={ __( 'Close', 'gratis-ai-agent' ) }
+					>
+						&times;
+					</button>
+				</div>
+				<div className="gratis-ai-agent-feedback-modal__body">
+					{ isSent ? (
+						<p className="gratis-ai-agent-feedback-modal__success">
+							{ __(
+								'Report sent. Thank you!',
+								'gratis-ai-agent'
+							) }
+						</p>
+					) : (
+						<>
+							<p className="gratis-ai-agent-feedback-modal__notice">
+								{ __(
+									'No passwords, API keys, or credentials are included. Server paths are anonymized.',
+									'gratis-ai-agent'
+								) }
+							</p>
+							<label
+								htmlFor="gratis-ai-agent-feedback-description"
+								className="gratis-ai-agent-feedback-modal__label"
+							>
+								{ __(
+									'Describe the issue (optional):',
+									'gratis-ai-agent'
+								) }
+							</label>
+							<textarea
+								id="gratis-ai-agent-feedback-description"
+								className="gratis-ai-agent-feedback-modal__textarea"
+								value={ description }
+								onChange={ ( e ) =>
+									setDescription( e.target.value )
+								}
+								rows={ 4 }
+								placeholder={ __(
+									'What went wrong?',
+									'gratis-ai-agent'
+								) }
+							/>
+							{ error && (
+								<p className="gratis-ai-agent-feedback-modal__error">
+									{ error }
+								</p>
+							) }
+						</>
+					) }
+				</div>
+				{ ! isSent && (
+					<div className="gratis-ai-agent-feedback-modal__footer">
+						<button
+							type="button"
+							className="button"
+							onClick={ onClose }
+							disabled={ isSending }
+						>
+							{ __( 'Dismiss', 'gratis-ai-agent' ) }
+						</button>
+						<button
+							type="button"
+							className="button button-primary"
+							onClick={ handleSend }
+							disabled={ isSending }
+						>
+							{ isSending
+								? __( 'Sending\u2026', 'gratis-ai-agent' )
+								: __( 'Send Report', 'gratis-ai-agent' ) }
+						</button>
+					</div>
+				) }
+			</div>
+		</div>
+	);
+}

--- a/src/components/message-input.js
+++ b/src/components/message-input.js
@@ -13,6 +13,7 @@ import apiFetch from '@wordpress/api-fetch';
  */
 import STORE_NAME from '../store';
 import SlashCommandMenu from './slash-command-menu';
+import FeedbackConsentModal from './feedback-consent-modal';
 import useSpeechRecognition from './use-speech-recognition';
 
 /** Maximum file size in bytes (10 MB). */
@@ -160,6 +161,11 @@ export default function MessageInput( { compact = false, onSlashCommand } ) {
 	const [ showSlash, setShowSlash ] = useState( false );
 	const [ attachments, setAttachments ] = useState( [] );
 	const [ isDragOver, setIsDragOver ] = useState( false );
+	const [ feedbackModal, setFeedbackModal ] = useState( {
+		isOpen: false,
+		reportType: 'user_reported',
+		userDescription: '',
+	} );
 	const textareaRef = useRef( null );
 	const fileInputRef = useRef( null );
 	const sending = useSelect(
@@ -420,6 +426,23 @@ export default function MessageInput( { compact = false, onSlashCommand } ) {
 			return;
 		}
 
+		// Handle /report-issue [optional description] command.
+		if (
+			trimmed === '/report-issue' ||
+			trimmed.startsWith( '/report-issue ' )
+		) {
+			const description = trimmed.startsWith( '/report-issue ' )
+				? trimmed.slice( 14 ).trim()
+				: '';
+			setFeedbackModal( {
+				isOpen: true,
+				reportType: 'user_reported',
+				userDescription: description,
+			} );
+			setText( '' );
+			return;
+		}
+
 		sendMessage( trimmed, attachments );
 		setText( '' );
 		setAttachments( [] );
@@ -490,6 +513,18 @@ export default function MessageInput( { compact = false, onSlashCommand } ) {
 						0
 					);
 					return;
+				case 'report-issue':
+					// Focus back on input for optional description typing.
+					// Pressing Enter will open the FeedbackConsentModal.
+					setText( '/report-issue ' );
+					setTimeout(
+						() =>
+							textareaRef.current?.focus( {
+								preventScroll: true,
+							} ),
+						0
+					);
+					return;
 			}
 
 			setTimeout(
@@ -539,6 +574,18 @@ export default function MessageInput( { compact = false, onSlashCommand } ) {
 					filter={ text }
 					onSelect={ handleSlashSelect }
 					onClose={ () => setShowSlash( false ) }
+				/>
+			) }
+			{ feedbackModal.isOpen && (
+				<FeedbackConsentModal
+					reportType={ feedbackModal.reportType }
+					userDescription={ feedbackModal.userDescription }
+					onClose={ () =>
+						setFeedbackModal( ( prev ) => ( {
+							...prev,
+							isOpen: false,
+						} ) )
+					}
 				/>
 			) }
 			<AttachmentPreviews

--- a/src/components/shared.css
+++ b/src/components/shared.css
@@ -463,3 +463,109 @@
 	padding: 12px 20px 16px;
 	border-top: 1px solid #dcdcde;
 }
+
+/* ── Feedback consent modal ────────────────────────────────────────────────── */
+.gratis-ai-agent-feedback-modal {
+	background: #fff;
+	border-radius: 8px;
+	width: 480px;
+	max-width: 90vw;
+	max-height: 80vh;
+	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
+}
+
+.gratis-ai-agent-feedback-modal__header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 16px 20px 12px;
+	border-bottom: 1px solid #dcdcde;
+}
+
+.gratis-ai-agent-feedback-modal__header h3 {
+	margin: 0;
+	font-size: 16px;
+	color: #1d2327;
+}
+
+.gratis-ai-agent-feedback-modal__close {
+	background: none;
+	border: none;
+	cursor: pointer;
+	font-size: 20px;
+	line-height: 1;
+	color: #787c82;
+	padding: 0 4px;
+}
+
+.gratis-ai-agent-feedback-modal__close:hover {
+	color: #1d2327;
+}
+
+.gratis-ai-agent-feedback-modal__body {
+	padding: 16px 20px;
+	overflow-y: auto;
+	display: flex;
+	flex-direction: column;
+	gap: 10px;
+}
+
+.gratis-ai-agent-feedback-modal__notice {
+	margin: 0;
+	font-size: 12px;
+	color: #646970;
+	background: #f6f7f7;
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	padding: 8px 10px;
+	line-height: 1.5;
+}
+
+.gratis-ai-agent-feedback-modal__label {
+	font-size: 13px;
+	font-weight: 600;
+	color: #1d2327;
+}
+
+.gratis-ai-agent-feedback-modal__textarea {
+	width: 100%;
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	padding: 8px 10px;
+	font-size: 13px;
+	line-height: 1.5;
+	resize: vertical;
+	box-sizing: border-box;
+	font-family: inherit;
+}
+
+.gratis-ai-agent-feedback-modal__textarea:focus {
+	border-color: var(--wp-admin-theme-color, #2271b1);
+	outline: none;
+	box-shadow: 0 0 0 1px var(--wp-admin-theme-color, #2271b1);
+}
+
+.gratis-ai-agent-feedback-modal__error {
+	margin: 0;
+	font-size: 12px;
+	color: #d63638;
+}
+
+.gratis-ai-agent-feedback-modal__success {
+	margin: 0;
+	font-size: 14px;
+	color: #008a20;
+	text-align: center;
+	padding: 8px 0;
+}
+
+.gratis-ai-agent-feedback-modal__footer {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	padding: 12px 20px 16px;
+	border-top: 1px solid #dcdcde;
+}

--- a/src/components/slash-command-menu.js
+++ b/src/components/slash-command-menu.js
@@ -74,6 +74,14 @@ const COMMANDS = [
 		),
 		action: 'debug',
 	},
+	{
+		name: '/report-issue',
+		description: __(
+			'Send a bug report or feedback (type description after)',
+			'gratis-ai-agent'
+		),
+		action: 'report-issue',
+	},
 ];
 
 /**


### PR DESCRIPTION
## Summary

- Adds `/report-issue [optional description]` slash command to the chat input
- Creating `FeedbackConsentModal` component (minimal implementation required by t184; designed for t182 to extend with payload preview and environment summary)
- Handles both menu-selection flow (set text → user types description → Enter) and direct-type flow (`/report-issue something broke` + Enter)

## Changes

| File | Type | Description |
|------|------|-------------|
| `src/components/feedback-consent-modal.js` | NEW | Modal with description textarea, privacy notice, Send Report/Dismiss buttons; calls `POST /gratis-ai-agent/v1/feedback/send` |
| `src/components/slash-command-menu.js` | EDIT | Add `/report-issue` to COMMANDS list |
| `src/components/message-input.js` | EDIT | Import modal, add `feedbackModal` state, handle in `handleSend` and `handleSlashSelect` |
| `src/components/shared.css` | EDIT | Add `.gratis-ai-agent-feedback-modal*` CSS classes |
| `src/components/__tests__/MessageInput.test.js` | EDIT | 4 new tests for the slash command behaviour |

## Verification

- `npm run test:js` — 248/248 tests pass (36/36 in MessageInput.test.js)
- `npm run lint:js` — 0 errors on changed files
- Manual: type `/report-issue something broke` in chat, Enter opens modal with description pre-filled
- Manual: type `/report-issue ` (trailing space) + Enter opens modal with empty description textarea

## Notes on dependency

t184 depends on t182 (FeedbackConsentModal). Since t182 had no active branch or PR at implementation time, `feedback-consent-modal.js` is created here as a minimal but functional implementation. The t182 worker can extend it with the full payload preview, environment summary stats, and "Strip tool results" checkbox described in the t182 spec without changing the props interface.

Resolves #941