### PR TITLE
refactor: convert all remaining REST controllers to DI handlers (PR 5/6)

### DIFF
--- a/gratis-ai-agent.php
+++ b/gratis-ai-agent.php
@@ -92,7 +92,6 @@ use GratisAiAgent\Core\FreshInstallDetector;
 use GratisAiAgent\Core\OnboardingManager;
 use GratisAiAgent\Core\ProviderTraceLogger;
 use GratisAiAgent\Knowledge\KnowledgeHooks;
-use GratisAiAgent\REST\RestController;
 use GratisAiAgent\Tools\CustomToolExecutor;
 use GratisAiAgent\Tools\ToolDiscovery;
 
@@ -144,8 +143,8 @@ add_action(
 	}
 );
 
-add_action( 'rest_api_init', [ RestController::class, 'register_routes' ] );
-// BenchmarkController, TraceController, McpController are now DI-managed #[REST_Handler] classes.
+// All REST controllers are now DI-managed #[Handler] / #[REST_Handler] classes
+// registered in Plugin.php — no manual rest_api_init wiring needed.
 
 // Unified admin menu — single top-level menu with hash-based React routing.
 add_action( 'admin_menu', [ UnifiedAdminMenu::class, 'register' ] );

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -24,12 +24,22 @@ use GratisAiAgent\Infrastructure\AiClient\RequestTimeoutFilter;
 use GratisAiAgent\Infrastructure\WordPress\Abilities\AbilityCategoryRegistrar;
 use GratisAiAgent\Infrastructure\WordPress\Abilities\AbilitySchemaFilter;
 use GratisAiAgent\Infrastructure\WordPress\Abilities\UsageInstructionsFilter;
+use GratisAiAgent\REST\AgentController;
+use GratisAiAgent\REST\AutomationController;
 use GratisAiAgent\REST\BenchmarkController;
+use GratisAiAgent\REST\ChangesController;
 use GratisAiAgent\REST\FeedbackController;
+use GratisAiAgent\REST\KnowledgeController;
 use GratisAiAgent\REST\McpController;
 use GratisAiAgent\REST\MemoryController;
+use GratisAiAgent\REST\ResaleApiController;
+use GratisAiAgent\REST\RestController;
+use GratisAiAgent\REST\SessionController;
+use GratisAiAgent\REST\SettingsController;
 use GratisAiAgent\REST\SkillController;
+use GratisAiAgent\REST\ToolController;
 use GratisAiAgent\REST\TraceController;
+use GratisAiAgent\REST\WebhookController;
 use XWP\DI\Decorators\Module;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -65,6 +75,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 		TraceController::class,
 		McpController::class,
 		BenchmarkController::class,
+		RestController::class,
+		ToolController::class,
+		AgentController::class,
+		ChangesController::class,
+		AutomationController::class,
+		KnowledgeController::class,
+		SessionController::class,
+		SettingsController::class,
+		WebhookController::class,
+		ResaleApiController::class,
 	),
 	extendable: true,
 )]

--- a/includes/REST/AgentController.php
+++ b/includes/REST/AgentController.php
@@ -16,33 +16,48 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
-class AgentController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manages agents and conversation templates via REST.
+ *
+ * Uses #[Handler] + #[Action] because this controller serves multiple
+ * basenames (/agents, /conversation-templates).
+ */
+#[Handler(
+	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class AgentController {
 
 	use PermissionTrait;
-
-	const NAMESPACE = 'gratis-ai-agent/v1';
 
 	/**
 	 * Register REST routes.
 	 */
-	public static function register_routes(): void {
-		$instance = new self();
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
 
 		// Agents endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/agents',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_list_agents' ),
-					'permission_callback' => array( $instance, 'check_chat_permission' ),
+					'callback'            => array( $this, 'handle_list_agents' ),
+					'permission_callback' => array( $this, 'check_chat_permission' ),
 				),
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_create_agent' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_create_agent' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'slug'           => array(
 							'required'          => true,
@@ -110,13 +125,13 @@ class AgentController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/agents/(?P<id>\d+)',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_get_agent' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_get_agent' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -127,8 +142,8 @@ class AgentController {
 				),
 				array(
 					'methods'             => 'PATCH',
-					'callback'            => array( $instance, 'handle_update_agent' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_update_agent' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id'             => array(
 							'required'          => true,
@@ -191,8 +206,8 @@ class AgentController {
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $instance, 'handle_delete_agent' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_delete_agent' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -206,13 +221,13 @@ class AgentController {
 
 		// Conversation Templates endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/conversation-templates',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_list_conversation_templates' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_list_conversation_templates' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'category' => array(
 							'required'          => false,
@@ -223,8 +238,8 @@ class AgentController {
 				),
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_create_conversation_template' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_create_conversation_template' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'name'   => array(
 							'required'          => true,
@@ -241,13 +256,13 @@ class AgentController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/conversation-templates/(?P<id>\d+)',
 			array(
 				array(
 					'methods'             => 'PATCH',
-					'callback'            => array( $instance, 'handle_update_conversation_template' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_update_conversation_template' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -258,8 +273,8 @@ class AgentController {
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $instance, 'handle_delete_conversation_template' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_delete_conversation_template' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,

--- a/includes/REST/AutomationController.php
+++ b/includes/REST/AutomationController.php
@@ -21,33 +21,48 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
-class AutomationController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manages automations, event-automations, logs, and triggers via REST.
+ *
+ * Uses #[Handler] + #[Action] because this controller serves multiple
+ * basenames (/automations, /event-automations, /automation-logs, etc.).
+ */
+#[Handler(
+	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class AutomationController {
 
 	use PermissionTrait;
-
-	const NAMESPACE = 'gratis-ai-agent/v1';
 
 	/**
 	 * Register REST routes.
 	 */
-	public static function register_routes(): void {
-		$instance = new self();
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
 
 		// Automations endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/automations',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_list_automations' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_list_automations' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 				),
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_create_automation' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_create_automation' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'name'     => array(
 							'required'          => true,
@@ -70,13 +85,13 @@ class AutomationController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/automations/(?P<id>\d+)',
 			array(
 				array(
 					'methods'             => 'PATCH',
-					'callback'            => array( $instance, 'handle_update_automation' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_update_automation' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -87,8 +102,8 @@ class AutomationController {
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $instance, 'handle_delete_automation' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_delete_automation' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -101,12 +116,12 @@ class AutomationController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/automations/(?P<id>\d+)/run',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_run_automation' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_run_automation' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'id' => array(
 						'required'          => true,
@@ -118,12 +133,12 @@ class AutomationController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/automations/(?P<id>\d+)/logs',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_automation_logs' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_automation_logs' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'id' => array(
 						'required'          => true,
@@ -135,29 +150,29 @@ class AutomationController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/automation-templates',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_automation_templates' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_automation_templates' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		// Event Automations endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/event-automations',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_list_event_automations' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_list_event_automations' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 				),
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_create_event_automation' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_create_event_automation' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'name'            => array(
 							'required'          => true,
@@ -179,13 +194,13 @@ class AutomationController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/event-automations/(?P<id>\d+)',
 			array(
 				array(
 					'methods'             => 'PATCH',
-					'callback'            => array( $instance, 'handle_update_event_automation' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_update_event_automation' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -196,8 +211,8 @@ class AutomationController {
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $instance, 'handle_delete_event_automation' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_delete_event_automation' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -210,32 +225,32 @@ class AutomationController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/event-triggers',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_list_event_triggers' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_list_event_triggers' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/automation-logs',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_list_all_logs' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_list_all_logs' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/automations/test-notification',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_test_notification' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_test_notification' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'type'        => array(
 						'required'          => true,

--- a/includes/REST/ChangesController.php
+++ b/includes/REST/ChangesController.php
@@ -16,27 +16,42 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
-class ChangesController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manages changes, modified-plugins, and download endpoints via REST.
+ *
+ * Uses #[Handler] + #[Action] because this controller serves multiple
+ * basenames (/changes, /modified-plugins, /download-plugin, /plugins).
+ */
+#[Handler(
+	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class ChangesController {
 
 	use PermissionTrait;
-
-	const NAMESPACE = 'gratis-ai-agent/v1';
 
 	/**
 	 * Register REST routes.
 	 */
-	public static function register_routes(): void {
-		$instance = new self();
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
 
 		// Changes log endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/changes',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_list_changes' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_list_changes' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'session_id'  => array(
 						'required'          => false,
@@ -67,13 +82,13 @@ class ChangesController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/changes/(?P<id>\d+)',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_get_change' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_get_change' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -84,8 +99,8 @@ class ChangesController {
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $instance, 'handle_delete_change' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_delete_change' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -98,12 +113,12 @@ class ChangesController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/changes/(?P<id>\d+)/diff',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_get_change_diff' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_get_change_diff' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'id' => array(
 						'required'          => true,
@@ -115,12 +130,12 @@ class ChangesController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/changes/(?P<id>\d+)/revert',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_revert_change' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_revert_change' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'id' => array(
 						'required'          => true,
@@ -132,12 +147,12 @@ class ChangesController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/changes/export',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_export_changes' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_export_changes' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'ids' => array(
 						'required' => true,
@@ -150,22 +165,22 @@ class ChangesController {
 
 		// Plugin download endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/modified-plugins',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_list_modified_plugins' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_list_modified_plugins' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/download-plugin/(?P<slug>[a-z0-9\-_]+)',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_download_plugin' ),
-				'permission_callback' => array( $instance, 'check_download_permission' ),
+				'callback'            => array( $this, 'handle_download_plugin' ),
+				'permission_callback' => array( $this, 'check_download_permission' ),
 				'args'                => array(
 					'slug' => array(
 						'required'          => true,
@@ -441,7 +456,7 @@ class ChangesController {
 		foreach ( $rows as $row ) {
 			$slug         = $row->plugin_slug ?? '';
 			$nonce        = wp_create_nonce( 'gratis_ai_agent_download_plugin_' . $slug );
-			$rest_url     = rest_url( self::NAMESPACE . '/download-plugin/' . rawurlencode( $slug ) );
+			$rest_url     = rest_url( RestController::NAMESPACE . '/download-plugin/' . rawurlencode( $slug ) );
 			$download_url = add_query_arg( '_wpnonce', $nonce, $rest_url );
 
 			$plugins[] = array(
@@ -465,9 +480,9 @@ class ChangesController {
 	 * Stream a zip archive of an AI-modified plugin directory.
 	 *
 	 * @param WP_REST_Request $request REST request.
-	 * @return WP_REST_Response|WP_Error
+	 * @return WP_Error
 	 */
-	public function handle_download_plugin( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_download_plugin( WP_REST_Request $request ): WP_Error {
 		// @phpstan-ignore-next-line
 		$slug = sanitize_key( $request->get_param( 'slug' ) );
 

--- a/includes/REST/KnowledgeController.php
+++ b/includes/REST/KnowledgeController.php
@@ -16,33 +16,45 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
-class KnowledgeController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manages knowledge collections, sources, search, stats, and upload via REST.
+ */
+#[Handler(
+	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class KnowledgeController {
 
 	use PermissionTrait;
-
-	const NAMESPACE = 'gratis-ai-agent/v1';
 
 	/**
 	 * Register REST routes.
 	 */
-	public static function register_routes(): void {
-		$instance = new self();
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
 
 		// Knowledge endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/knowledge/collections',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_list_collections' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_list_collections' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 				),
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_create_collection' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_create_collection' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'name'          => array(
 							'required'          => true,
@@ -76,13 +88,13 @@ class KnowledgeController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/knowledge/collections/(?P<id>\d+)',
 			array(
 				array(
 					'methods'             => 'PATCH',
-					'callback'            => array( $instance, 'handle_update_collection' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_update_collection' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id'            => array(
 							'required'          => true,
@@ -111,8 +123,8 @@ class KnowledgeController {
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $instance, 'handle_delete_collection' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_delete_collection' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -125,12 +137,12 @@ class KnowledgeController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/knowledge/collections/(?P<id>\d+)/sources',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_list_sources' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_list_sources' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'id' => array(
 						'required'          => true,
@@ -142,12 +154,12 @@ class KnowledgeController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/knowledge/collections/(?P<id>\d+)/index',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_index_collection' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_index_collection' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'id' => array(
 						'required'          => true,
@@ -159,22 +171,22 @@ class KnowledgeController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/knowledge/upload',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_knowledge_upload' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_knowledge_upload' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/knowledge/sources/(?P<id>\d+)',
 			array(
 				'methods'             => WP_REST_Server::DELETABLE,
-				'callback'            => array( $instance, 'handle_delete_source' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_delete_source' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'id' => array(
 						'required'          => true,
@@ -186,12 +198,12 @@ class KnowledgeController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/knowledge/search',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_knowledge_search' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_knowledge_search' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'q'          => array(
 						'required'          => true,
@@ -208,12 +220,12 @@ class KnowledgeController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/knowledge/stats',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_knowledge_stats' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_knowledge_stats' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 	}

--- a/includes/REST/ResaleApiController.php
+++ b/includes/REST/ResaleApiController.php
@@ -37,25 +37,37 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
-class ResaleApiController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
-	const NAMESPACE = 'gratis-ai-agent/v1';
+/**
+ * Manages resale API clients and proxy endpoint via REST.
+ */
+#[Handler(
+	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class ResaleApiController {
 
 	/**
 	 * Register all resale API REST routes.
 	 */
-	public static function register_routes(): void {
-		$instance = new self();
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
 
 		// ─── Proxy endpoint ──────────────────────────────────────────
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/resale/proxy',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ $instance, 'handle_proxy' ],
-				'permission_callback' => [ $instance, 'check_resale_permission' ],
+				'callback'            => [ $this, 'handle_proxy' ],
+				'permission_callback' => [ $this, 'check_resale_permission' ],
 				'args'                => [
 					'model'       => [
 						'required'          => false,
@@ -86,18 +98,18 @@ class ResaleApiController {
 
 		// ─── Admin CRUD endpoints ────────────────────────────────────
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/resale/clients',
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ $instance, 'handle_list_clients' ],
-					'permission_callback' => [ $instance, 'check_admin_permission' ],
+					'callback'            => [ $this, 'handle_list_clients' ],
+					'permission_callback' => [ $this, 'check_admin_permission' ],
 				],
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ $instance, 'handle_create_client' ],
-					'permission_callback' => [ $instance, 'check_admin_permission' ],
+					'callback'            => [ $this, 'handle_create_client' ],
+					'permission_callback' => [ $this, 'check_admin_permission' ],
 					'args'                => [
 						'name'                => [
 							'required'          => true,
@@ -137,13 +149,13 @@ class ResaleApiController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/resale/clients/(?P<id>\d+)',
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ $instance, 'handle_get_client' ],
-					'permission_callback' => [ $instance, 'check_admin_permission' ],
+					'callback'            => [ $this, 'handle_get_client' ],
+					'permission_callback' => [ $this, 'check_admin_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -154,8 +166,8 @@ class ResaleApiController {
 				],
 				[
 					'methods'             => 'PATCH',
-					'callback'            => [ $instance, 'handle_update_client' ],
-					'permission_callback' => [ $instance, 'check_admin_permission' ],
+					'callback'            => [ $this, 'handle_update_client' ],
+					'permission_callback' => [ $this, 'check_admin_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -166,8 +178,8 @@ class ResaleApiController {
 				],
 				[
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => [ $instance, 'handle_delete_client' ],
-					'permission_callback' => [ $instance, 'check_admin_permission' ],
+					'callback'            => [ $this, 'handle_delete_client' ],
+					'permission_callback' => [ $this, 'check_admin_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -180,12 +192,12 @@ class ResaleApiController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/resale/clients/(?P<id>\d+)/rotate-key',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ $instance, 'handle_rotate_key' ],
-				'permission_callback' => [ $instance, 'check_admin_permission' ],
+				'callback'            => [ $this, 'handle_rotate_key' ],
+				'permission_callback' => [ $this, 'check_admin_permission' ],
 				'args'                => [
 					'id' => [
 						'required'          => true,
@@ -197,12 +209,12 @@ class ResaleApiController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/resale/clients/(?P<id>\d+)/usage',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ $instance, 'handle_get_usage' ],
-				'permission_callback' => [ $instance, 'check_admin_permission' ],
+				'callback'            => [ $this, 'handle_get_usage' ],
+				'permission_callback' => [ $this, 'check_admin_permission' ],
 				'args'                => [
 					'id'     => [
 						'required'          => true,
@@ -226,12 +238,12 @@ class ResaleApiController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/resale/clients/(?P<id>\d+)/usage/summary',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ $instance, 'handle_get_usage_summary' ],
-				'permission_callback' => [ $instance, 'check_admin_permission' ],
+				'callback'            => [ $this, 'handle_get_usage_summary' ],
+				'permission_callback' => [ $this, 'check_admin_permission' ],
 				'args'                => [
 					'id'         => [
 						'required'          => true,
@@ -591,7 +603,7 @@ class ResaleApiController {
 		// Return the API key on creation only — it is never returned again.
 		$response              = $this->sanitize_client_for_response( $client );
 		$response['api_key']   = $api_key;
-		$response['proxy_url'] = rest_url( self::NAMESPACE . '/resale/proxy' );
+		$response['proxy_url'] = rest_url( RestController::NAMESPACE . '/resale/proxy' );
 
 		return new WP_REST_Response( $response, 201 );
 	}
@@ -616,7 +628,7 @@ class ResaleApiController {
 		}
 
 		$response              = $this->sanitize_client_for_response( $client );
-		$response['proxy_url'] = rest_url( self::NAMESPACE . '/resale/proxy' );
+		$response['proxy_url'] = rest_url( RestController::NAMESPACE . '/resale/proxy' );
 
 		return new WP_REST_Response( $response, 200 );
 	}
@@ -688,7 +700,7 @@ class ResaleApiController {
 		}
 
 		$response              = $this->sanitize_client_for_response( $client );
-		$response['proxy_url'] = rest_url( self::NAMESPACE . '/resale/proxy' );
+		$response['proxy_url'] = rest_url( RestController::NAMESPACE . '/resale/proxy' );
 
 		return new WP_REST_Response( $response, 200 );
 	}

--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -38,8 +38,24 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
-class RestController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Core REST controller — holds the shared NAMESPACE constant and the
+ * /chat/tool-result endpoint. All domain controllers are now DI-managed
+ * and self-register via their own #[Handler] / #[REST_Handler] attributes.
+ */
+#[Handler(
+	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class RestController {
 
 	use PermissionTrait;
 
@@ -55,34 +71,14 @@ class RestController {
 	 */
 	const JOB_TTL = 600;
 
-
-
 	/**
-	 * Register REST routes.
+	 * Register the /chat/tool-result endpoint.
 	 *
-	 * Delegates to domain controllers and registers the /chat endpoint here.
+	 * All domain controllers are now DI-managed and register their own
+	 * routes via #[REST_Handler] or #[Handler] + #[Action(rest_api_init)].
 	 */
-	public static function register_routes(): void {
-		// McpController and BenchmarkController are now DI-managed #[REST_Handler] classes.
-
-		// Webhook API endpoints.
-		WebhookController::register_routes();
-
-		// Resale API endpoints.
-		ResaleApiController::register_routes();
-
-		// Domain controllers — migrating to DI-managed #[REST_Handler] classes.
-		// Already migrated: MemoryController, SkillController, FeedbackController,
-		// McpController, BenchmarkController, TraceController.
-		SessionController::register_routes();
-		SettingsController::register_routes();
-		AutomationController::register_routes();
-		KnowledgeController::register_routes();
-		ToolController::register_routes();
-		ChangesController::register_routes();
-		AgentController::register_routes();
-
-		$instance = new self();
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
 
 		// Client tool result endpoint — resumes the agent loop after the browser
 		// has executed client-side tool calls and POSTs the results back.
@@ -92,7 +88,7 @@ class RestController {
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( __CLASS__, 'handle_tool_result' ),
-				'permission_callback' => array( $instance, 'check_chat_permission' ),
+				'permission_callback' => array( $this, 'check_chat_permission' ),
 				'args'                => array(
 					'session_id'   => array(
 						'required'          => true,

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -23,12 +23,28 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
-class SessionController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manages sessions, messages, folders, sharing, export/import, site-builder,
+ * job-status, process, and tool confirmation via REST.
+ *
+ * Uses #[Handler] + #[Action] because this controller serves multiple
+ * basenames (/sessions, /run, /process, /job, /site-builder).
+ */
+#[Handler(
+	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class SessionController {
 
 	use PermissionTrait;
-
-	const NAMESPACE = 'gratis-ai-agent/v1';
 
 	/** @var Settings Injected settings dependency. */
 	private Settings $settings;
@@ -50,18 +66,18 @@ class SessionController {
 	/**
 	 * Register REST routes.
 	 */
-	public static function register_routes(): void {
-		$instance = new self();
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
 
 		// Sessions endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/sessions',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_list_sessions' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_list_sessions' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'status' => array(
 							'required'          => false,
@@ -87,8 +103,8 @@ class SessionController {
 				),
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_create_session' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_create_session' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'title'       => array(
 							'required'          => false,
@@ -120,22 +136,22 @@ class SessionController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/sessions/folders',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_list_folders' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_list_folders' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/sessions/bulk',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_bulk_sessions' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_bulk_sessions' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'ids'    => array(
 						'required' => true,
@@ -156,23 +172,23 @@ class SessionController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/sessions/trash',
 			array(
 				'methods'             => WP_REST_Server::DELETABLE,
-				'callback'            => array( $instance, 'handle_empty_trash' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_empty_trash' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/sessions/(?P<id>\d+)',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_get_session' ),
-					'permission_callback' => array( $instance, 'check_session_permission' ),
+					'callback'            => array( $this, 'handle_get_session' ),
+					'permission_callback' => array( $this, 'check_session_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -183,8 +199,8 @@ class SessionController {
 				),
 				array(
 					'methods'             => 'PATCH',
-					'callback'            => array( $instance, 'handle_update_session' ),
-					'permission_callback' => array( $instance, 'check_session_permission' ),
+					'callback'            => array( $this, 'handle_update_session' ),
+					'permission_callback' => array( $this, 'check_session_permission' ),
 					'args'                => array(
 						'id'     => array(
 							'required'          => true,
@@ -214,8 +230,8 @@ class SessionController {
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $instance, 'handle_delete_session' ),
-					'permission_callback' => array( $instance, 'check_session_permission' ),
+					'callback'            => array( $this, 'handle_delete_session' ),
+					'permission_callback' => array( $this, 'check_session_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -229,12 +245,12 @@ class SessionController {
 
 		// Export endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/sessions/(?P<id>\d+)/export',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_export_session' ),
-				'permission_callback' => array( $instance, 'check_session_permission' ),
+				'callback'            => array( $this, 'handle_export_session' ),
+				'permission_callback' => array( $this, 'check_session_permission' ),
 				'args'                => array(
 					'id'     => array(
 						'required'          => true,
@@ -253,35 +269,35 @@ class SessionController {
 
 		// Import endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/sessions/import',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_import_session' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_import_session' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		// Shared sessions list endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/sessions/shared',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_list_shared_sessions' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_list_shared_sessions' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		// Share / unshare a session.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/sessions/(?P<id>\d+)/share',
 			array(
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_share_session' ),
-					'permission_callback' => array( $instance, 'check_session_owner_permission' ),
+					'callback'            => array( $this, 'handle_share_session' ),
+					'permission_callback' => array( $this, 'check_session_owner_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -292,8 +308,8 @@ class SessionController {
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $instance, 'handle_unshare_session' ),
-					'permission_callback' => array( $instance, 'check_session_owner_permission' ),
+					'callback'            => array( $this, 'handle_unshare_session' ),
+					'permission_callback' => array( $this, 'check_session_owner_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -307,12 +323,12 @@ class SessionController {
 
 		// Job status endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/job/(?P<id>[a-f0-9-]+)',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_job_status' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_job_status' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'id' => array(
 						'required'          => true,
@@ -325,12 +341,12 @@ class SessionController {
 
 		// Process endpoint (background worker).
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/process',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_process' ),
-				'permission_callback' => array( $instance, 'check_process_permission' ),
+				'callback'            => array( $this, 'handle_process' ),
+				'permission_callback' => array( $this, 'check_process_permission' ),
 				'args'                => array(
 					'job_id' => array(
 						'required'          => true,
@@ -348,12 +364,12 @@ class SessionController {
 
 		// Run endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/run',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_run' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_run' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'message'            => array(
 						'required'          => true,
@@ -423,12 +439,12 @@ class SessionController {
 
 		// Tool confirmation endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/job/(?P<id>[a-f0-9-]+)/confirm',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_confirm_tool' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_confirm_tool' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'id'           => array(
 						'required'          => true,
@@ -445,12 +461,12 @@ class SessionController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/job/(?P<id>[a-f0-9-]+)/reject',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_reject_tool' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_reject_tool' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'id' => array(
 						'required'          => true,
@@ -463,12 +479,12 @@ class SessionController {
 
 		// Interrupt endpoint — inject a user message into a running job.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/job/(?P<id>[a-f0-9-]+)/interrupt',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_interrupt' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_interrupt' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'id'      => array(
 						'required'          => true,
@@ -486,22 +502,22 @@ class SessionController {
 
 		// Site builder endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/site-builder/start',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_site_builder_start' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_site_builder_start' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/site-builder/status',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_site_builder_status' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_site_builder_status' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 	}
@@ -1117,7 +1133,7 @@ class SessionController {
 
 		// Spawn background worker.
 		wp_remote_post(
-			rest_url( self::NAMESPACE . '/process' ),
+			rest_url( RestController::NAMESPACE . '/process' ),
 			array(
 				'timeout'  => 0.01,
 				'blocking' => false,
@@ -1148,9 +1164,9 @@ class SessionController {
 	 * Creates a job, spawns a background worker, and returns immediately.
 	 *
 	 * @param WP_REST_Request $request The request object.
-	 * @return WP_REST_Response|WP_Error
+	 * @return WP_REST_Response
 	 */
-	public function handle_run( WP_REST_Request $request ) {
+	public function handle_run( WP_REST_Request $request ): WP_REST_Response {
 		$job_id = wp_generate_uuid4();
 		$token  = wp_generate_password( 40, false );
 
@@ -1186,7 +1202,7 @@ class SessionController {
 
 		// Spawn background worker via non-blocking loopback.
 		wp_remote_post(
-			rest_url( self::NAMESPACE . '/process' ),
+			rest_url( RestController::NAMESPACE . '/process' ),
 			array(
 				'timeout'  => 0.01,
 				'blocking' => false,

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -23,12 +23,27 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
-class SettingsController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manages settings, providers, budget, usage, roles, and alerts via REST.
+ *
+ * Uses #[Handler] + #[Action] because this controller serves multiple
+ * basenames (/settings, /providers, /budget, /usage, /role-permissions, etc.).
+ */
+#[Handler(
+	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class SettingsController {
 
 	use PermissionTrait;
-
-	const NAMESPACE = 'gratis-ai-agent/v1';
 
 	/** @var Settings Injected settings dependency. */
 	private Settings $settings;
@@ -50,69 +65,69 @@ class SettingsController {
 	/**
 	 * Register REST routes.
 	 */
-	public static function register_routes(): void {
-		$instance = new self();
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
 
 		// Providers endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/providers',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_providers' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_providers' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		// Alerts endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/alerts',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_alerts' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_alerts' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		// WooCommerce store status endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/woocommerce/status',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_woocommerce_status' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_woocommerce_status' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		// Settings endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/settings',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_get_settings' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_get_settings' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 				),
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_update_settings' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_update_settings' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 				),
 			)
 		);
 
 		// Claude Max token endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/settings/claude-max-token',
 			array(
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_set_claude_max_token' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_set_claude_max_token' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'token' => array(
 							'required'          => true,
@@ -126,7 +141,7 @@ class SettingsController {
 
 		// Direct provider API key endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/settings/provider-key',
 			array(
 				array(
@@ -151,7 +166,7 @@ class SettingsController {
 
 		// Direct provider API key test endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/settings/provider-key/test',
 			array(
 				array(
@@ -176,18 +191,18 @@ class SettingsController {
 
 		// Role permissions endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/role-permissions',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_get_role_permissions' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_get_role_permissions' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 				),
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_update_role_permissions' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_update_role_permissions' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'permissions' => array(
 							'required' => true,
@@ -200,20 +215,20 @@ class SettingsController {
 
 		// Role permissions — available roles list.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/role-permissions/roles',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_get_roles' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_get_roles' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 				),
 			)
 		);
 
 		// Fresh install detection endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/fresh-install',
 			array(
 				array(
@@ -226,7 +241,7 @@ class SettingsController {
 
 		// Google Analytics credentials endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/settings/google-analytics',
 			array(
 				array(
@@ -260,7 +275,7 @@ class SettingsController {
 
 		// Google Search Console credentials endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/settings/gsc-credentials',
 			array(
 				array(
@@ -278,7 +293,7 @@ class SettingsController {
 
 		// Brave Search API key endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/settings/brave-search-key',
 			array(
 				array(
@@ -303,7 +318,7 @@ class SettingsController {
 
 		// Feedback receiver API key endpoint (t180).
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/settings/feedback-api-key',
 			array(
 				array(
@@ -328,12 +343,12 @@ class SettingsController {
 
 		// Usage endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/usage',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_get_usage' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_get_usage' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'period'     => array(
 						'required'          => false,
@@ -356,12 +371,12 @@ class SettingsController {
 
 		// Budget status endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/budget',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_get_budget' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_get_budget' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 	}

--- a/includes/REST/ToolController.php
+++ b/includes/REST/ToolController.php
@@ -19,55 +19,71 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
-class ToolController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manages custom-tools and abilities endpoints via REST.
+ *
+ * Uses #[Handler] + #[Action] instead of #[REST_Handler] because this
+ * controller serves multiple basenames (/abilities, /custom-tools) and
+ * the REST_Handler decorator supports only a single basename per class.
+ */
+#[Handler(
+	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class ToolController {
 
 	use PermissionTrait;
-
-	const NAMESPACE = 'gratis-ai-agent/v1';
 
 	/**
 	 * Register REST routes.
 	 */
-	public static function register_routes(): void {
-		$instance = new self();
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
 
 		// Abilities endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/abilities',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_abilities' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_abilities' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		// Abilities Explorer endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/abilities/explorer',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_abilities_explorer' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_abilities_explorer' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		// Custom Tools endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/custom-tools',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_list_custom_tools' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_list_custom_tools' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 				),
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_create_custom_tool' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_create_custom_tool' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'name'         => array(
 							'required'          => true,
@@ -111,13 +127,13 @@ class ToolController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/custom-tools/(?P<id>\d+)',
 			array(
 				array(
 					'methods'             => 'PATCH',
-					'callback'            => array( $instance, 'handle_update_custom_tool' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_update_custom_tool' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -128,8 +144,8 @@ class ToolController {
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $instance, 'handle_delete_custom_tool' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_delete_custom_tool' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -142,12 +158,12 @@ class ToolController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/custom-tools/(?P<id>\d+)/test',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_test_custom_tool' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_test_custom_tool' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'id'    => array(
 						'required'          => true,

--- a/includes/REST/WebhookController.php
+++ b/includes/REST/WebhookController.php
@@ -37,10 +37,25 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
-class WebhookController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
-	const NAMESPACE = 'gratis-ai-agent/v1';
+/**
+ * Manages webhook CRUD and public trigger endpoint via REST.
+ *
+ * Uses #[Handler] + #[Action] because this controller serves multiple
+ * basenames (/webhooks, /webhook/trigger, /process).
+ */
+#[Handler(
+	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class WebhookController {
 
 	/**
 	 * Transient prefix for webhook jobs (reuses the main job pattern).
@@ -55,17 +70,17 @@ class WebhookController {
 	/**
 	 * Register all webhook REST routes.
 	 */
-	public static function register_routes(): void {
-		$instance = new self();
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
 
 		// ─── Public trigger endpoint ────────────────────────────────
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/webhook/trigger',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ $instance, 'handle_trigger' ],
-				'permission_callback' => [ $instance, 'check_webhook_permission' ],
+				'callback'            => [ $this, 'handle_trigger' ],
+				'permission_callback' => [ $this, 'check_webhook_permission' ],
 				'args'                => [
 					'webhook_id'         => [
 						'required'          => false,
@@ -114,18 +129,18 @@ class WebhookController {
 
 		// ─── Admin CRUD endpoints ────────────────────────────────────
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/webhooks',
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ $instance, 'handle_list' ],
-					'permission_callback' => [ $instance, 'check_admin_permission' ],
+					'callback'            => [ $this, 'handle_list' ],
+					'permission_callback' => [ $this, 'check_admin_permission' ],
 				],
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ $instance, 'handle_create' ],
-					'permission_callback' => [ $instance, 'check_admin_permission' ],
+					'callback'            => [ $this, 'handle_create' ],
+					'permission_callback' => [ $this, 'check_admin_permission' ],
 					'args'                => [
 						'name'               => [
 							'required'          => true,
@@ -179,13 +194,13 @@ class WebhookController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/webhooks/(?P<id>\d+)',
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ $instance, 'handle_get' ],
-					'permission_callback' => [ $instance, 'check_admin_permission' ],
+					'callback'            => [ $this, 'handle_get' ],
+					'permission_callback' => [ $this, 'check_admin_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -196,8 +211,8 @@ class WebhookController {
 				],
 				[
 					'methods'             => 'PATCH',
-					'callback'            => [ $instance, 'handle_update' ],
-					'permission_callback' => [ $instance, 'check_admin_permission' ],
+					'callback'            => [ $this, 'handle_update' ],
+					'permission_callback' => [ $this, 'check_admin_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -208,8 +223,8 @@ class WebhookController {
 				],
 				[
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => [ $instance, 'handle_delete' ],
-					'permission_callback' => [ $instance, 'check_admin_permission' ],
+					'callback'            => [ $this, 'handle_delete' ],
+					'permission_callback' => [ $this, 'check_admin_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -222,12 +237,12 @@ class WebhookController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/webhooks/(?P<id>\d+)/logs',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ $instance, 'handle_logs' ],
-				'permission_callback' => [ $instance, 'check_admin_permission' ],
+				'callback'            => [ $this, 'handle_logs' ],
+				'permission_callback' => [ $this, 'check_admin_permission' ],
 				'args'                => [
 					'id'     => [
 						'required'          => true,
@@ -251,12 +266,12 @@ class WebhookController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/webhooks/(?P<id>\d+)/rotate-secret',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ $instance, 'handle_rotate_secret' ],
-				'permission_callback' => [ $instance, 'check_admin_permission' ],
+				'callback'            => [ $this, 'handle_rotate_secret' ],
+				'permission_callback' => [ $this, 'check_admin_permission' ],
 				'args'                => [
 					'id' => [
 						'required'          => true,
@@ -379,7 +394,7 @@ class WebhookController {
 		// Return the secret on creation only — it is never returned again.
 		$response                = $this->sanitize_webhook_for_response( $webhook );
 		$response['secret']      = $secret;
-		$response['trigger_url'] = rest_url( self::NAMESPACE . '/webhook/trigger' );
+		$response['trigger_url'] = rest_url( RestController::NAMESPACE . '/webhook/trigger' );
 
 		return new WP_REST_Response( $response, 201 );
 	}
@@ -404,7 +419,7 @@ class WebhookController {
 		}
 
 		$response                = $this->sanitize_webhook_for_response( $webhook );
-		$response['trigger_url'] = rest_url( self::NAMESPACE . '/webhook/trigger' );
+		$response['trigger_url'] = rest_url( RestController::NAMESPACE . '/webhook/trigger' );
 
 		return new WP_REST_Response( $response, 200 );
 	}
@@ -472,7 +487,7 @@ class WebhookController {
 		}
 
 		$response                = $this->sanitize_webhook_for_response( $webhook );
-		$response['trigger_url'] = rest_url( self::NAMESPACE . '/webhook/trigger' );
+		$response['trigger_url'] = rest_url( RestController::NAMESPACE . '/webhook/trigger' );
 
 		return new WP_REST_Response( $response, 200 );
 	}
@@ -697,7 +712,7 @@ class WebhookController {
 		set_transient( self::JOB_PREFIX . $job_id, $job, self::JOB_TTL );
 
 		wp_remote_post(
-			rest_url( self::NAMESPACE . '/process' ),
+			rest_url( RestController::NAMESPACE . '/process' ),
 			[
 				'timeout'  => 0.01,
 				'blocking' => false,

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'ultimate-multisite/ai-agent',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '276c49ec925e37bf489a1d880fad39613256dbbe',
+        'reference' => '7cc78bf63cbbeb33679e69aa41e04c8084e43313',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -119,7 +119,7 @@
         'ultimate-multisite/ai-agent' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '276c49ec925e37bf489a1d880fad39613256dbbe',
+            'reference' => '7cc78bf63cbbeb33679e69aa41e04c8084e43313',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Summary

PR 5 of the 6-PR [x-wp/di](https://github.com/x-wp/di) refactor. Completes the REST layer migration by converting all remaining 9 controllers (plus RestController itself) to DI-managed classes.

**Depends on:** #985 (PR 4 — must merge first, this PR targets that branch)

## What's converted

| Controller | Routes | Pattern |
|---|---|---|
| `ToolController` | 7 | `#[Handler]` + `#[Action]` (multi-basename: `/abilities`, `/custom-tools`) |
| `AgentController` | 4 | `#[Handler]` + `#[Action]` (multi-basename: `/agents`, `/conversation-templates`) |
| `ChangesController` | 7 | `#[Handler]` + `#[Action]` (multi-basename: `/changes`, `/modified-plugins`, etc.) |
| `AutomationController` | 10 | `#[Handler]` + `#[Action]` (5 basenames) |
| `KnowledgeController` | 8 | `#[Handler]` + `#[Action]` (all under `/knowledge/*`) |
| `SessionController` | 17 | `#[Handler]` + `#[Action]` (multi-basename: `/sessions`, `/run`, `/process`, etc.) |
| `SettingsController` | 16 | `#[Handler]` + `#[Action]` (8 basenames) |
| `WebhookController` | 5 | `#[Handler]` + `#[Action]` (multi-basename: `/webhooks`, `/webhook/trigger`) |
| `ResaleApiController` | 6 | `#[Handler]` + `#[Action]` (all under `/resale/*`) |
| `RestController` | 1 | `#[Handler]` + `#[Action]` (retains `/chat/tool-result` + shared constants) |

**Total across PRs 4+5: 110 routes across 16 REST controllers, all DI-managed.**

## Two DI patterns for REST controllers

**`#[REST_Handler]` + `#[REST_Route]`** (PR 4): Used for single-basename controllers. The decorator generates `register_rest_route()` calls automatically from method attributes. Used by: Memory, Skill, Feedback, Trace, MCP, Benchmark.

**`#[Handler]` + `#[Action(rest_api_init)]`** (this PR): Used for multi-basename controllers. The handler is DI-managed but the `register_routes()` method calls `register_rest_route()` directly. The `context: CTX_REST` guard still applies — these handlers only load during REST requests.

This two-pattern approach was chosen over splitting every multi-basename controller into 2-5 separate classes, which would have increased class count by ~30 without adding value.

## Key result

**`gratis-ai-agent.php` now has ZERO `rest_api_init` wiring.** All REST route registration flows through the DI container's handler system. `Plugin.php` has 20 handler entries (5 infrastructure + 2 bootstrap + 13 REST).

## PHPStan fixes

Two pre-existing issues surfaced when classes were made `final` (tightens return type analysis):
- `ChangesController::handle_download_plugin()` — removed `WP_REST_Response` from union (method streams zip + exits, never returns a response)
- `SessionController::handle_run()` — removed `WP_Error` from union (always returns `WP_REST_Response`)

## Verification

All 110 routes across 16 controllers verified via HTTP:
```
custom-tools        → 401    agents              → 401
changes             → 401    automations         → 401
knowledge/collections→ 401   sessions            → 401
settings            → 401    webhooks            → 401
resale/clients      → 401    chat/tool-result    → 400
```

## Static analysis

- `composer phpcs` — 8/8 ✅
- `composer phpstan` — 137/137 ✅
- `php -l` on all 13 modified files — clean

## Follow-up (PR 6)

The final PR will:
- Convert Abilities classes, admin handlers, automations, and CLI to `#[Handler]`
- Add DESIGN.md ADR documenting the DI architecture decisions
- Update AGENTS.md with new directory conventions
- Expand test coverage for the DI-managed handlers

Ref #983