### PR TITLE
GH#1268: docs: align readme WordPress version wording

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -18,7 +18,7 @@ Superdav AI Agent adds a powerful AI assistant directly inside your WordPress ad
 
 = Built on WordPress Core =
 
-Superdav AI Agent is built on official WordPress APIs shipping in version 7.0:
+Superdav AI Agent is built on official WordPress APIs available in supported WordPress versions:
 
 * **AI Client SDK** — One interface for all AI providers. Install a connector plugin for OpenAI, Anthropic, Ollama, or any compatible service and Superdav AI Agent works immediately.
 * **Abilities API** — The WordPress-native tool registry. Every tool registered by any plugin on your site is automatically available to the agent. As your site grows, so does the agent's capabilities.


### PR DESCRIPTION
## Summary

Aligned README wording around supported WordPress versions so the body no longer implies a hard WordPress 7.0 minimum while the plugin metadata and Requirements section state WordPress 6.9 or higher.

## Files Changed

readme.txt

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified readme.txt manually and ran git diff --check.

Resolves #1268


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 1m and 63,813 tokens on this as a headless worker.