### PR TITLE
t241: fix navigate-to infinite reload loop via deferred navigation

### DIFF
--- a/src/abilities/navigation.js
+++ b/src/abilities/navigation.js
@@ -29,7 +29,17 @@ function executeNavigateTo( args ) {
 			? window.location.origin + '/wp-admin/' + path.replace( /^\//, '' )
 			: '/wp-admin/' + path.replace( /^\//, '' );
 
-	window.location.assign( adminUrl );
+	// Defer the actual navigation so jobSlice can POST the tool result back to
+	// the server before the page unloads. Calling window.location.assign() here
+	// would abort the in-flight fetch, leaving the job stuck in
+	// `awaiting_client_tools` on the server. On the next page load the floating
+	// widget restores the job from sessionStorage, finds the same pending call,
+	// and navigates again — an infinite reload loop.
+	//
+	// jobSlice reads window._gratisAiAgentPendingNavigation after the POST
+	// succeeds, clears sessionStorage, and then triggers the navigation.
+	window._gratisAiAgentPendingNavigation = adminUrl;
+
 	return { navigated: true, path };
 }
 

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -530,6 +530,23 @@ export const actions = {
 							return;
 						}
 
+						// If a client ability deferred navigation (e.g.
+						// navigate-to), trigger it now that the tool result
+						// has been successfully posted. Clear sessionStorage
+						// first so the job is not replayed on the next page —
+						// this is the primary fix for the infinite-reload loop
+						// caused by navigate-to calling window.location.assign()
+						// before the POST could complete.
+						if ( window._gratisAiAgentPendingNavigation ) {
+							const target =
+								window._gratisAiAgentPendingNavigation;
+							delete window._gratisAiAgentPendingNavigation;
+							clearActiveJob( sessionId );
+							unsubscribeVisibility();
+							window.location.assign( target );
+							return;
+						}
+
 						// Resume polling — the server has resumed the agent
 						// loop; we continue polling the same job for the
 						// model's next response or another pause.


### PR DESCRIPTION
## Problem

When the agent called the `navigate-to` client ability (e.g. "show me the page you created"), the browser got stuck in an infinite reload loop on the target admin page.

**Root cause:** `executeNavigateTo()` called `window.location.assign()` synchronously during `Promise.all()` execution inside `jobSlice`. The page started navigating before the `apiFetch` POST to `/chat/tool-result` could complete. The server job stayed in `awaiting_client_tools` state. On the next page load, the floating widget restored the job from `sessionStorage` (`gratisAiAgent_activeJobs`), `pollJob` found the same `awaiting_client_tools` with the same pending `navigate-to` call, executed it again — infinite loop.

## Fix

Two-part deferred navigation pattern:

- **`src/abilities/navigation.js`** — instead of calling `window.location.assign()` directly, park the target URL on `window._gratisAiAgentPendingNavigation` and return `{ navigated: true, path }` immediately.

- **`src/store/slices/jobSlice.js`** — after the tool-result POST succeeds, check `window._gratisAiAgentPendingNavigation`. If set: delete the flag, call `clearActiveJob(sessionId)` (removes the job from `sessionStorage` so it cannot be replayed), `unsubscribeVisibility()`, then `window.location.assign(target)` and return. Loop broken — `sessionStorage` is clear before the new page loads.

## Testing

1. Ask the agent to create a page then "show me the page"
2. Agent calls `navigate-to` with the page URL
3. Browser navigates to target — no reload loop
4. DevTools → Application → Session Storage confirms `gratisAiAgent_activeJobs` is empty on arrival

**Workaround for anyone currently stuck:** open browser DevTools console and run `sessionStorage.clear()`, then navigate away manually.

Resolves #241

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 9m and 19,786 tokens on this with the user in an interactive session.
