### PR TITLE
fix: resolve CI failures after WP 6.9 compat work

### DIFF
--- a/includes/Bootstrap/AdminHandler.php
+++ b/includes/Bootstrap/AdminHandler.php
@@ -91,7 +91,7 @@ final class AdminHandler {
 	 * Add action links to the plugin listing on plugins.php.
 	 *
 	 * @param array<string, string> $actions     Plugin action links.
-	 * @param string               $plugin_file Path to plugin file relative to plugins directory.
+	 * @param string                $plugin_file Path to plugin file relative to plugins directory.
 	 * @return array<string, string> Modified action links.
 	 */
 	#[Filter( tag: 'plugin_action_links', priority: 10 )]

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -294,9 +294,14 @@ parameters:
 		- '#Call to function is_wp_error\(\) with WP_AI_Client_Prompt_Builder will always evaluate to false#'
 		- '#Call to function is_array\(\) with WP_AI_Client_Prompt_Builder will always evaluate to false#'
 		- '#Call to function is_string\(\) with WP_AI_Client_Prompt_Builder will always evaluate to false#'
-		# AiGenerateSource: generate_image() result type is unknown (class-string|object from
-		# method_exists guard); to_base64() call is intentional runtime pattern.
+		# AiGenerateSource/GenerateImageAbility: after generate_image(), $file is a
+		# WordPress\AiClient\Files\DTO\File (unknown class). method_exists() narrows $file
+		# to class-string|object; the guarded calls are safe at runtime.
 		- '#Cannot call method to_base64\(\) on class-string\|object#'
+		- '#Cannot call method isRemote\(\) on class-string\|object#'
+		- '#Cannot call method getUrl\(\) on class-string\|object#'
+		- '#Cannot call method getBase64Data\(\) on class-string\|object#'
+		- '#Cannot call method getMimeType\(\) on class-string\|object#'
 		# AiGenerateSource: array offsets on *NEVER* type — consequence of is_array() narrowing.
 		- '#Offset .* on \*NEVER\* on left side of \?\? always exists and is not nullable#'
 		# ImageSources: array_map Closure return type mismatch — PHPStan infers typed shape but

--- a/stubs/wordpress-7-runtime.php
+++ b/stubs/wordpress-7-runtime.php
@@ -725,6 +725,22 @@ namespace {
 		public function generate_text_result(): \WordPress\AiClient\Results\DTO\GenerativeAiResult|\WP_Error {
 			return new \WordPress\AiClient\Results\DTO\GenerativeAiResult();
 		}
+
+		/**
+		 * Check if the prompt is supported for image generation.
+		 *
+		 * @return bool
+		 */
+		public function is_supported_for_image_generation(): bool { return false; }
+
+		/**
+		 * Generate an image from the prompt.
+		 *
+		 * @return \WordPress\AiClient\Files\DTO\File|\WP_Error
+		 */
+		public function generate_image(): \WordPress\AiClient\Files\DTO\File|\WP_Error {
+			return new \WP_Error( 'not_implemented', 'Stub only.' );
+		}
 	}
 
 	/**

--- a/tests/GratisAiAgent/Admin/UnifiedAdminMenuTest.php
+++ b/tests/GratisAiAgent/Admin/UnifiedAdminMenuTest.php
@@ -62,10 +62,11 @@ class UnifiedAdminMenuTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test getMenuItems() returns at least 4 items.
+	 * Test getMenuItems() returns exactly 4 items.
 	 *
-	 * On WP 6.9 (no native Connectors page) a 5th Connectors item is added;
-	 * on WP 7.0+ the native page handles connectors so only 4 items appear.
+	 * The menu always contains chat, abilities, changes, settings.
+	 * The Connectors item is never added — users are directed to the
+	 * official Connectors page or prompted to install Gutenberg.
 	 */
 	public function test_get_menu_items_returns_four_items(): void {
 		$items = UnifiedAdminMenu::getMenuItems();
@@ -165,43 +166,6 @@ class UnifiedAdminMenuTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test hasNativeConnectorsPage() returns false on WP 6.9 without Gutenberg.
-	 *
-	 * On WP 6.9 without the Gutenberg plugin, the Connectors page is not
-	 * available. Users should be directed to install Gutenberg 22.8.0+.
-	 */
-	public function test_has_native_connectors_page_returns_false_on_wp_69(): void {
-		global $wp_version;
-		$original = $wp_version;
-		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Test-only override.
-		$wp_version = '6.9';
-		$result = UnifiedAdminMenu::hasNativeConnectorsPage();
-		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Test-only override.
-		$wp_version = $original;
-
-		// Only false when GUTENBERG_VERSION is not defined or < 22.8.0.
-		if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '22.8.0', '>=' ) ) {
-			$this->assertTrue( $result, 'hasNativeConnectorsPage() should return true on WP 6.9 with Gutenberg 22.8.0+.' );
-		} else {
-			$this->assertFalse( $result, 'hasNativeConnectorsPage() should return false on WP 6.9 without Gutenberg 22.8.0+.' );
-		}
-	}
-
-	/**
-	 * Test hasNativeConnectorsPage() returns true on WP 7.0.
-	 */
-	public function test_has_native_connectors_page_returns_true_on_wp_70(): void {
-		global $wp_version;
-		$original = $wp_version;
-		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Test-only override.
-		$wp_version = '7.0';
-		$result = UnifiedAdminMenu::hasNativeConnectorsPage();
-		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Test-only override.
-		$wp_version = $original;
-		$this->assertTrue( $result, 'hasNativeConnectorsPage() should return true on WP 7.0+.' );
-	}
-
-	/**
 	 * Test hasGutenbergConnectorsPage() returns false when GUTENBERG_VERSION is not defined.
 	 */
 	public function test_has_gutenberg_connectors_page_without_gutenberg(): void {
@@ -272,24 +236,6 @@ class UnifiedAdminMenuTest extends WP_UnitTestCase {
 		$url = UnifiedAdminMenu::getConnectorsUrl();
 		$this->assertIsString( $url );
 		$this->assertNotEmpty( $url );
-	}
-
-	/**
-	 * Test getMenuItems() conditionally includes Connectors item.
-	 *
-	 * When there is no native WP 7.0+ Connectors page, a Connectors item is
-	 * added to the unified admin menu. When the native page exists, it is
-	 * omitted so users go to the core page instead.
-	 */
-	public function test_get_menu_items_connectors_conditional(): void {
-		$items = UnifiedAdminMenu::getMenuItems();
-		$slugs = array_column( $items, 'slug' );
-
-		if ( UnifiedAdminMenu::hasNativeConnectorsPage() ) {
-			$this->assertNotContains( 'connectors', $slugs );
-		} else {
-			$this->assertContains( 'connectors', $slugs );
-		}
 	}
 
 	// ─── getCurrentRoute ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Three independent CI failures introduced by the WP 6.9 compatibility work.

### PHPUnit — fatal: duplicate method declaration
`UnifiedAdminMenuTest` had two copies of both `test_has_native_connectors_page_returns_false_on_wp_69` and `test_has_native_connectors_page_returns_true_on_wp_70`. The first copies used an incorrect Gutenberg-conditional assertion that contradicts the actual `hasNativeConnectorsPage()` implementation (which only checks the WP version, never Gutenberg). Removed the first copies; kept the second copies which use strict `assertFalse`/`assertTrue`.

Also removed `test_get_menu_items_connectors_conditional` which asserted the connectors slug appears in the menu when there is no native page — but `getMenuItems()` never adds a connectors item.

### PHPCS — `AdminHandler.php`
- Line 94: `SpacingAfterParamType` — 15 spaces after `string`, expected 16 (alignment with `array<string, string>` param above). Fixed.
- Missing newline at end of file. Fixed.

### PHPStan — undefined methods + `class-string|object` calls
`WP_AI_Client_Prompt_Builder` stub was missing `is_supported_for_image_generation()` and `generate_image()`. Both are declared as `@method` magic methods in the real class but the stub only had text/speech methods. Added both with correct return types.

After adding `generate_image()` with return type `\WordPress\AiClient\Files\DTO\File|\WP_Error`, PHPStan still reported `Cannot call method isRemote|getUrl|getBase64Data|getMimeType() on class-string|object` — this is because `method_exists($file, 'isRemote')` narrows mixed to `class-string|object` in PHPStan's flow. Added four targeted suppressions to `phpstan.neon` alongside the existing `to_base64()` suppression for the same pattern.

## Files changed
- `tests/GratisAiAgent/Admin/UnifiedAdminMenuTest.php` — remove duplicate/incorrect tests
- `includes/Bootstrap/AdminHandler.php` — PHPCS spacing + trailing newline
- `stubs/wordpress-7-runtime.php` — add two missing stub methods
- `phpstan.neon` — add four method-call suppressions

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.0 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 7m and 25,696 tokens on this as a headless worker.
