### PR TITLE
t190: Remove dead register() stubs from 35 ability classes

### DIFF
--- a/includes/Abilities/AiImageAbilities.php
+++ b/includes/Abilities/AiImageAbilities.php
@@ -48,13 +48,6 @@ class AiImageAbilities {
 	}
 
 	/**
-	 * Register abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register all AI image abilities with the WordPress Abilities API.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -22,13 +22,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class BlockAbilities {
 
 	/**
-	 * Register abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register all block-related abilities.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/ContentAbilities.php
+++ b/includes/Abilities/ContentAbilities.php
@@ -17,13 +17,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class ContentAbilities {
 
 	/**
-	 * Register abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register content analysis abilities.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/CustomPostTypeAbilities.php
+++ b/includes/Abilities/CustomPostTypeAbilities.php
@@ -37,17 +37,6 @@ class CustomPostTypeAbilities {
 	const OPTION_KEY = 'gratis_ai_agent_custom_post_types';
 
 	/**
-	 * Register the abilities and the persistent CPT re-registration hook.
-	 */
-	public static function register(): void {
-		// Re-register persisted CPTs on every init so they survive page reloads.
-		add_action( 'init', [ __CLASS__, 'restore_persisted_post_types' ], 5 );
-
-		// Register the AI abilities.
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Re-register all CPTs that were previously persisted via the register ability.
 	 *
 	 * Runs on `init` with priority 5 (before most plugins) so the CPTs are

--- a/includes/Abilities/CustomTaxonomyAbilities.php
+++ b/includes/Abilities/CustomTaxonomyAbilities.php
@@ -37,17 +37,6 @@ class CustomTaxonomyAbilities {
 	const OPTION_KEY = 'gratis_ai_agent_custom_taxonomies';
 
 	/**
-	 * Register the abilities and the persistent taxonomy re-registration hook.
-	 */
-	public static function register(): void {
-		// Re-register persisted taxonomies on every init so they survive page reloads.
-		add_action( 'init', [ __CLASS__, 'restore_persisted_taxonomies' ], 5 );
-
-		// Register the AI abilities.
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Re-register all taxonomies that were previously persisted via the register ability.
 	 *
 	 * Runs on `init` with priority 5 (before most plugins) so the taxonomies are

--- a/includes/Abilities/DatabaseAbilities.php
+++ b/includes/Abilities/DatabaseAbilities.php
@@ -42,13 +42,6 @@ class DatabaseAbilities {
 	}
 
 	/**
-	 * Register database abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register database abilities.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/DesignSystemAbilities.php
+++ b/includes/Abilities/DesignSystemAbilities.php
@@ -22,13 +22,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class DesignSystemAbilities {
 
 	/**
-	 * Register abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register all design system abilities.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/EditorialAbilities.php
+++ b/includes/Abilities/EditorialAbilities.php
@@ -34,15 +34,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class EditorialAbilities {
 
 	/**
-	 * Register abilities on the wp_abilities_api_init hook.
-	 *
-	 * @since 1.1.0
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register all editorial abilities.
 	 *
 	 * @since 1.1.0

--- a/includes/Abilities/FeedbackAbilities.php
+++ b/includes/Abilities/FeedbackAbilities.php
@@ -31,13 +31,6 @@ class FeedbackAbilities {
 	private static ?array $inability_data = null;
 
 	/**
-	 * Register feedback abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register the report-inability ability.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/FileAbilities.php
+++ b/includes/Abilities/FileAbilities.php
@@ -153,13 +153,6 @@ class FileAbilities {
 	}
 
 	/**
-	 * Register file abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register all file operation abilities.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/GitAbilities.php
+++ b/includes/Abilities/GitAbilities.php
@@ -34,13 +34,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class GitAbilities {
 
 	/**
-	 * Register git tracking abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register all git tracking abilities.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/GlobalStylesAbilities.php
+++ b/includes/Abilities/GlobalStylesAbilities.php
@@ -21,13 +21,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class GlobalStylesAbilities {
 
 	/**
-	 * Register abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register all global styles abilities.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/GoogleAnalyticsAbilities.php
+++ b/includes/Abilities/GoogleAnalyticsAbilities.php
@@ -99,15 +99,6 @@ class GoogleAnalyticsAbilities {
 		return $ability->run( $input );
 	}
 
-	// ─── Registration ────────────────────────────────────────────────────────
-
-	/**
-	 * Register abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
 	/**
 	 * Register Google Analytics abilities.
 	 */

--- a/includes/Abilities/GscAbilities.php
+++ b/includes/Abilities/GscAbilities.php
@@ -41,13 +41,6 @@ class GscAbilities {
 	const GOOGLE_TOKEN_URL = 'https://oauth2.googleapis.com/token';
 
 	/**
-	 * Register abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register GSC abilities.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/ImageAbilities.php
+++ b/includes/Abilities/ImageAbilities.php
@@ -42,15 +42,6 @@ class ImageAbilities {
 	private const MAX_ALT_TEXT_LENGTH = 125;
 
 	/**
-	 * Register abilities on the wp_abilities_api_init hook.
-	 *
-	 * @since 1.1.0
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register all image abilities.
 	 *
 	 * @since 1.1.0

--- a/includes/Abilities/InternetSearchAbilities.php
+++ b/includes/Abilities/InternetSearchAbilities.php
@@ -50,13 +50,6 @@ class InternetSearchAbilities {
 	const BRAVE_KEY_OPTION = 'gratis_ai_agent_brave_search_key';
 
 	/**
-	 * Register abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register the internet-search ability.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/KnowledgeAbilities.php
+++ b/includes/Abilities/KnowledgeAbilities.php
@@ -19,13 +19,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class KnowledgeAbilities {
 
 	/**
-	 * Register knowledge abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register the knowledge search ability.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/MarketingAbilities.php
+++ b/includes/Abilities/MarketingAbilities.php
@@ -17,13 +17,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class MarketingAbilities {
 
 	/**
-	 * Register abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register marketing abilities.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/MediaAbilities.php
+++ b/includes/Abilities/MediaAbilities.php
@@ -23,13 +23,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class MediaAbilities {
 
 	/**
-	 * Register media abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register all media library abilities.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/MemoryAbilities.php
+++ b/includes/Abilities/MemoryAbilities.php
@@ -19,13 +19,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class MemoryAbilities {
 
 	/**
-	 * Register memory abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register the three memory abilities.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/MenuAbilities.php
+++ b/includes/Abilities/MenuAbilities.php
@@ -21,13 +21,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class MenuAbilities {
 
 	/**
-	 * Register menu abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register all navigation menu management abilities.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/NavigationAbilities.php
+++ b/includes/Abilities/NavigationAbilities.php
@@ -59,13 +59,6 @@ class NavigationAbilities {
 	}
 
 	/**
-	 * Register navigation abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register navigation abilities.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/OptionsAbilities.php
+++ b/includes/Abilities/OptionsAbilities.php
@@ -71,13 +71,6 @@ class OptionsAbilities {
 	];
 
 	/**
-	 * Register options management abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register all options management abilities.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/PluginBuilderAbilities.php
+++ b/includes/Abilities/PluginBuilderAbilities.php
@@ -38,15 +38,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class PluginBuilderAbilities {
 
 	/**
-	 * Register abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-		// Auto-deactivate any plugins that triggered a fatal on a previous activation.
-		add_action( 'init', [ PluginSandbox::class, 'auto_deactivate_fatal_plugins' ] );
-	}
-
-	/**
 	 * Register all plugin builder abilities with the WordPress Abilities API.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/PluginDownloadAbilities.php
+++ b/includes/Abilities/PluginDownloadAbilities.php
@@ -61,13 +61,6 @@ class PluginDownloadAbilities {
 	}
 
 	/**
-	 * Register plugin download abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register all plugin download abilities.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/PostAbilities.php
+++ b/includes/Abilities/PostAbilities.php
@@ -24,13 +24,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class PostAbilities {
 
 	/**
-	 * Register post abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register all post management abilities.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/SeoAbilities.php
+++ b/includes/Abilities/SeoAbilities.php
@@ -17,13 +17,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class SeoAbilities {
 
 	/**
-	 * Register abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register SEO abilities.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/SiteBuilderAbilities.php
+++ b/includes/Abilities/SiteBuilderAbilities.php
@@ -99,13 +99,6 @@ class SiteBuilderAbilities {
 	}
 
 	/**
-	 * Register site builder abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register all site builder abilities.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/SiteHealthAbilities.php
+++ b/includes/Abilities/SiteHealthAbilities.php
@@ -26,13 +26,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class SiteHealthAbilities {
 
 	/**
-	 * Register site health abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register all site health abilities.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/SkillAbilities.php
+++ b/includes/Abilities/SkillAbilities.php
@@ -19,13 +19,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class SkillAbilities {
 
 	/**
-	 * Register skill abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register the skill-load and skill-list abilities.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/StockImageAbilities.php
+++ b/includes/Abilities/StockImageAbilities.php
@@ -20,13 +20,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class StockImageAbilities {
 
 	/**
-	 * Register abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register the import-stock-image ability.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/UserAbilities.php
+++ b/includes/Abilities/UserAbilities.php
@@ -23,13 +23,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class UserAbilities {
 
 	/**
-	 * Register user abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register all user management abilities.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/WooCommerceAbilities.php
+++ b/includes/Abilities/WooCommerceAbilities.php
@@ -140,13 +140,6 @@ class WooCommerceAbilities {
 	}
 
 	/**
-	 * Register WooCommerce abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register all WooCommerce abilities (only when WooCommerce is active).
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/WordPressAbilities.php
+++ b/includes/Abilities/WordPressAbilities.php
@@ -258,13 +258,6 @@ class WordPressAbilities {
 	}
 
 	/**
-	 * Register WordPress abilities on init.
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_init', [ __CLASS__, 'register_abilities' ] );
-	}
-
-	/**
 	 * Register all WordPress management abilities.
 	 */
 	public static function register_abilities(): void {

--- a/includes/Abilities/WpCliAbilities.php
+++ b/includes/Abilities/WpCliAbilities.php
@@ -149,16 +149,6 @@ class WpCliAbilities {
 	private static string $current_site_url = '';
 
 	/**
-	 * Register the wp-cli/execute ability.
-	 *
-	 * @return void
-	 */
-	public static function register(): void {
-		add_action( 'wp_abilities_api_categories_init', array( __CLASS__, 'register_category' ) );
-		add_action( 'wp_abilities_api_init', array( __CLASS__, 'register_ability' ) );
-	}
-
-	/**
 	 * Register the wp-cli ability category.
 	 *
 	 * @return void

--- a/includes/Bootstrap/AbilitiesHandler.php
+++ b/includes/Bootstrap/AbilitiesHandler.php
@@ -5,8 +5,14 @@
  * Replaces the 35 inline `XxxAbilities::register()` calls in
  * `gratis-ai-agent.php` with a single DI-managed handler. Each ability
  * class's `register_abilities()` method is called on the
- * `wp_abilities_api_init` hook — bypassing the intermediate `register()`
- * → `add_action()` layer since the DI system handles hook attachment.
+ * `wp_abilities_api_init` hook — bypassing the now-removed `register()`
+ * stub layer since the DI system handles hook attachment directly.
+ *
+ * Also owns the `init`-time hooks previously embedded in the three ability
+ * classes that needed extra wiring beyond abilities registration:
+ *  - CustomPostTypeAbilities::restore_persisted_post_types() at priority 5
+ *  - CustomTaxonomyAbilities::restore_persisted_taxonomies() at priority 5
+ *  - PluginSandbox::auto_deactivate_fatal_plugins() at priority 10
  *
  * @package GratisAiAgent\Bootstrap
  * @license GPL-2.0-or-later
@@ -41,6 +47,7 @@ use GratisAiAgent\Abilities\NavigationAbilities;
 use GratisAiAgent\Abilities\OptionsAbilities;
 use GratisAiAgent\Abilities\PluginBuilderAbilities;
 use GratisAiAgent\Abilities\PluginDownloadAbilities;
+use GratisAiAgent\PluginBuilder\PluginSandbox;
 use GratisAiAgent\Abilities\PostAbilities;
 use GratisAiAgent\Abilities\SeoAbilities;
 use GratisAiAgent\Abilities\SiteBuilderAbilities;
@@ -59,10 +66,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Registers all 35 ability groups on `wp_abilities_api_init`.
+ * Registers all ability groups on `wp_abilities_api_init` and wires
+ * the `init`-time hooks that were previously inside the per-class
+ * `register()` stubs.
  *
- * Uses `INIT_IMMEDIATELY` so the `wp_abilities_api_init` callback is
- * queued during `plugins_loaded` — well before `init` fires the hook.
+ * Uses `INIT_IMMEDIATELY` so all callbacks are queued during
+ * `plugins_loaded` — well before `init` or `wp_abilities_api_init` fires.
  */
 #[Handler(
 	container: 'gratis-ai-agent',
@@ -125,5 +134,31 @@ final class AbilitiesHandler {
 	#[Action( tag: 'wp_abilities_api_categories_init', priority: 10 )]
 	public function register_wpcli_category(): void {
 		WpCliAbilities::register_category();
+	}
+
+	/**
+	 * Re-register persisted custom post types and taxonomies on `init`.
+	 *
+	 * Runs at priority 5 (before most plugins) so AI-created CPTs and
+	 * taxonomies are available to the rest of WordPress on every request.
+	 * Previously wired by CustomPostTypeAbilities::register() and
+	 * CustomTaxonomyAbilities::register() via add_action() — those
+	 * register() stubs have been removed.
+	 */
+	#[Action( tag: 'init', priority: 5 )]
+	public function restore_persisted_types(): void {
+		CustomPostTypeAbilities::restore_persisted_post_types();
+		CustomTaxonomyAbilities::restore_persisted_taxonomies();
+	}
+
+	/**
+	 * Auto-deactivate plugins that triggered a fatal error on a previous activation.
+	 *
+	 * Previously wired by PluginBuilderAbilities::register() via add_action() —
+	 * that register() stub has been removed.
+	 */
+	#[Action( tag: 'init', priority: 10 )]
+	public function auto_deactivate_fatal_plugins(): void {
+		PluginSandbox::auto_deactivate_fatal_plugins();
 	}
 }

--- a/tests/GratisAiAgent/Abilities/AiImageAbilitiesTest.php
+++ b/tests/GratisAiAgent/Abilities/AiImageAbilitiesTest.php
@@ -119,21 +119,4 @@ class AiImageAbilitiesTest extends WP_UnitTestCase {
 		$this->assertNotSame( 'cartoon', $result->get_error_code() );
 	}
 
-	// ─── register ────────────────────────────────────────────────
-
-	/**
-	 * Test register adds the wp_abilities_api_init action hook.
-	 *
-	 * Calling register() should attach register_abilities to the
-	 * wp_abilities_api_init action without throwing.
-	 */
-	public function test_register_adds_action_hook() {
-		AiImageAbilities::register();
-
-		$this->assertGreaterThan(
-			0,
-			has_action( 'wp_abilities_api_init', [ AiImageAbilities::class, 'register_abilities' ] ),
-			'register() should add register_abilities to wp_abilities_api_init.'
-		);
-	}
 }

--- a/tests/GratisAiAgent/Abilities/PluginBuilderAbilitiesTest.php
+++ b/tests/GratisAiAgent/Abilities/PluginBuilderAbilitiesTest.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace GratisAiAgent\Tests\Abilities;
 
 use GratisAiAgent\Abilities\GeneratePluginAbility;
-use GratisAiAgent\Abilities\PluginBuilderAbilities;
 use GratisAiAgent\Abilities\SandboxActivatePluginAbility;
 use GratisAiAgent\Abilities\SandboxTestPluginAbility;
 use GratisAiAgent\Abilities\ScanPluginHooksAbility;
@@ -24,19 +23,6 @@ use WP_UnitTestCase;
  * Test PluginBuilderAbilities functionality.
  */
 class PluginBuilderAbilitiesTest extends WP_UnitTestCase {
-
-	// ── register ──────────────────────────────────────────────────────────
-
-	/**
-	 * register() hooks register_abilities to wp_abilities_api_init.
-	 */
-	public function test_register_hooks_register_abilities(): void {
-		PluginBuilderAbilities::register();
-
-		$this->assertNotFalse(
-			has_action( 'wp_abilities_api_init', [ PluginBuilderAbilities::class, 'register_abilities' ] )
-		);
-	}
 
 	// ── GeneratePluginAbility ─────────────────────────────────────────────
 

--- a/tests/GratisAiAgent/Abilities/PluginDownloadAbilitiesTest.php
+++ b/tests/GratisAiAgent/Abilities/PluginDownloadAbilitiesTest.php
@@ -19,19 +19,6 @@ use WP_UnitTestCase;
  */
 class PluginDownloadAbilitiesTest extends WP_UnitTestCase {
 
-	// ── register ──────────────────────────────────────────────────────────
-
-	/**
-	 * register() hooks register_abilities to wp_abilities_api_init.
-	 */
-	public function test_register_hooks_register_abilities(): void {
-		PluginDownloadAbilities::register();
-
-		$this->assertNotFalse(
-			has_action( 'wp_abilities_api_init', [ PluginDownloadAbilities::class, 'register_abilities' ] )
-		);
-	}
-
 	// ── handle_list_modified_plugins ──────────────────────────────────────
 
 	/**


### PR DESCRIPTION
## Summary

- Remove dead `register(): void` from all 35 `includes/Abilities/*.php` classes. These methods only called `add_action('wp_abilities_api_init', ...)`, which is now handled directly by `AbilitiesHandler` via the DI `#[Action]` decorator — making them unreachable since PR 6/6 of the DI migration (9c00f62).
- Migrate three `init`-time hooks that were silently broken since the DI migration (the hooks were only wired by `register()`, which was never called after the migration):
  - `restore_persisted_types()` at priority 5 — re-registers AI-created CPTs and taxonomies on every request
  - `auto_deactivate_fatal_plugins()` at priority 10 — cleans up plugins that crashed on activation
- Remove 3 test methods that tested the now-deleted `register()` stubs; drop one resulting unused import.

## Verification

- `git grep '::register()' includes/Abilities/` → 0 hits
- `phpstan analyse --configuration=phpstan.neon` → No errors
- `phpcs --standard=phpcs.xml` → 0 violations on all changed files

## Files changed

- **EDIT**: `includes/Bootstrap/AbilitiesHandler.php` — add `PluginSandbox` import and three new `#[Action]` methods for the migrated init hooks
- **EDIT**: `includes/Abilities/*.php` (35 files) — remove `register(): void` method and its preceding docblock
- **EDIT**: `tests/GratisAiAgent/Abilities/AiImageAbilitiesTest.php` — remove `test_register_adds_action_hook()`
- **EDIT**: `tests/GratisAiAgent/Abilities/PluginBuilderAbilitiesTest.php` — remove `test_register_hooks_register_abilities()`, remove unused import
- **EDIT**: `tests/GratisAiAgent/Abilities/PluginDownloadAbilitiesTest.php` — remove `test_register_hooks_register_abilities()`

Resolves #992