### PR TITLE
fix: deduplicate ability tool names to prevent 400 Tool names must be unique

### DIFF
--- a/includes/Abilities/ToolCapabilities.php
+++ b/includes/Abilities/ToolCapabilities.php
@@ -194,30 +194,26 @@ class ToolCapabilities {
 			'ai-agent/create-menu',
 			'ai-agent/delete-menu',
 			'ai-agent/add-menu-item',
-			// Ability discovery.
-			'gratis-ai-agent/discovery-list',
-			'gratis-ai-agent/discovery-get',
-			'gratis-ai-agent/discovery-execute',
 			// Images.
 			'gratis-ai-agent/stock-image',
 			'gratis-ai-agent/generate-image',
-			// SEO.
-			'gratis-ai-agent/seo-audit-url',
-			'gratis-ai-agent/seo-analyze-content',
-			// Content.
-			'gratis-ai-agent/content-analyze',
-			'gratis-ai-agent/content-performance-report',
-			// Marketing.
-			'gratis-ai-agent/fetch-url',
-			'gratis-ai-agent/analyze-headers',
-			// Blocks.
-			'gratis-ai-agent/markdown-to-blocks',
-			'gratis-ai-agent/list-block-types',
-			'gratis-ai-agent/get-block-type',
-			'gratis-ai-agent/list-block-patterns',
-			'gratis-ai-agent/list-block-templates',
-			'gratis-ai-agent/create-block-content',
-			'gratis-ai-agent/parse-block-content',
+			// SEO (registered under the WP core "ai-agent/" prefix).
+			'ai-agent/seo-audit-url',
+			'ai-agent/seo-analyze-content',
+			// Content (registered under the WP core "ai-agent/" prefix).
+			'ai-agent/content-analyze',
+			'ai-agent/content-performance-report',
+			// Marketing (registered under the WP core "ai-agent/" prefix).
+			'ai-agent/fetch-url',
+			'ai-agent/analyze-headers',
+			// Blocks (registered under the WP core "ai-agent/" prefix).
+			'ai-agent/markdown-to-blocks',
+			'ai-agent/list-block-types',
+			'ai-agent/get-block-type',
+			'ai-agent/list-block-patterns',
+			'ai-agent/list-block-templates',
+			'ai-agent/create-block-content',
+			'ai-agent/parse-block-content',
 			// Files.
 			'gratis-ai-agent/file-read',
 			'gratis-ai-agent/file-write',

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -952,7 +952,9 @@ class AgentLoop {
 				}
 			}
 			// Append client ability stubs even in explicit-abilities mode.
-			return array_merge( $resolved, $this->client_router->build_stubs() );
+			return $this->deduplicate_by_function_name(
+				array_merge( $resolved, $this->client_router->build_stubs() )
+			);
 		}
 
 		$tier_1 = ToolDiscovery::tier_1_for_run( $this->agent_tier_1_tools );
@@ -981,7 +983,75 @@ class AgentLoop {
 		}
 
 		// Append synthetic stubs for validated client-side abilities.
-		return array_merge( $resolved, $this->client_router->build_stubs() );
+		return $this->deduplicate_by_function_name(
+			array_merge( $resolved, $this->client_router->build_stubs() )
+		);
+	}
+
+	/**
+	 * Remove abilities whose API function name collides with an earlier entry.
+	 *
+	 * AI providers (e.g. Anthropic, OpenAI) reject requests with duplicate tool
+	 * names (HTTP 400 "tools: Tool names must be unique"). Collisions occur when:
+	 *
+	 *   • Two abilities are registered under different namespace prefixes but the
+	 *     same base name (e.g. "ai-agent/create-block-content" and
+	 *     "gratis-ai-agent/create-block-content"). WP 7.0-RC2's native
+	 *     ability_name_to_function_name() may normalise these to the same string,
+	 *     whereas the compat polyfill preserves the full prefixed form.
+	 *
+	 *   • A third-party plugin registers an ability whose name, after the
+	 *     namespace prefix is stripped, matches one this plugin has already
+	 *     registered (e.g. "some-plugin/create-block-content").
+	 *
+	 * The first occurrence in the list wins; later duplicates are silently
+	 * dropped. Tier-1 curated abilities appear first so they take priority over
+	 * usage-tracked or third-party entries.
+	 *
+	 * @param \WP_Ability[] $abilities Resolved ability list, possibly containing duplicates.
+	 * @return \WP_Ability[] De-duplicated list safe to pass to using_abilities().
+	 */
+	private function deduplicate_by_function_name( array $abilities ): array {
+		if ( ! class_exists( 'WP_AI_Client_Ability_Function_Resolver' ) ) {
+			return $abilities;
+		}
+
+		$seen   = array();
+		$unique = array();
+
+		foreach ( $abilities as $ability ) {
+			$fn_name = \WP_AI_Client_Ability_Function_Resolver::ability_name_to_function_name(
+				$ability->get_name()
+			);
+
+			// Normalise to the lowest-common-denominator form so that providers
+			// which treat hyphens and underscores as equivalent (or which strip the
+			// namespace prefix) do not see duplicates. Lowercase for safety.
+			$key = strtolower( str_replace( '-', '_', $fn_name ) );
+
+			if ( isset( $seen[ $key ] ) ) {
+				// Log the collision so it's visible in debug logs without throwing.
+				_doing_it_wrong(
+					__METHOD__,
+					esc_html(
+						sprintf(
+							/* translators: 1: duplicate ability name, 2: earlier ability name, 3: resolved function name */
+							__( 'Ability "%1$s" produces the same API tool name as "%2$s" (%3$s) and will be skipped to prevent a duplicate-tool-name API error. Register abilities under unique base names.', 'gratis-ai-agent' ),
+							$ability->get_name(),
+							$seen[ $key ],
+							$fn_name
+						)
+					),
+					'1.8.3'
+				);
+				continue;
+			}
+
+			$seen[ $key ] = $ability->get_name();
+			$unique[]     = $ability;
+		}
+
+		return $unique;
 	}
 
 	/**


### PR DESCRIPTION
## Problem

Sending a chat message like *"build the homepage content as Gutenberg blocks using create-block-content"* returned:

```
Error: Bad Request (400) - tools: Tool names must be unique.
```

The AI provider rejects the request before any tool is executed.

## Root cause

`ability_name_to_function_name()` converts ability IDs to API function names by replacing `/` with `__`. On WP 7.0-RC2's native implementation the normalisation can differ from the compat polyfill, causing two abilities with different namespace prefixes but the same base name (e.g. `ai-agent/create-block-content` and `gratis-ai-agent/create-block-content`) to produce the same output string. Any AI provider that also normalises hyphens → underscores before its uniqueness check compounds this. The same collision class can come from third-party plugins registering under `ai-agent/` (the standard WP namespace) with a base name already used by this plugin.

A second contributing issue: `ToolCapabilities::all_ability_ids()` listed 13 abilities under the wrong `gratis-ai-agent/` prefix — they are actually registered under `ai-agent/`. While `cap_name()` strips both prefixes so capability checking still worked, the stale names were the conceptual source of the cross-prefix collision.

## Changes

**`AgentLoop::deduplicate_by_function_name()` (new private method)**
Both return paths in `resolve_abilities()` now pass through deduplication that normalises each function name (lowercase + hyphens→underscores) before checking uniqueness. First occurrence wins (curated Tier-1 abilities have priority). Collisions emit `_doing_it_wrong()` to the debug log.

**`ToolCapabilities::all_ability_ids()` — 13 prefix corrections**
Block, SEO, Content, and Marketing abilities corrected from `gratis-ai-agent/` → `ai-agent/` to match their actual `wp_register_ability()` registrations.

**`ToolCapabilities::all_ability_ids()` — 3 dead stubs removed**
`gratis-ai-agent/discovery-{list,get,execute}` were never registered; removed.

## Verification

```bash
wp eval '
$ids = GratisAiAgent\Abilities\ToolCapabilities::all_ability_ids();
$bad = array_filter($ids, fn($id) => !wp_get_ability($id));
echo empty($bad) ? "All " . count($ids) . " IDs resolve.\n" : implode("\n", $bad);
'
# → All 68 IDs resolve.
```

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.6 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-opus-4-6 spent 21h 37m and 54,199 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved duplicate ability entries being sent to the AI client, preventing redundant processing and improving stability.
  * Optimized ability registration by consolidating capability variants and removing deprecated entries to streamline available tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->