### PR TITLE
feat: sound notifications (ding/dong/thinking) in General settings

### DIFF
--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -20,6 +20,7 @@ import {
 	useAvailableVoices,
 	isTTSSupported,
 } from '../components/use-text-to-speech';
+import { isSoundSupported } from '../utils/sound-manager';
 
 /**
  * Internal dependencies
@@ -53,6 +54,9 @@ export default function SettingsApp() {
 		setTtsVoiceURI,
 		setTtsRate,
 		setTtsPitch,
+		setSoundSuccessEnabled,
+		setSoundErrorEnabled,
+		setSoundThinkingEnabled,
 	} = useDispatch( STORE_NAME );
 	const {
 		settings,
@@ -62,6 +66,9 @@ export default function SettingsApp() {
 		ttsVoiceURI,
 		ttsRate,
 		ttsPitch,
+		soundSuccessEnabled,
+		soundErrorEnabled,
+		soundThinkingEnabled,
 	} = useSelect(
 		( select ) => ( {
 			settings: select( STORE_NAME ).getSettings(),
@@ -71,6 +78,9 @@ export default function SettingsApp() {
 			ttsVoiceURI: select( STORE_NAME ).getTtsVoiceURI(),
 			ttsRate: select( STORE_NAME ).getTtsRate(),
 			ttsPitch: select( STORE_NAME ).getTtsPitch(),
+			soundSuccessEnabled: select( STORE_NAME ).isSoundSuccessEnabled(),
+			soundErrorEnabled: select( STORE_NAME ).isSoundErrorEnabled(),
+			soundThinkingEnabled: select( STORE_NAME ).isSoundThinkingEnabled(),
 		} ),
 		[]
 	);
@@ -1249,6 +1259,108 @@ export default function SettingsApp() {
 												</tbody>
 											</table>
 										) }
+
+										<h3 className="gratis-ai-agent-settings-section-title">
+											{ __(
+												'Sound Notifications',
+												'gratis-ai-agent'
+											) }
+										</h3>
+										{ ! isSoundSupported && (
+											<p className="description">
+												{ __(
+													'Sound notifications are not supported in this browser.',
+													'gratis-ai-agent'
+												) }
+											</p>
+										) }
+										{ isSoundSupported && (
+											<table className="form-table gratis-ai-agent-form-table">
+												<tbody>
+													<tr>
+														<th scope="row">
+															{ __(
+																'Success Sound',
+																'gratis-ai-agent'
+															) }
+														</th>
+														<td>
+															<ToggleControl
+																label={ __(
+																	'Play a "ding" when the agent finishes successfully',
+																	'gratis-ai-agent'
+																) }
+																checked={
+																	soundSuccessEnabled
+																}
+																onChange={
+																	setSoundSuccessEnabled
+																}
+																help={ __(
+																	'A short ascending tone plays when the AI completes a request without error.',
+																	'gratis-ai-agent'
+																) }
+																__nextHasNoMarginBottom
+															/>
+														</td>
+													</tr>
+													<tr>
+														<th scope="row">
+															{ __(
+																'Error Sound',
+																'gratis-ai-agent'
+															) }
+														</th>
+														<td>
+															<ToggleControl
+																label={ __(
+																	'Play a "dong" when the agent encounters an error',
+																	'gratis-ai-agent'
+																) }
+																checked={
+																	soundErrorEnabled
+																}
+																onChange={
+																	setSoundErrorEnabled
+																}
+																help={ __(
+																	'A descending tone plays when the AI returns an error response.',
+																	'gratis-ai-agent'
+																) }
+																__nextHasNoMarginBottom
+															/>
+														</td>
+													</tr>
+													<tr>
+														<th scope="row">
+															{ __(
+																'Thinking Sound',
+																'gratis-ai-agent'
+															) }
+														</th>
+														<td>
+															<ToggleControl
+																label={ __(
+																	'Play a tick when a tool action completes',
+																	'gratis-ai-agent'
+																) }
+																checked={
+																	soundThinkingEnabled
+																}
+																onChange={
+																	setSoundThinkingEnabled
+																}
+																help={ __(
+																	'A subtle tick plays each time the agent completes a tool action during processing.',
+																	'gratis-ai-agent'
+																) }
+																__nextHasNoMarginBottom
+															/>
+														</td>
+													</tr>
+												</tbody>
+											</table>
+										) }
 									</div>
 								);
 
@@ -1508,44 +1620,44 @@ export default function SettingsApp() {
 									</div>
 								);
 
-						case 'access-branding':
-							return (
-								<div className="gratis-ai-agent-settings-section">
-									{ features.access_control && (
-										<>
-											<h3 className="gratis-ai-agent-settings-section-title">
-												{ __(
-													'Role Permissions',
-													'gratis-ai-agent'
-												) }
-											</h3>
-											<ErrorBoundary
-												label={ __(
-													'Role permissions manager',
-													'gratis-ai-agent'
-												) }
-											>
-												<RolePermissionsManager />
-											</ErrorBoundary>
-										</>
-									) }
+							case 'access-branding':
+								return (
+									<div className="gratis-ai-agent-settings-section">
+										{ features.access_control && (
+											<>
+												<h3 className="gratis-ai-agent-settings-section-title">
+													{ __(
+														'Role Permissions',
+														'gratis-ai-agent'
+													) }
+												</h3>
+												<ErrorBoundary
+													label={ __(
+														'Role permissions manager',
+														'gratis-ai-agent'
+													) }
+												>
+													<RolePermissionsManager />
+												</ErrorBoundary>
+											</>
+										) }
 
-									{ features.branding && (
-										<>
-											<h3 className="gratis-ai-agent-settings-section-title">
-												{ __(
-													'Branding',
-													'gratis-ai-agent'
-												) }
-											</h3>
-											<BrandingManager
-												local={ local }
-												updateField={ updateField }
-											/>
-										</>
-									) }
-								</div>
-							);
+										{ features.branding && (
+											<>
+												<h3 className="gratis-ai-agent-settings-section-title">
+													{ __(
+														'Branding',
+														'gratis-ai-agent'
+													) }
+												</h3>
+												<BrandingManager
+													local={ local }
+													updateField={ updateField }
+												/>
+											</>
+										) }
+									</div>
+								);
 
 							case 'usage':
 								return (

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
 import { onVisibilityChange } from '../../utils/visibility-manager';
 import { setActiveJob, clearActiveJob } from '../../utils/active-jobs-storage';
 import { notifyConfirmationNeeded } from '../../utils/notification-manager';
+import { playDing, playDong, playThinking } from '../../utils/sound-manager';
 
 export const initialState = {
 	// Active polling job ID (most-recently-started job for the current session).
@@ -135,7 +136,12 @@ export const actions = {
 				return 1000; // 1s initially.
 			};
 
+			// Tracks whether the last poll returned status 'complete'.
+			// Used outside the try block to decide whether to play the ding.
+			let lastStatusComplete = false;
+
 			const poll = async () => {
+				lastStatusComplete = false;
 				attempts++;
 				if ( attempts > maxAttempts ) {
 					unsubscribeVisibility();
@@ -181,6 +187,10 @@ export const actions = {
 						if ( newLen > lastToolCallsLength ) {
 							lastToolCallsLength = newLen;
 							attempts = 0; // Reset backoff on progress.
+							// Play thinking tick for each new tool action.
+							if ( select.getCurrentSessionId() === sessionId ) {
+								playThinking();
+							}
 						}
 
 						// Slow poll if tab is hidden.
@@ -293,6 +303,8 @@ export const actions = {
 									exitReason: 'max_iterations',
 								} );
 							}
+							// Play error sound for the active session.
+							playDong();
 						}
 					}
 
@@ -434,6 +446,8 @@ export const actions = {
 						if ( select.getCurrentSessionId() === sessionId ) {
 							dispatch.fetchSessions();
 						}
+						// Mark successful completion so the ding can fire below.
+						lastStatusComplete = true;
 					}
 				} catch {
 					// Network blip — keep polling with backoff.
@@ -448,6 +462,10 @@ export const actions = {
 				unsubscribeVisibility();
 				clearActiveJob( sessionId );
 				if ( select.getCurrentSessionId() === sessionId ) {
+					// Play success sound when the job completed without error.
+					if ( lastStatusComplete ) {
+						playDing();
+					}
 					dispatch.setSending( false );
 					dispatch.setLiveToolCalls( [] );
 					// Auto-drain the message queue.

--- a/src/store/slices/uiSlice.js
+++ b/src/store/slices/uiSlice.js
@@ -44,6 +44,14 @@ export const initialState = {
 	ttsPitch: parseFloat(
 		localStorage.getItem( 'gratisAiAgentTtsPitch' ) || '1'
 	),
+
+	// Sound notifications — persisted to localStorage.
+	soundSuccessEnabled:
+		localStorage.getItem( 'gratisAiAgentSoundSuccess' ) === 'true',
+	soundErrorEnabled:
+		localStorage.getItem( 'gratisAiAgentSoundError' ) === 'true',
+	soundThinkingEnabled:
+		localStorage.getItem( 'gratisAiAgentSoundThinking' ) === 'true',
 };
 
 export const actions = {
@@ -172,6 +180,50 @@ export const actions = {
 	setTtsPitch( pitch ) {
 		localStorage.setItem( 'gratisAiAgentTtsPitch', String( pitch ) );
 		return { type: 'SET_TTS_PITCH', pitch };
+	},
+
+	// ─── Sound notifications ──────────────────────────────────────
+
+	/**
+	 * Enable or disable the success "ding" sound and persist to localStorage.
+	 *
+	 * @param {boolean} enabled - Whether the ding sound should play on success.
+	 * @return {Object} Redux action.
+	 */
+	setSoundSuccessEnabled( enabled ) {
+		localStorage.setItem(
+			'gratisAiAgentSoundSuccess',
+			enabled ? 'true' : 'false'
+		);
+		return { type: 'SET_SOUND_SUCCESS_ENABLED', enabled };
+	},
+
+	/**
+	 * Enable or disable the error "dong" sound and persist to localStorage.
+	 *
+	 * @param {boolean} enabled - Whether the dong sound should play on error.
+	 * @return {Object} Redux action.
+	 */
+	setSoundErrorEnabled( enabled ) {
+		localStorage.setItem(
+			'gratisAiAgentSoundError',
+			enabled ? 'true' : 'false'
+		);
+		return { type: 'SET_SOUND_ERROR_ENABLED', enabled };
+	},
+
+	/**
+	 * Enable or disable the thinking tick sound and persist to localStorage.
+	 *
+	 * @param {boolean} enabled - Whether the tick should play on each tool action.
+	 * @return {Object} Redux action.
+	 */
+	setSoundThinkingEnabled( enabled ) {
+		localStorage.setItem(
+			'gratisAiAgentSoundThinking',
+			enabled ? 'true' : 'false'
+		);
+		return { type: 'SET_SOUND_THINKING_ENABLED', enabled };
 	},
 
 	/**
@@ -376,6 +428,32 @@ export const selectors = {
 	getTtsPitch( state ) {
 		return state.ttsPitch;
 	},
+
+	// Sound notifications
+
+	/**
+	 * @param {import('../../types').StoreState} state
+	 * @return {boolean} Whether the success "ding" sound is enabled.
+	 */
+	isSoundSuccessEnabled( state ) {
+		return state.soundSuccessEnabled;
+	},
+
+	/**
+	 * @param {import('../../types').StoreState} state
+	 * @return {boolean} Whether the error "dong" sound is enabled.
+	 */
+	isSoundErrorEnabled( state ) {
+		return state.soundErrorEnabled;
+	},
+
+	/**
+	 * @param {import('../../types').StoreState} state
+	 * @return {boolean} Whether the thinking tick sound is enabled.
+	 */
+	isSoundThinkingEnabled( state ) {
+		return state.soundThinkingEnabled;
+	},
 };
 
 /**
@@ -413,6 +491,12 @@ export function reducer( state, action ) {
 			return { ...state, ttsRate: action.rate };
 		case 'SET_TTS_PITCH':
 			return { ...state, ttsPitch: action.pitch };
+		case 'SET_SOUND_SUCCESS_ENABLED':
+			return { ...state, soundSuccessEnabled: action.enabled };
+		case 'SET_SOUND_ERROR_ENABLED':
+			return { ...state, soundErrorEnabled: action.enabled };
+		case 'SET_SOUND_THINKING_ENABLED':
+			return { ...state, soundThinkingEnabled: action.enabled };
 		default:
 			return state;
 	}

--- a/src/utils/sound-manager.js
+++ b/src/utils/sound-manager.js
@@ -1,0 +1,162 @@
+/**
+ * Sound Manager
+ *
+ * Synthesises notification sounds using the Web Audio API.
+ * No external audio files are required — all tones are generated in-browser.
+ *
+ * Three sounds are provided:
+ *   playDing()     — short ascending tones, played on a successful AI response.
+ *   playDong()     — descending tones, played when the agent returns an error.
+ *   playThinking() — subtle tick, played each time a tool action completes.
+ *
+ * Each function reads its corresponding localStorage flag before playing and
+ * silently returns when the flag is absent or set to 'false'.
+ *
+ * The shared AudioContext is created lazily on first use so that the module
+ * can be imported freely without triggering autoplay-policy warnings.
+ */
+
+/** Whether the Web Audio API is available in this browser. */
+export const isSoundSupported =
+	typeof window !== 'undefined' &&
+	( typeof AudioContext !== 'undefined' ||
+		typeof window.webkitAudioContext !== 'undefined' );
+
+/** @type {AudioContext|null} Shared AudioContext instance (created lazily). */
+let audioCtx = null;
+
+/**
+ * Return (or lazily create) the shared AudioContext.
+ *
+ * Resumes the context if it was suspended by the browser's autoplay policy.
+ * The browser requires a user gesture before audio can play; we rely on the
+ * settings toggle being that gesture.
+ *
+ * @return {AudioContext|null} Shared context, or null when unsupported.
+ */
+function getAudioContext() {
+	if ( ! isSoundSupported ) {
+		return null;
+	}
+	if ( ! audioCtx ) {
+		const Ctx =
+			typeof AudioContext !== 'undefined'
+				? AudioContext
+				: window.webkitAudioContext;
+		audioCtx = new Ctx();
+	}
+	// Resume if suspended (browser autoplay policy).
+	if ( audioCtx.state === 'suspended' ) {
+		audioCtx.resume().catch( () => {} );
+	}
+	return audioCtx;
+}
+
+/**
+ * Play a single synthesised oscillator tone with an amplitude envelope.
+ *
+ * The tone fades in instantly (10 ms attack) and fades out over the final
+ * fraction of its duration defined by `rampDown`.
+ *
+ * @param {Object} options
+ * @param {number} options.frequency  - Oscillator frequency in Hz.
+ * @param {number} options.duration   - Total tone duration in seconds.
+ * @param {number} options.gain       - Peak amplitude (0–1).
+ * @param {string} [options.type]     - OscillatorType ('sine'|'square'|'triangle'|'sawtooth'). Default 'sine'.
+ * @param {number} [options.rampDown] - Fraction of `duration` at which gain ramp-down begins. Default 0.7.
+ */
+function playTone( {
+	frequency,
+	duration,
+	gain,
+	type = 'sine',
+	rampDown = 0.7,
+} ) {
+	const ctx = getAudioContext();
+	if ( ! ctx ) {
+		return;
+	}
+	const now = ctx.currentTime;
+
+	const oscillator = ctx.createOscillator();
+	const gainNode = ctx.createGain();
+
+	oscillator.connect( gainNode );
+	gainNode.connect( ctx.destination );
+
+	oscillator.type = type;
+	oscillator.frequency.setValueAtTime( frequency, now );
+
+	// Attack: instant ramp from 0 to peak.
+	gainNode.gain.setValueAtTime( 0, now );
+	gainNode.gain.linearRampToValueAtTime( gain, now + 0.01 );
+	// Sustain: hold until rampDown point.
+	gainNode.gain.setValueAtTime( gain, now + duration * rampDown );
+	// Release: fade to silence.
+	gainNode.gain.linearRampToValueAtTime( 0, now + duration );
+
+	oscillator.start( now );
+	oscillator.stop( now + duration );
+}
+
+/**
+ * Play the success "ding" sound.
+ *
+ * Two ascending sine tones played in quick succession — pleasant and
+ * non-intrusive.  Skipped when `gratisAiAgentSoundSuccess` is not 'true'.
+ */
+export function playDing() {
+	if ( localStorage.getItem( 'gratisAiAgentSoundSuccess' ) !== 'true' ) {
+		return;
+	}
+	playTone( { frequency: 880, duration: 0.15, gain: 0.28, type: 'sine' } );
+	setTimeout( () => {
+		playTone( {
+			frequency: 1100,
+			duration: 0.2,
+			gain: 0.22,
+			type: 'sine',
+		} );
+	}, 120 );
+}
+
+/**
+ * Play the error "dong" sound.
+ *
+ * Two descending sine tones — clearly distinct from the ding, without being
+ * alarming.  Skipped when `gratisAiAgentSoundError` is not 'true'.
+ */
+export function playDong() {
+	if ( localStorage.getItem( 'gratisAiAgentSoundError' ) !== 'true' ) {
+		return;
+	}
+	playTone( { frequency: 440, duration: 0.25, gain: 0.3, type: 'sine' } );
+	setTimeout( () => {
+		playTone( {
+			frequency: 330,
+			duration: 0.3,
+			gain: 0.25,
+			type: 'sine',
+		} );
+	}, 200 );
+}
+
+/**
+ * Play the thinking / tool-action tick sound.
+ *
+ * A single soft triangle-wave tick — subtle enough to acknowledge activity
+ * without distracting from work.  Skipped when `gratisAiAgentSoundThinking`
+ * is not 'true'.
+ */
+export function playThinking() {
+	if ( localStorage.getItem( 'gratisAiAgentSoundThinking' ) !== 'true' ) {
+		return;
+	}
+	playTone( {
+		frequency: 660,
+		duration: 0.08,
+		gain: 0.16,
+		type: 'triangle',
+		rampDown: 0.4,
+	} );
+}


### PR DESCRIPTION
## Summary

Adds three browser sound notifications to **Settings > General > Sound Notifications**, synthesised via the Web Audio API — no audio files required.

- **Success sound (ding)** — two short ascending sine tones, plays when the agent finishes a request successfully.
- **Error sound (dong)** — two descending sine tones, plays when the agent returns an error response.
- **Thinking sound** — a subtle triangle-wave tick, plays each time a tool action completes during processing.

## Implementation

| File | Change |
|---|---|
| `src/utils/sound-manager.js` | New utility — `playDing()`, `playDong()`, `playThinking()` via Web Audio API; `isSoundSupported` export |
| `src/store/slices/uiSlice.js` | Three localStorage-persisted settings (`soundSuccessEnabled`, `soundErrorEnabled`, `soundThinkingEnabled`); actions, selectors, reducer cases — same pattern as TTS |
| `src/store/slices/jobSlice.js` | Calls `playDing()` on `status === 'complete'`, `playDong()` on `status === 'error'`, `playThinking()` on each new tool call during processing |
| `src/settings-page/settings-app.js` | New "Sound Notifications" section in General tab with three `ToggleControl`s; graceful fallback notice when API unavailable |

## Behaviour

- Settings default **off** (opt-in).
- Persisted to `localStorage` — survive page reloads without a server round-trip.
- Each `play*()` function reads its localStorage key before playing, so the sound manager can be imported freely without extra guard code at call sites.
- The shared `AudioContext` is created lazily on first play to avoid autoplay-policy warnings on page load.
- When Web Audio API is unavailable the UI shows a "not supported in this browser" notice and the play functions are no-ops.

## Verification

1. `npm run lint:js` — zero errors on changed files (2 pre-existing unresolved-import errors in `screenshot.js` remain).
2. Settings > General > Sound Notifications — three toggles visible.
3. Enable "Success sound", send a chat message, hear the ding on completion.
4. Enable "Error sound", trigger an error, hear the dong.
5. Enable "Thinking sound", watch tool calls tick during processing.