### PR TITLE
GH#1001: fix(e2e): wait for input enabled (sending=false) before TTS speak poll

### DIFF
--- a/tests/e2e/text-to-speech.spec.js
+++ b/tests/e2e/text-to-speech.spec.js
@@ -511,6 +511,19 @@ test.describe( 'TTS Auto-Speak on AI Responses', () => {
 			{ timeout: 30_000 }
 		);
 
+		// Wait for the store to finish sending (sending=false). The TTS
+		// effect only fires when sending is false, so we need to ensure the
+		// full job-completion state transition (setCurrentSession →
+		// setSending(false)) has been processed by React before polling for
+		// speak calls. The message input being enabled is a reliable proxy.
+		await expect(
+			page
+				.locator(
+					'.gratis-ai-agent-chat-panel:not(.is-compact) .gratis-ai-agent-input'
+				)
+				.first()
+		).toBeEnabled( { timeout: 15_000 } );
+
 		// Verify that speak() was called on the mock.
 		// TTS fires asynchronously after the stream completes (the useEffect
 		// in MessageList waits for sending=false + last message role=model),


### PR DESCRIPTION
## Summary

Added expect(...).toBeEnabled({ timeout: 15_000 }) between the new-bubble waitForFunction and the speak-count poll in the positive TTS auto-speak test. This serialises the sending→false state transition before polling, fixing the race where the TTS effect had not yet fired.

## Files Changed

tests/e2e/text-to-speech.spec.js

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Code review of the change. E2E tests run via npm run test:e2e:playwright — the toBeEnabled assertion waits for the React store to dispatch setSending(false) before the speak() poll starts, preventing the race condition.

Resolves #1001


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.65 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 5m and 14,669 tokens on this as a headless worker.