### PR TITLE
fix: connectors page links for WP 6.9 compat

### DIFF
--- a/src/components/__tests__/ConnectorGate.test.js
+++ b/src/components/__tests__/ConnectorGate.test.js
@@ -7,7 +7,7 @@
  * - Renders the description
  * - Renders the CTA link pointing to Connectors page
  * - Uses custom connectorsUrl from window.gratisAiAgentData when available
- * - Falls back to options-connectors.php when connectorsUrl is not set
+ * - Falls back to polyfill Connectors page when connectorsUrl is not set
  */
 
 import { createElement } from '@wordpress/element';
@@ -72,9 +72,9 @@ describe( 'ConnectorGate', () => {
 		expect( html ).toContain( 'Configure a Connector' );
 	} );
 
-	test( 'CTA button links to options-connectors.php by default', () => {
+	test( 'CTA button links to polyfill Connectors page by default', () => {
 		const html = renderToStaticMarkup( createElement( ConnectorGate, {} ) );
-		expect( html ).toContain( 'options-connectors.php' );
+		expect( html ).toContain( 'admin.php?page=gratis-ai-agent#/connectors' );
 	} );
 
 	test( 'uses connectorsUrl from window.gratisAiAgentData when available', () => {

--- a/src/components/__tests__/ConnectorGate.test.js
+++ b/src/components/__tests__/ConnectorGate.test.js
@@ -74,7 +74,9 @@ describe( 'ConnectorGate', () => {
 
 	test( 'CTA button links to polyfill Connectors page by default', () => {
 		const html = renderToStaticMarkup( createElement( ConnectorGate, {} ) );
-		expect( html ).toContain( 'admin.php?page=gratis-ai-agent#/connectors' );
+		expect( html ).toContain(
+			'admin.php?page=gratis-ai-agent#/connectors'
+		);
 	} );
 
 	test( 'uses connectorsUrl from window.gratisAiAgentData when available', () => {

--- a/src/components/__tests__/ProviderSelector.test.js
+++ b/src/components/__tests__/ProviderSelector.test.js
@@ -186,7 +186,9 @@ describe( 'ProviderSelector rendering', () => {
 			createElement( ProviderSelector, {} )
 		);
 		expect( html ).toContain( 'Configure a provider' );
-		expect( html ).toContain( 'admin.php?page=gratis-ai-agent#/connectors' );
+		expect( html ).toContain(
+			'admin.php?page=gratis-ai-agent#/connectors'
+		);
 	} );
 
 	test( 'does not render dropdowns when providers list is empty', () => {

--- a/src/components/__tests__/ProviderSelector.test.js
+++ b/src/components/__tests__/ProviderSelector.test.js
@@ -186,7 +186,7 @@ describe( 'ProviderSelector rendering', () => {
 			createElement( ProviderSelector, {} )
 		);
 		expect( html ).toContain( 'Configure a provider' );
-		expect( html ).toContain( 'options-connectors.php' );
+		expect( html ).toContain( 'admin.php?page=gratis-ai-agent#/connectors' );
 	} );
 
 	test( 'does not render dropdowns when providers list is empty', () => {

--- a/src/components/__tests__/__snapshots__/ProviderSelector.test.js.snap
+++ b/src/components/__tests__/__snapshots__/ProviderSelector.test.js.snap
@@ -4,4 +4,4 @@ exports[`ProviderSelector snapshots matches snapshot in compact mode 1`] = `"<di
 
 exports[`ProviderSelector snapshots matches snapshot in default (non-compact) mode 1`] = `"<div class="gratis-ai-agent-provider-selector "><div data-size="default"><label>Provider</label><select data-label="Provider"><option value="openai" selected="">OpenAI</option><option value="anthropic">Anthropic</option></select></div><div data-size="default"><label>Model</label><select data-label="Model"><option value="gpt-4o" selected="">GPT-4o</option><option value="gpt-4o-mini">GPT-4o Mini</option></select></div></div>"`;
 
-exports[`ProviderSelector snapshots matches snapshot with no providers 1`] = `"<div class="gratis-ai-agent-provider-selector"><p><a href="/wp-admin/options-connectors.php">Configure a provider</a></p></div>"`;
+exports[`ProviderSelector snapshots matches snapshot with no providers 1`] = `"<div class="gratis-ai-agent-provider-selector"><p><a href="admin.php?page=gratis-ai-agent#/connectors">Configure a provider</a></p></div>"`;

--- a/src/components/connector-gate.js
+++ b/src/components/connector-gate.js
@@ -10,7 +10,7 @@ import { __ } from '@wordpress/i18n';
  * @return {string} Connectors page URL.
  */
 function getConnectorsUrl() {
-	return window.gratisAiAgentData?.connectorsUrl || 'options-connectors.php';
+	return window.gratisAiAgentData?.connectorsUrl || 'admin.php?page=gratis-ai-agent#/connectors';
 }
 
 /**

--- a/src/components/connector-gate.js
+++ b/src/components/connector-gate.js
@@ -10,7 +10,10 @@ import { __ } from '@wordpress/i18n';
  * @return {string} Connectors page URL.
  */
 function getConnectorsUrl() {
-	return window.gratisAiAgentData?.connectorsUrl || 'admin.php?page=gratis-ai-agent#/connectors';
+	return (
+		window.gratisAiAgentData?.connectorsUrl ||
+		'admin.php?page=gratis-ai-agent#/connectors'
+	);
 }
 
 /**

--- a/src/components/onboarding-wizard.js
+++ b/src/components/onboarding-wizard.js
@@ -19,7 +19,7 @@ import ProviderSelector from './provider-selector';
  * @return {string} Connectors page URL.
  */
 function getConnectorsUrl() {
-	return window.gratisAiAgentData?.connectorsUrl || 'options-connectors.php';
+	return window.gratisAiAgentData?.connectorsUrl || 'admin.php?page=gratis-ai-agent#/connectors';
 }
 
 /**

--- a/src/components/onboarding-wizard.js
+++ b/src/components/onboarding-wizard.js
@@ -19,7 +19,10 @@ import ProviderSelector from './provider-selector';
  * @return {string} Connectors page URL.
  */
 function getConnectorsUrl() {
-	return window.gratisAiAgentData?.connectorsUrl || 'admin.php?page=gratis-ai-agent#/connectors';
+	return (
+		window.gratisAiAgentData?.connectorsUrl ||
+		'admin.php?page=gratis-ai-agent#/connectors'
+	);
 }
 
 /**

--- a/src/components/provider-selector.js
+++ b/src/components/provider-selector.js
@@ -45,10 +45,12 @@ export default function ProviderSelector( { compact = false } ) {
 		return (
 			<div className="gratis-ai-agent-provider-selector">
 				<p>
-					<a href={
-						window.gratisAiAgentData?.connectorsUrl ||
-						'admin.php?page=gratis-ai-agent#/connectors'
-					}>
+					<a
+						href={
+							window.gratisAiAgentData?.connectorsUrl ||
+							'admin.php?page=gratis-ai-agent#/connectors'
+						}
+					>
 						{ __( 'Configure a provider', 'gratis-ai-agent' ) }
 					</a>
 				</p>

--- a/src/components/provider-selector.js
+++ b/src/components/provider-selector.js
@@ -45,7 +45,10 @@ export default function ProviderSelector( { compact = false } ) {
 		return (
 			<div className="gratis-ai-agent-provider-selector">
 				<p>
-					<a href="/wp-admin/options-connectors.php">
+					<a href={
+						window.gratisAiAgentData?.connectorsUrl ||
+						'admin.php?page=gratis-ai-agent#/connectors'
+					}>
 						{ __( 'Configure a provider', 'gratis-ai-agent' ) }
 					</a>
 				</p>

--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -509,8 +509,8 @@ export default function SettingsApp() {
 				) }{ ' ' }
 				<a
 					href={
-				window.gratisAiAgentData?.connectorsUrl ||
-				'admin.php?page=gratis-ai-agent#/connectors'
+						window.gratisAiAgentData?.connectorsUrl ||
+						'admin.php?page=gratis-ai-agent#/connectors'
 					}
 				>
 					{ __( 'Open Connectors →', 'gratis-ai-agent' ) }

--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -509,8 +509,8 @@ export default function SettingsApp() {
 				) }{ ' ' }
 				<a
 					href={
-						window.gratisAiAgentData?.connectorsUrl ||
-						'options-connectors.php'
+				window.gratisAiAgentData?.connectorsUrl ||
+				'admin.php?page=gratis-ai-agent#/connectors'
 					}
 				>
 					{ __( 'Open Connectors →', 'gratis-ai-agent' ) }

--- a/src/unified-admin/routes/connectors.js
+++ b/src/unified-admin/routes/connectors.js
@@ -415,7 +415,8 @@ export default function ConnectorsRoute() {
 	}, [ fetchProviders ] );
 
 	const connectorsUrl =
-		window.gratisAiAgentData?.connectorsUrl || 'admin.php?page=gratis-ai-agent#/connectors';
+		window.gratisAiAgentData?.connectorsUrl ||
+		'admin.php?page=gratis-ai-agent#/connectors';
 
 	if ( state.loading ) {
 		return (

--- a/src/unified-admin/routes/connectors.js
+++ b/src/unified-admin/routes/connectors.js
@@ -415,7 +415,7 @@ export default function ConnectorsRoute() {
 	}, [ fetchProviders ] );
 
 	const connectorsUrl =
-		window.gratisAiAgentData?.connectorsUrl || 'options-connectors.php';
+		window.gratisAiAgentData?.connectorsUrl || 'admin.php?page=gratis-ai-agent#/connectors';
 
 	if ( state.loading ) {
 		return (


### PR DESCRIPTION
## Summary

On WP 6.9, `options-connectors.php` does not exist. The PHP side (`UnifiedAdminMenu::getConnectorsUrl()`) already routes to our polyfill page (`admin.php?page=gratis-ai-agent#/connectors`) on WP 6.9, but 5 JS files hardcoded `options-connectors.php` as a fallback — breaking all "Configure a Connector" links when `window.gratisAiAgentData.connectorsUrl` was not set.

## Changes

- **`provider-selector.js:48`** — replaced bare `/wp-admin/options-connectors.php` href with `connectorsUrl` lookup + polyfill fallback (this was the worst: no lookup at all, always 404'd on WP 6.9)
- **`connector-gate.js:13`** — fallback changed from `options-connectors.php` to `admin.php?page=gratis-ai-agent#/connectors`
- **`onboarding-wizard.js:22`** — same fallback fix
- **`settings-app.js:512`** — same fallback fix
- **`connectors.js:418`** — same fallback fix
- **`ProviderSelector.test.js` + snapshot** — updated assertions to match new fallback URL
- **`ConnectorGate.test.js`** — updated assertions and comment

## Testing

- `npm run lint:js` passes (0 errors, 0 warnings)
- `ConnectorGate.test.js` — all 7 tests pass
- `ProviderSelector.test.js` — 4 interaction tests pass; 11 rendering/snapshot tests fail due to a **pre-existing** missing `getProvidersLoading` mock (unrelated to this change)

## How to verify

1. On a WP 6.9 install, click any "Configure a Connector" / "Open Connectors" link in the plugin
2. Before: lands on a 404 at `/wp-admin/options-connectors.php`
3. After: lands on the polyfill Connectors page at `/wp-admin/admin.php?page=gratis-ai-agent#/connectors`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.3.17 with glm-5.1 spent 1h 32m and 1,501,165 tokens on this with the user in an interactive session.
