### PR TITLE
fix: load provider credentials in BenchmarkRunner before AI calls

### DIFF
--- a/includes/Benchmark/BenchmarkRunner.php
+++ b/includes/Benchmark/BenchmarkRunner.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace GratisAiAgent\Benchmark;
 
 use GratisAiAgent\Core\Database;
+use GratisAiAgent\Core\ProviderCredentialLoader;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -438,7 +439,9 @@ class BenchmarkRunner {
 			);
 		}
 
-		// WordPress AI SDK handles credentials internally.
+		// Ensure provider credentials are loaded (same logic the chat uses).
+		ProviderCredentialLoader::load();
+
 		$builder = wp_ai_client_prompt( $prompt );
 
 		// Set provider and model through the SDK registry.


### PR DESCRIPTION
## Summary

Restores `ProviderCredentialLoader::load()` in `BenchmarkRunner::call_wp_ai_client()` with correct namespace resolution via a `use` statement.

## Problem

PR #1106 added benchmark routing through `wp_ai_client_prompt()`. During review, CodeRabbit flagged a critical namespace bug: the call to `GratisAiAgent\Core\ProviderCredentialLoader::load()` used a relative namespace reference from the `GratisAiAgent\Benchmark` namespace, causing PHP to resolve it as `GratisAiAgent\Benchmark\GratisAiAgent\Core\ProviderCredentialLoader` (which doesn't exist — fatal error at runtime).

Instead of fixing the namespace issue, the call was removed before the final merge with a comment "WordPress AI SDK handles credentials internally." However, this is incorrect for the REST/loopback context benchmarks run in:

- `AgentLoop.php` (which also calls `wp_ai_client_prompt()`) explicitly calls `ProviderCredentialLoader::load()` with the comment "Ensure provider auth is available (critical for loopback requests)."
- Without this call, benchmarks running via REST API may fail to authenticate with configured providers because the credential-loading chain doesn't fully run in that context.

## Fix

- Added `use GratisAiAgent\Core\ProviderCredentialLoader;` import (correct namespace resolution)
- Added `ProviderCredentialLoader::load()` call before `wp_ai_client_prompt()`, matching the `AgentLoop` pattern

## Files Modified

- EDIT: `includes/Benchmark/BenchmarkRunner.php` — add `use` import (line 14) and `ProviderCredentialLoader::load()` call (before `wp_ai_client_prompt()`)

## Verification

- `php -l includes/Benchmark/BenchmarkRunner.php` — no syntax errors
- Pattern matches `AgentLoop.php:331` exactly

Resolves #1141

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.93 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 8m and 13,309 tokens on this as a headless worker.
