### PR TITLE
fix(tests): address PR #958 review feedback — unused var, heading regex, tie-aware scoring

### DIFF
--- a/tests/GratisAiAgent/Abilities/SkillAbilitiesTest.php
+++ b/tests/GratisAiAgent/Abilities/SkillAbilitiesTest.php
@@ -173,7 +173,7 @@ class SkillAbilitiesTest extends WP_UnitTestCase {
 
 		$definitions = Skill::get_builtin_definitions();
 
-		foreach ( $definitions as $slug => $definition ) {
+		foreach ( array_keys( $definitions ) as $slug ) {
 			$result = SkillAbilities::handle_skill_load( [ 'slug' => $slug ] );
 
 			$this->assertIsArray(
@@ -283,17 +283,17 @@ class SkillAbilitiesTest extends WP_UnitTestCase {
 		$definitions = Skill::get_builtin_definitions();
 		$this->assertArrayHasKey( $expected, $definitions );
 
-		// Score each skill's (name + description) against the prompt.
+		// Score each skill's index entry (slug: description) against the prompt,
+		// matching the format produced by Skill::get_index_for_prompt().
 		$scores = [];
 		foreach ( $definitions as $slug => $def ) {
 			$scores[ $slug ] = self::keyword_overlap_score(
 				$prompt,
-				$def['name'] . ' ' . $def['description']
+				$slug . ': ' . $def['description']
 			);
 		}
 
 		arsort( $scores );
-		$top_slug = array_key_first( $scores );
 
 		// The expected skill must have a positive score.
 		$this->assertGreaterThan(
@@ -302,13 +302,16 @@ class SkillAbilitiesTest extends WP_UnitTestCase {
 			"Skill '$expected' should have positive keyword overlap with: \"$prompt\""
 		);
 
-		// The expected skill should be the top match (or tied for top).
-		$this->assertSame(
+		// The expected skill should be the top match, or tied for top if multiple
+		// skills share the same highest score.
+		$top_score = reset( $scores );
+		$top_slugs = array_keys( array_filter( $scores, fn( $s ) => $s === $top_score ) );
+		$this->assertContains(
 			$expected,
-			$top_slug,
-			"Expected '$expected' to rank first for \"$prompt\", but '$top_slug' ranked higher. "
-			. "Scores: $expected=" . round( $scores[ $expected ], 3 )
-			. ", $top_slug=" . round( $scores[ $top_slug ], 3 )
+			$top_slugs,
+			"Expected '$expected' to rank first (or tied) for \"$prompt\", "
+			. "but top slug(s) were: " . implode( ', ', $top_slugs )
+			. ". Scores: $expected=" . round( $scores[ $expected ], 3 )
 		);
 	}
 

--- a/tests/GratisAiAgent/Models/SkillTest.php
+++ b/tests/GratisAiAgent/Models/SkillTest.php
@@ -523,10 +523,9 @@ class SkillTest extends WP_UnitTestCase {
 		$definitions = Skill::get_builtin_definitions();
 
 		foreach ( $definitions as $slug => $definition ) {
-			$has_heading = str_contains( $definition['content'], '## ' )
-				|| str_contains( $definition['content'], '# ' );
-			$this->assertTrue(
-				$has_heading,
+			$this->assertSame(
+				1,
+				preg_match( '/^#{1,6}\s+/m', $definition['content'] ),
 				"Built-in skill '$slug' is missing markdown headings."
 			);
 		}


### PR DESCRIPTION
## Summary

Addresses the 3 CodeRabbit findings from PR #958 review that were filed as issue #963:

1. **Unused `$definition` variable** (`SkillAbilitiesTest.php:176`) — replaced `foreach ($definitions as $slug => $definition)` with `foreach (array_keys($definitions) as $slug)` since only `$slug` is used in the loop body.

2. **Tie-aware prompt-skill scoring** (`SkillAbilitiesTest.php:286-315`) — changed scoring from `name + description` to `slug: description` (matching the `Skill::get_index_for_prompt()` output format the AI model actually sees), and replaced `assertSame($expected, array_key_first($scores))` with a tie-aware assertion that collects all slugs sharing the top score and uses `assertContains($expected, $top_slugs)`.

3. **Line-anchored markdown heading check** (`SkillTest.php:525-531`) — replaced `str_contains($content, '# ')` (which can match inline text like `"use #anchor"`) with `preg_match('/^#{1,6}\s+/m', $content)` to ensure only real line-start headings are detected.

## Testing

These are test-only changes (no production code modified). Verification:
- PHP linting: `composer phpcs -- tests/GratisAiAgent/Abilities/SkillAbilitiesTest.php tests/GratisAiAgent/Models/SkillTest.php`
- PHPUnit will run in CI

Resolves #963

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions and validation logic for skill abilities and markdown headings to ensure more robust testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->