### PR TITLE
fix: add Delete Permanently option to Trash context menu (GH#1166)

### DIFF
--- a/src/components/session-context-menu.js
+++ b/src/components/session-context-menu.js
@@ -43,6 +43,7 @@ export default function SessionContextMenu( {
 		archiveSession,
 		trashSession,
 		restoreSession,
+		deleteSession,
 		renameSession,
 		exportSession,
 	} = useDispatch( STORE_NAME );
@@ -173,6 +174,28 @@ export default function SessionContextMenu( {
 					} }
 				>
 					{ __( 'Move to Trash', 'gratis-ai-agent' ) }
+				</button>
+			) }
+			{ isOwner && isTrashed && (
+				<button
+					type="button"
+					role="menuitem"
+					className="gratis-ai-agent-context-menu-danger"
+					onClick={ () => {
+						// eslint-disable-next-line no-alert
+						const confirmed = window.confirm(
+							__(
+								'Permanently delete this conversation? This cannot be undone.',
+								'gratis-ai-agent'
+							)
+						);
+						if ( confirmed ) {
+							deleteSession( sessionId );
+							onClose();
+						}
+					} }
+				>
+					{ __( 'Delete Permanently', 'gratis-ai-agent' ) }
 				</button>
 			) }
 		</div>


### PR DESCRIPTION
## Summary

Adds a Delete Permanently action to the Trash tab context menu, resolving the missing option reported in #1166.

## Changes

- EDIT: src/components/session-context-menu.js — destructures `deleteSession` from the store dispatch, adds a danger-styled button visible only when the session is trashed that prompts for confirmation then calls `deleteSession`.

## Behaviour

- Trash tab session options now shows both **Restore** and **Delete Permanently**
- Clicking **Delete Permanently** shows a native confirm dialog: 'Permanently delete this conversation? This cannot be undone.'
- On confirmation, calls the existing `deleteSession` store action (DELETE /gratis-ai-agent/v1/sessions/{id}) and refreshes the session list
- Cancelling the dialog takes no action

## Verification

1. Open Chat tab, move a conversation to Trash
2. Switch to Trash tab, hover session, open context menu
3. Confirm both **Restore** and **Delete Permanently** are present
4. Click **Delete Permanently**, confirm dialog appears
5. Accept, conversation removed from Trash and database

Resolves #1166