### PR TITLE
feat: add Tavily search provider and unified multi-provider internet search

### DIFF
--- a/includes/Abilities/InternetSearchAbilities.php
+++ b/includes/Abilities/InternetSearchAbilities.php
@@ -7,15 +7,15 @@ declare(strict_types=1);
  * Provides web search capabilities so the agent can research topics and
  * produce well-sourced content (e.g. blog posts, product descriptions).
  *
- * Search provider strategy (zero-config first):
- *   1. Brave Search API — if a Brave API key is configured in settings.
- *   2. DuckDuckGo Instant Answer API — free, no API key required, always available.
- *
- * The Brave Search API returns richer results (full snippets, news, videos)
- * and is recommended for production use. DuckDuckGo is the reliable fallback
- * that works out of the box with zero configuration.
+ * Search provider priority (first configured provider wins):
+ *   1. Tavily Search API  — best results for AI agents, purpose-built for LLMs.
+ *   2. Brave Search API   — rich results (full snippets, news, videos).
+ *   3. DuckDuckGo Instant Answer API — free, no API key required, always available.
  *
  * Configuration:
+ *   - Tavily API key: Settings page → "Tavily API Key" field, or paste
+ *     it into the chat and ask the agent to save it.
+ *     Get a free key at https://app.tavily.com/
  *   - Brave API key: Settings page → "Brave Search API Key" field.
  *     Get a free key at https://brave.com/search/api/
  *
@@ -34,6 +34,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 class InternetSearchAbilities {
 
 	/**
+	 * Tavily Search API endpoint.
+	 */
+	const TAVILY_SEARCH_URL = 'https://api.tavily.com/search';
+
+	/**
 	 * Brave Search API endpoint.
 	 */
 	const BRAVE_SEARCH_URL = 'https://api.search.brave.com/res/v1/web/search';
@@ -50,7 +55,38 @@ class InternetSearchAbilities {
 	const BRAVE_KEY_OPTION = 'sd_ai_agent_brave_search_key';
 
 	/**
-	 * Register the internet-search ability.
+	 * Option name for the Tavily API key.
+	 * Stored separately from general settings to avoid credential leakage.
+	 */
+	const TAVILY_KEY_OPTION = 'sd_ai_agent_tavily_api_key';
+
+	/**
+	 * Supported search providers with metadata.
+	 * Used by the configure-search-provider ability and settings UI.
+	 */
+	const SEARCH_PROVIDERS = [
+		'tavily'     => [
+			'name'   => 'Tavily',
+			'url'    => 'https://app.tavily.com/',
+			'help'   => 'Purpose-built search API for AI agents. Free tier includes 1,000 searches/month.',
+			'prefix' => 'tvly-',
+		],
+		'brave'      => [
+			'name'   => 'Brave Search',
+			'url'    => 'https://brave.com/search/api/',
+			'help'   => 'Rich web search results with snippets, news, and videos. Free tier includes 2,000 queries/month.',
+			'prefix' => 'BSA',
+		],
+		'duckduckgo' => [
+			'name'   => 'DuckDuckGo',
+			'url'    => '',
+			'help'   => 'Free instant answers — no API key required. Limited to instant answers, not full web search.',
+			'prefix' => '',
+		],
+	];
+
+	/**
+	 * Register the internet-search ability and the configure-search-provider ability.
 	 */
 	public static function register_abilities(): void {
 		if ( ! function_exists( 'wp_register_ability' ) ) {
@@ -61,7 +97,7 @@ class InternetSearchAbilities {
 			'sd-ai-agent/internet-search',
 			[
 				'label'               => __( 'Internet Search', 'sd-ai-agent' ),
-				'description'         => __( 'Search the internet for current information. Returns a list of relevant results with titles, URLs, and snippets. Use this to research topics before writing blog posts or answering questions about recent events.', 'sd-ai-agent' ),
+				'description'         => __( 'Search the internet for current information. Returns a list of relevant results with titles, URLs, and snippets. Use this to research topics before writing blog posts or answering questions about recent events. Provider priority: Tavily (if configured) > Brave (if configured) > DuckDuckGo (free fallback).', 'sd-ai-agent' ),
 				'category'            => 'sd-ai-agent',
 				'input_schema'        => [
 					'type'       => 'object',
@@ -112,6 +148,64 @@ class InternetSearchAbilities {
 				'permission_callback' => [ __CLASS__, 'check_permission' ],
 			]
 		);
+
+		wp_register_ability(
+			'sd-ai-agent/configure-search-provider',
+			[
+				'label'               => __( 'Configure Search Provider', 'sd-ai-agent' ),
+				'description'         => __( 'Save or remove an API key for an internet search provider (Tavily or Brave). Use this when the user provides an API key in the chat so they do not need to visit the settings page. Also use this to check which providers are currently configured.', 'sd-ai-agent' ),
+				'category'            => 'sd-ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'action'   => [
+							'type'        => 'string',
+							'description' => 'The action to perform: "save" to store a key, "remove" to clear a key, "status" to check configured providers.',
+							'enum'        => [ 'save', 'remove', 'status' ],
+						],
+						'provider' => [
+							'type'        => 'string',
+							'description' => 'The search provider: "tavily" or "brave". Not required for "status" action.',
+							'enum'        => [ 'tavily', 'brave' ],
+						],
+						'api_key'  => [
+							'type'        => 'string',
+							'description' => 'The API key to save. Required for "save" action.',
+						],
+					],
+					'required'   => [ 'action' ],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'status'    => [ 'type' => 'string' ],
+						'message'   => [ 'type' => 'string' ],
+						'providers' => [
+							'type'  => 'array',
+							'items' => [
+								'type'       => 'object',
+								'properties' => [
+									'id'         => [ 'type' => 'string' ],
+									'name'       => [ 'type' => 'string' ],
+									'configured' => [ 'type' => 'boolean' ],
+									'active'     => [ 'type' => 'boolean' ],
+									'signup_url' => [ 'type' => 'string' ],
+								],
+							],
+						],
+					],
+				],
+				'meta'                => [
+					'annotations' => [
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => true,
+					],
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_configure_provider' ],
+				'permission_callback' => [ __CLASS__, 'check_admin_permission' ],
+			]
+		);
 	}
 
 	/**
@@ -125,10 +219,19 @@ class InternetSearchAbilities {
 	}
 
 	/**
+	 * Permission callback: only administrators may configure search providers.
+	 *
+	 * @param mixed $input Unused.
+	 * @return bool
+	 */
+	public static function check_admin_permission( $input ): bool {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
 	 * Handle the internet-search ability call.
 	 *
-	 * Routes to Brave Search if an API key is configured, otherwise falls back
-	 * to DuckDuckGo Instant Answer API (zero-config).
+	 * Routes to the first configured provider: Tavily → Brave → DuckDuckGo.
 	 *
 	 * @param array<string,mixed> $input Input with query, optional count and freshness.
 	 * @return array<string,mixed> Result with results array, provider, and query.
@@ -152,13 +255,245 @@ class InternetSearchAbilities {
 
 		$count = max( 1, min( 20, $count ) );
 
-		$brave_key = self::get_brave_api_key();
+		// Provider priority: Tavily → Brave → DuckDuckGo.
+		$tavily_key = self::get_tavily_api_key();
+		if ( '' !== $tavily_key ) {
+			return self::search_tavily( $query, $count, $freshness, $tavily_key );
+		}
 
+		$brave_key = self::get_brave_api_key();
 		if ( '' !== $brave_key ) {
 			return self::search_brave( $query, $count, $freshness, $brave_key );
 		}
 
 		return self::search_duckduckgo( $query, $count );
+	}
+
+	/**
+	 * Handle the configure-search-provider ability call.
+	 *
+	 * @param array<string,mixed> $input Input with action, provider, and optional api_key.
+	 * @return array<string,mixed> Status response.
+	 */
+	public static function handle_configure_provider( array $input ): array {
+		$action   = sanitize_key( (string) ( $input['action'] ?? '' ) );
+		$provider = sanitize_key( (string) ( $input['provider'] ?? '' ) );
+		$api_key  = (string) ( $input['api_key'] ?? '' );
+
+		if ( 'status' === $action ) {
+			return self::get_provider_status();
+		}
+
+		if ( '' === $provider || ! in_array( $provider, [ 'tavily', 'brave' ], true ) ) {
+			return [
+				'status'  => 'error',
+				'message' => 'provider must be "tavily" or "brave".',
+			];
+		}
+
+		if ( 'save' === $action ) {
+			$api_key = trim( $api_key );
+			if ( '' === $api_key ) {
+				$meta = self::SEARCH_PROVIDERS[ $provider ];
+				return [
+					'status'  => 'error',
+					'message' => sprintf(
+						'Please provide your %s API key. You can get one at %s',
+						$meta['name'],
+						$meta['url']
+					),
+				];
+			}
+
+			$success = 'tavily' === $provider
+				? self::set_tavily_api_key( $api_key )
+				: self::set_brave_api_key( $api_key );
+
+			if ( ! $success ) {
+				return [
+					'status'  => 'error',
+					'message' => 'Failed to save the API key.',
+				];
+			}
+
+			$status = self::get_provider_status();
+			return array_merge(
+				$status,
+				[
+					'status'  => 'saved',
+					'message' => sprintf(
+						'%s API key saved successfully. It is now the active search provider.',
+						self::SEARCH_PROVIDERS[ $provider ]['name']
+					),
+				]
+				);
+		}
+
+		if ( 'remove' === $action ) {
+			$success = 'tavily' === $provider
+				? self::set_tavily_api_key( '' )
+				: self::set_brave_api_key( '' );
+
+			$status = self::get_provider_status();
+			return array_merge(
+				$status,
+				[
+					'status'  => 'removed',
+					'message' => sprintf(
+						'%s API key removed.',
+						self::SEARCH_PROVIDERS[ $provider ]['name']
+					),
+				]
+				);
+		}
+
+		return [
+			'status'  => 'error',
+			'message' => 'action must be "save", "remove", or "status".',
+		];
+	}
+
+	/**
+	 * Get the status of all search providers.
+	 *
+	 * @return array<string,mixed> Provider status including which is active.
+	 */
+	private static function get_provider_status(): array {
+		$tavily_configured = '' !== self::get_tavily_api_key();
+		$brave_configured  = '' !== self::get_brave_api_key();
+
+		// Determine which provider is active (first configured wins).
+		$active_provider = 'duckduckgo';
+		if ( $tavily_configured ) {
+			$active_provider = 'tavily';
+		} elseif ( $brave_configured ) {
+			$active_provider = 'brave';
+		}
+
+		$providers = [];
+		foreach ( self::SEARCH_PROVIDERS as $id => $meta ) {
+			$configured = false;
+			if ( 'tavily' === $id ) {
+				$configured = $tavily_configured;
+			} elseif ( 'brave' === $id ) {
+				$configured = $brave_configured;
+			} else {
+				$configured = true; // DuckDuckGo is always available.
+			}
+
+			$providers[] = [
+				'id'         => $id,
+				'name'       => $meta['name'],
+				'configured' => $configured,
+				'active'     => $id === $active_provider,
+				'signup_url' => $meta['url'],
+			];
+		}
+
+		return [
+			'status'    => 'ok',
+			'providers' => $providers,
+		];
+	}
+
+	/**
+	 * Search using the Tavily Search API.
+	 *
+	 * @param string $query     Search query.
+	 * @param int    $count     Number of results.
+	 * @param string $freshness Optional freshness filter (pd/pw/pm/py).
+	 * @param string $api_key   Tavily API key.
+	 * @return array<string,mixed> Results array.
+	 */
+	private static function search_tavily( string $query, int $count, string $freshness, string $api_key ): array {
+		$body = [
+			'query'       => $query,
+			'max_results' => $count,
+		];
+
+		// Map freshness codes to Tavily time_range values.
+		$freshness_map = [
+			'pd' => 'day',
+			'pw' => 'week',
+			'pm' => 'month',
+			'py' => 'year',
+		];
+		if ( '' !== $freshness && isset( $freshness_map[ $freshness ] ) ) {
+			$body['time_range'] = $freshness_map[ $freshness ];
+		}
+
+		$response = wp_remote_post(
+			self::TAVILY_SEARCH_URL,
+			[
+				'timeout' => 15,
+				'headers' => [
+					'Content-Type'  => 'application/json',
+					'Authorization' => 'Bearer ' . $api_key,
+				],
+				'body'    => (string) wp_json_encode( $body ),
+			]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			// Fall through to next provider on network error.
+			$brave_key = self::get_brave_api_key();
+			if ( '' !== $brave_key ) {
+				return self::search_brave( $query, $count, $freshness, $brave_key );
+			}
+			return self::search_duckduckgo( $query, $count );
+		}
+
+		$status = wp_remote_retrieve_response_code( $response );
+		if ( 200 !== (int) $status ) {
+			// Fall through to next provider on API error (e.g. invalid key, quota exceeded).
+			$brave_key = self::get_brave_api_key();
+			if ( '' !== $brave_key ) {
+				return self::search_brave( $query, $count, $freshness, $brave_key );
+			}
+			return self::search_duckduckgo( $query, $count );
+		}
+
+		$response_body = wp_remote_retrieve_body( $response );
+		$data          = json_decode( $response_body, true );
+
+		if ( ! is_array( $data ) ) {
+			$brave_key = self::get_brave_api_key();
+			if ( '' !== $brave_key ) {
+				return self::search_brave( $query, $count, $freshness, $brave_key );
+			}
+			return self::search_duckduckgo( $query, $count );
+		}
+
+		$results = [];
+
+		// Extract search results from Tavily response.
+		$tavily_results = $data['results'] ?? [];
+		if ( is_array( $tavily_results ) ) {
+			foreach ( $tavily_results as $item ) {
+				if ( ! is_array( $item ) ) {
+					continue;
+				}
+				$results[] = [
+					'title'   => (string) ( $item['title'] ?? '' ),
+					'url'     => (string) ( $item['url'] ?? '' ),
+					'snippet' => (string) ( $item['content'] ?? '' ),
+				];
+			}
+		}
+
+		$output = [
+			'results'  => $results,
+			'provider' => 'tavily',
+			'query'    => $query,
+		];
+
+		// Include the AI-generated answer if present.
+		$answer = (string) ( $data['answer'] ?? '' );
+		if ( '' !== $answer ) {
+			$output['answer'] = $answer;
+		}
+
+		return $output;
 	}
 
 	/**
@@ -244,7 +579,7 @@ class InternetSearchAbilities {
 	 * and the AbstractText to build a useful result set.
 	 *
 	 * Note: DuckDuckGo's API is designed for instant answers, not full web
-	 * search. For comprehensive research, configure a Brave Search API key.
+	 * search. For comprehensive research, configure a Tavily or Brave Search API key.
 	 *
 	 * @param string $query  Search query.
 	 * @param int    $count  Maximum number of results to return.
@@ -349,7 +684,7 @@ class InternetSearchAbilities {
 				'results'  => [],
 				'provider' => 'duckduckgo',
 				'query'    => $query,
-				'tip'      => 'DuckDuckGo returned no instant answers for this query. For comprehensive web search results, configure a Brave Search API key in Superdav AI Agent settings.',
+				'tip'      => 'DuckDuckGo returned no instant answers for this query. For comprehensive web search results, configure a Tavily or Brave Search API key in settings (or paste your API key here and ask me to save it).',
 			];
 		}
 
@@ -388,6 +723,31 @@ class InternetSearchAbilities {
 			'url'     => $first_url,
 			'snippet' => $text,
 		];
+	}
+
+	/**
+	 * Get the configured Tavily API key.
+	 *
+	 * @return string Empty string when not configured.
+	 */
+	public static function get_tavily_api_key(): string {
+		$key = get_option( self::TAVILY_KEY_OPTION, '' );
+		return is_string( $key ) ? trim( $key ) : '';
+	}
+
+	/**
+	 * Persist the Tavily API key.
+	 *
+	 * Pass an empty string to clear the key.
+	 *
+	 * @param string $api_key The Tavily API key.
+	 * @return bool True on success.
+	 */
+	public static function set_tavily_api_key( string $api_key ): bool {
+		if ( '' === $api_key ) {
+			return delete_option( self::TAVILY_KEY_OPTION );
+		}
+		return update_option( self::TAVILY_KEY_OPTION, $api_key );
 	}
 
 	/**

--- a/includes/Abilities/InternetSearchAbilities.php
+++ b/includes/Abilities/InternetSearchAbilities.php
@@ -134,6 +134,10 @@ class InternetSearchAbilities {
 						],
 						'provider' => [ 'type' => 'string' ],
 						'query'    => [ 'type' => 'string' ],
+						'answer'   => [
+							'type'        => 'string',
+							'description' => 'AI-generated answer summarising the search results (Tavily only; omitted when not available).',
+						],
 						'error'    => [ 'type' => 'string' ],
 					],
 				],

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -287,6 +287,31 @@ final class SettingsController {
 			)
 		);
 
+		// Tavily API key endpoint.
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/settings/tavily-api-key',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'handle_set_tavily_api_key' ),
+					'permission_callback' => array( __CLASS__, 'check_admin_permission' ),
+					'args'                => array(
+						'api_key' => array(
+							'required'          => true,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'handle_delete_tavily_api_key' ),
+					'permission_callback' => array( __CLASS__, 'check_admin_permission' ),
+				),
+			)
+		);
+
 		// Google Analytics credentials endpoint.
 		register_rest_route(
 			RestController::NAMESPACE,
@@ -334,31 +359,6 @@ final class SettingsController {
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
 					'callback'            => array( __CLASS__, 'handle_delete_gsc_credentials' ),
-					'permission_callback' => array( __CLASS__, 'check_admin_permission' ),
-				),
-			)
-		);
-
-		// Brave Search API key endpoint.
-		register_rest_route(
-			RestController::NAMESPACE,
-			'/settings/brave-search-key',
-			array(
-				array(
-					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( __CLASS__, 'handle_set_brave_search_key' ),
-					'permission_callback' => array( __CLASS__, 'check_admin_permission' ),
-					'args'                => array(
-						'api_key' => array(
-							'required'          => true,
-							'type'              => 'string',
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-					),
-				),
-				array(
-					'methods'             => WP_REST_Server::DELETABLE,
-					'callback'            => array( __CLASS__, 'handle_delete_brave_search_key' ),
 					'permission_callback' => array( __CLASS__, 'check_admin_permission' ),
 				),
 			)
@@ -438,9 +438,11 @@ final class SettingsController {
 			'default_site_url' => $gsc_creds['default_site_url'] ?? null,
 		);
 
-		// Indicate whether a Brave Search API key is configured (boolean only, no key value).
+		// Indicate whether search provider API keys are configured (boolean only, no key values).
 		// @phpstan-ignore-next-line
 		$settings['_brave_search_key_configured'] = '' !== InternetSearchAbilities::get_brave_api_key();
+		// @phpstan-ignore-next-line
+		$settings['_tavily_api_key_configured'] = '' !== InternetSearchAbilities::get_tavily_api_key();
 
 		// Indicate whether a feedback-report receiver API key is configured (boolean only, no key value — t180).
 		// @phpstan-ignore-next-line
@@ -961,6 +963,51 @@ final class SettingsController {
 	 */
 	public function handle_delete_brave_search_key( WP_REST_Request $request ): WP_REST_Response {
 		InternetSearchAbilities::set_brave_api_key( '' );
+
+		return new WP_REST_Response(
+			array(
+				'deleted'    => true,
+				'configured' => false,
+			),
+			200
+		);
+	}
+
+	/**
+	 * Handle POST /settings/tavily-api-key — save the Tavily API key.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 */
+	public function handle_set_tavily_api_key( WP_REST_Request $request ): WP_REST_Response {
+		// @phpstan-ignore-next-line
+		$api_key = sanitize_text_field( (string) $request->get_param( 'api_key' ) );
+
+		if ( '' === $api_key ) {
+			return new WP_REST_Response( array( 'error' => 'api_key is required.' ), 400 );
+		}
+
+		$success = InternetSearchAbilities::set_tavily_api_key( $api_key );
+
+		if ( ! $success ) {
+			return new WP_REST_Response( array( 'error' => 'Failed to save Tavily API key.' ), 500 );
+		}
+
+		return new WP_REST_Response(
+			array(
+				'saved'      => true,
+				'configured' => true,
+			),
+			200
+		);
+	}
+
+	/**
+	 * Handle DELETE /settings/tavily-api-key — remove the Tavily API key.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 */
+	public function handle_delete_tavily_api_key( WP_REST_Request $request ): WP_REST_Response {
+		InternetSearchAbilities::set_tavily_api_key( '' );
 
 		return new WP_REST_Response(
 			array(

--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -124,6 +124,12 @@ export default function SettingsApp() {
 	const [ braveSaving, setBraveSaving ] = useState( false );
 	const [ braveNotice, setBraveNotice ] = useState( null );
 
+	// Tavily API key state.
+	const [ tavilyApiKey, setTavilyApiKey ] = useState( '' );
+	const [ tavilyConfigured, setTavilyConfigured ] = useState( false );
+	const [ tavilySaving, setTavilySaving ] = useState( false );
+	const [ tavilyNotice, setTavilyNotice ] = useState( null );
+
 	useEffect( () => {
 		fetchSettings();
 		fetchProviders();
@@ -140,10 +146,11 @@ export default function SettingsApp() {
 				}
 			} )
 			.catch( () => {} );
-		// Fetch Brave Search key status from the general settings response.
+		// Fetch search provider key status from the general settings response.
 		apiFetch( { path: '/sd-ai-agent/v1/settings' } )
 			.then( ( data ) => {
 				setBraveConfigured( !! data?._brave_search_key_configured );
+				setTavilyConfigured( !! data?._tavily_api_key_configured );
 			} )
 			.catch( () => {} );
 	}, [ fetchSettings, fetchProviders ] );
@@ -272,6 +279,57 @@ export default function SettingsApp() {
 			} );
 		}
 		setBraveSaving( false );
+	}, [] );
+
+	const handleTavilySave = useCallback( async () => {
+		setTavilySaving( true );
+		setTavilyNotice( null );
+		try {
+			await apiFetch( {
+				path: '/sd-ai-agent/v1/settings/tavily-api-key',
+				method: 'POST',
+				data: { api_key: tavilyApiKey },
+			} );
+			setTavilyConfigured( true );
+			setTavilyApiKey( '' ); // Clear the field after saving.
+			setTavilyNotice( {
+				status: 'success',
+				message: __( 'Tavily API key saved.', 'sd-ai-agent' ),
+			} );
+		} catch ( err ) {
+			setTavilyNotice( {
+				status: 'error',
+				message:
+					err?.message ||
+					__( 'Failed to save Tavily API key.', 'sd-ai-agent' ),
+			} );
+		}
+		setTavilySaving( false );
+	}, [ tavilyApiKey ] );
+
+	const handleTavilyClear = useCallback( async () => {
+		setTavilySaving( true );
+		setTavilyNotice( null );
+		try {
+			await apiFetch( {
+				path: '/sd-ai-agent/v1/settings/tavily-api-key',
+				method: 'DELETE',
+			} );
+			setTavilyConfigured( false );
+			setTavilyNotice( {
+				status: 'success',
+				message: __( 'Tavily API key removed.', 'sd-ai-agent' ),
+			} );
+		} catch {
+			setTavilyNotice( {
+				status: 'error',
+				message: __(
+					'Failed to remove Tavily API key.',
+					'sd-ai-agent'
+				),
+			} );
+		}
+		setTavilySaving( false );
 	}, [] );
 
 	useEffect( () => {
@@ -1926,13 +1984,152 @@ export default function SettingsApp() {
 
 										<h4 className="sd-ai-agent-settings-subsection-title">
 											{ __(
-												'Internet Search (Brave Search API)',
+												'Internet Search',
 												'sd-ai-agent'
 											) }
 										</h4>
 										<p className="description">
 											{ __(
-												'Enable richer internet search results by connecting a Brave Search API key. Without a key, the agent uses DuckDuckGo instant answers (free, no setup required). Get a free Brave Search API key at',
+												'The agent searches the internet to research topics and answer questions about current events. Configure one or more search providers below. Provider priority: Tavily > Brave > DuckDuckGo (free fallback). You can also paste an API key into the chat and ask the agent to save it.',
+												'sd-ai-agent'
+											) }
+										</p>
+										{ /* Active provider indicator */ }
+										<Notice
+											status="info"
+											isDismissible={ false }
+										>
+											{ ( () => {
+												if ( tavilyConfigured ) {
+													return __(
+														'Active provider: Tavily (best for AI agents).',
+														'sd-ai-agent'
+													);
+												}
+												if ( braveConfigured ) {
+													return __(
+														'Active provider: Brave Search.',
+														'sd-ai-agent'
+													);
+												}
+												return __(
+													'Active provider: DuckDuckGo (free fallback — limited to instant answers). Configure Tavily or Brave for full web search.',
+													'sd-ai-agent'
+												);
+											} )() }
+										</Notice>
+
+										{ /* ── Tavily ── */ }
+										<h5 className="sd-ai-agent-settings-subsection-title">
+											{ __( 'Tavily', 'sd-ai-agent' ) }
+											{ tavilyConfigured && ' \u2713' }
+										</h5>
+										<p className="description">
+											{ __(
+												'Purpose-built search API for AI agents. Free tier includes 1,000 searches/month. Get an API key at',
+												'sd-ai-agent'
+											) }{ ' ' }
+											<a
+												href="https://app.tavily.com/"
+												target="_blank"
+												rel="noopener noreferrer"
+											>
+												app.tavily.com
+											</a>
+										</p>
+										{ tavilyNotice && (
+											<Notice
+												status={ tavilyNotice.status }
+												isDismissible
+												onDismiss={ () =>
+													setTavilyNotice( null )
+												}
+											>
+												{ tavilyNotice.message }
+											</Notice>
+										) }
+										<table className="form-table sd-ai-agent-form-table">
+											<tbody>
+												<tr>
+													<th scope="row">
+														<label htmlFor="sd-tavily-api-key">
+															{ __(
+																'Tavily API Key',
+																'sd-ai-agent'
+															) }
+														</label>
+													</th>
+													<td>
+														<TextControl
+															id="sd-tavily-api-key"
+															type="password"
+															value={
+																tavilyApiKey
+															}
+															onChange={
+																setTavilyApiKey
+															}
+															placeholder={
+																tavilyConfigured
+																	? __(
+																			'Key saved — enter a new key to replace it',
+																			'sd-ai-agent'
+																	  )
+																	: 'tvly-...'
+															}
+															help={ __(
+																'Get a free API key at app.tavily.com — the free tier includes 1,000 searches/month.',
+																'sd-ai-agent'
+															) }
+															__nextHasNoMarginBottom
+														/>
+													</td>
+												</tr>
+											</tbody>
+										</table>
+										<div className="sd-ai-agent-settings-row-actions">
+											<Button
+												variant="primary"
+												onClick={ handleTavilySave }
+												isBusy={ tavilySaving }
+												disabled={
+													tavilySaving ||
+													! tavilyApiKey
+												}
+											>
+												{ __(
+													'Save Tavily API Key',
+													'sd-ai-agent'
+												) }
+											</Button>
+											{ tavilyConfigured && (
+												<Button
+													variant="secondary"
+													onClick={
+														handleTavilyClear
+													}
+													isBusy={ tavilySaving }
+													disabled={ tavilySaving }
+												>
+													{ __(
+														'Remove Key',
+														'sd-ai-agent'
+													) }
+												</Button>
+											) }
+										</div>
+
+										{ /* ── Brave Search ── */ }
+										<h5 className="sd-ai-agent-settings-subsection-title">
+											{ __(
+												'Brave Search',
+												'sd-ai-agent'
+											) }
+											{ braveConfigured && ' \u2713' }
+										</h5>
+										<p className="description">
+											{ __(
+												'Rich web search results with snippets, news, and videos. Free tier includes 2,000 queries/month. Get an API key at',
 												'sd-ai-agent'
 											) }{ ' ' }
 											<a
@@ -1943,28 +2140,6 @@ export default function SettingsApp() {
 												brave.com/search/api/
 											</a>
 										</p>
-										{ braveConfigured && (
-											<Notice
-												status="success"
-												isDismissible={ false }
-											>
-												{ __(
-													'Brave Search API key is configured. The agent will use Brave Search for internet searches.',
-													'sd-ai-agent'
-												) }
-											</Notice>
-										) }
-										{ ! braveConfigured && (
-											<Notice
-												status="info"
-												isDismissible={ false }
-											>
-												{ __(
-													'No Brave Search API key configured. The agent will use DuckDuckGo instant answers (zero-config fallback).',
-													'sd-ai-agent'
-												) }
-											</Notice>
-										) }
 										{ braveNotice && (
 											<Notice
 												status={ braveNotice.status }


### PR DESCRIPTION
## Summary

- Adds **Tavily Search API** as a new internet search provider, purpose-built for AI agents, with highest priority in the provider chain (Tavily > Brave > DuckDuckGo)
- Introduces a **`configure-search-provider` ability** so the AI agent can save/remove API keys directly from the chat — users no longer need to visit the settings page to set up search
- Updates the **Settings UI** to show all search providers with an active-provider indicator and per-provider key management

## Changes

### `includes/Abilities/InternetSearchAbilities.php`
- New `search_tavily()` method calling Tavily's POST `/search` endpoint with Bearer auth
- New `configure-search-provider` ability with `save`, `remove`, and `status` actions
- Provider priority chain: Tavily > Brave > DuckDuckGo with cascading fallback on errors
- Freshness filter mapping (`pd/pw/pm/py` to Tavily's `day/week/month/year`)
- `SEARCH_PROVIDERS` constant with metadata for all 3 providers

### `includes/REST/SettingsController.php`
- New `POST/DELETE /settings/tavily-api-key` endpoints (mirrors existing Brave pattern)
- New `_tavily_api_key_configured` boolean flag in `GET /settings` response
- Removed duplicate route registrations for `brave-search-key` and `gsc-credentials`

### `src/settings-page/settings-app.js`
- Refactored single "Brave Search API" section into multi-provider UI
- Active provider indicator showing which provider is currently in use
- Separate key management sections for Tavily and Brave with save/remove buttons
- Tavily API key state management and REST handlers

## How to test

1. Go to Settings > Advanced > Internet Search
2. Verify the active provider indicator shows "DuckDuckGo" when no keys are configured
3. Save a Tavily API key (`tvly-...`) — indicator should switch to "Tavily"
4. Save a Brave key too — Tavily should remain active (higher priority)
5. Remove Tavily key — Brave should become active
6. Test search via chat — verify provider field in results matches the active provider
7. Test pasting an API key in chat and asking the agent to save it (uses `configure-search-provider` ability)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.17 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 1h 19m and 8 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Tavily as a new internet search provider with highest priority
  * Implemented multi-provider search system with automatic fallback (Tavily → Brave → DuckDuckGo)
  * New Tavily API key configuration interface in administrator settings
  * Updated internet search settings UI to manage multiple providers

* **Changes**
  * Replaced Brave-only search configuration with unified multi-provider search setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->