### PR TITLE
t181: Feedback report payload builder + sender-side sanitizer

### DIFF
--- a/includes/Feedback/ReportBuilder.php
+++ b/includes/Feedback/ReportBuilder.php
@@ -42,8 +42,13 @@ class ReportBuilder {
 			return null;
 		}
 
-		$messages   = json_decode( $session->messages ?? '[]', true ) ?: [];
-		$tool_calls = json_decode( $session->tool_calls ?? '[]', true ) ?: [];
+		$decoded_messages   = json_decode( $session->messages ?? '[]', true );
+		$decoded_tool_calls = json_decode( $session->tool_calls ?? '[]', true );
+
+		/** @var array<int, array<string, mixed>> $messages */
+		$messages = is_array( $decoded_messages ) ? $decoded_messages : [];
+		/** @var array<int, array<string, mixed>> $tool_calls */
+		$tool_calls = is_array( $decoded_tool_calls ) ? $decoded_tool_calls : [];
 
 		if ( $strip_tool_results ) {
 			$tool_calls = self::strip_tool_results( $tool_calls );
@@ -54,16 +59,16 @@ class ReportBuilder {
 			'report_type'      => $report_type,
 			'user_description' => $user_description,
 			'session'          => array(
-				'id'               => $session_id,
-				'title'            => $session->title ?? '',
-				'provider_id'      => $session->provider_id ?? '',
-				'model_id'         => $session->model_id ?? '',
-				'prompt_tokens'    => (int) ( $session->prompt_tokens ?? 0 ),
+				'id'                => $session_id,
+				'title'             => $session->title ?? '',
+				'provider_id'       => $session->provider_id ?? '',
+				'model_id'          => $session->model_id ?? '',
+				'prompt_tokens'     => (int) ( $session->prompt_tokens ?? 0 ),
 				'completion_tokens' => (int) ( $session->completion_tokens ?? 0 ),
-				'messages'         => $messages,
-				'tool_calls'       => $tool_calls,
-				'message_count'    => count( $messages ),
-				'tool_call_count'  => count( $tool_calls ),
+				'messages'          => $messages,
+				'tool_calls'        => $tool_calls,
+				'message_count'     => count( $messages ),
+				'tool_call_count'   => count( $tool_calls ),
 			),
 			'environment'      => self::collect_environment(),
 			'generated_at'     => gmdate( 'c' ),
@@ -85,16 +90,18 @@ class ReportBuilder {
 			return null;
 		}
 
-		$messages   = json_decode( $session->messages ?? '[]', true ) ?: [];
-		$tool_calls = json_decode( $session->tool_calls ?? '[]', true ) ?: [];
+		$decoded_messages   = json_decode( $session->messages ?? '[]', true );
+		$decoded_tool_calls = json_decode( $session->tool_calls ?? '[]', true );
+		$messages           = is_array( $decoded_messages ) ? $decoded_messages : [];
+		$tool_calls         = is_array( $decoded_tool_calls ) ? $decoded_tool_calls : [];
 
 		return array(
-			'message_count'    => count( $messages ),
-			'tool_call_count'  => count( $tool_calls ),
+			'message_count'      => count( $messages ),
+			'tool_call_count'    => count( $tool_calls ),
 			'strip_tool_results' => $strip_tool_results,
-			'environment_keys' => array_keys( self::collect_environment() ),
-			'model_id'         => $session->model_id ?? '',
-			'provider_id'      => $session->provider_id ?? '',
+			'environment_keys'   => array_keys( self::collect_environment() ),
+			'model_id'           => $session->model_id ?? '',
+			'provider_id'        => $session->provider_id ?? '',
 		);
 	}
 
@@ -118,9 +125,9 @@ class ReportBuilder {
 		);
 
 		// Site URL: scheme + host only, no path.
-		$site_url     = get_site_url();
-		$parsed       = wp_parse_url( $site_url );
-		$site_host    = ( $parsed['scheme'] ?? 'https' ) . '://' . ( $parsed['host'] ?? '' );
+		$site_url  = get_site_url();
+		$parsed    = wp_parse_url( $site_url );
+		$site_host = ( $parsed['scheme'] ?? 'https' ) . '://' . ( $parsed['host'] ?? '' );
 
 		return array(
 			'wp_version'     => get_bloginfo( 'version' ),
@@ -170,7 +177,10 @@ class ReportBuilder {
 
 				if ( is_array( $msg['content'] ?? null ) ) {
 					$msg['content'] = array_map(
-						static function ( array $part ): array {
+						static function ( mixed $part ): mixed {
+							if ( ! is_array( $part ) ) {
+								return $part;
+							}
 							if ( ( $part['type'] ?? '' ) === 'tool_result' ) {
 								$part['content'] = '[redacted — strip_tool_results enabled]';
 							}

--- a/includes/Feedback/ReportSanitizer.php
+++ b/includes/Feedback/ReportSanitizer.php
@@ -25,15 +25,15 @@ class ReportSanitizer {
 	 * @var array<string, string>
 	 */
 	private const CREDENTIAL_PATTERNS = array(
-		'bearer_token'     => '/\bBearer\s+[A-Za-z0-9\-._~+\/]+=*/i',
-		'basic_auth'       => '/\bBasic\s+[A-Za-z0-9+\/]+=*/i',
-		'api_key_param'    => '/\b(?:api[_-]?key|apikey|access[_-]?token|secret[_-]?key)\s*[=:]\s*[^\s&"\']{8,}/i',
-		'password_param'   => '/\b(?:password|passwd|pwd)\s*[=:]\s*[^\s&"\']{3,}/i',
-		'aws_key_id'       => '/\bAKIA[0-9A-Z]{16}\b/',
-		'aws_secret'       => '/\b[A-Za-z0-9\/+]{40}\b/',
-		'openai_key'       => '/\bsk-[A-Za-z0-9]{20,}\b/',
-		'anthropic_key'    => '/\bsk-ant-[A-Za-z0-9\-]{20,}\b/',
-		'jwt_token'        => '/\beyJ[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+\b/',
+		'bearer_token'   => '/\bBearer\s+[A-Za-z0-9\-._~+\/]+=*/i',
+		'basic_auth'     => '/\bBasic\s+[A-Za-z0-9+\/]+=*/i',
+		'api_key_param'  => '/\b(?:api[_-]?key|apikey|access[_-]?token|secret[_-]?key)\s*[=:]\s*[^\s&"\']{8,}/i',
+		'password_param' => '/\b(?:password|passwd|pwd)\s*[=:]\s*[^\s&"\']{3,}/i',
+		'aws_key_id'     => '/\bAKIA[0-9A-Z]{16}\b/',
+		'aws_secret'     => '/\b[A-Za-z0-9\/+]{40}\b/',
+		'openai_key'     => '/\bsk-[A-Za-z0-9]{20,}\b/',
+		'anthropic_key'  => '/\bsk-ant-[A-Za-z0-9\-]{20,}\b/',
+		'jwt_token'      => '/\beyJ[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+\b/',
 	);
 
 	/**
@@ -43,12 +43,19 @@ class ReportSanitizer {
 	 * @return array<string, mixed> Sanitized copy — the original is not mutated.
 	 */
 	public static function sanitize( array $payload ): array {
-		if ( isset( $payload['session']['messages'] ) && is_array( $payload['session']['messages'] ) ) {
-			$payload['session']['messages'] = self::sanitize_messages( $payload['session']['messages'] );
-		}
+		$session = $payload['session'] ?? null;
+		if ( is_array( $session ) ) {
+			if ( isset( $session['messages'] ) && is_array( $session['messages'] ) ) {
+				/** @var array<int, array<string, mixed>> $messages */
+				$messages                       = $session['messages'];
+				$payload['session']['messages'] = self::sanitize_messages( $messages );
+			}
 
-		if ( isset( $payload['session']['tool_calls'] ) && is_array( $payload['session']['tool_calls'] ) ) {
-			$payload['session']['tool_calls'] = self::sanitize_tool_calls( $payload['session']['tool_calls'] );
+			if ( isset( $session['tool_calls'] ) && is_array( $session['tool_calls'] ) ) {
+				/** @var array<int, array<string, mixed>> $tool_calls */
+				$tool_calls                       = $session['tool_calls'];
+				$payload['session']['tool_calls'] = self::sanitize_tool_calls( $tool_calls );
+			}
 		}
 
 		if ( isset( $payload['user_description'] ) && is_string( $payload['user_description'] ) ) {
@@ -71,7 +78,10 @@ class ReportSanitizer {
 					$msg['content'] = self::sanitize_string( $msg['content'] );
 				} elseif ( is_array( $msg['content'] ?? null ) ) {
 					$msg['content'] = array_map(
-						static function ( array $part ): array {
+						static function ( mixed $part ): mixed {
+							if ( ! is_array( $part ) ) {
+								return $part;
+							}
 							if ( is_string( $part['text'] ?? null ) ) {
 								$part['text'] = self::sanitize_string( $part['text'] );
 							}

--- a/includes/Feedback/ReportSender.php
+++ b/includes/Feedback/ReportSender.php
@@ -52,11 +52,16 @@ class ReportSender {
 			$headers['X-Feedback-Api-Key'] = $api_key;
 		}
 
+		$body = wp_json_encode( $payload );
+		if ( false === $body ) {
+			return new WP_Error( 'feedback_encode_error', 'Failed to JSON-encode the report payload.' );
+		}
+
 		$response = wp_remote_post(
 			$endpoint_url,
 			array(
 				'headers' => $headers,
-				'body'    => wp_json_encode( $payload ),
+				'body'    => $body,
 				'timeout' => 15,
 			)
 		);

--- a/includes/REST/FeedbackController.php
+++ b/includes/REST/FeedbackController.php
@@ -52,9 +52,9 @@ class FeedbackController {
 						'sanitize_callback' => 'absint',
 					),
 					'strip_tool_results' => array(
-						'required'          => false,
-						'type'              => 'boolean',
-						'default'           => false,
+						'required' => false,
+						'type'     => 'boolean',
+						'default'  => false,
 					),
 				),
 			)
@@ -85,9 +85,9 @@ class FeedbackController {
 						'sanitize_callback' => 'absint',
 					),
 					'strip_tool_results' => array(
-						'required'          => false,
-						'type'              => 'boolean',
-						'default'           => false,
+						'required' => false,
+						'type'     => 'boolean',
+						'default'  => false,
 					),
 				),
 			)


### PR DESCRIPTION
## Summary

Implements the three new classes required by t181:

- **ReportBuilder** (`includes/Feedback/ReportBuilder.php`): collects session messages, tool_calls, token_usage, model_id, provider_id, and environment metadata (WP/PHP/plugin version, theme, locale, is_multisite, active plugin slugs, site host scheme+host only). Supports optional `strip_tool_results` mode and a `build_summary()` method for the consent modal preview header.

- **ReportSanitizer** (`includes/Feedback/ReportSanitizer.php`): sender-side redaction of credentials (Bearer/Basic auth, API keys, AWS access keys, OpenAI/Anthropic keys, JWTs), absolute server paths (ABSPATH prefix + common Unix roots), and user-supplied free text — runs before any data leaves the site.

- **ReportSender** (`includes/Feedback/ReportSender.php`): `wp_remote_post()` to the configured endpoint with `X-Feedback-Api-Key` header. Returns `true` on 2xx; returns `WP_Error` for feedback-disabled, missing/invalid URL, JSON-encode failure, network error, or non-2xx HTTP response — never crashes or interrupts normal plugin operation.

## Verification

```
composer phpstan   # [OK] No errors
composer phpcs     # 0 errors, 0 warnings
```

## Files Modified

- EDIT: `includes/Feedback/ReportBuilder.php` — PHPStan fixes (json_decode type narrowing, inner array_map callbacks) + phpcbf alignment fixes
- EDIT: `includes/Feedback/ReportSanitizer.php` — PHPStan fixes (session array narrowing, inner array_map callback) + phpcbf alignment fixes
- EDIT: `includes/Feedback/ReportSender.php` — guard wp_json_encode() false return before passing to wp_remote_post()

Resolves #938