### PR TITLE
t185: report-inability ability — agent self-flags when it cannot complete a task

### DIFF
--- a/gratis-ai-agent.php
+++ b/gratis-ai-agent.php
@@ -43,6 +43,7 @@ if ( file_exists( GRATIS_AI_AGENT_DIR . '/vendor/autoload_packages.php' ) ) {
 
 use GratisAiAgent\Abilities\AiImageAbilities;
 use GratisAiAgent\Abilities\BlockAbilities;
+use GratisAiAgent\Abilities\FeedbackAbilities;
 use GratisAiAgent\Abilities\ContentAbilities;
 use GratisAiAgent\Abilities\CustomPostTypeAbilities;
 use GratisAiAgent\Abilities\CustomTaxonomyAbilities;
@@ -315,6 +316,9 @@ add_filter(
 
 // Memory abilities.
 MemoryAbilities::register();
+
+// Feedback abilities (report-inability).
+FeedbackAbilities::register();
 
 // Skill abilities.
 SkillAbilities::register();

--- a/includes/Abilities/FeedbackAbilities.php
+++ b/includes/Abilities/FeedbackAbilities.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Register feedback-related WordPress abilities for the AI agent.
+ *
+ * Provides the `gratis-ai-agent/report-inability` ability so the agent can
+ * self-flag when it cannot complete a task. The handler sets a static,
+ * request-scoped flag that AgentLoop reads at loop-end and injects into the
+ * REST response as `inability_reported`, which the frontend consumes to show
+ * a feedback prompt.
+ *
+ * @package GratisAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace GratisAiAgent\Abilities;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class FeedbackAbilities {
+
+	/**
+	 * Request-scoped inability data set by the handler.
+	 * Null means the ability was not called this request.
+	 *
+	 * @var array{reason: string, attempted_steps: string[]}|null
+	 */
+	private static ?array $inability_data = null;
+
+	/**
+	 * Register feedback abilities on init.
+	 */
+	public static function register(): void {
+		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
+	}
+
+	/**
+	 * Register the report-inability ability.
+	 */
+	public static function register_abilities(): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			'gratis-ai-agent/report-inability',
+			[
+				'label'               => __( 'Report Inability', 'gratis-ai-agent' ),
+				'description'         => __( 'Call this ability when you cannot complete the user\'s request after genuinely trying. Provide a clear reason and list the steps you attempted. This helps the team improve the agent.', 'gratis-ai-agent' ),
+				'category'            => 'gratis-ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'reason'          => [
+							'type'        => 'string',
+							'description' => 'A clear, concise explanation of why the task could not be completed.',
+						],
+						'attempted_steps' => [
+							'type'        => 'array',
+							'description' => 'List of steps that were attempted before giving up.',
+							'items'       => [ 'type' => 'string' ],
+						],
+					],
+					'required'   => [ 'reason' ],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'success' => [ 'type' => 'boolean' ],
+						'message' => [ 'type' => 'string' ],
+					],
+				],
+				'meta'                => [
+					'annotations' => [
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => false,
+					],
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_report_inability' ],
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+			]
+		);
+	}
+
+	/**
+	 * Handle the report-inability ability call.
+	 *
+	 * Sets a request-scoped static flag that AgentLoop reads after the loop
+	 * finishes to include `inability_reported` in the REST response.
+	 *
+	 * @param array<string,mixed> $input Input with reason and optional attempted_steps.
+	 * @return array<string,mixed> Result confirming the flag was set.
+	 */
+	public static function handle_report_inability( array $input ): array {
+		$reason          = trim( (string) ( $input['reason'] ?? '' ) );
+		$attempted_steps = $input['attempted_steps'] ?? [];
+
+		if ( empty( $reason ) ) {
+			return [
+				'success' => false,
+				'message' => 'A reason is required to report inability.',
+			];
+		}
+
+		// Normalise attempted_steps to a plain string array.
+		$steps = array_values(
+			array_filter(
+				array_map( static fn( $s ) => (string) $s, (array) $attempted_steps ),
+				static fn( string $s ) => '' !== trim( $s )
+			)
+		);
+
+		self::$inability_data = [
+			'reason'          => $reason,
+			'attempted_steps' => $steps,
+		];
+
+		return [
+			'success' => true,
+			'message' => 'Inability flagged. The user will be offered the option to send a report.',
+		];
+	}
+
+	/**
+	 * Return the inability data set during this request, if any.
+	 *
+	 * Called by AgentLoop after the loop finishes.
+	 *
+	 * @return array{reason: string, attempted_steps: string[]}|null
+	 */
+	public static function get_inability_data(): ?array {
+		return self::$inability_data;
+	}
+
+	/**
+	 * Reset the request-scoped flag.
+	 * Exposed for unit-test isolation.
+	 */
+	public static function reset(): void {
+		self::$inability_data = null;
+	}
+}

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace GratisAiAgent\Core;
 
+use GratisAiAgent\Abilities\FeedbackAbilities;
 use GratisAiAgent\Abilities\Js\JsAbilityCatalog;
 use GratisAiAgent\Core\BudgetManager;
 use GratisAiAgent\Core\ChangeLogger;
@@ -493,13 +494,15 @@ class AgentLoop {
 					}
 				}
 
-				return array(
-					'reply'           => $reply,
-					'history'         => $this->serialize_history(),
-					'tool_calls'      => $this->tool_call_log,
-					'token_usage'     => $this->token_usage,
-					'iterations_used' => $this->iterations_used,
-					'model_id'        => $this->model_id,
+				return $this->inject_inability_data(
+					array(
+						'reply'           => $reply,
+						'history'         => $this->serialize_history(),
+						'tool_calls'      => $this->tool_call_log,
+						'token_usage'     => $this->token_usage,
+						'iterations_used' => $this->iterations_used,
+						'model_id'        => $this->model_id,
+					)
 				);
 			}
 
@@ -645,14 +648,16 @@ class AgentLoop {
 					$reply = '';
 				}
 
-				return [
-					'reply'           => $reply,
-					'history'         => $this->serialize_history(),
-					'tool_calls'      => $this->tool_call_log,
-					'token_usage'     => $this->token_usage,
-					'iterations_used' => $this->iterations_used,
-					'model_id'        => $this->model_id,
-				];
+				return $this->inject_inability_data(
+					[
+						'reply'           => $reply,
+						'history'         => $this->serialize_history(),
+						'tool_calls'      => $this->tool_call_log,
+						'token_usage'     => $this->token_usage,
+						'iterations_used' => $this->iterations_used,
+						'model_id'        => $this->model_id,
+					]
+				);
 			}
 		}
 
@@ -1292,6 +1297,21 @@ class AgentLoop {
 	}
 
 	/**
+	 * Inject inability_reported data into a loop result array if the
+	 * FeedbackAbilities::report-inability ability was called this request.
+	 *
+	 * @param array<string,mixed> $result The loop result to augment.
+	 * @return array<string,mixed> The result, potentially with inability_reported added.
+	 */
+	private function inject_inability_data( array $result ): array {
+		$inability = FeedbackAbilities::get_inability_data();
+		if ( null !== $inability ) {
+			$result['inability_reported'] = $inability;
+		}
+		return $result;
+	}
+
+	/**
 	 * Classify an ability as 'read' or 'write' based on its meta annotations.
 	 *
 	 * Uses the WordPress Abilities API `readonly` annotation:
@@ -1646,7 +1666,11 @@ class AgentLoop {
 			. "## Error Handling\n"
 			. "- If a tool call fails, try a different approach or skip it and continue with the next step.\n"
 			. "- Never stop after a single error — complete as many steps as possible.\n"
-			. "- If you've retried the same tool 2 times with similar args, move on.";
+			. "- If you've retried the same tool 2 times with similar args, move on.\n\n"
+			. "## Reporting Inability\n"
+			. "- If you have genuinely tried and cannot complete the user's request, call `gratis-ai-agent/report-inability` with a clear reason and the steps you attempted.\n"
+			. "- Use this only as a last resort — after at least 2 different approaches have failed.\n"
+			. '- Always provide a helpful text response explaining what you tried before calling the ability.';
 	}
 
 	/**

--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -486,6 +486,10 @@ Assistant: %s',
 			$response['exit_reason'] = $result['exit_reason'];
 		}
 
+		if ( ! empty( $result['inability_reported'] ) ) {
+			$response['inability_reported'] = $result['inability_reported'];
+		}
+
 		return new WP_REST_Response( $response, 200 );
 	}
 }

--- a/src/components/message-list.js
+++ b/src/components/message-list.js
@@ -284,6 +284,7 @@ export default function MessageList() {
 		liveToolCalls,
 		currentSessionId,
 		sessionJobs,
+		inabilityReported,
 	} = useSelect( ( select ) => {
 		const store = select( STORE_NAME );
 		return {
@@ -303,6 +304,7 @@ export default function MessageList() {
 			liveToolCalls: store.getLiveToolCalls(),
 			currentSessionId: store.getCurrentSessionId(),
 			sessionJobs: store.getSessionJobs(),
+			inabilityReported: store.getInabilityReported(),
 		};
 	}, [] );
 
@@ -313,8 +315,13 @@ export default function MessageList() {
 		getBranding().greetingMessage ||
 		__( 'Send a message to start a conversation.', 'gratis-ai-agent' );
 
-	const { sendMessage, confirmToolCall, rejectToolCall, retryLastMessage } =
-		useDispatch( STORE_NAME );
+	const {
+		sendMessage,
+		confirmToolCall,
+		rejectToolCall,
+		retryLastMessage,
+		setInabilityReported,
+	} = useDispatch( STORE_NAME );
 	const messagesRef = useRef( null );
 
 	// TTS hook — configured from store state.
@@ -490,6 +497,29 @@ export default function MessageList() {
 							rejectToolCall( pendingActionCard.jobId )
 						}
 					/>
+				</div>
+			) }
+			{ inabilityReported && ! sending && (
+				<div className="gratis-ai-agent-message-row gratis-ai-agent-inability-banner">
+					<div className="gratis-ai-agent-inability-banner__content">
+						<p className="gratis-ai-agent-inability-banner__text">
+							{ __(
+								'The AI was unable to complete your request.',
+								'gratis-ai-agent'
+							) }
+						</p>
+						<Button
+							variant="link"
+							className="gratis-ai-agent-inability-banner__dismiss"
+							onClick={ () => setInabilityReported( null ) }
+							aria-label={ __(
+								'Dismiss inability notice',
+								'gratis-ai-agent'
+							) }
+						>
+							{ __( 'Dismiss', 'gratis-ai-agent' ) }
+						</Button>
+					</div>
 				</div>
 			) }
 			{ sending && ! isStreaming && ! pendingActionCard && (

--- a/src/store/slices/sessionsSlice.js
+++ b/src/store/slices/sessionsSlice.js
@@ -69,6 +69,10 @@ export const initialState = {
 	// round-trip returning "Untitled" from the server does not overwrite a title
 	// that was already delivered via the SSE done event.
 	pendingTitles: {},
+
+	// Inability-reported flag (t185) — set when the AI calls report-inability.
+	// { reason: string, attempted_steps: string[] } or null.
+	inabilityReported: null,
 };
 
 export const actions = {
@@ -322,6 +326,18 @@ export const actions = {
 	 */
 	setLastUserMessage( message ) {
 		return { type: 'SET_LAST_USER_MESSAGE', message };
+	},
+
+	/**
+	 * Set or clear the inability-reported data (t185).
+	 * Set to an object { reason, attempted_steps } when the AI calls
+	 * report-inability; set to null to dismiss the banner.
+	 *
+	 * @param {Object|null} data - Inability data or null.
+	 * @return {Object} Redux action.
+	 */
+	setInabilityReported( data ) {
+		return { type: 'SET_INABILITY_REPORTED', data };
 	},
 
 	/**
@@ -712,6 +728,7 @@ export const actions = {
 			dispatch.setIsStreaming( false );
 			dispatch.setStreamingText( '' );
 			dispatch.setStreamError( false );
+			dispatch.setInabilityReported( null );
 			dispatch.setLastUserMessage( message );
 
 			// Build message parts — text first, then image attachments.
@@ -1119,6 +1136,14 @@ export const actions = {
 							);
 						}
 
+						// Handle inability-reported flag (t185).
+						// Set when the AI called report-inability ability.
+						if ( result.inability_reported ) {
+							dispatch.setInabilityReported(
+								result.inability_reported
+							);
+						}
+
 						dispatch.fetchSessions();
 					}
 				} catch {
@@ -1418,6 +1443,17 @@ export const selectors = {
 	},
 
 	/**
+	 * Get inability-reported data (t185).
+	 * Returns the data object { reason, attempted_steps } or null.
+	 *
+	 * @param {import('../../types').StoreState} state
+	 * @return {Object|null} Inability data or null.
+	 */
+	getInabilityReported( state ) {
+		return state.inabilityReported || null;
+	},
+
+	/**
 	 * @param {import('../../types').StoreState} state
 	 * @return {Session[]} Sessions shared with all admins.
 	 */
@@ -1564,6 +1600,8 @@ export function reducer( state, action ) {
 			return { ...state, streamError: action.error };
 		case 'SET_LAST_USER_MESSAGE':
 			return { ...state, lastUserMessage: action.message };
+		case 'SET_INABILITY_REPORTED':
+			return { ...state, inabilityReported: action.data };
 		case 'SET_SHARED_SESSIONS':
 			return {
 				...state,


### PR DESCRIPTION
## Summary

Implements the `report-inability` ability (t185) so the AI agent can self-flag when it cannot complete a user request. This is part of the customer feedback & issue reporting system (t180-t187).

### What was built

- **`includes/Abilities/FeedbackAbilities.php`** (new): Registers the `gratis-ai-agent/report-inability` ability with schema `{ reason: string, attempted_steps?: string[] }`. The execute handler sets a request-scoped static flag (`self::$inability_data`) that persists within the PHP request lifecycle.

- **`includes/Core/AgentLoop.php`**: Added `inject_inability_data()` private helper that merges the inability flag into loop result arrays at the two normal exit points (text reply and fallback summarisation). Added `FeedbackAbilities` import. Extended `default_system_instruction()` with a "Reporting Inability" section instructing the model to call the ability after genuinely exhausting 2+ approaches.

- **`includes/REST/RestController.php`**: Passes `inability_reported` field through in the REST response (mirrors the existing `exit_reason` passthrough pattern).

- **`gratis-ai-agent.php`**: Imports and registers `FeedbackAbilities`.

- **`src/store/slices/sessionsSlice.js`**: Adds `inabilityReported` state field, `setInabilityReported` action, `SET_INABILITY_REPORTED` reducer case, and `getInabilityReported` selector. Detects `inability_reported` in the job-poll completion handler and stores it. Clears the flag when the user sends a new message.

- **`src/components/message-list.js`**: Renders a dismissible inline banner ("The AI was unable to complete your request.") when `inabilityReported` is truthy and not currently sending. Dismiss clears the Redux state.

### Architecture notes

The inability flag travels the same path as the existing `exit_reason` field:
`FeedbackAbilities::handle_report_inability()` → static flag → `AgentLoop::inject_inability_data()` → result array → `RestController` REST response → `sessionsSlice` job-poll handler → React `message-list` banner.

The "Send Report" button is intentionally absent from this PR — the `FeedbackConsentModal` (t182) and report sender (t181) are prerequisites for that flow. This PR delivers the detection and surface layer; the action wiring follows in t182/t183.

### Verification

- `composer phpcs` — no violations on all modified PHP files
- `composer phpstan` — no errors on all modified PHP files
- `npm run lint:js` — no ESLint violations on modified JS files

Resolves #942