### PR TITLE
fix: remove hard-coded session_id from E2E upload-clear job mock

### DIFF
--- a/tests/e2e/chat-upload.spec.js
+++ b/tests/e2e/chat-upload.spec.js
@@ -534,7 +534,6 @@ test.describe( 'Chat Upload - Send Button State (t122)', () => {
 					contentType: 'application/json',
 					body: JSON.stringify( {
 						status: 'complete',
-						session_id: 1,
 						reply: 'OK',
 					} ),
 				} );


### PR DESCRIPTION
## Summary

Removes the hard-coded `session_id: 1` from the mocked job response in the E2E test `'attachments are cleared after sending a message'` in `tests/e2e/chat-upload.spec.js`.

When `session_id` is present in the mock job result, the Redux store treats it as authoritative and triggers a reload of `/gratis-ai-agent/v1/sessions/1`. This makes the test depend on whether session ID 1 exists in the wp-env database — causing failures for reasons unrelated to attachment clearing.

The fix omits `session_id` from the fulfilled body entirely so the store does not attempt a session reload, and the test remains focused on its actual assertion: that attachments are cleared after sending.

## Changes

- **EDIT**: `tests/e2e/chat-upload.spec.js` — removed `session_id: 1` from the mock job response body (1 line deleted)

## Testing

The test still verifies that `getAttachmentPreviews()` is not visible after sending — no functional logic changed, only the mock data.

Resolves #966