### PR TITLE
GH#1236: fix memory-save ability prefix in SystemInstructionBuilder

### DIFF
--- a/includes/Core/SystemInstructionBuilder.php
+++ b/includes/Core/SystemInstructionBuilder.php
@@ -383,7 +383,7 @@ class SystemInstructionBuilder {
 			. "- Use `ai-agent/update-global-styles` to apply a color palette and typography matching the site tone.\n"
 			. "- Output: \"**Progress:** Global styles applied ✓ ([N]/[total] steps done)\"\n\n"
 			. "**Step 8 — Save site info to memory**\n"
-			. "- Use `gratis-ai-agent/memory-save` to store: business name, type, goals, page IDs, installed plugins.\n"
+			. "- Use `ai-agent/memory-save` to store: business name, type, goals, page IDs, installed plugins.\n"
 			. "- Output: \"**Progress:** Site info saved to memory ✓ ([N]/[total] steps done)\"\n\n"
 			. "**Step 9 — Mark site builder complete**\n"
 			. "- Call `gratis-ai-agent/complete-site-builder` to disable site builder mode.\n"


### PR DESCRIPTION
## Summary

Fixes the legacy `gratis-ai-agent/memory-save` prefix in the site builder Step 8 instruction, replacing it with the registered WP core prefix `ai-agent/memory-save`.

## What

- **EDIT**: `includes/Core/SystemInstructionBuilder.php:386` — updated the Step 8 string literal to use the correct `ai-agent/memory-save` ability prefix

## Why

`MemoryAbilities::register_abilities()` registers memory abilities exclusively under the `ai-agent/` namespace. The legacy `gratis-ai-agent/memory-save` prefix is not registered and would cause the Step 8 ability call to fail silently. This was caught in the PR #1228 code review.

## Verification

All four `memory-save` references in `SystemInstructionBuilder.php` now consistently use the `ai-agent/memory-save` prefix.

```bash
grep -n 'memory-save' includes/Core/SystemInstructionBuilder.php
# All lines show ai-agent/memory-save
```

Resolves #1236


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 1m and 2,133 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the site builder's memory-save functionality to ensure proper tool alignment during the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->