### PR TITLE
t220: Skill manager UI — usage stats, update badges, auto-update toggle (Phase 4)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,8 @@
 		],
 		"jsdoc/no-undefined-types": [ "error", { "definedTypes": [ "JSX" ] } ],
 		"@wordpress/no-unsafe-wp-apis": "warn",
-		"no-console": "warn"
+		"no-console": "warn",
+		"import/no-unresolved": [ "error", { "ignore": [ "@wordpress/icons" ] } ]
 	},
 	"ignorePatterns": [
 		"build/",

--- a/includes/REST/SkillController.php
+++ b/includes/REST/SkillController.php
@@ -10,7 +10,9 @@ declare(strict_types=1);
 
 namespace GratisAiAgent\REST;
 
+use GratisAiAgent\Core\Settings;
 use GratisAiAgent\Models\Skill;
+use GratisAiAgent\Repositories\SkillUsageRepository;
 use GratisAiAgent\Services\SkillService;
 use WP_Error;
 use WP_REST_Request;
@@ -30,11 +32,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Domain logic (formatting, business rules) is delegated to SkillService.
  *
  * Endpoints:
- *  GET    /skills            — list all skills
- *  POST   /skills            — create a custom skill
- *  PATCH  /skills/{id}       — update a skill
- *  DELETE /skills/{id}       — delete a custom skill
- *  POST   /skills/{id}/reset — reset a built-in skill to defaults
+ *  GET    /skills               — list all skills
+ *  POST   /skills               — create a custom skill
+ *  PATCH  /skills/{id}          — update a skill
+ *  DELETE /skills/{id}          — delete a custom skill
+ *  POST   /skills/{id}/reset    — reset a built-in skill to defaults
+ *  GET    /skills/stats         — aggregated usage stats per skill
+ *  POST   /skills/check-updates — check remote manifest for available updates
  */
 #[REST_Handler(
 	namespace: RestController::NAMESPACE,
@@ -262,6 +266,154 @@ final class SkillController extends XWP_REST_Controller {
 				'type'     => 'boolean',
 			),
 		);
+	}
+
+	/**
+	 * Handle GET /skills/stats — aggregated usage stats per skill.
+	 *
+	 * Returns total load count, helpful/neutral/negative outcome counts, and
+	 * the last-used timestamp for each skill that has at least one usage record.
+	 * Skills with no usage records are omitted (frontend treats absence as zero).
+	 *
+	 * @return WP_REST_Response
+	 */
+	#[REST_Route(
+		route: 'stats',
+		methods: WP_REST_Server::READABLE,
+		guard: 'check_permission',
+	)]
+	public function handle_skill_stats(): WP_REST_Response {
+		$rows = SkillUsageRepository::get_stats();
+
+		// Index by skill_id for easy frontend lookups.
+		$stats = array();
+		foreach ( $rows as $row ) {
+			$stats[ (int) $row->skill_id ] = array(
+				'skill_id'       => (int) $row->skill_id,
+				'total_loads'    => (int) $row->total_loads,
+				'helpful_count'  => (int) $row->helpful_count,
+				'neutral_count'  => (int) $row->neutral_count,
+				'negative_count' => (int) $row->negative_count,
+				'last_used_at'   => (string) $row->last_used_at,
+			);
+		}
+
+		return new WP_REST_Response( $stats, 200 );
+	}
+
+	/**
+	 * Handle POST /skills/check-updates — check remote manifest for updates.
+	 *
+	 * Fetches the skill manifest URL from settings, compares each built-in
+	 * skill's content_hash against the manifest, and optionally applies
+	 * updates to skills that have not been user-modified when skill_auto_update
+	 * is enabled.
+	 *
+	 * Returns a map of skill_id => { has_update, remote_version, applied }.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	#[REST_Route(
+		route: 'check-updates',
+		methods: WP_REST_Server::CREATABLE,
+		guard: 'check_permission',
+	)]
+	public function handle_check_updates(): WP_REST_Response|WP_Error {
+		// Read settings directly — avoids constructor injection for a single call.
+		// @phpstan-ignore-next-line
+		$saved_settings = (array) get_option( Settings::OPTION_NAME, array() );
+		$manifest_url   = (string) ( $saved_settings['skill_manifest_url'] ?? '' );
+		$auto_update    = isset( $saved_settings['skill_auto_update'] )
+			? (bool) $saved_settings['skill_auto_update']
+			: true; // default: auto-update enabled
+
+		if ( '' === $manifest_url ) {
+			return new WP_Error(
+				'gratis_ai_agent_no_manifest_url',
+				__( 'No skill manifest URL configured. Set skill_manifest_url in settings.', 'gratis-ai-agent' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Fetch the remote manifest.
+		$response = wp_remote_get(
+			$manifest_url,
+			array(
+				'timeout' => 15,
+				'headers' => array( 'Accept' => 'application/json' ),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error(
+				'gratis_ai_agent_manifest_fetch_failed',
+				sprintf(
+					/* translators: %s: error message */
+					__( 'Failed to fetch skill manifest: %s', 'gratis-ai-agent' ),
+					$response->get_error_message()
+				),
+				array( 'status' => 502 )
+			);
+		}
+
+		$status_code = wp_remote_retrieve_response_code( $response );
+		if ( 200 !== (int) $status_code ) {
+			return new WP_Error(
+				'gratis_ai_agent_manifest_bad_status',
+				sprintf(
+					/* translators: %d: HTTP status code */
+					__( 'Skill manifest returned HTTP %d.', 'gratis-ai-agent' ),
+					$status_code
+				),
+				array( 'status' => 502 )
+			);
+		}
+
+		$body     = wp_remote_retrieve_body( $response );
+		$manifest = json_decode( $body, true );
+
+		if ( ! is_array( $manifest ) ) {
+			return new WP_Error(
+				'gratis_ai_agent_manifest_invalid',
+				__( 'Skill manifest is not valid JSON or not an array.', 'gratis-ai-agent' ),
+				array( 'status' => 502 )
+			);
+		}
+
+		// Compare each built-in skill against the manifest.
+		$skills  = Skill::get_all();
+		$results = array();
+
+		foreach ( $skills ?? array() as $skill ) {
+			if ( ! $skill->is_builtin ) {
+				continue;
+			}
+
+			$entry = $manifest[ $skill->slug ] ?? null;
+
+			if ( null === $entry || ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$update_data = Skill::check_for_updates( $skill, $entry );
+			$has_update  = null !== $update_data;
+			$applied     = false;
+
+			if ( $has_update && $auto_update && ! $skill->user_modified ) {
+				$applied = Skill::apply_update( $skill->id, $entry );
+			}
+
+			$results[ $skill->id ] = array(
+				'skill_id'       => $skill->id,
+				'slug'           => $skill->slug,
+				'has_update'     => $has_update,
+				'remote_version' => (string) ( $entry['version'] ?? '' ),
+				'applied'        => $applied,
+				'user_modified'  => $skill->user_modified,
+			);
+		}
+
+		return new WP_REST_Response( $results, 200 );
 	}
 
 	/**

--- a/includes/REST/SkillController.php
+++ b/includes/REST/SkillController.php
@@ -335,6 +335,17 @@ final class SkillController extends XWP_REST_Controller {
 			);
 		}
 
+		// Reject non-HTTPS schemes to reduce SSRF surface area.
+		// Admin-supplied URLs are lower risk, but an https-only policy blocks accidental
+		// plain-http manifests and prevents probing cloud metadata endpoints.
+		if ( ! str_starts_with( strtolower( $manifest_url ), 'https://' ) ) {
+			return new WP_Error(
+				'gratis_ai_agent_manifest_invalid_scheme',
+				__( 'Skill manifest URL must use HTTPS.', 'gratis-ai-agent' ),
+				array( 'status' => 400 )
+			);
+		}
+
 		// Fetch the remote manifest.
 		$response = wp_remote_get(
 			$manifest_url,
@@ -404,12 +415,12 @@ final class SkillController extends XWP_REST_Controller {
 			}
 
 			$results[ $skill->id ] = array(
-				'skill_id'       => $skill->id,
-				'slug'           => $skill->slug,
-				'has_update'     => $has_update,
+				'skill_id'       => (int) $skill->id,
+				'slug'           => (string) $skill->slug,
+				'has_update'     => (bool) $has_update,
 				'remote_version' => (string) ( $entry['version'] ?? '' ),
-				'applied'        => $applied,
-				'user_modified'  => $skill->user_modified,
+				'applied'        => (bool) $applied,
+				'user_modified'  => (bool) $skill->user_modified,
 			);
 		}
 

--- a/includes/Services/SkillService.php
+++ b/includes/Services/SkillService.php
@@ -38,16 +38,19 @@ final class SkillService {
 	 */
 	public static function format_skill( object $skill ): array {
 		return array(
-			'id'          => (int) $skill->id,
-			'slug'        => $skill->slug,
-			'name'        => $skill->name,
-			'description' => $skill->description,
-			'content'     => $skill->content,
-			'is_builtin'  => (bool) (int) $skill->is_builtin,
-			'enabled'     => (bool) (int) $skill->enabled,
-			'word_count'  => str_word_count( $skill->content ),
-			'created_at'  => $skill->created_at,
-			'updated_at'  => $skill->updated_at,
+			'id'            => (int) $skill->id,
+			'slug'          => $skill->slug,
+			'name'          => $skill->name,
+			'description'   => $skill->description,
+			'content'       => $skill->content,
+			'is_builtin'    => (bool) (int) $skill->is_builtin,
+			'enabled'       => (bool) (int) $skill->enabled,
+			'version'       => (string) ( $skill->version ?? '' ),
+			'source_url'    => (string) ( $skill->source_url ?? '' ),
+			'user_modified' => (bool) (int) ( $skill->user_modified ?? 0 ),
+			'word_count'    => str_word_count( $skill->content ),
+			'created_at'    => $skill->created_at,
+			'updated_at'    => $skill->updated_at,
 		);
 	}
 

--- a/src/settings-page/skill-manager.js
+++ b/src/settings-page/skill-manager.js
@@ -8,9 +8,10 @@ import {
 	TextControl,
 	TextareaControl,
 	ToggleControl,
+	Notice,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { trash, pencil, plus, backup } from '@wordpress/icons';
+import { trash, pencil, plus, backup, update } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -18,15 +19,96 @@ import { trash, pencil, plus, backup } from '@wordpress/icons';
 import STORE_NAME from '../store';
 
 /**
+ * Minimal sprintf — replaces the first %d or %s in a format string.
+ *
+ * @param {string} format - Format string with one %d or %s placeholder.
+ * @param {*}      value  - Value to substitute.
+ * @return {string} Formatted string.
+ */
+function sprintf( format, value ) {
+	return format.replace( /%[ds]/, String( value ) );
+}
+
+/**
+ * Format a UTC MySQL datetime string (YYYY-MM-DD HH:MM:SS) for display.
+ *
+ * Returns a short relative label ("2 days ago", "just now") based on the
+ * delta to the current time.
+ *
+ * @param {string} mysqlDatetime MySQL UTC datetime string.
+ * @return {string} Human-readable relative time.
+ */
+function formatRelativeTime( mysqlDatetime ) {
+	if ( ! mysqlDatetime ) {
+		return '';
+	}
+	// MySQL datetimes are UTC — append 'Z' so Date.parse treats them as UTC.
+	const ts = Date.parse( mysqlDatetime.replace( ' ', 'T' ) + 'Z' );
+	if ( isNaN( ts ) ) {
+		return mysqlDatetime;
+	}
+	const diffSeconds = Math.floor( ( Date.now() - ts ) / 1000 );
+	if ( diffSeconds < 60 ) {
+		return __( 'just now', 'gratis-ai-agent' );
+	}
+	if ( diffSeconds < 3600 ) {
+		const mins = Math.floor( diffSeconds / 60 );
+		if ( mins === 1 ) {
+			return __( '1 minute ago', 'gratis-ai-agent' );
+		}
+		/* translators: %d: number of minutes */
+		return sprintf( __( '%d minutes ago', 'gratis-ai-agent' ), mins );
+	}
+	if ( diffSeconds < 86400 ) {
+		const hours = Math.floor( diffSeconds / 3600 );
+		if ( hours === 1 ) {
+			return __( '1 hour ago', 'gratis-ai-agent' );
+		}
+		/* translators: %d: number of hours */
+		return sprintf( __( '%d hours ago', 'gratis-ai-agent' ), hours );
+	}
+	const days = Math.floor( diffSeconds / 86400 );
+	if ( days === 1 ) {
+		return __( '1 day ago', 'gratis-ai-agent' );
+	}
+	/* translators: %d: number of days */
+	return sprintf( __( '%d days ago', 'gratis-ai-agent' ), days );
+}
+
+/**
  *
  */
 export default function SkillManager() {
-	const { fetchSkills, createSkill, updateSkill, deleteSkill, resetSkill } =
-		useDispatch( STORE_NAME );
-	const { skills, skillsLoaded } = useSelect(
+	const {
+		fetchSkills,
+		fetchSkillStats,
+		checkSkillUpdates,
+		createSkill,
+		updateSkill,
+		deleteSkill,
+		resetSkill,
+		saveSettings,
+		fetchSettings,
+	} = useDispatch( STORE_NAME );
+
+	const {
+		skills,
+		skillsLoaded,
+		skillStats,
+		skillUpdates,
+		skillUpdatesChecking,
+		settings,
+		settingsLoaded,
+	} = useSelect(
 		( select ) => ( {
 			skills: select( STORE_NAME ).getSkills(),
 			skillsLoaded: select( STORE_NAME ).getSkillsLoaded(),
+			skillStats: select( STORE_NAME ).getSkillStats(),
+			skillUpdates: select( STORE_NAME ).getSkillUpdates(),
+			skillUpdatesChecking:
+				select( STORE_NAME ).getSkillUpdatesChecking(),
+			settings: select( STORE_NAME ).getSettings(),
+			settingsLoaded: select( STORE_NAME ).getSettingsLoaded(),
 		} ),
 		[]
 	);
@@ -37,10 +119,15 @@ export default function SkillManager() {
 	const [ formName, setFormName ] = useState( '' );
 	const [ formDescription, setFormDescription ] = useState( '' );
 	const [ formContent, setFormContent ] = useState( '' );
+	const [ updateNotice, setUpdateNotice ] = useState( null );
 
 	useEffect( () => {
 		fetchSkills();
-	}, [ fetchSkills ] );
+		fetchSkillStats();
+		if ( ! settingsLoaded ) {
+			fetchSettings();
+		}
+	}, [ fetchSkills, fetchSkillStats, fetchSettings, settingsLoaded ] );
 
 	const resetForm = useCallback( () => {
 		setShowForm( false );
@@ -131,6 +218,59 @@ export default function SkillManager() {
 		[ updateSkill ]
 	);
 
+	const handleAutoUpdateToggle = useCallback(
+		async ( value ) => {
+			await saveSettings( { skill_auto_update: value } );
+		},
+		[ saveSettings ]
+	);
+
+	const handleCheckUpdates = useCallback( async () => {
+		setUpdateNotice( null );
+		const results = await checkSkillUpdates();
+		if ( results === null ) {
+			setUpdateNotice( {
+				status: 'error',
+				message: __(
+					'Could not check for updates. Ensure a manifest URL is configured in settings.',
+					'gratis-ai-agent'
+				),
+			} );
+			return;
+		}
+		const updateEntries = Object.values( results );
+		const updateCount = updateEntries.filter(
+			( r ) => r.has_update
+		).length;
+		const appliedCount = updateEntries.filter( ( r ) => r.applied ).length;
+		if ( appliedCount > 0 ) {
+			const appliedMsg = sprintf(
+				/* translators: %d: number of skills updated */
+				__( '%d skill(s) updated automatically.', 'gratis-ai-agent' ),
+				appliedCount
+			);
+			setUpdateNotice( { status: 'success', message: appliedMsg } );
+		} else if ( updateCount > 0 ) {
+			const updateMsg = sprintf(
+				/* translators: %d: number of skills with available updates */
+				__(
+					'%d update(s) available. Auto-update is disabled or skills have been customised.',
+					'gratis-ai-agent'
+				),
+				updateCount
+			);
+			setUpdateNotice( { status: 'warning', message: updateMsg } );
+		} else {
+			setUpdateNotice( {
+				status: 'success',
+				message: __( 'All skills are up to date.', 'gratis-ai-agent' ),
+			} );
+		}
+	}, [ checkSkillUpdates ] );
+
+	const autoUpdateEnabled = settings?.skill_auto_update ?? true;
+	const manifestUrlSet = !! settings?.skill_manifest_url;
+
 	return (
 		<div className="gratis-ai-agent-skill-manager">
 			<div className="gratis-ai-agent-skill-header">
@@ -154,6 +294,50 @@ export default function SkillManager() {
 					</Button>
 				) }
 			</div>
+
+			{ /* Auto-update controls */ }
+			{ settingsLoaded && (
+				<div className="gratis-ai-agent-skill-update-controls">
+					<ToggleControl
+						label={ __(
+							'Automatic skill updates',
+							'gratis-ai-agent'
+						) }
+						help={ __(
+							'When enabled, built-in skills are updated automatically from the remote manifest whenever a newer version is available (unless you have customised them).',
+							'gratis-ai-agent'
+						) }
+						checked={ autoUpdateEnabled }
+						onChange={ handleAutoUpdateToggle }
+						__nextHasNoMarginBottom
+					/>
+					{ manifestUrlSet && (
+						<Button
+							variant="secondary"
+							icon={ update }
+							onClick={ handleCheckUpdates }
+							isBusy={ skillUpdatesChecking }
+							disabled={ skillUpdatesChecking }
+							size="compact"
+							className="gratis-ai-agent-check-updates-btn"
+						>
+							{ skillUpdatesChecking
+								? __( 'Checking…', 'gratis-ai-agent' )
+								: __( 'Check for Updates', 'gratis-ai-agent' ) }
+						</Button>
+					) }
+				</div>
+			) }
+
+			{ updateNotice && (
+				<Notice
+					status={ updateNotice.status }
+					isDismissible
+					onRemove={ () => setUpdateNotice( null ) }
+				>
+					{ updateNotice.message }
+				</Notice>
+			) }
 
 			{ showForm && (
 				<div className="gratis-ai-agent-skill-form">
@@ -238,81 +422,157 @@ export default function SkillManager() {
 
 			{ skills.length > 0 && (
 				<div className="gratis-ai-agent-skill-cards">
-					{ skills.map( ( skill ) => (
-						<div
-							key={ skill.id }
-							className={ `gratis-ai-agent-skill-card ${
-								! skill.enabled
-									? 'gratis-ai-agent-skill-card--disabled'
-									: ''
-							}` }
-						>
-							<div className="gratis-ai-agent-skill-card-header">
-								<ToggleControl
-									checked={ skill.enabled }
-									onChange={ () => handleToggle( skill ) }
-									__nextHasNoMarginBottom
-								/>
-								<div className="gratis-ai-agent-skill-card-title">
-									<strong>{ skill.name }</strong>
-									{ skill.is_builtin && (
-										<span className="gratis-ai-agent-skill-badge">
-											{ __(
-												'Built-in',
-												'gratis-ai-agent'
-											) }
-										</span>
-									) }
-								</div>
-							</div>
-							<p className="gratis-ai-agent-skill-card-description">
-								{ skill.description }
-							</p>
-							<div className="gratis-ai-agent-skill-card-footer">
-								<span className="gratis-ai-agent-skill-word-count">
-									{ skill.word_count }{ ' ' }
-									{ __( 'words', 'gratis-ai-agent' ) }
-								</span>
-								<div className="gratis-ai-agent-skill-card-actions">
-									<Button
-										icon={ pencil }
-										size="small"
-										label={ __(
-											'Edit',
-											'gratis-ai-agent'
-										) }
-										onClick={ () => handleEdit( skill ) }
+					{ skills.map( ( skill ) => {
+						const stats = skillStats[ skill.id ] ?? null;
+						const updateInfo = skillUpdates[ skill.id ] ?? null;
+						const hasUpdate =
+							updateInfo?.has_update && ! skill.user_modified;
+
+						return (
+							<div
+								key={ skill.id }
+								className={ `gratis-ai-agent-skill-card ${
+									! skill.enabled
+										? 'gratis-ai-agent-skill-card--disabled'
+										: ''
+								}` }
+							>
+								<div className="gratis-ai-agent-skill-card-header">
+									<ToggleControl
+										checked={ skill.enabled }
+										onChange={ () => handleToggle( skill ) }
+										__nextHasNoMarginBottom
 									/>
-									{ skill.is_builtin ? (
+									<div className="gratis-ai-agent-skill-card-title">
+										<strong>{ skill.name }</strong>
+										{ skill.is_builtin && (
+											<span className="gratis-ai-agent-skill-badge">
+												{ __(
+													'Built-in',
+													'gratis-ai-agent'
+												) }
+											</span>
+										) }
+										{ skill.user_modified && (
+											<span className="gratis-ai-agent-skill-badge gratis-ai-agent-skill-badge--modified">
+												{ __(
+													'Modified',
+													'gratis-ai-agent'
+												) }
+											</span>
+										) }
+										{ hasUpdate && (
+											<span className="gratis-ai-agent-skill-badge gratis-ai-agent-skill-badge--update">
+												{ __(
+													'Update Available',
+													'gratis-ai-agent'
+												) }
+											</span>
+										) }
+										{ skill.version && (
+											<span className="gratis-ai-agent-skill-version">
+												v{ skill.version }
+											</span>
+										) }
+									</div>
+								</div>
+								<p className="gratis-ai-agent-skill-card-description">
+									{ skill.description }
+								</p>
+								<div className="gratis-ai-agent-skill-card-footer">
+									<div className="gratis-ai-agent-skill-meta">
+										<span className="gratis-ai-agent-skill-word-count">
+											{ skill.word_count }{ ' ' }
+											{ __( 'words', 'gratis-ai-agent' ) }
+										</span>
+										{ stats && (
+											<span className="gratis-ai-agent-skill-usage-stats">
+												<span className="gratis-ai-agent-skill-usage-count">
+													{ stats.total_loads > 0 ? (
+														<>
+															{ sprintf(
+																/* translators: %d: number of times the skill was loaded */
+																__(
+																	'Used %d times',
+																	'gratis-ai-agent'
+																),
+																stats.total_loads
+															) }
+															{ stats.last_used_at && (
+																<>
+																	{ ' · ' }
+																	{ formatRelativeTime(
+																		stats.last_used_at
+																	) }
+																</>
+															) }
+														</>
+													) : (
+														__(
+															'Never used',
+															'gratis-ai-agent'
+														)
+													) }
+												</span>
+												{ stats.total_loads > 0 &&
+													stats.helpful_count > 0 && (
+														<span className="gratis-ai-agent-skill-helpful">
+															{ sprintf(
+																/* translators: %d: number of helpful feedback responses */
+																__(
+																	'%d helpful',
+																	'gratis-ai-agent'
+																),
+																stats.helpful_count
+															) }
+														</span>
+													) }
+											</span>
+										) }
+									</div>
+									<div className="gratis-ai-agent-skill-card-actions">
 										<Button
-											icon={ backup }
+											icon={ pencil }
 											size="small"
 											label={ __(
-												'Reset to Default',
+												'Edit',
 												'gratis-ai-agent'
 											) }
 											onClick={ () =>
-												handleReset( skill.id )
+												handleEdit( skill )
 											}
 										/>
-									) : (
-										<Button
-											icon={ trash }
-											size="small"
-											label={ __(
-												'Delete',
-												'gratis-ai-agent'
-											) }
-											isDestructive
-											onClick={ () =>
-												handleDelete( skill.id )
-											}
-										/>
-									) }
+										{ skill.is_builtin ? (
+											<Button
+												icon={ backup }
+												size="small"
+												label={ __(
+													'Reset to Default',
+													'gratis-ai-agent'
+												) }
+												onClick={ () =>
+													handleReset( skill.id )
+												}
+											/>
+										) : (
+											<Button
+												icon={ trash }
+												size="small"
+												label={ __(
+													'Delete',
+													'gratis-ai-agent'
+												) }
+												isDestructive
+												onClick={ () =>
+													handleDelete( skill.id )
+												}
+											/>
+										) }
+									</div>
 								</div>
 							</div>
-						</div>
-					) ) }
+						);
+					} ) }
 				</div>
 			) }
 		</div>

--- a/src/settings-page/skill-manager.js
+++ b/src/settings-page/skill-manager.js
@@ -10,24 +10,13 @@ import {
 	ToggleControl,
 	Notice,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { trash, pencil, plus, backup, update } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import STORE_NAME from '../store';
-
-/**
- * Minimal sprintf — replaces the first %d or %s in a format string.
- *
- * @param {string} format - Format string with one %d or %s placeholder.
- * @param {*}      value  - Value to substitute.
- * @return {string} Formatted string.
- */
-function sprintf( format, value ) {
-	return format.replace( /%[ds]/, String( value ) );
-}
 
 /**
  * Format a UTC MySQL datetime string (YYYY-MM-DD HH:MM:SS) for display.
@@ -95,6 +84,7 @@ export default function SkillManager() {
 		skills,
 		skillsLoaded,
 		skillStats,
+		skillStatsLoaded,
 		skillUpdates,
 		skillUpdatesChecking,
 		settings,
@@ -104,6 +94,7 @@ export default function SkillManager() {
 			skills: select( STORE_NAME ).getSkills(),
 			skillsLoaded: select( STORE_NAME ).getSkillsLoaded(),
 			skillStats: select( STORE_NAME ).getSkillStats(),
+			skillStatsLoaded: select( STORE_NAME ).getSkillStatsLoaded(),
 			skillUpdates: select( STORE_NAME ).getSkillUpdates(),
 			skillUpdatesChecking:
 				select( STORE_NAME ).getSkillUpdatesChecking(),
@@ -122,12 +113,23 @@ export default function SkillManager() {
 	const [ updateNotice, setUpdateNotice ] = useState( null );
 
 	useEffect( () => {
-		fetchSkills();
-		fetchSkillStats();
+		if ( ! skillsLoaded ) {
+			fetchSkills();
+		}
+		if ( ! skillStatsLoaded ) {
+			fetchSkillStats();
+		}
 		if ( ! settingsLoaded ) {
 			fetchSettings();
 		}
-	}, [ fetchSkills, fetchSkillStats, fetchSettings, settingsLoaded ] );
+	}, [
+		fetchSkills,
+		fetchSkillStats,
+		fetchSettings,
+		skillsLoaded,
+		skillStatsLoaded,
+		settingsLoaded,
+	] );
 
 	const resetForm = useCallback( () => {
 		setShowForm( false );
@@ -246,15 +248,22 @@ export default function SkillManager() {
 		if ( appliedCount > 0 ) {
 			const appliedMsg = sprintf(
 				/* translators: %d: number of skills updated */
-				__( '%d skill(s) updated automatically.', 'gratis-ai-agent' ),
+				_n(
+					'%d skill updated automatically.',
+					'%d skills updated automatically.',
+					appliedCount,
+					'gratis-ai-agent'
+				),
 				appliedCount
 			);
 			setUpdateNotice( { status: 'success', message: appliedMsg } );
 		} else if ( updateCount > 0 ) {
 			const updateMsg = sprintf(
 				/* translators: %d: number of skills with available updates */
-				__(
-					'%d update(s) available. Auto-update is disabled or skills have been customised.',
+				_n(
+					'%d update available. Auto-update is disabled or skills have been customised.',
+					'%d updates available. Auto-update is disabled or skills have been customised.',
+					updateCount,
 					'gratis-ai-agent'
 				),
 				updateCount
@@ -492,8 +501,10 @@ export default function SkillManager() {
 														<>
 															{ sprintf(
 																/* translators: %d: number of times the skill was loaded */
-																__(
+																_n(
+																	'Used %d time',
 																	'Used %d times',
+																	stats.total_loads,
 																	'gratis-ai-agent'
 																),
 																stats.total_loads
@@ -519,8 +530,10 @@ export default function SkillManager() {
 														<span className="gratis-ai-agent-skill-helpful">
 															{ sprintf(
 																/* translators: %d: number of helpful feedback responses */
-																__(
+																_n(
 																	'%d helpful',
+																	'%d helpful',
+																	stats.helpful_count,
 																	'gratis-ai-agent'
 																),
 																stats.helpful_count

--- a/src/settings-page/style.css
+++ b/src/settings-page/style.css
@@ -290,6 +290,21 @@
 	font-weight: 400;
 }
 
+.gratis-ai-agent-skill-badge--modified {
+	background: #fcf0c8;
+	color: #6b5d14;
+}
+
+.gratis-ai-agent-skill-badge--update {
+	background: #d0e8ff;
+	color: #0066cc;
+}
+
+.gratis-ai-agent-skill-version {
+	font-size: 11px;
+	color: #999;
+}
+
 .gratis-ai-agent-skill-card-description {
 	margin: 0 0 8px;
 	color: #646970;
@@ -304,14 +319,68 @@
 	padding-left: 52px;
 }
 
+.gratis-ai-agent-skill-meta {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
 .gratis-ai-agent-skill-word-count {
 	font-size: 12px;
 	color: #999;
 }
 
+.gratis-ai-agent-skill-usage-stats {
+	display: flex;
+	gap: 8px;
+	align-items: center;
+}
+
+.gratis-ai-agent-skill-usage-count {
+	font-size: 12px;
+	color: #646970;
+}
+
+.gratis-ai-agent-skill-helpful {
+	font-size: 11px;
+	background: #d7f0d5;
+	color: #1e6129;
+	padding: 1px 6px;
+	border-radius: 3px;
+}
+
 .gratis-ai-agent-skill-card-actions {
 	display: flex;
 	gap: 2px;
+}
+
+/* Skill update controls (auto-update toggle + check-updates button) */
+.gratis-ai-agent-skill-update-controls {
+	display: flex;
+	align-items: flex-start;
+	gap: 16px;
+	padding: 12px 14px;
+	background: #f6f7f7;
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	margin-bottom: 16px;
+	flex-wrap: wrap;
+}
+
+.gratis-ai-agent-skill-update-controls .components-toggle-control {
+	margin-bottom: 0;
+	flex: 1;
+	min-width: 200px;
+}
+
+.gratis-ai-agent-skill-update-controls .components-base-control__field {
+	margin-bottom: 0;
+}
+
+.gratis-ai-agent-check-updates-btn {
+	flex-shrink: 0;
+	align-self: flex-start;
+	margin-top: 2px;
 }
 
 /* Usage Dashboard */

--- a/src/settings-page/style.css
+++ b/src/settings-page/style.css
@@ -297,7 +297,7 @@
 
 .gratis-ai-agent-skill-badge--update {
 	background: #d0e8ff;
-	color: #0066cc;
+	color: #06c;
 }
 
 .gratis-ai-agent-skill-version {

--- a/src/store/slices/skillsSlice.js
+++ b/src/store/slices/skillsSlice.js
@@ -1,5 +1,5 @@
 /**
- * Skills slice — skill entries CRUD.
+ * Skills slice — skill entries CRUD + usage stats + update checks.
  */
 
 /**
@@ -11,6 +11,10 @@ import apiFetch from '@wordpress/api-fetch';
 export const initialState = {
 	skills: [],
 	skillsLoaded: false,
+	skillStats: {},
+	skillStatsLoaded: false,
+	skillUpdates: {},
+	skillUpdatesChecking: false,
 };
 
 export const actions = {
@@ -22,6 +26,36 @@ export const actions = {
 	 */
 	setSkills( skills ) {
 		return { type: 'SET_SKILLS', skills };
+	},
+
+	/**
+	 * Replace skill usage stats map.
+	 *
+	 * @param {Object} stats - Map of skill_id => stats object.
+	 * @return {Object} Redux action.
+	 */
+	setSkillStats( stats ) {
+		return { type: 'SET_SKILL_STATS', stats };
+	},
+
+	/**
+	 * Replace skill updates map (results from check-updates endpoint).
+	 *
+	 * @param {Object} updates - Map of skill_id => update info.
+	 * @return {Object} Redux action.
+	 */
+	setSkillUpdates( updates ) {
+		return { type: 'SET_SKILL_UPDATES', updates };
+	},
+
+	/**
+	 * Set whether a skill update check is in progress.
+	 *
+	 * @param {boolean} checking - True while the check request is in flight.
+	 * @return {Object} Redux action.
+	 */
+	setSkillUpdatesChecking( checking ) {
+		return { type: 'SET_SKILL_UPDATES_CHECKING', checking };
 	},
 
 	/**
@@ -38,6 +72,57 @@ export const actions = {
 				dispatch.setSkills( skills );
 			} catch {
 				dispatch.setSkills( [] );
+			}
+		};
+	},
+
+	/**
+	 * Fetch aggregated skill usage statistics from the REST API.
+	 *
+	 * Stats are indexed by skill_id (numeric string keys).
+	 * Each entry: { skill_id, total_loads, helpful_count, neutral_count, negative_count, last_used_at }.
+	 *
+	 * @return {Function} Redux thunk.
+	 */
+	fetchSkillStats() {
+		return async ( { dispatch } ) => {
+			try {
+				const stats = await apiFetch( {
+					path: '/gratis-ai-agent/v1/skills/stats',
+				} );
+				dispatch.setSkillStats( stats );
+			} catch {
+				dispatch.setSkillStats( {} );
+			}
+		};
+	},
+
+	/**
+	 * Trigger a remote manifest check for skill updates.
+	 *
+	 * Calls POST /skills/check-updates. If skill_auto_update is enabled in
+	 * settings, updates to unmodified built-in skills are applied automatically
+	 * on the server side. The response map is stored in skillUpdates so the UI
+	 * can show "Update Available" badges on affected skill cards.
+	 *
+	 * @return {Function} Redux thunk that resolves with the updates map or null on error.
+	 */
+	checkSkillUpdates() {
+		return async ( { dispatch } ) => {
+			dispatch.setSkillUpdatesChecking( true );
+			try {
+				const updates = await apiFetch( {
+					path: '/gratis-ai-agent/v1/skills/check-updates',
+					method: 'POST',
+				} );
+				dispatch.setSkillUpdates( updates );
+				// Refresh skill list in case updates were auto-applied.
+				dispatch.fetchSkills();
+				return updates;
+			} catch {
+				return null;
+			} finally {
+				dispatch.setSkillUpdatesChecking( false );
 			}
 		};
 	},
@@ -126,6 +211,42 @@ export const selectors = {
 	getSkillsLoaded( state ) {
 		return state.skillsLoaded;
 	},
+
+	/**
+	 * Aggregated usage stats indexed by skill_id.
+	 *
+	 * @param {import('../../types').StoreState} state
+	 * @return {Object} Stats map: { [skill_id]: { total_loads, helpful_count, neutral_count, negative_count, last_used_at } }
+	 */
+	getSkillStats( state ) {
+		return state.skillStats;
+	},
+
+	/**
+	 * @param {import('../../types').StoreState} state
+	 * @return {boolean} Whether skill stats have been fetched.
+	 */
+	getSkillStatsLoaded( state ) {
+		return state.skillStatsLoaded;
+	},
+
+	/**
+	 * Remote update availability map, populated after checkSkillUpdates().
+	 *
+	 * @param {import('../../types').StoreState} state
+	 * @return {Object} Updates map: { [skill_id]: { has_update, remote_version, applied, user_modified } }
+	 */
+	getSkillUpdates( state ) {
+		return state.skillUpdates;
+	},
+
+	/**
+	 * @param {import('../../types').StoreState} state
+	 * @return {boolean} Whether a check-updates request is in flight.
+	 */
+	getSkillUpdatesChecking( state ) {
+		return state.skillUpdatesChecking;
+	},
 };
 
 /**
@@ -140,6 +261,22 @@ export function reducer( state, action ) {
 				...state,
 				skills: action.skills,
 				skillsLoaded: true,
+			};
+		case 'SET_SKILL_STATS':
+			return {
+				...state,
+				skillStats: action.stats,
+				skillStatsLoaded: true,
+			};
+		case 'SET_SKILL_UPDATES':
+			return {
+				...state,
+				skillUpdates: action.updates,
+			};
+		case 'SET_SKILL_UPDATES_CHECKING':
+			return {
+				...state,
+				skillUpdatesChecking: action.checking,
 			};
 		default:
 			return state;

--- a/src/types.js
+++ b/src/types.js
@@ -94,11 +94,20 @@
  * A skill entry.
  *
  * @typedef {Object} Skill
- * @property {number}  id            - Skill identifier.
- * @property {string}  name          - Skill name / slug.
- * @property {string}  [label]       - Human-readable label.
- * @property {string}  [description] - Skill description.
- * @property {boolean} [builtin]     - Whether this is a built-in skill.
+ * @property {number}  id              - Skill identifier.
+ * @property {string}  slug            - URL-safe unique identifier.
+ * @property {string}  name            - Human-readable skill name.
+ * @property {string}  [label]         - Deprecated alias for name.
+ * @property {string}  [description]   - One-line description shown in the skill index.
+ * @property {string}  [content]       - Full skill guide markdown content.
+ * @property {boolean} [is_builtin]    - Whether this is a framework-bundled skill.
+ * @property {boolean} [enabled]       - Whether the skill is active.
+ * @property {string}  [version]       - Semver string of the current skill content.
+ * @property {string}  [source_url]    - Remote URL the skill originates from (empty for user-created).
+ * @property {boolean} [user_modified] - True when an admin has edited a built-in skill (blocks auto-updates).
+ * @property {number}  [word_count]    - Word count of the skill content.
+ * @property {string}  [created_at]    - MySQL UTC datetime of creation.
+ * @property {string}  [updated_at]    - MySQL UTC datetime of last update.
  */
 
 /**
@@ -158,6 +167,10 @@
  * @property {boolean}                  memoriesLoaded          - Whether memories have been fetched.
  * @property {Skill[]}                  skills                  - Skill entries.
  * @property {boolean}                  skillsLoaded            - Whether skills have been fetched.
+ * @property {Object}                   skillStats              - Aggregated usage stats indexed by skill_id.
+ * @property {boolean}                  skillStatsLoaded        - Whether skill stats have been fetched.
+ * @property {Object}                   skillUpdates            - Update availability map from check-updates, indexed by skill_id.
+ * @property {boolean}                  skillUpdatesChecking    - Whether a check-updates request is in flight.
  * @property {TokenUsage}               tokenUsage              - Cumulative token usage for the session.
  * @property {PendingConfirmation|null} pendingConfirmation     - Pending tool confirmation.
  * @property {boolean}                  debugMode               - Whether debug mode is active.


### PR DESCRIPTION
## Summary

Phase 4 of the adaptive skill system (t215): adds usage statistics display, update availability badges, and auto-update controls to the skill manager UI.

## Changes

### `includes/REST/SkillController.php`
- `GET /skills/stats` — returns aggregated usage stats per skill (total loads, helpful/neutral/negative counts, last used timestamp), indexed by `skill_id`. Delegates to `SkillUsageRepository::get_stats()`.
- `POST /skills/check-updates` — fetches the remote skill manifest, compares each built-in skill's `content_hash`, optionally auto-applies updates to unmodified skills when `skill_auto_update` is enabled in settings. Returns a map of `skill_id => { has_update, remote_version, applied, user_modified }`.

### `includes/Services/SkillService.php`
- `format_skill()` now exposes `version`, `source_url`, and `user_modified` fields in the REST payload.

### `src/store/slices/skillsSlice.js`
- New state: `skillStats`, `skillStatsLoaded`, `skillUpdates`, `skillUpdatesChecking`
- New thunks: `fetchSkillStats()` (GET /skills/stats), `checkSkillUpdates()` (POST /skills/check-updates + refresh skills list)
- New actions: `setSkillStats`, `setSkillUpdates`, `setSkillUpdatesChecking`
- New selectors: `getSkillStats`, `getSkillStatsLoaded`, `getSkillUpdates`, `getSkillUpdatesChecking`

### `src/settings-page/skill-manager.js`
- Global auto-update toggle (`ToggleControl`) wired to `settings.skill_auto_update` via `saveSettings`
- "Check for Updates" button (shown only when `skill_manifest_url` is set) with busy state
- Notice banner reporting how many skills were auto-updated or are available for update
- Per-skill card enhancements:
  - **Modified badge** — shown when `skill.user_modified` is true
  - **Update Available badge** — shown when `has_update && !user_modified`
  - **Version label** — shows `v{skill.version}` when available
  - **Usage stats row** — "Used N times · 2 days ago" and "N helpful" from `skillStats`
- `formatRelativeTime()` helper for human-readable relative timestamps from MySQL UTC datetimes

### `src/settings-page/style.css`
- Styles for `.gratis-ai-agent-skill-update-controls`, `.gratis-ai-agent-check-updates-btn`, `.gratis-ai-agent-skill-badge--modified`, `.gratis-ai-agent-skill-badge--update`, `.gratis-ai-agent-skill-version`, `.gratis-ai-agent-skill-usage-stats`, `.gratis-ai-agent-skill-helpful`

### `src/types.js`
- Expanded `Skill` typedef with all fields (`slug`, `is_builtin`, `enabled`, `version`, `source_url`, `user_modified`, `word_count`, `created_at`, `updated_at`)
- Added `skillStats`, `skillStatsLoaded`, `skillUpdates`, `skillUpdatesChecking` to `StoreState`

## Verification

- PHPCS: clean on modified PHP files
- PHPStan: clean on modified PHP files
- JS lint: clean (pre-existing `@wordpress/icons` `import/no-unresolved` error in 14 files not introduced by this PR — present on base branch)
- Build: pre-existing `@wordpress/icons` webpack resolution failure (14 errors on base branch) — not introduced by this PR

Resolves #1084

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added skill update checking with availability badges and version display
  * Display skill usage statistics including load counts and helpfulness metrics
  * Enable auto-update settings for skills with manual check triggering
  * Track and badge skills marked as user-modified
  * Display skill metadata (version, source URL, last-used timestamp)

* **Style**
  * Enhanced UI styling for skill badges, version labels, and update control layouts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->