### PR TITLE
GH#1062: fix(tests): add configurable:true and try-finally to sessionStorage mocks

### DIFF
--- a/src/utils/__tests__/active-jobs-storage.test.js
+++ b/src/utils/__tests__/active-jobs-storage.test.js
@@ -34,6 +34,7 @@ const sessionStorageMock = ( () => {
 
 Object.defineProperty( global, 'sessionStorage', {
 	value: sessionStorageMock,
+	configurable: true,
 	writable: true,
 } );
 
@@ -68,18 +69,21 @@ describe( 'setActiveJob', () => {
 
 	test( 'does not throw when sessionStorage is unavailable', () => {
 		const original = global.sessionStorage;
-		Object.defineProperty( global, 'sessionStorage', {
-			get() {
-				throw new Error( 'storage unavailable' );
-			},
-			configurable: true,
-		} );
-		expect( () => setActiveJob( 1, 'job_x' ) ).not.toThrow();
-		Object.defineProperty( global, 'sessionStorage', {
-			value: original,
-			configurable: true,
-			writable: true,
-		} );
+		try {
+			Object.defineProperty( global, 'sessionStorage', {
+				get() {
+					throw new Error( 'storage unavailable' );
+				},
+				configurable: true,
+			} );
+			expect( () => setActiveJob( 1, 'job_x' ) ).not.toThrow();
+		} finally {
+			Object.defineProperty( global, 'sessionStorage', {
+				value: original,
+				configurable: true,
+				writable: true,
+			} );
+		}
 	} );
 } );
 
@@ -130,18 +134,21 @@ describe( 'getActiveJobs', () => {
 
 	test( 'returns an empty object when sessionStorage is unavailable', () => {
 		const original = global.sessionStorage;
-		Object.defineProperty( global, 'sessionStorage', {
-			get() {
-				throw new Error( 'storage unavailable' );
-			},
-			configurable: true,
-		} );
-		expect( getActiveJobs() ).toEqual( {} );
-		Object.defineProperty( global, 'sessionStorage', {
-			value: original,
-			configurable: true,
-			writable: true,
-		} );
+		try {
+			Object.defineProperty( global, 'sessionStorage', {
+				get() {
+					throw new Error( 'storage unavailable' );
+				},
+				configurable: true,
+			} );
+			expect( getActiveJobs() ).toEqual( {} );
+		} finally {
+			Object.defineProperty( global, 'sessionStorage', {
+				value: original,
+				configurable: true,
+				writable: true,
+			} );
+		}
 	} );
 
 	test( 'returns an empty object when storage contains malformed JSON', () => {


### PR DESCRIPTION
## Summary

Added configurable:true to the initial sessionStorage mock definition and wrapped both accessor-redefinition blocks in try-finally to prevent TypeError and test pollution.

## Files Changed

src/utils/__tests__/active-jobs-storage.test.js,src/utils/active-jobs-storage.js

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run test:js -- active-jobs-storage: 12/12 tests pass

Resolves #1062


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.70 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 3m and 2,991 tokens on this as a headless worker.