### PR TITLE
GH#1172: feat: linkify URLs in system/error message bubbles

### DIFF
--- a/src/components/chat-redesign/message-items.js
+++ b/src/components/chat-redesign/message-items.js
@@ -33,6 +33,7 @@ import {
 	pairToolCalls,
 	parseSuggestions,
 } from './message-helpers';
+import { linkifyText } from '../../utils/linkify';
 
 /**
  *
@@ -465,7 +466,7 @@ export function RunningMessage( { step, liveToolCalls } ) {
 export function SystemMessage( { text } ) {
 	return (
 		<div className="gaa-cr-msg-row">
-			<div className="gaa-cr-msg-system">{ text }</div>
+			<div className="gaa-cr-msg-system">{ linkifyText( text ) }</div>
 		</div>
 	);
 }

--- a/src/components/message-list.js
+++ b/src/components/message-list.js
@@ -19,6 +19,7 @@ import FeedbackConsentModal from './feedback-consent-modal';
 import { getBranding } from '../utils/branding';
 import useTextToSpeech from './use-text-to-speech';
 import { MessageTokenAnnotation } from './token-counter';
+import { linkifyText } from '../utils/linkify';
 
 /**
  * Parse suggestion chips from the end of a model response.
@@ -131,7 +132,9 @@ function MessageBubble( { role, text, attachments, queued } ) {
 	}
 
 	return (
-		<div className={ classMap[ role ] || classMap.system }>{ text }</div>
+		<div className={ classMap[ role ] || classMap.system }>
+			{ linkifyText( text ) }
+		</div>
 	);
 }
 

--- a/src/utils/__tests__/linkify.test.js
+++ b/src/utils/__tests__/linkify.test.js
@@ -1,0 +1,182 @@
+/**
+ * Unit tests for utils/linkify.js
+ *
+ * Tests cover:
+ * - Plain text with no URLs is returned as-is.
+ * - A single URL is converted to an anchor element.
+ * - Surrounding text is preserved as string segments.
+ * - Multiple URLs produce the correct number of elements.
+ * - Trailing sentence punctuation is stripped from the URL.
+ * - The anchor element has the correct href, target, and rel attributes.
+ * - Edge cases: empty string, falsy input.
+ */
+
+import { linkifyText } from '../linkify';
+
+// @wordpress/element's createElement returns a plain React element object.
+// We inspect its shape (type, props) directly to avoid needing a DOM.
+
+/**
+ * Helper: returns true when the value looks like a React/WP element for an <a>.
+ *
+ * @param {*} val Value to check.
+ * @return {boolean} Whether val is a rendered anchor element.
+ */
+function isAnchorElement( val ) {
+	return (
+		val !== null &&
+		typeof val === 'object' &&
+		val.type === 'a' &&
+		typeof val.props === 'object'
+	);
+}
+
+// ─── No URL in text ────────────────────────────────────────────────────────────
+
+describe( 'linkifyText — no URLs', () => {
+	test( 'returns original text in array when no URL present', () => {
+		const result = linkifyText( 'Hello world' );
+		expect( result ).toEqual( [ 'Hello world' ] );
+	} );
+
+	test( 'returns empty string in array', () => {
+		const result = linkifyText( '' );
+		expect( result ).toEqual( [ '' ] );
+	} );
+
+	test( 'returns [null] for null input', () => {
+		const result = linkifyText( null );
+		expect( result ).toEqual( [ null ] );
+	} );
+
+	test( 'returns [undefined] for undefined input', () => {
+		const result = linkifyText( undefined );
+		expect( result ).toEqual( [ undefined ] );
+	} );
+} );
+
+// ─── Single URL ────────────────────────────────────────────────────────────────
+
+describe( 'linkifyText — single URL', () => {
+	test( 'URL-only string produces one anchor element', () => {
+		const result = linkifyText( 'https://example.com' );
+		expect( result ).toHaveLength( 1 );
+		expect( isAnchorElement( result[ 0 ] ) ).toBe( true );
+		expect( result[ 0 ].props.href ).toBe( 'https://example.com' );
+	} );
+
+	test( 'anchor element has target="_blank"', () => {
+		const [ anchor ] = linkifyText( 'https://example.com' );
+		expect( anchor.props.target ).toBe( '_blank' );
+	} );
+
+	test( 'anchor element has rel="noopener noreferrer"', () => {
+		const [ anchor ] = linkifyText( 'https://example.com' );
+		expect( anchor.props.rel ).toBe( 'noopener noreferrer' );
+	} );
+
+	test( 'URL at the end of text: preserves prefix text', () => {
+		const result = linkifyText( 'Read more: https://example.com' );
+		expect( result ).toHaveLength( 2 );
+		expect( result[ 0 ] ).toBe( 'Read more: ' );
+		expect( isAnchorElement( result[ 1 ] ) ).toBe( true );
+		expect( result[ 1 ].props.href ).toBe( 'https://example.com' );
+	} );
+
+	test( 'URL at the start of text: preserves suffix text', () => {
+		const result = linkifyText( 'https://example.com is the link' );
+		expect( result ).toHaveLength( 2 );
+		expect( isAnchorElement( result[ 0 ] ) ).toBe( true );
+		expect( result[ 0 ].props.href ).toBe( 'https://example.com' );
+		expect( result[ 1 ] ).toBe( ' is the link' );
+	} );
+
+	test( 'URL in the middle of text: preserves prefix and suffix', () => {
+		const result = linkifyText( 'See https://example.com for details.' );
+		expect( result ).toHaveLength( 3 );
+		expect( result[ 0 ] ).toBe( 'See ' );
+		expect( isAnchorElement( result[ 1 ] ) ).toBe( true );
+		expect( result[ 1 ].props.href ).toBe( 'https://example.com' );
+		expect( result[ 2 ] ).toBe( ' for details.' );
+	} );
+
+	test( 'http:// URLs are also linkified', () => {
+		const result = linkifyText( 'http://example.com' );
+		expect( result ).toHaveLength( 1 );
+		expect( isAnchorElement( result[ 0 ] ) ).toBe( true );
+		expect( result[ 0 ].props.href ).toBe( 'http://example.com' );
+	} );
+} );
+
+// ─── Trailing punctuation stripping ───────────────────────────────────────────
+
+describe( 'linkifyText — trailing punctuation stripping', () => {
+	test( 'trailing period is stripped from URL', () => {
+		const result = linkifyText( 'See https://example.com.' );
+		expect( result ).toHaveLength( 3 );
+		expect( isAnchorElement( result[ 1 ] ) ).toBe( true );
+		expect( result[ 1 ].props.href ).toBe( 'https://example.com' );
+		expect( result[ 2 ] ).toBe( '.' );
+	} );
+
+	test( 'trailing comma is stripped from URL', () => {
+		const result = linkifyText(
+			'Visit https://example.com, then continue.'
+		);
+		const anchor = result.find( isAnchorElement );
+		expect( anchor ).toBeDefined();
+		expect( anchor.props.href ).toBe( 'https://example.com' );
+	} );
+
+	test( 'trailing question mark is stripped from URL', () => {
+		const result = linkifyText( 'Did you check https://example.com?' );
+		const anchor = result.find( isAnchorElement );
+		expect( anchor ).toBeDefined();
+		expect( anchor.props.href ).toBe( 'https://example.com' );
+	} );
+
+	test( 'real-world OpenAI 429 error URL with trailing period', () => {
+		const text =
+			'Too many requests. Read the docs: https://platform.openai.com/docs/guides/error-codes/api-errors.';
+		const result = linkifyText( text );
+		const anchor = result.find( isAnchorElement );
+		expect( anchor ).toBeDefined();
+		expect( anchor.props.href ).toBe(
+			'https://platform.openai.com/docs/guides/error-codes/api-errors'
+		);
+		// The stripped period should appear in the trailing text segment.
+		const lastPart = result[ result.length - 1 ];
+		expect( typeof lastPart === 'string' && lastPart.endsWith( '.' ) ).toBe(
+			true
+		);
+	} );
+} );
+
+// ─── Multiple URLs ─────────────────────────────────────────────────────────────
+
+describe( 'linkifyText — multiple URLs', () => {
+	test( 'two URLs are each converted to anchor elements', () => {
+		const result = linkifyText(
+			'Go to https://example.com or https://other.org for info.'
+		);
+		const anchors = result.filter( isAnchorElement );
+		expect( anchors ).toHaveLength( 2 );
+		expect( anchors[ 0 ].props.href ).toBe( 'https://example.com' );
+		expect( anchors[ 1 ].props.href ).toBe( 'https://other.org' );
+	} );
+
+	test( 'text between two URLs is preserved as string segment', () => {
+		const result = linkifyText(
+			'First: https://a.com, second: https://b.com.'
+		);
+		const strings = result.filter( ( p ) => typeof p === 'string' );
+		// Expect "First: ", ", second: ", and "." (stripped punctuation parts).
+		expect( strings.some( ( s ) => s.includes( 'second' ) ) ).toBe( true );
+	} );
+
+	test( 'each anchor has unique key to support React reconciliation', () => {
+		const result = linkifyText( 'https://a.com and https://b.com' );
+		const anchors = result.filter( isAnchorElement );
+		expect( anchors[ 0 ].key ).not.toBe( anchors[ 1 ].key );
+	} );
+} );

--- a/src/utils/linkify.js
+++ b/src/utils/linkify.js
@@ -1,0 +1,74 @@
+/**
+ * WordPress dependencies
+ */
+import { createElement } from '@wordpress/element';
+
+/**
+ * Regex that matches http/https URLs in plain text.
+ * Using the source string so each linkifyText call creates a fresh stateful
+ * RegExp (required for correct `exec` iteration).
+ */
+const URL_REGEX_SOURCE = /https?:\/\/[^\s<>"]+/.source;
+
+/**
+ * Trailing punctuation that is commonly appended after a URL in prose
+ * (e.g. "See https://example.com.") but is not part of the URL itself.
+ */
+const TRAILING_PUNCT = /[.,;:!?'")\]]+$/;
+
+/**
+ * Splits plain text into an array of strings and React anchor elements,
+ * converting any http/https URLs into clickable `<a>` tags.
+ *
+ * Trailing sentence-ending punctuation (`.`, `,`, `;`, `:`, `!`, `?`) is
+ * stripped from the URL so that prose like "read the docs: https://example.com."
+ * links to the correct URL while the trailing period appears as regular text.
+ *
+ * @param {string} text Plain text that may contain URLs.
+ * @return {Array<string|import('@wordpress/element').WPElement>} Mixed array of
+ *   text segments and anchor elements suitable for direct rendering in JSX.
+ */
+export function linkifyText( text ) {
+	if ( ! text ) {
+		return [ text ];
+	}
+
+	const regex = new RegExp( URL_REGEX_SOURCE, 'g' );
+	const parts = [];
+	let lastIndex = 0;
+	let match;
+
+	while ( ( match = regex.exec( text ) ) !== null ) {
+		// Strip trailing punctuation that is not part of the URL.
+		const url = match[ 0 ].replace( TRAILING_PUNCT, '' );
+		// urlEnd points to just after the trimmed URL in the source text,
+		// so any stripped characters fall into the next text segment.
+		const urlEnd = match.index + url.length;
+
+		if ( match.index > lastIndex ) {
+			parts.push( text.slice( lastIndex, match.index ) );
+		}
+
+		parts.push(
+			createElement(
+				'a',
+				{
+					key: `link-${ match.index }`,
+					href: url,
+					target: '_blank',
+					rel: 'noopener noreferrer',
+				},
+				url
+			)
+		);
+
+		lastIndex = urlEnd;
+	}
+
+	if ( lastIndex < text.length ) {
+		parts.push( text.slice( lastIndex ) );
+	}
+
+	// When no URLs were found the parts array is empty; return the original text.
+	return parts.length > 0 ? parts : [ text ];
+}


### PR DESCRIPTION
## Summary

Added linkifyText utility and applied it to system-role error message rendering in both MessageList and ChatRedesign SystemMessage components

## Files Changed

src/components/chat-redesign/message-items.js,src/components/message-list.js,src/utils/__tests__/linkify.test.js,src/utils/linkify.js

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 18 unit tests pass (npm run test:unit -- --testPathPattern=linkify), lint clean

Resolves #1172


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.7 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 7m and 20,543 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System and informational messages now automatically detect and linkify URLs. Links open in new tabs with appropriate security settings, allowing users to access referenced resources without interrupting their chat experience.

* **Tests**
  * Added comprehensive test coverage for URL detection and link generation, including edge cases with trailing punctuation and multiple URLs in a single message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->