### PR TITLE
Fix Tier 2 ability-call: decode JSON string arguments before validation

### DIFF
--- a/includes/Core/AbilityFunctionResolver.php
+++ b/includes/Core/AbilityFunctionResolver.php
@@ -227,18 +227,41 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 	}
 
 	/**
-	 * Recursively convert stdClass objects to associative arrays.
+	 * Recursively normalize function-call arguments for WordPress abilities.
 	 *
-	 * AI provider JSON decoders may return nested stdClass objects for
-	 * function-call arguments. WordPress abilities expect plain arrays.
+	 * Handles three cases that AI provider JSON decoders may produce:
+	 * 1. stdClass objects — converted to associative arrays.
+	 * 2. JSON strings — some providers (especially OpenAI-compatible) serialize
+	 *    nested object-typed arguments as a raw JSON string rather than a parsed
+	 *    object. These are decoded so that `validate_input()` sees the correct
+	 *    type instead of rejecting a string where the schema declares `object`.
+	 * 3. Arrays — recursed into for nested normalization.
+	 *
+	 * Without this normalization, `WP_Ability::validate_input()` rejects
+	 * JSON-string arguments with `ability_invalid_input` because
+	 * `rest_is_object()` returns false for strings, preventing
+	 * `do_execute()` (and therefore `handle_ability_call()`) from ever
+	 * running.
 	 *
 	 * @param array<string, mixed> $args Function call arguments.
-	 * @return array<string, mixed> Normalized arguments with all stdClass converted.
+	 * @return array<string, mixed> Normalized arguments with stdClass and JSON strings converted.
 	 */
 	private static function normalize_args( array $args ): array {
 		foreach ( $args as $key => $value ) {
 			if ( $value instanceof \stdClass ) {
 				$args[ $key ] = self::normalize_args( (array) $value );
+			} elseif ( is_string( $value ) && '' !== $value ) {
+				// Decode JSON strings that represent objects/arrays.
+				// This is critical for the Tier 2 ability-call meta-tool,
+				// where the `arguments` property is declared as `type: object`
+				// but some AI providers send it as a JSON string.
+				$decoded = json_decode( $value, true );
+				if ( is_array( $decoded ) ) {
+					$args[ $key ] = self::normalize_args( $decoded );
+				}
+				// If json_decode failed or returned a scalar, leave the
+				// original string value untouched — it may be a legitimate
+				// string argument, not a mis-typed object.
 			} elseif ( is_array( $value ) ) {
 				$args[ $key ] = self::normalize_args( $value );
 			}


### PR DESCRIPTION
## Summary

- **Root cause**: Some AI providers (especially OpenAI-compatible) serialize the inner `arguments` field of the `ability-call` meta-tool as a JSON string instead of a parsed object. `WP_Ability::validate_input()` rejects these strings because the schema declares `type: object` and `rest_is_object()` returns false for strings. This means `handle_ability_call()` never executes — the error is returned at the validation step with code `ability_invalid_input`.

- **Fix**: Add JSON string decoding to `AbilityFunctionResolver::normalize_args()` so that string values containing valid JSON objects/arrays are decoded **before** `validate_input()` runs. Non-JSON strings are left untouched (they may be legitimate string arguments).

- **Effect**: The existing JSON-string handling in `ToolDiscovery::handle_ability_call()` (lines 618-633) becomes reachable as a second safety net, instead of being dead code.

## How

- **EDIT: `includes/Core/AbilityFunctionResolver.php`** — `normalize_args()` now has a `is_string()` branch that attempts `json_decode($value, true)`. If the result is an array, it recurses into it for nested normalization. If decoding fails or returns a scalar, the original string is preserved.

## Verification

```bash
npm run lint:php -- includes/Core/AbilityFunctionResolver.php
# PASS — 0 violations
```

## Context

The full execution path for a Tier 2 ability call:

1. Model calls `gratis-ai-agent/ability-call` with args `{ability: "some-id", arguments: {key: "value"}}`
2. `AbilityFunctionResolver::execute_ability()` normalizes args via `normalize_args()` → calls `$ability->execute($args)`
3. `WP_Ability::execute()` calls `validate_input()` → **was failing here** for JSON-string `arguments`
4. `handle_ability_call()` — **was never reached** (has dead JSON-string handling at lines 618-633)

With this fix, step 3 now receives a properly decoded array instead of a string, so validation passes and execution proceeds.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.92 plugin for [OpenCode](https://opencode.ai) v1.3.17 with glm-5.1 spent 1h 22m and 4,498,699 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved argument handling to prevent invalid rejection of properly formatted argument values, enhancing system reliability and flexibility when processing various input types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->