### PR TITLE
fix: edit & resend enters only the clicked message's edit mode

### DIFF
--- a/src/components/chat-redesign/MessageList.js
+++ b/src/components/chat-redesign/MessageList.js
@@ -114,7 +114,7 @@ export default function MessageList() {
 						if ( msg.role === 'user' ) {
 							return (
 								<UserMessage
-									key={ i }
+									key={ index }
 									msg={ msg }
 									index={ index }
 								/>
@@ -123,7 +123,7 @@ export default function MessageList() {
 						if ( msg.role === 'model' ) {
 							return (
 								<AssistantMessage
-									key={ i }
+									key={ index }
 									msg={ msg }
 									index={ index }
 									onSuggestionSelect={ sendMessage }
@@ -135,7 +135,7 @@ export default function MessageList() {
 						if ( msg.role === 'system' ) {
 							return (
 								<SystemMessage
-									key={ i }
+									key={ index }
 									text={ extractText( msg ) }
 								/>
 							);

--- a/src/components/chat-redesign/message-items.js
+++ b/src/components/chat-redesign/message-items.js
@@ -144,11 +144,10 @@ function AssistantMeta( { tokens } ) {
  */
 export function UserMessage( { msg, index } ) {
 	const [ copied, setCopied ] = useState( false );
-	const [ editing, setEditing ] = useState( false );
 	const [ draft, setDraft ] = useState( '' );
 	const textareaRef = useRef( null );
-	const { editAndResend } = useDispatch( STORE_NAME );
-	const { sending, messageToken, selectedModelName } = useSelect(
+	const { editAndResend, setEditingMessageIndex } = useDispatch( STORE_NAME );
+	const { sending, messageToken, selectedModelName, editing } = useSelect(
 		( sel ) => {
 			const store = sel( STORE_NAME );
 			const tokens = store.getMessageTokens() || [];
@@ -163,6 +162,12 @@ export function UserMessage( { msg, index } ) {
 				sending: store.isSending(),
 				messageToken: tokens[ index ],
 				selectedModelName: model?.name || model?.id || '',
+				// Derive editing from the store's editingMessageIndex so only the
+				// exact message whose index matches enters edit mode. Using a
+				// store-level flag (rather than local useState) means a single
+				// dispatch controls which message is active, preventing the bug
+				// where all user messages simultaneously showed the editing UI.
+				editing: store.getEditingMessageIndex() === index,
 			};
 		},
 		[ index ]
@@ -191,9 +196,10 @@ export function UserMessage( { msg, index } ) {
 	const handleSubmit = useCallback( () => {
 		if ( draft.trim() && draft.trim() !== text ) {
 			editAndResend( index, draft.trim() );
+		} else {
+			setEditingMessageIndex( null );
 		}
-		setEditing( false );
-	}, [ draft, text, index, editAndResend ] );
+	}, [ draft, text, index, editAndResend, setEditingMessageIndex ] );
 
 	// Prefer the model actually used for the nearest assistant reply if
 	// available, else show the currently-selected model.
@@ -215,7 +221,7 @@ export function UserMessage( { msg, index } ) {
 								handleSubmit();
 							}
 							if ( e.key === 'Escape' ) {
-								setEditing( false );
+								setEditingMessageIndex( null );
 							}
 						} }
 						rows={ 3 }
@@ -224,7 +230,7 @@ export function UserMessage( { msg, index } ) {
 						<button
 							type="button"
 							className="gaa-cr-btn-sm"
-							onClick={ () => setEditing( false ) }
+							onClick={ () => setEditingMessageIndex( null ) }
 						>
 							{ __( 'Cancel', 'gratis-ai-agent' ) }
 						</button>
@@ -276,7 +282,7 @@ export function UserMessage( { msg, index } ) {
 						className="gaa-cr-icon-btn"
 						onClick={ () => {
 							setDraft( text || '' );
-							setEditing( true );
+							setEditingMessageIndex( index );
 						} }
 						disabled={ sending }
 						title={ __( 'Edit & resend', 'gratis-ai-agent' ) }

--- a/src/components/chat-widget/widget-message-list.js
+++ b/src/components/chat-widget/widget-message-list.js
@@ -97,7 +97,7 @@ export default function WidgetMessageList() {
 						if ( msg.role === 'user' ) {
 							return (
 								<UserMessage
-									key={ i }
+									key={ index }
 									msg={ msg }
 									index={ index }
 								/>
@@ -106,7 +106,7 @@ export default function WidgetMessageList() {
 						if ( msg.role === 'model' ) {
 							return (
 								<AssistantMessage
-									key={ i }
+									key={ index }
 									msg={ msg }
 									index={ index }
 									onSuggestionSelect={ sendMessage }
@@ -118,7 +118,7 @@ export default function WidgetMessageList() {
 						if ( msg.role === 'system' ) {
 							return (
 								<SystemMessage
-									key={ i }
+									key={ index }
 									text={ extractText( msg ) }
 								/>
 							);

--- a/src/store/slices/sessionsSlice.js
+++ b/src/store/slices/sessionsSlice.js
@@ -188,6 +188,11 @@ export const initialState = {
 	// Drained automatically when the current job completes.
 	messageQueue: [],
 
+	// Index of the message currently in edit mode, or null when no message is
+	// being edited.  Keyed by the actual message index (position in
+	// currentSessionMessages) so only a single message can be editing at once.
+	editingMessageIndex: null,
+
 	// Open tabs for the chat tab bar (t207).
 	// Array of integer session IDs representing sessions pinned as tabs.
 	// Persisted to localStorage so tabs survive page reload.
@@ -328,6 +333,21 @@ export const actions = {
 	 */
 	truncateMessagesTo( index ) {
 		return { type: 'TRUNCATE_MESSAGES_TO', index };
+	},
+
+	/**
+	 * Set the index of the message currently in edit mode, or null to clear.
+	 *
+	 * Only one message may be in edit mode at a time; keying on the actual
+	 * message index prevents the "all user messages enter edit mode" bug where
+	 * local component state coupled with non-unique visibility-position keys
+	 * caused every user bubble to show the editing UI.
+	 *
+	 * @param {number|null} index - Message index to enter edit mode, or null.
+	 * @return {Object} Redux action.
+	 */
+	setEditingMessageIndex( index ) {
+		return { type: 'SET_EDITING_MESSAGE_INDEX', index };
 	},
 
 	/**
@@ -844,6 +864,7 @@ export const actions = {
 	 */
 	editAndResend( index, newText ) {
 		return async ( { dispatch } ) => {
+			dispatch.setEditingMessageIndex( null );
 			dispatch.truncateMessagesTo( index );
 			dispatch.sendMessage( newText );
 		};
@@ -1480,6 +1501,16 @@ export const selectors = {
 	},
 
 	/**
+	 * Get the index of the message currently in edit mode, or null.
+	 *
+	 * @param {import('../../types').StoreState} state
+	 * @return {number|null} Message index currently being edited, or null.
+	 */
+	getEditingMessageIndex( state ) {
+		return state.editingMessageIndex ?? null;
+	},
+
+	/**
 	 * Get inability-reported data (t185).
 	 * Returns the data object { reason, attempted_steps } or null.
 	 *
@@ -1647,6 +1678,7 @@ export function reducer( state, action ) {
 					0,
 					action.index
 				),
+				editingMessageIndex: null,
 			};
 		case 'SET_SEND_TIMESTAMP':
 			return { ...state, sendTimestamp: action.ts };
@@ -1654,6 +1686,8 @@ export function reducer( state, action ) {
 			return { ...state, streamError: action.error };
 		case 'SET_LAST_USER_MESSAGE':
 			return { ...state, lastUserMessage: action.message };
+		case 'SET_EDITING_MESSAGE_INDEX':
+			return { ...state, editingMessageIndex: action.index ?? null };
 		case 'SET_INABILITY_REPORTED':
 			return { ...state, inabilityReported: action.data };
 		case 'SET_FEEDBACK_BANNER':


### PR DESCRIPTION
## Summary

Resolves #1165

Clicking **Edit & resend** on any user message was causing every user message to simultaneously enter edit mode. The  class was applied to all user bubbles, showing multiple editable textareas at once.

## Root Cause

Two related issues:

1. **Wrong React keys** —  (visible-array position) was used for all message components. When the store changes and the visible array is rebuilt, React can map a message to a different component slot, transferring local state (including `editing=true`) to an unintended `UserMessage` instance.

2. **Local component state** — `editing` was `useState(false)` per component, with no global coordination. Nothing prevented multiple components from independently having `editing=true`.

## Fix

### Store changes (`sessionsSlice.js`)
- Added `editingMessageIndex: null` to initial state
- Added `setEditingMessageIndex(index)` action + `SET_EDITING_MESSAGE_INDEX` reducer
- Added `getEditingMessageIndex()` selector
- `TRUNCATE_MESSAGES_TO` now also clears `editingMessageIndex`
- `editAndResend` clears `editingMessageIndex` before truncating

### Component changes (`message-items.js`)
- Removed `const [editing, setEditing] = useState(false)`
- `editing` is now derived from `store.getEditingMessageIndex() === index` — only the exact message whose index matches the store value enters edit mode
- Edit button dispatches `setEditingMessageIndex(index)`; cancel/submit dispatch `setEditingMessageIndex(null)`

### Key stability (`MessageList.js` + `widget-message-list.js`)
- Changed `key={i}` → `key={index}` (actual message index, not visible-array position) for stable React component identity across store updates

## Verification

After fix:
```js
document.querySelectorAll('.gaa-cr-bubble-user--editing').length
// Returns: 1  (only the clicked message)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved message editing state management to ensure consistent behavior across the application
  * Enhanced message list rendering stability by refining how list items are identified
  * Strengthened edit mode handling to prevent conflicting states when managing multiple messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->