### PR TITLE
GH#1065: fix: add int|false return type to ModifiedFilesRepository::record()

### DIFF
--- a/includes/Repositories/ModifiedFilesRepository.php
+++ b/includes/Repositories/ModifiedFilesRepository.php
@@ -33,7 +33,7 @@ class ModifiedFilesRepository {
 	 * @param int    $user_id    User ID performing the action.
 	 * @return int|false Inserted row ID or false on failure.
 	 */
-	public static function record( string $file_path, string $action = 'write', int $session_id = 0, int $user_id = 0 ) {
+	public static function record( string $file_path, string $action = 'write', int $session_id = 0, int $user_id = 0 ): int|false {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 


### PR DESCRIPTION
## Summary

Added explicit int|false return type to the record() method in ModifiedFilesRepository, matching the existing docblock declaration. No logic changes.

## Files Changed

includes/Repositories/ModifiedFilesRepository.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PHP syntax check passed (php -l). The change is a signature-only addition with no runtime behaviour change.

Resolves #1065


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.70 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 2m and 1,935 tokens on this as a headless worker.