### PR TITLE
fix: normalize REQUEST_URI for plain-permalink REST to fix DI context detection (#1023)

### DIFF
--- a/docs/x-wp-di.md
+++ b/docs/x-wp-di.md
@@ -268,6 +268,23 @@ $refl->setValue( null, XWP_Context::REST );
 
 **Outstanding issue:** Even with correct context, deferred handlers mark hooks as `$loaded` after first fire. When test `setUp()` creates a fresh `WP_REST_Server` and re-fires `rest_api_init`, routes don't re-register on the new server. Tracked in GitHub issues.
 
+### 5a. `CTX_REST` handlers don't load with plain permalinks (wp-env / CI)
+
+`XWP_Context::rest()` only detects REST context when `$_SERVER['REQUEST_URI']` contains the `wp-json/` prefix. When WordPress uses plain permalinks (the default in fresh wp-env installs), REST requests use `?rest_route=/...` in the query string. `REQUEST_URI` is then `/?rest_route=...` which does **not** contain `wp-json/`, so `XWP_Context::rest()` returns false, context is misdetected as `CTX_FRONTEND`, and all `CTX_REST` handlers fail to load — every REST endpoint returns 404.
+
+**Fix (applied in `gratis-ai-agent.php`):** Before calling `xwp_load_app()`, the plugin normalises `REQUEST_URI` for plain-permalink REST requests:
+
+```php
+if ( ! empty( $_GET['rest_route'] ) ) {
+    $prefix = rest_get_url_prefix(); // 'wp-json'
+    if ( false === strpos( $_SERVER['REQUEST_URI'] ?? '', $prefix ) ) {
+        $_SERVER['REQUEST_URI'] = '/' . $prefix . $_GET['rest_route'];
+    }
+}
+```
+
+This runs before `xwp_load_app()` queues the container build at `plugins_loaded:PHP_INT_MIN`, so `XWP_Context::get()` caches the correct `CTX_REST` value when the container initialises.
+
 ### 6. PHPStan cache corruption on PHP 8.4
 
 Occasionally `/tmp/phpstan/cache/` fatals with class-not-found errors. Fix: `rm -rf /tmp/phpstan && composer install` before re-running.

--- a/gratis-ai-agent.php
+++ b/gratis-ai-agent.php
@@ -64,6 +64,31 @@ use GratisAiAgent\Plugin;
 register_activation_hook( __FILE__, [ LifecycleHandler::class, 'activate' ] );
 register_deactivation_hook( __FILE__, [ LifecycleHandler::class, 'deactivate' ] );
 
+// Normalize REQUEST_URI for plain-permalink REST requests.
+//
+// `XWP_Context::rest()` detects REST context by checking if REQUEST_URI
+// contains the wp-json prefix (e.g. `/wp-json/`). WordPress also routes REST
+// requests via `?rest_route=/...` when pretty permalinks are disabled (the
+// default in fresh wp-env installs and many CI environments).
+//
+// Without this normalisation, `XWP_Context::rest()` returns false for
+// `?rest_route=` requests, so all DI handlers with `context: CTX_REST` are
+// never initialised and every REST endpoint returns 404.
+//
+// The normalisation runs before `xwp_load_app()` queues the container build
+// at `plugins_loaded:PHP_INT_MIN`, so XWP_Context::get() caches the correct
+// REST context when the container actually initialises.
+// phpcs:disable WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+if ( ! empty( $_GET['rest_route'] ) ) {
+	$_rest_prefix = function_exists( 'rest_get_url_prefix' ) ? rest_get_url_prefix() : 'wp-json';
+	$_request_uri = isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '';
+	if ( false === strpos( (string) $_request_uri, $_rest_prefix ) ) {
+		$_SERVER['REQUEST_URI'] = '/' . $_rest_prefix . wp_unslash( $_GET['rest_route'] );
+	}
+	unset( $_rest_prefix, $_request_uri );
+}
+// phpcs:enable WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.InputNotValidated
+
 // Bootstrap the DI container.
 //
 // `xwp_load_app()` schedules the container build at its default


### PR DESCRIPTION
## Problem

All 6 CI E2E shards fail since the DI migration (t190–t196). The Abilities Search/Filter block, session creation, and automation creation tests all fail with 404/element-not-found.

## Root Cause

`XWP_Context::rest()` detects REST context by checking if `REQUEST_URI` contains `wp-json/`. This works for pretty-permalink WordPress sites, but **wp-env (the CI test environment) uses plain permalinks by default**. With plain permalinks, REST requests use `?rest_route=/...` — `REQUEST_URI` is `/?rest_route=...` which does **not** contain `wp-json/`.

When context is detected as `CTX_FRONTEND` (not `CTX_REST`), all DI handlers with `context: Handler::CTX_REST` are never initialised. Their `rest_api_init` callbacks are never registered. Every REST endpoint returns 404.

Before the DI migration (commit `f630522b`), REST routes were wired via `add_action('rest_api_init', ...)` directly in `gratis-ai-agent.php` — unconditionally, with no context check. After the DI migration, they're only loaded when `XWP_Context::rest()` is true.

## Fix

Normalize `REQUEST_URI` in `gratis-ai-agent.php` **before** `xwp_load_app()` queues the container build at `plugins_loaded:PHP_INT_MIN`. When `$_GET['rest_route']` is set and `REQUEST_URI` doesn't already contain `wp-json/`, prefix it correctly. `XWP_Context::get()` then caches `CTX_REST` when the container initialises.

```php
if ( ! empty( $_GET['rest_route'] ) ) {
    $prefix = rest_get_url_prefix(); // 'wp-json'
    if ( false === strpos( $_SERVER['REQUEST_URI'] ?? '', $prefix ) ) {
        $_SERVER['REQUEST_URI'] = '/' . $prefix . wp_unslash( $_GET['rest_route'] );
    }
}
```

This does not affect URL routing (WordPress uses `$_GET['rest_route']` for that, not `REQUEST_URI`). It only fixes context detection for the DI framework.

## Files Changed

- `gratis-ai-agent.php` — add plain-permalink REST context normalisation before `xwp_load_app()`
- `docs/x-wp-di.md` — document as gotcha 5a

## Verification

The fix can be verified by running the E2E suite against wp-env (plain permalinks):

```bash
npx wp-env start
npx playwright test tests/e2e/admin-page.spec.js --grep "Abilities|session list"
npx playwright test tests/e2e/automations.spec.js --grep "creating"
```

Expected: all tests pass. Previously: all failed with 404s on REST endpoints.

Resolves #1023

---
[aidevops.sh](https://aidevops.sh) plugin for [Claude Code](https://Claude.ai) — headless worker session