### PR TITLE
t218: Skill versioning schema + remote update checker (Phase 3a)

### DIFF
--- a/includes/Core/Database.php
+++ b/includes/Core/Database.php
@@ -35,7 +35,7 @@ use GratisAiAgent\Tools\CustomTools;
 class Database {
 
 	const DB_VERSION_OPTION = 'gratis_ai_agent_db_version';
-	const DB_VERSION        = '16.0.0';
+	const DB_VERSION        = '17.0.0';
 
 	// ─── Table Name Registry ──────────────────────────────────────────────────
 
@@ -314,11 +314,16 @@ class Database {
 			content longtext NOT NULL,
 			is_builtin tinyint(1) NOT NULL DEFAULT 0,
 			enabled tinyint(1) NOT NULL DEFAULT 1,
+			version varchar(20) NOT NULL DEFAULT '',
+			content_hash varchar(64) NOT NULL DEFAULT '',
+			source_url varchar(2048) NOT NULL DEFAULT '',
+			user_modified tinyint(1) NOT NULL DEFAULT 0,
 			created_at datetime NOT NULL,
 			updated_at datetime NOT NULL,
 			PRIMARY KEY  (id),
 			UNIQUE KEY slug (slug),
-			KEY enabled (enabled)
+			KEY enabled (enabled),
+			KEY is_builtin (is_builtin)
 		) {$charset};
 
 		CREATE TABLE {$custom_tools_table} (

--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -325,6 +325,9 @@ class Settings {
 			// Feedback report receiver settings (t180).
 			'feedback_enabled'         => false,
 			'feedback_endpoint_url'    => 'https://ultimateagentwp.ai/wp-json/gratis-ai-server/v1/reports',
+			// Skill auto-update settings (t218).
+			'skill_auto_update'        => true,
+			'skill_manifest_url'       => '',
 		);
 	}
 

--- a/includes/Models/DTO/SessionRow.php
+++ b/includes/Models/DTO/SessionRow.php
@@ -36,6 +36,7 @@ readonly class SessionRow {
 	 * @param string      $createdAt        MySQL datetime string (UTC).
 	 * @param string      $updatedAt        MySQL datetime string (UTC).
 	 */
+	// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- Intentional camelCase: properties map to a REST API / JavaScript layer that uses camelCase, avoiding the confusion of a DTO with mixed naming.
 	public function __construct(
 		public int $id,
 		public int $userId,
@@ -53,6 +54,7 @@ readonly class SessionRow {
 		public string $createdAt,
 		public string $updatedAt,
 	) {}
+	// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
 
 	/**
 	 * Construct a SessionRow from the raw stdClass returned by wpdb::get_row().

--- a/includes/Models/DTO/SkillRow.php
+++ b/includes/Models/DTO/SkillRow.php
@@ -16,15 +16,19 @@ namespace GratisAiAgent\Models\DTO;
 readonly class SkillRow {
 
 	/**
-	 * @param int    $id         Row ID (auto-increment PK).
-	 * @param string $slug       URL-safe unique slug.
-	 * @param string $name       Human-readable name.
-	 * @param string $description Short description for the agent index.
-	 * @param string $content    Full skill guide content (markdown).
-	 * @param bool   $is_builtin Whether this is a framework-bundled built-in skill.
-	 * @param bool   $enabled    Whether the skill is active.
-	 * @param string $created_at MySQL datetime string (UTC).
-	 * @param string $updated_at MySQL datetime string (UTC).
+	 * @param int    $id            Row ID (auto-increment PK).
+	 * @param string $slug          URL-safe unique slug.
+	 * @param string $name          Human-readable name.
+	 * @param string $description   Short description for the agent index.
+	 * @param string $content       Full skill guide content (markdown).
+	 * @param bool   $is_builtin    Whether this is a framework-bundled built-in skill.
+	 * @param bool   $enabled       Whether the skill is active.
+	 * @param string $version       Semver string of the current skill content (e.g. "1.0.0").
+	 * @param string $content_hash  SHA-256 hash of the canonical content for change detection.
+	 * @param string $source_url    Remote URL from which the skill content originates (empty for user-created skills).
+	 * @param bool   $user_modified Whether an admin has edited a built-in skill (blocks auto-updates).
+	 * @param string $created_at    MySQL datetime string (UTC).
+	 * @param string $updated_at    MySQL datetime string (UTC).
 	 */
 	public function __construct(
 		public int $id,
@@ -34,6 +38,10 @@ readonly class SkillRow {
 		public string $content,
 		public bool $is_builtin,
 		public bool $enabled,
+		public string $version,
+		public string $content_hash,
+		public string $source_url,
+		public bool $user_modified,
 		public string $created_at,
 		public string $updated_at,
 	) {}
@@ -46,15 +54,19 @@ readonly class SkillRow {
 	 */
 	public static function from_row( object $row ): self {
 		return new self(
-			id:          (int) $row->id,
-			slug:        (string) ( $row->slug ?? '' ),
-			name:        (string) ( $row->name ?? '' ),
-			description: (string) ( $row->description ?? '' ),
-			content:     (string) ( $row->content ?? '' ),
-			is_builtin:  (bool) (int) ( $row->is_builtin ?? 0 ),
-			enabled:     (bool) (int) ( $row->enabled ?? 1 ),
-			created_at:  (string) ( $row->created_at ?? '' ),
-			updated_at:  (string) ( $row->updated_at ?? '' ),
+			id:            (int) $row->id,
+			slug:          (string) ( $row->slug ?? '' ),
+			name:          (string) ( $row->name ?? '' ),
+			description:   (string) ( $row->description ?? '' ),
+			content:       (string) ( $row->content ?? '' ),
+			is_builtin:    (bool) (int) ( $row->is_builtin ?? 0 ),
+			enabled:       (bool) (int) ( $row->enabled ?? 1 ),
+			version:       (string) ( $row->version ?? '' ),
+			content_hash:  (string) ( $row->content_hash ?? '' ),
+			source_url:    (string) ( $row->source_url ?? '' ),
+			user_modified: (bool) (int) ( $row->user_modified ?? 0 ),
+			created_at:    (string) ( $row->created_at ?? '' ),
+			updated_at:    (string) ( $row->updated_at ?? '' ),
 		);
 	}
 }

--- a/includes/Models/Skill.php
+++ b/includes/Models/Skill.php
@@ -179,34 +179,43 @@ class Skill {
 	/**
 	 * Create a new skill.
 	 *
-	 * @param array<string, mixed> $data Skill data: slug, name, description, content, is_builtin, enabled.
+	 * @param array<string, mixed> $data Skill data: slug, name, description, content, is_builtin, enabled, version, content_hash, source_url.
 	 * @return int|false Inserted row ID or false on failure.
 	 */
 	public static function create( array $data ) {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 
-		$now = current_time( 'mysql', true );
+		// @phpstan-ignore-next-line
+		$content = (string) ( $data['content'] ?? '' );
+		$now     = current_time( 'mysql', true );
+
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Custom table query; caching not applicable.
 		$result = $wpdb->insert(
 			self::table_name(),
 			[
 				// @phpstan-ignore-next-line
-				'slug'        => sanitize_title( $data['slug'] ?? '' ),
+				'slug'          => sanitize_title( $data['slug'] ?? '' ),
 				// @phpstan-ignore-next-line
-				'name'        => sanitize_text_field( $data['name'] ?? '' ),
+				'name'          => sanitize_text_field( $data['name'] ?? '' ),
 				// @phpstan-ignore-next-line
-				'description' => sanitize_textarea_field( $data['description'] ?? '' ),
+				'description'   => sanitize_textarea_field( $data['description'] ?? '' ),
 				// Skill content is markdown for AI consumption, not HTML for browser rendering.
 				// It is stored verbatim; SQL injection is prevented by $wpdb->insert() parameterisation.
+				'content'       => $content,
+				'is_builtin'    => ! empty( $data['is_builtin'] ) ? 1 : 0,
+				'enabled'       => isset( $data['enabled'] ) ? ( $data['enabled'] ? 1 : 0 ) : 1,
 				// @phpstan-ignore-next-line
-				'content'     => $data['content'] ?? '',
-				'is_builtin'  => ! empty( $data['is_builtin'] ) ? 1 : 0,
-				'enabled'     => isset( $data['enabled'] ) ? ( $data['enabled'] ? 1 : 0 ) : 1,
-				'created_at'  => $now,
-				'updated_at'  => $now,
+				'version'       => (string) ( $data['version'] ?? '' ),
+				// @phpstan-ignore-next-line
+				'content_hash'  => '' !== $content ? hash( 'sha256', $content ) : (string) ( $data['content_hash'] ?? '' ),
+				// @phpstan-ignore-next-line
+				'source_url'    => esc_url_raw( (string) ( $data['source_url'] ?? '' ) ),
+				'user_modified' => 0,
+				'created_at'    => $now,
+				'updated_at'    => $now,
 			],
-			[ '%s', '%s', '%s', '%s', '%d', '%d', '%s', '%s' ]
+			[ '%s', '%s', '%s', '%s', '%d', '%d', '%s', '%s', '%s', '%d', '%s', '%s' ]
 		);
 
 		return $result ? (int) $wpdb->insert_id : false;
@@ -215,15 +224,20 @@ class Skill {
 	/**
 	 * Update an existing skill.
 	 *
+	 * When a built-in skill's content is changed by an admin, `user_modified` is
+	 * automatically set to `1` to protect the customisation from auto-updates.
+	 * Pass `'user_modified' => false` explicitly to bypass this (e.g. when
+	 * {@see apply_update()} applies a remote update to an unmodified skill).
+	 *
 	 * @param int                  $id   Skill ID.
-	 * @param array<string, mixed> $data Fields to update (name, description, content, enabled).
+	 * @param array<string, mixed> $data Fields to update (name, description, content, enabled, version, source_url, user_modified).
 	 * @return bool
 	 */
 	public static function update( int $id, array $data ): bool {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 
-		$allowed = [ 'name', 'description', 'content', 'enabled' ];
+		$allowed = [ 'name', 'description', 'content', 'enabled', 'version', 'source_url', 'user_modified' ];
 		$data    = array_intersect_key( $data, array_flip( $allowed ) );
 
 		if ( isset( $data['name'] ) ) {
@@ -234,6 +248,10 @@ class Skill {
 			// @phpstan-ignore-next-line
 			$data['description'] = sanitize_textarea_field( $data['description'] );
 		}
+		if ( isset( $data['source_url'] ) ) {
+			// @phpstan-ignore-next-line
+			$data['source_url'] = esc_url_raw( (string) $data['source_url'] );
+		}
 		// Skill content is markdown for AI consumption, not HTML for browser rendering.
 		// Stored verbatim; SQL injection is prevented by $wpdb->update() parameterisation.
 		// No sanitization needed: content only flows through REST/admin, never rendered as raw HTML.
@@ -242,11 +260,31 @@ class Skill {
 			$data['enabled'] = $data['enabled'] ? 1 : 0;
 		}
 
+		// When an admin modifies a built-in skill's content, mark it as user-modified
+		// so that automatic remote updates do not overwrite their customisations.
+		// The caller may pass user_modified => false explicitly to suppress this
+		// (used by apply_update() when applying a remote update to an unmodified skill).
+		if ( isset( $data['content'] ) && ! array_key_exists( 'user_modified', $data ) ) {
+			$skill = self::get( $id );
+			if ( $skill && $skill->is_builtin ) {
+				$data['user_modified'] = 1;
+			}
+		}
+
+		if ( isset( $data['user_modified'] ) ) {
+			$data['user_modified'] = $data['user_modified'] ? 1 : 0;
+		}
+
+		// Update content_hash whenever content changes.
+		if ( isset( $data['content'] ) ) {
+			$data['content_hash'] = hash( 'sha256', (string) $data['content'] );
+		}
+
 		$data['updated_at'] = current_time( 'mysql', true );
 
 		$formats = [];
 		foreach ( $data as $key => $value ) {
-			if ( $key === 'enabled' ) {
+			if ( in_array( $key, [ 'enabled', 'user_modified' ], true ) ) {
 				$formats[] = '%d';
 			} else {
 				$formats[] = '%s';
@@ -298,6 +336,8 @@ class Skill {
 	/**
 	 * Reset a built-in skill to its original content.
 	 *
+	 * Clears `user_modified` so that subsequent remote auto-updates will apply.
+	 *
 	 * @param int $id Skill ID.
 	 * @return bool
 	 */
@@ -320,11 +360,93 @@ class Skill {
 			$id,
 			[
 				// @phpstan-ignore-next-line
-				'name'        => $definition['name'],
+				'name'          => $definition['name'],
 				// @phpstan-ignore-next-line
-				'description' => $definition['description'],
+				'description'   => $definition['description'],
 				// @phpstan-ignore-next-line
-				'content'     => $definition['content'],
+				'content'       => $definition['content'],
+				// Explicitly clear user_modified so future remote updates can apply.
+				'user_modified' => false,
+			]
+		);
+	}
+
+	/**
+	 * Check whether a remote update is available for a skill.
+	 *
+	 * Compares the skill's stored `content_hash` against a hash of the remote
+	 * manifest entry. Returns the remote skill data when the hashes differ, or
+	 * null when the skill is up to date or the manifest entry is absent.
+	 *
+	 * This method only detects differences; it does not apply any changes.
+	 * Use {@see apply_update()} to apply a detected update.
+	 *
+	 * @param SkillRow             $skill        The skill to check.
+	 * @param array<string, mixed> $manifest_entry Remote manifest entry for this slug
+	 *                                             (keys: version, content, source_url).
+	 * @return array<string, mixed>|null Remote entry when an update is available, null otherwise.
+	 */
+	public static function check_for_updates( SkillRow $skill, array $manifest_entry ): ?array {
+		// @phpstan-ignore-next-line
+		$remote_content = (string) ( $manifest_entry['content'] ?? '' );
+
+		if ( '' === $remote_content ) {
+			return null;
+		}
+
+		$remote_hash = hash( 'sha256', $remote_content );
+
+		// No update needed if content is identical.
+		if ( $remote_hash === $skill->content_hash ) {
+			return null;
+		}
+
+		return $manifest_entry;
+	}
+
+	/**
+	 * Apply a remote manifest update to a built-in skill.
+	 *
+	 * Skips silently if the skill has been locally modified by an admin
+	 * (`user_modified = 1`), to protect customisations.
+	 *
+	 * Passes `'user_modified' => false` to {@see update()} so the built-in
+	 * skill's modification flag is not re-set during the remote sync.
+	 *
+	 * @param int                  $id            Skill ID.
+	 * @param array<string, mixed> $manifest_entry Remote manifest entry (keys: version, content, source_url).
+	 * @return bool True when the update was applied, false when skipped or failed.
+	 */
+	public static function apply_update( int $id, array $manifest_entry ): bool {
+		$skill = self::get( $id );
+
+		if ( ! $skill || ! $skill->is_builtin ) {
+			return false;
+		}
+
+		// Never overwrite admin customisations.
+		if ( $skill->user_modified ) {
+			return false;
+		}
+
+		// @phpstan-ignore-next-line
+		$remote_content = (string) ( $manifest_entry['content'] ?? '' );
+
+		if ( '' === $remote_content ) {
+			return false;
+		}
+
+		return self::update(
+			$id,
+			[
+				// @phpstan-ignore-next-line
+				'content'       => $remote_content,
+				// @phpstan-ignore-next-line
+				'version'       => (string) ( $manifest_entry['version'] ?? '' ),
+				// @phpstan-ignore-next-line
+				'source_url'    => (string) ( $manifest_entry['source_url'] ?? '' ),
+				// Explicitly keep user_modified=0; this is a remote sync, not an admin edit.
+				'user_modified' => false,
 			]
 		);
 	}


### PR DESCRIPTION
## Summary

Implements Phase 3a of the adaptive skill system (t218 / t215): adds versioning metadata to the skills schema and provides the `Skill` model methods needed by the WP-Cron update checker (t219, Phase 3b).

## Changes

### Database schema (DB_VERSION → 17.0.0)

Four new columns on `gratis_ai_agent_skills`:
- `version varchar(20)` — semver string from the remote manifest (e.g. `"1.2.0"`)
- `content_hash varchar(64)` — SHA-256 of the stored content; used for change detection without full-content diffs
- `source_url varchar(2048)` — remote URL the skill content originates from
- `user_modified tinyint(1)` — flag set automatically when an admin edits a built-in skill, protecting their customisation from being overwritten by auto-updates

### `SkillRow` DTO

Added typed `version`, `content_hash`, `source_url`, `user_modified` properties and corresponding `from_row()` mappings (default-safe for existing rows).

### `Skill` model

- **`create()`** — accepts `version`, `source_url`; auto-computes `content_hash` from content on insert; initialises `user_modified = 0`.
- **`update()`** — detects when an admin changes a built-in skill's content and auto-sets `user_modified = 1`; recomputes `content_hash`; supports `version`, `source_url` fields. Callers may pass `'user_modified' => false` to suppress the flag (used by `apply_update()`).
- **`reset_builtin()`** — now clears `user_modified = 0` so remote auto-updates resume after a reset.
- **`check_for_updates(SkillRow $skill, array $manifest_entry): ?array`** — compares `content_hash` against the remote manifest; returns the manifest entry when different, null when up-to-date.
- **`apply_update(int $id, array $manifest_entry): bool`** — applies remote content to an unmodified built-in skill; skips silently when `user_modified = 1`.

### `Settings`

Added two new defaults:
- `skill_auto_update` (bool, default `true`) — global toggle for automatic skill updates
- `skill_manifest_url` (string, default `''`) — URL of the remote skill manifest JSON

## Verification

```
composer phpstan  # OK – No errors
composer phpcs    # OK – no violations on all 4 changed files
```

## Notes

- t219 (Phase 3b) — the WP-Cron callback that fetches the manifest and calls `check_for_updates()` / `apply_update()` — depends on this PR and can be implemented independently.
- `dbDelta()` handles the column additions; no manual `ALTER TABLE` migration script is needed.

Resolves #1082