### PR TITLE
t219: WP-Cron skill update checker + conditional HTTP (Phase 3b)

### DIFF
--- a/includes/Bootstrap/LifecycleHandler.php
+++ b/includes/Bootstrap/LifecycleHandler.php
@@ -25,6 +25,7 @@ use GratisAiAgent\Abilities\ToolCapabilities;
 use GratisAiAgent\Automations\AutomationRunner;
 use GratisAiAgent\Core\Database;
 use GratisAiAgent\Core\OnboardingManager;
+use GratisAiAgent\Core\SkillUpdateChecker;
 use GratisAiAgent\Core\SiteScanner;
 use GratisAiAgent\Knowledge\KnowledgeHooks;
 
@@ -52,6 +53,7 @@ final class LifecycleHandler {
 		Database::install();
 		AutomationRunner::reschedule_all();
 		OnboardingManager::on_activation();
+		SkillUpdateChecker::schedule();
 		ToolCapabilities::register_capabilities( ToolCapabilities::all_ability_ids() );
 	}
 
@@ -66,5 +68,6 @@ final class LifecycleHandler {
 		KnowledgeHooks::deactivate();
 		AutomationRunner::unschedule_all();
 		SiteScanner::unschedule();
+		SkillUpdateChecker::unschedule();
 	}
 }

--- a/includes/Bootstrap/OnboardingHandler.php
+++ b/includes/Bootstrap/OnboardingHandler.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace GratisAiAgent\Bootstrap;
 
 use GratisAiAgent\Core\OnboardingManager;
+use GratisAiAgent\Core\SkillUpdateChecker;
 use GratisAiAgent\Core\SiteScanner;
 use XWP\DI\Decorators\Action;
 use XWP\DI\Decorators\Handler;
@@ -46,6 +47,16 @@ final class OnboardingHandler {
 	#[Action( tag: SiteScanner::CRON_HOOK, priority: 10 )]
 	public function run_site_scan(): void {
 		SiteScanner::run();
+	}
+
+	/**
+	 * Run the daily skill update check cron job.
+	 *
+	 * Scheduled as a recurring daily event via {@see SkillUpdateChecker::schedule()}.
+	 */
+	#[Action( tag: SkillUpdateChecker::CRON_HOOK, priority: 10 )]
+	public function run_skill_update_check(): void {
+		SkillUpdateChecker::run();
 	}
 
 	/**

--- a/includes/Core/SkillUpdateChecker.php
+++ b/includes/Core/SkillUpdateChecker.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Skill Update Checker — WP-Cron callback for remote manifest-based skill updates.
+ *
+ * Runs daily. Fetches the manifest JSON configured in Settings → skill_manifest_url,
+ * compares content hashes per slug, and applies updates to built-in unmodified skills.
+ * Uses If-None-Match / If-Modified-Since headers to skip unnecessary transfers.
+ *
+ * @package GratisAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace GratisAiAgent\Core;
+
+use GratisAiAgent\Models\Skill;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class SkillUpdateChecker {
+
+	/**
+	 * WP-Cron hook name for the daily skill update check.
+	 */
+	const CRON_HOOK = 'gratis_ai_agent_skill_update_check';
+
+	/**
+	 * Option key for conditional-request caching headers (ETag, Last-Modified).
+	 */
+	const MANIFEST_CACHE_OPTION = 'gratis_ai_agent_skill_manifest_cache';
+
+	// ── Registration ─────────────────────────────────────────────────────
+
+	/**
+	 * Register the cron hook handler (add_action for the cron callback).
+	 */
+	public static function register(): void {
+		add_action( self::CRON_HOOK, [ __CLASS__, 'run' ] );
+	}
+
+	/**
+	 * Schedule a daily update check (idempotent — safe to call multiple times).
+	 */
+	public static function schedule(): void {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time(), 'daily', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Cancel the scheduled check (e.g. on plugin deactivation).
+	 */
+	public static function unschedule(): void {
+		$timestamp = wp_next_scheduled( self::CRON_HOOK );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, self::CRON_HOOK );
+		}
+	}
+
+	// ── Cron callback ────────────────────────────────────────────────────
+
+	/**
+	 * Execute the skill update check (called by WP-Cron).
+	 *
+	 * Skips silently when skill_auto_update is disabled or skill_manifest_url
+	 * is not configured. Fetches the manifest, compares content hashes, and
+	 * applies updates to unmodified built-in skills only.
+	 */
+	public static function run(): void {
+		$settings     = Settings::instance()->get();
+		$manifest_url = (string) ( $settings['skill_manifest_url'] ?? '' );
+
+		if ( '' === $manifest_url ) {
+			return;
+		}
+
+		if ( ! (bool) ( $settings['skill_auto_update'] ?? true ) ) {
+			return;
+		}
+
+		$manifest = self::fetch_manifest( $manifest_url );
+
+		if ( null === $manifest ) {
+			// 304 Not Modified, network error, or malformed JSON — nothing to apply.
+			return;
+		}
+
+		self::apply_manifest_updates( $manifest );
+	}
+
+	// ── HTTP fetch ───────────────────────────────────────────────────────
+
+	/**
+	 * Fetch the remote manifest JSON using conditional headers.
+	 *
+	 * Sends If-None-Match and If-Modified-Since headers when cached values
+	 * exist. Returns null when the manifest is unchanged (304), unreachable,
+	 * or not valid JSON. Stores the response ETag / Last-Modified for the
+	 * next run.
+	 *
+	 * @param string $url Manifest URL.
+	 * @return array<array-key, mixed>|null Parsed manifest keyed by skill slug, or null.
+	 */
+	private static function fetch_manifest( string $url ): ?array {
+		$cache   = self::get_manifest_cache();
+		$headers = [ 'Accept' => 'application/json' ];
+
+		if ( '' !== $cache['etag'] ) {
+			$headers['If-None-Match'] = $cache['etag'];
+		}
+
+		if ( '' !== $cache['last_modified'] ) {
+			$headers['If-Modified-Since'] = $cache['last_modified'];
+		}
+
+		$response = wp_remote_get(
+			$url,
+			[
+				'timeout'     => 30,
+				'redirection' => 3,
+				'headers'     => $headers,
+			]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return null;
+		}
+
+		$status = (int) wp_remote_retrieve_response_code( $response );
+
+		if ( 304 === $status ) {
+			// Manifest unchanged — nothing to do.
+			return null;
+		}
+
+		if ( 200 !== $status ) {
+			return null;
+		}
+
+		// Cache conditional-request headers from this response for next run.
+		$resp_headers  = wp_remote_retrieve_headers( $response );
+		$etag          = (string) ( $resp_headers['etag'] ?? '' );
+		$last_modified = (string) ( $resp_headers['last-modified'] ?? '' );
+		self::set_manifest_cache( $etag, $last_modified );
+
+		$body     = wp_remote_retrieve_body( $response );
+		$manifest = json_decode( $body, true );
+
+		if ( ! is_array( $manifest ) ) {
+			return null;
+		}
+
+		return $manifest;
+	}
+
+	// ── Update application ───────────────────────────────────────────────
+
+	/**
+	 * Apply manifest updates to all unmodified built-in skills.
+	 *
+	 * Iterates every stored skill. For each built-in skill whose slug appears
+	 * in the manifest and whose content hash differs, calls apply_update().
+	 * Skills with user_modified = 1 are skipped by apply_update() itself to
+	 * protect admin customisations.
+	 *
+	 * @param array<array-key, mixed> $manifest Parsed manifest keyed by skill slug.
+	 */
+	private static function apply_manifest_updates( array $manifest ): void {
+		$skills = Skill::get_all();
+
+		if ( empty( $skills ) ) {
+			return;
+		}
+
+		foreach ( $skills as $skill ) {
+			if ( ! $skill->is_builtin ) {
+				continue;
+			}
+
+			if ( ! isset( $manifest[ $skill->slug ] ) || ! is_array( $manifest[ $skill->slug ] ) ) {
+				continue;
+			}
+
+			/** @var array<string, mixed> $entry */
+			$entry  = $manifest[ $skill->slug ];
+			$update = Skill::check_for_updates( $skill, $entry );
+
+			if ( null !== $update ) {
+				Skill::apply_update( (int) $skill->id, $update );
+			}
+		}
+	}
+
+	// ── Manifest cache helpers ───────────────────────────────────────────
+
+	/**
+	 * Return the stored conditional-request cache headers.
+	 *
+	 * @return array{etag: string, last_modified: string}
+	 */
+	private static function get_manifest_cache(): array {
+		$raw = get_option( self::MANIFEST_CACHE_OPTION, [] );
+		$raw = is_array( $raw ) ? $raw : [];
+
+		return [
+			'etag'          => (string) ( $raw['etag'] ?? '' ),
+			'last_modified' => (string) ( $raw['last_modified'] ?? '' ),
+		];
+	}
+
+	/**
+	 * Persist ETag and Last-Modified from a successful manifest response.
+	 *
+	 * @param string $etag          ETag header value (may be empty string).
+	 * @param string $last_modified Last-Modified header value (may be empty string).
+	 */
+	private static function set_manifest_cache( string $etag, string $last_modified ): void {
+		update_option(
+			self::MANIFEST_CACHE_OPTION,
+			[
+				'etag'          => $etag,
+				'last_modified' => $last_modified,
+			],
+			false
+		);
+	}
+}

--- a/includes/Models/Skill.php
+++ b/includes/Models/Skill.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace GratisAiAgent\Models;
 
+use GratisAiAgent\Core\Settings;
 use GratisAiAgent\Models\DTO\SkillRow;
 
 class Skill {
@@ -336,6 +337,12 @@ class Skill {
 	/**
 	 * Reset a built-in skill to its original content.
 	 *
+	 * Tries to pull the canonical content from the remote manifest URL first
+	 * (when `skill_manifest_url` is configured), so that the "reset" action
+	 * restores the latest upstream version rather than the locally-bundled one.
+	 * Falls back to the bundled .md file when the remote fetch fails or is not
+	 * configured.
+	 *
 	 * Clears `user_modified` so that subsequent remote auto-updates will apply.
 	 *
 	 * @param int $id Skill ID.
@@ -348,6 +355,13 @@ class Skill {
 			return false;
 		}
 
+		// Prefer the latest upstream content from the remote manifest.
+		$remote_entry = self::fetch_manifest_entry( $skill->slug );
+		if ( null !== $remote_entry ) {
+			return self::apply_update( $id, $remote_entry );
+		}
+
+		// Fall back to the locally-bundled .md file.
 		$builtins = self::get_builtin_definitions();
 
 		if ( ! isset( $builtins[ $skill->slug ] ) ) {
@@ -369,6 +383,53 @@ class Skill {
 				'user_modified' => false,
 			]
 		);
+	}
+
+	/**
+	 * Fetch a single skill entry from the remote manifest URL.
+	 *
+	 * Returns null when skill_manifest_url is not configured, the remote
+	 * request fails, the response is not valid JSON, or the slug is absent
+	 * from the manifest.
+	 *
+	 * @param string $slug Skill slug to look up in the manifest.
+	 * @return array<array-key, mixed>|null Manifest entry for the slug, or null.
+	 */
+	private static function fetch_manifest_entry( string $slug ): ?array {
+		$settings     = Settings::instance()->get();
+		$manifest_url = (string) ( $settings['skill_manifest_url'] ?? '' );
+
+		if ( '' === $manifest_url ) {
+			return null;
+		}
+
+		$response = wp_remote_get(
+			$manifest_url,
+			[
+				'timeout'     => 15,
+				'redirection' => 3,
+				'headers'     => [ 'Accept' => 'application/json' ],
+			]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return null;
+		}
+
+		if ( 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
+			return null;
+		}
+
+		$body     = wp_remote_retrieve_body( $response );
+		$manifest = json_decode( $body, true );
+
+		if ( ! is_array( $manifest ) ) {
+			return null;
+		}
+
+		return isset( $manifest[ $slug ] ) && is_array( $manifest[ $slug ] )
+			? $manifest[ $slug ]
+			: null;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- **NEW** `includes/Core/SkillUpdateChecker.php` — daily WP-Cron callback that fetches the configured manifest JSON, compares `content_hash` per slug, and applies updates to `is_builtin=1 AND user_modified=0` skills. Uses `wp_remote_get` with `If-None-Match`/`If-Modified-Since` headers; caches ETag/Last-Modified in `gratis_ai_agent_skill_manifest_cache` to skip redundant downloads.

- **EDIT** `includes/Bootstrap/OnboardingHandler.php` — wire `SkillUpdateChecker::CRON_HOOK` callback via `#[Action]` attribute (same `CTX_GLOBAL` pattern as `SiteScanner`).

- **EDIT** `includes/Bootstrap/LifecycleHandler.php` — `activate()` calls `SkillUpdateChecker::schedule()` (daily recurring event); `deactivate()` calls `SkillUpdateChecker::unschedule()`.

- **EDIT** `includes/Models/Skill.php::reset_builtin()` — tries remote manifest entry first (new `fetch_manifest_entry()` helper that calls `skill_manifest_url`) before falling back to the bundled `.md` file. Clears `user_modified` in both paths.

## Verification

`composer phpstan && composer phpcs` — both pass (zero errors/violations).

Resolves #1083