### PR TITLE
t222: Wire /onboarding/bootstrap-start REST route via DI handler

### DIFF
--- a/includes/Bootstrap/OnboardingHandler.php
+++ b/includes/Bootstrap/OnboardingHandler.php
@@ -68,6 +68,14 @@ final class OnboardingHandler {
 	}
 
 	/**
+	 * Register the onboarding REST endpoints on rest_api_init.
+	 */
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_onboarding_rest_routes(): void {
+		OnboardingManager::register_rest_routes();
+	}
+
+	/**
 	 * Auto-enable WooCommerce abilities on first load when a provider is
 	 * detected and WooCommerce is active.
 	 */

--- a/includes/Core/OnboardingManager.php
+++ b/includes/Core/OnboardingManager.php
@@ -170,6 +170,16 @@ class OnboardingManager {
 				'permission_callback' => [ __CLASS__, 'rest_permission' ],
 			]
 		);
+
+		register_rest_route(
+			'gratis-ai-agent/v1',
+			'/onboarding/bootstrap-start',
+			[
+				'methods'             => 'POST',
+				'callback'            => [ __CLASS__, 'rest_bootstrap_start' ],
+				'permission_callback' => [ __CLASS__, 'rest_permission' ],
+			]
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Register the `/onboarding/bootstrap-start` REST route that the frontend `OnboardingBootstrap` component calls
- Add `rest_api_init` action to `OnboardingHandler` DI class so onboarding REST routes are registered

The bootstrap-start endpoint method existed in `OnboardingManager` but was never reachable — the DI handler replaced the old `register()` call but omitted the `rest_api_init` hook. The frontend called a 404 and silently fell through to an empty chat instead of auto-sending the discovery kickoff message.

## Testing

Verified in browser:
1. Fresh install with no connector → Connector Gate shows correctly
2. After configuring Anthropic connector → Gate auto-transitions to chat
3. Bootstrap auto-sends "Hi! I just set up this plugin and I'm ready to get started."
4. AI receives the discovery system prompt and begins exploring the site

Resolves #t222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new REST API endpoint (`POST /gratis-ai-agent/v1/onboarding/bootstrap-start`) to enable programmatic initiation of the onboarding bootstrap process with integrated permission controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->