### PR TITLE
t210: fix maybe_convert_markdown() mixed-content bug

### DIFF
--- a/includes/Abilities/PostAbilities.php
+++ b/includes/Abilities/PostAbilities.php
@@ -769,6 +769,12 @@ class PostAbilities {
 	/**
 	 * Detect whether content looks like markdown and convert to Gutenberg blocks.
 	 *
+	 * Handles three cases:
+	 * 1. Pure non-block content: apply markdown signal detection and convert if needed.
+	 * 2. Pure block markup (no markdown): return as-is.
+	 * 3. Mixed content (block markup + raw markdown): parse blocks, convert freeform
+	 *    markdown segments individually, and reassemble.
+	 *
 	 * @param string $content Raw content from the model.
 	 * @return string Content ready for post_content (blocks HTML or original).
 	 */
@@ -777,40 +783,91 @@ class PostAbilities {
 			return $content;
 		}
 
+		// Mixed or pure block content: parse blocks and handle freeform segments.
 		if ( str_contains( $content, '<!-- wp:' ) ) {
-			return $content;
+			return self::convert_mixed_content( $content );
 		}
 
+		// Pure non-block content: bail early if it looks like HTML.
 		$html_block_tags = preg_match_all( '/<(?:p|h[1-6]|div|section|ul|ol|table|blockquote|figure|header|footer|article|nav)\b/i', $content );
 		if ( $html_block_tags >= 3 ) {
 			return $content;
 		}
 
-		$markdown_signals = 0;
-		if ( preg_match( '/^#{1,6}\s+\S/m', $content ) ) {
-			++$markdown_signals;
-		}
-		if ( preg_match( '/\*{1,2}[^*\n]+\*{1,2}/', $content ) || preg_match( '/_{1,2}[^_\n]+_{1,2}/', $content ) ) {
-			++$markdown_signals;
-		}
-		if ( preg_match( '/^[\-\*]\s+\S/m', $content ) ) {
-			++$markdown_signals;
-		}
-		if ( preg_match( '/^\d+\.\s+\S/m', $content ) ) {
-			++$markdown_signals;
-		}
-		if ( preg_match( '/\[[^\]]+\]\([^)]+\)/', $content ) ) {
-			++$markdown_signals;
-		}
-		if ( str_contains( $content, '```' ) ) {
-			++$markdown_signals;
-		}
-
-		if ( $markdown_signals < 2 ) {
+		if ( self::count_markdown_signals( $content ) < 2 ) {
 			return $content;
 		}
 
 		return MarkdownToBlocks::convert( $content );
+	}
+
+	/**
+	 * Handle content that contains Gutenberg block markup and possibly raw markdown.
+	 *
+	 * Parses the content into blocks. Named blocks are preserved; freeform blocks
+	 * (null blockName) that contain markdown signals are converted with
+	 * MarkdownToBlocks::convert() before the blocks are reassembled.
+	 *
+	 * @param string $content Content containing block markup and possibly markdown.
+	 * @return string Reassembled content with freeform markdown segments converted.
+	 */
+	private static function convert_mixed_content( string $content ): string {
+		// @phpstan-ignore-next-line
+		$parsed_blocks = parse_blocks( $content );
+		$output_parts  = [];
+
+		foreach ( $parsed_blocks as $block ) {
+			// Named block — preserve exactly as serialized.
+			if ( null !== $block['blockName'] ) {
+				// @phpstan-ignore-next-line
+				$output_parts[] = serialize_block( $block );
+				continue;
+			}
+
+			// Freeform block (null blockName): inner HTML is raw text/markdown.
+			$freeform_content = trim( (string) $block['innerHTML'] );
+			if ( '' === $freeform_content ) {
+				continue;
+			}
+
+			if ( self::count_markdown_signals( $freeform_content ) >= 2 ) {
+				$output_parts[] = MarkdownToBlocks::convert( $freeform_content );
+			} else {
+				// @phpstan-ignore-next-line
+				$output_parts[] = serialize_block( $block );
+			}
+		}
+
+		return trim( implode( "\n\n", $output_parts ) );
+	}
+
+	/**
+	 * Count the number of distinct markdown signals present in a string.
+	 *
+	 * @param string $content Content to analyse.
+	 * @return int Number of detected markdown signals (0–6).
+	 */
+	private static function count_markdown_signals( string $content ): int {
+		$signals = 0;
+		if ( preg_match( '/^#{1,6}\s+\S/m', $content ) ) {
+			++$signals;
+		}
+		if ( preg_match( '/\*{1,2}[^*\n]+\*{1,2}/', $content ) || preg_match( '/_{1,2}[^_\n]+_{1,2}/', $content ) ) {
+			++$signals;
+		}
+		if ( preg_match( '/^[\-\*]\s+\S/m', $content ) ) {
+			++$signals;
+		}
+		if ( preg_match( '/^\d+\.\s+\S/m', $content ) ) {
+			++$signals;
+		}
+		if ( preg_match( '/\[[^\]]+\]\([^)]+\)/', $content ) ) {
+			++$signals;
+		}
+		if ( str_contains( $content, '```' ) ) {
+			++$signals;
+		}
+		return $signals;
 	}
 
 	/**

--- a/tests/GratisAiAgent/Abilities/PostAbilitiesTest.php
+++ b/tests/GratisAiAgent/Abilities/PostAbilitiesTest.php
@@ -375,4 +375,95 @@ class PostAbilitiesTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result );
 		$this->assertSame( 'My Titled Post', $result['title'] );
 	}
+
+	// ─── maybe_convert_markdown ───────────────────────────────────
+
+	/**
+	 * Invoke the private maybe_convert_markdown() method via reflection.
+	 *
+	 * @param string $content Content to pass.
+	 * @return string Processed content.
+	 */
+	private function call_maybe_convert_markdown( string $content ): string {
+		$method = new \ReflectionMethod( PostAbilities::class, 'maybe_convert_markdown' );
+		$method->setAccessible( true );
+		return (string) $method->invoke( null, $content );
+	}
+
+	/**
+	 * Test that empty content is returned unchanged.
+	 */
+	public function test_maybe_convert_markdown_empty_content() {
+		$result = $this->call_maybe_convert_markdown( '' );
+		$this->assertSame( '', $result );
+	}
+
+	/**
+	 * Test that plain text without markdown signals is returned unchanged.
+	 */
+	public function test_maybe_convert_markdown_plain_text_unchanged() {
+		$plain = 'This is a plain sentence with no markdown.';
+		$result = $this->call_maybe_convert_markdown( $plain );
+		$this->assertSame( $plain, $result );
+	}
+
+	/**
+	 * Test that pure markdown content (≥2 signals) is converted to blocks.
+	 */
+	public function test_maybe_convert_markdown_pure_markdown_converted() {
+		$markdown = "## Introduction\n\nThis is a paragraph.\n\n- Item one\n- Item two";
+		$result   = $this->call_maybe_convert_markdown( $markdown );
+
+		// After conversion, should contain wp: block markers.
+		$this->assertStringContainsString( '<!-- wp:', $result );
+		// Must not contain the raw markdown heading.
+		$this->assertStringNotContainsString( '## Introduction', $result );
+	}
+
+	/**
+	 * Test that pure block markup without any markdown is returned unchanged.
+	 */
+	public function test_maybe_convert_markdown_pure_blocks_unchanged() {
+		$blocks = "<!-- wp:paragraph -->\n<p>Hello world</p>\n<!-- /wp:paragraph -->";
+		$result = $this->call_maybe_convert_markdown( $blocks );
+
+		// No markdown signals in the freeform segments, so the image block is preserved.
+		$this->assertStringContainsString( '<!-- wp:paragraph -->', $result );
+	}
+
+	/**
+	 * Test that mixed content (block markup + freeform markdown) converts
+	 * the markdown portions while preserving existing named blocks.
+	 */
+	public function test_maybe_convert_markdown_mixed_content_converts_freeform() {
+		$mixed = "<!-- wp:image {\"id\":42} -->\n"
+			. "<figure class=\"wp-block-image\"><img src=\"test.jpg\" /></figure>\n"
+			. "<!-- /wp:image -->\n\n"
+			. "## Section Heading\n\nThis paragraph follows.\n\n- Bullet one\n- Bullet two";
+
+		$result = $this->call_maybe_convert_markdown( $mixed );
+
+		// The original image block must be preserved.
+		$this->assertStringContainsString( '<!-- wp:image', $result );
+		// The raw markdown heading must not appear in the output.
+		$this->assertStringNotContainsString( '## Section Heading', $result );
+		// The freeform markdown must have been converted to blocks.
+		$this->assertStringContainsString( '<!-- wp:heading', $result );
+	}
+
+	/**
+	 * Test that mixed content with freeform HTML (non-markdown) keeps freeform
+	 * blocks intact — only segments with ≥2 markdown signals are converted.
+	 */
+	public function test_maybe_convert_markdown_mixed_content_preserves_freeform_html() {
+		$mixed = "<!-- wp:paragraph -->\n<p>Intro</p>\n<!-- /wp:paragraph -->\n\n"
+			. "<p>A plain HTML paragraph without markdown signals.</p>";
+
+		$result = $this->call_maybe_convert_markdown( $mixed );
+
+		// The named block must be preserved.
+		$this->assertStringContainsString( '<!-- wp:paragraph -->', $result );
+		// The plain HTML freeform segment has no markdown signals; it stays.
+		$this->assertStringContainsString( 'A plain HTML paragraph', $result );
+	}
 }


### PR DESCRIPTION
## Summary

Fixes the `PostAbilities::maybe_convert_markdown()` early-return that silently dropped all raw markdown text when the LLM produced hybrid content (Gutenberg blocks mixed with freeform markdown). Previously any content containing `<!-- wp:` was returned unchanged; now freeform (null-blockName) segments containing ≥2 markdown signals are individually converted by `MarkdownToBlocks::convert()` before reassembly.

## Changes

- **`includes/Abilities/PostAbilities.php`**
  - `maybe_convert_markdown()`: replace early-return on `<!-- wp:` with a call to `convert_mixed_content()`.
  - NEW `convert_mixed_content()`: parses with `parse_blocks()`, preserves named blocks via `serialize_block()`, converts freeform markdown segments.
  - NEW `count_markdown_signals()`: extracted from the duplicated inline detection logic; used by both the pure-markdown and mixed-content paths.
- **`tests/GratisAiAgent/Abilities/PostAbilitiesTest.php`**: five new unit tests covering empty content, plain-text pass-through, pure-markdown conversion, mixed-content conversion, and mixed-content freeform-HTML preservation.

## Verification

```
composer phpcs  # zero violations
composer phpstan  # zero errors (190 files scanned)
```

Tests: `PostAbilitiesTest` — pass hybrid content (image block + `## Heading\n\nParagraph\n\n- list item`) → freeform markdown segments become proper blocks; existing image block is preserved.

Resolves #1039