### PR TITLE
fix: preserve exception context in ability errors

### DIFF
--- a/includes/Abilities/AbstractAbility.php
+++ b/includes/Abilities/AbstractAbility.php
@@ -207,6 +207,13 @@ abstract class AbstractAbility extends \WP_Ability {
 	 * This override intercepts the input before it reaches the callback and
 	 * recursively casts any stdClass values to arrays.
 	 *
+	 * Unlike parent::do_execute() which delegates to invoke_callback(), this
+	 * method calls execute_callback() directly. WP core's invoke_callback()
+	 * catches all Throwable exceptions and wraps them in a bare WP_Error that
+	 * strips file/line/trace — making it impossible for the user (or AI) to
+	 * know WHERE the error occurred. By calling the callback directly, we can
+	 * preserve the full exception context in the WP_Error's error_data.
+	 *
 	 * @since 1.0.0
 	 *
 	 * @param mixed $input Optional. The input data for the ability.
@@ -219,8 +226,51 @@ abstract class AbstractAbility extends \WP_Ability {
 			$input = self::stdclass_to_array( $input );
 		}
 
-		// @phpstan-ignore-next-line — do_execute() exists at runtime in WP 7.0.
-		return parent::do_execute( $input );
+		// Call execute_callback() directly instead of parent::do_execute()
+		// to preserve exception context that WP core's invoke_callback() strips.
+		// Always pass $input — concrete implementations either use it or
+		// declare $input = null; WP_Ability::execute() normalises to null
+		// when no input_schema is defined.
+		try {
+			return $this->execute_callback( $input );
+		} catch ( \Throwable $e ) {
+			// Log the full trace — this is the ONLY place it's available
+			// before WP core would strip it in invoke_callback().
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log(
+				sprintf(
+					'[Gratis AI Agent] Ability "%s" exception: %s in %s:%d',
+					$this->get_name(),
+					$e->getMessage(),
+					$e->getFile(),
+					$e->getLine()
+				) . "\n" . $e->getTraceAsString()
+			);
+
+			$trace_frames = array();
+			foreach ( array_slice( $e->getTrace(), 0, 10 ) as $frame ) {
+				$trace_frames[] = ( $frame['file'] ?? '?' )
+					. ':' . ( $frame['line'] ?? '?' )
+					. ' ' . ( $frame['class'] ?? '' )
+					. ( $frame['type'] ?? '' )
+					. ( $frame['function'] ?? '' ) . '()';
+			}
+
+			return new \WP_Error(
+				'ability_callback_exception',
+				sprintf(
+					/* translators: 1: Ability name, 2: Exception message. */
+					__( 'Ability "%1$s" threw an error: %2$s', 'gratis-ai-agent' ),
+					$this->get_name(),
+					$e->getMessage()
+				),
+				array(
+					'exception_file'  => $e->getFile(),
+					'exception_line'  => $e->getLine(),
+					'exception_trace' => $trace_frames,
+				)
+			);
+		}
 	}
 
 	/**

--- a/includes/Core/AbilityFunctionResolver.php
+++ b/includes/Core/AbilityFunctionResolver.php
@@ -122,8 +122,39 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 		// associative arrays. Abilities expect plain PHP arrays throughout.
 		$args = self::normalize_args( $args );
 
-		// @phpstan-ignore-next-line — execute() exists at runtime in WP 7.0.
-		$result = $ability->execute( $args );
+		// Wrap execute() in a try/catch to capture errors that occur
+		// OUTSIDE WP core's invoke_callback() — e.g. in validate_input()
+		// or validate_output(). Our AbstractAbility::do_execute() override
+		// handles errors inside the callback itself.
+		try {
+			// @phpstan-ignore-next-line — execute() exists at runtime in WP 7.0.
+			$result = $ability->execute( $args );
+		} catch ( \Throwable $e ) {
+			// Errors in schema validation (validate_input/validate_output)
+			// are not caught by WP core's invoke_callback(). Capture them
+			// here with full context so the model can report the location.
+			$trace_frames = array();
+			foreach ( array_slice( $e->getTrace(), 0, 5 ) as $frame ) {
+				$trace_frames[] = ( $frame['file'] ?? '?' )
+					. ':' . ( $frame['line'] ?? '?' )
+					. ' ' . ( $frame['function'] ?? '' ) . '()';
+			}
+
+			return new FunctionResponse(
+				$function_id,
+				$function_name,
+				array(
+					'error'         => $e->getMessage(),
+					'code'          => 'ability_exception',
+					'error_context' => sprintf(
+						'%s:%d — %s',
+						$e->getFile(),
+						$e->getLine(),
+						implode( ' → ', array_slice( $trace_frames, 0, 3 ) )
+					),
+				)
+			);
+		}
 
 		if ( is_wp_error( $result ) ) {
 			$error_code    = (string) $result->get_error_code();
@@ -131,6 +162,22 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 				'error' => $result->get_error_message(),
 				'code'  => $error_code,
 			);
+
+			// When our AbstractAbility::do_execute() catches an exception,
+			// it stores file/line/trace in the WP_Error's error_data.
+			// Extract it here so the model can report the error location
+			// to the user instead of a bare message.
+			$error_data = $result->get_error_data();
+			if ( is_array( $error_data ) && isset( $error_data['exception_file'] ) ) {
+				$response_data['error_context'] = sprintf(
+					'%s:%d',
+					$error_data['exception_file'],
+					$error_data['exception_line'] ?? 0
+				);
+				if ( ! empty( $error_data['exception_trace'] ) && is_array( $error_data['exception_trace'] ) ) {
+					$response_data['error_trace'] = array_slice( $error_data['exception_trace'], 0, 5 );
+				}
+			}
 
 			// For input-validation failures, inline the input_schema so the
 			// model can self-correct on the next turn instead of guessing


### PR DESCRIPTION
## Summary

- Fixes the root cause of bare "Cannot use object of type stdClass as array" errors showing no file/line/trace to the user
- `AbstractAbility::do_execute()` now calls `execute_callback()` directly instead of delegating to WP core's `invoke_callback()`, which catches all `Throwable` and strips debugging context
- `AbilityFunctionResolver::execute_ability()` now extracts exception context from `WP_Error` data and wraps `$ability->execute()` in try/catch for schema validation errors

## Problem

PR #1019 added `error_context` to `SessionController::handle_process()`, but that only fires when the **entire agent loop crashes**. Ability errors are caught gracefully by WP core's `WP_Ability::invoke_callback()` (which strips file/line/trace from exceptions) and flow back as tool responses — the loop never crashes, so `error_context` never fires.

## What changed

**`AbstractAbility::do_execute()`** — Bypasses WP core's `invoke_callback()` to preserve exception context:
- Logs the full stack trace to `debug.log`
- Returns `WP_Error` with `exception_file`, `exception_line`, `exception_trace` in error data

**`AbilityFunctionResolver::execute_ability()`** — Two additions:
- Wraps `$ability->execute()` in try/catch for errors outside `invoke_callback()` (schema validation)
- Extracts exception context from `WP_Error` data into `error_context`/`error_trace` in the `FunctionResponse`

## Testing

- PHPStan: 0 errors
- PHPCS: 0 violations
- Browser test: WooCommerce installed and activated successfully via the AI agent chat (Anthropic Max / Claude Sonnet 4.5) with no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for ability execution with richer diagnostic context, including exception file locations, line numbers, and complete execution trace information.
  * Improved exception capture and structured logging across all execution paths to provide consistent, detailed, and informative error reporting for debugging and issue resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->