### PR TITLE
fix: complete benchmark suite PHPStan types

### DIFF
--- a/includes/Benchmark/BenchmarkSuite.php
+++ b/includes/Benchmark/BenchmarkSuite.php
@@ -102,7 +102,7 @@ class BenchmarkSuite {
 	 * Get a suite by slug with its full question list.
 	 *
 	 * @param string $slug Suite slug.
-	 * @return array<string, mixed>|null
+	 * @return array{slug: string, name: string, description: string, questions: array<int, array<string, mixed>>}|null
 	 */
 	public static function get_suite( string $slug ): ?array {
 		switch ( $slug ) {


### PR DESCRIPTION
## Summary
- Tightens `BenchmarkSuite::get_suite()` PHPDoc so `get_questions()` returns the declared question array shape under PHPStan level 10.
- Completes the benchmark static-analysis cleanup for #1275 after `AssertionEngine` fixes landed on `main` via #1278.

## Testing
- `composer phpstan -- --error-format=github`
- `composer phpcs -- includes/Benchmark/AssertionEngine.php`

Resolves #1275.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.59 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 10m and 191,679 tokens on this as a headless worker.
