### PR TITLE
Fix connectors page showing WP 7.0 redirect on WP 6.9

### DIFF
--- a/includes/Admin/UnifiedAdminMenu.php
+++ b/includes/Admin/UnifiedAdminMenu.php
@@ -29,10 +29,15 @@ class UnifiedAdminMenu {
 	 * management at options-connectors.php. On WP 6.9, our polyfill page is
 	 * shown instead.
 	 *
+	 * Uses version_compare() against $wp_version rather than function_exists()
+	 * because the polyfill (wp-connectors-polyfill.php) defines the same
+	 * functions on WP 6.9, making function_exists() always return true.
+	 *
 	 * @return bool True when running on WP 7.0+ (native Connectors page exists).
 	 */
 	public static function hasNativeConnectorsPage(): bool {
-		return function_exists( '_wp_connectors_get_provider_settings' );
+		global $wp_version;
+		return version_compare( $wp_version, '7.0', '>=' );
 	}
 
 	/**

--- a/includes/REST/ConnectorsController.php
+++ b/includes/REST/ConnectorsController.php
@@ -53,6 +53,20 @@ final class ConnectorsController {
 	use PermissionTrait;
 
 	/**
+	 * Whether the native WP 7.0 Connectors page is available.
+	 *
+	 * Uses version_compare() against $wp_version rather than function_exists()
+	 * because the polyfill (wp-connectors-polyfill.php) defines the same
+	 * functions on WP 6.9, making function_exists() always return true.
+	 *
+	 * @return bool True when running on WP 7.0+ (native Connectors page exists).
+	 */
+	private static function has_native_connectors_page(): bool {
+		global $wp_version;
+		return version_compare( $wp_version, '7.0', '>=' );
+	}
+
+	/**
 	 * Known AI provider connectors with their plugin and option metadata.
 	 *
 	 * Option_key mirrors WP 7.0's Connectors API naming convention
@@ -157,7 +171,7 @@ final class ConnectorsController {
 		return new WP_REST_Response(
 			array(
 				'providers'     => $providers,
-				'wp_has_native' => function_exists( '_wp_connectors_get_provider_settings' ),
+				'wp_has_native' => self::has_native_connectors_page(),
 			),
 			200
 		);

--- a/includes/REST/ConnectorsController.php
+++ b/includes/REST/ConnectorsController.php
@@ -27,6 +27,7 @@ use WP_REST_Response;
 use WP_REST_Server;
 use XWP\DI\Decorators\Action;
 use XWP\DI\Decorators\Handler;
+use GratisAiAgent\Admin\UnifiedAdminMenu;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -51,20 +52,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 final class ConnectorsController {
 
 	use PermissionTrait;
-
-	/**
-	 * Whether the native WP 7.0 Connectors page is available.
-	 *
-	 * Uses version_compare() against $wp_version rather than function_exists()
-	 * because the polyfill (wp-connectors-polyfill.php) defines the same
-	 * functions on WP 6.9, making function_exists() always return true.
-	 *
-	 * @return bool True when running on WP 7.0+ (native Connectors page exists).
-	 */
-	private static function has_native_connectors_page(): bool {
-		global $wp_version;
-		return version_compare( $wp_version, '7.0', '>=' );
-	}
 
 	/**
 	 * Known AI provider connectors with their plugin and option metadata.
@@ -171,7 +158,7 @@ final class ConnectorsController {
 		return new WP_REST_Response(
 			array(
 				'providers'     => $providers,
-				'wp_has_native' => self::has_native_connectors_page(),
+				'wp_has_native' => UnifiedAdminMenu::hasNativeConnectorsPage(),
 			),
 			200
 		);

--- a/tests/GratisAiAgent/Admin/UnifiedAdminMenuTest.php
+++ b/tests/GratisAiAgent/Admin/UnifiedAdminMenuTest.php
@@ -173,6 +173,38 @@ class UnifiedAdminMenuTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test hasNativeConnectorsPage() returns false on WP 6.9.
+	 *
+	 * The polyfill defines _wp_connectors_get_provider_settings() on WP 6.9,
+	 * so function_exists() would incorrectly return true. The method must
+	 * use version_compare() instead.
+	 */
+	public function test_has_native_connectors_page_returns_false_on_wp_69(): void {
+		global $wp_version;
+		$original = $wp_version;
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Test-only override.
+		$wp_version = '6.9';
+		$result = UnifiedAdminMenu::hasNativeConnectorsPage();
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Test-only override.
+		$wp_version = $original;
+		$this->assertFalse( $result, 'hasNativeConnectorsPage() should return false on WP 6.9 even though the polyfill defines the function.' );
+	}
+
+	/**
+	 * Test hasNativeConnectorsPage() returns true on WP 7.0.
+	 */
+	public function test_has_native_connectors_page_returns_true_on_wp_70(): void {
+		global $wp_version;
+		$original = $wp_version;
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Test-only override.
+		$wp_version = '7.0';
+		$result = UnifiedAdminMenu::hasNativeConnectorsPage();
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Test-only override.
+		$wp_version = $original;
+		$this->assertTrue( $result, 'hasNativeConnectorsPage() should return true on WP 7.0+.' );
+	}
+
+	/**
 	 * Test getConnectorsUrl() returns a non-empty string.
 	 */
 	public function test_get_connectors_url_returns_string(): void {


### PR DESCRIPTION
## Problem

On WP 6.9, the `/connectors` route shows "WordPress 7.0+ includes a built-in Connectors page for managing AI provider API keys." instead of rendering the polyfill connectors UI.

## Root Cause

The native-connectors detection used `function_exists( '_wp_connectors_get_provider_settings' )` in two places:

- `UnifiedAdminMenu::hasNativeConnectorsPage()` (line 35)
- `ConnectorsController::handle_list()` (line 160)

The polyfill file `wp-connectors-polyfill.php` is loaded unconditionally (`ai-agent-for-wp.php:78`) and **defines** `_wp_connectors_get_provider_settings()` on WP 6.9 via a `function_exists()` guard. After the polyfill loads, `function_exists()` returns `true` regardless of WP version — making it impossible to distinguish "core WP 7.0 defined this" from "our own polyfill defined this."

Result: `wp_has_native: true` is sent to the frontend on WP 6.9, which triggers the redirect notice instead of the connectors UI.

## Fix

Replace `function_exists()` with `version_compare( $wp_version, '7.0', '>=' )` in both locations. This directly checks the WP version rather than relying on a function namespace that the polyfill pollutes.

### Files changed

- **EDIT: `includes/Admin/UnifiedAdminMenu.php:34-36`** — `hasNativeConnectorsPage()` now uses `version_compare()` against `$wp_version`
- **EDIT: `includes/REST/ConnectorsController.php:160`** — `wp_has_native` now calls `self::has_native_connectors_page()` (new private static method using same version check)
- **EDIT: `tests/GratisAiAgent/Admin/UnifiedAdminMenuTest.php:170-173`** — Added explicit tests for WP 6.9 (returns false) and WP 7.0 (returns true) with `$wp_version` override

### Verification

- On WP 6.9: `hasNativeConnectorsPage()` returns `false` → Connectors menu item appears → `/connectors` route renders the full provider card UI
- On WP 7.0+: `hasNativeConnectorsPage()` returns `true` → Connectors menu item hidden → `/connectors` route shows redirect to `options-connectors.php`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.3.17 with glm-5.1 spent 1h 49m and 2,880,767 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved WordPress 7.0 native connector availability detection by implementing version-based comparison instead of function existence checks, providing more reliable detection when polyfills are present.

* **Tests**
  * Added unit tests validating native connector availability detection behavior across WordPress versions 6.9 and 7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->