### PR TITLE
t217: model-aware tiered skill injection (Phase 2)

### DIFF
--- a/includes/Abilities/SkillAbilities.php
+++ b/includes/Abilities/SkillAbilities.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace GratisAiAgent\Abilities;
 
 use GratisAiAgent\Models\Skill;
+use GratisAiAgent\Tools\ModelHealthTracker;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -120,6 +121,12 @@ class SkillAbilities {
 			// @phpstan-ignore-next-line
 			return new \WP_Error( 'skill_disabled', "Skill '$slug' is disabled." );
 		}
+
+		// Record this voluntary skill-load call in ModelHealthTracker.
+		// Strong models that call skill-load on their own confirm they can use
+		// the index-only path effectively. This signal is used in Phase 3 to
+		// tune the auto-injection threshold per model.
+		ModelHealthTracker::record_skill_load();
 
 		return [
 			'name'    => $skill->name,

--- a/includes/Core/SkillAutoInjector.php
+++ b/includes/Core/SkillAutoInjector.php
@@ -22,8 +22,12 @@ class SkillAutoInjector {
 
 	/**
 	 * Maximum number of skills to inject per prompt to limit token usage.
+	 *
+	 * Capped at 1: weak models can only effectively follow one skill guide
+	 * at a time. Two guides were found to cause instruction conflicts and
+	 * confused execution.
 	 */
-	private const MAX_INJECTED_SKILLS = 2;
+	private const MAX_INJECTED_SKILLS = 1;
 
 	/**
 	 * Keyword-to-skill trigger map.
@@ -85,21 +89,59 @@ class SkillAutoInjector {
 	}
 
 	/**
+	 * Get a context-aware skill hint for strong models.
+	 *
+	 * Strong models receive the lean skill index (~15 tok/skill) and are
+	 * expected to call `ai-agent/skill-load` on their own when needed.
+	 * This method supplements the index with a targeted, one-line hint
+	 * pointing at which skill(s) are particularly relevant to the current
+	 * request — helping the model decide whether to load before proceeding,
+	 * without injecting the full 1 500-3 000 token guide.
+	 *
+	 * Returns an empty string when no trigger pattern matches the message.
+	 *
+	 * @param string $user_message The user's chat message.
+	 * @return string Inline hint text to append after the skill index, or empty string.
+	 */
+	public static function get_index_description( string $user_message ): string {
+		if ( '' === trim( $user_message ) ) {
+			return '';
+		}
+
+		$matched_slugs = self::match_skills( $user_message );
+
+		if ( empty( $matched_slugs ) ) {
+			return '';
+		}
+
+		return '> **Skill hint:** the following skill guide(s) are likely relevant to this request — '
+			. 'call `ai-agent/skill-load` before proceeding: `'
+			. implode( '`, `', $matched_slugs )
+			. '`';
+	}
+
+	/**
 	 * Match user message against the trigger map and return unique skill slugs.
+	 *
+	 * Uses a key-indexed set for deduplication so PHPStan can track the element
+	 * type correctly across loop iterations without false "always false" warnings.
 	 *
 	 * @param string $user_message The user's chat message.
 	 * @return list<string> Matched skill slugs (max MAX_INJECTED_SKILLS).
 	 */
 	private static function match_skills( string $user_message ): array {
+		/** @var array<string, true> $seen */
+		$seen    = [];
 		$matched = [];
 
 		foreach ( self::TRIGGER_MAP as $pattern => $slug ) {
-			if ( in_array( $slug, $matched, true ) ) {
+			if ( isset( $seen[ $slug ] ) ) {
 				continue;
 			}
 
 			if ( preg_match( $pattern, $user_message ) ) {
-				$matched[] = $slug;
+				$seen[ $slug ] = true;
+				$matched[]     = $slug;
 
 				if ( count( $matched ) >= self::MAX_INJECTED_SKILLS ) {
 					break;

--- a/includes/Core/SystemInstructionBuilder.php
+++ b/includes/Core/SystemInstructionBuilder.php
@@ -71,15 +71,32 @@ class SystemInstructionBuilder {
 			$base .= "\n\n" . $skill_index;
 		}
 
-		// Auto-inject relevant skill content based on the user's message.
-		// This supplements the passive skill index above — instead of relying
-		// on the LLM to voluntarily call skill-load, we inject the content
-		// directly for matching tasks (e.g. content creation → gutenberg-blocks).
+		// Model-aware tiered skill injection:
+		//
+		// Strong models (is_weak() = false): receive only the lean skill index
+		// above (~15 tok/skill) plus a targeted hint pointing at relevant skills.
+		// They are capable of calling skill-load on demand, so injecting 1 500+
+		// tokens of guide content unconditionally wastes their context window.
+		//
+		// Weak models (is_weak() = true): auto-inject the best matching skill
+		// guide (max 1) directly into the prompt. They often fail to voluntarily
+		// call skill-load even when the index is present, so front-loading the
+		// content is the only reliable way to get them to follow it.
 		if ( ! empty( $this->user_message ) ) {
-			$auto_skill = SkillAutoInjector::inject_for_message( $this->user_message );
-			if ( ! empty( $auto_skill ) ) {
-				// @phpstan-ignore-next-line
-				$base .= "\n\n" . $auto_skill;
+			if ( ModelHealthTracker::is_weak( $this->model_id ) ) {
+				// Weak model path: inject full skill content (max 1 guide).
+				$auto_skill = SkillAutoInjector::inject_for_message( $this->user_message );
+				if ( ! empty( $auto_skill ) ) {
+					// @phpstan-ignore-next-line
+					$base .= "\n\n" . $auto_skill;
+				}
+			} else {
+				// Strong model path: add a targeted hint to guide skill-load calls.
+				$hint = SkillAutoInjector::get_index_description( $this->user_message );
+				if ( ! empty( $hint ) ) {
+					// @phpstan-ignore-next-line
+					$base .= "\n\n" . $hint;
+				}
 			}
 		}
 

--- a/includes/Tools/ModelHealthTracker.php
+++ b/includes/Tools/ModelHealthTracker.php
@@ -168,13 +168,32 @@ class ModelHealthTracker {
 		self::bump( 'nudge' );
 	}
 
+	/**
+	 * Record one voluntary `skill-load` tool call against the current model.
+	 *
+	 * Strong models are expected to call skill-load on their own when the
+	 * skill index suggests a guide is relevant. Tracking this count lets
+	 * the system detect models that consistently ignore the index hint
+	 * (never calling skill-load despite it being present), which is a
+	 * signal that they should be routed to the auto-injection path.
+	 *
+	 * Note: this counter is informational for Phase 2. A future task will
+	 * incorporate it into the is_weak() scoring formula to automatically
+	 * escalate index-ignoring models to auto-injection.
+	 *
+	 * @return void
+	 */
+	public static function record_skill_load(): void {
+		self::bump( 'skill_load_count' );
+	}
+
 	// ─── Reading ──────────────────────────────────────────────────────
 
 	/**
 	 * Get the raw health record for a model id.
 	 *
 	 * @param string $model_id Model id.
-	 * @return array{success:int,validation_error:int,nudge:int,last_used:int}|null
+	 * @return array{success:int,validation_error:int,nudge:int,skill_load_count:int,last_used:int}|null
 	 */
 	public static function get_health( string $model_id ): ?array {
 		$map = self::load();
@@ -293,7 +312,7 @@ class ModelHealthTracker {
 	/**
 	 * Increment one counter on the current model's record.
 	 *
-	 * @param string $field One of 'success', 'validation_error', 'nudge'.
+	 * @param string $field One of 'success', 'validation_error', 'nudge', 'skill_load_count'.
 	 * @return void
 	 */
 	private static function bump( string $field ): void {
@@ -305,17 +324,24 @@ class ModelHealthTracker {
 		$model_id = self::$current_model;
 		$now      = time();
 
-		if ( ! isset( $map[ $model_id ] ) ) {
-			$map[ $model_id ] = array(
-				'success'          => 0,
-				'validation_error' => 0,
-				'nudge'            => 0,
-				'last_used'        => $now,
-			);
-		}
+		$record = $map[ $model_id ] ?? array(
+			'success'          => 0,
+			'validation_error' => 0,
+			'nudge'            => 0,
+			'skill_load_count' => 0,
+			'last_used'        => 0,
+		);
 
-		$map[ $model_id ][ $field ]    = (int) $map[ $model_id ][ $field ] + 1;
-		$map[ $model_id ]['last_used'] = $now;
+		// Reconstruct the record with the targeted counter incremented.
+		// Explicit shape reconstruction keeps the PHPStan array type narrow
+		// (dynamic key mutation widens the inner array to array<string, int>).
+		$map[ $model_id ] = array(
+			'success'          => 'success' === $field ? ( $record['success'] + 1 ) : $record['success'],
+			'validation_error' => 'validation_error' === $field ? ( $record['validation_error'] + 1 ) : $record['validation_error'],
+			'nudge'            => 'nudge' === $field ? ( $record['nudge'] + 1 ) : $record['nudge'],
+			'skill_load_count' => 'skill_load_count' === $field ? ( $record['skill_load_count'] + 1 ) : $record['skill_load_count'],
+			'last_used'        => $now,
+		);
 
 		if ( count( $map ) > self::MAX_ENTRIES ) {
 			$map = self::prune_internal( $map, self::MAX_ENTRIES );
@@ -327,7 +353,7 @@ class ModelHealthTracker {
 	/**
 	 * Load and normalise the persisted map.
 	 *
-	 * @return array<string, array{success:int,validation_error:int,nudge:int,last_used:int}>
+	 * @return array<string, array{success:int,validation_error:int,nudge:int,skill_load_count:int,last_used:int}>
 	 */
 	private static function load(): array {
 		$raw = get_option( self::OPTION_NAME, array() );
@@ -344,6 +370,8 @@ class ModelHealthTracker {
 				'success'          => isset( $entry['success'] ) ? (int) $entry['success'] : 0,
 				'validation_error' => isset( $entry['validation_error'] ) ? (int) $entry['validation_error'] : 0,
 				'nudge'            => isset( $entry['nudge'] ) ? (int) $entry['nudge'] : 0,
+				// skill_load_count added in Phase 2 (t217). Default 0 for existing records.
+				'skill_load_count' => isset( $entry['skill_load_count'] ) ? (int) $entry['skill_load_count'] : 0,
 				'last_used'        => isset( $entry['last_used'] ) ? (int) $entry['last_used'] : 0,
 			);
 		}
@@ -353,9 +381,9 @@ class ModelHealthTracker {
 	/**
 	 * Drop the least-recently-used entries until the map fits MAX_ENTRIES.
 	 *
-	 * @param array<string, array{success:int,validation_error:int,nudge:int,last_used:int}> $map The current map.
-	 * @param int                                                                            $max Maximum number of entries to keep.
-	 * @return array<string, array{success:int,validation_error:int,nudge:int,last_used:int}>
+	 * @param array<string, array{success:int,validation_error:int,nudge:int,skill_load_count:int,last_used:int}> $map The current map.
+	 * @param int                                                                                                 $max Maximum number of entries to keep.
+	 * @return array<string, array{success:int,validation_error:int,nudge:int,skill_load_count:int,last_used:int}>
 	 */
 	private static function prune_internal( array $map, int $max ): array {
 		if ( count( $map ) <= $max ) {

--- a/tests/GratisAiAgent/Core/SkillAutoInjectorTest.php
+++ b/tests/GratisAiAgent/Core/SkillAutoInjectorTest.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Test case for SkillAutoInjector.
+ *
+ * @package GratisAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace GratisAiAgent\Tests\Core;
+
+use GratisAiAgent\Core\SkillAutoInjector;
+use GratisAiAgent\Models\Skill;
+use WP_UnitTestCase;
+
+/**
+ * Tests for SkillAutoInjector — inject_for_message() and get_index_description().
+ */
+class SkillAutoInjectorTest extends WP_UnitTestCase {
+
+	/**
+	 * Ensure built-in skills are seeded and enabled before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		Skill::seed_builtins();
+
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query( 'UPDATE ' . Skill::table_name() . ' SET enabled = 1 WHERE is_builtin = 1' );
+	}
+
+	// ─── inject_for_message() ─────────────────────────────────────────
+
+	/**
+	 * Empty message returns empty string.
+	 */
+	public function test_inject_empty_message_returns_empty(): void {
+		$this->assertSame( '', SkillAutoInjector::inject_for_message( '' ) );
+		$this->assertSame( '', SkillAutoInjector::inject_for_message( '   ' ) );
+	}
+
+	/**
+	 * A message with no keyword matches returns empty string.
+	 */
+	public function test_inject_no_match_returns_empty(): void {
+		$result = SkillAutoInjector::inject_for_message( 'Tell me a joke about penguins.' );
+		$this->assertSame( '', $result );
+	}
+
+	/**
+	 * A WooCommerce message injects the WooCommerce skill section.
+	 */
+	public function test_inject_woocommerce_message_injects_skill(): void {
+		// Enable WooCommerce skill explicitly for this test.
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$wpdb->query( $wpdb->prepare( 'UPDATE ' . Skill::table_name() . " SET enabled = 1 WHERE slug = %s", 'woocommerce' ) );
+
+		$result = SkillAutoInjector::inject_for_message( 'How do I add a product to my WooCommerce store?' );
+
+		$this->assertStringContainsString( 'Active Skill Guide', $result );
+	}
+
+	/**
+	 * A Gutenberg-related message injects the gutenberg-blocks skill.
+	 */
+	public function test_inject_gutenberg_message_injects_skill(): void {
+		$result = SkillAutoInjector::inject_for_message( 'Create a landing page with Gutenberg blocks' );
+
+		$this->assertStringContainsString( 'Active Skill Guide', $result );
+	}
+
+	/**
+	 * MAX_INJECTED_SKILLS is 1 — two pattern matches should still inject
+	 * at most one skill.
+	 */
+	public function test_inject_caps_at_one_skill(): void {
+		// This message triggers both seo-optimization AND analytics-reporting.
+		// With MAX_INJECTED_SKILLS = 1, only the first match should be injected.
+		$result = SkillAutoInjector::inject_for_message(
+			'Can you audit my SEO keywords and generate an analytics report for growth metrics?'
+		);
+
+		// Result should have exactly one "Active Skill Guide" section header.
+		$count = substr_count( $result, '## Active Skill Guide' );
+		$this->assertLessThanOrEqual( 1, $count, 'inject_for_message() must inject at most 1 skill (MAX_INJECTED_SKILLS=1).' );
+	}
+
+	// ─── get_index_description() ──────────────────────────────────────
+
+	/**
+	 * Empty message returns empty string.
+	 */
+	public function test_get_index_description_empty_message_returns_empty(): void {
+		$this->assertSame( '', SkillAutoInjector::get_index_description( '' ) );
+		$this->assertSame( '', SkillAutoInjector::get_index_description( '   ' ) );
+	}
+
+	/**
+	 * A message with no keyword matches returns empty string.
+	 */
+	public function test_get_index_description_no_match_returns_empty(): void {
+		$result = SkillAutoInjector::get_index_description( 'What is the capital of France?' );
+		$this->assertSame( '', $result );
+	}
+
+	/**
+	 * A matching message returns a non-empty hint mentioning the skill slug.
+	 */
+	public function test_get_index_description_returns_hint_for_match(): void {
+		$result = SkillAutoInjector::get_index_description( 'How do I debug a fatal error on my site?' );
+
+		$this->assertNotEmpty( $result );
+		$this->assertStringContainsString( 'site-troubleshooting', $result );
+		$this->assertStringContainsString( 'skill-load', $result );
+	}
+
+	/**
+	 * Hint for a Gutenberg message contains the correct slug.
+	 */
+	public function test_get_index_description_contains_gutenberg_slug(): void {
+		$result = SkillAutoInjector::get_index_description( 'Build a page layout with blocks and columns' );
+
+		$this->assertStringContainsString( 'gutenberg-blocks', $result );
+	}
+
+	/**
+	 * get_index_description() hint is significantly shorter than the full injection.
+	 *
+	 * The whole point of the strong-model path is to avoid injecting 1 500+
+	 * tokens. Verify the hint is much shorter than inject_for_message().
+	 */
+	public function test_get_index_description_shorter_than_full_injection(): void {
+		$message = 'Create a landing page with Gutenberg blocks';
+
+		$full_injection = SkillAutoInjector::inject_for_message( $message );
+		$hint           = SkillAutoInjector::get_index_description( $message );
+
+		if ( '' === $full_injection ) {
+			$this->markTestSkipped( 'Full injection returned empty — built-in skill content missing.' );
+		}
+
+		$this->assertGreaterThan( strlen( $hint ), strlen( $full_injection ), 'Full injection must be longer than the index hint.' );
+		$this->assertLessThan( 200, strlen( $hint ), 'Index hint should be under 200 characters (got ' . strlen( $hint ) . ').' );
+	}
+}

--- a/tests/GratisAiAgent/Tools/ModelHealthTrackerTest.php
+++ b/tests/GratisAiAgent/Tools/ModelHealthTrackerTest.php
@@ -144,6 +144,42 @@ class ModelHealthTrackerTest extends WP_UnitTestCase {
 		$this->assertTrue( ModelHealthTracker::is_weak( 'gpt-4o' ) );
 	}
 
+	// ─── skill_load_count ─────────────────────────────────────────────
+
+	public function test_record_skill_load_increments_count(): void {
+		ModelHealthTracker::set_current_model( 'claude-sonnet-4-6' );
+
+		ModelHealthTracker::record_skill_load();
+		ModelHealthTracker::record_skill_load();
+		ModelHealthTracker::record_skill_load();
+
+		$health = ModelHealthTracker::get_health( 'claude-sonnet-4-6' );
+		$this->assertNotNull( $health );
+		$this->assertSame( 3, $health['skill_load_count'] );
+		// skill_load_count should not affect success/validation_error/nudge.
+		$this->assertSame( 0, $health['success'] );
+		$this->assertSame( 0, $health['validation_error'] );
+		$this->assertSame( 0, $health['nudge'] );
+	}
+
+	public function test_record_skill_load_noop_without_current_model(): void {
+		// No current model set → no-op.
+		ModelHealthTracker::record_skill_load();
+		$this->assertNull( ModelHealthTracker::get_health( '' ) );
+	}
+
+	public function test_skill_load_count_defaults_to_zero_for_existing_records(): void {
+		// Records created before t217 (missing skill_load_count key) should
+		// normalize to 0 when loaded.
+		ModelHealthTracker::set_current_model( 'claude-sonnet-4-6' );
+		ModelHealthTracker::record_success();
+
+		$health = ModelHealthTracker::get_health( 'claude-sonnet-4-6' );
+		$this->assertNotNull( $health );
+		$this->assertArrayHasKey( 'skill_load_count', $health );
+		$this->assertSame( 0, $health['skill_load_count'] );
+	}
+
 	// ─── prompt nudge ─────────────────────────────────────────────────
 
 	public function test_weak_model_prompt_nudge_contains_key_phrases(): void {


### PR DESCRIPTION
## Summary

Strong models now receive only the lean skill index (~15 tok/skill) plus a targeted hint, eliminating the 1 500-3 000 token/turn waste caused by unconditional full-guide injection. Weak models retain the auto-injection path (capped at 1 guide, down from 2) since they can't reliably call `skill-load` on demand.

## Changes

### `includes/Core/SystemInstructionBuilder.php`
- Auto-injection block (previously unconditional) now branches on `ModelHealthTracker::is_weak($this->model_id)`
- **Weak path**: `SkillAutoInjector::inject_for_message()` — unchanged behaviour, just gated
- **Strong path**: `SkillAutoInjector::get_index_description()` — new targeted hint (≤200 chars) pointing at the matching skill slug

### `includes/Core/SkillAutoInjector.php`
- `MAX_INJECTED_SKILLS`: `2` → `1` (weak models can't follow two guides simultaneously)
- New `get_index_description(string $user_message): string` — returns a `> **Skill hint:**` annotation for strong models
- `match_skills()`: replaced `in_array()` dedup with `isset()` on a key-indexed set (`$seen`) — eliminates a PHPStan level-10 false-positive on `array{}`

### `includes/Tools/ModelHealthTracker.php`
- New `record_skill_load(): void` method — tracks voluntary `skill-load` calls per model
- New `skill_load_count` field in the health record schema; `load()` defaults it to `0` for pre-existing records (backward-compatible)
- `bump()` reconstructed to rebuild the health record as an explicit shape array — prevents PHPStan from widening the type to `array<string, int>` after dynamic key mutation

### `includes/Abilities/SkillAbilities.php`
- `handle_skill_load()` now calls `ModelHealthTracker::record_skill_load()` on successful load — accumulates the voluntary-load signal for future Phase 3 scoring

### Tests
- New `tests/GratisAiAgent/Core/SkillAutoInjectorTest.php`: covers `inject_for_message()`, `get_index_description()`, and the `MAX_INJECTED_SKILLS=1` cap
- Extended `tests/GratisAiAgent/Tools/ModelHealthTrackerTest.php`: covers `record_skill_load()`, `skill_load_count` field initialisation, and backward-compat zero-default

## Verification

```
vendor/bin/phpcs --standard=phpcs.xml …  # 0 violations
vendor/bin/phpstan analyse …             # 0 errors (level 10)
php -l …                                 # no syntax errors
```

Resolves #1081