### PR TITLE
t206: cross-page navigation survival via sessionStorage (Phase 4)

### DIFF
--- a/src/floating-widget/index.js
+++ b/src/floating-widget/index.js
@@ -17,6 +17,7 @@ import FloatingButton from './floating-button';
 import FloatingPanel from './floating-panel';
 import SiteBuilderOverlay from './site-builder-overlay';
 import useKeyboardShortcut from './use-keyboard-shortcut';
+import { getActiveJobs } from '../utils/active-jobs-storage';
 import '../components/shared.css';
 import './style.css';
 
@@ -40,6 +41,7 @@ function FloatingWidget() {
 		setPageContext,
 		setSiteBuilderMode,
 		setFloatingOpen,
+		pollJob,
 	} = useDispatch( STORE_NAME );
 
 	const { isOpen, isSiteBuilderMode, settings, bootError } = useSelect(
@@ -63,6 +65,28 @@ function FloatingWidget() {
 		fetchProviders();
 		fetchSessions();
 	}, [ fetchProviders, fetchSessions ] );
+
+	// Cross-page navigation survival (Phase 4 / t206):
+	// Restore any active poll loops from sessionStorage. If the user navigated
+	// away from an admin page while a background job was running, sessionStorage
+	// still holds the jobId → sessionId mapping. Re-starting the poll loop here
+	// reconnects to the in-progress job without a full page reload.
+	// sessionStorage is cleared when the tab closes, so stale entries from a
+	// previous tab session are never restored. pollJob handles already-completed
+	// jobs gracefully — the first poll returns 'complete' and exits cleanly.
+	useEffect( () => {
+		const activeJobs = getActiveJobs();
+		const entries = Object.entries( activeJobs );
+		if ( entries.length === 0 ) {
+			return;
+		}
+		for ( const [ sessionIdStr, jobId ] of entries ) {
+			const sessionId = parseInt( sessionIdStr, 10 );
+			if ( ! isNaN( sessionId ) && jobId ) {
+				pollJob( jobId, sessionId );
+			}
+		}
+	}, [ pollJob ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	// Fetch settings on mount so the keyboard shortcut is available.
 	const { fetchSettings } = useDispatch( STORE_NAME );

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -8,6 +8,7 @@
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import { onVisibilityChange } from '../../utils/visibility-manager';
+import { setActiveJob, clearActiveJob } from '../../utils/active-jobs-storage';
 
 export const initialState = {
 	// Active polling job ID (most-recently-started job for the current session).
@@ -137,6 +138,7 @@ export const actions = {
 				attempts++;
 				if ( attempts > maxAttempts ) {
 					unsubscribeVisibility();
+					clearActiveJob( sessionId );
 					// Only append error and update UI for the current session.
 					if ( select.getCurrentSessionId() === sessionId ) {
 						dispatch.appendMessage( {
@@ -206,6 +208,7 @@ export const actions = {
 						if ( currentJobId !== jobId && currentJobId !== null ) {
 							// Different job is now active; stop this poller.
 							unsubscribeVisibility();
+							clearActiveJob( sessionId );
 							return;
 						}
 
@@ -231,6 +234,7 @@ export const actions = {
 						}
 						// Don't clear sending — still waiting.
 						unsubscribeVisibility();
+						clearActiveJob( sessionId );
 						return;
 					}
 
@@ -388,6 +392,7 @@ export const actions = {
 
 				// Job finished (complete or error).
 				unsubscribeVisibility();
+				clearActiveJob( sessionId );
 				if ( select.getCurrentSessionId() === sessionId ) {
 					dispatch.setSending( false );
 					dispatch.setLiveToolCalls( [] );
@@ -397,6 +402,10 @@ export const actions = {
 				dispatch.setCurrentJobId( null );
 				dispatch.setSessionJob( sessionId, null );
 			};
+
+			// Persist to sessionStorage so the poll loop survives same-tab
+			// wp-admin page navigation (Phase 4 / t206).
+			setActiveJob( sessionId, jobId );
 
 			// Initial delay before first poll.
 			setTimeout( poll, 2000 );

--- a/src/utils/__tests__/active-jobs-storage.test.js
+++ b/src/utils/__tests__/active-jobs-storage.test.js
@@ -96,7 +96,9 @@ describe( 'clearActiveJob', () => {
 	test( 'removes the key entirely when the map becomes empty', () => {
 		setActiveJob( 7, 'job_seven' );
 		clearActiveJob( 7 );
-		expect( sessionStorage.getItem( 'gratisAiAgent_activeJobs' ) ).toBeNull();
+		expect(
+			sessionStorage.getItem( 'gratisAiAgent_activeJobs' )
+		).toBeNull();
 	} );
 
 	test( 'is a no-op when sessionStorage is empty', () => {

--- a/src/utils/__tests__/active-jobs-storage.test.js
+++ b/src/utils/__tests__/active-jobs-storage.test.js
@@ -1,0 +1,149 @@
+/**
+ * Unit tests for utils/active-jobs-storage.js
+ *
+ * Tests cover:
+ * - setActiveJob: persists jobId for a session
+ * - clearActiveJob: removes session from storage, cleans up empty map
+ * - getActiveJobs: reads all persisted entries
+ * - Graceful degradation when sessionStorage throws (quota, private mode)
+ */
+
+import {
+	setActiveJob,
+	clearActiveJob,
+	getActiveJobs,
+} from '../active-jobs-storage';
+
+// ─── sessionStorage mock ──────────────────────────────────────────────────────
+
+const sessionStorageMock = ( () => {
+	let store = {};
+	return {
+		getItem: ( key ) => store[ key ] ?? null,
+		setItem: ( key, value ) => {
+			store[ key ] = String( value );
+		},
+		removeItem: ( key ) => {
+			delete store[ key ];
+		},
+		clear: () => {
+			store = {};
+		},
+	};
+} )();
+
+Object.defineProperty( global, 'sessionStorage', {
+	value: sessionStorageMock,
+	writable: true,
+} );
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+beforeEach( () => {
+	sessionStorageMock.clear();
+} );
+
+// ─── setActiveJob ─────────────────────────────────────────────────────────────
+
+describe( 'setActiveJob', () => {
+	test( 'persists a job entry to sessionStorage', () => {
+		setActiveJob( 42, 'job_abc' );
+		const raw = sessionStorage.getItem( 'gratisAiAgent_activeJobs' );
+		expect( JSON.parse( raw ) ).toEqual( { 42: 'job_abc' } );
+	} );
+
+	test( 'adds a second session without overwriting the first', () => {
+		setActiveJob( 1, 'job_a' );
+		setActiveJob( 2, 'job_b' );
+		const raw = sessionStorage.getItem( 'gratisAiAgent_activeJobs' );
+		expect( JSON.parse( raw ) ).toEqual( { 1: 'job_a', 2: 'job_b' } );
+	} );
+
+	test( 'updates an existing session entry', () => {
+		setActiveJob( 1, 'job_old' );
+		setActiveJob( 1, 'job_new' );
+		const raw = sessionStorage.getItem( 'gratisAiAgent_activeJobs' );
+		expect( JSON.parse( raw ) ).toEqual( { 1: 'job_new' } );
+	} );
+
+	test( 'does not throw when sessionStorage is unavailable', () => {
+		const original = global.sessionStorage;
+		Object.defineProperty( global, 'sessionStorage', {
+			get() {
+				throw new Error( 'storage unavailable' );
+			},
+			configurable: true,
+		} );
+		expect( () => setActiveJob( 1, 'job_x' ) ).not.toThrow();
+		Object.defineProperty( global, 'sessionStorage', {
+			value: original,
+			configurable: true,
+			writable: true,
+		} );
+	} );
+} );
+
+// ─── clearActiveJob ───────────────────────────────────────────────────────────
+
+describe( 'clearActiveJob', () => {
+	test( 'removes the entry for the given session', () => {
+		setActiveJob( 5, 'job_five' );
+		setActiveJob( 6, 'job_six' );
+		clearActiveJob( 5 );
+		expect( getActiveJobs() ).toEqual( { 6: 'job_six' } );
+	} );
+
+	test( 'removes the key entirely when the map becomes empty', () => {
+		setActiveJob( 7, 'job_seven' );
+		clearActiveJob( 7 );
+		expect( sessionStorage.getItem( 'gratisAiAgent_activeJobs' ) ).toBeNull();
+	} );
+
+	test( 'is a no-op when sessionStorage is empty', () => {
+		expect( () => clearActiveJob( 99 ) ).not.toThrow();
+	} );
+
+	test( 'is a no-op when the session was not registered', () => {
+		setActiveJob( 10, 'job_ten' );
+		clearActiveJob( 999 ); // Unrelated session.
+		expect( getActiveJobs() ).toEqual( { 10: 'job_ten' } );
+	} );
+} );
+
+// ─── getActiveJobs ────────────────────────────────────────────────────────────
+
+describe( 'getActiveJobs', () => {
+	test( 'returns an empty object when storage is empty', () => {
+		expect( getActiveJobs() ).toEqual( {} );
+	} );
+
+	test( 'returns all persisted entries', () => {
+		setActiveJob( 20, 'job_twenty' );
+		setActiveJob( 21, 'job_twentyone' );
+		expect( getActiveJobs() ).toEqual( {
+			20: 'job_twenty',
+			21: 'job_twentyone',
+		} );
+	} );
+
+	test( 'returns an empty object when sessionStorage is unavailable', () => {
+		const original = global.sessionStorage;
+		Object.defineProperty( global, 'sessionStorage', {
+			get() {
+				throw new Error( 'storage unavailable' );
+			},
+			configurable: true,
+		} );
+		expect( getActiveJobs() ).toEqual( {} );
+		Object.defineProperty( global, 'sessionStorage', {
+			value: original,
+			configurable: true,
+			writable: true,
+		} );
+	} );
+
+	test( 'returns an empty object when storage contains malformed JSON', () => {
+		sessionStorage.setItem( 'gratisAiAgent_activeJobs', 'not-json{' );
+		expect( getActiveJobs() ).toEqual( {} );
+	} );
+} );

--- a/src/utils/active-jobs-storage.js
+++ b/src/utils/active-jobs-storage.js
@@ -1,0 +1,80 @@
+/**
+ * Active-jobs sessionStorage utility — cross-page navigation survival (t206).
+ *
+ * Persists active job IDs to sessionStorage on poll start and restores them
+ * on FloatingWidget mount, allowing background job polling to survive same-tab
+ * wp-admin page navigation (e.g. user navigates away and back while a job runs).
+ *
+ * Scope: sessionStorage is cleared when the tab is closed, so this utility
+ * only covers same-tab navigation. Cross-session reconnection (tab close/reopen
+ * or browser restart) requires the DB-backed endpoint from Phase 1c (t202).
+ *
+ * Silently tolerates storage unavailability (private mode, quota exceeded) —
+ * cross-page survival is best-effort; the UI degrades gracefully.
+ */
+
+/** @type {string} sessionStorage key for the active-jobs map. */
+const STORAGE_KEY = 'gratisAiAgent_activeJobs';
+
+/**
+ * Register or update an active job in sessionStorage.
+ *
+ * Called when a poll loop starts so the job survives navigation.
+ *
+ * @param {number} sessionId - Session the job belongs to.
+ * @param {string} jobId     - Background job identifier.
+ */
+export function setActiveJob( sessionId, jobId ) {
+	try {
+		const raw = sessionStorage.getItem( STORAGE_KEY );
+		const jobs = raw ? JSON.parse( raw ) : {};
+		jobs[ sessionId ] = jobId;
+		sessionStorage.setItem( STORAGE_KEY, JSON.stringify( jobs ) );
+	} catch {
+		// sessionStorage unavailable or quota exceeded — silently degrade.
+	}
+}
+
+/**
+ * Remove a session's job entry from sessionStorage when polling ends.
+ *
+ * Called on all poll-loop exit paths (complete, error, timeout,
+ * awaiting_confirmation).
+ *
+ * @param {number} sessionId - Session identifier to clear.
+ */
+export function clearActiveJob( sessionId ) {
+	try {
+		const raw = sessionStorage.getItem( STORAGE_KEY );
+		if ( ! raw ) {
+			return;
+		}
+		const jobs = JSON.parse( raw );
+		delete jobs[ sessionId ];
+		if ( Object.keys( jobs ).length === 0 ) {
+			sessionStorage.removeItem( STORAGE_KEY );
+		} else {
+			sessionStorage.setItem( STORAGE_KEY, JSON.stringify( jobs ) );
+		}
+	} catch {
+		// Silently degrade.
+	}
+}
+
+/**
+ * Read all active jobs persisted in sessionStorage.
+ *
+ * Used by FloatingWidget on mount to restore interrupted poll loops
+ * after same-tab wp-admin navigation.
+ *
+ * @return {Object} Map of sessionId (string key) → jobId (string value).
+ *                  Returns an empty object when storage is unavailable or empty.
+ */
+export function getActiveJobs() {
+	try {
+		const raw = sessionStorage.getItem( STORAGE_KEY );
+		return raw ? JSON.parse( raw ) : {};
+	} catch {
+		return {};
+	}
+}


### PR DESCRIPTION
## Summary

Phase 4 of the resumable background jobs feature (t199). Adds `sessionStorage`-based persistence so active background job poll loops survive same-tab wp-admin page navigation.

## What

- **NEW** `src/utils/active-jobs-storage.js` — thin wrapper around `sessionStorage` with three exports:
  - `setActiveJob(sessionId, jobId)` — called when a poll loop starts
  - `clearActiveJob(sessionId)` — called on all poll-loop exit paths
  - `getActiveJobs()` — returns all persisted `{sessionId → jobId}` entries

- **EDIT** `src/store/slices/jobSlice.js` — integrate storage with `pollJob`:
  - `setActiveJob` before the initial `setTimeout(poll, 2000)`
  - `clearActiveJob` at every exit path: maxAttempts timeout, different-job preemption, `awaiting_confirmation`, and job complete/error

- **EDIT** `src/floating-widget/index.js` — on mount, read `sessionStorage` and dispatch `pollJob` for each surviving entry. Already-complete jobs are handled gracefully: the first poll returns `complete` and the loop exits cleanly without side-effects.

- **NEW** `src/utils/__tests__/active-jobs-storage.test.js` — 12 unit tests covering set/clear/get, multi-session, update, quota errors, and malformed JSON.

## Scope

`sessionStorage` is cleared when the tab closes, so this only covers **same-tab** navigation. Cross-session reconnection (tab close/reopen or browser restart) requires the DB-backed endpoint from Phase 1c (t202), which is tracked separately.

## Verification

- 12 new unit tests pass (`active-jobs-storage.test.js`)
- 98 existing store tests pass (`store/__tests__/index.test.js`)
- ESLint clean on all changed files

Resolves #1034

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Background job polling tasks now automatically persist and resume across same-tab page navigation, maintaining state when you navigate away and return to the admin interface.

* **Tests**
  * Added comprehensive test coverage for the polling persistence functionality, including edge cases for unavailable storage, empty states, malformed data, and session cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->