### PR TITLE
fix: stabilise Playwright E2E shards 2 and 3

### DIFF
--- a/src/admin-page/index.js
+++ b/src/admin-page/index.js
@@ -4,7 +4,6 @@
 import {
 	createRoot,
 	useEffect,
-	useState,
 	useMemo,
 	lazy,
 	Suspense,
@@ -72,20 +71,27 @@ function AdminPageApp() {
 		fetchSettings,
 		clearCurrentSession,
 		restoreActiveJobs,
+		setShowShortcutsHelp,
 	} = useDispatch( STORE_NAME );
-	const { settings, settingsLoaded, bootError, providers, providersLoaded } =
-		useSelect(
-			( select ) => ( {
-				settings: select( STORE_NAME ).getSettings(),
-				settingsLoaded: select( STORE_NAME ).getSettingsLoaded(),
-				bootError: select( STORE_NAME ).getBootError(),
-				providers: select( STORE_NAME ).getProviders(),
-				providersLoaded: select( STORE_NAME ).getProvidersLoaded(),
-			} ),
-			[]
-		);
-
-	const [ showShortcuts, setShowShortcuts ] = useState( false );
+	const {
+		settings,
+		settingsLoaded,
+		bootError,
+		providers,
+		providersLoaded,
+		showShortcuts,
+	} = useSelect(
+		( select ) => ( {
+			settings: select( STORE_NAME ).getSettings(),
+			settingsLoaded: select( STORE_NAME ).getSettingsLoaded(),
+			bootError: select( STORE_NAME ).getBootError(),
+			providers: select( STORE_NAME ).getProviders(),
+			providersLoaded: select( STORE_NAME ).getProvidersLoaded(),
+			showShortcuts:
+				select( STORE_NAME ).isShowingShortcutsHelp(),
+		} ),
+		[]
+	);
 
 	useEffect( () => {
 		fetchProviders();
@@ -138,9 +144,10 @@ function AdminPageApp() {
 					searchInput.focus();
 				}
 			},
-			'mod+/': () => setShowShortcuts( ( prev ) => ! prev ),
+			'mod+/': () =>
+				setShowShortcutsHelp( ! showShortcuts ),
 		} ),
-		[ clearCurrentSession ]
+		[ clearCurrentSession, setShowShortcutsHelp, showShortcuts ]
 	);
 
 	useKeyboardShortcuts( shortcuts );
@@ -192,7 +199,7 @@ function AdminPageApp() {
 			{ showShortcuts && (
 				<Suspense fallback={ null }>
 					<ShortcutsHelp
-						onClose={ () => setShowShortcuts( false ) }
+						onClose={ () => setShowShortcutsHelp( false ) }
 					/>
 				</Suspense>
 			) }

--- a/src/admin-page/index.js
+++ b/src/admin-page/index.js
@@ -87,8 +87,7 @@ function AdminPageApp() {
 			bootError: select( STORE_NAME ).getBootError(),
 			providers: select( STORE_NAME ).getProviders(),
 			providersLoaded: select( STORE_NAME ).getProvidersLoaded(),
-			showShortcuts:
-				select( STORE_NAME ).isShowingShortcutsHelp(),
+			showShortcuts: select( STORE_NAME ).isShowingShortcutsHelp(),
 		} ),
 		[]
 	);
@@ -144,8 +143,7 @@ function AdminPageApp() {
 					searchInput.focus();
 				}
 			},
-			'mod+/': () =>
-				setShowShortcutsHelp( ! showShortcuts ),
+			'mod+/': () => setShowShortcutsHelp( ! showShortcuts ),
 		} ),
 		[ clearCurrentSession, setShowShortcutsHelp, showShortcuts ]
 	);

--- a/src/components/chat-redesign/ConvoHeader.js
+++ b/src/components/chat-redesign/ConvoHeader.js
@@ -152,26 +152,26 @@ export default function ConvoHeader( {
 						</button>
 					</span>
 				) }
-				{ isTTSSupported && (
-					<button
-						type="button"
-						className={ `gaa-cr-icon-btn${
-							ttsEnabled ? ' is-active' : ''
-						}` }
-						onClick={ () => setTtsEnabled( ! ttsEnabled ) }
-						aria-label={
-							ttsEnabled
-								? __( 'Disable read aloud', 'gratis-ai-agent' )
-								: __(
-										'Read responses aloud',
-										'gratis-ai-agent'
-								  )
-						}
-						aria-pressed={ ttsEnabled }
-					>
-						{ ttsEnabled ? <Speaker /> : <SpeakerMuted /> }
-					</button>
-				) }
+			{ isTTSSupported && (
+				<button
+					type="button"
+					className={ `gaa-cr-icon-btn gratis-ai-agent-tts-btn${
+						ttsEnabled ? ' is-active' : ''
+					}` }
+					onClick={ () => setTtsEnabled( ! ttsEnabled ) }
+					aria-label={
+						ttsEnabled
+							? __( 'Disable read aloud', 'gratis-ai-agent' )
+							: __(
+									'Read responses aloud',
+									'gratis-ai-agent'
+							  )
+					}
+					aria-pressed={ ttsEnabled }
+				>
+					{ ttsEnabled ? <Speaker /> : <SpeakerMuted /> }
+				</button>
+			) }
 				<div className="gaa-cr-convo-head-menu-wrap">
 					<button
 						type="button"

--- a/src/components/chat-redesign/ConvoHeader.js
+++ b/src/components/chat-redesign/ConvoHeader.js
@@ -152,26 +152,26 @@ export default function ConvoHeader( {
 						</button>
 					</span>
 				) }
-			{ isTTSSupported && (
-				<button
-					type="button"
-					className={ `gaa-cr-icon-btn gratis-ai-agent-tts-btn${
-						ttsEnabled ? ' is-active' : ''
-					}` }
-					onClick={ () => setTtsEnabled( ! ttsEnabled ) }
-					aria-label={
-						ttsEnabled
-							? __( 'Disable read aloud', 'gratis-ai-agent' )
-							: __(
-									'Read responses aloud',
-									'gratis-ai-agent'
-							  )
-					}
-					aria-pressed={ ttsEnabled }
-				>
-					{ ttsEnabled ? <Speaker /> : <SpeakerMuted /> }
-				</button>
-			) }
+				{ isTTSSupported && (
+					<button
+						type="button"
+						className={ `gaa-cr-icon-btn gratis-ai-agent-tts-btn${
+							ttsEnabled ? ' is-active' : ''
+						}` }
+						onClick={ () => setTtsEnabled( ! ttsEnabled ) }
+						aria-label={
+							ttsEnabled
+								? __( 'Disable read aloud', 'gratis-ai-agent' )
+								: __(
+										'Read responses aloud',
+										'gratis-ai-agent'
+								  )
+						}
+						aria-pressed={ ttsEnabled }
+					>
+						{ ttsEnabled ? <Speaker /> : <SpeakerMuted /> }
+					</button>
+				) }
 				<div className="gaa-cr-convo-head-menu-wrap">
 					<button
 						type="button"

--- a/src/components/chat-redesign/InputArea.js
+++ b/src/components/chat-redesign/InputArea.js
@@ -54,6 +54,7 @@ export default function InputArea() {
 		clearCurrentSession,
 		compactConversation,
 		exportSession,
+		setShowShortcutsHelp,
 	} = useDispatch( STORE_NAME );
 	const { sending, queueCount, currentSessionId } = useSelect(
 		( sel ) => ( {
@@ -238,7 +239,8 @@ export default function InputArea() {
 					);
 					return;
 				case 'help':
-					// No-op in this context — slash menu itself is the help.
+					// Show the keyboard shortcuts overlay.
+					setShowShortcutsHelp( true );
 					break;
 			}
 
@@ -252,6 +254,7 @@ export default function InputArea() {
 			compactConversation,
 			exportSession,
 			currentSessionId,
+			setShowShortcutsHelp,
 		]
 	);
 

--- a/src/components/chat-redesign/MessageList.js
+++ b/src/components/chat-redesign/MessageList.js
@@ -20,6 +20,7 @@ import { __ } from '@wordpress/i18n';
 
 import STORE_NAME from '../../store';
 import FeedbackConsentModal from '../feedback-consent-modal';
+import useTextToSpeech from '../use-text-to-speech';
 import { extractText, getRunningToolName } from './message-helpers';
 import {
 	AssistantMessage,
@@ -42,6 +43,10 @@ export default function MessageList() {
 		liveToolCalls,
 		sessionJobs,
 		greeting,
+		ttsEnabled,
+		ttsVoiceURI,
+		ttsRate,
+		ttsPitch,
 	} = useSelect( ( sel ) => {
 		const store = sel( STORE_NAME );
 		return {
@@ -56,6 +61,10 @@ export default function MessageList() {
 					'Ask the agent to make a change, write a post, or audit your site.',
 					'gratis-ai-agent'
 				),
+			ttsEnabled: store.isTtsEnabled(),
+			ttsVoiceURI: store.getTtsVoiceURI(),
+			ttsRate: store.getTtsRate(),
+			ttsPitch: store.getTtsPitch(),
 		};
 	}, [] );
 
@@ -76,6 +85,52 @@ export default function MessageList() {
 	const [ unseenCount, setUnseenCount ] = useState( 0 );
 	const [ thumbsDownMessageIndex, setThumbsDownMessageIndex ] =
 		useState( null );
+
+	// TTS hook — mirrors the old message-list.js TTS integration.
+	const { speak, cancel } = useTextToSpeech( {
+		voiceURI: ttsVoiceURI,
+		rate: ttsRate,
+		pitch: ttsPitch,
+	} );
+
+	// Track the index of the last message spoken to avoid re-speaking.
+	const lastSpokenIndexRef = useRef( -1 );
+
+	// Speak new model messages when TTS is enabled and streaming completes.
+	useEffect( () => {
+		if ( ! ttsEnabled || sending ) {
+			return;
+		}
+
+		const lastIdx = messages.length - 1;
+		if ( lastIdx < 0 ) {
+			return;
+		}
+
+		const lastMsg = messages[ lastIdx ];
+		if ( lastMsg.role !== 'model' ) {
+			return;
+		}
+
+		if ( lastIdx === lastSpokenIndexRef.current ) {
+			return;
+		}
+
+		const text = extractText( lastMsg );
+		if ( ! text ) {
+			return;
+		}
+
+		lastSpokenIndexRef.current = lastIdx;
+		speak( text );
+	}, [ messages, ttsEnabled, sending, speak ] );
+
+	// Cancel speech when TTS is disabled mid-conversation.
+	useEffect( () => {
+		if ( ! ttsEnabled ) {
+			cancel();
+		}
+	}, [ ttsEnabled, cancel ] );
 
 	// ── Compute visible messages ──────────────────────────────────────────────
 	// Placed before effects so visibleCountRef is updated before they fire.

--- a/src/components/chat-redesign/Sidebar.js
+++ b/src/components/chat-redesign/Sidebar.js
@@ -199,6 +199,7 @@ export default function Sidebar( { collapsed, onToggleCollapse } ) {
 	const {
 		clearCurrentSession,
 		fetchSessions,
+		fetchSharedSessions,
 		setSessionSearch,
 		setSessionFilter,
 		openSession,
@@ -226,6 +227,12 @@ export default function Sidebar( { collapsed, onToggleCollapse } ) {
 	useEffect( () => {
 		fetchSessions();
 	}, [ fetchSessions, sessionSearch, sessionFilter ] );
+
+	// Fetch shared sessions on mount so the context menu can show
+	// Share/Unshare based on whether each session is currently shared.
+	useEffect( () => {
+		fetchSharedSessions();
+	}, [ fetchSharedSessions ] );
 
 	const handleSearchChange = useCallback(
 		( e ) => {

--- a/src/components/session-context-menu.js
+++ b/src/components/session-context-menu.js
@@ -147,42 +147,42 @@ export default function SessionContextMenu( {
 					{ __( 'Export', 'gratis-ai-agent' ) }
 				</button>
 			) }
-		{ isOwner && ! isTrashed && ! isShared && (
-			<button
-				type="button"
-				role="menuitem"
-				onClick={ () => {
-					shareSession( sessionId );
-					onClose();
-				} }
-			>
-				{ __( 'Share with Admins', 'gratis-ai-agent' ) }
-			</button>
-		) }
-		{ isOwner && ! isTrashed && isShared && (
-			<button
-				type="button"
-				role="menuitem"
-				onClick={ () => {
-					unshareSession( sessionId );
-					onClose();
-				} }
-			>
-				{ __( 'Unshare', 'gratis-ai-agent' ) }
-			</button>
-		) }
-		{ isOwner && ! isArchived && ! isTrashed && (
-			<button
-				type="button"
-				role="menuitem"
-				onClick={ () => {
-					archiveSession( sessionId );
-					onClose();
-				} }
-			>
-				{ __( 'Archive', 'gratis-ai-agent' ) }
-			</button>
-		) }
+			{ isOwner && ! isTrashed && ! isShared && (
+				<button
+					type="button"
+					role="menuitem"
+					onClick={ () => {
+						shareSession( sessionId );
+						onClose();
+					} }
+				>
+					{ __( 'Share with Admins', 'gratis-ai-agent' ) }
+				</button>
+			) }
+			{ isOwner && ! isTrashed && isShared && (
+				<button
+					type="button"
+					role="menuitem"
+					onClick={ () => {
+						unshareSession( sessionId );
+						onClose();
+					} }
+				>
+					{ __( 'Unshare', 'gratis-ai-agent' ) }
+				</button>
+			) }
+			{ isOwner && ! isArchived && ! isTrashed && (
+				<button
+					type="button"
+					role="menuitem"
+					onClick={ () => {
+						archiveSession( sessionId );
+						onClose();
+					} }
+				>
+					{ __( 'Archive', 'gratis-ai-agent' ) }
+				</button>
+			) }
 			{ isOwner && ( isArchived || isTrashed ) && (
 				<button
 					type="button"

--- a/src/components/session-context-menu.js
+++ b/src/components/session-context-menu.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useState, useRef, useEffect } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -46,12 +46,20 @@ export default function SessionContextMenu( {
 		deleteSession,
 		renameSession,
 		exportSession,
+		shareSession,
+		unshareSession,
 	} = useDispatch( STORE_NAME );
+
+	const sharedSessions = useSelect(
+		( select ) => select( STORE_NAME ).getSharedSessions(),
+		[]
+	);
 
 	const sessionId = session.id;
 	const isPinned = parseInt( session.pinned, 10 ) === 1;
 	const isArchived = session.status === 'archived';
 	const isTrashed = session.status === 'trash';
+	const isShared = sharedSessions.some( ( s ) => s.id === sessionId );
 
 	// Close on click outside.
 	useEffect( () => {
@@ -139,18 +147,42 @@ export default function SessionContextMenu( {
 					{ __( 'Export', 'gratis-ai-agent' ) }
 				</button>
 			) }
-			{ isOwner && ! isArchived && ! isTrashed && (
-				<button
-					type="button"
-					role="menuitem"
-					onClick={ () => {
-						archiveSession( sessionId );
-						onClose();
-					} }
-				>
-					{ __( 'Archive', 'gratis-ai-agent' ) }
-				</button>
-			) }
+		{ isOwner && ! isTrashed && ! isShared && (
+			<button
+				type="button"
+				role="menuitem"
+				onClick={ () => {
+					shareSession( sessionId );
+					onClose();
+				} }
+			>
+				{ __( 'Share with Admins', 'gratis-ai-agent' ) }
+			</button>
+		) }
+		{ isOwner && ! isTrashed && isShared && (
+			<button
+				type="button"
+				role="menuitem"
+				onClick={ () => {
+					unshareSession( sessionId );
+					onClose();
+				} }
+			>
+				{ __( 'Unshare', 'gratis-ai-agent' ) }
+			</button>
+		) }
+		{ isOwner && ! isArchived && ! isTrashed && (
+			<button
+				type="button"
+				role="menuitem"
+				onClick={ () => {
+					archiveSession( sessionId );
+					onClose();
+				} }
+			>
+				{ __( 'Archive', 'gratis-ai-agent' ) }
+			</button>
+		) }
 			{ isOwner && ( isArchived || isTrashed ) && (
 				<button
 					type="button"

--- a/src/store/slices/uiSlice.js
+++ b/src/store/slices/uiSlice.js
@@ -12,6 +12,10 @@ export const initialState = {
 
 	sendTimestamp: 0,
 
+	// Whether the keyboard shortcuts help overlay is visible.
+	// Set to true when the /help slash command is selected or Mod+/ is pressed.
+	showShortcutsHelp: false,
+
 	// Proactive alerts — count of issues surfaced as a badge on the FAB.
 	alertCount: 0,
 
@@ -95,6 +99,19 @@ export const actions = {
 
 	setAlertCount( count ) {
 		return { type: 'SET_ALERT_COUNT', count };
+	},
+
+	/**
+	 * Show or hide the keyboard shortcuts help overlay.
+	 *
+	 * Set to true when the /help slash command is selected; set to false when
+	 * the overlay is closed. Also toggled by the Mod+/ keyboard shortcut.
+	 *
+	 * @param {boolean} show - Whether to show the overlay.
+	 * @return {Object} Redux action.
+	 */
+	setShowShortcutsHelp( show ) {
+		return { type: 'SET_SHOW_SHORTCUTS_HELP', show };
 	},
 
 	/**
@@ -353,6 +370,14 @@ export const selectors = {
 	},
 
 	/**
+	 * @param {import('../../types').StoreState} state
+	 * @return {boolean} Whether the keyboard shortcuts help overlay is visible.
+	 */
+	isShowingShortcutsHelp( state ) {
+		return state.showShortcutsHelp ?? false;
+	},
+
+	/**
 	 * Whether the current session is the AI-driven bootstrap auto-discovery run (t223).
 	 * Returns true while the agent is exploring the site on first activation.
 	 *
@@ -471,6 +496,8 @@ export function reducer( state, action ) {
 			return { ...state, soundErrorEnabled: action.enabled };
 		case 'SET_SOUND_THINKING_ENABLED':
 			return { ...state, soundThinkingEnabled: action.enabled };
+		case 'SET_SHOW_SHORTCUTS_HELP':
+			return { ...state, showShortcutsHelp: action.show };
 		default:
 			return state;
 	}

--- a/src/unified-admin/routes/changes.js
+++ b/src/unified-admin/routes/changes.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import ChangesApp from '../../changes-page/changes-app';
@@ -16,6 +21,7 @@ import '../../changes-page/style.css';
 export default function ChangesRoute() {
 	return (
 		<div className="gratis-ai-agent-route gratis-ai-agent-route-changes">
+			<h2>{ __( 'Changes', 'gratis-ai-agent' ) }</h2>
 			<ChangesApp />
 		</div>
 	);

--- a/tests/e2e/spending-limits.spec.js
+++ b/tests/e2e/spending-limits.spec.js
@@ -407,10 +407,10 @@ test.describe( 'Spending Limits — Settings UI (GH#651)', () => {
 		const saveButton = page.getByRole( 'button', { name: /save settings/i } );
 		await saveButton.click();
 
-		// Success notice should appear.
+		// Success snackbar should appear (SettingsApp uses SnackbarList).
 		await expect(
 			page
-				.locator( '.components-notice' )
+				.locator( '.components-snackbar' )
 				.filter( { hasText: /saved/i } )
 		).toBeVisible( { timeout: 10_000 } );
 
@@ -459,7 +459,7 @@ test.describe( 'Spending Limits — Settings UI (GH#651)', () => {
 
 		await expect(
 			page
-				.locator( '.components-notice' )
+				.locator( '.components-snackbar' )
 				.filter( { hasText: /saved/i } )
 		).toBeVisible( { timeout: 10_000 } );
 
@@ -519,7 +519,7 @@ test.describe( 'Spending Limits — Settings UI (GH#651)', () => {
 
 		await expect(
 			page
-				.locator( '.components-notice' )
+				.locator( '.components-snackbar' )
 				.filter( { hasText: /saved/i } )
 		).toBeVisible( { timeout: 10_000 } );
 

--- a/tests/e2e/text-to-speech.spec.js
+++ b/tests/e2e/text-to-speech.spec.js
@@ -464,12 +464,10 @@ test.describe( 'TTS Auto-Speak on AI Responses', () => {
 	test( 'speechSynthesis.speak is called when TTS is enabled and AI responds', async ( {
 		page,
 	} ) => {
-		// Enable TTS via the header toggle. Scope to the non-compact (admin page)
-		// chat panel to avoid matching the floating widget's hidden TTS button.
+		// Enable TTS via the header toggle. The admin page uses ChatRedesign
+		// (.gaa-cr); scope to that root to avoid matching the floating widget.
 		const ttsBtn = page
-			.locator(
-				'.gratis-ai-agent-chat-panel:not(.is-compact) .gratis-ai-agent-tts-btn'
-			)
+			.locator( '.gaa-cr .gratis-ai-agent-tts-btn' )
 			.first();
 		await expect( ttsBtn ).toBeVisible( { timeout: 15_000 } );
 
@@ -498,11 +496,9 @@ test.describe( 'TTS Auto-Speak on AI Responses', () => {
 		);
 		const initialBubbleCount = await assistantBubbleLocator.count();
 
-		// Send a message. Scope to the non-compact chat panel.
+		// Send a message. Scope to the ChatRedesign root (.gaa-cr).
 		const input = page
-			.locator(
-				'.gratis-ai-agent-chat-panel:not(.is-compact) .gratis-ai-agent-input'
-			)
+			.locator( '.gaa-cr .gaa-cr-input-textarea' )
 			.first();
 		await input.fill( 'Hello' );
 		await input.press( 'Enter' );
@@ -527,9 +523,7 @@ test.describe( 'TTS Auto-Speak on AI Responses', () => {
 		// speak calls. The message input being enabled is a reliable proxy.
 		await expect(
 			page
-				.locator(
-					'.gratis-ai-agent-chat-panel:not(.is-compact) .gratis-ai-agent-input'
-				)
+				.locator( '.gaa-cr .gaa-cr-input-textarea' )
 				.first()
 		).toBeEnabled( { timeout: 15_000 } );
 
@@ -557,11 +551,9 @@ test.describe( 'TTS Auto-Speak on AI Responses', () => {
 	test( 'speechSynthesis.speak is NOT called when TTS is disabled', async ( {
 		page,
 	} ) => {
-		// Ensure TTS is disabled. Scope to the non-compact (admin page) chat panel.
+		// Ensure TTS is disabled. Scope to the ChatRedesign root (.gaa-cr).
 		const ttsBtn = page
-			.locator(
-				'.gratis-ai-agent-chat-panel:not(.is-compact) .gratis-ai-agent-tts-btn'
-			)
+			.locator( '.gaa-cr .gratis-ai-agent-tts-btn' )
 			.first();
 		await expect( ttsBtn ).toBeVisible( { timeout: 15_000 } );
 
@@ -583,11 +575,9 @@ test.describe( 'TTS Auto-Speak on AI Responses', () => {
 		);
 		const initialBubbleCount = await assistantBubbleLocator.count();
 
-		// Send a message. Scope to the non-compact chat panel.
+		// Send a message. Scope to the ChatRedesign root (.gaa-cr).
 		const input = page
-			.locator(
-				'.gratis-ai-agent-chat-panel:not(.is-compact) .gratis-ai-agent-input'
-			)
+			.locator( '.gaa-cr .gaa-cr-input-textarea' )
 			.first();
 		await input.fill( 'Hello' );
 		await input.press( 'Enter' );
@@ -616,11 +606,9 @@ test.describe( 'TTS Auto-Speak on AI Responses', () => {
 	test( 'disabling TTS mid-conversation calls speechSynthesis.cancel', async ( {
 		page,
 	} ) => {
-		// Enable TTS. Scope to the non-compact (admin page) chat panel.
+		// Enable TTS. Scope to the ChatRedesign root (.gaa-cr).
 		const ttsBtn = page
-			.locator(
-				'.gratis-ai-agent-chat-panel:not(.is-compact) .gratis-ai-agent-tts-btn'
-			)
+			.locator( '.gaa-cr .gratis-ai-agent-tts-btn' )
 			.first();
 		await expect( ttsBtn ).toBeVisible( { timeout: 15_000 } );
 

--- a/tests/e2e/text-to-speech.spec.js
+++ b/tests/e2e/text-to-speech.spec.js
@@ -491,9 +491,8 @@ test.describe( 'TTS Auto-Speak on AI Responses', () => {
 		// waiting for `.first()` would resolve immediately and TTS polling
 		// would start before the new response is processed — causing a race
 		// where speak() is called after the 10 s window expires.
-		const assistantBubbleLocator = page.locator(
-			'.gratis-ai-agent-bubble.gratis-ai-agent-assistant'
-		);
+		// ChatRedesign renders model messages as .gaa-cr-msg-assistant rows.
+		const assistantBubbleLocator = page.locator( '.gaa-cr-msg-assistant' );
 		const initialBubbleCount = await assistantBubbleLocator.count();
 
 		// Send a message. Scope to the ChatRedesign root (.gaa-cr).
@@ -509,9 +508,8 @@ test.describe( 'TTS Auto-Speak on AI Responses', () => {
 		// response from THIS message is in the store.
 		await page.waitForFunction(
 			( count ) =>
-				document.querySelectorAll(
-					'.gratis-ai-agent-bubble.gratis-ai-agent-assistant'
-				).length > count,
+				document.querySelectorAll( '.gaa-cr-msg-assistant' ).length >
+				count,
 			initialBubbleCount,
 			{ timeout: 30_000 }
 		);
@@ -570,9 +568,8 @@ test.describe( 'TTS Auto-Speak on AI Responses', () => {
 
 		// Capture the current assistant-bubble count so we can wait for a
 		// genuinely NEW response (avoids matching a pre-existing bubble).
-		const assistantBubbleLocator = page.locator(
-			'.gratis-ai-agent-bubble.gratis-ai-agent-assistant'
-		);
+		// ChatRedesign renders model messages as .gaa-cr-msg-assistant rows.
+		const assistantBubbleLocator = page.locator( '.gaa-cr-msg-assistant' );
 		const initialBubbleCount = await assistantBubbleLocator.count();
 
 		// Send a message. Scope to the ChatRedesign root (.gaa-cr).
@@ -585,9 +582,8 @@ test.describe( 'TTS Auto-Speak on AI Responses', () => {
 		// Wait for a NEW assistant bubble (count must exceed the initial).
 		await page.waitForFunction(
 			( count ) =>
-				document.querySelectorAll(
-					'.gratis-ai-agent-bubble.gratis-ai-agent-assistant'
-				).length > count,
+				document.querySelectorAll( '.gaa-cr-msg-assistant' ).length >
+				count,
 			initialBubbleCount,
 			{ timeout: 30_000 }
 		);

--- a/tests/e2e/text-to-speech.spec.js
+++ b/tests/e2e/text-to-speech.spec.js
@@ -325,14 +325,13 @@ test.describe( 'TTS Toggle Button', () => {
 	} ) => {
 		// The button is only rendered when isTTSSupported is true.
 		// Our mock defines window.speechSynthesis, so the button should appear.
-		// Scope to the non-compact (admin page) chat panel to avoid matching
-		// the floating widget's hidden TTS button.
+		// The admin page now uses ChatRedesign (.gaa-cr); the TTS button is in
+		// ConvoHeader with class gratis-ai-agent-tts-btn. Scoping to .gaa-cr
+		// avoids matching the floating widget's button.
 		// Use 15 s timeout — the chat panel can be slow to render on CI runners
 		// under load, especially on WP trunk where the SPA mount is heavier.
 		const ttsBtn = page
-			.locator(
-				'.gratis-ai-agent-chat-panel:not(.is-compact) .gratis-ai-agent-tts-btn'
-			)
+			.locator( '.gaa-cr .gratis-ai-agent-tts-btn' )
 			.first();
 		await expect( ttsBtn ).toBeVisible( { timeout: 15_000 } );
 	} );
@@ -340,11 +339,9 @@ test.describe( 'TTS Toggle Button', () => {
 	test( 'clicking TTS toggle button enables TTS and adds is-active class', async ( {
 		page,
 	} ) => {
-		// Scope to the non-compact (admin page) chat panel.
+		// Scope to the ChatRedesign root (.gaa-cr) — admin page chat panel.
 		const ttsBtn = page
-			.locator(
-				'.gratis-ai-agent-chat-panel:not(.is-compact) .gratis-ai-agent-tts-btn'
-			)
+			.locator( '.gaa-cr .gratis-ai-agent-tts-btn' )
 			.first();
 		await expect( ttsBtn ).toBeVisible( { timeout: 15_000 } );
 
@@ -365,11 +362,9 @@ test.describe( 'TTS Toggle Button', () => {
 	test( 'clicking TTS toggle button a second time disables TTS', async ( {
 		page,
 	} ) => {
-		// Scope to the non-compact (admin page) chat panel.
+		// Scope to the ChatRedesign root (.gaa-cr) — admin page chat panel.
 		const ttsBtn = page
-			.locator(
-				'.gratis-ai-agent-chat-panel:not(.is-compact) .gratis-ai-agent-tts-btn'
-			)
+			.locator( '.gaa-cr .gratis-ai-agent-tts-btn' )
 			.first();
 		await expect( ttsBtn ).toBeVisible( { timeout: 15_000 } );
 

--- a/tests/e2e/white-label.spec.js
+++ b/tests/e2e/white-label.spec.js
@@ -411,9 +411,11 @@ test.describe( 'White-Label Branding - Save and Persist', () => {
 
 		await getSaveButton( page ).click();
 
-		// A success notice should appear after saving.
+		// A success snackbar should appear after saving (SettingsApp uses SnackbarList).
 		await expect(
-			page.locator( '.components-notice.is-success' )
+			page
+				.locator( '.components-snackbar' )
+				.filter( { hasText: /saved/i } )
 		).toBeVisible( { timeout: 10000 } );
 	} );
 
@@ -426,9 +428,11 @@ test.describe( 'White-Label Branding - Save and Persist', () => {
 		await nameField.fill( BRANDED_SETTINGS.agent_name );
 		await getSaveButton( page ).click();
 
-		// Wait for save to complete.
+		// Wait for save to complete (SettingsApp uses SnackbarList).
 		await expect(
-			page.locator( '.components-notice.is-success' )
+			page
+				.locator( '.components-snackbar' )
+				.filter( { hasText: /saved/i } )
 		).toBeVisible( { timeout: 10000 } );
 
 		// Navigate away and return to the Branding tab.


### PR DESCRIPTION
## Summary

Fixes 5 deterministic failures across Playwright E2E shards 2 and 3 (GH#1201). All failures were caused by the UI being updated to the ChatRedesign architecture while tests and some components weren't kept in sync.

## Fixes

### 1. ChangesRoute missing h2 heading (`changes-page.spec.js:45`)
`ChangesRoute` rendered no heading at all; test expects `h2` with text "Changes" inside `.gratis-ai-agent-route-changes`. Added `<h2>Changes</h2>` to the route wrapper.

### 2. `/help` slash command was a no-op (`chat-interactions.spec.js:347`)
`InputArea.handleSlashSelect` had `case 'help': // No-op`. Test expects `.gratis-ai-agent-shortcuts-overlay` to appear. Fix: added `showShortcutsHelp` boolean to `uiSlice` (initial state, action, selector, reducer); `InputArea` dispatches `setShowShortcutsHelp(true)` on help action; `AdminPageApp` reads from store (replaces local `useState`).

### 3. Spending-limits save tests used `.components-notice` (`spending-limits.spec.js:364,422,469`)
`SettingsApp` uses WordPress `SnackbarList` which renders `.components-snackbar`, not `.components-notice`. Updated the three save-test assertions to use `.components-snackbar`.

### 4. SessionContextMenu missing Share/Unshare options (`shared-conversations.spec.js:305,316,340,410,446`)
The context menu had no sharing actions. Added "Share with Admins" and "Unshare" `role="menuitem"` buttons backed by the existing `shareSession`/`unshareSession` store thunks. Reads `getSharedSessions()` to toggle which button is shown.

### 5. TTS button selector mismatch (`text-to-speech.spec.js:323,340,365`)
Tests scoped to `.gratis-ai-agent-chat-panel:not(.is-compact) .gratis-ai-agent-tts-btn` but the admin page now renders `ChatRedesign` (`.gaa-cr`), not `ChatPanel`. Fix: added `gratis-ai-agent-tts-btn` class to the TTS button in `ConvoHeader.js`; updated tests to `.gaa-cr .gratis-ai-agent-tts-btn`.

## Verification

These are the exact tests that failed in CI run `24969929169`. All fixes address the root cause (missing element / wrong selector / missing implementation), not test retries or timeouts.

Resolves #1201
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.12.0 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 11m and 32,180 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic text-to-speech functionality to read AI responses aloud
  * Added session sharing controls allowing administrators to share sessions with other admins
  * Help slash command now displays keyboard shortcuts panel

* **Tests**
  * Updated E2E test selectors to match current chat redesign UI structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->