### PR TITLE
GH#962: remove non-functional tool-profile UI and hard-coded session_id in E2E test

### DIFF
--- a/src/settings-page/agent-builder.js
+++ b/src/settings-page/agent-builder.js
@@ -16,8 +16,6 @@ import {
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { trash, pencil, plus } from '@wordpress/icons';
-import apiFetch from '@wordpress/api-fetch';
-
 /**
  * Internal dependencies
  */
@@ -63,18 +61,9 @@ export default function AgentBuilder() {
 	const [ form, setForm ] = useState( { ...EMPTY_FORM } );
 	const [ saving, setSaving ] = useState( false );
 	const [ notice, setNotice ] = useState( null );
-	const [ toolProfiles, setToolProfiles ] = useState( [] );
 	useEffect( () => {
 		fetchAgents();
 		fetchProviders();
-		// Fetch tool profiles for the form dropdown.
-		apiFetch( { path: '/gratis-ai-agent/v1/tool-profiles' } )
-			.then( ( profiles ) => {
-				if ( Array.isArray( profiles ) ) {
-					setToolProfiles( profiles );
-				}
-			} )
-			.catch( () => {} );
 	}, [ fetchAgents, fetchProviders ] );
 
 	const resetForm = useCallback( () => {
@@ -422,30 +411,6 @@ export default function AgentBuilder() {
 							'Message shown when this agent starts a conversation. Leave empty for the global default.',
 							'gratis-ai-agent'
 						) }
-					/>
-
-					<SelectControl
-						label={ __( 'Tool Profile', 'gratis-ai-agent' ) }
-						value={ form.tool_profile }
-						options={ [
-							{
-								label: __(
-									'(global default)',
-									'gratis-ai-agent'
-								),
-								value: '',
-							},
-							...toolProfiles.map( ( p ) => ( {
-								label: p.name,
-								value: p.slug,
-							} ) ),
-						] }
-						onChange={ ( v ) => updateField( 'tool_profile', v ) }
-						help={ __(
-							'Restrict which tools this agent can use. Leave empty to allow all tools.',
-							'gratis-ai-agent'
-						) }
-						__nextHasNoMarginBottom
 					/>
 
 					<SelectControl

--- a/tests/e2e/agent-builder.spec.js
+++ b/tests/e2e/agent-builder.spec.js
@@ -271,26 +271,6 @@ async function mockAgentsApi( page, opts = {} ) {
 		}
 	);
 
-	// Stub tool-profiles endpoint (used by the form dropdown).
-	// Slugs must match the built-in profiles defined in ToolProfiles::get_builtins()
-	// so that selectOption() calls in tests use values that actually exist in the
-	// real implementation (avoids "did not find some options" failures in CI).
-	// Use a function matcher so wp-env's URL-encoded paths (%2F) are decoded first.
-	await page.route(
-		( url ) =>
-			decodeUrl( url ).includes( 'gratis-ai-agent/v1/tool-profiles' ),
-		async ( route ) => {
-			await route.fulfill( {
-				status: 200,
-				contentType: 'application/json',
-				body: JSON.stringify( [
-					{ slug: 'wp-read-only', name: 'WP Read Only' },
-					{ slug: 'wp-full-management', name: 'WP Full Management' },
-				] ),
-			} );
-		}
-	);
-
 	// Stub providers endpoint (used by the provider/model dropdowns).
 	// Use a function matcher so wp-env's URL-encoded paths (%2F) are decoded first.
 	await page.route(
@@ -509,7 +489,6 @@ test.describe( 'Agent Builder - Create Agent', () => {
 		await expect( form.getByLabel( /Slug/i ) ).toBeVisible();
 		await expect( form.getByLabel( /^Name/i ) ).toBeVisible();
 		await expect( form.getByLabel( /System Prompt/i ) ).toBeVisible();
-		await expect( form.getByLabel( /Tool Profile/i ) ).toBeVisible();
 	} );
 
 	test( 'submitting without a name shows a validation error', async ( {
@@ -562,33 +541,6 @@ test.describe( 'Agent Builder - Create Agent', () => {
 		const cards = getAgentCards( page );
 		await expect( cards ).toHaveCount( 1 );
 		await expect( cards.first() ).toContainText( AGENT_FIXTURE.name );
-	} );
-
-	test( 'assigns a tool profile (abilities) when creating an agent', async ( {
-		page,
-	} ) => {
-		await getAddAgentButton( page ).click();
-
-		const form = getAgentForm( page );
-		await form.getByLabel( /Slug/i ).fill( 'tool-agent' );
-		await form.getByLabel( /^Name/i ).fill( 'Tool Agent' );
-
-		// Wait for the tool-profiles API response to populate the dropdown
-		// before attempting to select an option.
-		const toolProfileSelect = form.getByLabel( /Tool Profile/i );
-		await expect(
-			toolProfileSelect.locator( 'option', { hasText: 'WP Read Only' } )
-		).toBeAttached();
-
-		// Select the "WP Read Only" tool profile by value. The slug 'wp-read-only'
-		// matches the built-in profile defined in ToolProfiles::get_builtins().
-		await toolProfileSelect.selectOption( 'wp-read-only' );
-
-		await getCreateAgentButton( page ).click();
-
-		// Form closes and card appears — the create succeeded.
-		await expect( getAgentForm( page ) ).not.toBeVisible();
-		await expect( getAgentCards( page ) ).toHaveCount( 1 );
 	} );
 
 	test( '"Cancel" button hides the form without saving', async ( {
@@ -907,15 +859,6 @@ test.describe( 'Agent Builder - Full Lifecycle', () => {
 		await form
 			.getByLabel( /System Prompt/i )
 			.fill( AGENT_FIXTURE.system_prompt );
-
-		// Wait for tool-profile options to load before selecting.
-		const toolProfileSelect = form.getByLabel( /Tool Profile/i );
-		await expect(
-			toolProfileSelect.locator( 'option', { hasText: 'WP Read Only' } )
-		).toBeAttached();
-		// Select the "WP Read Only" profile by value — matches the built-in
-		// slug in ToolProfiles::get_builtins().
-		await toolProfileSelect.selectOption( 'wp-read-only' );
 
 		await getCreateAgentButton( page ).click();
 

--- a/tests/e2e/chat-upload.spec.js
+++ b/tests/e2e/chat-upload.spec.js
@@ -534,7 +534,6 @@ test.describe( 'Chat Upload - Send Button State (t122)', () => {
 					contentType: 'application/json',
 					body: JSON.stringify( {
 						status: 'complete',
-						session_id: 1,
 						reply: 'OK',
 					} ),
 				} );


### PR DESCRIPTION
## Summary

Addresses two unresolved review bot comments from PR #945.

### agent-builder.js — remove non-functional Tool Profile dropdown

The `/gratis-ai-agent/v1/tool-profiles` REST endpoint does not exist. `Agent.php:10` documents `tool_profile` as *"legacy, no longer applied — kept on the row for backward compatibility"*. The empty `.catch(() => {})` silently masked the failed API call, and the dropdown label *"Restrict which tools this agent can use"* was misleading users about a feature that has no effect.

Changes:
- Remove `apiFetch` call for `/gratis-ai-agent/v1/tool-profiles` from `useEffect`
- Remove `toolProfiles` state
- Remove the Tool Profile `SelectControl`
- Remove unused `apiFetch` import

`tool_profile` is kept in the form state and API payload so existing agent rows are not corrupted on next save.

### chat-upload.spec.js — remove hard-coded `session_id: 1`

The mocked job response contained `session_id: 1`. The store treats this field as authoritative and reloads `/gratis-ai-agent/v1/sessions/:id`, making the test depend on whatever session IDs exist in wp-env. Omitting `session_id` from the mock avoids the unnecessary session reload and removes the environment coupling.

## Verification

- `npm run lint:js src/settings-page/agent-builder.js` — clean (zero errors)
- No `/gratis-ai-agent/v1/tool-profiles` registration exists anywhere in `includes/` (confirmed via grep)
- `tool_profile` field documented as legacy in `includes/Models/Agent.php:10`

Resolves #962