### PR TITLE
fix: resolve PHPUnit duplicate methods and Playwright selectors for widget redesign

### DIFF
--- a/tests/GratisAiAgent/Admin/UnifiedAdminMenuTest.php
+++ b/tests/GratisAiAgent/Admin/UnifiedAdminMenuTest.php
@@ -165,43 +165,6 @@ class UnifiedAdminMenuTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test hasNativeConnectorsPage() returns false on WP 6.9 without Gutenberg.
-	 *
-	 * On WP 6.9 without the Gutenberg plugin, the Connectors page is not
-	 * available. Users should be directed to install Gutenberg 22.8.0+.
-	 */
-	public function test_has_native_connectors_page_returns_false_on_wp_69(): void {
-		global $wp_version;
-		$original = $wp_version;
-		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Test-only override.
-		$wp_version = '6.9';
-		$result = UnifiedAdminMenu::hasNativeConnectorsPage();
-		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Test-only override.
-		$wp_version = $original;
-
-		// Only false when GUTENBERG_VERSION is not defined or < 22.8.0.
-		if ( defined( 'GUTENBERG_VERSION' ) && version_compare( GUTENBERG_VERSION, '22.8.0', '>=' ) ) {
-			$this->assertTrue( $result, 'hasNativeConnectorsPage() should return true on WP 6.9 with Gutenberg 22.8.0+.' );
-		} else {
-			$this->assertFalse( $result, 'hasNativeConnectorsPage() should return false on WP 6.9 without Gutenberg 22.8.0+.' );
-		}
-	}
-
-	/**
-	 * Test hasNativeConnectorsPage() returns true on WP 7.0.
-	 */
-	public function test_has_native_connectors_page_returns_true_on_wp_70(): void {
-		global $wp_version;
-		$original = $wp_version;
-		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Test-only override.
-		$wp_version = '7.0';
-		$result = UnifiedAdminMenu::hasNativeConnectorsPage();
-		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Test-only override.
-		$wp_version = $original;
-		$this->assertTrue( $result, 'hasNativeConnectorsPage() should return true on WP 7.0+.' );
-	}
-
-	/**
 	 * Test hasGutenbergConnectorsPage() returns false when GUTENBERG_VERSION is not defined.
 	 */
 	public function test_has_gutenberg_connectors_page_without_gutenberg(): void {
@@ -212,13 +175,17 @@ class UnifiedAdminMenuTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test getConnectorsUrl() always returns the official Connectors page URL.
+	 * Test getConnectorsUrl() always returns a Connectors page URL.
+	 *
+	 * On WP 7.0+ the URL is options-connectors.php; on WP 6.9 it points to the
+	 * polyfill at options-general.php?page=options-connectors-wp-admin. Both
+	 * contain 'options-connectors'.
 	 */
 	public function test_get_connectors_url_returns_official_url(): void {
 		$url = UnifiedAdminMenu::getConnectorsUrl();
 		$this->assertIsString( $url );
 		$this->assertNotEmpty( $url );
-		$this->assertStringContainsString( 'options-connectors-wp-admin', $url );
+		$this->assertStringContainsString( 'options-connectors', $url );
 	}
 
 	/**
@@ -275,21 +242,17 @@ class UnifiedAdminMenuTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test getMenuItems() conditionally includes Connectors item.
+	 * Test getMenuItems() never includes a Connectors item regardless of WP version.
 	 *
-	 * When there is no native WP 7.0+ Connectors page, a Connectors item is
-	 * added to the unified admin menu. When the native page exists, it is
-	 * omitted so users go to the core page instead.
+	 * The polyfill Connectors menu item was removed. Users are directed to the
+	 * official WP 7.0+ page or prompted to install Gutenberg — no menu item is
+	 * added for either case.
 	 */
 	public function test_get_menu_items_connectors_conditional(): void {
 		$items = UnifiedAdminMenu::getMenuItems();
 		$slugs = array_column( $items, 'slug' );
 
-		if ( UnifiedAdminMenu::hasNativeConnectorsPage() ) {
-			$this->assertNotContains( 'connectors', $slugs );
-		} else {
-			$this->assertContains( 'connectors', $slugs );
-		}
+		$this->assertNotContains( 'connectors', $slugs );
 	}
 
 	// ─── getCurrentRoute ──────────────────────────────────────────────────────

--- a/tests/e2e/automations.spec.js
+++ b/tests/e2e/automations.spec.js
@@ -1230,11 +1230,11 @@ test.describe( 'Proactive Alert Badge on FAB', () => {
 
 		await goToAdminDashboard( page );
 
-		const fab = page.locator( '.gratis-ai-agent-fab' );
+		const fab = page.locator( '.gaa-w-launcher' );
 		await expect( fab ).toBeVisible();
 
 		// Badge should not be present when count is 0.
-		const badge = fab.locator( '.gratis-ai-agent-fab-badge' );
+		const badge = fab.locator( '.gaa-w-launcher-badge' );
 		await expect( badge ).toHaveCount( 0 );
 	} );
 
@@ -1252,11 +1252,11 @@ test.describe( 'Proactive Alert Badge on FAB', () => {
 
 		await goToAdminDashboard( page );
 
-		const fab = page.locator( '.gratis-ai-agent-fab' );
+		const fab = page.locator( '.gaa-w-launcher' );
 		await expect( fab ).toBeVisible();
 
 		// Badge should appear with the count.
-		const badge = fab.locator( '.gratis-ai-agent-fab-badge' );
+		const badge = fab.locator( '.gaa-w-launcher-badge' );
 		await expect( badge ).toBeVisible( { timeout: 10_000 } );
 		await expect( badge ).toContainText( '3' );
 	} );
@@ -1278,7 +1278,7 @@ test.describe( 'Proactive Alert Badge on FAB', () => {
 
 		// Use 20 s — the badge appears after fetchAlerts() resolves, which can
 		// take longer than 10 s on CI runners under load with 3 parallel workers.
-		const badge = page.locator( '.gratis-ai-agent-fab-badge' );
+		const badge = page.locator( '.gaa-w-launcher-badge' );
 		await expect( badge ).toBeVisible( { timeout: 20_000 } );
 		await expect( badge ).toContainText( '9+' );
 	} );
@@ -1292,7 +1292,7 @@ test.describe( 'Proactive Alert Badge on FAB', () => {
 
 		await goToAdminDashboard( page );
 
-		const badge = page.locator( '.gratis-ai-agent-fab-badge' );
+		const badge = page.locator( '.gaa-w-launcher-badge' );
 		await expect( badge ).toBeVisible( { timeout: 10_000 } );
 
 		// aria-label should include the count for screen readers.

--- a/tests/e2e/client-abilities.spec.js
+++ b/tests/e2e/client-abilities.spec.js
@@ -54,10 +54,11 @@ const { loginToWordPress } = require( './utils/wp-admin' );
 async function goToDashboard( page ) {
 	await page.goto( '/wp-admin/index.php' );
 	await page.waitForLoadState( 'domcontentloaded' );
-	// Wait for the FAB button — it renders once React has mounted and the
+	// Wait for the launcher button — it renders once React has mounted and the
 	// floating-widget bundle has executed (triggering ensureRegistered()).
+	// The redesign (#1157) renamed .gratis-ai-agent-fab to .gaa-w-launcher.
 	await page
-		.locator( '.gratis-ai-agent-fab' )
+		.locator( '.gaa-w-launcher' )
 		.waitFor( { state: 'visible', timeout: 30_000 } );
 }
 

--- a/tests/e2e/floating-widget.spec.js
+++ b/tests/e2e/floating-widget.spec.js
@@ -1,8 +1,15 @@
 /**
  * E2E tests for the Gratis AI Agent floating widget.
  *
- * Tests the FAB button and floating panel that appear on all admin pages.
+ * Tests the launcher button and floating panel that appear on all admin pages.
  * Requires a running wp-env environment with the plugin active.
+ *
+ * The chat widget was redesigned in #1157. Class names changed:
+ *   .gratis-ai-agent-fab         → .gaa-w-launcher  (WidgetLauncher)
+ *   .gratis-ai-agent-floating-panel → .gaa-w-panel  (WidgetPanel)
+ *   .gratis-ai-agent-chat-panel  → .gaa-w-body-wrap (panel body area)
+ *   .gratis-ai-agent-input       → .gaa-w-input-textarea
+ *   .gratis-ai-agent-send-btn    → .gaa-cr-send-btn
  *
  * Run: npm run test:e2e:playwright
  */
@@ -30,7 +37,8 @@ test.describe( 'Floating Widget', () => {
 		const fab = getFloatingButton( page );
 		const panel = getFloatingPanel( page );
 
-		// Panel should not be visible initially.
+		// Panel should not be visible initially (ChatWidget renders launcher OR
+		// panel, never both — so the panel element is absent from the DOM).
 		await expect( panel ).not.toBeVisible();
 
 		await fab.click();
@@ -43,12 +51,14 @@ test.describe( 'Floating Widget', () => {
 		await fab.click();
 
 		const panel = getFloatingPanel( page );
-		// Scope to the floating panel to avoid strict-mode violations when
-		// screen-meta also renders a chat panel on the same page.
-		const chatPanel = panel.locator( '.gratis-ai-agent-chat-panel' );
-		await expect( chatPanel ).toBeVisible();
+		// The redesigned widget panel body is .gaa-w-body-wrap (WidgetPanel,
+		// widget-panel.js). It contains WidgetEmpty or WidgetMessageList.
+		const bodyWrap = panel.locator( '.gaa-w-body-wrap' );
+		await expect( bodyWrap ).toBeVisible();
 
-		const input = panel.locator( '.gratis-ai-agent-input' );
+		// The input area is always present when the panel is open.
+		// .gaa-w-input-textarea is the textarea inside WidgetInput.
+		const input = panel.locator( '.gaa-w-input-textarea' );
 		await expect( input ).toBeVisible();
 	} );
 
@@ -65,7 +75,7 @@ test.describe( 'Floating Widget', () => {
 
 		await expect( panel ).not.toBeVisible();
 
-		// FAB should reappear.
+		// Launcher should reappear after closing.
 		await expect( fab ).toBeVisible();
 	} );
 
@@ -82,9 +92,10 @@ test.describe( 'Floating Widget', () => {
 		// Panel element stays in DOM but body is hidden (is-minimized class).
 		await expect( panel ).toHaveClass( /is-minimized/ );
 
-		// Chat panel body should not be visible.
-		const chatPanel = panel.locator( '.gratis-ai-agent-chat-panel' );
-		await expect( chatPanel ).not.toBeVisible();
+		// Body wrap is conditionally rendered: { !isMinimized && <div.gaa-w-body-wrap> }
+		// so when minimized it is removed from the DOM entirely.
+		const bodyWrap = panel.locator( '.gaa-w-body-wrap' );
+		await expect( bodyWrap ).not.toBeVisible();
 	} );
 
 	test( 'expand button restores minimized panel', async ( { page } ) => {
@@ -105,8 +116,9 @@ test.describe( 'Floating Widget', () => {
 
 		await expect( panel ).not.toHaveClass( /is-minimized/ );
 
-		const chatPanel = panel.locator( '.gratis-ai-agent-chat-panel' );
-		await expect( chatPanel ).toBeVisible();
+		// Body wrap should be visible again after expanding.
+		const bodyWrap = panel.locator( '.gaa-w-body-wrap' );
+		await expect( bodyWrap ).toBeVisible();
 	} );
 
 	// All tests below scope locators to the floating panel to avoid
@@ -117,7 +129,8 @@ test.describe( 'Floating Widget', () => {
 		await fab.click();
 
 		const panel = getFloatingPanel( page );
-		const input = panel.locator( '.gratis-ai-agent-input' );
+		// .gaa-w-input-textarea is the textarea in WidgetInput (widget-input.js).
+		const input = panel.locator( '.gaa-w-input-textarea' );
 		await input.fill( 'Hello, AI Agent!' );
 
 		await expect( input ).toHaveValue( 'Hello, AI Agent!' );
@@ -128,8 +141,10 @@ test.describe( 'Floating Widget', () => {
 		await fab.click();
 
 		const panel = getFloatingPanel( page );
-		const input = panel.locator( '.gratis-ai-agent-input' );
-		const sendButton = panel.locator( '.gratis-ai-agent-send-btn' );
+		// .gaa-w-input-textarea is the textarea in WidgetInput.
+		const input = panel.locator( '.gaa-w-input-textarea' );
+		// .gaa-cr-send-btn is the send button in WidgetInput (widget-input.js).
+		const sendButton = panel.locator( '.gaa-cr-send-btn' );
 
 		// Send button should be disabled (or absent) when input is empty.
 		await expect( sendButton ).toBeDisabled();
@@ -145,41 +160,12 @@ test.describe( 'Floating Widget', () => {
 		await fab.click();
 
 		const panel = getFloatingPanel( page );
-		const input = panel.locator( '.gratis-ai-agent-input' );
+		// .gaa-w-input-textarea is the textarea in WidgetInput.
+		const input = panel.locator( '.gaa-w-input-textarea' );
 		await input.fill( 'Test message via Enter' );
 		await input.press( 'Enter' );
 
 		// Input should be cleared after submission.
 		await expect( input ).toHaveValue( '' );
-	} );
-
-	test( 'slash command menu appears when typing /', async ( { page } ) => {
-		const fab = getFloatingButton( page );
-		await fab.click();
-
-		const panel = getFloatingPanel( page );
-		const input = panel.locator( '.gratis-ai-agent-input' );
-		await input.fill( '/' );
-
-		// Slash command menu should appear.
-		const slashMenu = panel.locator( '.gratis-ai-agent-slash-menu' );
-		await expect( slashMenu ).toBeVisible();
-	} );
-
-	test( 'slash command menu disappears when typing a space', async ( {
-		page,
-	} ) => {
-		const fab = getFloatingButton( page );
-		await fab.click();
-
-		const panel = getFloatingPanel( page );
-		const input = panel.locator( '.gratis-ai-agent-input' );
-		await input.fill( '/' );
-
-		const slashMenu = panel.locator( '.gratis-ai-agent-slash-menu' );
-		await expect( slashMenu ).toBeVisible();
-
-		await input.fill( '/remember something' );
-		await expect( slashMenu ).not.toBeVisible();
 	} );
 } );

--- a/tests/e2e/utils/wp-admin.js
+++ b/tests/e2e/utils/wp-admin.js
@@ -124,34 +124,41 @@ async function goToAgentPage( page ) {
 async function goToAdminDashboard( page ) {
 	await page.goto( '/wp-admin/index.php' );
 	await page.waitForLoadState( 'networkidle' );
-	// Wait for the floating widget React app to mount and render the FAB.
-	// The FAB renders after FloatingWidget mounts and fetchSettings() resolves.
-	// Without this wait, tests that immediately call fab.click() can time out
-	// when the CI runner is under load.
+	// Wait for the floating widget React app to mount and render the launcher.
+	// The launcher (FAB) renders after FloatingWidget mounts and fetchSettings()
+	// resolves. Without this wait, tests that immediately click the launcher can
+	// time out when the CI runner is under load.
+	// The redesign (#1157) renamed .gratis-ai-agent-fab to .gaa-w-launcher.
 	await page
-		.locator( '.gratis-ai-agent-fab' )
+		.locator( '.gaa-w-launcher' )
 		.waitFor( { state: 'visible', timeout: 15_000 } )
-		.catch( () => {} ); // Non-fatal: some tests may not need the FAB.
+		.catch( () => {} ); // Non-fatal: some tests may not need the launcher.
 }
 
 /**
- * Wait for the floating action button to be visible.
+ * Wait for the floating action button (launcher) to be visible.
+ *
+ * The redesign (#1157) replaced the legacy .gratis-ai-agent-fab class with
+ * .gaa-w-launcher in the new WidgetLauncher component.
  *
  * @param {import('@playwright/test').Page} page - Playwright page object.
- * @return {import('@playwright/test').Locator} The FAB locator.
+ * @return {import('@playwright/test').Locator} The launcher locator.
  */
 function getFloatingButton( page ) {
-	return page.locator( '.gratis-ai-agent-fab' );
+	return page.locator( '.gaa-w-launcher' );
 }
 
 /**
- * Wait for the floating panel to be visible.
+ * Get the floating widget panel.
+ *
+ * The redesign (#1157) replaced the legacy .gratis-ai-agent-floating-panel
+ * class with .gaa-w-panel in the new WidgetPanel component.
  *
  * @param {import('@playwright/test').Page} page - Playwright page object.
  * @return {import('@playwright/test').Locator} The floating panel locator.
  */
 function getFloatingPanel( page ) {
-	return page.locator( '.gratis-ai-agent-floating-panel' );
+	return page.locator( '.gaa-w-panel' );
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the systemic CI failures introduced by the chat widget redesign (#1157) and the Connectors menu item removal (#1151/#1152).

Resolves #1158

## PHPUnit failures

**Root cause:** `UnifiedAdminMenuTest.php` had two duplicate method names, causing a PHP fatal error (cannot redeclare method):
- `test_has_native_connectors_page_returns_false_on_wp_69` (lines 173 and 243)
- `test_has_native_connectors_page_returns_true_on_wp_70` (lines 193 and 257)

**Fix:**
- Removed the older (stale) first copy of each duplicate. The stale version checked `GUTENBERG_VERSION` -- but `hasNativeConnectorsPage()` in production only uses `version_compare($wp_version, '7.0-alpha1')`, never `GUTENBERG_VERSION`.
- Fixed `test_get_connectors_url_returns_official_url`: the assertion `assertStringContainsString('options-connectors-wp-admin', $url)` only passes on WP 6.9. On WP trunk (the CI target) the URL is `options-connectors.php`. Changed to assert `'options-connectors'` which is present in both.
- Fixed `test_get_menu_items_connectors_conditional`: was asserting connectors IS in the menu on WP 6.9, but `getMenuItems()` never adds it (the polyfill item was removed). Now always asserts it is absent.

## Playwright E2E failures

**Root cause:** The chat widget redesign (#1157) renamed CSS classes throughout `WidgetLauncher`, `WidgetPanel`, and `WidgetInput`. The E2E test files still used the old class names.

**Class name changes (old to new):**

- `.gratis-ai-agent-fab` to `.gaa-w-launcher` (WidgetLauncher)
- `.gratis-ai-agent-floating-panel` to `.gaa-w-panel` (WidgetPanel)
- `.gratis-ai-agent-chat-panel` inside panel to `.gaa-w-body-wrap` (panel body)
- `.gratis-ai-agent-input` to `.gaa-w-input-textarea` (WidgetInput)
- `.gratis-ai-agent-send-btn` to `.gaa-cr-send-btn` (WidgetInput)
- `.gratis-ai-agent-fab-badge` to `.gaa-w-launcher-badge` (WidgetLauncher)

**Files updated:**
- `tests/e2e/utils/wp-admin.js` -- `goToAdminDashboard`, `getFloatingButton`, `getFloatingPanel`
- `tests/e2e/floating-widget.spec.js` -- all selectors; also removed slash-command tests since `WidgetInput` no longer has `SlashCommandMenu`
- `tests/e2e/automations.spec.js` -- FAB/badge selectors in proactive alert tests
- `tests/e2e/client-abilities.spec.js` -- `goToDashboard` FAB wait

## Verification

- PHP syntax: no errors
- PHP: 25 unique test methods, zero duplicates
- JS: no remaining old functional selectors (comments only)

<!-- aidevops:sig -->
---
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.0 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 11m and 35,958 tokens on this as a headless worker.