### PR TITLE
t205: Browser notifications for permission prompts (Phase 3)

### DIFF
--- a/src/admin-page/style.css
+++ b/src/admin-page/style.css
@@ -247,6 +247,22 @@ body.toplevel_page_gratis-ai-agent #wpbody-content > .updated {
 	50% { opacity: 0.3; }
 }
 
+/* Warning badge for sessions with a pending tool confirmation */
+.gratis-ai-agent-session-confirm-badge {
+	display: inline-block;
+	color: #d63638;
+	font-size: 14px;
+	line-height: 1;
+	margin-left: 4px;
+	vertical-align: middle;
+	animation: gratis-ai-agent-confirm-pulse 1s ease-in-out infinite;
+}
+
+@keyframes gratis-ai-agent-confirm-pulse {
+	0%, 100% { opacity: 1; transform: scale(1); }
+	50% { opacity: 0.6; transform: scale(1.2); }
+}
+
 .gratis-ai-agent-session-meta {
 	font-size: 11px;
 	color: #8c8f94;

--- a/src/components/session-sidebar.js
+++ b/src/components/session-sidebar.js
@@ -60,11 +60,12 @@ function relativeTime( dateStr ) {
  * Clicking the row opens the session. The ⋯ button opens a context menu
  * with rename, pin, folder, export, archive, trash, and share actions.
  *
- * @param {Object}  props              - Component props.
- * @param {Session} props.session      - Session data.
- * @param {boolean} props.isActive     - Whether this session is currently open.
- * @param {boolean} props.isOwner      - Whether the current user owns this session.
- * @param {boolean} props.hasActiveJob - Whether the session has an active job running.
+ * @param {Object}  props                        - Component props.
+ * @param {Session} props.session                - Session data.
+ * @param {boolean} props.isActive               - Whether this session is currently open.
+ * @param {boolean} props.isOwner                - Whether the current user owns this session.
+ * @param {boolean} props.hasActiveJob           - Whether the session has an active job running.
+ * @param {boolean} props.hasPendingConfirmation - Whether the session job is awaiting tool confirmation.
  * @return {JSX.Element} The session item element.
  */
 function SessionItem( {
@@ -72,6 +73,7 @@ function SessionItem( {
 	isActive,
 	isOwner = true,
 	hasActiveJob = false,
+	hasPendingConfirmation = false,
 } ) {
 	const [ showMenu, setShowMenu ] = useState( false );
 	const { openSession } = useDispatch( STORE_NAME );
@@ -117,7 +119,22 @@ function SessionItem( {
 					</span>
 				) }
 				{ session.title || __( 'Untitled', 'gratis-ai-agent' ) }
-				{ hasActiveJob && ! isActive && (
+				{ hasPendingConfirmation && ! isActive && (
+					<span
+						className="gratis-ai-agent-session-confirm-badge"
+						title={ __(
+							'Approval needed',
+							'gratis-ai-agent'
+						) }
+						aria-label={ __(
+							'Approval needed',
+							'gratis-ai-agent'
+						) }
+					>
+						{ '\u26A0' }
+					</span>
+				) }
+				{ hasActiveJob && ! hasPendingConfirmation && ! isActive && (
 					<span
 						className="gratis-ai-agent-session-job-badge"
 						title={ __( 'Agent is working', 'gratis-ai-agent' ) }
@@ -424,6 +441,10 @@ export default function SessionSidebar( { onClose } ) {
 						}
 						hasActiveJob={
 							!! sessionJobs[ parseInt( session.id, 10 ) ]
+						}
+						hasPendingConfirmation={
+							sessionJobs[ parseInt( session.id, 10 ) ]
+								?.status === 'awaiting_confirmation'
 						}
 					/>
 				) ) }

--- a/src/components/session-sidebar.js
+++ b/src/components/session-sidebar.js
@@ -122,10 +122,7 @@ function SessionItem( {
 				{ hasPendingConfirmation && ! isActive && (
 					<span
 						className="gratis-ai-agent-session-confirm-badge"
-						title={ __(
-							'Approval needed',
-							'gratis-ai-agent'
-						) }
+						title={ __( 'Approval needed', 'gratis-ai-agent' ) }
 						aria-label={ __(
 							'Approval needed',
 							'gratis-ai-agent'

--- a/src/floating-widget/session-tabs.js
+++ b/src/floating-widget/session-tabs.js
@@ -61,15 +61,12 @@ export default function SessionTabs() {
 							isActive ? 'is-active' : ''
 						} ${ needsApproval ? 'needs-approval' : '' }` }
 						onClick={ () => openSession( id ) }
-						title={
-							needsApproval
-								? __(
-										'Approval needed',
-										'gratis-ai-agent'
-								  )
-								: session.title ||
-								  __( 'Untitled', 'gratis-ai-agent' )
-						}
+					title={
+						needsApproval
+							? __( 'Approval needed', 'gratis-ai-agent' )
+							: session.title ||
+							  __( 'Untitled', 'gratis-ai-agent' )
+					}
 						type="button"
 					>
 						{ needsApproval && (

--- a/src/floating-widget/session-tabs.js
+++ b/src/floating-widget/session-tabs.js
@@ -20,10 +20,11 @@ import STORE_NAME from '../store';
  * @return {JSX.Element|null} The session tabs element, or null when empty.
  */
 export default function SessionTabs() {
-	const { sessions, currentSessionId } = useSelect(
+	const { sessions, currentSessionId, sessionJobs } = useSelect(
 		( select ) => ( {
 			sessions: select( STORE_NAME ).getSessions(),
 			currentSessionId: select( STORE_NAME ).getCurrentSessionId(),
+			sessionJobs: select( STORE_NAME ).getSessionJobs(),
 		} ),
 		[]
 	);
@@ -50,18 +51,35 @@ export default function SessionTabs() {
 			{ recentSessions.map( ( session ) => {
 				const id = parseInt( session.id, 10 );
 				const isActive = currentSessionId === id;
+				const jobState = sessionJobs[ id ];
+				const needsApproval =
+					jobState?.status === 'awaiting_confirmation';
 				return (
 					<button
 						key={ session.id }
 						className={ `gratis-ai-agent-tab-item ${
 							isActive ? 'is-active' : ''
-						}` }
+						} ${ needsApproval ? 'needs-approval' : '' }` }
 						onClick={ () => openSession( id ) }
 						title={
-							session.title || __( 'Untitled', 'gratis-ai-agent' )
+							needsApproval
+								? __(
+										'Approval needed',
+										'gratis-ai-agent'
+								  )
+								: session.title ||
+								  __( 'Untitled', 'gratis-ai-agent' )
 						}
 						type="button"
 					>
+						{ needsApproval && (
+							<span
+								className="gratis-ai-agent-tab-confirm-dot"
+								aria-hidden="true"
+							>
+								{ '\u26A0' }
+							</span>
+						) }
 						{ truncateTitle( session.title ) }
 					</button>
 				);

--- a/src/floating-widget/session-tabs.js
+++ b/src/floating-widget/session-tabs.js
@@ -61,12 +61,12 @@ export default function SessionTabs() {
 							isActive ? 'is-active' : ''
 						} ${ needsApproval ? 'needs-approval' : '' }` }
 						onClick={ () => openSession( id ) }
-					title={
-						needsApproval
-							? __( 'Approval needed', 'gratis-ai-agent' )
-							: session.title ||
-							  __( 'Untitled', 'gratis-ai-agent' )
-					}
+						title={
+							needsApproval
+								? __( 'Approval needed', 'gratis-ai-agent' )
+								: session.title ||
+								  __( 'Untitled', 'gratis-ai-agent' )
+						}
 						type="button"
 					>
 						{ needsApproval && (

--- a/src/floating-widget/style.css
+++ b/src/floating-widget/style.css
@@ -220,6 +220,25 @@
 	color: #fff;
 }
 
+.gratis-ai-agent-tab-item.needs-approval {
+	border-color: #d63638;
+}
+
+/* Warning icon inside tab for pending tool confirmation */
+.gratis-ai-agent-tab-confirm-dot {
+	display: inline-block;
+	color: #d63638;
+	font-size: 12px;
+	margin-right: 3px;
+	vertical-align: middle;
+	animation: gratis-ai-agent-confirm-pulse 1s ease-in-out infinite;
+}
+
+@keyframes gratis-ai-agent-confirm-pulse {
+	0%, 100% { opacity: 1; transform: scale(1); }
+	50% { opacity: 0.6; transform: scale(1.2); }
+}
+
 .gratis-ai-agent-tab-new.components-button {
 	padding: 2px;
 	min-width: auto;

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -8,6 +8,7 @@
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import { onVisibilityChange } from '../../utils/visibility-manager';
+import { notifyConfirmationNeeded } from '../../utils/notification-manager';
 
 export const initialState = {
 	// Active polling job ID (most-recently-started job for the current session).
@@ -229,6 +230,21 @@ export const actions = {
 							dispatch.setPendingConfirmation( cardData );
 							dispatch.setPendingActionCard( cardData );
 						}
+
+						// Fire a browser notification when the user is not
+						// looking at the page so they know approval is needed.
+						if (
+							typeof document !== 'undefined' &&
+							document.hidden
+						) {
+							const firstTool = result.pending_tools?.[ 0 ];
+							const toolName =
+								firstTool?.function?.name ||
+								firstTool?.name ||
+								'';
+							notifyConfirmationNeeded( jobId, toolName );
+						}
+
 						// Don't clear sending — still waiting.
 						unsubscribeVisibility();
 						return;

--- a/src/store/slices/sessionsSlice.js
+++ b/src/store/slices/sessionsSlice.js
@@ -18,6 +18,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import { snapshotDescriptors } from '../../abilities/registry';
 import { ensureRegistered as ensureClientAbilitiesRegistered } from '../../abilities';
+import { clearNotification } from '../../utils/notification-manager';
 
 /**
  * Associate tool call log entries with the correct model text messages.
@@ -1045,6 +1046,8 @@ export const actions = {
 			dispatch.setPendingConfirmation( null );
 			dispatch.setPendingActionCard( null );
 			const sessionId = select.getCurrentSessionId();
+			// Dismiss any browser notification that was fired for this job.
+			clearNotification( jobId );
 			try {
 				await apiFetch( {
 					path: `/gratis-ai-agent/v1/job/${ jobId }/confirm`,
@@ -1080,6 +1083,8 @@ export const actions = {
 			dispatch.setPendingConfirmation( null );
 			dispatch.setPendingActionCard( null );
 			const sessionId = select.getCurrentSessionId();
+			// Dismiss any browser notification that was fired for this job.
+			clearNotification( jobId );
 			try {
 				await apiFetch( {
 					path: `/gratis-ai-agent/v1/job/${ jobId }/reject`,

--- a/src/utils/notification-manager.js
+++ b/src/utils/notification-manager.js
@@ -1,0 +1,221 @@
+/**
+ * Notification Manager
+ *
+ * Manages browser notifications for pending tool confirmations and
+ * document title flashing when the page is hidden. Singleton pattern
+ * so all callers share the same active-notification registry and the
+ * title flash loop.
+ *
+ * Usage:
+ *   import { requestPermission, notifyConfirmationNeeded, clearNotification } from '../utils/notification-manager';
+ *
+ *   // On first tool confirmation (or from settings):
+ *   requestPermission();
+ *
+ *   // When awaiting_confirmation and document.hidden:
+ *   notifyConfirmationNeeded( jobId, toolName );
+ *
+ *   // When confirmation resolved:
+ *   clearNotification( jobId );
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/** @type {Map<string, Notification>} Active notifications keyed by jobId. */
+const activeNotifications = new Map();
+
+/** @type {number|null} setInterval ID for the title flash loop. */
+let titleFlashInterval = null;
+
+/** @type {string} Original document title before flashing started. */
+let originalTitle = '';
+
+/** @type {string[]} Job IDs currently awaiting confirmation (drives flash loop). */
+const pendingJobIds = [];
+
+/**
+ * Start flashing the document title with an approval-needed prefix.
+ * No-op when there are no pending jobs or the page is already visible.
+ *
+ * The flash alternates between "⚠ Approval needed" and the original
+ * title every 1500 ms, and is cleared automatically when the page
+ * becomes visible again.
+ */
+function startTitleFlash() {
+	if ( titleFlashInterval !== null ) {
+		// Already flashing.
+		return;
+	}
+
+	originalTitle = document.title;
+	let toggle = false;
+
+	titleFlashInterval = setInterval( () => {
+		if ( ! document.hidden ) {
+			stopTitleFlash();
+			return;
+		}
+		document.title = toggle
+			? originalTitle
+			: `\u26A0 ${ __( 'Approval needed', 'gratis-ai-agent' ) } \u2014 ${ originalTitle }`;
+		toggle = ! toggle;
+	}, 1500 );
+}
+
+/**
+ * Stop flashing the document title and restore the original value.
+ */
+function stopTitleFlash() {
+	if ( titleFlashInterval !== null ) {
+		clearInterval( titleFlashInterval );
+		titleFlashInterval = null;
+	}
+	if ( originalTitle ) {
+		document.title = originalTitle;
+		originalTitle = '';
+	}
+}
+
+/**
+ * Request browser notification permission from the user.
+ *
+ * Should be called in response to a user gesture (e.g. first tool
+ * confirmation click or from the settings page) so that browsers
+ * that require user activation can honour the prompt.
+ *
+ * @return {Promise<NotificationPermission>} Resolved permission state.
+ */
+export async function requestPermission() {
+	if ( ! ( 'Notification' in window ) ) {
+		return 'denied';
+	}
+
+	if ( Notification.permission !== 'default' ) {
+		return Notification.permission;
+	}
+
+	return Notification.requestPermission();
+}
+
+/**
+ * Fire a browser notification when a tool confirmation is needed and
+ * the page is not visible.  Starts the document title flash loop too.
+ *
+ * Skips silently when:
+ *  - The Notifications API is not available.
+ *  - Permission is 'denied'.
+ *  - A notification for this jobId is already active.
+ *  - `document.hidden` is false (user is already looking at the page).
+ *
+ * @param {string} jobId    Job identifier awaiting confirmation.
+ * @param {string} toolName Name of the tool awaiting approval (for the notification body).
+ */
+export function notifyConfirmationNeeded( jobId, toolName ) {
+	if ( ! pendingJobIds.includes( jobId ) ) {
+		pendingJobIds.push( jobId );
+	}
+
+	if ( document.hidden ) {
+		startTitleFlash();
+	}
+
+	if ( ! ( 'Notification' in window ) ) {
+		return;
+	}
+
+	if ( Notification.permission !== 'granted' ) {
+		return;
+	}
+
+	if ( activeNotifications.has( jobId ) ) {
+		// Already notified for this job.
+		return;
+	}
+
+	const body = toolName
+		? `${ __( 'Tool approval needed:', 'gratis-ai-agent' ) } ${ toolName }`
+		: __( 'A tool is awaiting your approval.', 'gratis-ai-agent' );
+
+	const notification = new Notification(
+		__( 'AI Agent — Approval Required', 'gratis-ai-agent' ),
+		{
+			body,
+			requireInteraction: true,
+			tag: `job-confirm-${ jobId }`,
+			icon: window.gratisAiAgentData?.pluginUrl
+				? `${ window.gratisAiAgentData.pluginUrl }assets/icon-128.png`
+				: undefined,
+		}
+	);
+
+	notification.onclick = () => {
+		window.focus();
+		notification.close();
+	};
+
+	activeNotifications.set( jobId, notification );
+}
+
+/**
+ * Clear the browser notification and stop the title flash for a job.
+ *
+ * Call this when the confirmation has been resolved (confirmed or rejected)
+ * or when the job transitions away from `awaiting_confirmation`.
+ *
+ * @param {string} jobId Job identifier whose notification should be cleared.
+ */
+export function clearNotification( jobId ) {
+	const notification = activeNotifications.get( jobId );
+	if ( notification ) {
+		notification.close();
+		activeNotifications.delete( jobId );
+	}
+
+	const idx = pendingJobIds.indexOf( jobId );
+	if ( idx !== -1 ) {
+		pendingJobIds.splice( idx, 1 );
+	}
+
+	// If no more pending jobs, stop flashing.
+	if ( pendingJobIds.length === 0 ) {
+		stopTitleFlash();
+	}
+}
+
+/**
+ * Clear all active notifications and stop the title flash.
+ * Useful on page unload or plugin reset.
+ */
+export function clearAllNotifications() {
+	activeNotifications.forEach( ( notification ) => notification.close() );
+	activeNotifications.clear();
+	pendingJobIds.length = 0;
+	stopTitleFlash();
+}
+
+/**
+ * Return whether the Notifications API is available and permission is granted.
+ *
+ * @return {boolean} True when notifications can be fired.
+ */
+export function canNotify() {
+	return (
+		'Notification' in window && Notification.permission === 'granted'
+	);
+}
+
+/**
+ * Return the current Notification permission state, or 'unsupported'
+ * when the API is unavailable.
+ *
+ * @return {string} 'granted' | 'denied' | 'default' | 'unsupported'
+ */
+export function getPermissionState() {
+	if ( ! ( 'Notification' in window ) ) {
+		return 'unsupported';
+	}
+	return Notification.permission;
+}

--- a/src/utils/notification-manager.js
+++ b/src/utils/notification-manager.js
@@ -51,6 +51,12 @@ function startTitleFlash() {
 	}
 
 	originalTitle = document.title;
+	// Build the flash title once so we don't call __() on every interval tick.
+	const flashTitle =
+		'\u26A0 ' +
+		__( 'Approval needed', 'gratis-ai-agent' ) +
+		' \u2014 ' +
+		originalTitle;
 	let toggle = false;
 
 	titleFlashInterval = setInterval( () => {
@@ -58,9 +64,7 @@ function startTitleFlash() {
 			stopTitleFlash();
 			return;
 		}
-		document.title = toggle
-			? originalTitle
-			: `\u26A0 ${ __( 'Approval needed', 'gratis-ai-agent' ) } \u2014 ${ originalTitle }`;
+		document.title = toggle ? originalTitle : flashTitle;
 		toggle = ! toggle;
 	}, 1500 );
 }
@@ -86,7 +90,7 @@ function stopTitleFlash() {
  * confirmation click or from the settings page) so that browsers
  * that require user activation can honour the prompt.
  *
- * @return {Promise<NotificationPermission>} Resolved permission state.
+ * @return {Promise<string>} Resolved permission state ('granted'|'denied'|'default').
  */
 export async function requestPermission() {
 	if ( ! ( 'Notification' in window ) ) {
@@ -202,9 +206,7 @@ export function clearAllNotifications() {
  * @return {boolean} True when notifications can be fired.
  */
 export function canNotify() {
-	return (
-		'Notification' in window && Notification.permission === 'granted'
-	);
+	return 'Notification' in window && Notification.permission === 'granted';
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements Phase 3 of the resumable background jobs feature (t199): browser notifications and UI badges for pending tool confirmations, so users know when the AI is waiting for their approval even when they've navigated away.

- **NEW** `src/utils/notification-manager.js` — singleton managing browser Notification API and document title flashing for `awaiting_confirmation` jobs. Exports `requestPermission()`, `notifyConfirmationNeeded(jobId, toolName)`, `clearNotification(jobId)`.
- **EDIT** `src/store/slices/jobSlice.js` — integrate notification-manager into `pollJob()`: fires `notifyConfirmationNeeded()` when `status === 'awaiting_confirmation'` and `document.hidden`.
- **EDIT** `src/store/slices/sessionsSlice.js` — `confirmToolCall()` and `rejectToolCall()` both call `clearNotification(jobId)` to dismiss notification on resolution.
- **EDIT** `src/components/session-sidebar.js` — add `hasPendingConfirmation` prop to `SessionItem`; renders a pulsing red ⚠ badge when `sessionJobs[id].status === 'awaiting_confirmation'`.
- **EDIT** `src/floating-widget/session-tabs.js` — subscribe to `sessionJobs` in `useSelect`; render ⚠ icon in tab buttons and add `.needs-approval` border highlight when status is `awaiting_confirmation`.
- **EDIT** `src/admin-page/style.css` / `src/floating-widget/style.css` — CSS for new badges with `gratis-ai-agent-confirm-pulse` keyframe animation.

## Behaviour

1. `pollJob()` (in jobSlice) detects `awaiting_confirmation` → calls `notifyConfirmationNeeded(jobId, toolName)`
2. If `Notification.permission === 'granted'` and `document.hidden`: fires a `requireInteraction: true` browser notification tagged `job-confirm-{jobId}`
3. `document.title` flashes "⚠ Approval needed — {original title}" every 1.5s while hidden; auto-stops on tab focus
4. Session sidebar and floating-widget tab strip show a pulsing ⚠ badge on the session row/tab
5. User clicks Confirm or Reject → `clearNotification(jobId)` dismisses notification and stops title flash

## Notes on t204 dependency

t204 was merged (#1045) before this PR, which created `jobSlice.js` and extracted `pollJob` from `sessionsSlice.js`. This PR is rebased on top of t204's work: `notifyConfirmationNeeded` is integrated in `jobSlice.js:pollJob()` and `clearNotification` in `sessionsSlice.js:confirmToolCall()/rejectToolCall()`.

## Testing

`npm run lint:js && npm run build`

Manual: trigger a tool confirmation, switch to another browser tab — verify notification fires and title flashes. Switch back — verify title restores. Confirm or reject — verify ⚠ badge disappears.

Resolves #1033

---
[aidevops.sh](https://aidevops.sh) v3.8.68 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 49m and 61,846 tokens on this as a headless worker.