### PR TITLE
t216: Skill usage tracking table + telemetry (Phase 1)

### DIFF
--- a/includes/Abilities/SkillAbilities.php
+++ b/includes/Abilities/SkillAbilities.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace GratisAiAgent\Abilities;
 
 use GratisAiAgent\Models\Skill;
+use GratisAiAgent\Models\SkillUsageRepository;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -116,10 +117,22 @@ class SkillAbilities {
 			return new \WP_Error( 'skill_not_found', "Skill '$slug' not found." );
 		}
 
-		if ( ! (int) $skill->enabled ) {
+		if ( ! $skill->enabled ) {
 			// @phpstan-ignore-next-line
 			return new \WP_Error( 'skill_disabled', "Skill '$slug' is disabled." );
 		}
+
+		// Record the tool_call load event for telemetry.
+		$injected_tokens = (int) ceil( mb_strlen( $skill->content ) / 4 );
+		$session_id      = (int) ( $input['_session_id'] ?? 0 );
+		$model_id        = (string) ( $input['_model_id'] ?? '' );
+		SkillUsageRepository::create(
+			$skill->id,
+			$session_id,
+			SkillUsageRepository::TRIGGER_TOOL_CALL,
+			$injected_tokens,
+			$model_id
+		);
 
 		return [
 			'name'    => $skill->name,

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -25,6 +25,7 @@ namespace GratisAiAgent\Core;
 use GratisAiAgent\Abilities\FeedbackAbilities;
 use GratisAiAgent\Core\BudgetManager;
 use GratisAiAgent\Core\ChangeLogger;
+use GratisAiAgent\Models\SkillUsageRepository;
 use GratisAiAgent\Tools\ModelHealthTracker;
 use GratisAiAgent\Tools\ToolDiscovery;
 use GratisAiAgent\Core\RolePermissions;
@@ -251,12 +252,13 @@ class AgentLoop {
 
 		// ── Initialise focused service objects ───────────────────────────
 
-		// SystemInstructionBuilder needs the model_id for weak-model nudges
-		// and user_message for knowledge RAG, both resolved above.
+		// SystemInstructionBuilder needs the model_id for weak-model nudges,
+		// user_message for knowledge RAG, and session_id for skill telemetry.
 		$this->instruction_builder = new SystemInstructionBuilder(
 			(string) $this->model_id,
 			$this->user_message,
-			$this->page_context
+			$this->page_context,
+			$this->session_id
 		);
 
 		// ToolPermissionResolver encapsulates yolo_mode and tool_permissions.
@@ -319,7 +321,12 @@ class AgentLoop {
 		// Append the new user message to history.
 		$this->history[] = new UserMessage( array( new MessagePart( $this->user_message ) ) );
 
-		return $this->run_loop( $this->max_iterations );
+		$result = $this->run_loop( $this->max_iterations );
+
+		// Apply Phase-1 outcome heuristic to skill usage rows for this session.
+		$this->evaluate_skill_outcomes( $result );
+
+		return $result;
 	}
 
 	/**
@@ -1192,6 +1199,41 @@ class AgentLoop {
 			$result['inability_reported'] = $inability;
 		}
 		return $result;
+	}
+
+	// ── Skill usage outcome heuristic ─────────────────────────────────────
+
+	/**
+	 * Apply the outcome heuristic to skill usage rows for the current session.
+	 *
+	 * Called after the loop completes. If the loop exited cleanly (reply returned,
+	 * no error exit_reason), injected skills are marked 'helpful'. All other
+	 * exits (timeout, spin, error) are marked 'neutral' — we cannot infer benefit
+	 * when the agent did not reach a conclusive answer.
+	 *
+	 * This is a Phase-1 heuristic. Phase-2 will refine based on model-reported
+	 * inability, thumbs-down feedback (t186), and follow-up message correlation.
+	 *
+	 * @param array<string,mixed>|WP_Error $result The loop result.
+	 */
+	private function evaluate_skill_outcomes( $result ): void {
+		if ( $this->session_id <= 0 ) {
+			return;
+		}
+
+		if ( is_wp_error( $result ) ) {
+			SkillUsageRepository::update_session_outcomes( $this->session_id, SkillUsageRepository::OUTCOME_NEUTRAL );
+			return;
+		}
+
+		// @phpstan-ignore-next-line
+		$exit_reason = $result['exit_reason'] ?? '';
+
+		$outcome = ( '' === $exit_reason )
+			? SkillUsageRepository::OUTCOME_HELPFUL
+			: SkillUsageRepository::OUTCOME_NEUTRAL;
+
+		SkillUsageRepository::update_session_outcomes( $this->session_id, $outcome );
 	}
 
 	// ── Client ability partitioning ───────────────────────────────────────

--- a/includes/Core/Database.php
+++ b/includes/Core/Database.php
@@ -35,7 +35,7 @@ use GratisAiAgent\Tools\CustomTools;
 class Database {
 
 	const DB_VERSION_OPTION = 'gratis_ai_agent_db_version';
-	const DB_VERSION        = '16.0.0';
+	const DB_VERSION        = '17.0.0';
 
 	// ─── Table Name Registry ──────────────────────────────────────────────────
 
@@ -213,6 +213,15 @@ class Database {
 		return $wpdb->prefix . 'gratis_ai_agent_active_jobs';
 	}
 
+	/**
+	 * Get the skill usage table name.
+	 */
+	public static function skill_usage_table_name(): string {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+		return $wpdb->prefix . 'gratis_ai_agent_skill_usage';
+	}
+
 	// ─── Schema Installation ──────────────────────────────────────────────────
 
 	/**
@@ -250,6 +259,7 @@ class Database {
 		$provider_trace_table         = self::provider_trace_table_name();
 		$generated_plugins_table      = self::generated_plugins_table_name();
 		$active_jobs_table            = self::active_jobs_table_name();
+		$skill_usage_table            = self::skill_usage_table_name();
 		$charset                      = $wpdb->get_charset_collate();
 
 		// Knowledge tables.
@@ -595,6 +605,22 @@ class Database {
 			UNIQUE KEY job_id (job_id),
 			KEY session_id (session_id),
 			KEY user_id_status (user_id, status)
+		) {$charset};
+
+		CREATE TABLE {$skill_usage_table} (
+			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+			skill_id bigint(20) unsigned NOT NULL,
+			session_id bigint(20) unsigned NOT NULL DEFAULT 0,
+			trigger_type varchar(20) NOT NULL DEFAULT 'auto',
+			injected_tokens int(11) NOT NULL DEFAULT 0,
+			outcome varchar(20) NOT NULL DEFAULT 'unknown',
+			model_id varchar(100) NOT NULL DEFAULT '',
+			created_at datetime NOT NULL,
+			PRIMARY KEY  (id),
+			KEY skill_id (skill_id),
+			KEY session_id (session_id),
+			KEY outcome (outcome),
+			KEY created_at (created_at)
 		) {$charset};";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';

--- a/includes/Core/SkillAutoInjector.php
+++ b/includes/Core/SkillAutoInjector.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace GratisAiAgent\Core;
 
 use GratisAiAgent\Models\Skill;
+use GratisAiAgent\Models\SkillUsageRepository;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -24,6 +25,17 @@ class SkillAutoInjector {
 	 * Maximum number of skills to inject per prompt to limit token usage.
 	 */
 	private const MAX_INJECTED_SKILLS = 2;
+
+	/**
+	 * Per-request dedup cache: tracks (session_id, skill_id) pairs already
+	 * recorded this PHP request so we don't insert a row on every prompt
+	 * rebuild (inject_for_message is called each iteration of the agent loop).
+	 *
+	 * Key: "{session_id}:{skill_id}", value: true.
+	 *
+	 * @var array<string, true>
+	 */
+	private static array $recorded_this_request = [];
 
 	/**
 	 * Keyword-to-skill trigger map.
@@ -48,10 +60,15 @@ class SkillAutoInjector {
 	/**
 	 * Analyze the user message and return matching skill content to inject.
 	 *
+	 * When $session_id > 0 or $model_id is non-empty, each injected skill is
+	 * recorded in the skill_usage table for telemetry.
+	 *
 	 * @param string $user_message The user's chat message.
+	 * @param int    $session_id   Session ID for telemetry (0 = no session).
+	 * @param string $model_id     Model ID for telemetry ('').
 	 * @return string Formatted skill content for system prompt injection, or empty string.
 	 */
-	public static function inject_for_message( string $user_message ): string {
+	public static function inject_for_message( string $user_message, int $session_id = 0, string $model_id = '' ): string {
 		if ( '' === trim( $user_message ) ) {
 			return '';
 		}
@@ -65,13 +82,33 @@ class SkillAutoInjector {
 		$sections = [];
 
 		foreach ( $matched_slugs as $slug ) {
-			$content = Skill::get_content_by_slug( $slug );
+			$skill = Skill::get_by_slug( $slug );
 
-			if ( null === $content || '' === $content ) {
+			if ( null === $skill || ! $skill->enabled ) {
+				continue;
+			}
+
+			$content = $skill->content;
+
+			if ( '' === $content ) {
 				continue;
 			}
 
 			$sections[] = $content;
+
+			// Record the auto-injection event for telemetry (once per session+skill per request).
+			$dedup_key = "{$session_id}:{$skill->id}";
+			if ( ! isset( self::$recorded_this_request[ $dedup_key ] ) ) {
+				$injected_tokens = (int) ceil( mb_strlen( $content ) / 4 );
+				SkillUsageRepository::create(
+					$skill->id,
+					$session_id,
+					SkillUsageRepository::TRIGGER_AUTO,
+					$injected_tokens,
+					$model_id
+				);
+				self::$recorded_this_request[ $dedup_key ] = true;
+			}
 		}
 
 		if ( empty( $sections ) ) {

--- a/includes/Core/SystemInstructionBuilder.php
+++ b/includes/Core/SystemInstructionBuilder.php
@@ -26,11 +26,13 @@ class SystemInstructionBuilder {
 	 * @param string                   $model_id     Current AI model ID (for weak-model nudges).
 	 * @param string                   $user_message User's message (for knowledge context RAG).
 	 * @param array<int|string, mixed> $page_context Page context from the widget.
+	 * @param int                      $session_id   Session ID for skill usage telemetry (0 = no session).
 	 */
 	public function __construct(
 		private string $model_id = '',
 		private string $user_message = '',
-		private array $page_context = array()
+		private array $page_context = array(),
+		private int $session_id = 0
 	) {}
 
 	/**
@@ -76,7 +78,7 @@ class SystemInstructionBuilder {
 		// on the LLM to voluntarily call skill-load, we inject the content
 		// directly for matching tasks (e.g. content creation → gutenberg-blocks).
 		if ( ! empty( $this->user_message ) ) {
-			$auto_skill = SkillAutoInjector::inject_for_message( $this->user_message );
+			$auto_skill = SkillAutoInjector::inject_for_message( $this->user_message, $this->session_id, $this->model_id );
 			if ( ! empty( $auto_skill ) ) {
 				// @phpstan-ignore-next-line
 				$base .= "\n\n" . $auto_skill;

--- a/includes/Models/DTO/SkillUsageRow.php
+++ b/includes/Models/DTO/SkillUsageRow.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Typed DTO for a skill_usage row returned by wpdb::get_row() / wpdb::get_results().
+ *
+ * @package GratisAiAgent\Models\DTO
+ * @license GPL-2.0-or-later
+ */
+
+namespace GratisAiAgent\Models\DTO;
+
+/**
+ * Immutable DTO for the gratis_ai_agent_skill_usage table row.
+ */
+readonly class SkillUsageRow {
+
+	/**
+	 * @param int    $id              Row ID (auto-increment PK).
+	 * @param int    $skill_id        FK to gratis_ai_agent_skills.id.
+	 * @param int    $session_id      FK to gratis_ai_agent_sessions.id (0 = no session).
+	 * @param string $trigger_type    How the skill was loaded: 'auto', 'manual', or 'tool_call'.
+	 * @param int    $injected_tokens Estimated token cost of injecting the skill content.
+	 * @param string $outcome         Heuristic result: 'helpful', 'neutral', 'negative', or 'unknown'.
+	 * @param string $model_id        Model ID that received the skill content.
+	 * @param string $created_at      MySQL datetime string (UTC).
+	 */
+	public function __construct(
+		public int $id,
+		public int $skill_id,
+		public int $session_id,
+		public string $trigger_type,
+		public int $injected_tokens,
+		public string $outcome,
+		public string $model_id,
+		public string $created_at,
+	) {}
+
+	/**
+	 * Construct a SkillUsageRow from the raw stdClass returned by wpdb::get_row() or get_results().
+	 *
+	 * @param object $row Raw row from wpdb.
+	 * @return self
+	 */
+	public static function from_row( object $row ): self {
+		return new self(
+			id:              (int) $row->id,
+			skill_id:        (int) ( $row->skill_id ?? 0 ),
+			session_id:      (int) ( $row->session_id ?? 0 ),
+			trigger_type:    (string) ( $row->trigger_type ?? 'auto' ),
+			injected_tokens: (int) ( $row->injected_tokens ?? 0 ),
+			outcome:         (string) ( $row->outcome ?? 'unknown' ),
+			model_id:        (string) ( $row->model_id ?? '' ),
+			created_at:      (string) ( $row->created_at ?? '' ),
+		);
+	}
+}

--- a/includes/Models/SkillUsageRepository.php
+++ b/includes/Models/SkillUsageRepository.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Repository for skill usage tracking persistence.
+ *
+ * Records which skills were loaded, how they were triggered, and
+ * provides aggregated effectiveness statistics for the skill manager UI.
+ *
+ * @package GratisAiAgent\Models
+ * @license GPL-2.0-or-later
+ */
+
+namespace GratisAiAgent\Models;
+
+use GratisAiAgent\Core\Database;
+use GratisAiAgent\Models\DTO\SkillUsageRow;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles persistence for skill-load events and outcome telemetry.
+ */
+class SkillUsageRepository {
+
+	/**
+	 * Valid trigger types.
+	 */
+	const TRIGGER_AUTO      = 'auto';
+	const TRIGGER_MANUAL    = 'manual';
+	const TRIGGER_TOOL_CALL = 'tool_call';
+
+	/**
+	 * Valid outcome values.
+	 */
+	const OUTCOME_HELPFUL  = 'helpful';
+	const OUTCOME_NEUTRAL  = 'neutral';
+	const OUTCOME_NEGATIVE = 'negative';
+	const OUTCOME_UNKNOWN  = 'unknown';
+
+	/**
+	 * Record a skill load event.
+	 *
+	 * @param int    $skill_id        FK to gratis_ai_agent_skills.id.
+	 * @param int    $session_id      FK to gratis_ai_agent_sessions.id (0 = no session).
+	 * @param string $trigger_type    How the skill was loaded: 'auto', 'manual', or 'tool_call'.
+	 * @param int    $injected_tokens Estimated token cost of injecting the skill content.
+	 * @param string $model_id        Model ID that received the skill.
+	 * @param string $outcome         Initial outcome: default 'unknown', updated later.
+	 * @return int|false Inserted row ID or false on failure.
+	 */
+	public static function create(
+		int $skill_id,
+		int $session_id,
+		string $trigger_type,
+		int $injected_tokens,
+		string $model_id,
+		string $outcome = self::OUTCOME_UNKNOWN
+	): int|false {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Custom table query; caching not applicable.
+		$result = $wpdb->insert(
+			Database::skill_usage_table_name(),
+			[
+				'skill_id'        => $skill_id,
+				'session_id'      => $session_id,
+				'trigger_type'    => $trigger_type,
+				'injected_tokens' => $injected_tokens,
+				'outcome'         => $outcome,
+				'model_id'        => $model_id,
+				'created_at'      => current_time( 'mysql', true ),
+			],
+			[ '%d', '%d', '%s', '%d', '%s', '%s', '%s' ]
+		);
+
+		return $result ? (int) $wpdb->insert_id : false;
+	}
+
+	/**
+	 * Update the outcome for a skill usage row.
+	 *
+	 * Called by the outcome heuristic after the agent loop completes.
+	 *
+	 * @param int    $id      Row ID to update.
+	 * @param string $outcome New outcome: 'helpful', 'neutral', 'negative', or 'unknown'.
+	 * @return bool Whether the update succeeded.
+	 */
+	public static function update_outcome( int $id, string $outcome ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
+		$result = $wpdb->update(
+			Database::skill_usage_table_name(),
+			[ 'outcome' => $outcome ],
+			[ 'id' => $id ],
+			[ '%s' ],
+			[ '%d' ]
+		);
+
+		return false !== $result;
+	}
+
+	/**
+	 * Update the outcome for all 'unknown' skill usage rows in a session.
+	 *
+	 * Called by AgentLoop after the loop completes to apply the outcome
+	 * heuristic across all skills injected during that session.
+	 *
+	 * @param int    $session_id Session ID (0 = no-op).
+	 * @param string $outcome    Outcome to apply: 'helpful', 'neutral', 'negative'.
+	 * @return int Number of rows updated.
+	 */
+	public static function update_session_outcomes( int $session_id, string $outcome ): int {
+		if ( $session_id <= 0 ) {
+			return 0;
+		}
+
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
+		$rows_affected = $wpdb->update(
+			Database::skill_usage_table_name(),
+			[ 'outcome' => $outcome ],
+			[
+				'session_id' => $session_id,
+				'outcome'    => self::OUTCOME_UNKNOWN,
+			],
+			[ '%s' ],
+			[ '%d', '%s' ]
+		);
+
+		return is_int( $rows_affected ) ? $rows_affected : 0;
+	}
+
+	/**
+	 * Get all usage records for a specific skill.
+	 *
+	 * @param int $skill_id Skill ID.
+	 * @param int $limit    Max rows to return (default 100).
+	 * @return list<SkillUsageRow>
+	 */
+	public static function get_by_skill( int $skill_id, int $limit = 100 ): array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$table = Database::skill_usage_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE skill_id = %d ORDER BY created_at DESC LIMIT %d',
+				$table,
+				$skill_id,
+				$limit
+			)
+		);
+
+		if ( empty( $rows ) ) {
+			return [];
+		}
+
+		return array_map( [ SkillUsageRow::class, 'from_row' ], $rows );
+	}
+
+	/**
+	 * Get aggregated usage statistics per skill.
+	 *
+	 * Returns load counts, outcome breakdown, and estimated token cost
+	 * grouped by skill ID — suitable for the skill manager admin UI.
+	 *
+	 * @return list<object> Each row has: skill_id, load_count, helpful_count,
+	 *                       neutral_count, negative_count, unknown_count,
+	 *                       total_tokens, last_used_at.
+	 */
+	public static function get_stats(): array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$table = Database::skill_usage_table_name();
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Custom table; table name from internal method.
+		$rows = $wpdb->get_results(
+			"SELECT
+				skill_id,
+				COUNT(*) AS load_count,
+				SUM(outcome = 'helpful')  AS helpful_count,
+				SUM(outcome = 'neutral')  AS neutral_count,
+				SUM(outcome = 'negative') AS negative_count,
+				SUM(outcome = 'unknown')  AS unknown_count,
+				COALESCE(SUM(injected_tokens), 0) AS total_tokens,
+				MAX(created_at) AS last_used_at
+			FROM {$table}
+			GROUP BY skill_id
+			ORDER BY load_count DESC"
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter
+
+		return is_array( $rows ) ? $rows : [];
+	}
+
+	/**
+	 * Get aggregated statistics for a single skill.
+	 *
+	 * @param int $skill_id Skill ID.
+	 * @return object|null Stats object (load_count, helpful_count, neutral_count,
+	 *                       negative_count, unknown_count, total_tokens, last_used_at)
+	 *                       or null if no records exist.
+	 */
+	public static function get_stats_for_skill( int $skill_id ): ?object {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$table = Database::skill_usage_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT
+					skill_id,
+					COUNT(*) AS load_count,
+					SUM(outcome = 'helpful')  AS helpful_count,
+					SUM(outcome = 'neutral')  AS neutral_count,
+					SUM(outcome = 'negative') AS negative_count,
+					SUM(outcome = 'unknown')  AS unknown_count,
+					COALESCE(SUM(injected_tokens), 0) AS total_tokens,
+					MAX(created_at) AS last_used_at
+				FROM %i
+				WHERE skill_id = %d
+				GROUP BY skill_id",
+				$table,
+				$skill_id
+			)
+		);
+
+		return $row instanceof \stdClass ? $row : null;
+	}
+}

--- a/tests/GratisAiAgent/Core/DatabaseSchemaTest.php
+++ b/tests/GratisAiAgent/Core/DatabaseSchemaTest.php
@@ -60,6 +60,7 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 		'gratis_ai_agent_provider_trace',
 		'gratis_ai_agent_generated_plugins',
 		'gratis_ai_agent_active_jobs',
+		'gratis_ai_agent_skill_usage',
 	];
 
 	/**
@@ -472,6 +473,19 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 		$this->assertSame( 'user', $messages[0]['role'] );
 		$this->assertSame( 'Hello, world!', $messages[0]['content'] );
 		$this->assertSame( 'assistant', $messages[1]['role'] );
+	}
+
+	/**
+	 * Skill usage table has the required columns.
+	 */
+	public function test_skill_usage_table_has_required_columns(): void {
+		Database::install();
+
+		$columns = $this->get_column_names( Database::skill_usage_table_name() );
+
+		foreach ( [ 'id', 'skill_id', 'session_id', 'trigger_type', 'injected_tokens', 'outcome', 'model_id', 'created_at' ] as $col ) {
+			$this->assertContains( $col, $columns, "Skill usage table missing column '{$col}'." );
+		}
 	}
 
 	// ── Table count ───────────────────────────────────────────────────────

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'ultimate-multisite/ai-agent',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '3f1367a14883b87123ab0e4436743cbf2971b524',
+        'reference' => '0ca32423e0e06b32f8123014638e9237d87a5956',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -470,7 +470,7 @@
         'ultimate-multisite/ai-agent' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '3f1367a14883b87123ab0e4436743cbf2971b524',
+            'reference' => '0ca32423e0e06b32f8123014638e9237d87a5956',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
## Summary

Implements Phase 1 of the adaptive skill system (t215 parent): skill usage tracking table and telemetry pipeline.

**Resolves #1080**

## What changed

### New: `gratis_ai_agent_skill_usage` table (DB_VERSION 16 → 17)
Schema tracks every skill load event: `skill_id`, `session_id`, `trigger_type` (auto/manual/tool_call), `injected_tokens`, `outcome` (helpful/neutral/negative/unknown), `model_id`, `created_at`.

### New: `SkillUsageRow` DTO (`includes/Models/DTO/SkillUsageRow.php`)
Readonly typed DTO following the `SkillRow` pattern. `from_row()` factory for wpdb results.

### New: `SkillUsageRepository` (`includes/Models/SkillUsageRepository.php`)
- `create()` — insert a skill load event
- `update_outcome()` — update a single row outcome
- `update_session_outcomes()` — batch-update all unknown rows for a session
- `get_by_skill()` — paginated events per skill
- `get_stats()` / `get_stats_for_skill()` — aggregated telemetry (load count, helpful/neutral/negative counts, total tokens, last used)

### Modified: `SkillAutoInjector` — records `auto` trigger events
Each matching skill is recorded on first injection per session (per-request static dedup prevents duplicate rows since `inject_for_message()` is called on every agent loop iteration). Token cost estimated as `⌈chars / 4⌉`.

### Modified: `SkillAbilities::handle_skill_load()` — records `tool_call` trigger events
The `skill-load` WordPress ability now records a usage row on success. `_session_id` and `_model_id` can be passed via input to attach context; both default to 0/''.

### Modified: `AgentLoop` — Phase-1 outcome heuristic
After `run_loop()` completes, `evaluate_skill_outcomes()` updates all `unknown` rows for the session:
- Clean exit (no `exit_reason`) → **helpful**
- Timeout / spin / WP_Error → **neutral**

Phase 2 (t217) will refine this with inability reporting (t186), thumbs-down feedback, and follow-up message correlation.

### Modified: `SystemInstructionBuilder` — threads `session_id`
Constructor gains an optional `$session_id` parameter (default 0) passed through to `inject_for_message()`. `AgentLoop` passes `$this->session_id`.

## Verification

```bash
vendor/bin/phpcs --standard=phpcs.xml \
  includes/Models/DTO/SkillUsageRow.php \
  includes/Models/SkillUsageRepository.php \
  includes/Core/Database.php \
  includes/Core/SkillAutoInjector.php \
  includes/Abilities/SkillAbilities.php \
  includes/Core/AgentLoop.php \
  includes/Core/SystemInstructionBuilder.php
# 7/7 pass, no violations
```

## Runtime Testing

**Risk: Low** — new table + passive telemetry writes; no changes to AI response path or user-visible behaviour. The `evaluate_skill_outcomes()` call is best-effort (only fires when `session_id > 0`). The auto-injection path (`inject_for_message`) continues to return the same string content; the only change is a DB insert side-effect.

Self-assessed: no runtime environment available in this headless session.