### PR TITLE
GH#1180: agent UX — AgentPicker with icons, form-table layout, CLI --agent, null-safe save

### DIFF
--- a/includes/Admin/FloatingWidget.php
+++ b/includes/Admin/FloatingWidget.php
@@ -187,7 +187,7 @@ class FloatingWidget {
 			'gratis-ai-agent-floating-widget',
 			'gratisAiAgentData',
 			[
-				'currentUserId'      => get_current_user_id(),
+				'currentUserId'       => get_current_user_id(),
 				'onboarding_complete' => OnboardingManager::is_complete(),
 			]
 		);

--- a/includes/CLI/CliCommand.php
+++ b/includes/CLI/CliCommand.php
@@ -168,7 +168,13 @@ class CliCommand extends \WP_CLI_Command {
 			: null;
 		$max_iterations = $cli_max ?? $agent_max;
 
-		$options['max_iterations'] = $max_iterations;
+		// Only write max_iterations when a CLI flag was supplied or the key was
+		// already present in options (from agent settings). Without this guard
+		// the hard-coded fallback of 25 would overwrite AgentLoop's own default
+		// whenever no agent or flag is provided.
+		if ( isset( $assoc_args['max-iterations'] ) || array_key_exists( 'max_iterations', $options ) ) {
+			$options['max_iterations'] = $max_iterations;
+		}
 
 		if ( $model ) {
 			$options['model_id'] = $model;

--- a/src/admin-page/index.js
+++ b/src/admin-page/index.js
@@ -1,7 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { createRoot, useEffect, useState, useMemo } from '@wordpress/element';
+import {
+	createRoot,
+	useEffect,
+	useState,
+	useMemo,
+	lazy,
+	Suspense,
+} from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
@@ -13,12 +20,33 @@ import STORE_NAME from '../store';
 import '../abilities';
 import ChatRedesign from '../components/chat-redesign';
 import BootError from '../components/boot-error';
-import ConnectorGate from '../components/connector-gate';
-import OnboardingBootstrap from '../components/onboarding-bootstrap';
-import ShortcutsHelp from '../components/shortcuts-help';
 import { useKeyboardShortcuts } from '../utils/keyboard-shortcuts';
 import '../components/shared.css';
 import './style.css';
+
+// These components are rendered only in specific, uncommon states:
+//  - ConnectorGate   → zero providers configured (first install)
+//  - OnboardingBootstrap → provider exists but onboarding not yet done (once per site)
+//  - ShortcutsHelp   → user presses Mod+/ (explicitly intentional)
+// None of them appear during a normal chat session, so they are lazy-loaded.
+const ConnectorGate = lazy( () =>
+	import(
+		/* webpackChunkName: "connector-gate", webpackPrefetch: true */
+		'../components/connector-gate'
+	)
+);
+const OnboardingBootstrap = lazy( () =>
+	import(
+		/* webpackChunkName: "onboarding-bootstrap", webpackPrefetch: true */
+		'../components/onboarding-bootstrap'
+	)
+);
+const ShortcutsHelp = lazy( () =>
+	import(
+		/* webpackChunkName: "shortcuts-help", webpackPrefetch: true */
+		'../components/shortcuts-help'
+	)
+);
 
 /**
  * Root admin page application component.
@@ -129,13 +157,21 @@ function AdminPageApp() {
 	// Phase 1 gate: no connector → show connector gate.
 	const hasProvider = providers.length > 0;
 	if ( ! hasProvider ) {
-		return <ConnectorGate />;
+		return (
+			<Suspense fallback={ null }>
+				<ConnectorGate />
+			</Suspense>
+		);
 	}
 
 	// Phase 2 gate: connector exists but onboarding not yet started → bootstrap.
 	const onboardingComplete = settings?.onboarding_complete !== false;
 	if ( ! onboardingComplete ) {
-		return <OnboardingBootstrap />;
+		return (
+			<Suspense fallback={ null }>
+				<OnboardingBootstrap />
+			</Suspense>
+		);
 	}
 
 	// Normal chat layout — redesigned shell.
@@ -143,7 +179,11 @@ function AdminPageApp() {
 		<>
 			<ChatRedesign />
 			{ showShortcuts && (
-				<ShortcutsHelp onClose={ () => setShowShortcuts( false ) } />
+				<Suspense fallback={ null }>
+					<ShortcutsHelp
+						onClose={ () => setShowShortcuts( false ) }
+					/>
+				</Suspense>
 			) }
 		</>
 	);

--- a/src/components/chat-redesign/AgentPicker.js
+++ b/src/components/chat-redesign/AgentPicker.js
@@ -106,6 +106,19 @@ export default function AgentPicker() {
 		}
 	}, [ open, updatePosition ] );
 
+	// When the popover opens, move focus to the active menu item so keyboard
+	// users land on a sensible starting point without having to tab through.
+	useEffect( () => {
+		if ( ! open || ! popoverRef.current ) {
+			return;
+		}
+		const active = popoverRef.current.querySelector(
+			'[role="menuitem"].is-active'
+		);
+		const first = popoverRef.current.querySelector( '[role="menuitem"]' );
+		( active ?? first )?.focus();
+	}, [ open ] );
+
 	useEffect( () => {
 		if ( ! open ) {
 			return undefined;
@@ -121,11 +134,44 @@ export default function AgentPicker() {
 			}
 		};
 		const onScrollOrResize = () => updatePosition();
+		const onKeyDown = ( e ) => {
+			if ( ! popoverRef.current ) {
+				return;
+			}
+			const items = Array.from(
+				popoverRef.current.querySelectorAll( '[role="menuitem"]' )
+			);
+			const focused = popoverRef.current.ownerDocument.activeElement;
+			const currentIndex = items.indexOf( focused );
+
+			if ( e.key === 'Escape' ) {
+				e.preventDefault();
+				setOpen( false );
+				chipRef.current?.focus();
+			} else if ( e.key === 'ArrowDown' ) {
+				e.preventDefault();
+				const next = items[ currentIndex + 1 ] ?? items[ 0 ];
+				next?.focus();
+			} else if ( e.key === 'ArrowUp' ) {
+				e.preventDefault();
+				const prev =
+					items[ currentIndex - 1 ] ?? items[ items.length - 1 ];
+				prev?.focus();
+			} else if ( e.key === 'Home' ) {
+				e.preventDefault();
+				items[ 0 ]?.focus();
+			} else if ( e.key === 'End' ) {
+				e.preventDefault();
+				items[ items.length - 1 ]?.focus();
+			}
+		};
 		document.addEventListener( 'mousedown', handler );
+		document.addEventListener( 'keydown', onKeyDown );
 		window.addEventListener( 'resize', onScrollOrResize );
 		window.addEventListener( 'scroll', onScrollOrResize, true );
 		return () => {
 			document.removeEventListener( 'mousedown', handler );
+			document.removeEventListener( 'keydown', onKeyDown );
 			window.removeEventListener( 'resize', onScrollOrResize );
 			window.removeEventListener( 'scroll', onScrollOrResize, true );
 		};
@@ -153,6 +199,7 @@ export default function AgentPicker() {
 					ref={ popoverRef }
 					className="gaa-cr-popover gaa-cr-popover-fixed"
 					role="menu"
+					aria-label={ __( 'Select agent', 'gratis-ai-agent' ) }
 					style={ {
 						left: pos.left,
 						bottom: pos.bottom,

--- a/src/components/chat-redesign/ModelPicker.js
+++ b/src/components/chat-redesign/ModelPicker.js
@@ -71,6 +71,19 @@ export default function ModelPicker() {
 		}
 	}, [ open, updatePosition ] );
 
+	// When the popover opens, move focus to the active menu item so keyboard
+	// users land on a sensible starting point without having to tab through.
+	useEffect( () => {
+		if ( ! open || ! popoverRef.current ) {
+			return;
+		}
+		const active = popoverRef.current.querySelector(
+			'[role="menuitem"].is-active'
+		);
+		const first = popoverRef.current.querySelector( '[role="menuitem"]' );
+		( active ?? first )?.focus();
+	}, [ open ] );
+
 	useEffect( () => {
 		if ( ! open ) {
 			return undefined;
@@ -86,11 +99,44 @@ export default function ModelPicker() {
 			}
 		};
 		const onScrollOrResize = () => updatePosition();
+		const onKeyDown = ( e ) => {
+			if ( ! popoverRef.current ) {
+				return;
+			}
+			const items = Array.from(
+				popoverRef.current.querySelectorAll( '[role="menuitem"]' )
+			);
+			const focused = popoverRef.current.ownerDocument.activeElement;
+			const currentIndex = items.indexOf( focused );
+
+			if ( e.key === 'Escape' ) {
+				e.preventDefault();
+				setOpen( false );
+				chipRef.current?.focus();
+			} else if ( e.key === 'ArrowDown' ) {
+				e.preventDefault();
+				const next = items[ currentIndex + 1 ] ?? items[ 0 ];
+				next?.focus();
+			} else if ( e.key === 'ArrowUp' ) {
+				e.preventDefault();
+				const prev =
+					items[ currentIndex - 1 ] ?? items[ items.length - 1 ];
+				prev?.focus();
+			} else if ( e.key === 'Home' ) {
+				e.preventDefault();
+				items[ 0 ]?.focus();
+			} else if ( e.key === 'End' ) {
+				e.preventDefault();
+				items[ items.length - 1 ]?.focus();
+			}
+		};
 		document.addEventListener( 'mousedown', handler );
+		document.addEventListener( 'keydown', onKeyDown );
 		window.addEventListener( 'resize', onScrollOrResize );
 		window.addEventListener( 'scroll', onScrollOrResize, true );
 		return () => {
 			document.removeEventListener( 'mousedown', handler );
+			document.removeEventListener( 'keydown', onKeyDown );
 			window.removeEventListener( 'resize', onScrollOrResize );
 			window.removeEventListener( 'scroll', onScrollOrResize, true );
 		};
@@ -121,6 +167,7 @@ export default function ModelPicker() {
 					ref={ popoverRef }
 					className="gaa-cr-popover gaa-cr-popover-fixed"
 					role="menu"
+					aria-label={ __( 'Select model', 'gratis-ai-agent' ) }
 					style={ {
 						left: pos.left,
 						bottom: pos.bottom,

--- a/src/components/chat-redesign/chat-redesign.css
+++ b/src/components/chat-redesign/chat-redesign.css
@@ -462,7 +462,8 @@ input[type="text"].gaa-cr-search-input {
 	transition: opacity var(--gaa-duration);
 }
 
-.gaa-cr-convo-head-title:hover .gaa-cr-convo-head-rename-hint {
+.gaa-cr-convo-head-title:hover .gaa-cr-convo-head-rename-hint,
+.gaa-cr-convo-head-title:focus .gaa-cr-convo-head-rename-hint {
 	opacity: 1;
 }
 

--- a/src/components/chat-widget/index.js
+++ b/src/components/chat-widget/index.js
@@ -3,19 +3,35 @@
  * when closed, or the redesigned widget panel when open. State for
  * open/minimized comes from the shared store so every surface
  * (keyboard shortcut, close button, legacy code paths) stays in sync.
+ *
+ * Bundle strategy: WidgetPanel (and every component it imports —
+ * ChangesDrawer, WidgetInput, ModelPicker, AgentPicker,
+ * WidgetMessageList, ToolConfirmationDialog, SlashCommandMenu, …) lives
+ * in a separate async chunk.  The browser downloads that chunk only the
+ * first time the user opens the widget.
+ *
+ * webpackPrefetch causes the browser to fetch the chunk in the background
+ * during idle time after the main page loads, so when the user clicks the
+ * FAB the chunk is already cached — no visible delay on first open.
  */
 
+import { lazy, Suspense } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
 import STORE_NAME from '../../store';
 import WidgetLauncher from './widget-launcher';
-import WidgetPanel from './widget-panel';
-// chat-redesign base styles provide the primitives (.gaa-cr-tool-card,
-// .gaa-cr-changes-drawer, .gaa-cr-icon-btn, .gaa-cr-btn-sm) used by the
-// shared components we import from chat-redesign. All rules are scoped
-// under .gaa-cr* so they don't leak into the wp-admin surface.
-import '../chat-redesign/chat-redesign.css';
+// widget.css contains the launcher (FAB) styles and is required in the
+// initial bundle so the FAB is styled immediately on every page load.
+// chat-redesign.css is imported inside widget-panel.js so it lands in
+// the async chunk and is only fetched when the panel first opens.
 import './widget.css';
+
+const WidgetPanel = lazy( () =>
+	import(
+		/* webpackChunkName: "widget-panel", webpackPrefetch: true */
+		'./widget-panel'
+	)
+);
 
 /**
  *
@@ -25,5 +41,16 @@ export default function ChatWidget() {
 		( sel ) => sel( STORE_NAME ).isFloatingOpen(),
 		[]
 	);
-	return isOpen ? <WidgetPanel /> : <WidgetLauncher />;
+
+	if ( ! isOpen ) {
+		return <WidgetLauncher />;
+	}
+
+	// Suspense renders nothing while the panel chunk is downloading.
+	// On a cache hit (prefetch or repeat visit) this is imperceptible.
+	return (
+		<Suspense fallback={ null }>
+			<WidgetPanel />
+		</Suspense>
+	);
 }

--- a/src/components/chat-widget/widget-input.js
+++ b/src/components/chat-widget/widget-input.js
@@ -141,9 +141,13 @@ export default function WidgetInput() {
 					path: '/gratis-ai-agent/v1/memory',
 					method: 'POST',
 					data: { category: 'general', content: fact },
-				} ).catch( () => {} );
+				} ).catch( ( err ) => {
+					// eslint-disable-next-line no-console
+					console.error( 'Memory save failed:', err );
+				} );
 			}
 			setText( '' );
+			setAttachments( [] );
 			return;
 		}
 
@@ -154,9 +158,13 @@ export default function WidgetInput() {
 					path: '/gratis-ai-agent/v1/memory/forget',
 					method: 'POST',
 					data: { topic },
-				} ).catch( () => {} );
+				} ).catch( ( err ) => {
+					// eslint-disable-next-line no-console
+					console.error( 'Memory forget failed:', err );
+				} );
 			}
 			setText( '' );
+			setAttachments( [] );
 			return;
 		}
 
@@ -173,6 +181,7 @@ export default function WidgetInput() {
 				userDescription: description,
 			} );
 			setText( '' );
+			setAttachments( [] );
 			return;
 		}
 

--- a/src/components/chat-widget/widget-panel.js
+++ b/src/components/chat-widget/widget-panel.js
@@ -14,6 +14,10 @@ import STORE_NAME from '../../store';
 import ErrorBoundary from '../error-boundary';
 import ToolConfirmationDialog from '../tool-confirmation-dialog';
 import ChangesDrawer from '../chat-redesign/ChangesDrawer';
+// chat-redesign base styles (.gaa-cr-*) are only needed by panel
+// sub-components, so the import lives here rather than in index.js.
+// This keeps the CSS in the async panel chunk and out of the initial bundle.
+import '../chat-redesign/chat-redesign.css';
 import WidgetHeader from './widget-header';
 import WidgetEmpty from './widget-empty';
 import WidgetMessageList from './widget-message-list';

--- a/src/components/markdown-message.js
+++ b/src/components/markdown-message.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useMemo } from '@wordpress/element';
+import { useMemo, lazy, Suspense } from '@wordpress/element';
 
 /**
  * External dependencies
@@ -12,9 +12,55 @@ import remarkGfm from 'remark-gfm';
 /**
  * Internal dependencies
  */
-import CodeBlock from './code-block';
-import ChartBlock from './chart-block';
 import DataTable from './data-table';
+
+/**
+ * CodeBlock and ChartBlock are lazy-loaded so their heavy dependencies
+ * (CodeMirror ~800 KB, Chart.js ~220 KB) are bundled into separate async
+ * chunks that are only downloaded the first time the AI returns a fenced
+ * code block. webpackPrefetch causes the browser to fetch the chunks in
+ * the background during idle time so the download is usually already
+ * complete by the time a code block first appears.
+ */
+const CodeBlock = lazy( () =>
+	import(
+		/* webpackChunkName: "code-block", webpackPrefetch: true */
+		'./code-block'
+	)
+);
+const ChartBlock = lazy( () =>
+	import(
+		/* webpackChunkName: "chart-block", webpackPrefetch: true */
+		'./chart-block'
+	)
+);
+
+/**
+ * Plain fallback rendered while the syntax-highlighter chunk downloads.
+ * Shows the raw code text immediately so the user can read it before
+ * the interactive editor hydrates (~50 ms on a cached chunk).
+ *
+ * @param {Object} props          - Fallback props.
+ * @param {string} [props.lang]   - Language label for the header line.
+ * @param {*}      props.children - Code text.
+ * @return {JSX.Element} Preformatted code element.
+ */
+function CodeFallback( { lang, children } ) {
+	return (
+		<div className="gratis-ai-agent-code-block">
+			{ lang && (
+				<div className="gratis-ai-agent-code-header">
+					<span className="gratis-ai-agent-code-language">
+						{ lang }
+					</span>
+				</div>
+			) }
+			<pre className="gratis-ai-agent-code-cm gratis-ai-agent-code-plain">
+				<code>{ children }</code>
+			</pre>
+		</div>
+	);
+}
 
 /** Languages that should render as interactive Chart.js charts. */
 const CHART_LANGUAGES = new Set( [ 'chart', 'chartjs', 'chart.js' ] );
@@ -26,13 +72,38 @@ const components = {
 	code( { inline, className, children, ...props } ) {
 		const match = /language-(\w+)/.exec( className || '' );
 		if ( ! inline && match ) {
-			if ( CHART_LANGUAGES.has( match[ 1 ].toLowerCase() ) ) {
-				return <ChartBlock>{ children }</ChartBlock>;
+			const lang = match[ 1 ];
+			if ( CHART_LANGUAGES.has( lang.toLowerCase() ) ) {
+				return (
+					<Suspense
+						fallback={
+							<CodeFallback lang={ lang }>
+								{ children }
+							</CodeFallback>
+						}
+					>
+						<ChartBlock>{ children }</ChartBlock>
+					</Suspense>
+				);
 			}
-			return <CodeBlock language={ match[ 1 ] }>{ children }</CodeBlock>;
+			return (
+				<Suspense
+					fallback={
+						<CodeFallback lang={ lang }>{ children }</CodeFallback>
+					}
+				>
+					<CodeBlock language={ lang }>{ children }</CodeBlock>
+				</Suspense>
+			);
 		}
 		if ( ! inline && String( children ).includes( '\n' ) ) {
-			return <CodeBlock>{ children }</CodeBlock>;
+			return (
+				<Suspense
+					fallback={ <CodeFallback>{ children }</CodeFallback> }
+				>
+					<CodeBlock>{ children }</CodeBlock>
+				</Suspense>
+			);
 		}
 		return (
 			<code className={ className } { ...props }>

--- a/src/settings-page/style.css
+++ b/src/settings-page/style.css
@@ -892,7 +892,8 @@
 	transition: opacity 120ms;
 }
 
-.gratis-ai-agent-card:hover .gratis-ai-agent-card-actions {
+.gratis-ai-agent-card:hover .gratis-ai-agent-card-actions,
+.gratis-ai-agent-card:focus-within .gratis-ai-agent-card-actions {
 	opacity: 1;
 }
 

--- a/src/unified-admin/index.js
+++ b/src/unified-admin/index.js
@@ -1,8 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { createRoot, useState, useEffect } from '@wordpress/element';
-import { Notice } from '@wordpress/components';
+import { createRoot, useState, useEffect, Suspense } from '@wordpress/element';
+import { Notice, Spinner } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -126,7 +126,9 @@ function UnifiedAdminApp() {
 
 				<div className="gratis-ai-admin-layout">
 					<main className="gratis-ai-admin-main">
-						<Router route={ currentRoute } />
+						<Suspense fallback={ <Spinner /> }>
+							<Router route={ currentRoute } />
+						</Suspense>
 					</main>
 				</div>
 			</div>

--- a/src/unified-admin/router.js
+++ b/src/unified-admin/router.js
@@ -1,15 +1,38 @@
 /**
  * WordPress dependencies
  */
+import { lazy } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+// ChatRoute is the default landing route — keep it in the initial chunk so
+// the chat UI appears without any async loading on the first visit.
 import ChatRoute from './routes/chat';
-import AbilitiesRoute from './routes/abilities';
-import ChangesRoute from './routes/changes';
-import SettingsRoute from './routes/settings';
+
+// All non-default routes are lazy-loaded so their code (SettingsApp and its
+// 12 managers, AbilitiesExplorer, ChangesPage, …) is only downloaded when
+// the user first navigates to that section.  webpackPrefetch fetches the
+// chunks in the background during idle time so transitions feel instant.
+const AbilitiesRoute = lazy( () =>
+	import(
+		/* webpackChunkName: "route-abilities", webpackPrefetch: true */
+		'./routes/abilities'
+	)
+);
+const ChangesRoute = lazy( () =>
+	import(
+		/* webpackChunkName: "route-changes", webpackPrefetch: true */
+		'./routes/changes'
+	)
+);
+const SettingsRoute = lazy( () =>
+	import(
+		/* webpackChunkName: "route-settings", webpackPrefetch: true */
+		'./routes/settings'
+	)
+);
 
 /**
  * Redirect #/connectors to the appropriate destination.


### PR DESCRIPTION
## Summary

- **AgentPicker chip** added to both the main chat (`InputArea`) and floating widget toolbars, displaying each agent's configured dashicon or emoji alongside the name
- **Agent settings form** converted to `form-table` label-left layout (matches General Settings); system prompt populated from full `GET /agents/{id}` fetch on edit open; avatar icon live preview; temperature/max_iterations placeholders
- **Agent list cards**: edit/delete buttons sit directly after the Built-in badge; description on second line; hover highlight; `Temp:` removed; delete confirm simplified
- **Save bug fixed**: blank temperature/max_iterations no longer produce `Invalid parameter(s)` — JS sends `null` with NaN guard, PHP schema allows `[type, null]`, `Agent::update` uses `array_key_exists`
- **Tier1ToolsEditor crash fixed**: `a.id`, `a.label`, `a.category` all guarded against `undefined` before `.toLowerCase()`
- **WP-CLI `--agent=<slug>` flag**: loads agent system prompt, tier-1 tools, temperature, model, provider; CLI flags override agent defaults; `--verbose` prints agent info before sending

Resolves #1180

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.7 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 2h 6m and 2,084 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent picker UI for selecting between multiple configured agents in chat
  * Slash-command support: `/remember`, `/forget`, and `/report-issue` for chat actions
  * CLI `--agent` flag to select and apply agent configurations to commands

* **Bug Fixes**
  * Fixed chat layout overflow on mobile screens

* **Improvements**
  * Lazy-loaded components for faster page loads
  * Enhanced agent builder interface with improved card layout and controls
  * Support for clearing agent-specific settings via null values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->