### PR TITLE
GH#1061: fix: correct reversed mapping comment in floating-widget sessionStorage restore

### DIFF
--- a/src/floating-widget/index.js
+++ b/src/floating-widget/index.js
@@ -71,7 +71,7 @@ function FloatingWidget() {
 	// Cross-page navigation survival (Phase 4 / t206):
 	// Restore any active poll loops from sessionStorage. If the user navigated
 	// away from an admin page while a background job was running, sessionStorage
-	// still holds the jobId → sessionId mapping. Re-starting the poll loop here
+	// still holds the sessionId → jobId mapping. Re-starting the poll loop here
 	// reconnects to the in-progress job without a full page reload.
 	// sessionStorage is cleared when the tab closes, so stale entries from a
 	// previous tab session are never restored. pollJob handles already-completed


### PR DESCRIPTION
## Summary

Fixed the reversed mapping comment at src/floating-widget/index.js:74. The comment incorrectly said 'jobId → sessionId' but the code iterates sessionStorage entries as [sessionIdStr, jobId], making the actual mapping 'sessionId → jobId'. Updated the comment to accurately reflect the code.

## Files Changed

src/floating-widget/index.js

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Visual review: grep confirmed the comment at line 74 now reads 'sessionId → jobId' matching the for-loop destructuring at line 85.

Resolves #1061


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.70 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 1m and 1,514 tokens on this as a headless worker.