### PR TITLE
t242: fix feedback endpoint namespace and add top-level report fields

### DIFF
--- a/includes/Feedback/ReportBuilder.php
+++ b/includes/Feedback/ReportBuilder.php
@@ -95,11 +95,17 @@ class ReportBuilder {
 			'tool_call_count'   => count( $tool_calls ),
 		);
 
+		$environment = self::collect_environment();
+
 		return array(
 			'report_type'      => $report_type,
 			'user_description' => $user_description,
+			// Top-level fields for server-side indexing (model, provider, site).
+			'model_id'         => $session->model_id ?? '',
+			'provider_id'      => $session->provider_id ?? '',
+			'site_url'         => $environment['site_host'] ?? '',
 			'session_data'     => $session_data,
-			'environment'      => self::collect_environment(),
+			'environment'      => $environment,
 			'generated_at'     => gmdate( 'c' ),
 		);
 	}

--- a/includes/Feedback/ReportSender.php
+++ b/includes/Feedback/ReportSender.php
@@ -27,7 +27,7 @@ class ReportSender {
 	 *
 	 * Reports are always sent here. No configuration or API key is required.
 	 */
-	const ENDPOINT_URL = 'https://ultimateagentwp.ai/wp-json/sd-ai-server/v1/reports';
+	const ENDPOINT_URL = 'https://ultimateagentwp.ai/wp-json/gratis-ai-server/v1/reports';
 
 	/**
 	 * Send a sanitized report payload to the feedback endpoint.


### PR DESCRIPTION
## Summary

- ****: Fix REST namespace `sd-ai-server` → `gratis-ai-server` — reports were 404ing silently, never reaching the server
- ****: Add top-level `model_id`, `provider_id`, `site_url` fields to the payload so the server can store them as indexed columns (previously only nested in `session_data`/`environment`)

## Root Cause

Diagnosed via live API testing against `ultimateagentwp.ai`:
- `POST /wp-json/sd-ai-server/v1/reports` → 404 (namespace never existed)
- `POST /wp-json/gratis-ai-server/v1/reports` → 201
- Server stores `model_id`, `provider_id`, `site_url` as top-level DB columns but payload only sent them nested — confirmed by fetching stored reports and seeing empty fields

## Verification

Round-trip tested manually: sent payload with top-level fields, fetched report via `feedback-triage.sh get`, confirmed all three fields populated correctly.

Resolves #

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.22 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 2h 21m and 6,660 tokens on this with the user in an interactive session.