### PR TITLE
GH#1265: test: guard models command docblock accuracy

### DIFF
--- a/tests/SdAiAgent/CLI/ModelsCommandTest.php
+++ b/tests/SdAiAgent/CLI/ModelsCommandTest.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Test case for ModelsCommand documentation.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\CLI;
+
+use WP_UnitTestCase;
+
+/**
+ * Test ModelsCommand documentation accuracy.
+ */
+class ModelsCommandTest extends WP_UnitTestCase {
+
+	/**
+	 * Test the file-level docblock documents in-process provider listing.
+	 */
+	public function test_file_docblock_documents_in_process_provider_listing(): void {
+		$contents = file_get_contents( dirname( __DIR__, 3 ) . '/includes/CLI/ModelsCommand.php' );
+
+		$this->assertIsString( $contents );
+		$this->assertStringContainsString( 'Mirrors the logic of SettingsController::handle_providers() in-process', $contents );
+		$this->assertStringNotContainsString( 'Reuses the /providers REST endpoint', $contents );
+	}
+}


### PR DESCRIPTION
## Summary

Added a CLI regression test that verifies ModelsCommand documents in-process provider listing and does not refer to the /providers REST endpoint.

## Files Changed

tests/SdAiAgent/CLI/ModelsCommandTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** php -l tests/SdAiAgent/CLI/ModelsCommandTest.php passed. vendor/bin/phpunit tests/SdAiAgent/CLI/ModelsCommandTest.php and vendor/bin/phpcs tests/SdAiAgent/CLI/ModelsCommandTest.php could not run because vendor/bin tools are not installed in this worktree.

Resolves #1265


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 2m and 72,395 tokens on this as a headless worker.