### PR TITLE
t215: adaptive skill system — usage tracking and model-aware injection

### DIFF
--- a/includes/Abilities/SkillAbilities.php
+++ b/includes/Abilities/SkillAbilities.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace GratisAiAgent\Abilities;
 
 use GratisAiAgent\Models\Skill;
+use GratisAiAgent\Repositories\SkillUsageRepository;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -120,6 +121,20 @@ class SkillAbilities {
 			// @phpstan-ignore-next-line
 			return new \WP_Error( 'skill_disabled', "Skill '$slug' is disabled." );
 		}
+
+		// Record tool_call usage for telemetry (Phase 1 / t215).
+		// Model ID is unknown here (abilities don't receive request context),
+		// so model_id defaults to '' and session_id to 0.
+		SkillUsageRepository::create(
+			[
+				'skill_id'        => $skill->id,
+				'session_id'      => 0,
+				'trigger_type'    => 'tool_call',
+				'injected_tokens' => SkillUsageRepository::estimate_tokens( $skill->content ),
+				'outcome'         => 'unknown',
+				'model_id'        => '',
+			]
+		);
 
 		return [
 			'name'    => $skill->name,

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -253,10 +253,13 @@ class AgentLoop {
 
 		// SystemInstructionBuilder needs the model_id for weak-model nudges
 		// and user_message for knowledge RAG, both resolved above.
+		// session_id is passed so skill injection events are recorded to the
+		// skill_usage telemetry table (Phase 1 / t215).
 		$this->instruction_builder = new SystemInstructionBuilder(
 			(string) $this->model_id,
 			$this->user_message,
-			$this->page_context
+			$this->page_context,
+			$this->session_id
 		);
 
 		// ToolPermissionResolver encapsulates yolo_mode and tool_permissions.

--- a/includes/Core/Database.php
+++ b/includes/Core/Database.php
@@ -35,7 +35,7 @@ use GratisAiAgent\Tools\CustomTools;
 class Database {
 
 	const DB_VERSION_OPTION = 'gratis_ai_agent_db_version';
-	const DB_VERSION        = '16.0.0';
+	const DB_VERSION        = '17.0.0';
 
 	// ─── Table Name Registry ──────────────────────────────────────────────────
 
@@ -213,6 +213,18 @@ class Database {
 		return $wpdb->prefix . 'gratis_ai_agent_active_jobs';
 	}
 
+	/**
+	 * Get the skill usage table name.
+	 *
+	 * Tracks which skills are loaded per session/model and records
+	 * quality outcome signals (helpful/neutral/negative) for telemetry.
+	 */
+	public static function skill_usage_table_name(): string {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+		return $wpdb->prefix . 'gratis_ai_agent_skill_usage';
+	}
+
 	// ─── Schema Installation ──────────────────────────────────────────────────
 
 	/**
@@ -250,6 +262,7 @@ class Database {
 		$provider_trace_table         = self::provider_trace_table_name();
 		$generated_plugins_table      = self::generated_plugins_table_name();
 		$active_jobs_table            = self::active_jobs_table_name();
+		$skill_usage_table            = self::skill_usage_table_name();
 		$charset                      = $wpdb->get_charset_collate();
 
 		// Knowledge tables.
@@ -595,6 +608,24 @@ class Database {
 			UNIQUE KEY job_id (job_id),
 			KEY session_id (session_id),
 			KEY user_id_status (user_id, status)
+		) {$charset};
+
+		CREATE TABLE {$skill_usage_table} (
+			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+			skill_id bigint(20) unsigned NOT NULL,
+			session_id bigint(20) unsigned NOT NULL DEFAULT 0,
+			trigger_type varchar(20) NOT NULL DEFAULT 'auto',
+			injected_tokens int(11) unsigned NOT NULL DEFAULT 0,
+			outcome varchar(20) NOT NULL DEFAULT 'unknown',
+			model_id varchar(100) NOT NULL DEFAULT '',
+			created_at datetime NOT NULL,
+			PRIMARY KEY  (id),
+			KEY skill_id (skill_id),
+			KEY session_id (session_id),
+			KEY trigger_type (trigger_type),
+			KEY outcome (outcome),
+			KEY model_id (model_id),
+			KEY created_at (created_at)
 		) {$charset};";
 
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';

--- a/includes/Core/SkillAutoInjector.php
+++ b/includes/Core/SkillAutoInjector.php
@@ -6,6 +6,14 @@ declare(strict_types=1);
  * the user's message. Mirrors the knowledge-base RAG injection pattern
  * but uses keyword matching instead of vector search.
  *
+ * Phase 2 (t216): Auto-injection is now model-aware. Strong models receive
+ * the skill index only and call skill-load on demand. Weak models receive
+ * auto-injected content (capped at 1 skill) to compensate for unreliable
+ * tool-call behaviour.
+ *
+ * Phase 1 (t215): Injection events are recorded to gratis_ai_agent_skill_usage
+ * when model_id/session_id context is supplied.
+ *
  * @package GratisAiAgent\Core
  * @license GPL-2.0-or-later
  */
@@ -13,6 +21,7 @@ declare(strict_types=1);
 namespace GratisAiAgent\Core;
 
 use GratisAiAgent\Models\Skill;
+use GratisAiAgent\Repositories\SkillUsageRepository;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -21,9 +30,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 class SkillAutoInjector {
 
 	/**
-	 * Maximum number of skills to inject per prompt to limit token usage.
+	 * Maximum number of skills to inject per prompt.
+	 *
+	 * Reduced from 2 to 1 (Phase 2/t216): weak models cannot effectively
+	 * use two guides simultaneously, and injecting both wastes tokens.
 	 */
-	private const MAX_INJECTED_SKILLS = 2;
+	private const MAX_INJECTED_SKILLS = 1;
 
 	/**
 	 * Keyword-to-skill trigger map.
@@ -48,10 +60,15 @@ class SkillAutoInjector {
 	/**
 	 * Analyze the user message and return matching skill content to inject.
 	 *
+	 * When model_id and session_id are provided, each injected skill is
+	 * recorded to the skill_usage table for telemetry.
+	 *
 	 * @param string $user_message The user's chat message.
+	 * @param string $model_id     Model ID receiving the injection (for telemetry).
+	 * @param int    $session_id   Session ID (0 if unknown) (for telemetry).
 	 * @return string Formatted skill content for system prompt injection, or empty string.
 	 */
-	public static function inject_for_message( string $user_message ): string {
+	public static function inject_for_message( string $user_message, string $model_id = '', int $session_id = 0 ): string {
 		if ( '' === trim( $user_message ) ) {
 			return '';
 		}
@@ -72,6 +89,11 @@ class SkillAutoInjector {
 			}
 
 			$sections[] = $content;
+
+			// Record the injection event for telemetry (Phase 1 / t215).
+			if ( '' !== $model_id ) {
+				self::record_injection( $slug, $content, $model_id, $session_id );
+			}
 		}
 
 		if ( empty( $sections ) ) {
@@ -87,26 +109,54 @@ class SkillAutoInjector {
 	/**
 	 * Match user message against the trigger map and return unique skill slugs.
 	 *
+	 * Collects all pattern matches first, then de-duplicates with array_unique
+	 * and caps at MAX_INJECTED_SKILLS. The two-pass approach avoids PHPStan
+	 * type-narrowing issues with in_array/isset on a dynamically-growing array.
+	 *
 	 * @param string $user_message The user's chat message.
 	 * @return list<string> Matched skill slugs (max MAX_INJECTED_SKILLS).
 	 */
 	private static function match_skills( string $user_message ): array {
-		$matched = [];
+		$raw = [];
 
 		foreach ( self::TRIGGER_MAP as $pattern => $slug ) {
-			if ( in_array( $slug, $matched, true ) ) {
-				continue;
-			}
-
 			if ( preg_match( $pattern, $user_message ) ) {
-				$matched[] = $slug;
-
-				if ( count( $matched ) >= self::MAX_INJECTED_SKILLS ) {
-					break;
-				}
+				$raw[] = $slug;
 			}
 		}
 
-		return $matched;
+		$unique = array_values( array_unique( $raw ) );
+
+		return array_slice( $unique, 0, self::MAX_INJECTED_SKILLS );
+	}
+
+	/**
+	 * Record a skill auto-injection event to the usage table.
+	 *
+	 * Looks up the skill by slug to get its ID. Silently no-ops if the
+	 * skill cannot be found (e.g. custom slug not yet in DB).
+	 *
+	 * @param string $slug       Skill slug that was injected.
+	 * @param string $content    Injected content (used to estimate token cost).
+	 * @param string $model_id   Model receiving the injection.
+	 * @param int    $session_id Session context (0 if unknown).
+	 * @return void
+	 */
+	private static function record_injection( string $slug, string $content, string $model_id, int $session_id ): void {
+		$skill = Skill::get_by_slug( $slug );
+		if ( ! $skill ) {
+			return;
+		}
+
+		SkillUsageRepository::create(
+			[
+				'skill_id'        => $skill->id,
+				'session_id'      => $session_id,
+				'trigger_type'    => 'auto',
+				'injected_tokens' => SkillUsageRepository::estimate_tokens( $content ),
+				'outcome'         => 'unknown',
+				'model_id'        => $model_id,
+			]
+		);
 	}
 }

--- a/includes/Core/SystemInstructionBuilder.php
+++ b/includes/Core/SystemInstructionBuilder.php
@@ -26,11 +26,13 @@ class SystemInstructionBuilder {
 	 * @param string                   $model_id     Current AI model ID (for weak-model nudges).
 	 * @param string                   $user_message User's message (for knowledge context RAG).
 	 * @param array<int|string, mixed> $page_context Page context from the widget.
+	 * @param int                      $session_id   Session ID for skill usage telemetry (0 if unknown).
 	 */
 	public function __construct(
 		private string $model_id = '',
 		private string $user_message = '',
-		private array $page_context = array()
+		private array $page_context = array(),
+		private int $session_id = 0,
 	) {}
 
 	/**
@@ -71,12 +73,18 @@ class SystemInstructionBuilder {
 			$base .= "\n\n" . $skill_index;
 		}
 
-		// Auto-inject relevant skill content based on the user's message.
-		// This supplements the passive skill index above — instead of relying
-		// on the LLM to voluntarily call skill-load, we inject the content
-		// directly for matching tasks (e.g. content creation → gutenberg-blocks).
-		if ( ! empty( $this->user_message ) ) {
-			$auto_skill = SkillAutoInjector::inject_for_message( $this->user_message );
+		// Auto-inject relevant skill content based on the user's message —
+		// but only for models that need it (Phase 2 / t216).
+		//
+		// Strong models (GPT-4.1, Claude Sonnet/Opus) reliably call skill-load
+		// from the index alone, so auto-injection just burns 1500-3000 tokens/turn.
+		// Weak models (quantized open-weight, small-param models) tend to ignore
+		// the index and benefit from having the skill content pre-loaded.
+		//
+		// The model_id also passes through so injections are recorded to the
+		// skill_usage table for telemetry (Phase 1 / t215).
+		if ( ! empty( $this->user_message ) && ModelHealthTracker::is_weak( $this->model_id ) ) {
+			$auto_skill = SkillAutoInjector::inject_for_message( $this->user_message, $this->model_id, $this->session_id );
 			if ( ! empty( $auto_skill ) ) {
 				// @phpstan-ignore-next-line
 				$base .= "\n\n" . $auto_skill;

--- a/includes/Models/DTO/SkillUsageRow.php
+++ b/includes/Models/DTO/SkillUsageRow.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Typed DTO for a skill usage row returned by wpdb::get_row() / wpdb::get_results().
+ *
+ * @package GratisAiAgent\Models\DTO
+ * @license GPL-2.0-or-later
+ */
+
+namespace GratisAiAgent\Models\DTO;
+
+/**
+ * Immutable DTO for the gratis_ai_agent_skill_usage table row.
+ */
+readonly class SkillUsageRow {
+
+	/**
+	 * @param int    $id              Row ID (auto-increment PK).
+	 * @param int    $skill_id        FK to gratis_ai_agent_skills.id.
+	 * @param int    $session_id      FK to gratis_ai_agent_sessions.id (0 = no session).
+	 * @param string $trigger_type    How the skill was loaded: 'auto', 'manual', 'tool_call'.
+	 * @param int    $injected_tokens Estimated token cost of the injected content.
+	 * @param string $outcome         Heuristic quality signal: 'helpful', 'neutral', 'negative', 'unknown'.
+	 * @param string $model_id        Model ID that received the skill injection.
+	 * @param string $created_at      MySQL datetime string (UTC).
+	 */
+	public function __construct(
+		public int $id,
+		public int $skill_id,
+		public int $session_id,
+		public string $trigger_type,
+		public int $injected_tokens,
+		public string $outcome,
+		public string $model_id,
+		public string $created_at,
+	) {}
+
+	/**
+	 * Construct a SkillUsageRow from the raw stdClass returned by wpdb::get_row() or get_results().
+	 *
+	 * @param object $row Raw row from wpdb.
+	 * @return self
+	 */
+	public static function from_row( object $row ): self {
+		return new self(
+			id:              (int) $row->id,
+			skill_id:        (int) ( $row->skill_id ?? 0 ),
+			session_id:      (int) ( $row->session_id ?? 0 ),
+			trigger_type:    (string) ( $row->trigger_type ?? 'auto' ),
+			injected_tokens: (int) ( $row->injected_tokens ?? 0 ),
+			outcome:         (string) ( $row->outcome ?? 'unknown' ),
+			model_id:        (string) ( $row->model_id ?? '' ),
+			created_at:      (string) ( $row->created_at ?? '' ),
+		);
+	}
+}

--- a/includes/Repositories/SkillUsageRepository.php
+++ b/includes/Repositories/SkillUsageRepository.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Repository for skill usage telemetry.
+ *
+ * Tracks which skills are loaded, how they were triggered, and which model
+ * received them. Used to surface quality signals (helpful/neutral/negative)
+ * and to tune the auto-injection trigger patterns over time.
+ *
+ * @package GratisAiAgent\Repositories
+ * @license GPL-2.0-or-later
+ */
+
+namespace GratisAiAgent\Repositories;
+
+use GratisAiAgent\Core\Database;
+use GratisAiAgent\Models\DTO\SkillUsageRow;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles persistence for skill usage records.
+ */
+class SkillUsageRepository {
+
+	/**
+	 * Record a skill usage event.
+	 *
+	 * Keys: skill_id (int FK), session_id (int, 0 = no session), trigger_type
+	 * ('auto'|'manual'|'tool_call'), injected_tokens (int), outcome
+	 * ('helpful'|'neutral'|'negative'|'unknown'), model_id (string).
+	 *
+	 * @param array<string, mixed> $data Skill usage event data.
+	 * @return int|false Inserted row ID or false on failure.
+	 */
+	public static function create( array $data ): int|false {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$trigger_type = $data['trigger_type'] ?? 'auto';
+		if ( ! in_array( $trigger_type, [ 'auto', 'manual', 'tool_call' ], true ) ) {
+			$trigger_type = 'auto';
+		}
+
+		$outcome = $data['outcome'] ?? 'unknown';
+		if ( ! in_array( $outcome, [ 'helpful', 'neutral', 'negative', 'unknown' ], true ) ) {
+			$outcome = 'unknown';
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Custom table query; caching not applicable.
+		$result = $wpdb->insert(
+			Database::skill_usage_table_name(),
+			[
+				'skill_id'        => (int) ( $data['skill_id'] ?? 0 ),
+				'session_id'      => (int) ( $data['session_id'] ?? 0 ),
+				'trigger_type'    => $trigger_type,
+				'injected_tokens' => (int) ( $data['injected_tokens'] ?? 0 ),
+				'outcome'         => $outcome,
+				'model_id'        => (string) ( $data['model_id'] ?? '' ),
+				'created_at'      => current_time( 'mysql', true ),
+			],
+			[ '%d', '%d', '%s', '%d', '%s', '%s', '%s' ]
+		);
+
+		return $result ? (int) $wpdb->insert_id : false;
+	}
+
+	/**
+	 * Get usage records for a specific skill.
+	 *
+	 * @param int $skill_id Skill ID.
+	 * @param int $limit    Maximum number of records to return (default 100).
+	 * @return list<SkillUsageRow>
+	 */
+	public static function get_by_skill( int $skill_id, int $limit = 100 ): array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$table = Database::skill_usage_table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
+		$rows = $wpdb->get_results(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE skill_id = %d ORDER BY created_at DESC LIMIT %d',
+				$table,
+				$skill_id,
+				$limit
+			)
+		);
+
+		if ( empty( $rows ) ) {
+			return [];
+		}
+
+		return array_map( [ SkillUsageRow::class, 'from_row' ], $rows );
+	}
+
+	/**
+	 * Get aggregated usage statistics per skill.
+	 *
+	 * Returns load count, helpful count, and last used timestamp for each skill
+	 * that has at least one usage record.
+	 *
+	 * @return list<object> Each object has: skill_id, total_loads, helpful_count, neutral_count,
+	 *                      negative_count, last_used_at.
+	 */
+	public static function get_stats(): array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$table = Database::skill_usage_table_name();
+
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Custom table query; table name from internal method.
+		$rows = $wpdb->get_results(
+			"SELECT
+				skill_id,
+				COUNT(*) AS total_loads,
+				SUM(CASE WHEN outcome = 'helpful'  THEN 1 ELSE 0 END) AS helpful_count,
+				SUM(CASE WHEN outcome = 'neutral'  THEN 1 ELSE 0 END) AS neutral_count,
+				SUM(CASE WHEN outcome = 'negative' THEN 1 ELSE 0 END) AS negative_count,
+				MAX(created_at) AS last_used_at
+			FROM {$table}
+			GROUP BY skill_id
+			ORDER BY total_loads DESC"
+		);
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter
+
+		return $rows ?? [];
+	}
+
+	/**
+	 * Estimate the token count for a string of text.
+	 *
+	 * Uses chars/4 as a rough approximation for English text.
+	 * Sufficient for order-of-magnitude token budgeting; not for billing.
+	 *
+	 * @param string $text The text to estimate tokens for.
+	 * @return int Estimated token count.
+	 */
+	public static function estimate_tokens( string $text ): int {
+		return (int) ceil( mb_strlen( $text ) / 4 );
+	}
+}

--- a/tests/GratisAiAgent/Core/DatabaseSchemaTest.php
+++ b/tests/GratisAiAgent/Core/DatabaseSchemaTest.php
@@ -60,6 +60,7 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 		'gratis_ai_agent_provider_trace',
 		'gratis_ai_agent_generated_plugins',
 		'gratis_ai_agent_active_jobs',
+		'gratis_ai_agent_skill_usage',
 	];
 
 	/**


### PR DESCRIPTION
## Summary

Implements phases 1 and 2 of the adaptive skill system (GH#1079).

**Phase 1 (t215) — Skill usage telemetry:**
- New `gratis_ai_agent_skill_usage` DB table tracking skill load events per session/model with `trigger_type` ('auto'/'manual'/'tool_call'), `injected_tokens` estimate, and `outcome` signal.
- `SkillUsageRow` readonly DTO + `SkillUsageRepository` with `create()`, `get_by_skill()`, `get_stats()`, and `estimate_tokens()`.
- `SkillAutoInjector::inject_for_message()` records auto-injection events when model context is provided.
- `SkillAbilities::handle_skill_load()` records tool_call events on every agent-initiated skill load.
- DB version bumped to 17.0.0.

**Phase 2 (t216) — Model-aware tiered injection:**
- `SystemInstructionBuilder::build()` now gates auto-injection on `ModelHealthTracker::is_weak($model_id)`. Strong models (GPT-4.1, Claude Sonnet/Opus) receive only the skill index (~150 tokens) and call `skill-load` on demand. Weak models (quantized/small-param) continue to receive auto-injected content.
- `MAX_INJECTED_SKILLS` reduced from 2 → 1. Weak models can't effectively use two guides simultaneously.
- `SystemInstructionBuilder` accepts a `$session_id` constructor param; `AgentLoop` passes it through for telemetry context.

**Token cost impact:**
- Strong models (default for most users): save 1500–3000 tokens/turn — auto-injection no longer fires.
- Weak models: still receive 1 skill guide (down from 2 maximum).

## Runtime Testing

Risk level: **Medium** (DB schema change + system prompt assembly path change).

- PHPCS: ✅ zero violations on all changed files
- PHPStan: ✅ no errors (`phpstan.neon` config)
- `self-assessed` — no active `wp-env` runtime available in this session
- DB upgrade is idempotent via `dbDelta` (safe for existing installs)

## Files Modified

- NEW: `includes/Models/DTO/SkillUsageRow.php`
- NEW: `includes/Repositories/SkillUsageRepository.php`
- EDIT: `includes/Core/Database.php` — new table method + schema + version bump
- EDIT: `includes/Core/SkillAutoInjector.php` — MAX cap 2→1, context params, telemetry recording
- EDIT: `includes/Abilities/SkillAbilities.php` — record tool_call events
- EDIT: `includes/Core/SystemInstructionBuilder.php` — gate injection on is_weak(), add session_id param
- EDIT: `includes/Core/AgentLoop.php` — pass session_id to builder

Resolves #1079

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.73 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 14m and 29,370 tokens on this as a headless worker.