### PR TITLE
t236: retry all free image sources on download failure before AI fallback

### DIFF
--- a/includes/Abilities/ImageAbilities/StockImageAbility.php
+++ b/includes/Abilities/ImageAbilities/StockImageAbility.php
@@ -149,29 +149,36 @@ class StockImageAbility extends \GratisAiAgent\Abilities\AbstractAbility {
 			return new WP_Error( 'missing_keyword', 'keyword is required.' );
 		}
 
-		// Find the first available free source.
-		$source = null;
+		// Verify at least one free source is configured before attempting import.
+		$has_free = false;
 		foreach ( ImageSourceFactory::get_available() as $s ) {
 			if ( 'free' === $s->get_cost_type() ) {
-				$source = $s;
+				$has_free = true;
 				break;
 			}
 		}
 
-		if ( null === $source ) {
+		if ( ! $has_free ) {
 			return [
 				'attachment_id' => 0,
 				'url'           => '',
 				'alt'           => '',
 				'title'         => '',
 				'source'        => '',
-				'error'         => 'No free stock image source is available. Configure Openverse or Pixabay, or use gratis-ai-agent/generate-image to create an AI-generated image instead.',
+				'error'         => 'No free stock image source is available. Configure Openverse or Pixabay.',
+				'tip'           => 'Use gratis-ai-agent/generate-image to create an AI-generated image instead.',
 			];
 		}
 
-		$options = [ 'site_url' => $site_url ];
+		// Let the factory try all available free sources in priority order
+		// (openverse → pixabay) before giving up. Never fall back to AI generation —
+		// this ability is explicitly for stock images only.
+		$options = [
+			'site_url'             => $site_url,
+			'no_generate_fallback' => true,
+		];
 
-		$result = ImageSourceFactory::import_image( $keyword, $source->get_id(), $width, $height, $options );
+		$result = ImageSourceFactory::import_image( $keyword, '', $width, $height, $options );
 
 		if ( is_wp_error( $result ) ) {
 			return [
@@ -180,7 +187,9 @@ class StockImageAbility extends \GratisAiAgent\Abilities\AbstractAbility {
 				'alt'           => '',
 				'title'         => '',
 				'source'        => '',
+				// Error message from the factory lists each source tried and why it failed.
 				'error'         => $result->get_error_message(),
+				'tip'           => 'Use gratis-ai-agent/generate-image to create an AI-generated image instead.',
 			];
 		}
 

--- a/includes/Abilities/ImageSources/ImageSourceFactory.php
+++ b/includes/Abilities/ImageSources/ImageSourceFactory.php
@@ -155,11 +155,17 @@ class ImageSourceFactory {
 	/**
 	 * Import an image from any source.
 	 *
-	 * @param string $keyword     Search keyword or generation prompt.
-	 * @param string $source_id   Source ID (auto-selected if empty).
+	 * On download failure or empty results, the method automatically retries
+	 * all remaining available free sources before falling back to AI generation.
+	 *
+	 * @param string $keyword   Search keyword or generation prompt.
+	 * @param string $source_id Source ID (auto-selected if empty). Use 'generate' for AI.
 	 * @param int    $width     Desired width (0 for original).
 	 * @param int    $height    Desired height (0 for original).
-	 * @param array  $options   Additional options.
+	 * @param array  $options   Additional options:
+	 *                          - 'site_url'             (string) Multisite subsite URL.
+	 *                          - 'post_id'              (int)    Attach to this post.
+	 *                          - 'no_generate_fallback' (bool)   Skip AI generation fallback.
 	 * @return array{\attachment_id: int, url: string, alt: string, title: string, source: string}|\WP_Error
 	 */
 	public static function import_image(
@@ -170,17 +176,17 @@ class ImageSourceFactory {
 		array $options = []
 	): array|\WP_Error {
 
-		// Auto-select source if not specified.
-		$source = self::select_source( $source_id );
+		// Explicit AI generation request — bypass the free-source chain entirely.
+		if ( 'generate' === $source_id ) {
+			$generate = self::get( 'generate' );
+			if ( ! $generate || ! $generate->is_available() ) {
+				return new WP_Error(
+					'image_source_unavailable',
+					'AI image generation is not available.'
+				);
+			}
 
-		// Handle error from select_source (e.g., explicitly requested source unavailable).
-		if ( is_wp_error( $source ) ) {
-			return $source;
-		}
-
-		// For AI generation, use the download method directly.
-		if ( 'generate' === $source->get_id() ) {
-			$tmp_file = $source->download( $keyword, $width, $height );
+			$tmp_file = $generate->download( $keyword, $width, $height );
 
 			if ( is_wp_error( $tmp_file ) ) {
 				return $tmp_file;
@@ -189,48 +195,118 @@ class ImageSourceFactory {
 			return self::handle_sideload( $tmp_file, $keyword, $options );
 		}
 
-		// For search-based sources, search first then download.
-		$search_result = $source->search( $keyword, 1 );
+		// If a specific free source was explicitly requested, validate it up-front.
+		if ( ! empty( $source_id ) ) {
+			$requested = self::get( $source_id );
 
-		if ( is_wp_error( $search_result ) ) {
-			return $search_result;
+			if ( ! $requested ) {
+				return new WP_Error(
+					'unknown_image_source',
+					sprintf( 'Unknown image source: %s.', $source_id )
+				);
+			}
+
+			if ( ! $requested->is_available() ) {
+				return new WP_Error(
+					'image_source_unavailable',
+					sprintf( 'Image source "%s" is not available.', $source_id )
+				);
+			}
 		}
 
-		$hits = $search_result['hits'] ?? [];
+		// Build an ordered fallback chain of all available free sources.
+		// The explicitly requested source (if any) goes first; the rest follow
+		// in their registered priority order (openverse → pixabay).
+		$available    = self::get_available();
+		$free_sources = array_filter(
+			$available,
+			static fn( ImageSourceInterface $source ): bool => 'free' === $source->get_cost_type()
+		);
 
-		if ( empty( $hits ) ) {
-			// No results - try AI generation as fallback.
+		if ( ! empty( $source_id ) ) {
+			// Reorder: put the requested source first, then the remaining ones.
+			$ordered = [];
+			if ( isset( $free_sources[ $source_id ] ) ) {
+				$ordered[ $source_id ] = $free_sources[ $source_id ];
+			}
+			foreach ( $free_sources as $id => $s ) {
+				if ( $id !== $source_id ) {
+					$ordered[ $id ] = $s;
+				}
+			}
+			$free_sources = $ordered;
+		}
+
+		// Try each free source in order, recording the failure reason for each.
+		/** @var array<string, string> $tried */
+		$tried = [];
+
+		foreach ( $free_sources as $try_source ) {
+			$search_result = $try_source->search( $keyword, 1 );
+
+			if ( is_wp_error( $search_result ) ) {
+				$tried[ $try_source->get_id() ] = sprintf(
+					'search failed: %s',
+					$search_result->get_error_message()
+				);
+				continue;
+			}
+
+			$hits = $search_result['hits'] ?? [];
+
+			if ( empty( $hits ) ) {
+				$tried[ $try_source->get_id() ] = 'no results found';
+				continue;
+			}
+
+			$hit      = $hits[0];
+			$image_id = (string) ( $hit['id'] ?? '' );
+
+			$tmp_file = $try_source->download( $image_id, $width, $height );
+
+			if ( is_wp_error( $tmp_file ) ) {
+				$tried[ $try_source->get_id() ] = sprintf(
+					'download failed: %s',
+					$tmp_file->get_error_message()
+				);
+				continue;
+			}
+
+			// Success — sideload and return.
+			return self::handle_sideload( $tmp_file, $keyword, $options, $hit );
+		}
+
+		// All free sources failed (or none were available).
+		// Fall back to AI generation unless the caller opted out.
+		$no_generate = (bool) ( $options['no_generate_fallback'] ?? false );
+		if ( ! $no_generate ) {
 			$generate = self::get( 'generate' );
 			if ( $generate && $generate->is_available() ) {
 				return self::import_image( $keyword, 'generate', $width, $height, $options );
 			}
+		}
 
+		// Return a descriptive error listing every source that was attempted.
+		if ( empty( $tried ) ) {
 			return new WP_Error(
-				'no_images_found',
-				sprintf(
-					'No images found for "%s" from %s.',
-					$keyword,
-					$source->get_name()
-				)
+				'no_sources_available',
+				sprintf( 'No free image sources are available for "%s".', $keyword )
 			);
 		}
 
-		// Get the first hit.
-		$hit      = $hits[0];
-		$image_id = $hit['id'] ?? '';
-
-		// Download the image.
-		$tmp_file = $source->download( $image_id, $width, $height );
-
-		if ( is_wp_error( $tmp_file ) ) {
-			// Try next hit or fallback.
-			return new WP_Error(
-				'download_failed',
-				'Failed to download: ' . $tmp_file->get_error_message()
-			);
+		$tried_parts = [];
+		foreach ( $tried as $src_id => $reason ) {
+			$tried_parts[] = sprintf( '%s (%s)', $src_id, $reason );
 		}
 
-		return self::handle_sideload( $tmp_file, $keyword, $options, $hit );
+		return new WP_Error(
+			'all_sources_failed',
+			sprintf(
+				'All free image sources failed for "%s". Tried: %s.',
+				$keyword,
+				implode( ', ', $tried_parts )
+			)
+		);
 	}
 
 	/**

--- a/includes/Abilities/ImageSources/ImageSourceFactory.php
+++ b/includes/Abilities/ImageSources/ImageSourceFactory.php
@@ -212,6 +212,21 @@ class ImageSourceFactory {
 					sprintf( 'Image source "%s" is not available.', $source_id )
 				);
 			}
+
+			// Reject non-free sources here rather than silently dropping them
+			// from the free-source chain below. Paid sources that are not AI
+			// generation have no defined path in import_image(); rejecting early
+			// prevents the call from silently falling through to other sources
+			// in a way the caller did not intend.
+			if ( 'free' !== $requested->get_cost_type() ) {
+				return new WP_Error(
+					'non_free_source_not_supported',
+					sprintf(
+						'Image source "%s" is not a free source. Use source_id="generate" for AI generation.',
+						$source_id
+					)
+				);
+			}
 		}
 
 		// Build an ordered fallback chain of all available free sources.
@@ -282,7 +297,14 @@ class ImageSourceFactory {
 		if ( ! $no_generate ) {
 			$generate = self::get( 'generate' );
 			if ( $generate && $generate->is_available() ) {
-				return self::import_image( $keyword, 'generate', $width, $height, $options );
+				$ai_result = self::import_image( $keyword, 'generate', $width, $height, $options );
+
+				if ( ! is_wp_error( $ai_result ) ) {
+					return $ai_result;
+				}
+
+				// Record the AI failure so the final error lists all sources tried.
+				$tried['generate'] = sprintf( 'AI generation failed: %s', $ai_result->get_error_message() );
 			}
 		}
 


### PR DESCRIPTION
## What

Implements a robust fallback chain in `ImageSourceFactory::import_image()`: on search failure, empty results, or download failure, the method now automatically retries all remaining available free sources before falling back to AI generation.

Also updates `StockImageAbility` to delegate the full fallback chain to the factory and surface source-tried information in error responses.

## Why

Previously, when a free image source returned an error during download, `import_image()` immediately returned a generic `download_failed` WP_Error — silently discarding other configured free sources. A user who had both Openverse and Pixabay configured would never benefit from the second source if the first failed mid-download.

## How

**`ImageSourceFactory::import_image()`** (replaces the single-source path):
1. `source_id = 'generate'` → AI generation path unchanged (bypasses chain).
2. Builds an ordered free-source list: explicitly requested source first, then remaining free sources in priority order (`openverse → pixabay`).
3. For each source: search → on empty hits, continue to next; download → on failure, continue to next.
4. After all free sources exhausted, falls back to AI generation — unless `options['no_generate_fallback'] = true`.
5. Returns a descriptive `WP_Error` listing every source tried and its failure reason.

New `options` key: `no_generate_fallback` (bool) — lets callers like `StockImageAbility` opt out of the AI fallback.

**`StockImageAbility::execute_callback()`**:
- Passes `source_id = ''` (factory selects and iterates all free sources automatically).
- Passes `no_generate_fallback = true` (stock-image ability never uses AI generation).
- Error response now includes the factory's detailed tried-source message plus a `tip` pointing to `gratis-ai-agent/generate-image`.

## Verification

```
composer phpstan  # passes with no errors
composer phpcs    # passes with no errors
```

Resolves #1210
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 6m and 19,009 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stock image sourcing now attempts multiple free sources in sequence, increasing the likelihood of finding suitable images.

* **Improvements**
  * Enhanced error messaging when free stock sources fail, with helpful tips guiding users to available alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->