### PR TITLE
t200: Active jobs DB table + repository class (Phase 1a)

### DIFF
--- a/includes/Core/Database.php
+++ b/includes/Core/Database.php
@@ -36,7 +36,7 @@ use GratisAiAgent\Tools\CustomTools;
 class Database {
 
 	const DB_VERSION_OPTION = 'gratis_ai_agent_db_version';
-	const DB_VERSION        = '15.0.0';
+	const DB_VERSION        = '16.0.0';
 
 	// ─── Table Name Registry ──────────────────────────────────────────────────
 
@@ -205,6 +205,15 @@ class Database {
 		return $wpdb->prefix . 'gratis_ai_agent_generated_plugins';
 	}
 
+	/**
+	 * Get the active jobs table name.
+	 */
+	public static function active_jobs_table_name(): string {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+		return $wpdb->prefix . 'gratis_ai_agent_active_jobs';
+	}
+
 	// ─── Schema Installation ──────────────────────────────────────────────────
 
 	/**
@@ -241,6 +250,7 @@ class Database {
 		$benchmark_results_table      = self::benchmark_results_table_name();
 		$provider_trace_table         = self::provider_trace_table_name();
 		$generated_plugins_table      = self::generated_plugins_table_name();
+		$active_jobs_table            = self::active_jobs_table_name();
 		$charset                      = $wpdb->get_charset_collate();
 
 		// Knowledge tables.
@@ -573,6 +583,22 @@ class Database {
 			KEY slug (slug),
 			KEY status (status),
 			KEY created_at (created_at)
+		) {$charset};
+
+		CREATE TABLE {$active_jobs_table} (
+			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+			session_id bigint(20) unsigned NOT NULL,
+			job_id varchar(36) NOT NULL,
+			user_id bigint(20) unsigned NOT NULL,
+			status varchar(30) NOT NULL DEFAULT 'processing',
+			pending_tools longtext NOT NULL,
+			tool_calls longtext NOT NULL,
+			created_at datetime NOT NULL,
+			updated_at datetime NOT NULL,
+			PRIMARY KEY  (id),
+			UNIQUE KEY job_id (job_id),
+			KEY session_id (session_id),
+			KEY user_id_status (user_id, status)
 		) {$charset};";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';

--- a/includes/Models/ActiveJobRepository.php
+++ b/includes/Models/ActiveJobRepository.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Active jobs repository — persistent storage for background job state.
+ *
+ * Tracks the lifecycle of background AI jobs so that clients can reconnect
+ * after page navigation and resume polling for completion.
+ *
+ * @package GratisAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace GratisAiAgent\Models;
+
+use GratisAiAgent\Models\DTO\ActiveJobRow;
+
+class ActiveJobRepository {
+
+	/**
+	 * Valid job status values.
+	 */
+	const STATUSES = [ 'processing', 'awaiting_confirmation', 'complete', 'error' ];
+
+	/**
+	 * Get the active jobs table name.
+	 */
+	public static function table_name(): string {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+		return $wpdb->prefix . 'gratis_ai_agent_active_jobs';
+	}
+
+	/**
+	 * Create a new active job record.
+	 *
+	 * @param int    $session_id Session ID.
+	 * @param string $job_id     UUID identifying the background job.
+	 * @param int    $user_id    WordPress user ID.
+	 * @param string $status     Initial job status (default 'processing').
+	 * @return int|false Inserted row ID or false on failure.
+	 */
+	public static function create( int $session_id, string $job_id, int $user_id, string $status = 'processing' ) {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		if ( ! in_array( $status, self::STATUSES, true ) ) {
+			$status = 'processing';
+		}
+
+		$now = current_time( 'mysql', true );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Custom table query; caching not applicable.
+		$result = $wpdb->insert(
+			self::table_name(),
+			[
+				'session_id'    => $session_id,
+				'job_id'        => $job_id,
+				'user_id'       => $user_id,
+				'status'        => $status,
+				'pending_tools' => '[]',
+				'tool_calls'    => '[]',
+				'created_at'    => $now,
+				'updated_at'    => $now,
+			],
+			[ '%d', '%s', '%d', '%s', '%s', '%s', '%s', '%s' ]
+		);
+
+		return $result ? (int) $wpdb->insert_id : false;
+	}
+
+	/**
+	 * Get an active job row by its UUID.
+	 *
+	 * @param string $job_id The job UUID.
+	 * @return ActiveJobRow|null Row DTO or null if not found.
+	 */
+	public static function get_by_job_id( string $job_id ): ?ActiveJobRow {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$table = self::table_name();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE job_id = %s LIMIT 1',
+				$table,
+				$job_id
+			)
+		);
+
+		if ( null === $row ) {
+			return null;
+		}
+
+		return ActiveJobRow::from_row( $row );
+	}
+
+	/**
+	 * Get the active (non-terminal) job for a session.
+	 *
+	 * Returns the most-recently-created job that is still in a non-terminal
+	 * state (processing or awaiting_confirmation).
+	 *
+	 * @param int $session_id Session ID.
+	 * @return ActiveJobRow|null Row DTO or null if no active job exists.
+	 */
+	public static function get_by_session_id( int $session_id ): ?ActiveJobRow {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$table = self::table_name();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT * FROM %i WHERE session_id = %d AND status IN ('processing', 'awaiting_confirmation') ORDER BY created_at DESC LIMIT 1",
+				$table,
+				$session_id
+			)
+		);
+
+		if ( null === $row ) {
+			return null;
+		}
+
+		return ActiveJobRow::from_row( $row );
+	}
+
+	/**
+	 * Get all active (non-terminal) jobs for a user.
+	 *
+	 * @param int $user_id WordPress user ID.
+	 * @return list<ActiveJobRow>
+	 */
+	public static function get_active_for_user( int $user_id ): array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$table = self::table_name();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM %i WHERE user_id = %d AND status IN ('processing', 'awaiting_confirmation') ORDER BY created_at DESC",
+				$table,
+				$user_id
+			)
+		);
+
+		return array_map( [ ActiveJobRow::class, 'from_row' ], $rows ?: [] );
+	}
+
+	/**
+	 * Update the status (and optional fields) of an active job.
+	 *
+	 * @param string               $job_id The job UUID.
+	 * @param string               $status New status value.
+	 * @param array<string, mixed> $extra  Optional extra fields to update (pending_tools, tool_calls).
+	 * @return bool True on success, false on failure.
+	 */
+	public static function update_status( string $job_id, string $status, array $extra = [] ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		if ( ! in_array( $status, self::STATUSES, true ) ) {
+			return false;
+		}
+
+		$allowed = [ 'pending_tools', 'tool_calls' ];
+		$data    = array_intersect_key( $extra, array_flip( $allowed ) );
+
+		$data['status']     = $status;
+		$data['updated_at'] = current_time( 'mysql', true );
+
+		$formats = array_fill( 0, count( $data ), '%s' );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
+		$result = $wpdb->update(
+			self::table_name(),
+			$data,
+			[ 'job_id' => $job_id ],
+			$formats,
+			[ '%s' ]
+		);
+
+		return $result !== false;
+	}
+
+	/**
+	 * Delete an active job record by its UUID.
+	 *
+	 * @param string $job_id The job UUID.
+	 * @return bool True on success, false on failure.
+	 */
+	public static function delete( string $job_id ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
+		$result = $wpdb->delete(
+			self::table_name(),
+			[ 'job_id' => $job_id ],
+			[ '%s' ]
+		);
+
+		return $result !== false;
+	}
+}

--- a/includes/Models/DTO/ActiveJobRow.php
+++ b/includes/Models/DTO/ActiveJobRow.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Typed DTO for an active job row returned by wpdb::get_row().
+ *
+ * Eliminates `object::$` property-access phpstan errors throughout callers
+ * by providing explicit, typed property declarations for every column in the
+ * gratis_ai_agent_active_jobs table.
+ *
+ * @package GratisAiAgent\Models\DTO
+ * @license GPL-2.0-or-later
+ */
+
+namespace GratisAiAgent\Models\DTO;
+
+/**
+ * Immutable DTO for the gratis_ai_agent_active_jobs table row.
+ */
+readonly class ActiveJobRow {
+
+	/**
+	 * @param int    $id            Row ID (auto-increment PK).
+	 * @param int    $session_id    WordPress session ID (FK to sessions table).
+	 * @param string $job_id        UUID identifying the background job.
+	 * @param int    $user_id       WordPress user ID.
+	 * @param string $status        Job status: processing|awaiting_confirmation|complete|error.
+	 * @param string $pending_tools JSON-encoded pending tool-call confirmations (default '[]').
+	 * @param string $tool_calls    JSON-encoded tool-call log (default '[]').
+	 * @param string $created_at    MySQL datetime string (UTC).
+	 * @param string $updated_at    MySQL datetime string (UTC).
+	 */
+	public function __construct(
+		public int $id,
+		public int $session_id,
+		public string $job_id,
+		public int $user_id,
+		public string $status,
+		public string $pending_tools,
+		public string $tool_calls,
+		public string $created_at,
+		public string $updated_at,
+	) {}
+
+	/**
+	 * Construct an ActiveJobRow from the raw stdClass returned by wpdb::get_row().
+	 *
+	 * @param object $row Raw row from wpdb::get_row().
+	 * @return self
+	 */
+	public static function from_row( object $row ): self {
+		return new self(
+			id:            (int) $row->id,
+			session_id:    (int) $row->session_id,
+			job_id:        (string) ( $row->job_id ?? '' ),
+			user_id:       (int) $row->user_id,
+			status:        (string) ( $row->status ?? 'processing' ),
+			pending_tools: (string) ( $row->pending_tools ?? '[]' ),
+			tool_calls:    (string) ( $row->tool_calls ?? '[]' ),
+			created_at:    (string) ( $row->created_at ?? '' ),
+			updated_at:    (string) ( $row->updated_at ?? '' ),
+		);
+	}
+}

--- a/tests/GratisAiAgent/Core/DatabaseSchemaTest.php
+++ b/tests/GratisAiAgent/Core/DatabaseSchemaTest.php
@@ -61,6 +61,7 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 		'gratis_ai_agent_benchmark_results',
 		'gratis_ai_agent_provider_trace',
 		'gratis_ai_agent_generated_plugins',
+		'gratis_ai_agent_active_jobs',
 	];
 
 	/**


### PR DESCRIPTION
## Summary

Implements t200 (Phase 1a of resumable background jobs, GH#1028).

- **`includes/Models/DTO/ActiveJobRow.php`** — Readonly DTO for the `gratis_ai_agent_active_jobs` table row. Models on `SessionRow` pattern with `from_row()` factory.
- **`includes/Models/ActiveJobRepository.php`** — Static CRUD repository with `create()`, `get_by_job_id()`, `get_by_session_id()`, `get_active_for_user()`, `update_status()`, and `delete()`. Models on `Memory` static CRUD pattern.
- **`includes/Core/Database.php`** — Adds `gratis_ai_agent_active_jobs` table schema with `UNIQUE KEY job_id`, `KEY session_id`, and `KEY user_id_status` composite index. Bumps `DB_VERSION` from `15.0.0` to `16.0.0`. Adds `active_jobs_table_name()` to the table name registry.

## Verification

PHPCS: zero violations on all three files (`vendor/bin/phpcs` via canonical repo).

## Resolves

Resolves #1028