### PR TITLE
t183: Auto-prompt feedback banner on exit_reason (spin/timeout/max_iterations)

### DIFF
--- a/src/components/message-list.js
+++ b/src/components/message-list.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useRef, useEffect } from '@wordpress/element';
+import { useRef, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button, Spinner } from '@wordpress/components';
 
@@ -15,6 +15,7 @@ import MarkdownMessage from './markdown-message';
 import MessageActions from './message-actions';
 import DebugPanel from './debug-panel';
 import ActionCard from './action-card';
+import FeedbackConsentModal from './feedback-consent-modal';
 import { getBranding } from '../utils/branding';
 import useTextToSpeech from './use-text-to-speech';
 import { MessageTokenAnnotation } from './token-counter';
@@ -285,6 +286,7 @@ export default function MessageList() {
 		currentSessionId,
 		sessionJobs,
 		inabilityReported,
+		feedbackBanner,
 	} = useSelect( ( select ) => {
 		const store = select( STORE_NAME );
 		return {
@@ -305,6 +307,7 @@ export default function MessageList() {
 			currentSessionId: store.getCurrentSessionId(),
 			sessionJobs: store.getSessionJobs(),
 			inabilityReported: store.getInabilityReported(),
+			feedbackBanner: store.getFeedbackBanner(),
 		};
 	}, [] );
 
@@ -321,7 +324,12 @@ export default function MessageList() {
 		rejectToolCall,
 		retryLastMessage,
 		setInabilityReported,
+		setFeedbackBanner,
 	} = useDispatch( STORE_NAME );
+
+	// Local state: whether the feedback consent modal is open (t183).
+	const [ feedbackModalOpen, setFeedbackModalOpen ] = useState( false );
+
 	const messagesRef = useRef( null );
 
 	// TTS hook — configured from store state.
@@ -521,6 +529,47 @@ export default function MessageList() {
 						</Button>
 					</div>
 				</div>
+			) }
+			{ feedbackBanner && ! sending && (
+				<div className="gratis-ai-agent-message-row gratis-ai-agent-feedback-banner">
+					<div className="gratis-ai-agent-feedback-banner__content">
+						<p className="gratis-ai-agent-feedback-banner__text">
+							{ __(
+								'The AI had trouble completing your request. Would you like to send a report to help us improve?',
+								'gratis-ai-agent'
+							) }
+						</p>
+						<div className="gratis-ai-agent-feedback-banner__actions">
+							<Button
+								variant="secondary"
+								className="gratis-ai-agent-feedback-banner__send-btn"
+								onClick={ () => setFeedbackModalOpen( true ) }
+							>
+								{ __( 'Send Report', 'gratis-ai-agent' ) }
+							</Button>
+							<Button
+								variant="link"
+								className="gratis-ai-agent-feedback-banner__dismiss"
+								onClick={ () => setFeedbackBanner( null ) }
+								aria-label={ __(
+									'Dismiss feedback notice',
+									'gratis-ai-agent'
+								) }
+							>
+								{ __( 'Dismiss', 'gratis-ai-agent' ) }
+							</Button>
+						</div>
+					</div>
+				</div>
+			) }
+			{ feedbackModalOpen && feedbackBanner && (
+				<FeedbackConsentModal
+					reportType={ feedbackBanner.exitReason }
+					onClose={ () => {
+						setFeedbackModalOpen( false );
+						setFeedbackBanner( null );
+					} }
+				/>
 			) }
 			{ sending && ! isStreaming && ! pendingActionCard && (
 				<div className="gratis-ai-agent-bubble gratis-ai-agent-assistant gratis-ai-agent-thinking">

--- a/src/components/shared.css
+++ b/src/components/shared.css
@@ -569,3 +569,46 @@
 	padding: 12px 20px 16px;
 	border-top: 1px solid #dcdcde;
 }
+
+/* ── Feedback banner (t183) ────────────────────────────────────────────────── */
+.gratis-ai-agent-feedback-banner {
+	margin: 4px 0;
+}
+
+.gratis-ai-agent-feedback-banner__content {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	background: #fff8e5;
+	border: 1px solid #f0c540;
+	border-radius: 4px;
+	padding: 10px 14px;
+	font-size: 13px;
+}
+
+.gratis-ai-agent-feedback-banner__text {
+	margin: 0;
+	color: #1d2327;
+	flex: 1;
+}
+
+.gratis-ai-agent-feedback-banner__actions {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	flex-shrink: 0;
+}
+
+.gratis-ai-agent-feedback-banner__send-btn {
+	font-size: 12px !important;
+	padding: 4px 10px !important;
+	height: auto !important;
+	min-height: 0 !important;
+}
+
+.gratis-ai-agent-feedback-banner__dismiss {
+	font-size: 12px !important;
+	color: #646970 !important;
+	text-decoration: none !important;
+}

--- a/src/store/slices/sessionsSlice.js
+++ b/src/store/slices/sessionsSlice.js
@@ -73,6 +73,10 @@ export const initialState = {
 	// Inability-reported flag (t185) — set when the AI calls report-inability.
 	// { reason: string, attempted_steps: string[] } or null.
 	inabilityReported: null,
+
+	// Feedback banner (t183) — set when the AI exits due to spin/timeout/max_iterations.
+	// { exitReason: string } or null.
+	feedbackBanner: null,
 };
 
 export const actions = {
@@ -338,6 +342,18 @@ export const actions = {
 	 */
 	setInabilityReported( data ) {
 		return { type: 'SET_INABILITY_REPORTED', data };
+	},
+
+	/**
+	 * Set or clear the feedback banner (t183).
+	 * Set to an object { exitReason } when the AI exits due to
+	 * spin_detected, timeout, or max_iterations; set to null to dismiss.
+	 *
+	 * @param {Object|null} data - Banner data or null.
+	 * @return {Object} Redux action.
+	 */
+	setFeedbackBanner( data ) {
+		return { type: 'SET_FEEDBACK_BANNER', data };
 	},
 
 	/**
@@ -729,6 +745,7 @@ export const actions = {
 			dispatch.setStreamingText( '' );
 			dispatch.setStreamError( false );
 			dispatch.setInabilityReported( null );
+			dispatch.setFeedbackBanner( null );
 			dispatch.setLastUserMessage( message );
 
 			// Build message parts — text first, then image attachments.
@@ -1064,6 +1081,13 @@ export const actions = {
 								},
 							],
 						} );
+						// WP_Error max_iterations — show feedback banner (t183).
+						const errMsg = result.message || '';
+						if ( /max.?iteration/i.test( errMsg ) ) {
+							dispatch.setFeedbackBanner( {
+								exitReason: 'max_iterations',
+							} );
+						}
 					}
 
 					if ( result.status === 'complete' ) {
@@ -1142,6 +1166,23 @@ export const actions = {
 							dispatch.setInabilityReported(
 								result.inability_reported
 							);
+						}
+
+						// Show feedback banner on problematic exit reasons (t183).
+						// spin_detected and timeout arrive as exit_reason on the
+						// complete result; max_iterations may also arrive here
+						// (distinct from the WP_Error path above).
+						const FEEDBACK_EXIT_REASONS = [
+							'spin_detected',
+							'timeout',
+							'max_iterations',
+						];
+						if (
+							FEEDBACK_EXIT_REASONS.includes( result.exit_reason )
+						) {
+							dispatch.setFeedbackBanner( {
+								exitReason: result.exit_reason,
+							} );
 						}
 
 						dispatch.fetchSessions();
@@ -1454,6 +1495,17 @@ export const selectors = {
 	},
 
 	/**
+	 * Get feedback banner data (t183).
+	 * Returns { exitReason } when the AI exited due to spin/timeout/max_iterations, or null.
+	 *
+	 * @param {import('../../types').StoreState} state
+	 * @return {Object|null} Feedback banner data or null.
+	 */
+	getFeedbackBanner( state ) {
+		return state.feedbackBanner || null;
+	},
+
+	/**
 	 * @param {import('../../types').StoreState} state
 	 * @return {Session[]} Sessions shared with all admins.
 	 */
@@ -1514,6 +1566,7 @@ export function reducer( state, action ) {
 				sessionTokens: 0,
 				sessionCost: 0,
 				messageTokens: [],
+				feedbackBanner: null,
 			};
 		case 'SET_SENDING':
 			return { ...state, sending: action.sending };
@@ -1602,6 +1655,8 @@ export function reducer( state, action ) {
 			return { ...state, lastUserMessage: action.message };
 		case 'SET_INABILITY_REPORTED':
 			return { ...state, inabilityReported: action.data };
+		case 'SET_FEEDBACK_BANNER':
+			return { ...state, feedbackBanner: action.data };
 		case 'SET_SHARED_SESSIONS':
 			return {
 				...state,


### PR DESCRIPTION
## Summary

Adds an inline feedback banner at the bottom of the chat when the AI exits due to spin_detected, timeout, or max_iterations. The banner shows 'The AI had trouble completing your request. Would you like to send a report to help us improve?' with Send Report and Dismiss actions. Send Report opens FeedbackConsentModal pre-configured with the exit_reason as the report_type. Also detects WP_Error max_iterations responses in the error path.

## Files Changed

src/components/message-list.js,src/components/shared.css,src/store/slices/sessionsSlice.js

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run lint:js — 0 errors; npm run lint:css — 0 errors; npm run test:js — 248/248 pass

Resolves #940


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.37 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 6m and 15,131 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a feedback banner that appears during certain scenarios, allowing users to submit feedback reports about their session
  * Includes a consent modal for collecting feedback information
  * Users can dismiss the feedback banner if they prefer not to participate

<!-- end of auto-generated comment: release notes by coderabbit.ai -->