### PR TITLE
fix: import shared.css in screen-meta entry point for tool confirmation dialog styles

### DIFF
--- a/src/screen-meta/index.js
+++ b/src/screen-meta/index.js
@@ -22,6 +22,7 @@ import STORE_NAME from '../store';
 // before the chat mounts (t165 — closes the wiring gap in #815).
 import '../abilities';
 import ChatPanel from '../components/ChatPanel';
+import '../components/shared.css';
 import './style.css';
 
 /**


### PR DESCRIPTION
## Summary

The tool confirmation dialog had no styles when triggered from the screen-meta (Help tab) context because `src/screen-meta/index.js` was missing the `shared.css` import.

All `ToolConfirmationDialog` styles live in `src/components/shared.css`. The other two entry points that render `ChatPanel` already had the import:
- `src/admin-page/index.js` — had it ✓
- `src/floating-widget/index.js` — had it ✓
- `src/screen-meta/index.js` — was missing it ✗

## Change

Added `import '../components/shared.css';` to `src/screen-meta/index.js` alongside the existing `ChatPanel` import.