### PR TITLE
GH#987: fix PHPUnit failures — convert REST_Handler controllers to INIT_IMMEDIATELY

### DIFF
--- a/gratis-ai-agent.php
+++ b/gratis-ai-agent.php
@@ -83,8 +83,6 @@ use GratisAiAgent\Admin\FloatingWidget;
 use GratisAiAgent\Admin\ModelBenchmarkPage;
 use GratisAiAgent\Admin\ScreenMetaPanel;
 use GratisAiAgent\Admin\UnifiedAdminMenu;
-use GratisAiAgent\REST\BenchmarkController;
-use GratisAiAgent\REST\TraceController;
 use GratisAiAgent\Automations\AutomationRunner;
 use GratisAiAgent\Models\GitTrackerManager;
 use GratisAiAgent\Automations\EventTriggerHandler;
@@ -147,8 +145,7 @@ add_action(
 );
 
 add_action( 'rest_api_init', [ RestController::class, 'register_routes' ] );
-add_action( 'rest_api_init', [ BenchmarkController::class, 'register_routes' ] );
-add_action( 'rest_api_init', [ TraceController::class, 'register_routes' ] );
+// BenchmarkController, TraceController, McpController are now DI-managed #[REST_Handler] classes.
 
 // Unified admin menu — single top-level menu with hash-based React routing.
 add_action( 'admin_menu', [ UnifiedAdminMenu::class, 'register' ] );

--- a/gratis-ai-agent.php
+++ b/gratis-ai-agent.php
@@ -92,7 +92,6 @@ use GratisAiAgent\Core\FreshInstallDetector;
 use GratisAiAgent\Core\OnboardingManager;
 use GratisAiAgent\Core\ProviderTraceLogger;
 use GratisAiAgent\Knowledge\KnowledgeHooks;
-use GratisAiAgent\REST\RestController;
 use GratisAiAgent\Tools\CustomToolExecutor;
 use GratisAiAgent\Tools\ToolDiscovery;
 
@@ -144,8 +143,8 @@ add_action(
 	}
 );
 
-add_action( 'rest_api_init', [ RestController::class, 'register_routes' ] );
-// BenchmarkController, TraceController, McpController are now DI-managed #[REST_Handler] classes.
+// All REST controllers are now DI-managed #[Handler] / #[REST_Handler] classes
+// registered in Plugin.php — no manual rest_api_init wiring needed.
 
 // Unified admin menu — single top-level menu with hash-based React routing.
 add_action( 'admin_menu', [ UnifiedAdminMenu::class, 'register' ] );

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -24,12 +24,22 @@ use GratisAiAgent\Infrastructure\AiClient\RequestTimeoutFilter;
 use GratisAiAgent\Infrastructure\WordPress\Abilities\AbilityCategoryRegistrar;
 use GratisAiAgent\Infrastructure\WordPress\Abilities\AbilitySchemaFilter;
 use GratisAiAgent\Infrastructure\WordPress\Abilities\UsageInstructionsFilter;
+use GratisAiAgent\REST\AgentController;
+use GratisAiAgent\REST\AutomationController;
 use GratisAiAgent\REST\BenchmarkController;
+use GratisAiAgent\REST\ChangesController;
 use GratisAiAgent\REST\FeedbackController;
+use GratisAiAgent\REST\KnowledgeController;
 use GratisAiAgent\REST\McpController;
 use GratisAiAgent\REST\MemoryController;
+use GratisAiAgent\REST\ResaleApiController;
+use GratisAiAgent\REST\RestController;
+use GratisAiAgent\REST\SessionController;
+use GratisAiAgent\REST\SettingsController;
 use GratisAiAgent\REST\SkillController;
+use GratisAiAgent\REST\ToolController;
 use GratisAiAgent\REST\TraceController;
+use GratisAiAgent\REST\WebhookController;
 use XWP\DI\Decorators\Module;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -65,6 +75,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 		TraceController::class,
 		McpController::class,
 		BenchmarkController::class,
+		RestController::class,
+		ToolController::class,
+		AgentController::class,
+		ChangesController::class,
+		AutomationController::class,
+		KnowledgeController::class,
+		SessionController::class,
+		SettingsController::class,
+		WebhookController::class,
+		ResaleApiController::class,
 	),
 	extendable: true,
 )]

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -24,6 +24,12 @@ use GratisAiAgent\Infrastructure\AiClient\RequestTimeoutFilter;
 use GratisAiAgent\Infrastructure\WordPress\Abilities\AbilityCategoryRegistrar;
 use GratisAiAgent\Infrastructure\WordPress\Abilities\AbilitySchemaFilter;
 use GratisAiAgent\Infrastructure\WordPress\Abilities\UsageInstructionsFilter;
+use GratisAiAgent\REST\BenchmarkController;
+use GratisAiAgent\REST\FeedbackController;
+use GratisAiAgent\REST\McpController;
+use GratisAiAgent\REST\MemoryController;
+use GratisAiAgent\REST\SkillController;
+use GratisAiAgent\REST\TraceController;
 use XWP\DI\Decorators\Module;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -53,6 +59,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 		UsageInstructionsFilter::class,
 		RequestTimeoutFilter::class,
 		CliHandler::class,
+		MemoryController::class,
+		SkillController::class,
+		FeedbackController::class,
+		TraceController::class,
+		McpController::class,
+		BenchmarkController::class,
 	),
 	extendable: true,
 )]

--- a/includes/REST/AgentController.php
+++ b/includes/REST/AgentController.php
@@ -16,33 +16,48 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
-class AgentController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manages agents and conversation templates via REST.
+ *
+ * Uses #[Handler] + #[Action] because this controller serves multiple
+ * basenames (/agents, /conversation-templates).
+ */
+#[Handler(
+	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class AgentController {
 
 	use PermissionTrait;
-
-	const NAMESPACE = 'gratis-ai-agent/v1';
 
 	/**
 	 * Register REST routes.
 	 */
-	public static function register_routes(): void {
-		$instance = new self();
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
 
 		// Agents endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/agents',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_list_agents' ),
-					'permission_callback' => array( $instance, 'check_chat_permission' ),
+					'callback'            => array( $this, 'handle_list_agents' ),
+					'permission_callback' => array( $this, 'check_chat_permission' ),
 				),
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_create_agent' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_create_agent' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'slug'           => array(
 							'required'          => true,
@@ -110,13 +125,13 @@ class AgentController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/agents/(?P<id>\d+)',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_get_agent' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_get_agent' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -127,8 +142,8 @@ class AgentController {
 				),
 				array(
 					'methods'             => 'PATCH',
-					'callback'            => array( $instance, 'handle_update_agent' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_update_agent' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id'             => array(
 							'required'          => true,
@@ -191,8 +206,8 @@ class AgentController {
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $instance, 'handle_delete_agent' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_delete_agent' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -206,13 +221,13 @@ class AgentController {
 
 		// Conversation Templates endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/conversation-templates',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_list_conversation_templates' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_list_conversation_templates' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'category' => array(
 							'required'          => false,
@@ -223,8 +238,8 @@ class AgentController {
 				),
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_create_conversation_template' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_create_conversation_template' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'name'   => array(
 							'required'          => true,
@@ -241,13 +256,13 @@ class AgentController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/conversation-templates/(?P<id>\d+)',
 			array(
 				array(
 					'methods'             => 'PATCH',
-					'callback'            => array( $instance, 'handle_update_conversation_template' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_update_conversation_template' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -258,8 +273,8 @@ class AgentController {
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $instance, 'handle_delete_conversation_template' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_delete_conversation_template' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,

--- a/includes/REST/AutomationController.php
+++ b/includes/REST/AutomationController.php
@@ -21,33 +21,48 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
-class AutomationController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manages automations, event-automations, logs, and triggers via REST.
+ *
+ * Uses #[Handler] + #[Action] because this controller serves multiple
+ * basenames (/automations, /event-automations, /automation-logs, etc.).
+ */
+#[Handler(
+	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class AutomationController {
 
 	use PermissionTrait;
-
-	const NAMESPACE = 'gratis-ai-agent/v1';
 
 	/**
 	 * Register REST routes.
 	 */
-	public static function register_routes(): void {
-		$instance = new self();
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
 
 		// Automations endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/automations',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_list_automations' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_list_automations' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 				),
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_create_automation' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_create_automation' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'name'     => array(
 							'required'          => true,
@@ -70,13 +85,13 @@ class AutomationController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/automations/(?P<id>\d+)',
 			array(
 				array(
 					'methods'             => 'PATCH',
-					'callback'            => array( $instance, 'handle_update_automation' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_update_automation' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -87,8 +102,8 @@ class AutomationController {
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $instance, 'handle_delete_automation' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_delete_automation' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -101,12 +116,12 @@ class AutomationController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/automations/(?P<id>\d+)/run',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_run_automation' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_run_automation' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'id' => array(
 						'required'          => true,
@@ -118,12 +133,12 @@ class AutomationController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/automations/(?P<id>\d+)/logs',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_automation_logs' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_automation_logs' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'id' => array(
 						'required'          => true,
@@ -135,29 +150,29 @@ class AutomationController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/automation-templates',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_automation_templates' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_automation_templates' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		// Event Automations endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/event-automations',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_list_event_automations' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_list_event_automations' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 				),
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_create_event_automation' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_create_event_automation' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'name'            => array(
 							'required'          => true,
@@ -179,13 +194,13 @@ class AutomationController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/event-automations/(?P<id>\d+)',
 			array(
 				array(
 					'methods'             => 'PATCH',
-					'callback'            => array( $instance, 'handle_update_event_automation' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_update_event_automation' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -196,8 +211,8 @@ class AutomationController {
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $instance, 'handle_delete_event_automation' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_delete_event_automation' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -210,32 +225,32 @@ class AutomationController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/event-triggers',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_list_event_triggers' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_list_event_triggers' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/automation-logs',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_list_all_logs' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_list_all_logs' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/automations/test-notification',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_test_notification' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_test_notification' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'type'        => array(
 						'required'          => true,

--- a/includes/REST/BenchmarkController.php
+++ b/includes/REST/BenchmarkController.php
@@ -12,14 +12,12 @@ namespace GratisAiAgent\REST;
 
 use GratisAiAgent\Benchmark\BenchmarkRunner;
 use GratisAiAgent\Benchmark\BenchmarkSuite;
-use GratisAiAgent\Core\Database;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
-use XWP\DI\Decorators\REST_Handler;
-use XWP\DI\Decorators\REST_Route;
-use XWP_REST_Controller;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -37,13 +35,100 @@ if ( ! defined( 'ABSPATH' ) ) {
  *  POST   /benchmark/runs/{id}/run-next   — run next question
  *  DELETE /benchmark/runs/{id}            — delete a run
  *  POST   /benchmark/compare              — compare multiple runs
+ *
+ * Uses #[Handler] + INIT_IMMEDIATELY so register_routes() is called directly
+ * on rest_api_init, which is the only strategy that works in the PHPUnit test
+ * environment (the #[REST_Handler] INIT_DEFFERED path fails to fire its
+ * do_action chain when rest_api_init is manually triggered by test setUp()).
  */
-#[REST_Handler(
-	namespace: RestController::NAMESPACE,
-	basename: 'benchmark',
+#[Handler(
 	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
 )]
-final class BenchmarkController extends XWP_REST_Controller {
+final class BenchmarkController {
+
+	/**
+	 * Register REST routes for the benchmark endpoints.
+	 */
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/benchmark/suites',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'handle_list_suites' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+			)
+		);
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/benchmark/suites/(?P<slug>[a-z0-9\-_]+)',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'handle_get_suite' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+				'args'                => $this->get_slug_args(),
+			)
+		);
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/benchmark/runs',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'handle_list_runs' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+					'args'                => $this->get_list_runs_args(),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'handle_create_run' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+					'args'                => $this->get_create_run_args(),
+				),
+			)
+		);
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/benchmark/runs/(?P<id>\d+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'handle_get_run' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+					'args'                => $this->get_id_args(),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'handle_delete_run' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+					'args'                => $this->get_id_args(),
+				),
+			)
+		);
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/benchmark/runs/(?P<id>\d+)/run-next',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'handle_run_next' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+				'args'                => $this->get_id_args(),
+			)
+		);
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/benchmark/compare',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'handle_compare' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+				'args'                => $this->get_compare_args(),
+			)
+		);
+	}
 
 	/**
 	 * Permission check — admin only.
@@ -59,11 +144,6 @@ final class BenchmarkController extends XWP_REST_Controller {
 	 *
 	 * @return WP_REST_Response
 	 */
-	#[REST_Route(
-		route: 'suites',
-		methods: WP_REST_Server::READABLE,
-		guard: 'check_permission',
-	)]
 	public function handle_list_suites(): WP_REST_Response {
 		$suites = BenchmarkSuite::list_suites();
 		return new WP_REST_Response( $suites );
@@ -75,12 +155,6 @@ final class BenchmarkController extends XWP_REST_Controller {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	#[REST_Route(
-		route: 'suites/(?P<slug>[a-z0-9\-_]+)',
-		methods: WP_REST_Server::READABLE,
-		vars: 'get_slug_args',
-		guard: 'check_permission',
-	)]
 	public function handle_get_suite( WP_REST_Request $request ) {
 		$slug  = $request->get_param( 'slug' );
 		$suite = BenchmarkSuite::get_suite( $slug );
@@ -102,12 +176,6 @@ final class BenchmarkController extends XWP_REST_Controller {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response
 	 */
-	#[REST_Route(
-		route: 'runs',
-		methods: WP_REST_Server::READABLE,
-		vars: 'get_list_runs_args',
-		guard: 'check_permission',
-	)]
 	public function handle_list_runs( WP_REST_Request $request ): WP_REST_Response {
 		$per_page = (int) $request->get_param( 'per_page' );
 		$page     = (int) $request->get_param( 'page' );
@@ -123,12 +191,6 @@ final class BenchmarkController extends XWP_REST_Controller {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	#[REST_Route(
-		route: 'runs/(?P<id>\d+)',
-		methods: WP_REST_Server::READABLE,
-		vars: 'get_id_args',
-		guard: 'check_permission',
-	)]
 	public function handle_get_run( WP_REST_Request $request ) {
 		$run_id = absint( $request->get_param( 'id' ) );
 		$run    = BenchmarkRunner::get_run( $run_id );
@@ -152,12 +214,6 @@ final class BenchmarkController extends XWP_REST_Controller {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	#[REST_Route(
-		route: 'runs',
-		methods: WP_REST_Server::CREATABLE,
-		vars: 'get_create_run_args',
-		guard: 'check_permission',
-	)]
 	public function handle_create_run( WP_REST_Request $request ) {
 		$name         = $request->get_param( 'name' );
 		$description  = $request->get_param( 'description' );
@@ -201,12 +257,6 @@ final class BenchmarkController extends XWP_REST_Controller {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	#[REST_Route(
-		route: 'runs/(?P<id>\d+)/run-next',
-		methods: WP_REST_Server::CREATABLE,
-		vars: 'get_id_args',
-		guard: 'check_permission',
-	)]
 	public function handle_run_next( WP_REST_Request $request ) {
 		$run_id = absint( $request->get_param( 'id' ) );
 
@@ -265,12 +315,6 @@ final class BenchmarkController extends XWP_REST_Controller {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	#[REST_Route(
-		route: 'runs/(?P<id>\d+)',
-		methods: WP_REST_Server::DELETABLE,
-		vars: 'get_id_args',
-		guard: 'check_permission',
-	)]
 	public function handle_delete_run( WP_REST_Request $request ) {
 		$run_id = absint( $request->get_param( 'id' ) );
 
@@ -293,12 +337,6 @@ final class BenchmarkController extends XWP_REST_Controller {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	#[REST_Route(
-		route: 'compare',
-		methods: WP_REST_Server::CREATABLE,
-		vars: 'get_compare_args',
-		guard: 'check_permission',
-	)]
 	public function handle_compare( WP_REST_Request $request ) {
 		$run_ids = $request->get_param( 'run_ids' );
 

--- a/includes/REST/BenchmarkController.php
+++ b/includes/REST/BenchmarkController.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 /**
  * REST API controller for Model Benchmarking.
  *
- * Provides endpoints for running benchmarks and retrieving results.
- *
  * @package GratisAiAgent
  * @license GPL-2.0-or-later
  */
@@ -19,182 +17,38 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\REST_Handler;
+use XWP\DI\Decorators\REST_Route;
+use XWP_REST_Controller;
 
-class BenchmarkController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
-	const NAMESPACE = 'gratis-ai-agent/v1';
-
-	/**
-	 * Register REST routes for benchmarking.
-	 */
-	public static function register_routes(): void {
-		$instance = new self();
-
-		// List available test suites.
-		register_rest_route(
-			self::NAMESPACE,
-			'/benchmark/suites',
-			array(
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_list_suites' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
-			)
-		);
-
-		// Get questions for a suite.
-		register_rest_route(
-			self::NAMESPACE,
-			'/benchmark/suites/(?P<slug>[a-z0-9\-_]+)',
-			array(
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_get_suite' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
-				'args'                => array(
-					'slug' => array(
-						'required'          => true,
-						'type'              => 'string',
-						'sanitize_callback' => 'sanitize_text_field',
-					),
-				),
-			)
-		);
-
-		// List benchmark runs.
-		register_rest_route(
-			self::NAMESPACE,
-			'/benchmark/runs',
-			array(
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_list_runs' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
-				'args'                => array(
-					'per_page' => array(
-						'required'          => false,
-						'type'              => 'integer',
-						'default'           => 20,
-						'sanitize_callback' => 'absint',
-					),
-					'page'     => array(
-						'required'          => false,
-						'type'              => 'integer',
-						'default'           => 1,
-						'sanitize_callback' => 'absint',
-					),
-				),
-			)
-		);
-
-		// Get a specific benchmark run with results.
-		register_rest_route(
-			self::NAMESPACE,
-			'/benchmark/runs/(?P<id>\d+)',
-			array(
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_get_run' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
-				'args'                => array(
-					'id' => array(
-						'required'          => true,
-						'type'              => 'integer',
-						'sanitize_callback' => 'absint',
-					),
-				),
-			)
-		);
-
-		// Create a new benchmark run.
-		register_rest_route(
-			self::NAMESPACE,
-			'/benchmark/runs',
-			array(
-				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_create_run' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
-				'args'                => array(
-					'name'         => array(
-						'required'          => true,
-						'type'              => 'string',
-						'sanitize_callback' => 'sanitize_text_field',
-					),
-					'description'  => array(
-						'required'          => false,
-						'type'              => 'string',
-						'sanitize_callback' => 'sanitize_textarea_field',
-					),
-					'test_suite'   => array(
-						'required'          => false,
-						'type'              => 'string',
-						'default'           => 'wp-core-v1',
-						'sanitize_callback' => 'sanitize_text_field',
-					),
-					'models'       => array(
-						'required' => true,
-						'type'     => 'array',
-					),
-					'question_ids' => array(
-						'required' => false,
-						'type'     => 'array',
-					),
-				),
-			)
-		);
-
-		// Run a single benchmark question (step-by-step execution).
-		register_rest_route(
-			self::NAMESPACE,
-			'/benchmark/runs/(?P<id>\d+)/run-next',
-			array(
-				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_run_next' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
-				'args'                => array(
-					'id' => array(
-						'required'          => true,
-						'type'              => 'integer',
-						'sanitize_callback' => 'absint',
-					),
-				),
-			)
-		);
-
-		// Delete a benchmark run.
-		register_rest_route(
-			self::NAMESPACE,
-			'/benchmark/runs/(?P<id>\d+)',
-			array(
-				'methods'             => WP_REST_Server::DELETABLE,
-				'callback'            => array( $instance, 'handle_delete_run' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
-				'args'                => array(
-					'id' => array(
-						'required'          => true,
-						'type'              => 'integer',
-						'sanitize_callback' => 'absint',
-					),
-				),
-			)
-		);
-
-		// Compare multiple runs.
-		register_rest_route(
-			self::NAMESPACE,
-			'/benchmark/compare',
-			array(
-				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_compare' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
-				'args'                => array(
-					'run_ids' => array(
-						'required' => true,
-						'type'     => 'array',
-					),
-				),
-			)
-		);
-	}
+/**
+ * Manages model benchmark runs via REST.
+ *
+ * Endpoints:
+ *  GET    /benchmark/suites               — list available test suites
+ *  GET    /benchmark/suites/{slug}        — get a specific suite
+ *  GET    /benchmark/runs                 — list benchmark runs
+ *  GET    /benchmark/runs/{id}            — get a specific run
+ *  POST   /benchmark/runs                 — create a new run
+ *  POST   /benchmark/runs/{id}/run-next   — run next question
+ *  DELETE /benchmark/runs/{id}            — delete a run
+ *  POST   /benchmark/compare              — compare multiple runs
+ */
+#[REST_Handler(
+	namespace: RestController::NAMESPACE,
+	basename: 'benchmark',
+	container: 'gratis-ai-agent',
+)]
+final class BenchmarkController extends XWP_REST_Controller {
 
 	/**
 	 * Permission check — admin only.
+	 *
+	 * @return bool
 	 */
 	public function check_permission(): bool {
 		return current_user_can( 'manage_options' );
@@ -205,6 +59,11 @@ class BenchmarkController {
 	 *
 	 * @return WP_REST_Response
 	 */
+	#[REST_Route(
+		route: 'suites',
+		methods: WP_REST_Server::READABLE,
+		guard: 'check_permission',
+	)]
 	public function handle_list_suites(): WP_REST_Response {
 		$suites = BenchmarkSuite::list_suites();
 		return new WP_REST_Response( $suites );
@@ -216,6 +75,12 @@ class BenchmarkController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
+	#[REST_Route(
+		route: 'suites/(?P<slug>[a-z0-9\-_]+)',
+		methods: WP_REST_Server::READABLE,
+		vars: 'get_slug_args',
+		guard: 'check_permission',
+	)]
 	public function handle_get_suite( WP_REST_Request $request ) {
 		$slug  = $request->get_param( 'slug' );
 		$suite = BenchmarkSuite::get_suite( $slug );
@@ -237,6 +102,12 @@ class BenchmarkController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response
 	 */
+	#[REST_Route(
+		route: 'runs',
+		methods: WP_REST_Server::READABLE,
+		vars: 'get_list_runs_args',
+		guard: 'check_permission',
+	)]
 	public function handle_list_runs( WP_REST_Request $request ): WP_REST_Response {
 		$per_page = (int) $request->get_param( 'per_page' );
 		$page     = (int) $request->get_param( 'page' );
@@ -252,6 +123,12 @@ class BenchmarkController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
+	#[REST_Route(
+		route: 'runs/(?P<id>\d+)',
+		methods: WP_REST_Server::READABLE,
+		vars: 'get_id_args',
+		guard: 'check_permission',
+	)]
 	public function handle_get_run( WP_REST_Request $request ) {
 		$run_id = absint( $request->get_param( 'id' ) );
 		$run    = BenchmarkRunner::get_run( $run_id );
@@ -275,6 +152,12 @@ class BenchmarkController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
+	#[REST_Route(
+		route: 'runs',
+		methods: WP_REST_Server::CREATABLE,
+		vars: 'get_create_run_args',
+		guard: 'check_permission',
+	)]
 	public function handle_create_run( WP_REST_Request $request ) {
 		$name         = $request->get_param( 'name' );
 		$description  = $request->get_param( 'description' );
@@ -318,6 +201,12 @@ class BenchmarkController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
+	#[REST_Route(
+		route: 'runs/(?P<id>\d+)/run-next',
+		methods: WP_REST_Server::CREATABLE,
+		vars: 'get_id_args',
+		guard: 'check_permission',
+	)]
 	public function handle_run_next( WP_REST_Request $request ) {
 		$run_id = absint( $request->get_param( 'id' ) );
 
@@ -376,6 +265,12 @@ class BenchmarkController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
+	#[REST_Route(
+		route: 'runs/(?P<id>\d+)',
+		methods: WP_REST_Server::DELETABLE,
+		vars: 'get_id_args',
+		guard: 'check_permission',
+	)]
 	public function handle_delete_run( WP_REST_Request $request ) {
 		$run_id = absint( $request->get_param( 'id' ) );
 
@@ -398,6 +293,12 @@ class BenchmarkController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
+	#[REST_Route(
+		route: 'compare',
+		methods: WP_REST_Server::CREATABLE,
+		vars: 'get_compare_args',
+		guard: 'check_permission',
+	)]
 	public function handle_compare( WP_REST_Request $request ) {
 		$run_ids = $request->get_param( 'run_ids' );
 
@@ -412,5 +313,105 @@ class BenchmarkController {
 		$comparison = BenchmarkRunner::compare_runs( $run_ids );
 
 		return new WP_REST_Response( $comparison );
+	}
+
+	/**
+	 * Schema arguments for slug-based routes.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_slug_args(): array {
+		return array(
+			'slug' => array(
+				'required'          => true,
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+		);
+	}
+
+	/**
+	 * Schema arguments for GET /benchmark/runs (list).
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_list_runs_args(): array {
+		return array(
+			'per_page' => array(
+				'required'          => false,
+				'type'              => 'integer',
+				'default'           => 20,
+				'sanitize_callback' => 'absint',
+			),
+			'page'     => array(
+				'required'          => false,
+				'type'              => 'integer',
+				'default'           => 1,
+				'sanitize_callback' => 'absint',
+			),
+		);
+	}
+
+	/**
+	 * Schema arguments for ID-based routes.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_id_args(): array {
+		return array(
+			'id' => array(
+				'required'          => true,
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+			),
+		);
+	}
+
+	/**
+	 * Schema arguments for POST /benchmark/runs (create).
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_create_run_args(): array {
+		return array(
+			'name'         => array(
+				'required'          => true,
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'description'  => array(
+				'required'          => false,
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_textarea_field',
+			),
+			'test_suite'   => array(
+				'required'          => false,
+				'type'              => 'string',
+				'default'           => 'wp-core-v1',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'models'       => array(
+				'required' => true,
+				'type'     => 'array',
+			),
+			'question_ids' => array(
+				'required' => false,
+				'type'     => 'array',
+			),
+		);
+	}
+
+	/**
+	 * Schema arguments for POST /benchmark/compare.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_compare_args(): array {
+		return array(
+			'run_ids' => array(
+				'required' => true,
+				'type'     => 'array',
+			),
+		);
 	}
 }

--- a/includes/REST/ChangesController.php
+++ b/includes/REST/ChangesController.php
@@ -16,27 +16,42 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
-class ChangesController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manages changes, modified-plugins, and download endpoints via REST.
+ *
+ * Uses #[Handler] + #[Action] because this controller serves multiple
+ * basenames (/changes, /modified-plugins, /download-plugin, /plugins).
+ */
+#[Handler(
+	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class ChangesController {
 
 	use PermissionTrait;
-
-	const NAMESPACE = 'gratis-ai-agent/v1';
 
 	/**
 	 * Register REST routes.
 	 */
-	public static function register_routes(): void {
-		$instance = new self();
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
 
 		// Changes log endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/changes',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_list_changes' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_list_changes' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'session_id'  => array(
 						'required'          => false,
@@ -67,13 +82,13 @@ class ChangesController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/changes/(?P<id>\d+)',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_get_change' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_get_change' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -84,8 +99,8 @@ class ChangesController {
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $instance, 'handle_delete_change' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_delete_change' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -98,12 +113,12 @@ class ChangesController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/changes/(?P<id>\d+)/diff',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_get_change_diff' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_get_change_diff' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'id' => array(
 						'required'          => true,
@@ -115,12 +130,12 @@ class ChangesController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/changes/(?P<id>\d+)/revert',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_revert_change' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_revert_change' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'id' => array(
 						'required'          => true,
@@ -132,12 +147,12 @@ class ChangesController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/changes/export',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_export_changes' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_export_changes' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'ids' => array(
 						'required' => true,
@@ -150,22 +165,22 @@ class ChangesController {
 
 		// Plugin download endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/modified-plugins',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_list_modified_plugins' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_list_modified_plugins' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/download-plugin/(?P<slug>[a-z0-9\-_]+)',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_download_plugin' ),
-				'permission_callback' => array( $instance, 'check_download_permission' ),
+				'callback'            => array( $this, 'handle_download_plugin' ),
+				'permission_callback' => array( $this, 'check_download_permission' ),
 				'args'                => array(
 					'slug' => array(
 						'required'          => true,
@@ -441,7 +456,7 @@ class ChangesController {
 		foreach ( $rows as $row ) {
 			$slug         = $row->plugin_slug ?? '';
 			$nonce        = wp_create_nonce( 'gratis_ai_agent_download_plugin_' . $slug );
-			$rest_url     = rest_url( self::NAMESPACE . '/download-plugin/' . rawurlencode( $slug ) );
+			$rest_url     = rest_url( RestController::NAMESPACE . '/download-plugin/' . rawurlencode( $slug ) );
 			$download_url = add_query_arg( '_wpnonce', $nonce, $rest_url );
 
 			$plugins[] = array(
@@ -465,9 +480,9 @@ class ChangesController {
 	 * Stream a zip archive of an AI-modified plugin directory.
 	 *
 	 * @param WP_REST_Request $request REST request.
-	 * @return WP_REST_Response|WP_Error
+	 * @return WP_Error
 	 */
-	public function handle_download_plugin( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+	public function handle_download_plugin( WP_REST_Request $request ): WP_Error {
 		// @phpstan-ignore-next-line
 		$slug = sanitize_key( $request->get_param( 'slug' ) );
 

--- a/includes/REST/FeedbackController.php
+++ b/includes/REST/FeedbackController.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
  * REST API controller for feedback report sending.
  *
  * Provides two endpoints:
- *   GET  /gratis-ai-agent/v1/feedback/preview — returns sanitized payload for
- *        the consent modal's collapsible "View full payload" section.
- *   POST /gratis-ai-agent/v1/feedback/send    — builds, sanitizes, and forwards
- *        the report to the configured feedback receiver endpoint.
+ *   GET  /feedback/preview — returns sanitized payload for the consent modal.
+ *   POST /feedback/send    — builds, sanitizes, and forwards the report.
  *
  * The API key is held server-side and never exposed to the browser.
  *
@@ -25,100 +23,41 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\REST_Handler;
+use XWP\DI\Decorators\REST_Route;
+use XWP_REST_Controller;
 
-class FeedbackController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manages feedback report preview and submission.
+ */
+#[REST_Handler(
+	namespace: RestController::NAMESPACE,
+	basename: 'feedback',
+	container: 'gratis-ai-agent',
+)]
+final class FeedbackController extends XWP_REST_Controller {
 
 	use PermissionTrait;
-
-	const NAMESPACE = 'gratis-ai-agent/v1';
-
-	/**
-	 * Register REST routes.
-	 */
-	public static function register_routes(): void {
-		$instance = new self();
-
-		register_rest_route(
-			self::NAMESPACE,
-			'/feedback/preview',
-			array(
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_preview' ),
-				'permission_callback' => array( $instance, 'check_chat_permission' ),
-				'args'                => array(
-					'session_id'         => array(
-						'required'          => true,
-						'type'              => 'integer',
-						'sanitize_callback' => 'absint',
-					),
-					'strip_tool_results' => array(
-						'required' => false,
-						'type'     => 'boolean',
-						'default'  => false,
-					),
-					'message_index'      => array(
-						'required'          => false,
-						'type'              => 'integer',
-						'sanitize_callback' => 'absint',
-						'default'           => -1,
-					),
-				),
-			)
-		);
-
-		register_rest_route(
-			self::NAMESPACE,
-			'/feedback/send',
-			array(
-				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_send' ),
-				'permission_callback' => array( $instance, 'check_chat_permission' ),
-				'args'                => array(
-					'report_type'        => array(
-						'required'          => true,
-						'type'              => 'string',
-						'sanitize_callback' => 'sanitize_text_field',
-					),
-					'user_description'   => array(
-						'required'          => false,
-						'type'              => 'string',
-						'default'           => '',
-						'sanitize_callback' => 'sanitize_textarea_field',
-					),
-					'session_id'         => array(
-						'required'          => false,
-						'type'              => 'integer',
-						'sanitize_callback' => 'absint',
-					),
-					'strip_tool_results' => array(
-						'required' => false,
-						'type'     => 'boolean',
-						'default'  => false,
-					),
-					'message_index'      => array(
-						'required'          => false,
-						'type'              => 'integer',
-						'sanitize_callback' => 'absint',
-						'default'           => -1,
-					),
-				),
-			)
-		);
-	}
 
 	/**
 	 * Handle GET /feedback/preview — return the sanitized payload for modal preview.
 	 *
-	 * Returns:
-	 *   - summary  (message_count, tool_call_count, environment_keys, model_id, …)
-	 *   - payload  (full sanitized report, suitable for JSON display)
-	 *
-	 * When message_index >= 0, only the targeted message ± 2 surrounding messages
+	 * When message_index >= 0, only the targeted message +/- 2 surrounding messages
 	 * are included (thumbs-down scoped context, t186).
 	 *
 	 * @param WP_REST_Request $request REST request.
 	 * @return WP_REST_Response|WP_Error
 	 */
+	#[REST_Route(
+		route: 'preview',
+		methods: WP_REST_Server::READABLE,
+		vars: 'get_preview_args',
+		guard: 'check_chat_permission',
+	)]
 	public function handle_preview( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$session_id         = (int) $request->get_param( 'session_id' );
 		$strip_tool_results = (bool) $request->get_param( 'strip_tool_results' );
@@ -134,7 +73,6 @@ class FeedbackController {
 			);
 		}
 
-		// Build the sanitized payload for the collapsible preview section.
 		$raw_payload = ReportBuilder::build(
 			$session_id,
 			'preview',
@@ -165,12 +103,18 @@ class FeedbackController {
 	/**
 	 * Handle POST /feedback/send — build, sanitize, and forward the report.
 	 *
-	 * When message_index >= 0, only the targeted message ± 2 surrounding messages
+	 * When message_index >= 0, only the targeted message +/- 2 surrounding messages
 	 * are included in the report (thumbs-down scoped context, t186).
 	 *
 	 * @param WP_REST_Request $request REST request.
 	 * @return WP_REST_Response|WP_Error
 	 */
+	#[REST_Route(
+		route: 'send',
+		methods: WP_REST_Server::CREATABLE,
+		vars: 'get_send_args',
+		guard: 'check_chat_permission',
+	)]
 	public function handle_send( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$report_type        = (string) $request->get_param( 'report_type' );
 		$user_description   = (string) $request->get_param( 'user_description' );
@@ -178,8 +122,6 @@ class FeedbackController {
 		$strip_tool_results = (bool) $request->get_param( 'strip_tool_results' );
 		$message_index      = (int) $request->get_param( 'message_index' );
 
-		// When a session_id is provided, build a rich payload; otherwise send a
-		// minimal report (for cases where no session is active yet, e.g. onboarding).
 		if ( $session_id > 0 ) {
 			$payload = ReportBuilder::build(
 				$session_id,
@@ -210,7 +152,6 @@ class FeedbackController {
 		$result    = ReportSender::send( $sanitized );
 
 		if ( is_wp_error( $result ) ) {
-			// Map well-known error codes to appropriate HTTP status codes.
 			$http_status = 500;
 			$error_code  = $result->get_error_code();
 
@@ -226,5 +167,68 @@ class FeedbackController {
 		}
 
 		return new WP_REST_Response( array( 'success' => true ), 200 );
+	}
+
+	/**
+	 * Schema arguments for GET /feedback/preview.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_preview_args(): array {
+		return array(
+			'session_id'         => array(
+				'required'          => true,
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+			),
+			'strip_tool_results' => array(
+				'required' => false,
+				'type'     => 'boolean',
+				'default'  => false,
+			),
+			'message_index'      => array(
+				'required'          => false,
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+				'default'           => -1,
+			),
+		);
+	}
+
+	/**
+	 * Schema arguments for POST /feedback/send.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_send_args(): array {
+		return array(
+			'report_type'        => array(
+				'required'          => true,
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'user_description'   => array(
+				'required'          => false,
+				'type'              => 'string',
+				'default'           => '',
+				'sanitize_callback' => 'sanitize_textarea_field',
+			),
+			'session_id'         => array(
+				'required'          => false,
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+			),
+			'strip_tool_results' => array(
+				'required' => false,
+				'type'     => 'boolean',
+				'default'  => false,
+			),
+			'message_index'      => array(
+				'required'          => false,
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+				'default'           => -1,
+			),
+		);
 	}
 }

--- a/includes/REST/FeedbackController.php
+++ b/includes/REST/FeedbackController.php
@@ -23,9 +23,8 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
-use XWP\DI\Decorators\REST_Handler;
-use XWP\DI\Decorators\REST_Route;
-use XWP_REST_Controller;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -33,15 +32,47 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Manages feedback report preview and submission.
+ *
+ * Uses #[Handler] + INIT_IMMEDIATELY so register_routes() is called directly
+ * on rest_api_init, which is the only strategy that works in the PHPUnit test
+ * environment (the #[REST_Handler] INIT_DEFFERED path fails to fire its
+ * do_action chain when rest_api_init is manually triggered by test setUp()).
  */
-#[REST_Handler(
-	namespace: RestController::NAMESPACE,
-	basename: 'feedback',
+#[Handler(
 	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
 )]
-final class FeedbackController extends XWP_REST_Controller {
+final class FeedbackController {
 
 	use PermissionTrait;
+
+	/**
+	 * Register REST routes for feedback endpoints.
+	 */
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/feedback/preview',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'handle_preview' ),
+				'permission_callback' => array( $this, 'check_chat_permission' ),
+				'args'                => $this->get_preview_args(),
+			)
+		);
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/feedback/send',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'handle_send' ),
+				'permission_callback' => array( $this, 'check_chat_permission' ),
+				'args'                => $this->get_send_args(),
+			)
+		);
+	}
 
 	/**
 	 * Handle GET /feedback/preview — return the sanitized payload for modal preview.
@@ -52,12 +83,6 @@ final class FeedbackController extends XWP_REST_Controller {
 	 * @param WP_REST_Request $request REST request.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	#[REST_Route(
-		route: 'preview',
-		methods: WP_REST_Server::READABLE,
-		vars: 'get_preview_args',
-		guard: 'check_chat_permission',
-	)]
 	public function handle_preview( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$session_id         = (int) $request->get_param( 'session_id' );
 		$strip_tool_results = (bool) $request->get_param( 'strip_tool_results' );
@@ -109,12 +134,6 @@ final class FeedbackController extends XWP_REST_Controller {
 	 * @param WP_REST_Request $request REST request.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	#[REST_Route(
-		route: 'send',
-		methods: WP_REST_Server::CREATABLE,
-		vars: 'get_send_args',
-		guard: 'check_chat_permission',
-	)]
 	public function handle_send( WP_REST_Request $request ): WP_REST_Response|WP_Error {
 		$report_type        = (string) $request->get_param( 'report_type' );
 		$user_description   = (string) $request->get_param( 'user_description' );

--- a/includes/REST/KnowledgeController.php
+++ b/includes/REST/KnowledgeController.php
@@ -16,33 +16,45 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
-class KnowledgeController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manages knowledge collections, sources, search, stats, and upload via REST.
+ */
+#[Handler(
+	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class KnowledgeController {
 
 	use PermissionTrait;
-
-	const NAMESPACE = 'gratis-ai-agent/v1';
 
 	/**
 	 * Register REST routes.
 	 */
-	public static function register_routes(): void {
-		$instance = new self();
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
 
 		// Knowledge endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/knowledge/collections',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_list_collections' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_list_collections' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 				),
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_create_collection' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_create_collection' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'name'          => array(
 							'required'          => true,
@@ -76,13 +88,13 @@ class KnowledgeController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/knowledge/collections/(?P<id>\d+)',
 			array(
 				array(
 					'methods'             => 'PATCH',
-					'callback'            => array( $instance, 'handle_update_collection' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_update_collection' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id'            => array(
 							'required'          => true,
@@ -111,8 +123,8 @@ class KnowledgeController {
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $instance, 'handle_delete_collection' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_delete_collection' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -125,12 +137,12 @@ class KnowledgeController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/knowledge/collections/(?P<id>\d+)/sources',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_list_sources' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_list_sources' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'id' => array(
 						'required'          => true,
@@ -142,12 +154,12 @@ class KnowledgeController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/knowledge/collections/(?P<id>\d+)/index',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_index_collection' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_index_collection' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'id' => array(
 						'required'          => true,
@@ -159,22 +171,22 @@ class KnowledgeController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/knowledge/upload',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_knowledge_upload' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_knowledge_upload' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/knowledge/sources/(?P<id>\d+)',
 			array(
 				'methods'             => WP_REST_Server::DELETABLE,
-				'callback'            => array( $instance, 'handle_delete_source' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_delete_source' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'id' => array(
 						'required'          => true,
@@ -186,12 +198,12 @@ class KnowledgeController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/knowledge/search',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_knowledge_search' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_knowledge_search' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'q'          => array(
 						'required'          => true,
@@ -208,12 +220,12 @@ class KnowledgeController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/knowledge/stats',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_knowledge_stats' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_knowledge_stats' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 	}

--- a/includes/REST/McpController.php
+++ b/includes/REST/McpController.php
@@ -27,9 +27,8 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
-use XWP\DI\Decorators\REST_Handler;
-use XWP\DI\Decorators\REST_Route;
-use XWP_REST_Controller;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -37,18 +36,40 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Implements the MCP protocol over a single WordPress REST endpoint.
+ *
+ * Uses #[Handler] + INIT_IMMEDIATELY so register_routes() is called directly
+ * on rest_api_init, which is the only strategy that works in the PHPUnit test
+ * environment (the #[REST_Handler] INIT_DEFFERED path fails to fire its
+ * do_action chain when rest_api_init is manually triggered by test setUp()).
  */
-#[REST_Handler(
-	namespace: RestController::NAMESPACE,
-	basename: 'mcp',
+#[Handler(
 	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
 )]
-final class McpController extends XWP_REST_Controller {
+final class McpController {
 
 	/**
 	 * MCP protocol version advertised in responses.
 	 */
 	const MCP_PROTOCOL_VERSION = '2024-11-05';
+
+	/**
+	 * Register the MCP REST route.
+	 */
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/mcp',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'handle_request' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+				'args'                => $this->get_mcp_args(),
+			)
+		);
+	}
 
 	/**
 	 * Permission check — requires manage_options capability.
@@ -65,12 +86,6 @@ final class McpController extends XWP_REST_Controller {
 	 * @param WP_REST_Request $request The REST request.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	#[REST_Route(
-		route: '',
-		methods: WP_REST_Server::CREATABLE,
-		vars: 'get_mcp_args',
-		guard: 'check_permission',
-	)]
 	public function handle_request( WP_REST_Request $request ) {
 		$method = $request->get_param( 'method' );
 		$params = $request->get_param( 'params' );

--- a/includes/REST/McpController.php
+++ b/includes/REST/McpController.php
@@ -27,13 +27,23 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\REST_Handler;
+use XWP\DI\Decorators\REST_Route;
+use XWP_REST_Controller;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 /**
- * McpController class
- *
  * Implements the MCP protocol over a single WordPress REST endpoint.
  */
-class McpController {
+#[REST_Handler(
+	namespace: RestController::NAMESPACE,
+	basename: 'mcp',
+	container: 'gratis-ai-agent',
+)]
+final class McpController extends XWP_REST_Controller {
 
 	/**
 	 * MCP protocol version advertised in responses.
@@ -41,44 +51,11 @@ class McpController {
 	const MCP_PROTOCOL_VERSION = '2024-11-05';
 
 	/**
-	 * Register the /mcp REST route.
-	 */
-	public static function register_routes(): void {
-		register_rest_route(
-			RestController::NAMESPACE,
-			'/mcp',
-			[
-				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ __CLASS__, 'handle_request' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
-				'args'                => [
-					'method' => [
-						'required'          => true,
-						'type'              => 'string',
-						'sanitize_callback' => 'sanitize_text_field',
-						'description'       => 'MCP method: list_tools or call_tool.',
-					],
-					'params' => [
-						'required' => false,
-						'type'     => 'object',
-						'default'  => [],
-					],
-				],
-			]
-		);
-	}
-
-	/**
 	 * Permission check — requires manage_options capability.
-	 *
-	 * Satisfied by:
-	 *   - Cookie + nonce (browser / admin-ajax)
-	 *   - Application Password (HTTP Basic Auth)
-	 *   - Any other WP auth mechanism that sets the current user
 	 *
 	 * @return bool
 	 */
-	public static function check_permission(): bool {
+	public function check_permission(): bool {
 		return current_user_can( 'manage_options' );
 	}
 
@@ -88,7 +65,13 @@ class McpController {
 	 * @param WP_REST_Request $request The REST request.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public static function handle_request( WP_REST_Request $request ) {
+	#[REST_Route(
+		route: '',
+		methods: WP_REST_Server::CREATABLE,
+		vars: 'get_mcp_args',
+		guard: 'check_permission',
+	)]
+	public function handle_request( WP_REST_Request $request ) {
 		$method = $request->get_param( 'method' );
 		$params = $request->get_param( 'params' );
 
@@ -119,11 +102,28 @@ class McpController {
 	}
 
 	/**
-	 * Handle the list_tools MCP method.
+	 * Schema arguments for POST /mcp.
 	 *
-	 * Returns all registered WordPress abilities as MCP tool definitions.
-	 * Each tool definition includes name, description, and inputSchema
-	 * following the JSON Schema / OpenAI function-calling format.
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_mcp_args(): array {
+		return array(
+			'method' => array(
+				'required'          => true,
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+				'description'       => 'MCP method: list_tools or call_tool.',
+			),
+			'params' => array(
+				'required' => false,
+				'type'     => 'object',
+				'default'  => array(),
+			),
+		);
+	}
+
+	/**
+	 * Handle the list_tools MCP method.
 	 *
 	 * @return WP_REST_Response
 	 */
@@ -141,9 +141,6 @@ class McpController {
 
 	/**
 	 * Handle the call_tool MCP method.
-	 *
-	 * Executes a named ability with the provided arguments and returns
-	 * the result in MCP tool-result format.
 	 *
 	 * @param array<string, mixed> $params MCP params: { name: string, arguments?: object }.
 	 * @return WP_REST_Response|WP_Error
@@ -171,8 +168,6 @@ class McpController {
 			);
 		}
 
-		// MCP tool names use underscores; ability names use slashes and hyphens.
-		// Convert back: e.g. "ai_agent__memory_save" → "ai-agent/memory-save".
 		$ability_name = self::mcp_name_to_ability_name( $tool_name );
 		$ability      = wp_get_ability( $ability_name );
 
@@ -188,8 +183,6 @@ class McpController {
 			);
 		}
 
-		// execute() checks the ability's own permission_callback internally
-		// and returns WP_Error( 'ability_invalid_permissions', ... ) on failure.
 		$result = $ability->execute( ! empty( $arguments ) ? $arguments : null );
 
 		if ( is_wp_error( $result ) ) {
@@ -209,7 +202,6 @@ class McpController {
 			);
 		}
 
-		// Normalise result to a scalar or JSON-serialisable value.
 		$text = is_string( $result ) ? $result : wp_json_encode( $result );
 
 		return new WP_REST_Response(
@@ -246,18 +238,15 @@ class McpController {
 			$description  = $ability->get_description();
 			$input_schema = $ability->get_input_schema();
 
-			// Ensure inputSchema is a valid JSON Schema object.
 			if ( empty( $input_schema ) || ! is_array( $input_schema ) ) {
 				$input_schema = [
 					'type'       => 'object',
 					'properties' => new \stdClass(),
 				];
 			} else {
-				// Normalise empty properties arrays to objects (JSON Schema requires {}).
 				if ( isset( $input_schema['properties'] ) && $input_schema['properties'] === [] ) {
 					$input_schema['properties'] = new \stdClass();
 				}
-				// Remove empty required arrays (some clients reject them).
 				if ( isset( $input_schema['required'] ) && is_array( $input_schema['required'] ) && empty( $input_schema['required'] ) ) {
 					unset( $input_schema['required'] );
 				}
@@ -276,12 +265,6 @@ class McpController {
 	/**
 	 * Convert a WordPress ability name to an MCP-safe tool name.
 	 *
-	 * MCP tool names must match [a-zA-Z0-9_-]+.
-	 * Ability names use the format "namespace/tool-name" (slash + hyphens).
-	 *
-	 * Conversion: "ai-agent/memory-save" → "ai-agent__memory-save"
-	 * (slash replaced with double-underscore; hyphens preserved)
-	 *
 	 * @param string $ability_name WordPress ability name.
 	 * @return string MCP tool name.
 	 */
@@ -291,9 +274,6 @@ class McpController {
 
 	/**
 	 * Convert an MCP tool name back to a WordPress ability name.
-	 *
-	 * Reverses ability_name_to_mcp_name():
-	 * "ai-agent__memory-save" → "ai-agent/memory-save"
 	 *
 	 * @param string $mcp_name MCP tool name.
 	 * @return string WordPress ability name.

--- a/includes/REST/MemoryController.php
+++ b/includes/REST/MemoryController.php
@@ -15,9 +15,8 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
-use XWP\DI\Decorators\REST_Handler;
-use XWP\DI\Decorators\REST_Route;
-use XWP_REST_Controller;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -32,15 +31,72 @@ if ( ! defined( 'ABSPATH' ) ) {
  *  PATCH  /memory/{id}   — update a memory
  *  DELETE /memory/{id}   — delete a memory
  *  POST   /memory/forget — bulk-delete by topic
+ *
+ * Uses #[Handler] + INIT_IMMEDIATELY so register_routes() is called directly
+ * on rest_api_init, which is the only strategy that works in the PHPUnit test
+ * environment (the #[REST_Handler] INIT_DEFFERED path fails to fire its
+ * do_action chain when rest_api_init is manually triggered by test setUp()).
  */
-#[REST_Handler(
-	namespace: RestController::NAMESPACE,
-	basename: 'memory',
+#[Handler(
 	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
 )]
-final class MemoryController extends XWP_REST_Controller {
+final class MemoryController {
 
 	use PermissionTrait;
+
+	/**
+	 * Register REST routes for memory management.
+	 */
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/memory',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'handle_list_memory' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'handle_create_memory' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+					'args'                => $this->get_create_args(),
+				),
+			)
+		);
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/memory/forget',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'handle_forget_memory' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+				'args'                => $this->get_forget_args(),
+			)
+		);
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/memory/(?P<id>\d+)',
+			array(
+				array(
+					'methods'             => 'PATCH',
+					'callback'            => array( $this, 'handle_update_memory' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+					'args'                => $this->get_update_args(),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'handle_delete_memory' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+					'args'                => $this->get_delete_args(),
+				),
+			)
+		);
+	}
 
 	/**
 	 * Handle GET /memory — list memories.
@@ -48,11 +104,6 @@ final class MemoryController extends XWP_REST_Controller {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response
 	 */
-	#[REST_Route(
-		route: '',
-		methods: WP_REST_Server::READABLE,
-		guard: 'check_permission',
-	)]
 	public function handle_list_memory( WP_REST_Request $request ): WP_REST_Response {
 		$category = $request->get_param( 'category' );
 		// @phpstan-ignore-next-line
@@ -85,12 +136,6 @@ final class MemoryController extends XWP_REST_Controller {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	#[REST_Route(
-		route: '',
-		methods: WP_REST_Server::CREATABLE,
-		vars: 'get_create_args',
-		guard: 'check_permission',
-	)]
 	public function handle_create_memory( WP_REST_Request $request ) {
 		$category = $request->get_param( 'category' );
 		$content  = $request->get_param( 'content' );
@@ -118,12 +163,6 @@ final class MemoryController extends XWP_REST_Controller {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	#[REST_Route(
-		route: '(?P<id>\d+)',
-		methods: 'PATCH',
-		vars: 'get_update_args',
-		guard: 'check_permission',
-	)]
 	public function handle_update_memory( WP_REST_Request $request ) {
 		$id   = self::get_int_param( $request, 'id' );
 		$data = array();
@@ -156,12 +195,6 @@ final class MemoryController extends XWP_REST_Controller {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	#[REST_Route(
-		route: '(?P<id>\d+)',
-		methods: WP_REST_Server::DELETABLE,
-		vars: 'get_delete_args',
-		guard: 'check_permission',
-	)]
 	public function handle_delete_memory( WP_REST_Request $request ) {
 		$id      = self::get_int_param( $request, 'id' );
 		$deleted = Memory::delete( $id );
@@ -179,12 +212,6 @@ final class MemoryController extends XWP_REST_Controller {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response
 	 */
-	#[REST_Route(
-		route: 'forget',
-		methods: WP_REST_Server::CREATABLE,
-		vars: 'get_forget_args',
-		guard: 'check_permission',
-	)]
 	public function handle_forget_memory( WP_REST_Request $request ): WP_REST_Response {
 		$topic = $request->get_param( 'topic' );
 		// @phpstan-ignore-next-line

--- a/includes/REST/MemoryController.php
+++ b/includes/REST/MemoryController.php
@@ -15,114 +15,44 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\REST_Handler;
+use XWP\DI\Decorators\REST_Route;
+use XWP_REST_Controller;
 
-class MemoryController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manages agent memories via REST.
+ *
+ * Endpoints:
+ *  GET    /memory        — list all memories (optionally filtered by category)
+ *  POST   /memory        — create a memory
+ *  PATCH  /memory/{id}   — update a memory
+ *  DELETE /memory/{id}   — delete a memory
+ *  POST   /memory/forget — bulk-delete by topic
+ */
+#[REST_Handler(
+	namespace: RestController::NAMESPACE,
+	basename: 'memory',
+	container: 'gratis-ai-agent',
+)]
+final class MemoryController extends XWP_REST_Controller {
 
 	use PermissionTrait;
-
-	const NAMESPACE = 'gratis-ai-agent/v1';
-
-	/**
-	 * Register REST routes.
-	 */
-	public static function register_routes(): void {
-		$instance = new self();
-
-		// Memory endpoints.
-		register_rest_route(
-			self::NAMESPACE,
-			'/memory',
-			array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_list_memory' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
-				),
-				array(
-					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_create_memory' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
-					'args'                => array(
-						'category' => array(
-							'required'          => true,
-							'type'              => 'string',
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-						'content'  => array(
-							'required'          => true,
-							'type'              => 'string',
-							'sanitize_callback' => 'sanitize_textarea_field',
-						),
-					),
-				),
-			)
-		);
-
-		register_rest_route(
-			self::NAMESPACE,
-			'/memory/(?P<id>\d+)',
-			array(
-				array(
-					'methods'             => 'PATCH',
-					'callback'            => array( $instance, 'handle_update_memory' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
-					'args'                => array(
-						'id'       => array(
-							'required'          => true,
-							'type'              => 'integer',
-							'sanitize_callback' => 'absint',
-						),
-						'category' => array(
-							'required'          => false,
-							'type'              => 'string',
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-						'content'  => array(
-							'required'          => false,
-							'type'              => 'string',
-							'sanitize_callback' => 'sanitize_textarea_field',
-						),
-					),
-				),
-				array(
-					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $instance, 'handle_delete_memory' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
-					'args'                => array(
-						'id' => array(
-							'required'          => true,
-							'type'              => 'integer',
-							'sanitize_callback' => 'absint',
-						),
-					),
-				),
-			)
-		);
-
-		// Memory forget endpoint.
-		register_rest_route(
-			self::NAMESPACE,
-			'/memory/forget',
-			array(
-				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_forget_memory' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
-				'args'                => array(
-					'topic' => array(
-						'required'          => true,
-						'type'              => 'string',
-						'sanitize_callback' => 'sanitize_text_field',
-					),
-				),
-			)
-		);
-	}
 
 	/**
 	 * Handle GET /memory — list memories.
 	 *
 	 * @param WP_REST_Request $request The request object.
+	 * @return WP_REST_Response
 	 */
+	#[REST_Route(
+		route: '',
+		methods: WP_REST_Server::READABLE,
+		guard: 'check_permission',
+	)]
 	public function handle_list_memory( WP_REST_Request $request ): WP_REST_Response {
 		$category = $request->get_param( 'category' );
 		// @phpstan-ignore-next-line
@@ -155,6 +85,12 @@ class MemoryController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
+	#[REST_Route(
+		route: '',
+		methods: WP_REST_Server::CREATABLE,
+		vars: 'get_create_args',
+		guard: 'check_permission',
+	)]
 	public function handle_create_memory( WP_REST_Request $request ) {
 		$category = $request->get_param( 'category' );
 		$content  = $request->get_param( 'content' );
@@ -182,6 +118,12 @@ class MemoryController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
+	#[REST_Route(
+		route: '(?P<id>\d+)',
+		methods: 'PATCH',
+		vars: 'get_update_args',
+		guard: 'check_permission',
+	)]
 	public function handle_update_memory( WP_REST_Request $request ) {
 		$id   = self::get_int_param( $request, 'id' );
 		$data = array();
@@ -214,6 +156,12 @@ class MemoryController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
+	#[REST_Route(
+		route: '(?P<id>\d+)',
+		methods: WP_REST_Server::DELETABLE,
+		vars: 'get_delete_args',
+		guard: 'check_permission',
+	)]
 	public function handle_delete_memory( WP_REST_Request $request ) {
 		$id      = self::get_int_param( $request, 'id' );
 		$deleted = Memory::delete( $id );
@@ -231,6 +179,12 @@ class MemoryController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response
 	 */
+	#[REST_Route(
+		route: 'forget',
+		methods: WP_REST_Server::CREATABLE,
+		vars: 'get_forget_args',
+		guard: 'check_permission',
+	)]
 	public function handle_forget_memory( WP_REST_Request $request ): WP_REST_Response {
 		$topic = $request->get_param( 'topic' );
 		// @phpstan-ignore-next-line
@@ -242,6 +196,81 @@ class MemoryController {
 				'topic'   => $topic,
 			),
 			200
+		);
+	}
+
+	/**
+	 * Schema arguments for POST /memory (create).
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_create_args(): array {
+		return array(
+			'category' => array(
+				'required'          => true,
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'content'  => array(
+				'required'          => true,
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_textarea_field',
+			),
+		);
+	}
+
+	/**
+	 * Schema arguments for PATCH /memory/{id} (update).
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_update_args(): array {
+		return array(
+			'id'       => array(
+				'required'          => true,
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+			),
+			'category' => array(
+				'required'          => false,
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'content'  => array(
+				'required'          => false,
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_textarea_field',
+			),
+		);
+	}
+
+	/**
+	 * Schema arguments for DELETE /memory/{id}.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_delete_args(): array {
+		return array(
+			'id' => array(
+				'required'          => true,
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+			),
+		);
+	}
+
+	/**
+	 * Schema arguments for POST /memory/forget.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_forget_args(): array {
+		return array(
+			'topic' => array(
+				'required'          => true,
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
 		);
 	}
 }

--- a/includes/REST/ResaleApiController.php
+++ b/includes/REST/ResaleApiController.php
@@ -37,25 +37,37 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
-class ResaleApiController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
-	const NAMESPACE = 'gratis-ai-agent/v1';
+/**
+ * Manages resale API clients and proxy endpoint via REST.
+ */
+#[Handler(
+	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class ResaleApiController {
 
 	/**
 	 * Register all resale API REST routes.
 	 */
-	public static function register_routes(): void {
-		$instance = new self();
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
 
 		// ─── Proxy endpoint ──────────────────────────────────────────
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/resale/proxy',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ $instance, 'handle_proxy' ],
-				'permission_callback' => [ $instance, 'check_resale_permission' ],
+				'callback'            => [ $this, 'handle_proxy' ],
+				'permission_callback' => [ $this, 'check_resale_permission' ],
 				'args'                => [
 					'model'       => [
 						'required'          => false,
@@ -86,18 +98,18 @@ class ResaleApiController {
 
 		// ─── Admin CRUD endpoints ────────────────────────────────────
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/resale/clients',
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ $instance, 'handle_list_clients' ],
-					'permission_callback' => [ $instance, 'check_admin_permission' ],
+					'callback'            => [ $this, 'handle_list_clients' ],
+					'permission_callback' => [ $this, 'check_admin_permission' ],
 				],
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ $instance, 'handle_create_client' ],
-					'permission_callback' => [ $instance, 'check_admin_permission' ],
+					'callback'            => [ $this, 'handle_create_client' ],
+					'permission_callback' => [ $this, 'check_admin_permission' ],
 					'args'                => [
 						'name'                => [
 							'required'          => true,
@@ -137,13 +149,13 @@ class ResaleApiController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/resale/clients/(?P<id>\d+)',
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ $instance, 'handle_get_client' ],
-					'permission_callback' => [ $instance, 'check_admin_permission' ],
+					'callback'            => [ $this, 'handle_get_client' ],
+					'permission_callback' => [ $this, 'check_admin_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -154,8 +166,8 @@ class ResaleApiController {
 				],
 				[
 					'methods'             => 'PATCH',
-					'callback'            => [ $instance, 'handle_update_client' ],
-					'permission_callback' => [ $instance, 'check_admin_permission' ],
+					'callback'            => [ $this, 'handle_update_client' ],
+					'permission_callback' => [ $this, 'check_admin_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -166,8 +178,8 @@ class ResaleApiController {
 				],
 				[
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => [ $instance, 'handle_delete_client' ],
-					'permission_callback' => [ $instance, 'check_admin_permission' ],
+					'callback'            => [ $this, 'handle_delete_client' ],
+					'permission_callback' => [ $this, 'check_admin_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -180,12 +192,12 @@ class ResaleApiController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/resale/clients/(?P<id>\d+)/rotate-key',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ $instance, 'handle_rotate_key' ],
-				'permission_callback' => [ $instance, 'check_admin_permission' ],
+				'callback'            => [ $this, 'handle_rotate_key' ],
+				'permission_callback' => [ $this, 'check_admin_permission' ],
 				'args'                => [
 					'id' => [
 						'required'          => true,
@@ -197,12 +209,12 @@ class ResaleApiController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/resale/clients/(?P<id>\d+)/usage',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ $instance, 'handle_get_usage' ],
-				'permission_callback' => [ $instance, 'check_admin_permission' ],
+				'callback'            => [ $this, 'handle_get_usage' ],
+				'permission_callback' => [ $this, 'check_admin_permission' ],
 				'args'                => [
 					'id'     => [
 						'required'          => true,
@@ -226,12 +238,12 @@ class ResaleApiController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/resale/clients/(?P<id>\d+)/usage/summary',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ $instance, 'handle_get_usage_summary' ],
-				'permission_callback' => [ $instance, 'check_admin_permission' ],
+				'callback'            => [ $this, 'handle_get_usage_summary' ],
+				'permission_callback' => [ $this, 'check_admin_permission' ],
 				'args'                => [
 					'id'         => [
 						'required'          => true,
@@ -591,7 +603,7 @@ class ResaleApiController {
 		// Return the API key on creation only — it is never returned again.
 		$response              = $this->sanitize_client_for_response( $client );
 		$response['api_key']   = $api_key;
-		$response['proxy_url'] = rest_url( self::NAMESPACE . '/resale/proxy' );
+		$response['proxy_url'] = rest_url( RestController::NAMESPACE . '/resale/proxy' );
 
 		return new WP_REST_Response( $response, 201 );
 	}
@@ -616,7 +628,7 @@ class ResaleApiController {
 		}
 
 		$response              = $this->sanitize_client_for_response( $client );
-		$response['proxy_url'] = rest_url( self::NAMESPACE . '/resale/proxy' );
+		$response['proxy_url'] = rest_url( RestController::NAMESPACE . '/resale/proxy' );
 
 		return new WP_REST_Response( $response, 200 );
 	}
@@ -688,7 +700,7 @@ class ResaleApiController {
 		}
 
 		$response              = $this->sanitize_client_for_response( $client );
-		$response['proxy_url'] = rest_url( self::NAMESPACE . '/resale/proxy' );
+		$response['proxy_url'] = rest_url( RestController::NAMESPACE . '/resale/proxy' );
 
 		return new WP_REST_Response( $response, 200 );
 	}

--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -63,8 +63,7 @@ class RestController {
 	 * Delegates to domain controllers and registers the /chat endpoint here.
 	 */
 	public static function register_routes(): void {
-		// MCP (Model Context Protocol) endpoint.
-		McpController::register_routes();
+		// McpController and BenchmarkController are now DI-managed #[REST_Handler] classes.
 
 		// Webhook API endpoints.
 		WebhookController::register_routes();
@@ -72,17 +71,16 @@ class RestController {
 		// Resale API endpoints.
 		ResaleApiController::register_routes();
 
-		// Domain controllers.
+		// Domain controllers — migrating to DI-managed #[REST_Handler] classes.
+		// Already migrated: MemoryController, SkillController, FeedbackController,
+		// McpController, BenchmarkController, TraceController.
 		SessionController::register_routes();
 		SettingsController::register_routes();
-		MemoryController::register_routes();
-		SkillController::register_routes();
 		AutomationController::register_routes();
 		KnowledgeController::register_routes();
 		ToolController::register_routes();
 		ChangesController::register_routes();
 		AgentController::register_routes();
-		FeedbackController::register_routes();
 
 		$instance = new self();
 

--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -38,8 +38,24 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
-class RestController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Core REST controller — holds the shared NAMESPACE constant and the
+ * /chat/tool-result endpoint. All domain controllers are now DI-managed
+ * and self-register via their own #[Handler] / #[REST_Handler] attributes.
+ */
+#[Handler(
+	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class RestController {
 
 	use PermissionTrait;
 
@@ -55,34 +71,14 @@ class RestController {
 	 */
 	const JOB_TTL = 600;
 
-
-
 	/**
-	 * Register REST routes.
+	 * Register the /chat/tool-result endpoint.
 	 *
-	 * Delegates to domain controllers and registers the /chat endpoint here.
+	 * All domain controllers are now DI-managed and register their own
+	 * routes via #[REST_Handler] or #[Handler] + #[Action(rest_api_init)].
 	 */
-	public static function register_routes(): void {
-		// McpController and BenchmarkController are now DI-managed #[REST_Handler] classes.
-
-		// Webhook API endpoints.
-		WebhookController::register_routes();
-
-		// Resale API endpoints.
-		ResaleApiController::register_routes();
-
-		// Domain controllers — migrating to DI-managed #[REST_Handler] classes.
-		// Already migrated: MemoryController, SkillController, FeedbackController,
-		// McpController, BenchmarkController, TraceController.
-		SessionController::register_routes();
-		SettingsController::register_routes();
-		AutomationController::register_routes();
-		KnowledgeController::register_routes();
-		ToolController::register_routes();
-		ChangesController::register_routes();
-		AgentController::register_routes();
-
-		$instance = new self();
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
 
 		// Client tool result endpoint — resumes the agent loop after the browser
 		// has executed client-side tool calls and POSTs the results back.
@@ -92,7 +88,7 @@ class RestController {
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( __CLASS__, 'handle_tool_result' ),
-				'permission_callback' => array( $instance, 'check_chat_permission' ),
+				'permission_callback' => array( $this, 'check_chat_permission' ),
 				'args'                => array(
 					'session_id'   => array(
 						'required'          => true,

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -23,12 +23,28 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
-class SessionController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manages sessions, messages, folders, sharing, export/import, site-builder,
+ * job-status, process, and tool confirmation via REST.
+ *
+ * Uses #[Handler] + #[Action] because this controller serves multiple
+ * basenames (/sessions, /run, /process, /job, /site-builder).
+ */
+#[Handler(
+	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class SessionController {
 
 	use PermissionTrait;
-
-	const NAMESPACE = 'gratis-ai-agent/v1';
 
 	/** @var Settings Injected settings dependency. */
 	private Settings $settings;
@@ -50,18 +66,18 @@ class SessionController {
 	/**
 	 * Register REST routes.
 	 */
-	public static function register_routes(): void {
-		$instance = new self();
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
 
 		// Sessions endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/sessions',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_list_sessions' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_list_sessions' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'status' => array(
 							'required'          => false,
@@ -87,8 +103,8 @@ class SessionController {
 				),
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_create_session' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_create_session' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'title'       => array(
 							'required'          => false,
@@ -120,22 +136,22 @@ class SessionController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/sessions/folders',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_list_folders' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_list_folders' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/sessions/bulk',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_bulk_sessions' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_bulk_sessions' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'ids'    => array(
 						'required' => true,
@@ -156,23 +172,23 @@ class SessionController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/sessions/trash',
 			array(
 				'methods'             => WP_REST_Server::DELETABLE,
-				'callback'            => array( $instance, 'handle_empty_trash' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_empty_trash' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/sessions/(?P<id>\d+)',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_get_session' ),
-					'permission_callback' => array( $instance, 'check_session_permission' ),
+					'callback'            => array( $this, 'handle_get_session' ),
+					'permission_callback' => array( $this, 'check_session_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -183,8 +199,8 @@ class SessionController {
 				),
 				array(
 					'methods'             => 'PATCH',
-					'callback'            => array( $instance, 'handle_update_session' ),
-					'permission_callback' => array( $instance, 'check_session_permission' ),
+					'callback'            => array( $this, 'handle_update_session' ),
+					'permission_callback' => array( $this, 'check_session_permission' ),
 					'args'                => array(
 						'id'     => array(
 							'required'          => true,
@@ -214,8 +230,8 @@ class SessionController {
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $instance, 'handle_delete_session' ),
-					'permission_callback' => array( $instance, 'check_session_permission' ),
+					'callback'            => array( $this, 'handle_delete_session' ),
+					'permission_callback' => array( $this, 'check_session_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -229,12 +245,12 @@ class SessionController {
 
 		// Export endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/sessions/(?P<id>\d+)/export',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_export_session' ),
-				'permission_callback' => array( $instance, 'check_session_permission' ),
+				'callback'            => array( $this, 'handle_export_session' ),
+				'permission_callback' => array( $this, 'check_session_permission' ),
 				'args'                => array(
 					'id'     => array(
 						'required'          => true,
@@ -253,35 +269,35 @@ class SessionController {
 
 		// Import endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/sessions/import',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_import_session' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_import_session' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		// Shared sessions list endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/sessions/shared',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_list_shared_sessions' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_list_shared_sessions' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		// Share / unshare a session.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/sessions/(?P<id>\d+)/share',
 			array(
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_share_session' ),
-					'permission_callback' => array( $instance, 'check_session_owner_permission' ),
+					'callback'            => array( $this, 'handle_share_session' ),
+					'permission_callback' => array( $this, 'check_session_owner_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -292,8 +308,8 @@ class SessionController {
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $instance, 'handle_unshare_session' ),
-					'permission_callback' => array( $instance, 'check_session_owner_permission' ),
+					'callback'            => array( $this, 'handle_unshare_session' ),
+					'permission_callback' => array( $this, 'check_session_owner_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -307,12 +323,12 @@ class SessionController {
 
 		// Job status endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/job/(?P<id>[a-f0-9-]+)',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_job_status' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_job_status' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'id' => array(
 						'required'          => true,
@@ -325,12 +341,12 @@ class SessionController {
 
 		// Process endpoint (background worker).
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/process',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_process' ),
-				'permission_callback' => array( $instance, 'check_process_permission' ),
+				'callback'            => array( $this, 'handle_process' ),
+				'permission_callback' => array( $this, 'check_process_permission' ),
 				'args'                => array(
 					'job_id' => array(
 						'required'          => true,
@@ -348,12 +364,12 @@ class SessionController {
 
 		// Run endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/run',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_run' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_run' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'message'            => array(
 						'required'          => true,
@@ -423,12 +439,12 @@ class SessionController {
 
 		// Tool confirmation endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/job/(?P<id>[a-f0-9-]+)/confirm',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_confirm_tool' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_confirm_tool' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'id'           => array(
 						'required'          => true,
@@ -445,12 +461,12 @@ class SessionController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/job/(?P<id>[a-f0-9-]+)/reject',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_reject_tool' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_reject_tool' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'id' => array(
 						'required'          => true,
@@ -463,12 +479,12 @@ class SessionController {
 
 		// Interrupt endpoint — inject a user message into a running job.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/job/(?P<id>[a-f0-9-]+)/interrupt',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_interrupt' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_interrupt' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'id'      => array(
 						'required'          => true,
@@ -486,22 +502,22 @@ class SessionController {
 
 		// Site builder endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/site-builder/start',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_site_builder_start' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_site_builder_start' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/site-builder/status',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_site_builder_status' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_site_builder_status' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 	}
@@ -1117,7 +1133,7 @@ class SessionController {
 
 		// Spawn background worker.
 		wp_remote_post(
-			rest_url( self::NAMESPACE . '/process' ),
+			rest_url( RestController::NAMESPACE . '/process' ),
 			array(
 				'timeout'  => 0.01,
 				'blocking' => false,
@@ -1148,9 +1164,9 @@ class SessionController {
 	 * Creates a job, spawns a background worker, and returns immediately.
 	 *
 	 * @param WP_REST_Request $request The request object.
-	 * @return WP_REST_Response|WP_Error
+	 * @return WP_REST_Response
 	 */
-	public function handle_run( WP_REST_Request $request ) {
+	public function handle_run( WP_REST_Request $request ): WP_REST_Response {
 		$job_id = wp_generate_uuid4();
 		$token  = wp_generate_password( 40, false );
 
@@ -1186,7 +1202,7 @@ class SessionController {
 
 		// Spawn background worker via non-blocking loopback.
 		wp_remote_post(
-			rest_url( self::NAMESPACE . '/process' ),
+			rest_url( RestController::NAMESPACE . '/process' ),
 			array(
 				'timeout'  => 0.01,
 				'blocking' => false,

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -23,12 +23,27 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
-class SettingsController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manages settings, providers, budget, usage, roles, and alerts via REST.
+ *
+ * Uses #[Handler] + #[Action] because this controller serves multiple
+ * basenames (/settings, /providers, /budget, /usage, /role-permissions, etc.).
+ */
+#[Handler(
+	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class SettingsController {
 
 	use PermissionTrait;
-
-	const NAMESPACE = 'gratis-ai-agent/v1';
 
 	/** @var Settings Injected settings dependency. */
 	private Settings $settings;
@@ -50,69 +65,69 @@ class SettingsController {
 	/**
 	 * Register REST routes.
 	 */
-	public static function register_routes(): void {
-		$instance = new self();
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
 
 		// Providers endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/providers',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_providers' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_providers' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		// Alerts endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/alerts',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_alerts' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_alerts' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		// WooCommerce store status endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/woocommerce/status',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_woocommerce_status' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_woocommerce_status' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		// Settings endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/settings',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_get_settings' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_get_settings' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 				),
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_update_settings' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_update_settings' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 				),
 			)
 		);
 
 		// Claude Max token endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/settings/claude-max-token',
 			array(
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_set_claude_max_token' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_set_claude_max_token' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'token' => array(
 							'required'          => true,
@@ -126,7 +141,7 @@ class SettingsController {
 
 		// Direct provider API key endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/settings/provider-key',
 			array(
 				array(
@@ -151,7 +166,7 @@ class SettingsController {
 
 		// Direct provider API key test endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/settings/provider-key/test',
 			array(
 				array(
@@ -176,18 +191,18 @@ class SettingsController {
 
 		// Role permissions endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/role-permissions',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_get_role_permissions' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_get_role_permissions' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 				),
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_update_role_permissions' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_update_role_permissions' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'permissions' => array(
 							'required' => true,
@@ -200,20 +215,20 @@ class SettingsController {
 
 		// Role permissions — available roles list.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/role-permissions/roles',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_get_roles' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_get_roles' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 				),
 			)
 		);
 
 		// Fresh install detection endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/fresh-install',
 			array(
 				array(
@@ -226,7 +241,7 @@ class SettingsController {
 
 		// Google Analytics credentials endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/settings/google-analytics',
 			array(
 				array(
@@ -260,7 +275,7 @@ class SettingsController {
 
 		// Google Search Console credentials endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/settings/gsc-credentials',
 			array(
 				array(
@@ -278,7 +293,7 @@ class SettingsController {
 
 		// Brave Search API key endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/settings/brave-search-key',
 			array(
 				array(
@@ -303,7 +318,7 @@ class SettingsController {
 
 		// Feedback receiver API key endpoint (t180).
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/settings/feedback-api-key',
 			array(
 				array(
@@ -328,12 +343,12 @@ class SettingsController {
 
 		// Usage endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/usage',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_get_usage' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_get_usage' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'period'     => array(
 						'required'          => false,
@@ -356,12 +371,12 @@ class SettingsController {
 
 		// Budget status endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/budget',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_get_budget' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_get_budget' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 	}

--- a/includes/REST/SkillController.php
+++ b/includes/REST/SkillController.php
@@ -15,135 +15,43 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\REST_Handler;
+use XWP\DI\Decorators\REST_Route;
+use XWP_REST_Controller;
 
-class SkillController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manages agent skills via REST.
+ *
+ * Endpoints:
+ *  GET    /skills            — list all skills
+ *  POST   /skills            — create a custom skill
+ *  PATCH  /skills/{id}       — update a skill
+ *  DELETE /skills/{id}       — delete a custom skill
+ *  POST   /skills/{id}/reset — reset a built-in skill to defaults
+ */
+#[REST_Handler(
+	namespace: RestController::NAMESPACE,
+	basename: 'skills',
+	container: 'gratis-ai-agent',
+)]
+final class SkillController extends XWP_REST_Controller {
 
 	use PermissionTrait;
-
-	const NAMESPACE = 'gratis-ai-agent/v1';
-
-	/**
-	 * Register REST routes.
-	 */
-	public static function register_routes(): void {
-		$instance = new self();
-
-		// Skills endpoints.
-		register_rest_route(
-			self::NAMESPACE,
-			'/skills',
-			array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_list_skills' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
-				),
-				array(
-					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_create_skill' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
-					'args'                => array(
-						'slug'        => array(
-							'required'          => true,
-							'type'              => 'string',
-							'sanitize_callback' => 'sanitize_title',
-						),
-						'name'        => array(
-							'required'          => true,
-							'type'              => 'string',
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-						'description' => array(
-							'required'          => false,
-							'type'              => 'string',
-							'default'           => '',
-							'sanitize_callback' => 'sanitize_textarea_field',
-						),
-						'content'     => array(
-							'required'          => true,
-							'type'              => 'string',
-							'sanitize_callback' => 'wp_kses_post',
-						),
-					),
-				),
-			)
-		);
-
-		register_rest_route(
-			self::NAMESPACE,
-			'/skills/(?P<id>\d+)',
-			array(
-				array(
-					'methods'             => 'PATCH',
-					'callback'            => array( $instance, 'handle_update_skill' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
-					'args'                => array(
-						'id'          => array(
-							'required'          => true,
-							'type'              => 'integer',
-							'sanitize_callback' => 'absint',
-						),
-						'name'        => array(
-							'required'          => false,
-							'type'              => 'string',
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-						'description' => array(
-							'required'          => false,
-							'type'              => 'string',
-							'sanitize_callback' => 'sanitize_textarea_field',
-						),
-						'content'     => array(
-							'required'          => false,
-							'type'              => 'string',
-							'sanitize_callback' => 'wp_kses_post',
-						),
-						'enabled'     => array(
-							'required' => false,
-							'type'     => 'boolean',
-						),
-					),
-				),
-				array(
-					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $instance, 'handle_delete_skill' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
-					'args'                => array(
-						'id' => array(
-							'required'          => true,
-							'type'              => 'integer',
-							'sanitize_callback' => 'absint',
-						),
-					),
-				),
-			)
-		);
-
-		register_rest_route(
-			self::NAMESPACE,
-			'/skills/(?P<id>\d+)/reset',
-			array(
-				array(
-					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_reset_skill' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
-					'args'                => array(
-						'id' => array(
-							'required'          => true,
-							'type'              => 'integer',
-							'sanitize_callback' => 'absint',
-						),
-					),
-				),
-			)
-		);
-	}
 
 	/**
 	 * Handle GET /skills — list all skills.
 	 *
 	 * @return WP_REST_Response
 	 */
+	#[REST_Route(
+		route: '',
+		methods: WP_REST_Server::READABLE,
+		guard: 'check_permission',
+	)]
 	public function handle_list_skills(): WP_REST_Response {
 		$skills = Skill::get_all();
 
@@ -184,6 +92,12 @@ class SkillController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
+	#[REST_Route(
+		route: '',
+		methods: WP_REST_Server::CREATABLE,
+		vars: 'get_create_args',
+		guard: 'check_permission',
+	)]
 	public function handle_create_skill( WP_REST_Request $request ) {
 		$slug = $request->get_param( 'slug' );
 
@@ -246,6 +160,12 @@ class SkillController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
+	#[REST_Route(
+		route: '(?P<id>\d+)',
+		methods: 'PATCH',
+		vars: 'get_update_args',
+		guard: 'check_permission',
+	)]
 	public function handle_update_skill( WP_REST_Request $request ) {
 		$id   = self::get_int_param( $request, 'id' );
 		$data = array();
@@ -302,6 +222,12 @@ class SkillController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
+	#[REST_Route(
+		route: '(?P<id>\d+)',
+		methods: WP_REST_Server::DELETABLE,
+		vars: 'get_id_args',
+		guard: 'check_permission',
+	)]
 	public function handle_delete_skill( WP_REST_Request $request ) {
 		$id     = self::get_int_param( $request, 'id' );
 		$result = Skill::delete( $id );
@@ -331,6 +257,12 @@ class SkillController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
+	#[REST_Route(
+		route: '(?P<id>\d+)/reset',
+		methods: WP_REST_Server::CREATABLE,
+		vars: 'get_id_args',
+		guard: 'check_permission',
+	)]
 	public function handle_reset_skill( WP_REST_Request $request ) {
 		$id    = self::get_int_param( $request, 'id' );
 		$reset = Skill::reset_builtin( $id );
@@ -363,6 +295,86 @@ class SkillController {
 				'updated_at'  => $skill->updated_at,
 			),
 			200
+		);
+	}
+
+	/**
+	 * Schema arguments for POST /skills (create).
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_create_args(): array {
+		return array(
+			'slug'        => array(
+				'required'          => true,
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_title',
+			),
+			'name'        => array(
+				'required'          => true,
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'description' => array(
+				'required'          => false,
+				'type'              => 'string',
+				'default'           => '',
+				'sanitize_callback' => 'sanitize_textarea_field',
+			),
+			'content'     => array(
+				'required'          => true,
+				'type'              => 'string',
+				'sanitize_callback' => 'wp_kses_post',
+			),
+		);
+	}
+
+	/**
+	 * Schema arguments for PATCH /skills/{id} (update).
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_update_args(): array {
+		return array(
+			'id'          => array(
+				'required'          => true,
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+			),
+			'name'        => array(
+				'required'          => false,
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'description' => array(
+				'required'          => false,
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_textarea_field',
+			),
+			'content'     => array(
+				'required'          => false,
+				'type'              => 'string',
+				'sanitize_callback' => 'wp_kses_post',
+			),
+			'enabled'     => array(
+				'required' => false,
+				'type'     => 'boolean',
+			),
+		);
+	}
+
+	/**
+	 * Schema arguments for routes that only need an ID parameter.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_id_args(): array {
+		return array(
+			'id' => array(
+				'required'          => true,
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+			),
 		);
 	}
 }

--- a/includes/REST/SkillController.php
+++ b/includes/REST/SkillController.php
@@ -15,9 +15,8 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
-use XWP\DI\Decorators\REST_Handler;
-use XWP\DI\Decorators\REST_Route;
-use XWP_REST_Controller;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -32,26 +31,78 @@ if ( ! defined( 'ABSPATH' ) ) {
  *  PATCH  /skills/{id}       — update a skill
  *  DELETE /skills/{id}       — delete a custom skill
  *  POST   /skills/{id}/reset — reset a built-in skill to defaults
+ *
+ * Uses #[Handler] + INIT_IMMEDIATELY so register_routes() is called directly
+ * on rest_api_init, which is the only strategy that works in the PHPUnit test
+ * environment (the #[REST_Handler] INIT_DEFFERED path fails to fire its
+ * do_action chain when rest_api_init is manually triggered by test setUp()).
  */
-#[REST_Handler(
-	namespace: RestController::NAMESPACE,
-	basename: 'skills',
+#[Handler(
 	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
 )]
-final class SkillController extends XWP_REST_Controller {
+final class SkillController {
 
 	use PermissionTrait;
+
+	/**
+	 * Register REST routes for skill management.
+	 */
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/skills',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'handle_list_skills' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'handle_create_skill' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+					'args'                => $this->get_create_args(),
+				),
+			)
+		);
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/skills/(?P<id>\d+)',
+			array(
+				array(
+					'methods'             => 'PATCH',
+					'callback'            => array( $this, 'handle_update_skill' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+					'args'                => $this->get_update_args(),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'handle_delete_skill' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+					'args'                => $this->get_id_args(),
+				),
+			)
+		);
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/skills/(?P<id>\d+)/reset',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'handle_reset_skill' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+				'args'                => $this->get_id_args(),
+			)
+		);
+	}
 
 	/**
 	 * Handle GET /skills — list all skills.
 	 *
 	 * @return WP_REST_Response
 	 */
-	#[REST_Route(
-		route: '',
-		methods: WP_REST_Server::READABLE,
-		guard: 'check_permission',
-	)]
 	public function handle_list_skills(): WP_REST_Response {
 		$skills = Skill::get_all();
 
@@ -92,12 +143,6 @@ final class SkillController extends XWP_REST_Controller {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	#[REST_Route(
-		route: '',
-		methods: WP_REST_Server::CREATABLE,
-		vars: 'get_create_args',
-		guard: 'check_permission',
-	)]
 	public function handle_create_skill( WP_REST_Request $request ) {
 		$slug = $request->get_param( 'slug' );
 
@@ -160,12 +205,6 @@ final class SkillController extends XWP_REST_Controller {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	#[REST_Route(
-		route: '(?P<id>\d+)',
-		methods: 'PATCH',
-		vars: 'get_update_args',
-		guard: 'check_permission',
-	)]
 	public function handle_update_skill( WP_REST_Request $request ) {
 		$id   = self::get_int_param( $request, 'id' );
 		$data = array();
@@ -222,12 +261,6 @@ final class SkillController extends XWP_REST_Controller {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	#[REST_Route(
-		route: '(?P<id>\d+)',
-		methods: WP_REST_Server::DELETABLE,
-		vars: 'get_id_args',
-		guard: 'check_permission',
-	)]
 	public function handle_delete_skill( WP_REST_Request $request ) {
 		$id     = self::get_int_param( $request, 'id' );
 		$result = Skill::delete( $id );
@@ -257,12 +290,6 @@ final class SkillController extends XWP_REST_Controller {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	#[REST_Route(
-		route: '(?P<id>\d+)/reset',
-		methods: WP_REST_Server::CREATABLE,
-		vars: 'get_id_args',
-		guard: 'check_permission',
-	)]
 	public function handle_reset_skill( WP_REST_Request $request ) {
 		$id    = self::get_int_param( $request, 'id' );
 		$reset = Skill::reset_builtin( $id );

--- a/includes/REST/ToolController.php
+++ b/includes/REST/ToolController.php
@@ -19,55 +19,71 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
-class ToolController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manages custom-tools and abilities endpoints via REST.
+ *
+ * Uses #[Handler] + #[Action] instead of #[REST_Handler] because this
+ * controller serves multiple basenames (/abilities, /custom-tools) and
+ * the REST_Handler decorator supports only a single basename per class.
+ */
+#[Handler(
+	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class ToolController {
 
 	use PermissionTrait;
-
-	const NAMESPACE = 'gratis-ai-agent/v1';
 
 	/**
 	 * Register REST routes.
 	 */
-	public static function register_routes(): void {
-		$instance = new self();
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
 
 		// Abilities endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/abilities',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_abilities' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_abilities' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		// Abilities Explorer endpoint.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/abilities/explorer',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_abilities_explorer' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_abilities_explorer' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 			)
 		);
 
 		// Custom Tools endpoints.
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/custom-tools',
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_list_custom_tools' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_list_custom_tools' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 				),
 				array(
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_create_custom_tool' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_create_custom_tool' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'name'         => array(
 							'required'          => true,
@@ -111,13 +127,13 @@ class ToolController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/custom-tools/(?P<id>\d+)',
 			array(
 				array(
 					'methods'             => 'PATCH',
-					'callback'            => array( $instance, 'handle_update_custom_tool' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_update_custom_tool' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -128,8 +144,8 @@ class ToolController {
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $instance, 'handle_delete_custom_tool' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
+					'callback'            => array( $this, 'handle_delete_custom_tool' ),
+					'permission_callback' => array( $this, 'check_permission' ),
 					'args'                => array(
 						'id' => array(
 							'required'          => true,
@@ -142,12 +158,12 @@ class ToolController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/custom-tools/(?P<id>\d+)/test',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $instance, 'handle_test_custom_tool' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
+				'callback'            => array( $this, 'handle_test_custom_tool' ),
+				'permission_callback' => array( $this, 'check_permission' ),
 				'args'                => array(
 					'id'    => array(
 						'required'          => true,

--- a/includes/REST/TraceController.php
+++ b/includes/REST/TraceController.php
@@ -18,9 +18,8 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
-use XWP\DI\Decorators\REST_Handler;
-use XWP\DI\Decorators\REST_Route;
-use XWP_REST_Controller;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -36,13 +35,18 @@ if ( ! defined( 'ABSPATH' ) ) {
  *  DELETE /trace             — clear all traces
  *  GET    /trace/settings    — get trace settings
  *  POST   /trace/settings    — update trace settings
+ *
+ * Uses #[Handler] + INIT_IMMEDIATELY so register_routes() is called directly
+ * on rest_api_init, which is the only strategy that works in the PHPUnit test
+ * environment (the #[REST_Handler] INIT_DEFFERED path fails to fire its
+ * do_action chain when rest_api_init is manually triggered by test setUp()).
  */
-#[REST_Handler(
-	namespace: RestController::NAMESPACE,
-	basename: 'trace',
+#[Handler(
 	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
 )]
-final class TraceController extends XWP_REST_Controller {
+final class TraceController {
 
 	/**
 	 * Permission check — admin only.
@@ -54,17 +58,72 @@ final class TraceController extends XWP_REST_Controller {
 	}
 
 	/**
+	 * Register REST routes for provider trace endpoints.
+	 */
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/trace',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'handle_list' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+					'args'                => $this->get_list_args(),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'handle_clear' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+				),
+			)
+		);
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/trace/settings',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'handle_get_settings' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'handle_update_settings' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+					'args'                => $this->get_settings_args(),
+				),
+			)
+		);
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/trace/(?P<id>\d+)',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'handle_get' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+				'args'                => $this->get_id_args(),
+			)
+		);
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/trace/(?P<id>\d+)/curl',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'handle_curl' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+				'args'                => $this->get_id_args(),
+			)
+		);
+	}
+
+	/**
 	 * Handle GET /trace — list trace records.
 	 *
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response
 	 */
-	#[REST_Route(
-		route: '',
-		methods: WP_REST_Server::READABLE,
-		vars: 'get_list_args',
-		guard: 'check_permission',
-	)]
 	public function handle_list( WP_REST_Request $request ): WP_REST_Response {
 		$filters = [];
 
@@ -102,12 +161,6 @@ final class TraceController extends XWP_REST_Controller {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	#[REST_Route(
-		route: '(?P<id>\d+)',
-		methods: WP_REST_Server::READABLE,
-		vars: 'get_id_args',
-		guard: 'check_permission',
-	)]
 	public function handle_get( WP_REST_Request $request ) {
 		$id    = absint( $request->get_param( 'id' ) );
 		$trace = ProviderTrace::get( $id );
@@ -129,12 +182,6 @@ final class TraceController extends XWP_REST_Controller {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
-	#[REST_Route(
-		route: '(?P<id>\d+)/curl',
-		methods: WP_REST_Server::READABLE,
-		vars: 'get_id_args',
-		guard: 'check_permission',
-	)]
 	public function handle_curl( WP_REST_Request $request ) {
 		$id    = absint( $request->get_param( 'id' ) );
 		$trace = ProviderTrace::get( $id );
@@ -159,11 +206,6 @@ final class TraceController extends XWP_REST_Controller {
 	 *
 	 * @return WP_REST_Response
 	 */
-	#[REST_Route(
-		route: '',
-		methods: WP_REST_Server::DELETABLE,
-		guard: 'check_permission',
-	)]
 	public function handle_clear(): WP_REST_Response {
 		ProviderTrace::clear();
 
@@ -177,11 +219,6 @@ final class TraceController extends XWP_REST_Controller {
 	 *
 	 * @return WP_REST_Response
 	 */
-	#[REST_Route(
-		route: 'settings',
-		methods: WP_REST_Server::READABLE,
-		guard: 'check_permission',
-	)]
 	public function handle_get_settings(): WP_REST_Response {
 		return new WP_REST_Response(
 			array(
@@ -201,12 +238,6 @@ final class TraceController extends XWP_REST_Controller {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response
 	 */
-	#[REST_Route(
-		route: 'settings',
-		methods: WP_REST_Server::CREATABLE,
-		vars: 'get_settings_args',
-		guard: 'check_permission',
-	)]
 	public function handle_update_settings( WP_REST_Request $request ): WP_REST_Response {
 		$enabled  = $request->get_param( 'enabled' );
 		$max_rows = $request->get_param( 'max_rows' );

--- a/includes/REST/TraceController.php
+++ b/includes/REST/TraceController.php
@@ -18,136 +18,36 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\REST_Handler;
+use XWP\DI\Decorators\REST_Route;
+use XWP_REST_Controller;
 
-class TraceController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
-	const NAMESPACE = 'gratis-ai-agent/v1';
-
-	/**
-	 * Register REST routes for provider tracing.
-	 */
-	public static function register_routes(): void {
-		$instance = new self();
-
-		// List trace records.
-		register_rest_route(
-			self::NAMESPACE,
-			'/trace',
-			array(
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_list' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
-				'args'                => array(
-					'limit'       => array(
-						'required'          => false,
-						'type'              => 'integer',
-						'default'           => 50,
-						'sanitize_callback' => 'absint',
-					),
-					'offset'      => array(
-						'required'          => false,
-						'type'              => 'integer',
-						'default'           => 0,
-						'sanitize_callback' => 'absint',
-					),
-					'provider'    => array(
-						'required'          => false,
-						'type'              => 'string',
-						'sanitize_callback' => 'sanitize_text_field',
-					),
-					'status_code' => array(
-						'required'          => false,
-						'type'              => 'integer',
-						'sanitize_callback' => 'absint',
-					),
-					'errors_only' => array(
-						'required' => false,
-						'type'     => 'boolean',
-						'default'  => false,
-					),
-				),
-			)
-		);
-
-		// Get a single trace record.
-		register_rest_route(
-			self::NAMESPACE,
-			'/trace/(?P<id>\d+)',
-			array(
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_get' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
-				'args'                => array(
-					'id' => array(
-						'required'          => true,
-						'type'              => 'integer',
-						'sanitize_callback' => 'absint',
-					),
-				),
-			)
-		);
-
-		// Get curl command for a trace record.
-		register_rest_route(
-			self::NAMESPACE,
-			'/trace/(?P<id>\d+)/curl',
-			array(
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $instance, 'handle_curl' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
-				'args'                => array(
-					'id' => array(
-						'required'          => true,
-						'type'              => 'integer',
-						'sanitize_callback' => 'absint',
-					),
-				),
-			)
-		);
-
-		// Clear all trace records.
-		register_rest_route(
-			self::NAMESPACE,
-			'/trace',
-			array(
-				'methods'             => WP_REST_Server::DELETABLE,
-				'callback'            => array( $instance, 'handle_clear' ),
-				'permission_callback' => array( $instance, 'check_permission' ),
-			)
-		);
-
-		// Trace settings (enable/disable, max rows).
-		register_rest_route(
-			self::NAMESPACE,
-			'/trace/settings',
-			array(
-				array(
-					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => array( $instance, 'handle_get_settings' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
-				),
-				array(
-					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $instance, 'handle_update_settings' ),
-					'permission_callback' => array( $instance, 'check_permission' ),
-					'args'                => array(
-						'enabled'  => array(
-							'required' => false,
-							'type'     => 'boolean',
-						),
-						'max_rows' => array(
-							'required'          => false,
-							'type'              => 'integer',
-							'sanitize_callback' => 'absint',
-						),
-					),
-				),
-			)
-		);
-	}
+/**
+ * Manages provider trace records via REST.
+ *
+ * Endpoints:
+ *  GET    /trace             — list trace records
+ *  GET    /trace/{id}        — get a single trace record
+ *  GET    /trace/{id}/curl   — get curl command for a trace
+ *  DELETE /trace             — clear all traces
+ *  GET    /trace/settings    — get trace settings
+ *  POST   /trace/settings    — update trace settings
+ */
+#[REST_Handler(
+	namespace: RestController::NAMESPACE,
+	basename: 'trace',
+	container: 'gratis-ai-agent',
+)]
+final class TraceController extends XWP_REST_Controller {
 
 	/**
 	 * Permission check — admin only.
+	 *
+	 * @return bool
 	 */
 	public function check_permission(): bool {
 		return current_user_can( 'manage_options' );
@@ -159,6 +59,12 @@ class TraceController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response
 	 */
+	#[REST_Route(
+		route: '',
+		methods: WP_REST_Server::READABLE,
+		vars: 'get_list_args',
+		guard: 'check_permission',
+	)]
 	public function handle_list( WP_REST_Request $request ): WP_REST_Response {
 		$filters = [];
 
@@ -196,6 +102,12 @@ class TraceController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
+	#[REST_Route(
+		route: '(?P<id>\d+)',
+		methods: WP_REST_Server::READABLE,
+		vars: 'get_id_args',
+		guard: 'check_permission',
+	)]
 	public function handle_get( WP_REST_Request $request ) {
 		$id    = absint( $request->get_param( 'id' ) );
 		$trace = ProviderTrace::get( $id );
@@ -217,6 +129,12 @@ class TraceController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response|WP_Error
 	 */
+	#[REST_Route(
+		route: '(?P<id>\d+)/curl',
+		methods: WP_REST_Server::READABLE,
+		vars: 'get_id_args',
+		guard: 'check_permission',
+	)]
 	public function handle_curl( WP_REST_Request $request ) {
 		$id    = absint( $request->get_param( 'id' ) );
 		$trace = ProviderTrace::get( $id );
@@ -241,6 +159,11 @@ class TraceController {
 	 *
 	 * @return WP_REST_Response
 	 */
+	#[REST_Route(
+		route: '',
+		methods: WP_REST_Server::DELETABLE,
+		guard: 'check_permission',
+	)]
 	public function handle_clear(): WP_REST_Response {
 		ProviderTrace::clear();
 
@@ -254,6 +177,11 @@ class TraceController {
 	 *
 	 * @return WP_REST_Response
 	 */
+	#[REST_Route(
+		route: 'settings',
+		methods: WP_REST_Server::READABLE,
+		guard: 'check_permission',
+	)]
 	public function handle_get_settings(): WP_REST_Response {
 		return new WP_REST_Response(
 			array(
@@ -273,6 +201,12 @@ class TraceController {
 	 * @param WP_REST_Request $request The request object.
 	 * @return WP_REST_Response
 	 */
+	#[REST_Route(
+		route: 'settings',
+		methods: WP_REST_Server::CREATABLE,
+		vars: 'get_settings_args',
+		guard: 'check_permission',
+	)]
 	public function handle_update_settings( WP_REST_Request $request ): WP_REST_Response {
 		$enabled  = $request->get_param( 'enabled' );
 		$max_rows = $request->get_param( 'max_rows' );
@@ -294,6 +228,77 @@ class TraceController {
 					? __( 'Provider tracing is enabled. Logs may contain prompt content. Disable on shared environments.', 'gratis-ai-agent' )
 					: '',
 			)
+		);
+	}
+
+	/**
+	 * Schema arguments for GET /trace (list).
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_list_args(): array {
+		return array(
+			'limit'       => array(
+				'required'          => false,
+				'type'              => 'integer',
+				'default'           => 50,
+				'sanitize_callback' => 'absint',
+			),
+			'offset'      => array(
+				'required'          => false,
+				'type'              => 'integer',
+				'default'           => 0,
+				'sanitize_callback' => 'absint',
+			),
+			'provider'    => array(
+				'required'          => false,
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+			'status_code' => array(
+				'required'          => false,
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+			),
+			'errors_only' => array(
+				'required' => false,
+				'type'     => 'boolean',
+				'default'  => false,
+			),
+		);
+	}
+
+	/**
+	 * Schema arguments for routes that only need an ID parameter.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_id_args(): array {
+		return array(
+			'id' => array(
+				'required'          => true,
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+			),
+		);
+	}
+
+	/**
+	 * Schema arguments for POST /trace/settings.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	public function get_settings_args(): array {
+		return array(
+			'enabled'  => array(
+				'required' => false,
+				'type'     => 'boolean',
+			),
+			'max_rows' => array(
+				'required'          => false,
+				'type'              => 'integer',
+				'sanitize_callback' => 'absint',
+			),
 		);
 	}
 }

--- a/includes/REST/WebhookController.php
+++ b/includes/REST/WebhookController.php
@@ -37,10 +37,25 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
 
-class WebhookController {
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
-	const NAMESPACE = 'gratis-ai-agent/v1';
+/**
+ * Manages webhook CRUD and public trigger endpoint via REST.
+ *
+ * Uses #[Handler] + #[Action] because this controller serves multiple
+ * basenames (/webhooks, /webhook/trigger, /process).
+ */
+#[Handler(
+	container: 'gratis-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class WebhookController {
 
 	/**
 	 * Transient prefix for webhook jobs (reuses the main job pattern).
@@ -55,17 +70,17 @@ class WebhookController {
 	/**
 	 * Register all webhook REST routes.
 	 */
-	public static function register_routes(): void {
-		$instance = new self();
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
 
 		// ─── Public trigger endpoint ────────────────────────────────
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/webhook/trigger',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ $instance, 'handle_trigger' ],
-				'permission_callback' => [ $instance, 'check_webhook_permission' ],
+				'callback'            => [ $this, 'handle_trigger' ],
+				'permission_callback' => [ $this, 'check_webhook_permission' ],
 				'args'                => [
 					'webhook_id'         => [
 						'required'          => false,
@@ -114,18 +129,18 @@ class WebhookController {
 
 		// ─── Admin CRUD endpoints ────────────────────────────────────
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/webhooks',
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ $instance, 'handle_list' ],
-					'permission_callback' => [ $instance, 'check_admin_permission' ],
+					'callback'            => [ $this, 'handle_list' ],
+					'permission_callback' => [ $this, 'check_admin_permission' ],
 				],
 				[
 					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => [ $instance, 'handle_create' ],
-					'permission_callback' => [ $instance, 'check_admin_permission' ],
+					'callback'            => [ $this, 'handle_create' ],
+					'permission_callback' => [ $this, 'check_admin_permission' ],
 					'args'                => [
 						'name'               => [
 							'required'          => true,
@@ -179,13 +194,13 @@ class WebhookController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/webhooks/(?P<id>\d+)',
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ $instance, 'handle_get' ],
-					'permission_callback' => [ $instance, 'check_admin_permission' ],
+					'callback'            => [ $this, 'handle_get' ],
+					'permission_callback' => [ $this, 'check_admin_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -196,8 +211,8 @@ class WebhookController {
 				],
 				[
 					'methods'             => 'PATCH',
-					'callback'            => [ $instance, 'handle_update' ],
-					'permission_callback' => [ $instance, 'check_admin_permission' ],
+					'callback'            => [ $this, 'handle_update' ],
+					'permission_callback' => [ $this, 'check_admin_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -208,8 +223,8 @@ class WebhookController {
 				],
 				[
 					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => [ $instance, 'handle_delete' ],
-					'permission_callback' => [ $instance, 'check_admin_permission' ],
+					'callback'            => [ $this, 'handle_delete' ],
+					'permission_callback' => [ $this, 'check_admin_permission' ],
 					'args'                => [
 						'id' => [
 							'required'          => true,
@@ -222,12 +237,12 @@ class WebhookController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/webhooks/(?P<id>\d+)/logs',
 			[
 				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => [ $instance, 'handle_logs' ],
-				'permission_callback' => [ $instance, 'check_admin_permission' ],
+				'callback'            => [ $this, 'handle_logs' ],
+				'permission_callback' => [ $this, 'check_admin_permission' ],
 				'args'                => [
 					'id'     => [
 						'required'          => true,
@@ -251,12 +266,12 @@ class WebhookController {
 		);
 
 		register_rest_route(
-			self::NAMESPACE,
+			RestController::NAMESPACE,
 			'/webhooks/(?P<id>\d+)/rotate-secret',
 			[
 				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => [ $instance, 'handle_rotate_secret' ],
-				'permission_callback' => [ $instance, 'check_admin_permission' ],
+				'callback'            => [ $this, 'handle_rotate_secret' ],
+				'permission_callback' => [ $this, 'check_admin_permission' ],
 				'args'                => [
 					'id' => [
 						'required'          => true,
@@ -379,7 +394,7 @@ class WebhookController {
 		// Return the secret on creation only — it is never returned again.
 		$response                = $this->sanitize_webhook_for_response( $webhook );
 		$response['secret']      = $secret;
-		$response['trigger_url'] = rest_url( self::NAMESPACE . '/webhook/trigger' );
+		$response['trigger_url'] = rest_url( RestController::NAMESPACE . '/webhook/trigger' );
 
 		return new WP_REST_Response( $response, 201 );
 	}
@@ -404,7 +419,7 @@ class WebhookController {
 		}
 
 		$response                = $this->sanitize_webhook_for_response( $webhook );
-		$response['trigger_url'] = rest_url( self::NAMESPACE . '/webhook/trigger' );
+		$response['trigger_url'] = rest_url( RestController::NAMESPACE . '/webhook/trigger' );
 
 		return new WP_REST_Response( $response, 200 );
 	}
@@ -472,7 +487,7 @@ class WebhookController {
 		}
 
 		$response                = $this->sanitize_webhook_for_response( $webhook );
-		$response['trigger_url'] = rest_url( self::NAMESPACE . '/webhook/trigger' );
+		$response['trigger_url'] = rest_url( RestController::NAMESPACE . '/webhook/trigger' );
 
 		return new WP_REST_Response( $response, 200 );
 	}
@@ -697,7 +712,7 @@ class WebhookController {
 		set_transient( self::JOB_PREFIX . $job_id, $job, self::JOB_TTL );
 
 		wp_remote_post(
-			rest_url( self::NAMESPACE . '/process' ),
+			rest_url( RestController::NAMESPACE . '/process' ),
 			[
 				'timeout'  => 0.01,
 				'blocking' => false,

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -41,8 +41,22 @@ require_once "{$_tests_dir}/includes/functions.php";
 
 /**
  * Manually load the plugin being tested.
+ *
+ * Sets $_SERVER['REQUEST_URI'] to a REST URL so the x-wp/di context detector
+ * (XWP_Context) recognizes the PHPUnit environment as CTX_REST. Without this,
+ * handlers decorated with `context: CTX_REST` (including all REST_Handler and
+ * Handler-based REST controllers) are silently skipped during plugins_loaded,
+ * and routes return 404 in tests.
+ *
+ * The WP test bootstrap hardcodes REQUEST_URI = '/' before muplugins_loaded,
+ * which makes XWP_Context::rest() return false. We override it here — before
+ * the plugin calls xwp_load_app() — so the context is correct when the DI
+ * Module processes handlers on plugins_loaded.
  */
 function _manually_load_plugin() {
+	// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- Test bootstrap only; not user input.
+	$_SERVER['REQUEST_URI'] = '/wp-json/gratis-ai-agent/v1/';
+
 	require dirname(__DIR__) . '/gratis-ai-agent.php';
 
 	// Install database tables (normally done on activation).

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'ultimate-multisite/ai-agent',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '276c49ec925e37bf489a1d880fad39613256dbbe',
+        'reference' => '7cc78bf63cbbeb33679e69aa41e04c8084e43313',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -119,7 +119,7 @@
         'ultimate-multisite/ai-agent' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '276c49ec925e37bf489a1d880fad39613256dbbe',
+            'reference' => '7cc78bf63cbbeb33679e69aa41e04c8084e43313',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'ultimate-multisite/ai-agent',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => 'bd19dba2eafed072d5e53dc13bcf68298dd77f60',
+        'reference' => '276c49ec925e37bf489a1d880fad39613256dbbe',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -119,7 +119,7 @@
         'ultimate-multisite/ai-agent' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => 'bd19dba2eafed072d5e53dc13bcf68298dd77f60',
+            'reference' => '276c49ec925e37bf489a1d880fad39613256dbbe',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Summary

Fixes 54 PHPUnit failures + errors introduced when BenchmarkController and McpController (plus Memory, Skill, Feedback, Trace) were converted to `#[REST_Handler]` DI handlers in PR 4/6.

## Root cause

The `#[REST_Handler]` decorator uses the `INIT_DEFFERED` strategy, which fires route registration through a nested `do_action('namespace/basename')` chain *inside* the `rest_api_init` closure. In the PHPUnit test environment — where `set_up()` fires `do_action('rest_api_init')` manually rather than going through `rest_get_server()` — this inner action chain does not complete, leaving routes unregistered and every dispatched request returning 404.

The `#[Handler] + INIT_IMMEDIATELY` pattern (used by SessionController, AutomationController, etc. introduced in PR5) works correctly because `register_routes()` is added directly to `rest_api_init` via `add_action` during `plugins_loaded`, before the hook fires.

## Fix

Converts all six remaining `#[REST_Handler]` controllers to use `#[Handler(context: CTX_REST, strategy: INIT_IMMEDIATELY)]` with explicit `register_routes()` methods that call `register_rest_route()` directly:

| Controller | Test impact |
|---|---|
| `MemoryController` | Fixes `RestControllerTest` memory route failures (9 tests) |
| `SkillController` | Fixes `RestControllerTest` skill route failures (6+ tests) |
| `McpController` | Fixes all `McpControllerTest` failures (12 failures + 2 errors) |
| `BenchmarkController` | Fixes all `BenchmarkControllerTest` failures (20 failures + 1 error) |
| `FeedbackController` | Proactive fix (same broken pattern, no dedicated tests) |
| `TraceController` | Proactive fix (same broken pattern, no dedicated tests) |

## Verification

```
vendor/bin/phpunit --filter BenchmarkControllerTest
vendor/bin/phpunit --filter McpControllerTest
vendor/bin/phpunit  # full suite should show 0 failures in REST tests
```

Resolves #987

<!-- aidevops:sig -->