### PR TITLE
fix: correct misleading comment in ChangeRevertService option-revert branch

### DIFF
--- a/includes/Services/ChangeRevertService.php
+++ b/includes/Services/ChangeRevertService.php
@@ -69,8 +69,10 @@ final class ChangeRevertService {
 
 			// ── Option (update, add, or restore deleted option) ───────────────────
 			case 'option':
-				// Empty after_value means the option was deleted; update_option()
-				// recreates it. maybe_unserialize() decodes serialised arrays/objects.
+				// Empty before_value → option was newly added; revert by deleting it.
+				// Otherwise restore the prior value (update_option() recreates the row
+				// if it was deleted). maybe_unserialize() decodes arrays/objects that
+				// the logger stored via maybe_serialize().
 				if ( '' === $change->before_value ) {
 					delete_option( $change->field_name );
 				} else {


### PR DESCRIPTION
## Summary

Corrects the misleading inline comment in the `option` branch of `ChangeRevertService::apply_revert()`.

The comment previously said:
> Empty after_value means the option was deleted; update_option() recreates it.

But:
1. The conditional checks `$change->before_value`, not `after_value`
2. The semantics described are inverted — an empty `before_value` means the option was **newly added** (so revert = delete it), while a non-empty `before_value` means the option existed before (so revert = restore via `update_option()`)

The new comment correctly describes both branches:
- Empty `before_value` → option was newly added; revert by deleting it
- Non-empty `before_value` → restore the prior value (update_option() recreates the row if it was deleted)

No functional code changes — comment fix only.

Resolves #1223


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 2m and 3,120 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved internal documentation to clarify behavior and logic flow.

---

**Note:** This release contains no user-visible changes or new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->