### PR TITLE
GH#1267: fix: persist invalid history job failures

### DIFF
--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -1414,6 +1414,7 @@ final class SessionController {
 				$job['error']  = __( 'Invalid conversation history format.', 'superdav-ai-agent' );
 				unset( $job['token'] );
 				set_transient( RestController::JOB_PREFIX . $job_id, $job, RestController::JOB_TTL );
+				ActiveJobRepository::update_status( $job_id, 'error' );
 				return new WP_REST_Response( array( 'ok' => false ), 200 );
 			}
 		}

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Tests\REST;
 
 use SdAiAgent\Core\Database;
+use SdAiAgent\Models\ActiveJobRepository;
 use SdAiAgent\Models\Memory;
 use SdAiAgent\Models\Skill;
 use SdAiAgent\REST\RestController;
@@ -888,6 +889,43 @@ class RestControllerTest extends WP_UnitTestCase {
 		$data = $status_response->get_data();
 		$this->assertArrayHasKey( 'status', $data );
 		$this->assertSame( 'processing', $data['status'] );
+	}
+
+	/**
+	 * Test invalid direct history processing persists the DB job status as error.
+	 */
+	public function test_process_invalid_history_persists_error_status(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$run_response = $this->dispatch( 'POST', '/sd-ai-agent/v1/run', [
+			'message' => 'Invalid history persistence test',
+		] );
+
+		$this->assertStatus( 202, $run_response );
+		$job_id = $run_response->get_data()['job_id'];
+		$job    = get_transient( RestController::JOB_PREFIX . $job_id );
+
+		$this->assertIsArray( $job );
+		$this->assertArrayHasKey( 'token', $job );
+
+		$job['params']['history'] = [
+			[
+				'role'  => 'invalid-role',
+				'parts' => [],
+			],
+		];
+		set_transient( RestController::JOB_PREFIX . $job_id, $job, RestController::JOB_TTL );
+
+		$process_response = $this->dispatch( 'POST', '/sd-ai-agent/v1/process', [
+			'job_id' => $job_id,
+			'token'  => $job['token'],
+		] );
+
+		$this->assertStatus( 200, $process_response );
+		$db_row = ActiveJobRepository::get_by_job_id( $job_id );
+
+		$this->assertNotNull( $db_row );
+		$this->assertSame( 'error', $db_row->status );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Persist invalid direct-history processing failures to ActiveJobRepository so DB fallback reports error instead of processing; added a REST regression covering the persisted error status.

## Files Changed

includes/REST/SessionController.php,tests/SdAiAgent/REST/RestControllerTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** php -l includes/REST/SessionController.php && php -l tests/SdAiAgent/REST/RestControllerTest.php (passed); composer test -- --filter test_process_invalid_history_persists_error_status (blocked: vendor/bin/phpunit missing); composer phpcs -- --standard=phpcs.xml includes/REST/SessionController.php tests/SdAiAgent/REST/RestControllerTest.php (blocked: vendor/bin/phpcs missing)

Resolves #1267


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 3m and 118,755 tokens on this as a headless worker.