### PR TITLE
remove Feedback Reports section from settings

### DIFF
--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -51,13 +51,6 @@ class Settings {
 	const GSC_CREDENTIALS_OPTION = 'gratis_ai_agent_gsc_credentials';
 
 	/**
-	 * Option name for the feedback-report receiver API key.
-	 * Stored separately from general settings to avoid leaking the credential
-	 * through the GET /settings endpoint.
-	 */
-	const FEEDBACK_API_KEY_OPTION = 'gratis_ai_agent_feedback_api_key';
-
-	/**
 	 * Supported direct providers with their metadata.
 	 */
 	/**
@@ -322,9 +315,6 @@ class Settings {
 			// Provider trace / debug mode (GH#830).
 			'provider_trace_enabled'   => false,
 			'provider_trace_max_rows'  => 200,
-			// Feedback report receiver settings (t180).
-			'feedback_enabled'         => false,
-			'feedback_endpoint_url'    => 'https://ultimateagentwp.ai/wp-json/gratis-ai-server/v1/reports',
 			// Skill auto-update settings (t218).
 			'skill_auto_update'        => true,
 			'skill_manifest_url'       => '',
@@ -540,44 +530,6 @@ class Settings {
 		$merged = array_merge( $current, $data );
 
 		return update_option( self::OPTION_NAME, $merged );
-	}
-
-	/**
-	 * Get the stored feedback-report receiver API key.
-	 *
-	 * The key is intentionally stored in a dedicated option so it is never
-	 * returned by GET /settings and cannot leak through the JSON response.
-	 *
-	 * @return string Empty string when not configured.
-	 */
-	public function get_feedback_api_key(): string {
-		$key = get_option( self::FEEDBACK_API_KEY_OPTION, '' );
-		return is_string( $key ) ? $key : '';
-	}
-
-	/**
-	 * Persist the feedback-report receiver API key.
-	 *
-	 * Pass an empty string to clear the credential.
-	 *
-	 * @param string $api_key The API key value.
-	 * @return bool True on success.
-	 */
-	public function set_feedback_api_key( string $api_key ): bool {
-		if ( '' === $api_key ) {
-			return delete_option( self::FEEDBACK_API_KEY_OPTION );
-		}
-
-		return update_option( self::FEEDBACK_API_KEY_OPTION, $api_key );
-	}
-
-	/**
-	 * Check whether a feedback-report receiver API key is configured.
-	 *
-	 * @return bool
-	 */
-	public function has_feedback_api_key(): bool {
-		return '' !== $this->get_feedback_api_key();
 	}
 
 	// ── WooCommerce ability auto-enable ───────────────────────────────────────

--- a/includes/Feedback/ReportSender.php
+++ b/includes/Feedback/ReportSender.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 /**
  * Feedback report HTTP sender.
  *
- * Forwards the sanitized payload to the configured feedback endpoint using
+ * Forwards the sanitized payload to the hardcoded feedback endpoint using
  * wp_remote_post(). Errors are returned as WP_Error objects; callers should
  * not crash on send failures (a broken feedback channel must never interrupt
  * normal plugin operation).
+ *
+ * The endpoint is fixed — no API key is required. User consent is collected
+ * per submission via the feedback-consent modal before this method is called.
  *
  * @package GratisAiAgent\Feedback
  * @license GPL-2.0-or-later
@@ -15,59 +18,33 @@ declare(strict_types=1);
 
 namespace GratisAiAgent\Feedback;
 
-use GratisAiAgent\Core\Settings;
 use WP_Error;
 
 class ReportSender {
 
 	/**
-	 * Send a sanitized report payload to the configured feedback endpoint.
+	 * Hardcoded feedback endpoint URL.
 	 *
-	 * @param array<string, mixed> $payload    Sanitized payload from ReportSanitizer::sanitize().
-	 * @param bool                 $force_send Bypass the enabled check. Set to true for manual user submissions
-	 *                                     from the feedback form; false for automatic background reporting.
+	 * Reports are always sent here. No configuration or API key is required.
+	 */
+	const ENDPOINT_URL = 'https://ultimateagentwp.ai/wp-json/gratis-ai-server/v1/reports';
+
+	/**
+	 * Send a sanitized report payload to the feedback endpoint.
+	 *
+	 * @param array<string, mixed> $payload Sanitized payload from ReportSanitizer::sanitize().
 	 * @return true|WP_Error True on success (2xx response), WP_Error on failure.
 	 */
-	public static function send( array $payload, bool $force_send = false ): true|WP_Error {
-		$endpoint_url = (string) ( Settings::instance()->get( 'feedback_endpoint_url' ) ?? '' );
-
-		// Skip enabled check when $force_send is true (manual form submissions).
-		// The setting only controls automatic/batch feedback reporting.
-		if ( ! $force_send ) {
-			$enabled = (bool) ( Settings::instance()->get( 'feedback_enabled' ) ?? false );
-
-			if ( ! $enabled ) {
-				return new WP_Error( 'feedback_disabled', 'Feedback reporting is not enabled in Settings.' );
-			}
-		}
-
-		if ( '' === $endpoint_url ) {
-			return new WP_Error( 'feedback_no_endpoint', 'No feedback endpoint URL configured.' );
-		}
-
-		if ( ! filter_var( $endpoint_url, FILTER_VALIDATE_URL ) ) {
-			return new WP_Error( 'feedback_invalid_url', 'Configured feedback endpoint URL is not valid.' );
-		}
-
-		$api_key = Settings::instance()->get_feedback_api_key();
-
-		$headers = array(
-			'Content-Type' => 'application/json',
-		);
-
-		if ( '' !== $api_key ) {
-			$headers['X-Feedback-Api-Key'] = $api_key;
-		}
-
+	public static function send( array $payload ): true|WP_Error {
 		$body = wp_json_encode( $payload );
 		if ( false === $body ) {
 			return new WP_Error( 'feedback_encode_error', 'Failed to JSON-encode the report payload.' );
 		}
 
 		$response = wp_remote_post(
-			$endpoint_url,
+			self::ENDPOINT_URL,
 			array(
-				'headers' => $headers,
+				'headers' => array( 'Content-Type' => 'application/json' ),
 				'body'    => $body,
 				'timeout' => 15,
 			)

--- a/includes/REST/FeedbackController.php
+++ b/includes/REST/FeedbackController.php
@@ -149,20 +149,13 @@ final class FeedbackController extends XWP_REST_Controller {
 		}
 
 		$sanitized = ReportSanitizer::sanitize( $payload );
-		$result    = ReportSender::send( $sanitized, true ); // Force send for manual user submissions.
+		$result    = ReportSender::send( $sanitized );
 
 		if ( is_wp_error( $result ) ) {
-			$http_status = 500;
-			$error_code  = $result->get_error_code();
-
-			if ( in_array( $error_code, array( 'feedback_disabled', 'feedback_no_endpoint', 'feedback_invalid_url' ), true ) ) {
-				$http_status = 422;
-			}
-
 			return new WP_Error(
-				$error_code,
+				$result->get_error_code(),
 				$result->get_error_message(),
-				array( 'status' => $http_status )
+				array( 'status' => 500 )
 			);
 		}
 

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -284,31 +284,6 @@ final class SettingsController {
 			)
 		);
 
-		// Feedback receiver API key endpoint (t180).
-		register_rest_route(
-			RestController::NAMESPACE,
-			'/settings/feedback-api-key',
-			array(
-				array(
-					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $this, 'handle_set_feedback_api_key' ),
-					'permission_callback' => array( __CLASS__, 'check_admin_permission' ),
-					'args'                => array(
-						'api_key' => array(
-							'required'          => true,
-							'type'              => 'string',
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-					),
-				),
-				array(
-					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( $this, 'handle_delete_feedback_api_key' ),
-					'permission_callback' => array( __CLASS__, 'check_admin_permission' ),
-				),
-			)
-		);
-
 		// Google Analytics credentials endpoint.
 		register_rest_route(
 			RestController::NAMESPACE,
@@ -381,31 +356,6 @@ final class SettingsController {
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
 					'callback'            => array( __CLASS__, 'handle_delete_brave_search_key' ),
-					'permission_callback' => array( __CLASS__, 'check_admin_permission' ),
-				),
-			)
-		);
-
-		// Feedback receiver API key endpoint (t180).
-		register_rest_route(
-			RestController::NAMESPACE,
-			'/settings/feedback-api-key',
-			array(
-				array(
-					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( __CLASS__, 'handle_set_feedback_api_key' ),
-					'permission_callback' => array( __CLASS__, 'check_admin_permission' ),
-					'args'                => array(
-						'api_key' => array(
-							'required'          => true,
-							'type'              => 'string',
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-					),
-				),
-				array(
-					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( __CLASS__, 'handle_delete_feedback_api_key' ),
 					'permission_callback' => array( __CLASS__, 'check_admin_permission' ),
 				),
 			)
@@ -488,10 +438,6 @@ final class SettingsController {
 		// Indicate whether a Brave Search API key is configured (boolean only, no key value).
 		// @phpstan-ignore-next-line
 		$settings['_brave_search_key_configured'] = '' !== InternetSearchAbilities::get_brave_api_key();
-
-		// Indicate whether a feedback-report receiver API key is configured (boolean only, no key value — t180).
-		// @phpstan-ignore-next-line
-		$settings['_feedback_api_key_configured'] = $this->settings->has_feedback_api_key();
 
 		return new WP_REST_Response( $settings, 200 );
 	}
@@ -1001,55 +947,6 @@ final class SettingsController {
 	 */
 	public function handle_delete_brave_search_key( WP_REST_Request $request ): WP_REST_Response {
 		InternetSearchAbilities::set_brave_api_key( '' );
-
-		return new WP_REST_Response(
-			array(
-				'deleted'    => true,
-				'configured' => false,
-			),
-			200
-		);
-	}
-
-	/**
-	 * Handle POST /settings/feedback-api-key — save the feedback-report receiver API key (t180).
-	 *
-	 * The key is stored in a dedicated option (Settings::FEEDBACK_API_KEY_OPTION)
-	 * and is never returned through GET /settings — only a boolean presence flag
-	 * is exposed via the _feedback_api_key_configured field.
-	 *
-	 * @param WP_REST_Request $request The request object.
-	 */
-	public function handle_set_feedback_api_key( WP_REST_Request $request ): WP_REST_Response {
-		// @phpstan-ignore-next-line
-		$api_key = sanitize_text_field( (string) $request->get_param( 'api_key' ) );
-
-		if ( '' === $api_key ) {
-			return new WP_REST_Response( array( 'error' => 'api_key is required.' ), 400 );
-		}
-
-		$success = $this->settings->set_feedback_api_key( $api_key );
-
-		if ( ! $success ) {
-			return new WP_REST_Response( array( 'error' => 'Failed to save feedback API key.' ), 500 );
-		}
-
-		return new WP_REST_Response(
-			array(
-				'saved'      => true,
-				'configured' => true,
-			),
-			200
-		);
-	}
-
-	/**
-	 * Handle DELETE /settings/feedback-api-key — remove the feedback-report receiver API key (t180).
-	 *
-	 * @param WP_REST_Request $request The request object.
-	 */
-	public function handle_delete_feedback_api_key( WP_REST_Request $request ): WP_REST_Response {
-		$this->settings->set_feedback_api_key( '' );
 
 		return new WP_REST_Response(
 			array(

--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -107,13 +107,6 @@ export default function SettingsApp() {
 	const [ braveSaving, setBraveSaving ] = useState( false );
 	const [ braveNotice, setBraveNotice ] = useState( null );
 
-	// Feedback report receiver API key state (t180).
-	const [ feedbackApiKey, setFeedbackApiKey ] = useState( '' );
-	const [ feedbackApiKeyConfigured, setFeedbackApiKeyConfigured ] =
-		useState( false );
-	const [ feedbackApiKeySaving, setFeedbackApiKeySaving ] = useState( false );
-	const [ feedbackNotice, setFeedbackNotice ] = useState( null );
-
 	useEffect( () => {
 		fetchSettings();
 		fetchProviders();
@@ -130,14 +123,10 @@ export default function SettingsApp() {
 				}
 			} )
 			.catch( () => {} );
-		// Fetch Brave Search key status and feedback API key status from the
-		// general settings response.
+		// Fetch Brave Search key status from the general settings response.
 		apiFetch( { path: '/gratis-ai-agent/v1/settings' } )
 			.then( ( data ) => {
 				setBraveConfigured( !! data?._brave_search_key_configured );
-				setFeedbackApiKeyConfigured(
-					!! data?._feedback_api_key_configured
-				);
 			} )
 			.catch( () => {} );
 	}, [ fetchSettings, fetchProviders ] );
@@ -272,58 +261,6 @@ export default function SettingsApp() {
 			} );
 		}
 		setBraveSaving( false );
-	}, [] );
-
-	// Feedback report receiver API key handlers (t180).
-	const handleFeedbackApiKeySave = useCallback( async () => {
-		setFeedbackApiKeySaving( true );
-		setFeedbackNotice( null );
-		try {
-			await apiFetch( {
-				path: '/gratis-ai-agent/v1/settings/feedback-api-key',
-				method: 'POST',
-				data: { api_key: feedbackApiKey },
-			} );
-			setFeedbackApiKeyConfigured( true );
-			setFeedbackApiKey( '' ); // Clear the field after saving.
-			setFeedbackNotice( {
-				status: 'success',
-				message: __( 'Feedback API key saved.', 'gratis-ai-agent' ),
-			} );
-		} catch ( err ) {
-			setFeedbackNotice( {
-				status: 'error',
-				message:
-					err?.message ||
-					__( 'Failed to save feedback API key.', 'gratis-ai-agent' ),
-			} );
-		}
-		setFeedbackApiKeySaving( false );
-	}, [ feedbackApiKey ] );
-
-	const handleFeedbackApiKeyRemove = useCallback( async () => {
-		setFeedbackApiKeySaving( true );
-		setFeedbackNotice( null );
-		try {
-			await apiFetch( {
-				path: '/gratis-ai-agent/v1/settings/feedback-api-key',
-				method: 'DELETE',
-			} );
-			setFeedbackApiKeyConfigured( false );
-			setFeedbackNotice( {
-				status: 'success',
-				message: __( 'Feedback API key removed.', 'gratis-ai-agent' ),
-			} );
-		} catch {
-			setFeedbackNotice( {
-				status: 'error',
-				message: __(
-					'Failed to remove feedback API key.',
-					'gratis-ai-agent'
-				),
-			} );
-		}
-		setFeedbackApiKeySaving( false );
 	}, [] );
 
 	useEffect( () => {
@@ -2018,179 +1955,6 @@ export default function SettingsApp() {
 													onClick={ handleBraveClear }
 													isBusy={ braveSaving }
 													disabled={ braveSaving }
-												>
-													{ __(
-														'Remove Key',
-														'gratis-ai-agent'
-													) }
-												</Button>
-											) }
-										</div>
-
-										<h4 className="gratis-ai-agent-settings-subsection-title">
-											{ __(
-												'Feedback Reports',
-												'gratis-ai-agent'
-											) }
-										</h4>
-										<p className="description">
-											{ __(
-												'Configure where feedback reports (errors, thumbs-down, user-reported issues) are sent. The receiving endpoint is the gratis-ai-feedback plugin. Leave blank to disable report submission.',
-												'gratis-ai-agent'
-											) }
-										</p>
-										{ feedbackNotice && (
-											<Notice
-												status={ feedbackNotice.status }
-												isDismissible
-												onDismiss={ () =>
-													setFeedbackNotice( null )
-												}
-											>
-												{ feedbackNotice.message }
-											</Notice>
-										) }
-										<table className="form-table gratis-ai-agent-form-table">
-											<tbody>
-												<tr>
-													<th scope="row">
-														{ __(
-															'Enable Feedback Submission',
-															'gratis-ai-agent'
-														) }
-													</th>
-													<td>
-														<ToggleControl
-															label={ __(
-																'Send feedback reports to the configured endpoint',
-																'gratis-ai-agent'
-															) }
-															checked={
-																!! local.feedback_enabled
-															}
-															onChange={ ( v ) =>
-																updateField(
-																	'feedback_enabled',
-																	v
-																)
-															}
-															help={ __(
-																'When enabled, the plugin can send feedback reports (with user consent) to the endpoint URL below.',
-																'gratis-ai-agent'
-															) }
-															__nextHasNoMarginBottom
-														/>
-													</td>
-												</tr>
-												<tr>
-													<th scope="row">
-														<label htmlFor="gratis-feedback-endpoint-url">
-															{ __(
-																'Endpoint URL',
-																'gratis-ai-agent'
-															) }
-														</label>
-													</th>
-													<td>
-														<TextControl
-															id="gratis-feedback-endpoint-url"
-															type="url"
-															value={
-																local.feedback_endpoint_url ||
-																''
-															}
-															onChange={ ( v ) =>
-																updateField(
-																	'feedback_endpoint_url',
-																	v
-																)
-															}
-															placeholder="https://example.com/wp-json/gratis-ai-feedback/v1/reports"
-															help={ __(
-																'REST API URL of the gratis-ai-feedback receiving plugin. Reports are sent as POST requests to this URL.',
-																'gratis-ai-agent'
-															) }
-															__nextHasNoMarginBottom
-														/>
-													</td>
-												</tr>
-												<tr>
-													<th scope="row">
-														<label htmlFor="gratis-feedback-api-key">
-															{ __(
-																'API Key',
-																'gratis-ai-agent'
-															) }
-														</label>
-													</th>
-													<td>
-														{ feedbackApiKeyConfigured && (
-															<p className="description">
-																{ __(
-																	'An API key is currently saved.',
-																	'gratis-ai-agent'
-																) }
-															</p>
-														) }
-														<TextControl
-															id="gratis-feedback-api-key"
-															type="password"
-															value={
-																feedbackApiKey
-															}
-															onChange={
-																setFeedbackApiKey
-															}
-															placeholder={
-																feedbackApiKeyConfigured
-																	? __(
-																			'Key saved — enter a new key to replace it',
-																			'gratis-ai-agent'
-																	  )
-																	: __(
-																			'Enter your feedback API key',
-																			'gratis-ai-agent'
-																	  )
-															}
-															help={ __(
-																'The API key is stored securely and never exposed via the settings API. Sent as the X-Feedback-Api-Key header with each report.',
-																'gratis-ai-agent'
-															) }
-															__nextHasNoMarginBottom
-														/>
-													</td>
-												</tr>
-											</tbody>
-										</table>
-										<div className="gratis-ai-agent-settings-row-actions">
-											<Button
-												variant="primary"
-												onClick={
-													handleFeedbackApiKeySave
-												}
-												isBusy={ feedbackApiKeySaving }
-												disabled={
-													feedbackApiKeySaving ||
-													! feedbackApiKey
-												}
-											>
-												{ __(
-													'Save API Key',
-													'gratis-ai-agent'
-												) }
-											</Button>
-											{ feedbackApiKeyConfigured && (
-												<Button
-													variant="secondary"
-													onClick={
-														handleFeedbackApiKeyRemove
-													}
-													isBusy={
-														feedbackApiKeySaving
-													}
-													disabled={
-														feedbackApiKeySaving
-													}
 												>
 													{ __(
 														'Remove Key',


### PR DESCRIPTION
## What

Remove the Feedback Reports section from the Advanced settings tab.

## Why

The feedback endpoint is fixed and requires no API key. User consent is collected per submission via the feedback-consent modal, making the opt-in toggle redundant.

## Changes

- **ReportSender.php** — hardcode ENDPOINT_URL; remove force_send param, enabled-check, API key logic
- **Settings.php** — remove FEEDBACK_API_KEY_OPTION, feedback_enabled, feedback_endpoint_url defaults, and three key methods
- **SettingsController.php** — remove both duplicate /settings/feedback-api-key routes, handler methods, _feedback_api_key_configured from GET /settings
- **FeedbackController.php** — update send() call signature; remove stale error-code checks
- **settings-app.js** — remove feedback state, handlers, and the entire Feedback Reports UI section from Advanced tab

## Verification

PHPCS zero violations on all 4 modified PHP files. ESLint/Prettier zero violations on settings-app.js.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.5 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 23m and 23,322 tokens on this with the user in an interactive session.