### PR TITLE
fix: show snackbar toast after Save Settings click

### DIFF
--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -13,6 +13,7 @@ import {
 	Notice,
 	Spinner,
 	SelectControl,
+	SnackbarList,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
@@ -78,9 +79,15 @@ export default function SettingsApp() {
 	// Available TTS voices (loaded asynchronously in some browsers).
 	const ttsVoices = useAvailableVoices();
 
+	const { createNotice, removeNotice } = useDispatch( 'core/notices' );
+	const snackbarNotices = useSelect( ( select ) =>
+		select( 'core/notices' )
+			.getNotices()
+			.filter( ( n ) => n.type === 'snackbar' )
+	);
+
 	const [ local, setLocal ] = useState( null );
 	const [ saving, setSaving ] = useState( false );
-	const [ notice, setNotice ] = useState( null );
 	const [ abilities, setAbilities ] = useState( [] );
 	const [ activeTab, setActiveTab ] = useState( 'general' );
 
@@ -327,21 +334,30 @@ export default function SettingsApp() {
 
 	const handleSave = useCallback( async () => {
 		setSaving( true );
-		setNotice( null );
 		try {
 			await saveSettings( local );
-			setNotice( {
-				status: 'success',
-				message: __( 'Settings saved.', 'gratis-ai-agent' ),
-			} );
+			createNotice(
+				'success',
+				__( 'Settings saved.', 'gratis-ai-agent' ),
+				{
+					type: 'snackbar',
+					isDismissible: true,
+					id: 'gratis-ai-agent-settings-save',
+				}
+			);
 		} catch {
-			setNotice( {
-				status: 'error',
-				message: __( 'Failed to save settings.', 'gratis-ai-agent' ),
-			} );
+			createNotice(
+				'error',
+				__( 'Failed to save settings.', 'gratis-ai-agent' ),
+				{
+					type: 'snackbar',
+					isDismissible: true,
+					id: 'gratis-ai-agent-settings-save',
+				}
+			);
 		}
 		setSaving( false );
-	}, [ local, saveSettings ] );
+	}, [ local, saveSettings, createNotice ] );
 
 	if ( ! settingsLoaded || ! local ) {
 		return (
@@ -447,15 +463,6 @@ export default function SettingsApp() {
 
 	return (
 		<div className="gratis-ai-agent-settings">
-			{ notice && (
-				<Notice
-					status={ notice.status }
-					isDismissible
-					onDismiss={ () => setNotice( null ) }
-				>
-					{ notice.message }
-				</Notice>
-			) }
 			<Notice
 				status="info"
 				isDismissible={ false }
@@ -1967,6 +1974,11 @@ export default function SettingsApp() {
 					</Button>
 				</div>
 			) }
+			<SnackbarList
+				notices={ snackbarNotices }
+				className="gratis-ai-agent-snackbar-list"
+				onRemove={ removeNotice }
+			/>
 		</div>
 	);
 }

--- a/src/settings-page/style.css
+++ b/src/settings-page/style.css
@@ -1000,3 +1000,11 @@
 	margin: 16px 0 4px;
 }
 
+/* Save-feedback snackbar — viewport-fixed so it is visible regardless of scroll position */
+.gratis-ai-agent-snackbar-list {
+	position: fixed;
+	bottom: 0;
+	right: 0;
+	z-index: 99999;
+}
+


### PR DESCRIPTION
## Summary

Resolves #1169

After clicking **Save Settings**, no toast, snackbar, or notice appeared to confirm success or failure. The root cause: the `Notice` component was rendered at the **top** of the settings panel, but the Save Settings button is at the **bottom** — when users scroll down to click it, the notice renders off-screen and is never seen.

## What Changed

**`src/settings-page/settings-app.js`**
- Removed the local `notice` / `setNotice` state and the top-of-panel `Notice` render block that was invisible after scrolling.
- Added `useDispatch('core/notices')` to get `createNotice` / `removeNotice`.
- Added `useSelect` on `core/notices` to get the active snackbar notices.
- `handleSave` now calls `createNotice('success'/'error', ..., { type: 'snackbar' })` on save result.
- Added `<SnackbarList>` at the bottom of the settings panel.

**`src/settings-page/style.css`**
- Added `.gratis-ai-agent-snackbar-list` with `position: fixed; bottom: 0; right: 0; z-index: 99999` so the toast is anchored to the viewport, not the scroll container.

## Verification

After the fix: clicking **Save Settings** shows a visible snackbar at the bottom-right of the screen within 2 seconds, regardless of how far the user has scrolled down the settings page.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.6 plugin for [OpenCode](https://opencode.ai) v1.3.17
