### PR TITLE
GH#990: fix duplicate abilities/providers/settings REST requests on admin page load

### DIFF
--- a/src/abilities/index.js
+++ b/src/abilities/index.js
@@ -16,16 +16,37 @@
  * `@wordpress/abilities` library throwing
  * "Ability references non-existent category" errors. (Fix landed in t166.)
  *
- * Each entry-point bundle has its own webpack-bundled module instance of
- * this file (and therefore its own `registrationPromise`), so we additionally
- * dedupe at the `@wordpress/abilities` API level inside registry.js — both
- * `registerCategory()` and `registerClientAbility()` swallow "already
- * registered" errors as a safe no-op.
+ * Cross-bundle deduplication (GH#990):
+ * Each webpack entry-point bundle has its own module scope and therefore its
+ * own `registrationPromise`. When multiple bundles (e.g. floating-widget.js
+ * and screen-meta.js) are enqueued on the same admin page, each bundle
+ * previously ran the full registration pipeline independently. This caused
+ * `wp.abilities.registerAbilityCategory()` to be called once per bundle,
+ * which in WP 7.0-RC2 triggers a REST fetch to `/wp-json/wp-abilities/v1/abilities`
+ * for each call — resulting in duplicate simultaneous requests, one of which
+ * was aborted and logged a console error.
+ *
+ * The fix: `ensureRegistered()` checks a page-level window global
+ * (`window.__gratisAiAgentAbilitiesRegistering`) before creating a new
+ * Promise. If another bundle on the same page has already started or
+ * completed the pipeline, the second bundle awaits the same Promise instead
+ * of launching a duplicate registration.
  */
 
 import { registerCategory } from './registry';
 import { registerNavigationAbility } from './navigation';
 import { registerEditorAbility } from './editor';
+
+/**
+ * Window-global key used to share the registration Promise across all
+ * webpack bundles on the same page. The first bundle to run
+ * `ensureRegistered()` creates and stores the Promise; every subsequent
+ * bundle (in any other webpack scope) reads and awaits it instead of
+ * starting a new registration pipeline.
+ *
+ * @type {string}
+ */
+const WIN_REGISTRATION_KEY = '__gratisAiAgentAbilitiesRegistering';
 
 /**
  * Single in-flight registration Promise for this module instance, so
@@ -41,26 +62,40 @@ let registrationPromise = null;
  * Ensure all client-side abilities are registered.
  *
  * Idempotent — calling this multiple times within a single bundle returns
- * the same in-flight Promise. Safe to import from multiple entry points
- * because the underlying registry helpers in registry.js dedupe at the
- * `@wordpress/abilities` API level.
+ * the same in-flight Promise. Cross-bundle dedup is provided by the
+ * page-level `window.__gratisAiAgentAbilitiesRegistering` key: if another
+ * bundle on the same page has already started or completed registration,
+ * this call returns the existing Promise without re-running the pipeline.
  *
  * If the abilities API was not available when the attempt ran (e.g. the
  * `@wordpress/core-abilities` script module hadn't loaded yet),
  * registerCategory() silently no-ops and the promise resolves without
- * registering anything. In that case registrationPromise is reset to null
- * AFTER the attempt completes so a future call can retry. Concurrent
- * callers during the in-flight attempt all receive the same promise —
- * the reset only happens once the promise has settled.
+ * registering anything. In that case both the module-level promise and the
+ * window global are reset to null AFTER the attempt completes so a future
+ * call can retry. Concurrent callers during the in-flight attempt all
+ * receive the same promise — the reset only happens once the promise settles.
  *
  * @return {Promise<void>}
  */
 export function ensureRegistered() {
+	// Cross-bundle dedup: another webpack bundle on this page may have
+	// already started or completed the registration pipeline. Reuse its
+	// Promise so we don't call wp.abilities.registerAbilityCategory() a
+	// second time (each call can trigger a REST fetch in WP 7.0-RC2).
+	if ( window[ WIN_REGISTRATION_KEY ] ) {
+		registrationPromise = window[ WIN_REGISTRATION_KEY ];
+		return registrationPromise;
+	}
+
+	// Same-bundle dedup: a concurrent caller within this bundle.
 	if ( registrationPromise ) {
 		return registrationPromise;
 	}
 
-	registrationPromise = ( async () => {
+	// Set both caches before any await so concurrent callers from this
+	// bundle and from other bundles that load immediately after see the
+	// in-flight Promise rather than starting a new one.
+	registrationPromise = window[ WIN_REGISTRATION_KEY ] = ( async () => {
 		// Category MUST come first AND its Promise MUST resolve before
 		// abilities can register into it.
 		await registerCategory();
@@ -70,7 +105,7 @@ export function ensureRegistered() {
 
 		// If the abilities API was not available (e.g. script module not
 		// yet loaded), the registration calls above silently no-oped.
-		// Reset the promise so a future call can retry after the API loads.
+		// Reset both caches so a future call can retry after the API loads.
 		// This MUST happen after the await chain settles — resetting during
 		// the in-flight attempt would break concurrent callers' dedup.
 		const apiAvailable =
@@ -79,6 +114,7 @@ export function ensureRegistered() {
 			typeof wp.abilities.getAbilities === 'function';
 		if ( ! apiAvailable ) {
 			registrationPromise = null;
+			window[ WIN_REGISTRATION_KEY ] = null;
 		}
 	} )();
 

--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -60,6 +60,7 @@ const { reducer, actions, selectors } = capturedConfig;
 const DEFAULT_STATE = {
 	providers: [],
 	providersLoaded: false,
+	providersLoading: false,
 	sessions: [],
 	sessionsLoaded: false,
 	currentSessionId: null,
@@ -79,6 +80,7 @@ const DEFAULT_STATE = {
 	foldersLoaded: false,
 	settings: null,
 	settingsLoaded: false,
+	settingsLoading: false,
 	memories: [],
 	memoriesLoaded: false,
 	skills: [],
@@ -327,6 +329,20 @@ describe( 'reducer', () => {
 		expect( state.providersLoaded ).toBe( true );
 	} );
 
+	test( 'SET_PROVIDERS_LOADING sets providersLoading flag', () => {
+		const loading = reducer( DEFAULT_STATE, {
+			type: 'SET_PROVIDERS_LOADING',
+			loading: true,
+		} );
+		expect( loading.providersLoading ).toBe( true );
+
+		const done = reducer( loading, {
+			type: 'SET_PROVIDERS_LOADING',
+			loading: false,
+		} );
+		expect( done.providersLoading ).toBe( false );
+	} );
+
 	test( 'SET_SESSIONS sets sessions and marks loaded', () => {
 		const sessions = [ { id: 1 } ];
 		const state = reducer( DEFAULT_STATE, {
@@ -507,6 +523,20 @@ describe( 'reducer', () => {
 		expect( state.settingsLoaded ).toBe( true );
 	} );
 
+	test( 'SET_SETTINGS_LOADING sets settingsLoading flag', () => {
+		const loading = reducer( DEFAULT_STATE, {
+			type: 'SET_SETTINGS_LOADING',
+			loading: true,
+		} );
+		expect( loading.settingsLoading ).toBe( true );
+
+		const done = reducer( loading, {
+			type: 'SET_SETTINGS_LOADING',
+			loading: false,
+		} );
+		expect( done.settingsLoading ).toBe( false );
+	} );
+
 	test( 'SET_MEMORIES sets memories and marks loaded', () => {
 		const memories = [ { id: 1 } ];
 		const state = reducer( DEFAULT_STATE, {
@@ -663,6 +693,10 @@ describe( 'selectors', () => {
 		expect( selectors.getProvidersLoaded( state ) ).toBe( true );
 	} );
 
+	test( 'getProvidersLoading returns false when not loading', () => {
+		expect( selectors.getProvidersLoading( state ) ).toBe( false );
+	} );
+
 	test( 'getSessions returns sessions array', () => {
 		expect( selectors.getSessions( state ) ).toEqual( state.sessions );
 	} );
@@ -734,6 +768,10 @@ describe( 'selectors', () => {
 
 	test( 'getSettingsLoaded returns true when loaded', () => {
 		expect( selectors.getSettingsLoaded( state ) ).toBe( true );
+	} );
+
+	test( 'getSettingsLoading returns false when not loading', () => {
+		expect( selectors.getSettingsLoading( state ) ).toBe( false );
 	} );
 
 	test( 'getMemories returns memories', () => {

--- a/src/store/slices/providersSlice.js
+++ b/src/store/slices/providersSlice.js
@@ -11,6 +11,7 @@ import apiFetch from '@wordpress/api-fetch';
 export const initialState = {
 	providers: [],
 	providersLoaded: false,
+	providersLoading: false,
 	selectedProviderId: localStorage.getItem( 'gratisAiAgentProvider' ) || '',
 	selectedModelId: localStorage.getItem( 'gratisAiAgentModel' ) || '',
 };
@@ -53,10 +54,25 @@ export const actions = {
 	 * Auto-selects the first provider/model when none is saved or the saved
 	 * provider is no longer available.
 	 *
+	 * Deduplicates concurrent in-flight calls: if a fetch is already in-flight
+	 * (tracked via the shared Redux store, so cross-bundle dedup works too),
+	 * the call is a no-op. This prevents duplicate REST requests when multiple
+	 * plugin bundles (e.g. floating-widget.js and screen-meta.js) are loaded on
+	 * the same admin page and each mount a component that calls fetchProviders()
+	 * on mount. Intentional refreshes (e.g. after saving API credentials) are
+	 * not blocked — once the in-flight fetch settles, the next call starts a
+	 * new request.
+	 *
 	 * @return {Function} Redux thunk.
 	 */
 	fetchProviders() {
-		return async ( { dispatch } ) => {
+		return async ( { dispatch, select } ) => {
+			// Skip if a fetch is already in-flight. The store is shared across
+			// all bundles on the page, so this guard is cross-bundle.
+			if ( select.getProvidersLoading() ) {
+				return;
+			}
+			dispatch( { type: 'SET_PROVIDERS_LOADING', loading: true } );
 			try {
 				const providers = await apiFetch( {
 					path: '/gratis-ai-agent/v1/providers',
@@ -81,6 +97,8 @@ export const actions = {
 				}
 			} catch {
 				dispatch.setProviders( [] );
+			} finally {
+				dispatch( { type: 'SET_PROVIDERS_LOADING', loading: false } );
 			}
 		};
 	},
@@ -101,6 +119,14 @@ export const selectors = {
 	 */
 	getProvidersLoaded( state ) {
 		return state.providersLoaded;
+	},
+
+	/**
+	 * @param {import('../../types').StoreState} state
+	 * @return {boolean} Whether a providers fetch is currently in-flight.
+	 */
+	getProvidersLoading( state ) {
+		return state.providersLoading;
 	},
 
 	/**
@@ -144,6 +170,8 @@ export function reducer( state, action ) {
 				providers: action.providers,
 				providersLoaded: true,
 			};
+		case 'SET_PROVIDERS_LOADING':
+			return { ...state, providersLoading: action.loading };
 		case 'SET_SELECTED_PROVIDER':
 			return { ...state, selectedProviderId: action.providerId };
 		case 'SET_SELECTED_MODEL':

--- a/src/store/slices/settingsSlice.js
+++ b/src/store/slices/settingsSlice.js
@@ -11,6 +11,7 @@ import apiFetch from '@wordpress/api-fetch';
 export const initialState = {
 	settings: null,
 	settingsLoaded: false,
+	settingsLoading: false,
 };
 
 export const actions = {
@@ -27,10 +28,21 @@ export const actions = {
 	/**
 	 * Fetch plugin settings from the REST API.
 	 *
+	 * Deduplicates concurrent in-flight calls: if a fetch is already in-flight
+	 * (tracked via the shared Redux store, so cross-bundle dedup works too),
+	 * the call is a no-op. This prevents duplicate REST requests when multiple
+	 * plugin bundles mount components that each call fetchSettings() on mount.
+	 * Intentional refreshes are not blocked once the in-flight fetch settles.
+	 *
 	 * @return {Function} Redux thunk.
 	 */
 	fetchSettings() {
-		return async ( { dispatch } ) => {
+		return async ( { dispatch, select } ) => {
+			// Skip if a fetch is already in-flight.
+			if ( select.getSettingsLoading() ) {
+				return;
+			}
+			dispatch( { type: 'SET_SETTINGS_LOADING', loading: true } );
 			try {
 				const settings = await apiFetch( {
 					path: '/gratis-ai-agent/v1/settings',
@@ -38,6 +50,8 @@ export const actions = {
 				dispatch.setSettings( settings );
 			} catch {
 				dispatch.setSettings( {} );
+			} finally {
+				dispatch( { type: 'SET_SETTINGS_LOADING', loading: false } );
 			}
 		};
 	},
@@ -82,6 +96,14 @@ export const selectors = {
 		return state.settingsLoaded;
 	},
 
+	/**
+	 * @param {import('../../types').StoreState} state
+	 * @return {boolean} Whether a settings fetch is currently in-flight.
+	 */
+	getSettingsLoading( state ) {
+		return state.settingsLoading;
+	},
+
 	// YOLO mode (skip all confirmations)
 	isYoloMode( state ) {
 		return state.settings?.yolo_mode ?? false;
@@ -101,6 +123,8 @@ export function reducer( state, action ) {
 				settings: action.settings,
 				settingsLoaded: true,
 			};
+		case 'SET_SETTINGS_LOADING':
+			return { ...state, settingsLoading: action.loading };
 		default:
 			return state;
 	}

--- a/src/types.js
+++ b/src/types.js
@@ -133,6 +133,7 @@
  * @typedef {Object} StoreState
  * @property {Provider[]}               providers               - Available AI providers.
  * @property {boolean}                  providersLoaded         - Whether providers have been fetched.
+ * @property {boolean}                  providersLoading        - Whether a providers fetch is in-flight.
  * @property {Session[]}                sessions                - Session list.
  * @property {boolean}                  sessionsLoaded          - Whether sessions have been fetched.
  * @property {number|null}              currentSessionId        - Active session ID.
@@ -152,6 +153,7 @@
  * @property {boolean}                  foldersLoaded           - Whether folders have been fetched.
  * @property {Settings|null}            settings                - Plugin settings.
  * @property {boolean}                  settingsLoaded          - Whether settings have been fetched.
+ * @property {boolean}                  settingsLoading         - Whether a settings fetch is in-flight.
  * @property {Memory[]}                 memories                - Memory entries.
  * @property {boolean}                  memoriesLoaded          - Whether memories have been fetched.
  * @property {Skill[]}                  skills                  - Skill entries.


### PR DESCRIPTION
## Problem

On every admin page load, the WordPress core Abilities API (`/wp-json/wp-abilities/v1/abilities`) fires two simultaneous GET requests — one completing (200) and one aborting (`net::ERR_ABORTED`). The same pattern affects `/gratis-ai-agent/v1/providers`.

## Root Causes

**1. `fetchProviders()` and `fetchSettings()` — no in-flight deduplication**

`floating-widget.js` and `screen-meta.js` are both enqueued on every non-plugin admin page. Each bundle mounts a React component that calls `fetchProviders()` and `fetchSettings()` on mount via `useEffect`. Both bundles share the same Redux store (guarded by `if (!wpSelect(STORE_NAME))`), but the thunks had no guard against concurrent in-flight requests. The second bundle's effect fired while the first bundle's fetch was in-flight, launching a duplicate request.

**2. `abilities/index.js` — per-bundle `registrationPromise`, not cross-bundle**

Each webpack entry-point bundle has its own module scope, so each had its own `registrationPromise`. Two bundles on the same page each called `wp.abilities.registerAbilityCategory()` independently. In WP 7.0-RC2, each `registerAbilityCategory()` call triggers a REST fetch to `/wp-json/wp-abilities/v1/abilities` — causing the duplicate request and console error.

## Changes

### `src/store/slices/providersSlice.js`
- Added `providersLoading: false` initial state
- Added `SET_PROVIDERS_LOADING` reducer case + `getProvidersLoading()` selector
- `fetchProviders()` checks `getProvidersLoading()` before starting a fetch; sets the flag true at start, resets in `finally`. Intentional refreshes (e.g. after saving API credentials) still work — the guard only prevents concurrent in-flight duplicates.

### `src/store/slices/settingsSlice.js`
- Added `settingsLoading: false` initial state
- Added `SET_SETTINGS_LOADING` reducer case + `getSettingsLoading()` selector
- `fetchSettings()` same in-flight guard pattern

### `src/abilities/index.js`
- `ensureRegistered()` now checks `window.__gratisAiAgentAbilitiesRegistering` before creating a new Promise. The first bundle to run sets this key; subsequent bundles await the same Promise instead of starting a duplicate registration pipeline.

### `src/types.js`
- Added JSDoc for `providersLoading` and `settingsLoading` in `StoreState`

### `src/store/__tests__/index.test.js`
- Added `providersLoading` and `settingsLoading` to `DEFAULT_STATE`
- Added reducer tests for `SET_PROVIDERS_LOADING` and `SET_SETTINGS_LOADING`
- Added selector tests for `getProvidersLoading` and `getSettingsLoading`

## Verification

Admin page load with zero duplicate REST requests for:
- `/wp-json/wp-abilities/v1/abilities` — no second request from second bundle's `registerAbilityCategory()` call
- `/gratis-ai-agent/v1/providers` — second bundle's effect sees `providersLoading: true`, returns early
- `/gratis-ai-agent/v1/settings` — same

Resolves #990