### PR TITLE
GH#1066: fix: add explicit int|false return type to UsageRepository::log()

### DIFF
--- a/includes/Repositories/UsageRepository.php
+++ b/includes/Repositories/UsageRepository.php
@@ -30,7 +30,7 @@ class UsageRepository {
 	 * @param array<string, mixed> $data Usage data: user_id, session_id, provider_id, model_id, prompt_tokens, completion_tokens, cost_usd.
 	 * @return int|false Inserted row ID or false.
 	 */
-	public static function log( array $data ) {
+	public static function log( array $data ): int|false {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 


### PR DESCRIPTION
## Summary

Added explicit int|false return type to UsageRepository::log() method signature to match docblock declaration, satisfying PHP 8.2+ type declaration requirements per coding guidelines.

## Files Changed

includes/Repositories/UsageRepository.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PHP syntax check passed (php -l). No callers needed adjustment as the return type matches actual behaviour.

Resolves #1066


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.70 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 2m and 1,795 tokens on this as a headless worker.