### PR TITLE
feat: add provider refresh on tab visibility change and manual refresh button

### DIFF
--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -1123,7 +1123,9 @@ final class SettingsController {
 					// For the OpenAI-compatible connector, fetch models directly
 					// from the endpoint rather than going through the SDK model
 					// directory (which can fail due to SDK transporter issues).
-					if ( 'ai-provider-for-any-openai-compatible' === $provider_id
+					// Use str_starts_with to handle multi-endpoint setups where each
+					// endpoint gets a unique ID (e.g., ai-provider-for-any-openai-compatible-1).
+					if ( str_starts_with( $provider_id, 'ai-provider-for-any-openai-compatible' )
 						&& function_exists( 'OpenAiCompatibleConnector\\rest_list_models' )
 					) {
 						$fake_request = new WP_REST_Request( 'GET' );

--- a/src/admin-page/index.js
+++ b/src/admin-page/index.js
@@ -90,6 +90,23 @@ function AdminPageApp() {
 		return () => clearInterval( timer );
 	}, [ providers, providersLoaded, fetchProviders ] );
 
+	// Refresh providers when user returns to the tab (e.g., after making
+	// changes on the Connectors admin page).
+	useEffect( () => {
+		const handleVisibilityChange = () => {
+			if ( ! document.hidden && providersLoaded ) {
+				fetchProviders();
+			}
+		};
+
+		document.addEventListener( 'visibilitychange', handleVisibilityChange );
+		return () =>
+			document.removeEventListener(
+				'visibilitychange',
+				handleVisibilityChange
+			);
+	}, [ providersLoaded, fetchProviders ] );
+
 	const handleSlashCommand = useCallback( ( command ) => {
 		if ( command === 'help' ) {
 			setShowShortcuts( true );

--- a/src/admin-page/style.css
+++ b/src/admin-page/style.css
@@ -499,6 +499,34 @@ body.toplevel_page_gratis-ai-agent #wpbody-content > .updated {
 	min-width: 160px;
 }
 
+.gratis-ai-agent-provider-selector__row {
+	display: flex;
+	align-items: flex-end;
+	gap: 4px;
+}
+
+.gratis-ai-agent-provider-selector__refresh {
+	flex-shrink: 0;
+	margin-bottom: 2px;
+}
+
+.gratis-ai-agent-provider-selector__refresh svg {
+	transition: transform 0.3s ease;
+}
+
+.gratis-ai-agent-provider-selector__refresh:disabled svg {
+	animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+	from {
+		transform: rotate( 0deg );
+	}
+	to {
+		transform: rotate( 360deg );
+	}
+}
+
 /* Messages */
 .gratis-ai-agent-messages {
 	flex: 1;

--- a/src/components/provider-selector.js
+++ b/src/components/provider-selector.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { SelectControl } from '@wordpress/components';
+import { Button, SelectControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -22,7 +22,7 @@ import STORE_NAME from '../store';
  * @return {JSX.Element} The provider/model selector element.
  */
 export default function ProviderSelector( { compact = false } ) {
-	const { providers, selectedProviderId, selectedModelId, models } =
+	const { providers, selectedProviderId, selectedModelId, models, loading } =
 		useSelect( ( select ) => {
 			const store = select( STORE_NAME );
 			return {
@@ -30,10 +30,16 @@ export default function ProviderSelector( { compact = false } ) {
 				selectedProviderId: store.getSelectedProviderId(),
 				selectedModelId: store.getSelectedModelId(),
 				models: store.getSelectedProviderModels(),
+				loading: store.getProvidersLoading(),
 			};
 		}, [] );
 
-	const { setSelectedProvider, setSelectedModel } = useDispatch( STORE_NAME );
+	const { setSelectedProvider, setSelectedModel, fetchProviders } =
+		useDispatch( STORE_NAME );
+
+	const onRefresh = () => {
+		fetchProviders();
+	};
 
 	if ( ! providers.length ) {
 		return (
@@ -75,14 +81,29 @@ export default function ProviderSelector( { compact = false } ) {
 				compact ? 'is-compact' : ''
 			}` }
 		>
-			<SelectControl
-				label={ compact ? null : __( 'Provider', 'gratis-ai-agent' ) }
-				value={ selectedProviderId }
-				options={ providerOptions }
-				onChange={ onProviderChange }
-				__nextHasNoMarginBottom
-				size={ compact ? 'compact' : 'default' }
-			/>
+			<div className="gratis-ai-agent-provider-selector__row">
+				<SelectControl
+					label={
+						compact ? null : __( 'Provider', 'gratis-ai-agent' )
+					}
+					value={ selectedProviderId }
+					options={ providerOptions }
+					onChange={ onProviderChange }
+					__nextHasNoMarginBottom
+					size={ compact ? 'compact' : 'default' }
+				/>
+				<Button
+					variant="tertiary"
+					onClick={ onRefresh }
+					disabled={ loading }
+					className="gratis-ai-agent-provider-selector__refresh"
+					icon={ loading ? undefined : 'update' }
+					title={ __( 'Refresh providers', 'gratis-ai-agent' ) }
+					__nextHasNoMarginBottom
+				>
+					{ loading ? '…' : '' }
+				</Button>
+			</div>
 			<SelectControl
 				label={ compact ? null : __( 'Model', 'gratis-ai-agent' ) }
 				value={ selectedModelId }

--- a/src/floating-widget/index.js
+++ b/src/floating-widget/index.js
@@ -68,6 +68,27 @@ function FloatingWidget() {
 		restoreActiveJobs();
 	}, [ fetchProviders, fetchSessions, restoreActiveJobs ] );
 
+	// Refresh providers when user returns to the tab (e.g., after making
+	// changes on the Connectors admin page).
+	const providersLoaded = useSelect(
+		( select ) => select( STORE_NAME ).getProvidersLoaded(),
+		[]
+	);
+	useEffect( () => {
+		const handleVisibilityChange = () => {
+			if ( ! document.hidden && providersLoaded ) {
+				fetchProviders();
+			}
+		};
+
+		document.addEventListener( 'visibilitychange', handleVisibilityChange );
+		return () =>
+			document.removeEventListener(
+				'visibilitychange',
+				handleVisibilityChange
+			);
+	}, [ providersLoaded, fetchProviders ] );
+
 	// Cross-page navigation survival (Phase 4 / t206):
 	// Restore any active poll loops from sessionStorage. If the user navigated
 	// away from an admin page while a background job was running, sessionStorage

--- a/src/floating-widget/style.css
+++ b/src/floating-widget/style.css
@@ -367,6 +367,25 @@
 	display: none;
 }
 
+.gratis-ai-agent-provider-selector__row {
+	display: flex;
+	align-items: flex-end;
+	gap: 4px;
+}
+
+.gratis-ai-agent-provider-selector__refresh {
+	flex-shrink: 0;
+	margin-bottom: 2px;
+}
+
+.gratis-ai-agent-provider-selector__refresh svg {
+	transition: transform 0.3s ease;
+}
+
+.gratis-ai-agent-provider-selector__refresh:disabled svg {
+	animation: spin 1s linear infinite;
+}
+
 /* Bubbles (needed for floating widget) — wp-admin form conventions */
 .gratis-ai-agent-floating-panel .gratis-ai-agent-user {
 	background: #f0f6fc;

--- a/src/screen-meta/index.js
+++ b/src/screen-meta/index.js
@@ -11,7 +11,7 @@
  * WordPress dependencies
  */
 import { createRoot, useEffect } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -67,11 +67,32 @@ function buildContextString( screenContext ) {
 function ScreenMetaChat() {
 	const { setPageContext, fetchProviders, fetchSessions } =
 		useDispatch( STORE_NAME );
+	const providersLoaded = useSelect(
+		( select ) => select( STORE_NAME ).getProvidersLoaded(),
+		[]
+	);
 
 	useEffect( () => {
 		fetchProviders();
 		fetchSessions();
 	}, [ fetchProviders, fetchSessions ] );
+
+	// Refresh providers when user returns to the tab (e.g., after making
+	// changes on the Connectors admin page).
+	useEffect( () => {
+		const handleVisibilityChange = () => {
+			if ( ! document.hidden && providersLoaded ) {
+				fetchProviders();
+			}
+		};
+
+		document.addEventListener( 'visibilitychange', handleVisibilityChange );
+		return () =>
+			document.removeEventListener(
+				'visibilitychange',
+				handleVisibilityChange
+			);
+	}, [ providersLoaded, fetchProviders ] );
 
 	// Set context from PHP-injected screen data on mount.
 	useEffect( () => {


### PR DESCRIPTION
## Summary

- Auto-refreshes provider list when user returns to the tab after configuring a connector on the Connectors admin page
- Adds a manual refresh button with spinning loader to the ProviderSelector component in all three UI entry points (admin page, floating widget, screen meta)
- Fixes OpenAI-compatible provider ID matching to use `str_starts_with` instead of exact equality, supporting multi-endpoint setups where each endpoint gets a unique suffix (e.g., `ai-provider-for-any-openai-compatible-1`)

## Problem

Users had to reload the entire page after adding/configuring a provider on the Connectors page for it to appear in the provider selector. The provider list was only fetched on initial load and on a 30-second timer.

## Files

- EDIT: `includes/REST/SettingsController.php` — use `str_starts_with` for OpenAI-compatible provider ID matching
- EDIT: `src/admin-page/index.js` — add `visibilitychange` listener
- EDIT: `src/admin-page/style.css` — styles for provider selector row and refresh button spinner
- EDIT: `src/components/provider-selector.js` — add refresh button with loading state
- EDIT: `src/floating-widget/index.js` — add `visibilitychange` listener
- EDIT: `src/floating-widget/style.css` — styles for provider selector row and refresh button spinner
- EDIT: `src/screen-meta/index.js` — add `visibilitychange` listener

## Verification

1. Open plugin admin page (or floating widget)
2. Navigate to Settings → Connectors in another tab and add/configure a provider
3. Switch back to the plugin tab — provider list should update automatically
4. Also verify the refresh button (↻) in the provider selector works manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a manual refresh button to the provider selector for updating provider data on demand
  * Providers now automatically refresh when you return to the browser tab
  * Loading state indicator displays during refresh operations

* **Style**
  * Enhanced provider selector layout with improved spacing and alignment

<!-- end of auto-generated comment: release notes by coderabbit.ai -->