### PR TITLE
fix: use camelCase property names in SessionRow DTO

### DIFF
--- a/includes/Models/DTO/SessionRow.php
+++ b/includes/Models/DTO/SessionRow.php
@@ -20,38 +20,38 @@ namespace GratisAiAgent\Models\DTO;
 readonly class SessionRow {
 
 	/**
-	 * @param int         $id                Session ID (auto-increment PK).
-	 * @param int         $user_id           WordPress user ID.
-	 * @param string      $title             Human-readable title (default '').
-	 * @param string      $provider_id       AI provider slug (default '').
-	 * @param string      $model_id          Model slug (default '').
-	 * @param string      $messages          JSON-encoded message array.
-	 * @param string      $tool_calls        JSON-encoded tool-call log.
-	 * @param int         $prompt_tokens     Total prompt tokens consumed.
-	 * @param int         $completion_tokens Total completion tokens consumed.
-	 * @param string      $status            Session status (active|archived|trash).
-	 * @param bool        $pinned            Whether the session is pinned.
-	 * @param string      $folder            Folder name (default '').
-	 * @param string|null $paused_state      JSON-encoded paused state, or null.
-	 * @param string      $created_at        MySQL datetime string (UTC).
-	 * @param string      $updated_at        MySQL datetime string (UTC).
+	 * @param int         $id               Session ID (auto-increment PK).
+	 * @param int         $userId           WordPress user ID.
+	 * @param string      $title            Human-readable title (default '').
+	 * @param string      $providerId       AI provider slug (default '').
+	 * @param string      $modelId          Model slug (default '').
+	 * @param string      $messages         JSON-encoded message array.
+	 * @param string      $toolCalls        JSON-encoded tool-call log.
+	 * @param int         $promptTokens     Total prompt tokens consumed.
+	 * @param int         $completionTokens Total completion tokens consumed.
+	 * @param string      $status           Session status (active|archived|trash).
+	 * @param bool        $pinned           Whether the session is pinned.
+	 * @param string      $folder           Folder name (default '').
+	 * @param string|null $pausedState      JSON-encoded paused state, or null.
+	 * @param string      $createdAt        MySQL datetime string (UTC).
+	 * @param string      $updatedAt        MySQL datetime string (UTC).
 	 */
 	public function __construct(
 		public int $id,
-		public int $user_id,
+		public int $userId,
 		public string $title,
-		public string $provider_id,
-		public string $model_id,
+		public string $providerId,
+		public string $modelId,
 		public string $messages,
-		public string $tool_calls,
-		public int $prompt_tokens,
-		public int $completion_tokens,
+		public string $toolCalls,
+		public int $promptTokens,
+		public int $completionTokens,
 		public string $status,
 		public bool $pinned,
 		public string $folder,
-		public ?string $paused_state,
-		public string $created_at,
-		public string $updated_at,
+		public ?string $pausedState,
+		public string $createdAt,
+		public string $updatedAt,
 	) {}
 
 	/**
@@ -62,21 +62,21 @@ readonly class SessionRow {
 	 */
 	public static function from_row( object $row ): self {
 		return new self(
-			id:                (int) $row->id,
-			user_id:           (int) $row->user_id,
-			title:             (string) ( $row->title ?? '' ),
-			provider_id:       (string) ( $row->provider_id ?? '' ),
-			model_id:          (string) ( $row->model_id ?? '' ),
-			messages:          (string) ( $row->messages ?? '[]' ),
-			tool_calls:        (string) ( $row->tool_calls ?? '[]' ),
-			prompt_tokens:     (int) ( $row->prompt_tokens ?? 0 ),
-			completion_tokens: (int) ( $row->completion_tokens ?? 0 ),
-			status:            (string) ( $row->status ?? 'active' ),
-			pinned:            (bool) (int) ( $row->pinned ?? 0 ),
-			folder:            (string) ( $row->folder ?? '' ),
-			paused_state:      isset( $row->paused_state ) && '' !== $row->paused_state ? (string) $row->paused_state : null,
-			created_at:        (string) ( $row->created_at ?? '' ),
-			updated_at:        (string) ( $row->updated_at ?? '' ),
+			id:               (int) $row->id,
+			userId:           (int) $row->user_id,
+			title:            (string) ( $row->title ?? '' ),
+			providerId:       (string) ( $row->provider_id ?? '' ),
+			modelId:          (string) ( $row->model_id ?? '' ),
+			messages:         (string) ( $row->messages ?? '[]' ),
+			toolCalls:        (string) ( $row->tool_calls ?? '[]' ),
+			promptTokens:     (int) ( $row->prompt_tokens ?? 0 ),
+			completionTokens: (int) ( $row->completion_tokens ?? 0 ),
+			status:           (string) ( $row->status ?? 'active' ),
+			pinned:           (bool) (int) ( $row->pinned ?? 0 ),
+			folder:           (string) ( $row->folder ?? '' ),
+			pausedState:      isset( $row->paused_state ) && '' !== $row->paused_state ? (string) $row->paused_state : null,
+			createdAt:        (string) ( $row->created_at ?? '' ),
+			updatedAt:        (string) ( $row->updated_at ?? '' ),
 		);
 	}
 }


### PR DESCRIPTION
## Summary

Rename the constructor-promoted properties in `SessionRow` from snake_case to camelCase, aligning them with the project coding standard: "Use camelCase for PHP property declarations with typed declarations."

### Changes

- `user_id` → `userId`
- `provider_id` → `providerId`
- `model_id` → `modelId`
- `tool_calls` → `toolCalls`
- `prompt_tokens` → `promptTokens`
- `completion_tokens` → `completionTokens`
- `paused_state` → `pausedState`
- `created_at` → `createdAt`
- `updated_at` → `updatedAt`

The `from_row()` factory's named arguments are updated to match the new property names. DB column names on the raw `$row` stdClass (snake_case) are unchanged — only the DTO property names change.

### Scope

`SessionRow::from_row()` is currently not called anywhere in the codebase — the repository still returns raw `stdClass` from `$wpdb->get_row()`. No consumer code needed updating.

### Verification

- `php -l includes/Models/DTO/SessionRow.php` → no syntax errors
- No callers of `SessionRow::from_row()` exist (confirmed via `grep -rn "SessionRow\|from_row"`)

Resolves #1064