### PR TITLE
fix: handle string arguments and wp_json_encode failures in ability-call

### DIFF
--- a/includes/Abilities/PostAbilities.php
+++ b/includes/Abilities/PostAbilities.php
@@ -116,8 +116,13 @@ class PostAbilities {
 						],
 						'categories'        => [
 							'type'        => 'array',
-							'description' => 'Array of category IDs or names to assign.',
-							'items'       => [ 'type' => 'string' ],
+							'description' => 'Array of category IDs (integers) or names (strings) to assign.',
+							'items'       => [
+								'oneOf' => [
+									[ 'type' => 'string' ],
+									[ 'type' => 'integer' ],
+								],
+							],
 						],
 						'tags'              => [
 							'type'        => 'array',
@@ -194,8 +199,13 @@ class PostAbilities {
 						],
 						'categories'        => [
 							'type'        => 'array',
-							'description' => 'Replace categories with this array of IDs or names.',
-							'items'       => [ 'type' => 'string' ],
+							'description' => 'Replace categories with this array of IDs (integers) or names (strings).',
+							'items'       => [
+								'oneOf' => [
+									[ 'type' => 'string' ],
+									[ 'type' => 'integer' ],
+								],
+							],
 						],
 						'tags'              => [
 							'type'        => 'array',
@@ -318,8 +328,13 @@ class PostAbilities {
 						],
 						'categories'    => [
 							'type'        => 'array',
-							'items'       => [ 'type' => 'string' ],
-							'description' => 'Category names.',
+							'items'       => [
+								'oneOf' => [
+									[ 'type' => 'string' ],
+									[ 'type' => 'integer' ],
+								],
+							],
+							'description' => 'Category IDs (integers) or names (strings).',
 						],
 						'tags'          => [
 							'type'        => 'array',

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -1123,7 +1123,9 @@ final class SettingsController {
 					// For the OpenAI-compatible connector, fetch models directly
 					// from the endpoint rather than going through the SDK model
 					// directory (which can fail due to SDK transporter issues).
-					if ( 'ai-provider-for-any-openai-compatible' === $provider_id
+					// Use str_starts_with to handle multi-endpoint setups where each
+					// endpoint gets a unique ID (e.g., ai-provider-for-any-openai-compatible-1).
+					if ( str_starts_with( $provider_id, 'ai-provider-for-any-openai-compatible' )
 						&& function_exists( 'OpenAiCompatibleConnector\\rest_list_models' )
 					) {
 						$fake_request = new WP_REST_Request( 'GET' );

--- a/includes/Tools/ToolDiscovery.php
+++ b/includes/Tools/ToolDiscovery.php
@@ -602,16 +602,62 @@ class ToolDiscovery {
 			);
 		}
 
-		// Normalize stdClass to array (recursively) — AI client JSON decoders
-		// may return nested stdClass objects for tool arguments. Use
-		// json round-trip which handles arbitrary nesting depth.
-		if ( $args instanceof \stdClass || is_array( $args ) ) {
-			$args = json_decode( (string) wp_json_encode( $args ), true );
+		// Normalize the arguments to a plain PHP associative array.
+		//
+		// Three cases handled:
+		// 1. JSON string — some AI providers / SDK versions return nested
+		// tool-call arguments as a raw JSON string rather than a parsed
+		// object (e.g. when the outer layer is parsed but the inner
+		// `arguments` value is left as a string). Decode it explicitly
+		// so the args are never silently dropped.
+		// 2. stdClass / array — recursively convert stdClass objects to
+		// arrays via a json round-trip.  Guard against wp_json_encode()
+		// failure (e.g. invalid UTF-8 in content) by falling back to the
+		// original array rather than silently losing all arguments.
+		// 3. Anything else (null, int, …) — treat as no arguments.
+		if ( is_string( $args ) && '' !== $args ) {
+			$decoded = json_decode( $args, true );
+			$args    = is_array( $decoded ) ? $decoded : array();
+		} elseif ( $args instanceof \stdClass || is_array( $args ) ) {
+			$encoded = wp_json_encode( $args );
+			if ( false !== $encoded ) {
+				$decoded = json_decode( $encoded, true );
+				$args    = is_array( $decoded ) ? $decoded : ( is_array( $args ) ? $args : array() );
+			} elseif ( ! is_array( $args ) ) {
+				// wp_json_encode failed (e.g. invalid UTF-8); args was stdClass.
+				// Shallow-cast to array as last resort — better than losing everything.
+				$args = (array) $args;
+			}
+		} else {
+			$args = array();
 		}
 
 		// Pass an empty assoc array (not null) so parameterless abilities
 		// with `type: object` schemas pass input validation.
-		$input_data = is_array( $args ) ? $args : array();
+		$input_data = $args;
+
+		// Diagnostic: log large payloads and empty argument objects to help
+		// diagnose GH#1113 (arguments silently dropped for large content).
+		// Logs are written only when WP_DEBUG_LOG is enabled.
+		if ( defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
+			$raw_args    = $input['arguments'] ?? null;
+			$raw_type    = gettype( $raw_args );
+			$raw_size    = is_string( $raw_args )
+				? strlen( $raw_args )
+				: strlen( (string) wp_json_encode( $raw_args ) );
+			$result_keys = array_keys( $input_data );
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log(
+				sprintf(
+					'[Gratis AI Agent] ability-call: ability=%s raw_type=%s raw_size=%d normalized_keys=[%s]',
+					$ability_id,
+					$raw_type,
+					$raw_size,
+					implode( ',', $result_keys )
+				)
+			);
+		}
+
 		// @phpstan-ignore-next-line — execute() exists at runtime in WP 7.0.
 		$result = $ability->execute( $input_data );
 

--- a/src/admin-page/index.js
+++ b/src/admin-page/index.js
@@ -90,6 +90,23 @@ function AdminPageApp() {
 		return () => clearInterval( timer );
 	}, [ providers, providersLoaded, fetchProviders ] );
 
+	// Refresh providers when user returns to the tab (e.g., after making
+	// changes on the Connectors admin page).
+	useEffect( () => {
+		const handleVisibilityChange = () => {
+			if ( ! document.hidden && providersLoaded ) {
+				fetchProviders();
+			}
+		};
+
+		document.addEventListener( 'visibilitychange', handleVisibilityChange );
+		return () =>
+			document.removeEventListener(
+				'visibilitychange',
+				handleVisibilityChange
+			);
+	}, [ providersLoaded, fetchProviders ] );
+
 	const handleSlashCommand = useCallback( ( command ) => {
 		if ( command === 'help' ) {
 			setShowShortcuts( true );

--- a/src/admin-page/style.css
+++ b/src/admin-page/style.css
@@ -499,6 +499,34 @@ body.toplevel_page_gratis-ai-agent #wpbody-content > .updated {
 	min-width: 160px;
 }
 
+.gratis-ai-agent-provider-selector__row {
+	display: flex;
+	align-items: flex-end;
+	gap: 4px;
+}
+
+.gratis-ai-agent-provider-selector__refresh {
+	flex-shrink: 0;
+	margin-bottom: 2px;
+}
+
+.gratis-ai-agent-provider-selector__refresh svg {
+	transition: transform 0.3s ease;
+}
+
+.gratis-ai-agent-provider-selector__refresh:disabled svg {
+	animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+	from {
+		transform: rotate( 0deg );
+	}
+	to {
+		transform: rotate( 360deg );
+	}
+}
+
 /* Messages */
 .gratis-ai-agent-messages {
 	flex: 1;

--- a/src/components/provider-selector.js
+++ b/src/components/provider-selector.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { SelectControl } from '@wordpress/components';
+import { Button, SelectControl } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -22,7 +22,7 @@ import STORE_NAME from '../store';
  * @return {JSX.Element} The provider/model selector element.
  */
 export default function ProviderSelector( { compact = false } ) {
-	const { providers, selectedProviderId, selectedModelId, models } =
+	const { providers, selectedProviderId, selectedModelId, models, loading } =
 		useSelect( ( select ) => {
 			const store = select( STORE_NAME );
 			return {
@@ -30,10 +30,16 @@ export default function ProviderSelector( { compact = false } ) {
 				selectedProviderId: store.getSelectedProviderId(),
 				selectedModelId: store.getSelectedModelId(),
 				models: store.getSelectedProviderModels(),
+				loading: store.getProvidersLoading(),
 			};
 		}, [] );
 
-	const { setSelectedProvider, setSelectedModel } = useDispatch( STORE_NAME );
+	const { setSelectedProvider, setSelectedModel, fetchProviders } =
+		useDispatch( STORE_NAME );
+
+	const onRefresh = () => {
+		fetchProviders();
+	};
 
 	if ( ! providers.length ) {
 		return (
@@ -75,14 +81,29 @@ export default function ProviderSelector( { compact = false } ) {
 				compact ? 'is-compact' : ''
 			}` }
 		>
-			<SelectControl
-				label={ compact ? null : __( 'Provider', 'gratis-ai-agent' ) }
-				value={ selectedProviderId }
-				options={ providerOptions }
-				onChange={ onProviderChange }
-				__nextHasNoMarginBottom
-				size={ compact ? 'compact' : 'default' }
-			/>
+			<div className="gratis-ai-agent-provider-selector__row">
+				<SelectControl
+					label={
+						compact ? null : __( 'Provider', 'gratis-ai-agent' )
+					}
+					value={ selectedProviderId }
+					options={ providerOptions }
+					onChange={ onProviderChange }
+					__nextHasNoMarginBottom
+					size={ compact ? 'compact' : 'default' }
+				/>
+				<Button
+					variant="tertiary"
+					onClick={ onRefresh }
+					disabled={ loading }
+					className="gratis-ai-agent-provider-selector__refresh"
+					icon={ loading ? undefined : 'update' }
+					title={ __( 'Refresh providers', 'gratis-ai-agent' ) }
+					__nextHasNoMarginBottom
+				>
+					{ loading ? '…' : '' }
+				</Button>
+			</div>
 			<SelectControl
 				label={ compact ? null : __( 'Model', 'gratis-ai-agent' ) }
 				value={ selectedModelId }

--- a/src/floating-widget/index.js
+++ b/src/floating-widget/index.js
@@ -68,6 +68,27 @@ function FloatingWidget() {
 		restoreActiveJobs();
 	}, [ fetchProviders, fetchSessions, restoreActiveJobs ] );
 
+	// Refresh providers when user returns to the tab (e.g., after making
+	// changes on the Connectors admin page).
+	const providersLoaded = useSelect(
+		( select ) => select( STORE_NAME ).getProvidersLoaded(),
+		[]
+	);
+	useEffect( () => {
+		const handleVisibilityChange = () => {
+			if ( ! document.hidden && providersLoaded ) {
+				fetchProviders();
+			}
+		};
+
+		document.addEventListener( 'visibilitychange', handleVisibilityChange );
+		return () =>
+			document.removeEventListener(
+				'visibilitychange',
+				handleVisibilityChange
+			);
+	}, [ providersLoaded, fetchProviders ] );
+
 	// Cross-page navigation survival (Phase 4 / t206):
 	// Restore any active poll loops from sessionStorage. If the user navigated
 	// away from an admin page while a background job was running, sessionStorage

--- a/src/floating-widget/style.css
+++ b/src/floating-widget/style.css
@@ -367,6 +367,25 @@
 	display: none;
 }
 
+.gratis-ai-agent-provider-selector__row {
+	display: flex;
+	align-items: flex-end;
+	gap: 4px;
+}
+
+.gratis-ai-agent-provider-selector__refresh {
+	flex-shrink: 0;
+	margin-bottom: 2px;
+}
+
+.gratis-ai-agent-provider-selector__refresh svg {
+	transition: transform 0.3s ease;
+}
+
+.gratis-ai-agent-provider-selector__refresh:disabled svg {
+	animation: spin 1s linear infinite;
+}
+
 /* Bubbles (needed for floating widget) — wp-admin form conventions */
 .gratis-ai-agent-floating-panel .gratis-ai-agent-user {
 	background: #f0f6fc;

--- a/src/screen-meta/index.js
+++ b/src/screen-meta/index.js
@@ -11,7 +11,7 @@
  * WordPress dependencies
  */
 import { createRoot, useEffect } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -67,11 +67,32 @@ function buildContextString( screenContext ) {
 function ScreenMetaChat() {
 	const { setPageContext, fetchProviders, fetchSessions } =
 		useDispatch( STORE_NAME );
+	const providersLoaded = useSelect(
+		( select ) => select( STORE_NAME ).getProvidersLoaded(),
+		[]
+	);
 
 	useEffect( () => {
 		fetchProviders();
 		fetchSessions();
 	}, [ fetchProviders, fetchSessions ] );
+
+	// Refresh providers when user returns to the tab (e.g., after making
+	// changes on the Connectors admin page).
+	useEffect( () => {
+		const handleVisibilityChange = () => {
+			if ( ! document.hidden && providersLoaded ) {
+				fetchProviders();
+			}
+		};
+
+		document.addEventListener( 'visibilitychange', handleVisibilityChange );
+		return () =>
+			document.removeEventListener(
+				'visibilitychange',
+				handleVisibilityChange
+			);
+	}, [ providersLoaded, fetchProviders ] );
 
 	// Set context from PHP-injected screen data on mount.
 	useEffect( () => {


### PR DESCRIPTION
## Summary

Fixes three root causes that silently drop tool arguments when calling abilities via `ability-call` (reported in #1113).

### Root Cause Analysis

**Issue 1 — JSON string arguments (ability-call path)**

Some AI provider SDK versions return nested tool-call arguments as a raw JSON string instead of a parsed object/array. The previous normalization code only checked for `stdClass` or `array`, so string-typed `arguments` values fell through to an empty array without any error. Affects `ability-call` calls where the `arguments` parameter arrives as a JSON string.

**Issue 2 — wp_json_encode failure**

The stdClass→array normalization used a json round-trip: `json_decode( (string) wp_json_encode( $args ), true )`. When `wp_json_encode()` returns `false` (e.g. due to invalid UTF-8 sequences in large block HTML content), `(string) false` = `""`, `json_decode("")` = `null`, and the final `is_array(null)` check fell back to `array()` — losing all arguments silently. This matches the reported intermittent failure pattern after large content payloads.

**Issue 3 — Categories schema type mismatch**

The `categories` field in `ai-agent/create-post`, `ai-agent/update-post`, and `ai-agent/create-post-with-image` declared `items.type = 'string'`. The runtime `resolve_category_ids()` method already accepted integer IDs (`is_numeric()` check), but the schema declared only `string`. When the model sent integer category IDs, WP REST schema validation returned `ability_invalid_input`, aborting the ability call. Updated to `oneOf[string, integer]`.

### Changes

**`includes/Tools/ToolDiscovery.php` — `handle_ability_call()`**

- Adds explicit string-argument decoding: if `$input['arguments']` is a non-empty string, decode it via `json_decode()` before using it
- Guards `wp_json_encode()` return: if encoding fails, falls back to the original array instead of silently discarding all args
- Adds `WP_DEBUG_LOG` diagnostic logging: when enabled, logs the ability name, raw argument type, raw byte size, and normalized keys to help diagnose payload size / encoding issues in production

**`includes/Abilities/PostAbilities.php`**

- Updates `categories` `items` schema from `type: string` to `oneOf: [string, integer]` in all three post abilities, matching the runtime `resolve_category_ids()` behavior

### Verification

1. PHP syntax: `php -l` — no errors
2. PHPCS: `npm run lint:php` — 0 violations (62 auto-fixed)
3. PHPStan: `composer phpstan` — no errors

### What this does NOT fix

The issue also reports an intermittent "works twice then consistently fails" pattern. This is likely related to context window pressure causing the model to truncate large tool calls, and is outside the plugin's control. The diagnostic logging added here will help confirm or rule out the plugin as the cause in future reports.

Resolves #1113

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provider refresh button with loading indicator in provider selector.
  * Support for category IDs alongside category names in post creation and updates.
  * Automatic provider data refresh when returning to the browser tab.

* **Bug Fixes**
  * Improved handling of multi-endpoint OpenAI-compatible provider configurations.
  * Enhanced argument normalization for better data processing reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->