### PR TITLE
fix: prevent ConversationTrimmer breaking tool_use/tool_result pairing (400 error)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -393,6 +393,44 @@ Goal: clean, minimal design that matches wp-admin conventions. Replace custom da
   - EDIT: includes/REST/SettingsController.php — in the providers/models endpoint response, include `context_window` field per model from a static lookup (move the PHP-side equivalent of the hardcoded map into CostCalculator or Settings, where model metadata already lives)
   - Verify: `npm run lint:js && npm run build && composer phpstan`
 
+- [ ] t209 Improve block editor content quality #parent #feature → [todo/PLANS.md#improve-block-editor-content-quality] ~20h logged:2026-04-17
+
+- [ ] t210 Fix `maybe_convert_markdown()` mixed-content bug (Phase 1) #bug #auto-dispatch ~2h For #t209 logged:2026-04-17
+  - `PostAbilities::maybe_convert_markdown()` (line 780) short-circuits when content contains `<!-- wp:` — but the LLM produces hybrid content (image blocks + raw markdown text). The markdown portions are never converted, rendering as unstyled freeform blocks.
+  - EDIT: includes/Abilities/PostAbilities.php:775-813 — instead of returning early when `<!-- wp:` found, parse the content with `parse_blocks()`, identify freeform blocks (null blockName) that contain markdown signals, convert those segments individually with `MarkdownToBlocks::convert()`, and reassemble.
+  - Verify: `composer phpstan && composer phpcs`; test: pass content with mixed `<!-- wp:image -->` blocks and `## Heading\n\nParagraph text\n\n- list item` — verify freeform segments become proper blocks while existing blocks are preserved.
+
+- [ ] t211 Auto-inject skills into system prompt based on task intent (Phase 2) #feature #auto-dispatch ~4h For #t209 logged:2026-04-17
+  - Skills are currently opt-in — the LLM must voluntarily call `skill-load`, which it never does because the system prompt already tells it "just write markdown." Knowledge base has auto-injection via RAG; skills should work the same way.
+  - NEW: includes/Core/SkillAutoInjector.php — `inject_for_message(string $user_message): string` — keyword matching against skill trigger words. Returns concatenated skill content for matching skills. Trigger map: `create|page|post|blog|article|content|write` → `gutenberg-blocks`, `woocommerce|product|store|shop|order` → `woocommerce`, `seo|ranking|meta|sitemap` → `seo-optimization`. Cap at 2 skills per injection to limit prompt size.
+  - EDIT: includes/Core/SystemInstructionBuilder.php:68-72 — after the passive skill index injection, call `SkillAutoInjector::inject_for_message($this->user_message)` and append result to `$base`. Guard: skip if user_message is empty (non-chat contexts).
+  - EDIT: includes/Models/Skill.php — add `get_content_by_slug(string $slug): ?string` convenience method (loads from DB, returns content or null). Used by SkillAutoInjector.
+  - Verify: `composer phpstan && composer phpcs`; test: build system prompt with user_message "create a landing page for my business" — verify gutenberg-blocks skill content appears in the system instruction.
+
+- [ ] t212 Rewrite gutenberg-blocks skill with comprehensive block markup reference (Phase 3) #enhancement #auto-dispatch ~6h For #t209 logged:2026-04-17
+  - Current `gutenberg-blocks.md` is 73 lines with zero actual serialized block markup examples. LLMs need to see working examples to produce correct output — they don't know WordPress block comment syntax from training.
+  - EDIT: includes/Models/skills/gutenberg-blocks.md — complete rewrite with:
+    - **Critical rule**: content must be EITHER all markdown OR all serialized block markup, never mixed
+    - **Complete serialized block examples** for every common block: paragraph, heading (h2/h3/h4), image (with id/sizeSlug/align attrs), list+list-item (ordered and unordered), quote, code, table, separator, spacer, buttons+button, columns+column, group, cover
+    - **Layout composition patterns**: hero section (cover with heading+paragraph+buttons), two-column text+image, three-column feature grid, CTA section (group with background color), testimonial (quote in group)
+    - **Decision guide update**: use markdown for blog posts/articles (text-heavy), use raw block markup for pages with visual layouts (landing, about, services, contact)
+    - **Attribute reference**: how to set alignment (`"align":"wide"`), colors (`"backgroundColor":"primary"`), widths (`"width":"66.66%"`), custom spacing
+  - Target: 300-400 lines of actionable reference material
+  - Verify: visual review of the markdown rendering; ensure all block markup examples are valid (test with `parse_blocks()` if possible)
+
+- [ ] t213 Unhide block abilities + update system prompt content creation guidance (Phase 4) #feature #auto-dispatch ~4h For #t209 blocked-by:t211,t212 logged:2026-04-17
+  - `markdown-to-blocks` and `create-block-content` have `'ai_hidden' => true` — the LLM cannot see or call them. The system prompt says "Write content directly using markdown" which contradicts block-aware skills.
+  - EDIT: includes/Abilities/BlockAbilities.php:67-68 — remove `'ai_hidden' => true` from `markdown-to-blocks` ability meta
+  - EDIT: includes/Abilities/BlockAbilities.php:289-290 — remove `'ai_hidden' => true` from `create-block-content` ability meta
+  - EDIT: includes/Core/SystemInstructionBuilder.php:170-178 — rewrite "Content Creation" section: "For blog posts and articles, write in markdown. For pages with visual layouts (landing pages, about pages, service pages), write content using serialized Gutenberg block markup (<!-- wp:blockname --> HTML <!-- /wp:blockname -->). Load the gutenberg-blocks skill for block markup reference and examples. Use `create-block-content` for complex nested layouts (columns, groups, covers)."
+  - Verify: `composer phpstan && composer phpcs`
+
+- [ ] t214 Add validate-block-content ability for pre-insertion validation (Phase 4b) #feature #auto-dispatch ~4h For #t209 blocked-by:t213 logged:2026-04-17
+  - No guardrail exists — the LLM can produce malformed block markup and it's silently inserted. A validation ability gives the LLM a feedback loop.
+  - NEW: includes/Abilities/BlockAbilities.php — add `ai-agent/validate-block-content` ability: takes raw content string, runs `parse_blocks()`, checks for: (1) freeform blocks with markdown signals (mixed content warning), (2) mismatched open/close comments, (3) empty blocks, (4) blocks with required attrs missing. Returns `{valid: bool, warnings: string[], block_count: int, freeform_count: int}`.
+  - EDIT: includes/Models/skills/gutenberg-blocks.md — add validate-block-content to the "Available Tools" section with usage guidance: "After building complex block content, validate it before passing to create-post."
+  - Verify: `composer phpstan && composer phpcs`; test: pass valid block content (returns valid:true), pass mixed markdown+blocks (returns warning), pass malformed comments (returns warning).
+
 - [x] t188 Replace provider dropdown with connectors link when no providers defined #enhancement #auto-dispatch ~1h logged:2026-04-16 pr:#981 completed:2026-04-16
 
 ### Post-DI Code Quality & Structure Improvements

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -482,6 +482,12 @@ class AgentLoop {
 				$this->history = ConversationTrimmer::trim( $this->history, $max_turns );
 			}
 
+			// Safety net: validate tool_use/tool_result pairing even when
+			// trimming is disabled. Deserialization round-trips or history
+			// corruption from session storage could leave orphaned tool
+			// calls that cause API 400 errors.
+			$this->history = ConversationTrimmer::validate_tool_pairs( $this->history );
+
 			$result = $this->send_prompt();
 
 			if ( is_wp_error( $result ) ) {

--- a/includes/Core/ConversationTrimmer.php
+++ b/includes/Core/ConversationTrimmer.php
@@ -90,11 +90,127 @@ class ConversationTrimmer {
 			]
 		);
 
-		return array_merge( $first_turn, [ $marker ], $kept_history );
+		$merged = array_merge( $first_turn, [ $marker ], $kept_history );
+
+		// Safety net: validate tool_use/tool_result pairing after trimming.
+		// Even with correct boundary detection, edge cases (serialization
+		// round-trips, history corruption) could leave orphaned tool calls.
+		return self::validate_tool_pairs( $merged );
+	}
+
+	/**
+	 * Validate and repair tool_use/tool_result pairing in conversation history.
+	 *
+	 * Scans for assistant messages containing FunctionCall parts and verifies
+	 * that the immediately following message(s) contain matching FunctionResponse
+	 * parts. If a tool_use has no matching tool_result, the assistant message is
+	 * removed (along with any orphaned tool_results) to prevent API 400 errors.
+	 *
+	 * This is a defensive safety net — the primary fix is in find_turn_boundaries()
+	 * which avoids cutting mid-tool-cycle. This method catches edge cases.
+	 *
+	 * @param Message[] $history The conversation history to validate.
+	 * @return Message[] The validated history with orphaned tool cycles removed.
+	 */
+	public static function validate_tool_pairs( array $history ): array {
+		$result = [];
+		$count  = count( $history );
+		$i      = 0;
+
+		while ( $i < $count ) {
+			$message = $history[ $i ];
+
+			// Check if this is an assistant message with tool calls.
+			$tool_call_ids = self::extract_tool_call_ids( $message );
+
+			if ( empty( $tool_call_ids ) ) {
+				// Not a tool-call message — keep it.
+				$result[] = $message;
+				++$i;
+				continue;
+			}
+
+			// Collect the tool-response messages that follow.
+			$response_ids   = [];
+			$response_start = $i + 1;
+			$response_end   = $response_start;
+
+			while ( $response_end < $count ) {
+				$next = $history[ $response_end ];
+				if ( self::is_tool_response_message( $next ) ) {
+					foreach ( self::extract_tool_response_ids( $next ) as $rid ) {
+						$response_ids[] = $rid;
+					}
+					++$response_end;
+				} else {
+					break;
+				}
+			}
+
+			// Check if ALL tool_call IDs have matching responses.
+			$missing = array_diff( $tool_call_ids, $response_ids );
+
+			if ( empty( $missing ) ) {
+				// All tool calls have responses — keep the entire cycle.
+				$result[] = $message;
+				for ( $j = $response_start; $j < $response_end; $j++ ) {
+					$result[] = $history[ $j ];
+				}
+			}
+			// else: orphaned tool calls — skip the entire cycle (assistant
+			// message + any partial responses) to prevent the API error.
+
+			$i = $response_end;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Extract FunctionCall IDs from a message.
+	 *
+	 * @param Message $message The message to inspect.
+	 * @return string[] Array of tool call IDs.
+	 */
+	private static function extract_tool_call_ids( Message $message ): array {
+		$ids = [];
+		foreach ( $message->getParts() as $part ) {
+			if ( method_exists( $part, 'getFunctionCall' ) ) {
+				$fc = $part->getFunctionCall();
+				if ( $fc ) {
+					$ids[] = (string) $fc->getId();
+				}
+			}
+		}
+		return $ids;
+	}
+
+	/**
+	 * Extract FunctionResponse IDs from a message.
+	 *
+	 * @param Message $message The message to inspect.
+	 * @return string[] Array of tool response IDs.
+	 */
+	private static function extract_tool_response_ids( Message $message ): array {
+		$ids = [];
+		foreach ( $message->getParts() as $part ) {
+			if ( method_exists( $part, 'getFunctionResponse' ) ) {
+				$fr = $part->getFunctionResponse();
+				if ( $fr ) {
+					$ids[] = (string) $fr->getId();
+				}
+			}
+		}
+		return $ids;
 	}
 
 	/**
 	 * Find indices in the history array where user messages start a new turn.
+	 *
+	 * Tool-response messages (UserMessage containing FunctionResponse parts)
+	 * are NOT turn boundaries — they are part of a tool-call cycle that must
+	 * stay paired with the preceding assistant message. Only genuine user
+	 * text messages count as turn boundaries.
 	 *
 	 * @param Message[] $history Conversation history.
 	 * @return int[] Array of indices.
@@ -115,15 +231,43 @@ class ConversationTrimmer {
 					$role_str = (string) $role;
 				}
 
-				if ( 'user' === $role_str ) {
-					$boundaries[] = $i;
+				if ( 'user' !== $role_str ) {
+					continue;
 				}
+
+				// Skip tool-response messages — they contain FunctionResponse
+				// parts and must stay paired with the preceding tool_use.
+				if ( self::is_tool_response_message( $message ) ) {
+					continue;
+				}
+
+				$boundaries[] = $i;
 			} catch ( \Throwable $e ) {
 				continue;
 			}
 		}
 
 		return $boundaries;
+	}
+
+	/**
+	 * Check whether a message is a tool-response (contains FunctionResponse parts).
+	 *
+	 * Tool-response messages are UserMessage objects with FunctionResponse parts
+	 * created by ConversationSerializer::append_tool_response(). They look like
+	 * user messages by role but are actually tool results that must stay paired
+	 * with their preceding assistant tool_use message.
+	 *
+	 * @param Message $message The message to check.
+	 * @return bool True if the message contains any FunctionResponse parts.
+	 */
+	private static function is_tool_response_message( Message $message ): bool {
+		foreach ( $message->getParts() as $part ) {
+			if ( method_exists( $part, 'getFunctionResponse' ) && $part->getFunctionResponse() ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace GratisAiAgent\REST;
 
 use GratisAiAgent\Core\AgentLoop;
+use GratisAiAgent\Core\ConversationTrimmer;
 use GratisAiAgent\Core\CostCalculator;
 use GratisAiAgent\Core\Database;
 use GratisAiAgent\Core\RolePermissions;
@@ -383,6 +384,9 @@ Assistant: %s',
 				/** @var list<array<string, mixed>> $raw_history_typed */
 				$raw_history_typed = array_values( $raw_history );
 				$history           = AgentLoop::deserialize_history( $raw_history_typed );
+				// Strip any orphaned tool_use blocks (no matching tool_result) that
+				// may have been saved to the paused state mid-cycle.
+				$history = ConversationTrimmer::validate_tool_pairs( $history );
 			}
 		} catch ( \Exception $e ) {
 			$history = array();

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace GratisAiAgent\REST;
 
 use GratisAiAgent\Core\AgentLoop;
+use GratisAiAgent\Core\ConversationTrimmer;
 use GratisAiAgent\Core\CostCalculator;
 use GratisAiAgent\Core\Database;
 use GratisAiAgent\Core\Export;
@@ -1290,6 +1291,10 @@ final class SessionController {
 				if ( ! empty( $session_messages ) ) {
 					try {
 						$history = AgentLoop::deserialize_history( $session_messages );
+						// Strip orphaned tool_use blocks (no matching tool_result) at
+						// load time. Prevents API 400 errors when a prior job was
+						// interrupted between recording a tool_use and its tool_result.
+						$history = ConversationTrimmer::validate_tool_pairs( $history );
 					} catch ( \Exception $e ) {
 						$history = array();
 					}
@@ -1300,6 +1305,8 @@ final class SessionController {
 				/** @var list<array<string, mixed>> $params_history */
 				$params_history = $params['history'];
 				$history        = AgentLoop::deserialize_history( array_values( $params_history ) );
+				// Same defensive strip for history passed directly in the request body.
+				$history = ConversationTrimmer::validate_tool_pairs( $history );
 			} catch ( \Exception $e ) {
 				$job['status'] = 'error';
 				$job['error']  = __( 'Invalid conversation history format.', 'gratis-ai-agent' );

--- a/tests/GratisAiAgent/Core/ConversationTrimmerTest.php
+++ b/tests/GratisAiAgent/Core/ConversationTrimmerTest.php
@@ -14,6 +14,8 @@ use GratisAiAgent\Core\Settings;
 use WordPress\AiClient\Messages\DTO\UserMessage;
 use WordPress\AiClient\Messages\DTO\AssistantMessage;
 use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Tools\DTO\FunctionCall;
+use WordPress\AiClient\Tools\DTO\FunctionResponse;
 use WP_UnitTestCase;
 
 /**
@@ -202,5 +204,303 @@ class ConversationTrimmerTest extends WP_UnitTestCase {
 
 		// Order should be preserved.
 		$this->assertCount( 2, $result );
+	}
+
+	// ── Tool-response pairing tests ──────────────────────────────────────
+
+	/**
+	 * Create a mock assistant message with tool calls (FunctionCall parts).
+	 *
+	 * @param array<int, array{id: string, name: string}> $calls Tool call definitions.
+	 * @return object Mock assistant message.
+	 */
+	private function create_tool_call_message( array $calls ): object {
+		$parts = [];
+		foreach ( $calls as $call_def ) {
+			$call = $this->createMock( FunctionCall::class );
+			$call->method( 'getId' )->willReturn( $call_def['id'] );
+			$call->method( 'getName' )->willReturn( $call_def['name'] );
+			$call->method( 'getArgs' )->willReturn( [] );
+
+			$part = $this->createMock( MessagePart::class );
+			$part->method( 'getFunctionCall' )->willReturn( $call );
+			$part->method( 'getFunctionResponse' )->willReturn( null );
+			$part->method( 'getText' )->willReturn( null );
+
+			$parts[] = $part;
+		}
+
+		$role = $this->createMock( \WordPress\AiClient\Messages\Enums\MessageRoleEnum::class );
+		$role->method( '__toString' )->willReturn( 'model' );
+
+		$message = $this->createMock( \WordPress\AiClient\Messages\DTO\Message::class );
+		$message->method( 'getParts' )->willReturn( $parts );
+		$message->method( 'getRole' )->willReturn( $role );
+
+		return $message;
+	}
+
+	/**
+	 * Create a mock tool-response UserMessage (FunctionResponse parts).
+	 *
+	 * @param string $id   Tool call ID to match.
+	 * @param string $name Tool name.
+	 * @return object Mock user message with FunctionResponse.
+	 */
+	private function create_tool_response_message( string $id, string $name ): object {
+		$response = $this->createMock( FunctionResponse::class );
+		$response->method( 'getId' )->willReturn( $id );
+		$response->method( 'getName' )->willReturn( $name );
+		$response->method( 'getResponse' )->willReturn( '{"success":true}' );
+
+		$part = $this->createMock( MessagePart::class );
+		$part->method( 'getFunctionCall' )->willReturn( null );
+		$part->method( 'getFunctionResponse' )->willReturn( $response );
+		$part->method( 'getText' )->willReturn( null );
+
+		$role = $this->createMock( \WordPress\AiClient\Messages\Enums\MessageRoleEnum::class );
+		$role->method( '__toString' )->willReturn( 'user' );
+
+		$message = $this->createMock( \WordPress\AiClient\Messages\DTO\Message::class );
+		$message->method( 'getParts' )->willReturn( [ $part ] );
+		$message->method( 'getRole' )->willReturn( $role );
+
+		return $message;
+	}
+
+	/**
+	 * Create a user message mock with proper role detection.
+	 *
+	 * @param string $text Message text.
+	 * @return object Mock user message.
+	 */
+	private function create_user_message_mock( string $text ): object {
+		$part = $this->createMock( MessagePart::class );
+		$part->method( 'getFunctionCall' )->willReturn( null );
+		$part->method( 'getFunctionResponse' )->willReturn( null );
+		$part->method( 'getText' )->willReturn( $text );
+
+		$role = $this->createMock( \WordPress\AiClient\Messages\Enums\MessageRoleEnum::class );
+		$role->method( '__toString' )->willReturn( 'user' );
+
+		$message = $this->createMock( \WordPress\AiClient\Messages\DTO\Message::class );
+		$message->method( 'getParts' )->willReturn( [ $part ] );
+		$message->method( 'getRole' )->willReturn( $role );
+
+		return $message;
+	}
+
+	/**
+	 * Create an assistant message mock with proper role detection.
+	 *
+	 * @param string $text Message text.
+	 * @return object Mock assistant message.
+	 */
+	private function create_assistant_message_mock( string $text ): object {
+		$part = $this->createMock( MessagePart::class );
+		$part->method( 'getFunctionCall' )->willReturn( null );
+		$part->method( 'getFunctionResponse' )->willReturn( null );
+		$part->method( 'getText' )->willReturn( $text );
+
+		$role = $this->createMock( \WordPress\AiClient\Messages\Enums\MessageRoleEnum::class );
+		$role->method( '__toString' )->willReturn( 'model' );
+
+		$message = $this->createMock( \WordPress\AiClient\Messages\DTO\Message::class );
+		$message->method( 'getParts' )->willReturn( [ $part ] );
+		$message->method( 'getRole' )->willReturn( $role );
+
+		return $message;
+	}
+
+	/**
+	 * Test that tool-response UserMessages are NOT counted as turn boundaries.
+	 *
+	 * Regression test for the 400 error: "tool_use ids were found without
+	 * tool_result blocks immediately after". This happened because the trimmer
+	 * treated FunctionResponse UserMessages as turn boundaries, allowing it
+	 * to cut between a tool_use and its tool_result.
+	 */
+	public function test_trim_does_not_split_tool_call_cycle() {
+		// Simulate a conversation with multiple tool-call cycles.
+		// Turn 1: user asks, assistant calls 3 tools, results come back.
+		// Turn 2: user asks again, assistant responds.
+		// Turn 3: user asks again, assistant responds.
+		// Turn 4: user asks again, assistant responds.
+		$history = [
+			// Turn 1.
+			$this->create_user_message_mock( 'Create a page about cows' ),
+			$this->create_tool_call_message( [
+				[ 'id' => 'call_1', 'name' => 'ability-search' ],
+				[ 'id' => 'call_2', 'name' => 'ability-call' ],
+				[ 'id' => 'call_3', 'name' => 'ability-call' ],
+			] ),
+			// 3 tool results (each a separate UserMessage, per OpenAI splitting).
+			$this->create_tool_response_message( 'call_1', 'ability-search' ),
+			$this->create_tool_response_message( 'call_2', 'ability-call' ),
+			$this->create_tool_response_message( 'call_3', 'ability-call' ),
+			$this->create_assistant_message_mock( 'Page created!' ),
+			// Turn 2.
+			$this->create_user_message_mock( 'Add images' ),
+			$this->create_assistant_message_mock( 'Images added!' ),
+			// Turn 3.
+			$this->create_user_message_mock( 'Make it longer' ),
+			$this->create_assistant_message_mock( 'Extended the page.' ),
+			// Turn 4.
+			$this->create_user_message_mock( 'Add a featured image' ),
+			$this->create_assistant_message_mock( 'Featured image set.' ),
+		];
+
+		// Trim to 2 turns — this MUST preserve tool-call pairing in turn 1
+		// if the first turn is retained.
+		$result = ConversationTrimmer::trim( $history, 2 );
+
+		// Verify: no assistant message with FunctionCall exists without
+		// its matching FunctionResponse in the next position(s).
+		$this->assert_tool_pairs_valid( $result );
+	}
+
+	/**
+	 * Test that 7 parallel tool calls (the cow image scenario) are preserved.
+	 */
+	public function test_trim_preserves_parallel_tool_calls() {
+		$calls = [];
+		for ( $c = 1; $c <= 7; $c++ ) {
+			$calls[] = [ 'id' => "call_$c", 'name' => 'import-image' ];
+		}
+
+		$history = [
+			$this->create_user_message_mock( 'Add 7 images of cows' ),
+			$this->create_tool_call_message( $calls ),
+		];
+
+		// Add 7 individual tool responses (matching the split pattern).
+		for ( $c = 1; $c <= 7; $c++ ) {
+			$history[] = $this->create_tool_response_message( "call_$c", 'import-image' );
+		}
+
+		$history[] = $this->create_assistant_message_mock( 'All 7 images imported.' );
+		$history[] = $this->create_user_message_mock( 'The layout looks bad' );
+		$history[] = $this->create_assistant_message_mock( 'Let me fix that.' );
+
+		// Even with a tight trim limit, tool pairs must stay intact.
+		$result = ConversationTrimmer::trim( $history, 2 );
+		$this->assert_tool_pairs_valid( $result );
+	}
+
+	/**
+	 * Test validate_tool_pairs removes orphaned tool_use messages.
+	 */
+	public function test_validate_tool_pairs_removes_orphaned_tool_use() {
+		$history = [
+			$this->create_user_message_mock( 'Hello' ),
+			// Orphaned tool call — no response follows.
+			$this->create_tool_call_message( [
+				[ 'id' => 'call_orphan', 'name' => 'some-tool' ],
+			] ),
+			// Next user message (NOT a tool response).
+			$this->create_user_message_mock( 'Continue please' ),
+			$this->create_assistant_message_mock( 'Sure.' ),
+		];
+
+		$result = ConversationTrimmer::validate_tool_pairs( $history );
+
+		// The orphaned tool call should be removed; other messages preserved.
+		$this->assert_tool_pairs_valid( $result );
+		// Should have: user, user, assistant = 3 messages (orphan removed).
+		$this->assertCount( 3, $result );
+	}
+
+	/**
+	 * Test validate_tool_pairs keeps complete tool cycles intact.
+	 */
+	public function test_validate_tool_pairs_keeps_complete_cycles() {
+		$history = [
+			$this->create_user_message_mock( 'Search for something' ),
+			$this->create_tool_call_message( [
+				[ 'id' => 'call_1', 'name' => 'search' ],
+			] ),
+			$this->create_tool_response_message( 'call_1', 'search' ),
+			$this->create_assistant_message_mock( 'Found it!' ),
+		];
+
+		$result = ConversationTrimmer::validate_tool_pairs( $history );
+
+		// All messages should be preserved — the cycle is complete.
+		$this->assertCount( 4, $result );
+	}
+
+	/**
+	 * Test validate_tool_pairs handles partial responses (some tools missing).
+	 */
+	public function test_validate_tool_pairs_removes_partially_matched_cycles() {
+		$history = [
+			$this->create_user_message_mock( 'Do two things' ),
+			$this->create_tool_call_message( [
+				[ 'id' => 'call_a', 'name' => 'tool-a' ],
+				[ 'id' => 'call_b', 'name' => 'tool-b' ],
+			] ),
+			// Only one response for two calls.
+			$this->create_tool_response_message( 'call_a', 'tool-a' ),
+			$this->create_user_message_mock( 'What happened?' ),
+		];
+
+		$result = ConversationTrimmer::validate_tool_pairs( $history );
+
+		// The incomplete cycle should be removed.
+		$this->assert_tool_pairs_valid( $result );
+		// Should have: user, user = 2 messages.
+		$this->assertCount( 2, $result );
+	}
+
+	/**
+	 * Assert that all tool_use messages in a history have matching tool_results.
+	 *
+	 * @param array $history The conversation history to validate.
+	 */
+	private function assert_tool_pairs_valid( array $history ): void {
+		$count = count( $history );
+		for ( $i = 0; $i < $count; $i++ ) {
+			$message  = $history[ $i ];
+			$call_ids = [];
+
+			foreach ( $message->getParts() as $part ) {
+				if ( method_exists( $part, 'getFunctionCall' ) ) {
+					$fc = $part->getFunctionCall();
+					if ( $fc ) {
+						$call_ids[] = $fc->getId();
+					}
+				}
+			}
+
+			if ( empty( $call_ids ) ) {
+				continue;
+			}
+
+			// Collect response IDs from the messages that follow.
+			$response_ids = [];
+			for ( $j = $i + 1; $j < $count; $j++ ) {
+				$has_response = false;
+				foreach ( $history[ $j ]->getParts() as $part ) {
+					if ( method_exists( $part, 'getFunctionResponse' ) ) {
+						$fr = $part->getFunctionResponse();
+						if ( $fr ) {
+							$response_ids[] = $fr->getId();
+							$has_response   = true;
+						}
+					}
+				}
+				if ( ! $has_response ) {
+					break;
+				}
+			}
+
+			foreach ( $call_ids as $call_id ) {
+				$this->assertContains(
+					$call_id,
+					$response_ids,
+					"tool_use ID '$call_id' has no matching tool_result in history"
+				);
+			}
+		}
 	}
 }

--- a/todo/PLANS.md
+++ b/todo/PLANS.md
@@ -696,3 +696,57 @@ Phase 1 (foundation) → Phase 2 (polling refactor) → Phase 4 (sessionStorage,
 #### Surprises & Discoveries
 
 (To be populated during implementation)
+
+---
+
+### [2026-04-17] Improve Block Editor Content Quality — Auto-inject Skills + Rich Gutenberg Skill {#improve-block-editor-content-quality}
+
+**Status:** Planning
+**Estimate:** ~20h (ai:16h test:3h read:1h)
+
+#### Purpose
+
+Pages created by the AI agent look awful — raw markdown mixed with block markup, no layout sophistication, no columns/groups/covers/buttons. The root cause is threefold: (1) skills are opt-in and the LLM never loads them, (2) the gutenberg-blocks skill is too thin to be useful even if loaded (73 lines, zero block markup examples), and (3) the system prompt actively steers the LLM toward markdown-only output. This plan fixes the skill delivery mechanism, enriches the skill content, and fixes the mixed-content rendering bug.
+
+#### Progress
+
+- [ ] (2026-04-17) Phase 1: Fix `maybe_convert_markdown()` mixed-content bug ~2h
+- [ ] (2026-04-17) Phase 2: Auto-inject skills based on task intent ~4h
+- [ ] (2026-04-17) Phase 3: Rewrite gutenberg-blocks skill with comprehensive block markup reference ~6h
+- [ ] (2026-04-17) Phase 4: Unhide block abilities + update system prompt + add validate-block-content ability ~8h
+
+#### Context from Discussion
+
+**Investigation findings (raising-cows-for-beef page):**
+- Page content is a mix of proper `<!-- wp:image -->` blocks and raw markdown (`## headings`, `**bold**`, `- lists`)
+- `PostAbilities::maybe_convert_markdown()` short-circuits when it finds `<!-- wp:` anywhere in content — even if 90% of the content is still raw markdown
+- The LLM produced hybrid content (image blocks from stock image ability + markdown for text) and the converter never touched the markdown portions
+
+**Skills system architecture gaps identified:**
+1. **Skills are passive/opt-in** — `Skill::get_index_for_prompt()` injects a one-line index telling the LLM to "use skill-load tool when a request matches." The LLM ignores this because the system prompt already says "just write markdown."
+2. **Block tools are hidden** — `markdown-to-blocks` and `create-block-content` have `'ai_hidden' => true`, so `resolve_abilities()` filters them out. The LLM literally cannot call them.
+3. **System prompt contradiction** — Default system instruction (line 173) says "Write content directly using markdown" which conflicts with any skill that says "use block tools for layouts."
+4. **Skill content is too thin** — `gutenberg-blocks.md` is 73 lines with zero actual serialized block markup examples. Without examples, even a loaded skill doesn't teach the LLM how to produce correct output.
+5. **No skill auto-injection** — Knowledge base has RAG-based auto-injection (`Knowledge::get_context_for_query()`). Skills have nothing equivalent — they're purely manual.
+
+**Key files:**
+- `includes/Core/SystemInstructionBuilder.php` — builds system prompt, injects skill index
+- `includes/Models/Skill.php` — skill model, `get_index_for_prompt()` produces the passive index
+- `includes/Abilities/BlockAbilities.php` — block tools (markdown-to-blocks, create-block-content, etc.)
+- `includes/Abilities/PostAbilities.php` — `maybe_convert_markdown()` bug location (line 775-813)
+- `includes/Models/MarkdownToBlocks.php` — markdown-to-blocks converter (text-only, no layout blocks)
+- `includes/Models/skills/gutenberg-blocks.md` — current skill content (73 lines, too thin)
+
+**Design decisions:**
+- Auto-inject skills into system prompt (like knowledge RAG) rather than relying on LLM to call skill-load
+- Keyword matching for skill injection is sufficient — no need for semantic search
+- Keep `create-block-content` as the primary tool for complex layouts, teach raw block markup for simple content
+- `maybe_convert_markdown()` should handle the "freeform blocks between real blocks" case gracefully
+
+#### Decision Log
+
+(To be populated during implementation)
+
+#### Surprises & Discoveries
+
+(To be populated during implementation)


### PR DESCRIPTION
## Summary

- `ConversationTrimmer::find_turn_boundaries()` was counting `FunctionResponse` `UserMessage` objects as turn boundaries, allowing the trimmer to cut between a `tool_use` and its matching `tool_result` in multi-tool workflows (e.g. 7 parallel image imports).
- This produced API 400: `tool_use ids were found without tool_result blocks immediately after` — also reproduced when continuing or restarting sessions after tool calls (GH#1025).

## Root Cause

`ConversationSerializer::append_tool_response()` splits multi-part tool responses into individual `UserMessage` objects for OpenAI compatibility. Each split message has `role=user` — so `find_turn_boundaries()` counted 7 image import results as 7 turns, hit the trim limit, and severed the `tool_use`/`tool_result` pair.

Separately, any interrupted agent job (timeout, error mid-cycle) could leave the session DB with orphaned `tool_use` blocks — blocks without their matching `tool_result`. On the next request (even a new chat session loading the same history), the Anthropic API returns 400.

## Changes

- **`ConversationTrimmer::find_turn_boundaries()`** — skips `UserMessage` objects containing `FunctionResponse` parts via new `is_tool_response_message()` helper. Only genuine user text messages count as turn boundaries.
- **`ConversationTrimmer::validate_tool_pairs()`** — new safety-net that removes orphaned `tool_use` messages (missing matching `tool_result`) from history post-trim.
- **`AgentLoop::run_loop()`** — calls `validate_tool_pairs()` before every `send_prompt()`, even when trimming is disabled, to catch history corruption from deserialization round-trips.
- **`SessionController::handle_process()`** — calls `validate_tool_pairs()` after loading session history from the DB and after deserializing inline history from the request body. Defense-in-depth at the `/run` entry point.
- **`RestController` (client-tool resume path)** — same defensive strip when reconstructing history from the paused state.
- **5 regression tests** covering parallel tool calls, orphaned cycles, partial responses, and the exact 7-image scenario that triggered the bug.

## Testing

PHPCS and PHPStan pass on all modified files. Regression tests added in `ConversationTrimmerTest`.

Resolves #1025