### PR TITLE
GH#1264: test: cover exact REST route assertions

### DIFF
--- a/tests/SdAiAgent/Benchmark/AssertionEngineTest.php
+++ b/tests/SdAiAgent/Benchmark/AssertionEngineTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Test case for benchmark assertion engine.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Benchmark;
+
+use SdAiAgent\Benchmark\AssertionEngine;
+use WP_REST_Response;
+use WP_REST_Server;
+use WP_UnitTestCase;
+
+/**
+ * Test benchmark assertion behavior.
+ */
+class AssertionEngineTest extends WP_UnitTestCase {
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		global $wp_rest_server;
+
+		$wp_rest_server = new WP_REST_Server();
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down(): void {
+		global $wp_rest_server;
+
+		$wp_rest_server = null;
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Test REST endpoint registration assertions require an exact route match.
+	 */
+	public function test_rest_endpoint_registered_rejects_partial_route_matches(): void {
+		add_action(
+			'rest_api_init',
+			static function (): void {
+				\register_rest_route(
+					'sd-ai-agent-test-partial/v1',
+					'/events-old',
+					array(
+						'methods'             => 'GET',
+						'callback'            => static function (): WP_REST_Response {
+							return new WP_REST_Response( array( 'ok' => true ) );
+						},
+						'permission_callback' => '__return_true',
+					)
+				);
+			}
+		);
+
+		$result = AssertionEngine::run(
+			array(
+				array(
+					'type'   => 'rest_endpoint_registered',
+					'method' => 'GET',
+					'path'   => '/sd-ai-agent-test-partial/v1/events',
+				),
+			)
+		);
+
+		$this->assertSame( 0, $result['passed'] );
+		$this->assertSame( 1, $result['failed'] );
+		$this->assertFalse( $result['results'][0]['pass'] );
+		$this->assertSame( 'route not found in REST server', $result['results'][0]['actual'] );
+	}
+
+	/**
+	 * Test REST endpoint registration assertions accept the exact normalized route.
+	 */
+	public function test_rest_endpoint_registered_accepts_exact_normalized_route(): void {
+		add_action(
+			'rest_api_init',
+			static function (): void {
+				\register_rest_route(
+					'sd-ai-agent-test-exact/v1',
+					'/events',
+					array(
+						'methods'             => 'GET',
+						'callback'            => static function (): WP_REST_Response {
+							return new WP_REST_Response( array( 'ok' => true ) );
+						},
+						'permission_callback' => '__return_true',
+					)
+				);
+			}
+		);
+
+		$result = AssertionEngine::run(
+			array(
+				array(
+					'type'   => 'rest_endpoint_registered',
+					'method' => 'GET',
+					'path'   => 'sd-ai-agent-test-exact/v1/events/',
+				),
+			)
+		);
+
+		$this->assertSame( 1, $result['passed'] );
+		$this->assertSame( 0, $result['failed'] );
+		$this->assertTrue( $result['results'][0]['pass'] );
+		$this->assertSame( 'found at route: /sd-ai-agent-test-exact/v1/events', $result['results'][0]['actual'] );
+	}
+}


### PR DESCRIPTION
## Summary

Added benchmark assertion regression coverage proving rest_endpoint_registered rejects partial REST route matches and accepts exact normalized matches.

## Files Changed

tests/SdAiAgent/Benchmark/AssertionEngineTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** php -l tests/SdAiAgent/Benchmark/AssertionEngineTest.php && php -l includes/Benchmark/AssertionEngine.php passed. composer phpcs -- tests/SdAiAgent/Benchmark/AssertionEngineTest.php and composer test -- --filter AssertionEngineTest could not run because vendor/bin/phpcs and vendor/bin/phpunit are absent (vendor/ is not installed in this worktree).

Resolves #1264


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 2m and 90,211 tokens on this as a headless worker.