### PR TITLE
GH#1186: fix: regenerate package-lock.json with typescript 6.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25380,6 +25380,21 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/typescript": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
 		"node_modules/uc.micro": {
 			"version": "1.0.6",
 			"dev": true,


### PR DESCRIPTION
## Summary

Ran npm install to regenerate package-lock.json. The lock file was broken by commit 44293ee which deleted the typescript peer dependency entry without adding the required typescript@6.0.3. The regenerated file now contains node_modules/typescript at version 6.0.3.

## Files Changed

package-lock.json

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified: grep shows node_modules/typescript entry with version 6.0.3 in package-lock.json.

Resolves #1186


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.7 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 3m and 2,568 tokens on this as a headless worker.