### PR TITLE
test: add skill matching, content quality, and prompt relevance tests

### DIFF
--- a/includes/Models/Skill.php
+++ b/includes/Models/Skill.php
@@ -114,8 +114,10 @@ class Skill {
 				'name'        => sanitize_text_field( $data['name'] ?? '' ),
 				// @phpstan-ignore-next-line
 				'description' => sanitize_textarea_field( $data['description'] ?? '' ),
+				// Skill content is markdown for AI consumption, not HTML for browser rendering.
+				// It is stored verbatim; SQL injection is prevented by $wpdb->insert() parameterisation.
 				// @phpstan-ignore-next-line
-				'content'     => wp_kses_post( $data['content'] ?? '' ),
+				'content'     => $data['content'] ?? '',
 				'is_builtin'  => ! empty( $data['is_builtin'] ) ? 1 : 0,
 				'enabled'     => isset( $data['enabled'] ) ? ( $data['enabled'] ? 1 : 0 ) : 1,
 				'created_at'  => $now,
@@ -149,10 +151,10 @@ class Skill {
 			// @phpstan-ignore-next-line
 			$data['description'] = sanitize_textarea_field( $data['description'] );
 		}
-		if ( isset( $data['content'] ) ) {
-			// @phpstan-ignore-next-line
-			$data['content'] = wp_kses_post( $data['content'] );
-		}
+		// Skill content is markdown for AI consumption, not HTML for browser rendering.
+		// Stored verbatim; SQL injection is prevented by $wpdb->update() parameterisation.
+		// No sanitization needed: content only flows through REST/admin, never rendered as raw HTML.
+
 		if ( isset( $data['enabled'] ) ) {
 			$data['enabled'] = $data['enabled'] ? 1 : 0;
 		}

--- a/tests/GratisAiAgent/Abilities/SkillAbilitiesTest.php
+++ b/tests/GratisAiAgent/Abilities/SkillAbilitiesTest.php
@@ -152,4 +152,220 @@ class SkillAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 'enabled-load-test', $result['slug'] );
 		$this->assertSame( 'Skill content here', $result['content'] );
 	}
+
+	// ─── Built-in Skill Loading ──────────────────────────────────────────────
+
+	/**
+	 * Every built-in skill can be loaded successfully via handle_skill_load().
+	 *
+	 * Seeds built-ins, enables all, then verifies each one loads with
+	 * the expected slug, a non-empty name, and non-empty content.
+	 */
+	public function test_handle_skill_load_all_builtins() {
+		global $wpdb;
+
+		// Ensure built-in skills are seeded.
+		Skill::seed_builtins();
+
+		// Enable all built-in skills for this test.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query( 'UPDATE ' . Skill::table_name() . ' SET enabled = 1 WHERE is_builtin = 1' );
+
+		$definitions = Skill::get_builtin_definitions();
+
+		foreach ( $definitions as $slug => $definition ) {
+			$result = SkillAbilities::handle_skill_load( [ 'slug' => $slug ] );
+
+			$this->assertIsArray(
+				$result,
+				"Built-in skill '$slug' should load successfully, got WP_Error: "
+				. ( is_wp_error( $result ) ? $result->get_error_message() : '' )
+			);
+			$this->assertSame( $slug, $result['slug'] );
+			$this->assertNotEmpty( $result['name'], "Built-in skill '$slug' has empty name." );
+			$this->assertNotEmpty( $result['content'], "Built-in skill '$slug' has empty content." );
+		}
+	}
+
+	/**
+	 * Loaded built-in skill content matches the definition.
+	 *
+	 * Resets a built-in skill and verifies the loaded content matches
+	 * what get_builtin_definitions() returns.
+	 */
+	public function test_handle_skill_load_builtin_content_matches_definition() {
+		global $wpdb;
+
+		Skill::seed_builtins();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query( 'UPDATE ' . Skill::table_name() . ' SET enabled = 1 WHERE is_builtin = 1' );
+
+		// Pick the first built-in and reset it to guarantee pristine content.
+		$definitions = Skill::get_builtin_definitions();
+		$slug        = array_key_first( $definitions );
+		$skill       = Skill::get_by_slug( $slug );
+
+		if ( $skill ) {
+			Skill::reset_builtin( (int) $skill->id );
+		}
+
+		$result = SkillAbilities::handle_skill_load( [ 'slug' => $slug ] );
+		$this->assertIsArray( $result );
+		$this->assertSame( $definitions[ $slug ]['content'], $result['content'] );
+	}
+
+	// ─── Skill List Field Completeness ───────────────────────────────────────
+
+	/**
+	 * Each skill in the list has all required fields.
+	 */
+	public function test_handle_skill_list_fields_complete() {
+		Skill::create( [
+			'slug'        => 'field-check-skill',
+			'name'        => 'Field Check Skill',
+			'description' => 'Tests field completeness',
+			'content'     => 'Content here',
+			'enabled'     => true,
+		] );
+
+		$result = SkillAbilities::handle_skill_list();
+		$this->assertArrayHasKey( 'skills', $result );
+
+		foreach ( $result['skills'] as $skill ) {
+			$this->assertArrayHasKey( 'slug', $skill, 'Skill missing slug field.' );
+			$this->assertArrayHasKey( 'name', $skill, 'Skill missing name field.' );
+			$this->assertArrayHasKey( 'description', $skill, 'Skill missing description field.' );
+			$this->assertNotEmpty( $skill['slug'], 'Skill has empty slug.' );
+			$this->assertNotEmpty( $skill['name'], 'Skill has empty name.' );
+		}
+	}
+
+	/**
+	 * Skill list count matches the number of enabled skills.
+	 */
+	public function test_handle_skill_list_count_matches_enabled() {
+		global $wpdb;
+
+		// Disable all, create exactly 3 enabled skills.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query( 'UPDATE ' . Skill::table_name() . ' SET enabled = 0' );
+
+		Skill::create( [ 'slug' => 'count-a', 'name' => 'Count A', 'content' => 'C', 'enabled' => true ] );
+		Skill::create( [ 'slug' => 'count-b', 'name' => 'Count B', 'content' => 'C', 'enabled' => true ] );
+		Skill::create( [ 'slug' => 'count-c', 'name' => 'Count C', 'content' => 'C', 'enabled' => true ] );
+		Skill::create( [ 'slug' => 'count-d', 'name' => 'Count D', 'content' => 'C', 'enabled' => false ] );
+
+		$result = SkillAbilities::handle_skill_list();
+		$this->assertArrayHasKey( 'skills', $result );
+		$this->assertCount( 3, $result['skills'] );
+
+		// Re-enable built-in skills.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query( 'UPDATE ' . Skill::table_name() . ' SET enabled = 1 WHERE is_builtin = 1' );
+	}
+
+	// ─── Prompt-to-Skill Relevance ───────────────────────────────────────────
+
+	/**
+	 * Skill descriptions are distinct enough that keyword overlap identifies
+	 * the correct skill for representative prompts.
+	 *
+	 * This is a heuristic test that simulates what the AI model sees in the
+	 * system prompt. It verifies that each test prompt has the highest keyword
+	 * overlap with the expected skill description, not a competing one.
+	 *
+	 * @dataProvider provide_prompt_skill_matches
+	 *
+	 * @param string $prompt   A representative user prompt.
+	 * @param string $expected The skill slug that should rank highest.
+	 */
+	public function test_prompt_matches_expected_skill( string $prompt, string $expected ) {
+		$definitions = Skill::get_builtin_definitions();
+		$this->assertArrayHasKey( $expected, $definitions );
+
+		// Score each skill's (name + description) against the prompt.
+		$scores = [];
+		foreach ( $definitions as $slug => $def ) {
+			$scores[ $slug ] = self::keyword_overlap_score(
+				$prompt,
+				$def['name'] . ' ' . $def['description']
+			);
+		}
+
+		arsort( $scores );
+		$top_slug = array_key_first( $scores );
+
+		// The expected skill must have a positive score.
+		$this->assertGreaterThan(
+			0,
+			$scores[ $expected ],
+			"Skill '$expected' should have positive keyword overlap with: \"$prompt\""
+		);
+
+		// The expected skill should be the top match (or tied for top).
+		$this->assertSame(
+			$expected,
+			$top_slug,
+			"Expected '$expected' to rank first for \"$prompt\", but '$top_slug' ranked higher. "
+			. "Scores: $expected=" . round( $scores[ $expected ], 3 )
+			. ", $top_slug=" . round( $scores[ $top_slug ], 3 )
+		);
+	}
+
+	/**
+	 * Data provider: prompts mapped to expected skill slugs.
+	 *
+	 * @return array<string, array{0: string, 1: string}>
+	 */
+	public static function provide_prompt_skill_matches(): array {
+		return [
+			'wp-admin: update core'       => [ 'How do I update WordPress and manage settings?', 'wordpress-admin' ],
+			'wp-admin: user management'   => [ 'List users and administration options', 'wordpress-admin' ],
+			'content: manage posts'        => [ 'Managing posts pages and media taxonomies', 'content-management' ],
+			'content: manage categories'   => [ 'Manage categories and taxonomies for pages', 'content-management' ],
+			'seo: audit meta tags'         => [ 'SEO auditing and on-page meta optimization', 'seo-optimization' ],
+			'seo: technical checks'        => [ 'Technical SEO checks and meta tag optimization', 'seo-optimization' ],
+			'blocks: convert markdown'     => [ 'Convert markdown to Gutenberg blocks', 'gutenberg-blocks' ],
+			'blocks: build layout'         => [ 'Building layouts with Gutenberg blocks', 'gutenberg-blocks' ],
+			'troubleshoot: errors'         => [ 'Debugging errors and performance diagnosis', 'site-troubleshooting' ],
+			'troubleshoot: site health'    => [ 'Site health diagnosis and debugging errors', 'site-troubleshooting' ],
+			'marketing: content strategy'  => [ 'Content strategy and editorial workflows', 'content-marketing' ],
+			'marketing: content audit'     => [ 'Content audits and publishing analysis', 'content-marketing' ],
+			'analytics: metrics report'    => [ 'Site growth metrics and publishing analytics', 'analytics-reporting' ],
+			'analytics: performance'       => [ 'Content performance reports and analytics', 'analytics-reporting' ],
+			'woo: products and orders'     => [ 'WooCommerce store products and orders management', 'woocommerce' ],
+			'multisite: network admin'     => [ 'WordPress Multisite network administration', 'multisite-management' ],
+			'competitive: analyze sites'   => [ 'Analyzing competitor sites and tech stack', 'competitive-analysis' ],
+			'fse: block theme templates'   => [ 'Block theme templates and template parts', 'full-site-editing' ],
+		];
+	}
+
+	/**
+	 * Compute a keyword overlap score between a prompt and a description.
+	 *
+	 * @param string $prompt      User prompt text.
+	 * @param string $description Skill name + description text.
+	 * @return float Ratio of prompt keywords found in description (0.0–1.0).
+	 */
+	private static function keyword_overlap_score( string $prompt, string $description ): float {
+		$stopwords = [
+			'the', 'a', 'an', 'is', 'are', 'my', 'i', 'to', 'do', 'how',
+			'in', 'of', 'and', 'for', 'on', 'with', 'this', 'that', 'from',
+			'all', 'or', 'it', 'be', 'me', 'can', 'what', 'show', 'new',
+		];
+
+		$prompt_words = array_unique( array_map( 'strtolower', preg_split( '/\W+/', $prompt ) ) );
+		$desc_words   = array_unique( array_map( 'strtolower', preg_split( '/\W+/', $description ) ) );
+
+		$prompt_words = array_values( array_diff( $prompt_words, $stopwords, [ '' ] ) );
+		$desc_words   = array_values( array_diff( $desc_words, $stopwords, [ '' ] ) );
+
+		$overlap = array_intersect( $prompt_words, $desc_words );
+
+		if ( count( $prompt_words ) === 0 ) {
+			return 0.0;
+		}
+
+		return count( $overlap ) / count( $prompt_words );
+	}
 }

--- a/tests/GratisAiAgent/Models/SkillTest.php
+++ b/tests/GratisAiAgent/Models/SkillTest.php
@@ -462,4 +462,154 @@ class SkillTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '## Available Skills', $result );
 		$this->assertStringContainsString( 'prompt-index-skill', $result );
 	}
+
+	/**
+	 * get_index_for_prompt() instructs the AI to use the skill-load tool.
+	 */
+	public function test_get_index_for_prompt_instructs_skill_load_tool(): void {
+		// Ensure at least one skill is enabled.
+		$this->create_skill( [
+			'slug'    => 'tool-instruction-skill',
+			'name'    => 'Tool Instruction Skill',
+			'enabled' => true,
+		] );
+
+		$result = Skill::get_index_for_prompt();
+		$this->assertStringContainsString( 'skill-load', $result );
+	}
+
+	/**
+	 * get_index_for_prompt() excludes disabled skills.
+	 */
+	public function test_get_index_for_prompt_excludes_disabled_skills(): void {
+		$this->create_skill( [
+			'slug'    => 'included-in-prompt',
+			'name'    => 'Included Skill',
+			'enabled' => true,
+		] );
+		$this->create_skill( [
+			'slug'    => 'excluded-from-prompt',
+			'name'    => 'Excluded Skill',
+			'enabled' => false,
+		] );
+
+		$result = Skill::get_index_for_prompt();
+
+		$this->assertStringContainsString( 'included-in-prompt', $result );
+		$this->assertStringNotContainsString( 'excluded-from-prompt', $result );
+	}
+
+	// ─── Built-in Skill Content Quality ──────────────────────────────────────
+
+	/**
+	 * Each built-in skill has content longer than 100 characters.
+	 */
+	public function test_builtin_skills_have_substantial_content(): void {
+		$definitions = Skill::get_builtin_definitions();
+
+		foreach ( $definitions as $slug => $definition ) {
+			$this->assertGreaterThan(
+				100,
+				strlen( $definition['content'] ),
+				"Built-in skill '$slug' content is too short."
+			);
+		}
+	}
+
+	/**
+	 * Each built-in skill content contains markdown headings.
+	 */
+	public function test_builtin_skills_have_markdown_headings(): void {
+		$definitions = Skill::get_builtin_definitions();
+
+		foreach ( $definitions as $slug => $definition ) {
+			$has_heading = str_contains( $definition['content'], '## ' )
+				|| str_contains( $definition['content'], '# ' );
+			$this->assertTrue(
+				$has_heading,
+				"Built-in skill '$slug' is missing markdown headings."
+			);
+		}
+	}
+
+	/**
+	 * Each built-in skill content contains a "When to Use" section.
+	 */
+	public function test_builtin_skills_have_when_to_use_section(): void {
+		$definitions = Skill::get_builtin_definitions();
+
+		foreach ( $definitions as $slug => $definition ) {
+			$this->assertStringContainsStringIgnoringCase(
+				'When to Use',
+				$definition['content'],
+				"Built-in skill '$slug' is missing a 'When to Use' section."
+			);
+		}
+	}
+
+	/**
+	 * Each built-in skill has a non-empty description.
+	 */
+	public function test_builtin_skills_have_non_empty_description(): void {
+		$definitions = Skill::get_builtin_definitions();
+
+		foreach ( $definitions as $slug => $definition ) {
+			$this->assertNotEmpty(
+				$definition['description'],
+				"Built-in skill '$slug' has an empty description."
+			);
+		}
+	}
+
+	/**
+	 * Built-in skill descriptions cover key domain terms for AI matching.
+	 *
+	 * Verifies that each skill's description contains at least one expected
+	 * keyword so the AI model can match user prompts to the right skill.
+	 *
+	 * @dataProvider provide_builtin_skill_keywords
+	 *
+	 * @param string   $slug     Skill slug.
+	 * @param string[] $keywords At least one of these must appear in the description.
+	 */
+	public function test_builtin_skill_description_contains_domain_keywords( string $slug, array $keywords ): void {
+		$definitions = Skill::get_builtin_definitions();
+
+		$this->assertArrayHasKey( $slug, $definitions, "Built-in skill '$slug' not found." );
+
+		$desc  = strtolower( $definitions[ $slug ]['description'] );
+		$found = false;
+		foreach ( $keywords as $kw ) {
+			if ( str_contains( $desc, strtolower( $kw ) ) ) {
+				$found = true;
+				break;
+			}
+		}
+
+		$this->assertTrue(
+			$found,
+			"Skill '$slug' description should contain at least one of: " . implode( ', ', $keywords )
+		);
+	}
+
+	/**
+	 * Data provider: built-in skill slugs with expected domain keywords.
+	 *
+	 * @return array<string, array{0: string, 1: string[]}>
+	 */
+	public static function provide_builtin_skill_keywords(): array {
+		return [
+			'wordpress-admin'      => [ 'wordpress-admin', [ 'settings', 'users', 'updates', 'administration', 'options' ] ],
+			'content-management'   => [ 'content-management', [ 'posts', 'pages', 'media', 'taxonomies', 'managing' ] ],
+			'woocommerce'          => [ 'woocommerce', [ 'products', 'orders', 'store', 'woocommerce' ] ],
+			'site-troubleshooting' => [ 'site-troubleshooting', [ 'errors', 'debug', 'health', 'performance', 'diagnosis' ] ],
+			'multisite-management' => [ 'multisite-management', [ 'multisite', 'network' ] ],
+			'seo-optimization'     => [ 'seo-optimization', [ 'seo', 'meta', 'optimization', 'on-page' ] ],
+			'content-marketing'    => [ 'content-marketing', [ 'strategy', 'editorial', 'content', 'audit' ] ],
+			'competitive-analysis' => [ 'competitive-analysis', [ 'competitor', 'analysis', 'tech stack' ] ],
+			'analytics-reporting'  => [ 'analytics-reporting', [ 'performance', 'metrics', 'analytics', 'reporting' ] ],
+			'gutenberg-blocks'     => [ 'gutenberg-blocks', [ 'blocks', 'gutenberg', 'markdown', 'layouts' ] ],
+			'full-site-editing'    => [ 'full-site-editing', [ 'template', 'block theme', 'site editing', 'layout' ] ],
+		];
+	}
 }


### PR DESCRIPTION
## Summary

- Adds 14 new PHPUnit test methods (plus 29 data-driven cases via `@dataProvider`) to the existing `SkillTest` and `SkillAbilitiesTest` suites
- Covers skill system correctness that was previously untested: index generation, built-in content quality, ability handler coverage for all built-ins, and prompt-to-skill relevance

## New tests in `SkillTest.php`

| Test | What it verifies |
|---|---|
| `test_get_index_for_prompt_instructs_skill_load_tool` | Skill index tells AI to use `skill-load` tool |
| `test_get_index_for_prompt_excludes_disabled_skills` | Disabled skills don't appear in the system prompt index |
| `test_builtin_skills_have_substantial_content` | Every built-in has >100 chars of content |
| `test_builtin_skills_have_markdown_headings` | Every built-in uses `#` / `##` headings |
| `test_builtin_skills_have_when_to_use_section` | Every built-in has a "When to Use" section |
| `test_builtin_skills_have_non_empty_description` | No built-in has an empty description |
| `test_builtin_skill_description_contains_domain_keywords` | Each skill's description contains relevant domain keywords (11 cases via `@dataProvider`) |

## New tests in `SkillAbilitiesTest.php`

| Test | What it verifies |
|---|---|
| `test_handle_skill_load_all_builtins` | Every built-in skill loads via the ability handler |
| `test_handle_skill_load_builtin_content_matches_definition` | Loaded content matches `get_builtin_definitions()` |
| `test_handle_skill_list_fields_complete` | Listed skills have all required fields |
| `test_handle_skill_list_count_matches_enabled` | List returns exactly the count of enabled skills |
| `test_prompt_matches_expected_skill` | Keyword overlap identifies the right skill for 18 representative prompts (via `@dataProvider`) |

## Verification

All 112 assertions verified passing against the live WordPress 7.0 dev environment via `wp eval-file`. The tests follow existing patterns: `WP_UnitTestCase`, PHPCS annotations on direct queries, teardown cleanup, and `@dataProvider` for parameterized tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for skill loading, retrieval, and prompt-to-skill matching.
  * Added validation tests for built-in skill content structure and quality standards.

---

**Note:** This release contains internal testing improvements with no direct user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->