### PR TITLE
GH#1266: fix: restore WP-CLI namespace aliases

### DIFF
--- a/includes/Bootstrap/CliHandler.php
+++ b/includes/Bootstrap/CliHandler.php
@@ -70,7 +70,7 @@ final class CliHandler {
 	 *
 	 * @var list<string>
 	 */
-	private const NAMESPACES = array( 'sd-ai-agent' );
+	private const NAMESPACES = array( 'ai-agent', 'superdav-ai-agent', 'sd-ai-agent' );
 
 	/**
 	 * Register every subcommand with WP-CLI.


### PR DESCRIPTION
## Summary

Restored the ai-agent and superdav-ai-agent WP-CLI root namespaces while keeping the sd-ai-agent alias so existing and renamed command invocations are registered together.

## Files Changed

includes/Bootstrap/CliHandler.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** php -l includes/Bootstrap/CliHandler.php (passed); composer phpcs -- includes/Bootstrap/CliHandler.php (blocked: vendor/bin/phpcs missing in worktree)

Resolves #1266


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 1m and 64,228 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WP-CLI commands are now accessible via additional namespace aliases (`ai-agent` and `superdav-ai-agent`), providing more flexible command invocation options alongside the existing namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->