### PR TITLE
fix: wire up pending_client_tool_calls pipeline end-to-end

### DIFF
--- a/includes/Core/ClientAbilityRouter.php
+++ b/includes/Core/ClientAbilityRouter.php
@@ -154,6 +154,15 @@ final class ClientAbilityRouter {
 		$php_parts = array();
 		$client    = array();
 
+		// Build a name→annotations lookup once for O(1) access inside the loop.
+		$annotations_by_name = array();
+		foreach ( $this->client_abilities as $descriptor ) {
+			$name = (string) ( $descriptor['name'] ?? '' );
+			if ( '' !== $name ) {
+				$annotations_by_name[ $name ] = $descriptor['annotations'] ?? array();
+			}
+		}
+
 		foreach ( $message->getParts() as $part ) {
 			$call = $part->getFunctionCall();
 			if ( ! $call ) {
@@ -169,9 +178,12 @@ final class ClientAbilityRouter {
 
 			if ( in_array( $ability_name, $client_names, true ) ) {
 				$client[] = array(
-					'id'   => (string) $call->getId(),
-					'name' => $ability_name,
-					'args' => $call->getArgs() ?: array(),
+					'id'          => (string) $call->getId(),
+					'name'        => $ability_name,
+					'args'        => $call->getArgs() ?: array(),
+					// Annotations are forwarded so the browser can decide whether
+					// to auto-execute (readonly=true) or show a confirmation dialog.
+					'annotations' => $annotations_by_name[ $ability_name ] ?? array(),
 				);
 			} else {
 				$php_parts[] = $part;

--- a/includes/Models/ActiveJobRepository.php
+++ b/includes/Models/ActiveJobRepository.php
@@ -20,7 +20,7 @@ class ActiveJobRepository {
 	/**
 	 * Valid job status values.
 	 */
-	const STATUSES = [ 'processing', 'awaiting_confirmation', 'complete', 'error' ];
+	const STATUSES = [ 'processing', 'awaiting_confirmation', 'awaiting_client_tools', 'complete', 'error' ];
 
 	/**
 	 * Get the active jobs table name.
@@ -112,7 +112,7 @@ class ActiveJobRepository {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
 		$row = $wpdb->get_row(
 			$wpdb->prepare(
-				"SELECT * FROM %i WHERE session_id = %d AND status IN ('processing', 'awaiting_confirmation') ORDER BY created_at DESC LIMIT 1",
+				"SELECT * FROM %i WHERE session_id = %d AND status IN ('processing', 'awaiting_confirmation', 'awaiting_client_tools') ORDER BY created_at DESC LIMIT 1",
 				$table,
 				$session_id
 			)
@@ -139,7 +139,7 @@ class ActiveJobRepository {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT * FROM %i WHERE user_id = %d AND status IN ('processing', 'awaiting_confirmation') ORDER BY created_at DESC",
+				"SELECT * FROM %i WHERE user_id = %d AND status IN ('processing', 'awaiting_confirmation', 'awaiting_client_tools') ORDER BY created_at DESC",
 				$table,
 				$user_id
 			)

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -982,6 +982,13 @@ final class SessionController {
 			return new WP_REST_Response( $response, 200 );
 		}
 
+		if ( 'awaiting_client_tools' === $job['status'] && isset( $job['pending_client_tool_calls'] ) ) {
+			// Surface the client-side pending calls so the browser can execute
+			// JS abilities and POST results back via /chat/tool-result.
+			$response['pending_client_tool_calls'] = $job['pending_client_tool_calls'];
+			return new WP_REST_Response( $response, 200 );
+		}
+
 		if ( 'complete' === $job['status'] && isset( $job['result'] ) ) {
 			// @phpstan-ignore-next-line
 			$response['reply'] = $job['result']['reply'] ?? '';
@@ -1070,6 +1077,14 @@ final class SessionController {
 			$pending = json_decode( $row->pending_tools, true );
 			if ( is_array( $pending ) ) {
 				$response['pending_tools'] = $pending;
+			}
+		}
+
+		if ( 'awaiting_client_tools' === $status ) {
+			// pending_tools column reused — contains pending_client_tool_calls JSON.
+			$pending = json_decode( $row->pending_tools, true );
+			if ( is_array( $pending ) ) {
+				$response['pending_client_tool_calls'] = $pending;
 			}
 		}
 
@@ -1597,6 +1612,38 @@ final class SessionController {
 				'awaiting_confirmation',
 				[
 					'pending_tools' => wp_json_encode( $pending_tools_for_db ),
+					'tool_calls'    => wp_json_encode( $tool_calls_for_db ),
+				]
+			);
+
+			return new WP_REST_Response( array( 'ok' => true ), 200 );
+		} elseif ( is_array( $result ) && ! empty( $result['pending_client_tool_calls'] ) ) {
+			// Agent loop paused — waiting for the browser to execute client-side
+			// (JS) tools and POST results back to /chat/tool-result.
+			// The AgentLoop already persisted the paused conversation state via
+			// Database::save_paused_state(), so /chat/tool-result can reconstruct
+			// the loop. We only need to surface the pending calls to the browser.
+			/** @var array<string, mixed> $result */
+			$job['status']                    = 'awaiting_client_tools';
+			$job['pending_client_tool_calls'] = $result['pending_client_tool_calls'];
+			// Preserve live tool-call progress so the UI stays current.
+			$job['tool_calls'] = $result['tool_call_log'] ?? array();
+
+			unset( $job['token'] );
+			set_transient( RestController::JOB_PREFIX . $job_id, $job, RestController::JOB_TTL );
+
+			// Persist to DB so the pending calls survive transient expiry.
+			// We reuse the pending_tools column (JSON) since the schema is
+			// shared and the data shape is compatible.
+			/** @var list<array<string, mixed>> $pending_calls_for_db */
+			$pending_calls_for_db = (array) $job['pending_client_tool_calls'];
+			/** @var list<array<string, mixed>> $tool_calls_for_db */
+			$tool_calls_for_db = (array) $job['tool_calls'];
+			ActiveJobRepository::update_status(
+				$job_id,
+				'awaiting_client_tools',
+				[
+					'pending_tools' => wp_json_encode( $pending_calls_for_db ),
 					'tool_calls'    => wp_json_encode( $tool_calls_for_db ),
 				]
 			);

--- a/src/abilities/registry.js
+++ b/src/abilities/registry.js
@@ -61,6 +61,17 @@ let categoryRegistrationPromise = null;
 const registeredAbilityNames = new Set();
 
 /**
+ * Callback map — name → async function(args) → result.
+ *
+ * Maintained in parallel to the WP 7.0 registry so jobSlice can invoke
+ * abilities by name without relying on wp.abilities.executeAbility() (which
+ * may not be available or may not surface the raw return value we need).
+ *
+ * @type {Map<string, Function>}
+ */
+const clientCallbacks = new Map();
+
+/**
  * Detect whether the WP 7.0 abilities API is available on this page.
  *
  * @return {boolean} True when wp.abilities is loaded and exposes the
@@ -191,6 +202,13 @@ export async function registerClientAbility( def ) {
 	}
 	registeredAbilityNames.add( def.name );
 
+	// Store the callback so executeClientAbility() can invoke it by name
+	// without going through the WP abilities API (which may not expose the
+	// raw return value needed for tool-result forwarding).
+	if ( typeof def.callback === 'function' ) {
+		clientCallbacks.set( def.name, def.callback );
+	}
+
 	try {
 		await wp.abilities.registerAbility( {
 			name: def.name,
@@ -276,4 +294,27 @@ export async function snapshotDescriptors() {
 	} catch ( _err ) {
 		return [];
 	}
+}
+
+/**
+ * Execute a registered client-side ability by name.
+ *
+ * Called by the job-polling logic in jobSlice when the server returns
+ * `pending_client_tool_calls`. The ability must have been registered via
+ * `registerClientAbility()` in the same page lifetime.
+ *
+ * @param {string} name Fully-qualified ability name (gratis-ai-agent-js/...).
+ * @param {Object} args Ability arguments from the model's tool call.
+ * @return {Promise<Object>} The ability's result object.
+ * @throws {Error} When the ability is not registered in the current page.
+ */
+export async function executeClientAbility( name, args ) {
+	const callback = clientCallbacks.get( name );
+	if ( ! callback ) {
+		throw new Error(
+			`Client ability "${ name }" is not registered on this page. ` +
+				'Ensure the ability was registered via registerClientAbility() before the job completed.'
+		);
+	}
+	return callback( args );
 }

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -323,8 +323,7 @@ export const actions = {
 
 						// POST results back to the server so the agent loop
 						// can continue with the screenshot/DOM data.
-						const currentSessionId =
-							select.getCurrentSessionId();
+						const currentSessionId = select.getCurrentSessionId();
 						try {
 							await apiFetch( {
 								path: '/gratis-ai-agent/v1/chat/tool-result',
@@ -351,7 +350,7 @@ export const actions = {
 													: __(
 															'Failed to submit client tool results.',
 															'gratis-ai-agent'
-														)
+													  )
 											}`,
 										},
 									],

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -11,6 +11,7 @@ import { onVisibilityChange } from '../../utils/visibility-manager';
 import { setActiveJob, clearActiveJob } from '../../utils/active-jobs-storage';
 import { notifyConfirmationNeeded } from '../../utils/notification-manager';
 import { playDing, playDong, playThinking } from '../../utils/sound-manager';
+import { executeClientAbility } from '../../abilities/registry';
 
 export const initialState = {
 	// Active polling job ID (most-recently-started job for the current session).
@@ -261,6 +262,116 @@ export const actions = {
 						// Don't clear sending — still waiting.
 						unsubscribeVisibility();
 						clearActiveJob( sessionId );
+						return;
+					}
+
+					if ( result.status === 'awaiting_client_tools' ) {
+						// The agent loop has paused and handed a set of JS
+						// abilities to the browser for execution.  Each call
+						// carries an `annotations` object; abilities with
+						// `readonly: true` execute immediately without a
+						// confirmation dialog (screenshots, DOM reads, etc.).
+						// Non-readonly abilities are not yet supported without
+						// an explicit confirmation flow — they will be handled
+						// in a future iteration.
+						const pendingCalls =
+							result.pending_client_tool_calls || [];
+
+						const toolResults = await Promise.all(
+							pendingCalls.map( async ( call ) => {
+								const isReadonly =
+									call.annotations?.readonly === true;
+
+								if ( ! isReadonly ) {
+									// Non-readonly client abilities are not yet
+									// auto-executed — return an error so the
+									// model gets feedback instead of silently
+									// hanging.
+									return {
+										id: call.id,
+										name: call.name,
+										error: __(
+											'Client-side ability requires user confirmation (not yet supported for non-readonly abilities).',
+											'gratis-ai-agent'
+										),
+									};
+								}
+
+								try {
+									const abilityResult =
+										await executeClientAbility(
+											call.name,
+											call.args || {}
+										);
+									return {
+										id: call.id,
+										name: call.name,
+										result: abilityResult,
+									};
+								} catch ( execErr ) {
+									return {
+										id: call.id,
+										name: call.name,
+										error:
+											execErr instanceof Error
+												? execErr.message
+												: String( execErr ),
+									};
+								}
+							} )
+						);
+
+						// POST results back to the server so the agent loop
+						// can continue with the screenshot/DOM data.
+						const currentSessionId =
+							select.getCurrentSessionId();
+						try {
+							await apiFetch( {
+								path: '/gratis-ai-agent/v1/chat/tool-result',
+								method: 'POST',
+								data: {
+									session_id: currentSessionId,
+									tool_results: toolResults,
+								},
+							} );
+						} catch ( postErr ) {
+							// Failed to post results — surface error to user
+							// and stop polling rather than hanging.
+							if ( currentSessionId === sessionId ) {
+								dispatch.appendMessage( {
+									role: 'system',
+									parts: [
+										{
+											text: `${ __(
+												'Error:',
+												'gratis-ai-agent'
+											) } ${
+												postErr instanceof Error
+													? postErr.message
+													: __(
+															'Failed to submit client tool results.',
+															'gratis-ai-agent'
+														)
+											}`,
+										},
+									],
+								} );
+								dispatch.setSending( false );
+							}
+							unsubscribeVisibility();
+							clearActiveJob( sessionId );
+							dispatch.setCurrentJobId( null );
+							dispatch.setSessionJob( sessionId, null );
+							return;
+						}
+
+						// Resume polling — the server has resumed the agent
+						// loop; we continue polling the same job for the
+						// model's next response or another pause.
+						await new Promise( ( resolve ) =>
+							setTimeout( resolve, getInterval( attempts ) )
+						);
+						poll();
 						return;
 					}
 


### PR DESCRIPTION
## Problem

Three separate defects caused client-side abilities (`screenshot-url`, `capture-screenshot`) to silently fail with a misleading `ability_not_allowed` error, and prevented read-only abilities from auto-executing without a spurious confirmation popup.

## Root causes and fixes

### 1. `SessionController::handle_process()` — silent swallow (PHP)

`AgentLoop::run()` returns `pending_client_tool_calls` when client routing intercepts a JS ability call. `handle_process` had **no branch** for this result — it fell into the `else`/complete path, wrote partial history to the session, and never signalled the browser to execute the JS ability.

→ Added an `elseif` branch that sets `job['status'] = 'awaiting_client_tools'`, stores the pending calls in both the transient and the DB `pending_tools` column, and returns without persisting partial history.

### 2. `handle_job_status()` + `job_status_from_db_row()` — new status invisible to poll

Even with fix 1, the poll response wouldn't carry the pending calls to the browser.

→ Added a guard in `handle_job_status` that returns `pending_client_tool_calls` for `awaiting_client_tools`. Added the same to the DB-fallback path so it survives transient expiry.

### 3. `ActiveJobRepository` — new status rejected + invisible to reconnect queries

`STATUSES` didn't include `'awaiting_client_tools'`, so `update_status()` silently returned `false`. The `get_by_session_id()` and `get_active_for_user()` `IN`-clauses also excluded it.

→ Added `awaiting_client_tools` to `STATUSES` and both SQL queries.

### 4. `ClientAbilityRouter::partition()` — annotations not forwarded (PHP)

Pending client call descriptors only included `id`, `name`, `args`. The browser couldn't check `readonly` without a separate API call.

→ Built a `name → annotations` lookup from `$this->client_abilities` and included `annotations` in each `$client` entry.

### 5. `src/abilities/registry.js` — no way to invoke callbacks by name (JS)

When the browser received pending calls, there was no mechanism to invoke the registered JS callback by ability name.

→ Added a parallel `clientCallbacks: Map<name, Function>` populated during `registerClientAbility()`. Exported `executeClientAbility(name, args)`.

### 6. `jobSlice.js` — poll loop never handled `awaiting_client_tools` (JS)

The poll loop only knew about `processing`, `awaiting_confirmation`, `complete`, and `error`.

→ Added an `awaiting_client_tools` handler that iterates pending calls, checks `annotations.readonly === true`, auto-executes readonly abilities (both screenshot abilities are `readonly: true`) via `executeClientAbility()`, and POSTs results to `/chat/tool-result` to resume the agent loop. Non-readonly abilities return a structured error for now (confirmation UX is a follow-up task).

## Files changed

- `includes/REST/SessionController.php` — `handle_process` + `handle_job_status` + `job_status_from_db_row`
- `includes/Models/ActiveJobRepository.php` — `STATUSES`, `get_by_session_id`, `get_active_for_user`
- `includes/Core/ClientAbilityRouter.php` — `partition()`
- `src/abilities/registry.js` — `clientCallbacks` map + `executeClientAbility()` export
- `src/store/slices/jobSlice.js` — `awaiting_client_tools` poll handler

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 1h 23m and 18,014 tokens on this as a headless worker.
