### PR TITLE
fix: return WP_Error for malformed/non-array JSON ability arguments (GH#1139)

### DIFF
--- a/includes/Tools/ToolDiscovery.php
+++ b/includes/Tools/ToolDiscovery.php
@@ -617,7 +617,23 @@ class ToolDiscovery {
 		// 3. Anything else (null, int, …) — treat as no arguments.
 		if ( is_string( $args ) && '' !== $args ) {
 			$decoded = json_decode( $args, true );
-			$args    = is_array( $decoded ) ? $decoded : array();
+			if ( JSON_ERROR_NONE !== json_last_error() ) {
+				return new WP_Error(
+					'invalid_ability_arguments',
+					sprintf(
+						/* translators: %s: JSON decode error message. */
+						__( 'arguments must be valid JSON: %s', 'gratis-ai-agent' ),
+						json_last_error_msg()
+					)
+				);
+			}
+			if ( ! is_array( $decoded ) ) {
+				return new WP_Error(
+					'invalid_ability_arguments',
+					__( 'arguments must decode to a JSON object.', 'gratis-ai-agent' )
+				);
+			}
+			$args = $decoded;
 		} elseif ( $args instanceof \stdClass || is_array( $args ) ) {
 			$encoded = wp_json_encode( $args );
 			if ( false !== $encoded ) {
@@ -642,18 +658,19 @@ class ToolDiscovery {
 		if ( defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
 			$raw_args    = $input['arguments'] ?? null;
 			$raw_type    = gettype( $raw_args );
-			$raw_size    = is_string( $raw_args )
-				? strlen( $raw_args )
-				: strlen( (string) wp_json_encode( $raw_args ) );
+			$raw_encoded = is_string( $raw_args ) ? $raw_args : wp_json_encode( $raw_args );
+			$raw_size    = is_string( $raw_encoded ) ? strlen( $raw_encoded ) : 0;
+			$encode_note = false === $raw_encoded ? ' raw_encode_failed=1' : '';
 			$result_keys = array_keys( $input_data );
 			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 			error_log(
 				sprintf(
-					'[Gratis AI Agent] ability-call: ability=%s raw_type=%s raw_size=%d normalized_keys=[%s]',
+					'[Gratis AI Agent] ability-call: ability=%s raw_type=%s raw_size=%d normalized_keys=[%s]%s',
 					$ability_id,
 					$raw_type,
 					$raw_size,
-					implode( ',', $result_keys )
+					implode( ',', $result_keys ),
+					$encode_note
 				)
 			);
 		}

--- a/tests/GratisAiAgent/Tools/ToolDiscoveryTest.php
+++ b/tests/GratisAiAgent/Tools/ToolDiscoveryTest.php
@@ -154,6 +154,30 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 		$this->assertInstanceOf( \WP_Error::class, $result );
 	}
 
+	public function test_ability_call_returns_error_for_malformed_json_arguments(): void {
+		$result = ToolDiscovery::handle_ability_call(
+			[
+				'ability'   => 'gratis-ai-agent/get-plugins',
+				'arguments' => '{"title":', // Truncated / malformed JSON.
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'invalid_ability_arguments', $result->get_error_code() );
+	}
+
+	public function test_ability_call_returns_error_for_non_object_json_arguments(): void {
+		$result = ToolDiscovery::handle_ability_call(
+			[
+				'ability'   => 'gratis-ai-agent/get-plugins',
+				'arguments' => '"just a string"', // Valid JSON but not an object/array.
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'invalid_ability_arguments', $result->get_error_code() );
+	}
+
 	// ── manifest ──────────────────────────────────────────────────────
 
 	public function test_manifest_lists_tier_2_abilities(): void {


### PR DESCRIPTION
## Summary

Fixes two code-review findings from PR #1114 against `includes/Tools/ToolDiscovery.php`.

### HIGH — malformed JSON arguments surface a `WP_Error` instead of being silently dropped

`handle_ability_call()` previously normalised any unparseable or non-array JSON string to `[]`, which contradicted the comment at lines 608–612 ("so the args are never silently dropped"). Callers could not distinguish "no arguments" from "arguments were corrupt".

Changes:
- After `json_decode()`, call `json_last_error()`. If not `JSON_ERROR_NONE`, return `WP_Error('invalid_ability_arguments', …)` with `json_last_error_msg()` for diagnostics.
- If decoding succeeds but the result is not an array, return `WP_Error('invalid_ability_arguments', 'arguments must decode to a JSON object.')`.
- The return type at line 566 already declared `|\WP_Error` as valid; no signature change needed.

### MEDIUM — encode failure logged as `raw_size=0` instead of an explicit marker

When `wp_json_encode($raw_args)` returns `false`, the old code cast it to `""` (an empty string), making encoding failures indistinguishable from empty payloads in log output.

Changes:
- Store the encode result in `$raw_encoded`; compute `$raw_size` from it only when it is a string.
- Append `raw_encode_failed=1` to the log line when encode returned `false`.

### Tests added

- `test_ability_call_returns_error_for_malformed_json_arguments` — truncated JSON `{"title":` returns `invalid_ability_arguments`.
- `test_ability_call_returns_error_for_non_object_json_arguments` — valid JSON `"just a string"` (not an object) returns `invalid_ability_arguments`.

## Files modified

- EDIT: `includes/Tools/ToolDiscovery.php` — lines 618–636 (HIGH fix), lines 661–675 (MEDIUM fix)
- EDIT: `tests/GratisAiAgent/Tools/ToolDiscoveryTest.php` — two new test methods after line 155

## Verification

```
composer phpcs -- includes/Tools/ToolDiscovery.php    # zero violations
composer phpcs -- tests/GratisAiAgent/Tools/ToolDiscoveryTest.php  # zero violations
```

PHPUnit tests require `npx wp-env start` + `npm run test:php`.

Resolves #1139

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.93 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 5m and 7,838 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ability call arguments now undergo strict validation: malformed or non-object JSON inputs return an explicit error instead of being silently converted to empty values.
  * Enhanced diagnostic logging for ability calls when debug logging is enabled to improve error identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->