### PR TITLE
GH#936: centralize WP_BASE_URL constant in shared-conversations E2E spec

### DIFF
--- a/tests/e2e/shared-conversations.spec.js
+++ b/tests/e2e/shared-conversations.spec.js
@@ -51,6 +51,7 @@ const { loginToWordPress, goToAgentPage } = require( './utils/wp-admin' );
 
 const SECOND_ADMIN_USER = 'admin2';
 const SECOND_ADMIN_PASS = 'password2';
+const WP_BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8890';
 
 /** Fake session returned by the intercepted sessions endpoint. */
 const MOCK_SESSION = {
@@ -603,7 +604,7 @@ test.describe( 'Shared Conversations (t091)', () => {
 			// Create an isolated context for the second admin.
 			// Pass baseURL so relative URLs in loginToWordPress/goToAgentPage work.
 			const secondContext = await browser.newContext( {
-				baseURL: process.env.WP_BASE_URL || 'http://localhost:8890',
+				baseURL: WP_BASE_URL,
 			} );
 			const secondPage = await secondContext.newPage();
 
@@ -654,7 +655,7 @@ test.describe( 'Shared Conversations (t091)', () => {
 			browser,
 		} ) => {
 			const secondContext = await browser.newContext( {
-				baseURL: process.env.WP_BASE_URL || 'http://localhost:8890',
+				baseURL: WP_BASE_URL,
 			} );
 			const secondPage = await secondContext.newPage();
 
@@ -721,7 +722,7 @@ test.describe( 'Shared Conversations (t091)', () => {
 			browser,
 		} ) => {
 			const secondContext = await browser.newContext( {
-				baseURL: process.env.WP_BASE_URL || 'http://localhost:8890',
+				baseURL: WP_BASE_URL,
 			} );
 			const secondPage = await secondContext.newPage();
 
@@ -819,7 +820,7 @@ test.describe( 'Shared Conversations (t091)', () => {
 			browser,
 		} ) => {
 			const secondContext = await browser.newContext( {
-				baseURL: process.env.WP_BASE_URL || 'http://localhost:8890',
+				baseURL: WP_BASE_URL,
 			} );
 			const secondPage = await secondContext.newPage();
 
@@ -878,7 +879,7 @@ test.describe( 'Shared Conversations (t091)', () => {
 			browser,
 		} ) => {
 			const secondContext = await browser.newContext( {
-				baseURL: process.env.WP_BASE_URL || 'http://localhost:8890',
+				baseURL: WP_BASE_URL,
 			} );
 			const secondPage = await secondContext.newPage();
 


### PR DESCRIPTION
## Summary

Extracts the repeated `process.env.WP_BASE_URL || 'http://localhost:8890'` fallback string into a single `WP_BASE_URL` constant and replaces all five `browser.newContext()` call sites in `tests/e2e/shared-conversations.spec.js`.

This addresses the CodeRabbit nitpick from PR #911: the same fallback appeared in five separate `browser.newContext` calls, creating a drift risk when the default port changes (which was exactly what required PR #911 in the first place).

## Changes

- `tests/e2e/shared-conversations.spec.js`: Added `const WP_BASE_URL = process.env.WP_BASE_URL || 'http://localhost:8890';` to the Constants section (line 54). Replaced five inline repetitions with the constant reference.

## Testing

- ESLint passes (tests/e2e/ is excluded from `npm run lint:js` as expected — project linter scopes to `src/`)
- No logic changes: `WP_BASE_URL` evaluates identically to the previous inline expression

Resolves #936