### PR TITLE
fix: make providers cache site-wide via version counter, hook connector writes

### DIFF
--- a/includes/Bootstrap/AdminHandler.php
+++ b/includes/Bootstrap/AdminHandler.php
@@ -19,6 +19,8 @@ use GratisAiAgent\Admin\ModelBenchmarkPage;
 use GratisAiAgent\Admin\ScreenMetaPanel;
 use GratisAiAgent\Admin\UnifiedAdminMenu;
 use GratisAiAgent\Core\Database;
+use GratisAiAgent\REST\ConnectorsController;
+use GratisAiAgent\REST\SettingsController;
 use XWP\DI\Decorators\Action;
 use XWP\DI\Decorators\Filter;
 use XWP\DI\Decorators\Handler;
@@ -58,12 +60,38 @@ final class AdminHandler {
 	 * - DB schema safety-net (dbDelta is no-op when schema is current).
 	 * - Per-tool capabilities for role-management plugins.
 	 * - Legacy URL redirects to unified menu.
+	 * - Connector option update hooks to invalidate the providers cache when
+	 *   credentials are changed via the native WP 7.0 Connectors admin page.
 	 */
 	#[Action( tag: 'admin_init', priority: 10 )]
 	public function on_admin_init(): void {
 		Database::install();
 		ToolCapabilities::register_capabilities( ToolCapabilities::all_ability_ids() );
 		UnifiedAdminMenu::handleLegacyRedirects();
+		$this->register_connector_cache_hooks();
+	}
+
+	/**
+	 * Register update_option hooks for WP Connectors API option keys.
+	 *
+	 * The native WP 7.0 Connectors page (options-connectors.php) writes
+	 * connectors_ai_{provider}_api_key options directly.  Hooking into
+	 * update_option_{key} ensures the site-wide providers transient cache is
+	 * invalidated whenever an external connector change is saved, so admins
+	 * see fresh provider data on the next GET /providers request.
+	 *
+	 * accepted_args=0 is intentional: flush_providers_cache() takes no
+	 * parameters, and update_option_{key} passes 3 args we do not need.
+	 */
+	private function register_connector_cache_hooks(): void {
+		foreach ( ConnectorsController::PROVIDERS as $meta ) {
+			add_action(
+				'update_option_' . $meta['option_key'],
+				[ SettingsController::class, 'flush_providers_cache' ],
+				10,
+				0
+			);
+		}
 	}
 
 	/**

--- a/includes/REST/ConnectorsController.php
+++ b/includes/REST/ConnectorsController.php
@@ -196,6 +196,10 @@ final class ConnectorsController {
 		$option_key = self::PROVIDERS[ $provider_id ]['option_key'];
 		update_option( $option_key, $api_key, false );
 
+		// Connector credentials changed — invalidate the site-wide providers cache
+		// so every admin sees the updated list on the next /providers request.
+		SettingsController::flush_providers_cache();
+
 		return new WP_REST_Response(
 			array(
 				'success'    => true,
@@ -227,6 +231,10 @@ final class ConnectorsController {
 
 		$option_key = self::PROVIDERS[ $provider_id ]['option_key'];
 		delete_option( $option_key );
+
+		// Connector credentials removed — invalidate the site-wide providers cache
+		// so every admin sees the updated list on the next /providers request.
+		SettingsController::flush_providers_cache();
 
 		return new WP_REST_Response(
 			array(

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -972,23 +972,45 @@ final class SettingsController {
 	}
 
 	/**
+	 * Site option that stores the cache version counter.
+	 *
+	 * Bumping this value effectively orphans all existing per-user transients,
+	 * ensuring every admin sees a fresh providers list on the next request.
+	 */
+	const PROVIDERS_CACHE_VERSION_OPTION = 'gratis_ai_providers_cache_version';
+
+	/**
 	 * Transient key for the cached providers list.
-	 * Scoped per-user so each admin sees their own credential state.
+	 *
+	 * Incorporates a site-wide version counter so that bumping the version in
+	 * flush_providers_cache() immediately invalidates every admin's cached copy
+	 * without needing to enumerate all user IDs.  The per-user suffix is
+	 * retained for compatibility with ProviderCredentialLoader, which may
+	 * resolve different credentials per user in future.
 	 *
 	 * @return string
 	 */
 	private static function providers_cache_key(): string {
-		return 'gratis_ai_providers_' . get_current_user_id();
+		$version = (int) get_option( self::PROVIDERS_CACHE_VERSION_OPTION, 0 );
+		return 'gratis_ai_providers_' . $version . '_' . get_current_user_id();
 	}
 
 	/**
-	 * Flush the cached providers list.
+	 * Flush the cached providers list for ALL admins.
+	 *
+	 * Increments the site-wide version counter so every existing per-user
+	 * transient (keyed on the previous version) is abandoned.  The orphaned
+	 * transients expire naturally within 5 minutes; no need to enumerate users.
 	 *
 	 * Call whenever provider credentials are added, changed, or removed so the
 	 * next GET /providers rebuilds the list from live data.
 	 */
 	public static function flush_providers_cache(): void {
-		delete_transient( self::providers_cache_key() );
+		update_option(
+			self::PROVIDERS_CACHE_VERSION_OPTION,
+			(int) get_option( self::PROVIDERS_CACHE_VERSION_OPTION, 0 ) + 1,
+			false
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes two stale-providers-cache bugs surfaced in PR #1196 review feedback (issue #1222).

### Problem 1 — multi-admin stale data

`providers_cache_key()` previously returned `'gratis_ai_providers_' . get_current_user_id()`, so `flush_providers_cache()` only deleted **the current admin's** transient. When Admin A saved a provider key, Admin B continued seeing the stale list for up to 5 minutes.

### Problem 2 — external connector changes not invalidating cache

Provider credentials saved via the **native WP 7.0 Connectors admin page** (`options-connectors.php`) write `connectors_ai_{provider}_api_key` options directly, without going through our REST API. `flush_providers_cache()` was never called on those code paths, so the `/providers` endpoint returned a stale empty result until the transient expired.

## Changes

**`includes/REST/SettingsController.php`**
- Added `PROVIDERS_CACHE_VERSION_OPTION` constant (`gratis_ai_providers_cache_version`).
- `providers_cache_key()`: now includes the version counter so a single bump orphans *every* admin's cached transient — O(1) invalidation regardless of how many admins are logged in. Per-user suffix retained for future-safety.
- `flush_providers_cache()`: increments the version counter via `update_option()` instead of deleting one transient.

**`includes/REST/ConnectorsController.php`**
- `handle_set_key()` and `handle_clear_key()` now call `SettingsController::flush_providers_cache()` after each write.

**`includes/Bootstrap/AdminHandler.php`**
- New `register_connector_cache_hooks()` method, called from `on_admin_init()`, registers `update_option_connectors_ai_{x}_api_key` actions for every provider in `ConnectorsController::PROVIDERS`. This catches saves from the native WP 7.0 Connectors page.

## Verification

- `php -l` on all three files: ✅ no syntax errors
- `vendor/bin/phpcs --standard=phpcs.xml`: ✅ no violations
- `vendor/bin/phpstan analyse` (level 5): ✅ no errors

Resolves #1222