### PR TITLE
GH#1188: fix Prettier formatting for scrollToRevealLazyContent call in screenshot.js

### DIFF
--- a/src/abilities/screenshot.js
+++ b/src/abilities/screenshot.js
@@ -213,7 +213,11 @@ async function executeCaptureScreenshot( args ) {
 			const originalScrollX = window.scrollX;
 			const originalScrollY = window.scrollY;
 			try {
-				await scrollToRevealLazyContent( window, document, captureHeight );
+				await scrollToRevealLazyContent(
+					window,
+					document,
+					captureHeight
+				);
 			} finally {
 				window.scrollTo( originalScrollX, originalScrollY );
 			}


### PR DESCRIPTION
## Summary

Fixes the `prettier/prettier` ESLint error at `src/abilities/screenshot.js:216` introduced by PR #1185.

The `scrollToRevealLazyContent` call had its three arguments (`window`, `document`, `captureHeight`) on a single line, which violates the project's Prettier configuration. This reformats them to multi-line argument style.

## Change

```js
// Before (single-line — Prettier error)
await scrollToRevealLazyContent( window, document, captureHeight );

// After (multi-line — Prettier compliant)
await scrollToRevealLazyContent(
    window,
    document,
    captureHeight
);
```

## Verification

- `npx eslint src/abilities/screenshot.js` exits 0 ✓

Resolves #1188


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.7 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 4m and 5,020 tokens on this as a headless worker. Solved in 6m.