### PR TITLE
fix: add phpcs:ignore for false-positive EnqueuedResources flag on AI…

### DIFF
--- a/includes/Abilities/ImageAbilities.php
+++ b/includes/Abilities/ImageAbilities.php
@@ -319,6 +319,7 @@ INSTRUCTION;
 			$prompt .= "\n\n<additional-context>" . $context . '</additional-context>';
 		}
 		if ( ! empty( $style ) ) {
+			// phpcs:ignore WordPress.WP.EnqueuedResources -- This is XML markup in an AI prompt string, not an HTML <style> element. No CSS is enqueued or rendered to the frontend.
 			$prompt .= "\n\n<style>" . $style . '</style>';
 		}
 


### PR DESCRIPTION
… prompt XML

The <style> tag at ImageAbilities.php:322 is XML markup within an AI prompt string passed to wp_ai_client_prompt(), not an HTML style element. No CSS is enqueued or rendered to the frontend. The WordPress plugin repository review flagged this as needing wp_register_style/ wp_enqueue_style — added phpcs:ignore with explanation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code quality improvements made to image generation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->