### PR TITLE
GH#1255: fix: guard missing event automation tables

### DIFF
--- a/includes/Automations/EventAutomations.php
+++ b/includes/Automations/EventAutomations.php
@@ -32,12 +32,37 @@ class EventAutomations {
 		/** @var \wpdb $wpdb */
 
 		$table = self::table_name();
+		if ( ! self::table_exists( $table ) ) {
+			return [];
+		}
+
 		$where = $enabled_only ? 'WHERE enabled = 1' : '';
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Custom table query; table/column names from internal methods, not user input.
 		$rows = $wpdb->get_results( "SELECT * FROM {$table} {$where} ORDER BY name ASC" );
 
 		return array_map( [ __CLASS__, 'decode_row' ], $rows ?: [] );
+	}
+
+	/**
+	 * Check whether the event automations table exists for the current site.
+	 *
+	 * Network-activated multisite installs can reach subsites before this custom
+	 * table has been created for the current blog. Guarding the read prevents a
+	 * failed SELECT from running on every request while event hooks attach.
+	 *
+	 * @param string $table Event automations table name.
+	 */
+	private static function table_exists( string $table ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Schema existence check for custom table before querying it.
+		$found = $wpdb->get_var(
+			$wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->esc_like( $table ) )
+		);
+
+		return $found === $table;
 	}
 
 	/**

--- a/tests/SdAiAgent/Automations/EventAutomationsTest.php
+++ b/tests/SdAiAgent/Automations/EventAutomationsTest.php
@@ -245,6 +245,25 @@ class EventAutomationsTest extends WP_UnitTestCase {
 		$this->assertSame( $sorted, $names );
 	}
 
+	/**
+	 * Test list returns empty without querying a missing subsite table.
+	 */
+	public function test_list_returns_empty_when_current_site_table_is_missing(): void {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$original_prefix = $wpdb->prefix;
+		$wpdb->prefix    = $original_prefix . 'missing_';
+		$wpdb->last_error = '';
+
+		try {
+			$this->assertSame( [], EventAutomations::list( true ) );
+			$this->assertSame( '', $wpdb->last_error );
+		} finally {
+			$wpdb->prefix = $original_prefix;
+		}
+	}
+
 	// -------------------------------------------------------------------------
 	// update
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Added a current-site table existence guard before EventAutomations::list queries enabled automations, preventing network-activated multisite requests from issuing repeated SELECTs against missing subsite tables. Added regression coverage that simulates a subsite prefix with no event automations table and verifies list(true) returns an empty result without a database error.

## Files Changed

includes/Automations/EventAutomations.php,tests/SdAiAgent/Automations/EventAutomationsTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** composer phpcs -- includes/Automations/EventAutomations.php tests/SdAiAgent/Automations/EventAutomationsTest.php (pass); composer phpstan -- --error-format=table includes/Automations/EventAutomations.php (pass); php -l includes/Automations/EventAutomations.php && php -l tests/SdAiAgent/Automations/EventAutomationsTest.php (pass); npm run test:php -- --filter EventAutomationsTest (blocked: wp-env docker-compose.yml missing before start); npx wp-env start (blocked: Docker BuildKit cachemount path missing under /mnt/data/docker/buildkit/containerd-overlayfs/cachemounts)

Resolves #1255


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 3m and 80,093 tokens on this as a headless worker.