### PR TITLE
feat: benchmark-driven agent UX improvements

### DIFF
--- a/includes/Abilities/FileAbilities.php
+++ b/includes/Abilities/FileAbilities.php
@@ -609,7 +609,7 @@ class FileEditAbility extends AbstractFileAbility {
 				],
 				'edits' => [
 					'type'        => 'array',
-					'description' => 'Array of {search, replace} edit operations to apply in order',
+					'description' => 'Array of {search, replace} edit operations to apply in order. Pass as a real JSON array, not a stringified JSON. Example: [{"search": "old code", "replace": "new code"}].',
 					'items'       => [
 						'type'       => 'object',
 						'properties' => [
@@ -645,6 +645,14 @@ class FileEditAbility extends AbstractFileAbility {
 		/** @var array<string, mixed> $input */
 		$path  = $input['path'] ?? '';
 		$edits = $input['edits'] ?? [];
+
+		// Defensive: some agents pass `edits` as a stringified JSON.
+		if ( is_string( $edits ) ) {
+			$decoded = json_decode( $edits, true );
+			if ( is_array( $decoded ) ) {
+				$edits = $decoded;
+			}
+		}
 
 		// @phpstan-ignore-next-line
 		$full_path = $this->resolve_path( $path );

--- a/includes/Abilities/GitListAbility.php
+++ b/includes/Abilities/GitListAbility.php
@@ -35,10 +35,14 @@ class GitListAbility extends AbstractAbility {
 		return [
 			'type'       => 'object',
 			'properties' => [
-				'status' => [
+				'status'       => [
 					'type'        => 'string',
 					'enum'        => [ 'unchanged', 'modified', 'deleted' ],
 					'description' => 'Filter by status. Omit to list all tracked files.',
+				],
+				'package_slug' => [
+					'type'        => 'string',
+					'description' => 'Filter to a single plugin or theme slug. Match is on `package_slug` (e.g. "akismet" or "akismet/akismet.php").',
 				],
 			],
 		];
@@ -62,8 +66,18 @@ class GitListAbility extends AbstractAbility {
 
 		$rows = GitTrackerManager::get_all_tracked_files( $status );
 
+		$slug_filter_raw = $input['package_slug'] ?? null;
+		$slug_filter     = is_string( $slug_filter_raw ) && '' !== $slug_filter_raw ? $slug_filter_raw : null;
+
 		$files = [];
 		foreach ( $rows as $row ) {
+			if ( null !== $slug_filter ) {
+				$row_slug = (string) $row->package_slug;
+				$head     = explode( '/', $row_slug, 2 )[0];
+				if ( $row_slug !== $slug_filter && $head !== $slug_filter ) {
+					continue;
+				}
+			}
 			$files[] = [
 				'id'           => (int) $row->id,
 				'package_slug' => $row->package_slug,

--- a/includes/Abilities/GitSnapshotAbility.php
+++ b/includes/Abilities/GitSnapshotAbility.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 /**
- * Git Snapshot ability — explicitly snapshot a file.
+ * Git Snapshot ability — explicitly snapshot a file or a whole package.
  *
  * @package SdAiAgent
  * @license GPL-2.0-or-later
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Git Snapshot ability — explicitly snapshot a file.
+ * Git Snapshot ability — explicitly snapshot a file or a whole package.
  *
  * @since 1.1.0
  */
@@ -29,19 +29,27 @@ class GitSnapshotAbility extends AbstractAbility {
 	}
 
 	protected function description(): string {
-		return __( 'Explicitly snapshot a file before editing. Note: FileAbilities automatically snapshots files on write/edit — use this for manual control.', 'superdav-ai-agent' );
+		return __( 'Snapshot a baseline before edits. Pass `path` for a single file, or `package_slug` (e.g. "akismet") to snapshot a plugin\'s files without knowing the filesystem path. Note: FileAbilities auto-snapshots on write/edit; this is for manual control.', 'superdav-ai-agent' );
 	}
 
 	protected function input_schema(): array {
 		return [
 			'type'       => 'object',
 			'properties' => [
-				'path' => [
+				'path'         => [
 					'type'        => 'string',
-					'description' => 'Absolute filesystem path to the file to snapshot.',
+					'description' => 'Absolute filesystem path to a single file to snapshot.',
+				],
+				'package_slug' => [
+					'type'        => 'string',
+					'description' => 'Plugin directory name (e.g. "akismet") or theme slug. Resolves to the package directory and snapshots every PHP file in it (capped).',
+				],
+				'package_type' => [
+					'type'        => 'string',
+					'enum'        => [ 'plugin', 'theme' ],
+					'description' => 'Whether `package_slug` refers to a plugin or theme. Defaults to "plugin".',
 				],
 			],
-			'required'   => [ 'path' ],
 		];
 	}
 
@@ -49,32 +57,108 @@ class GitSnapshotAbility extends AbstractAbility {
 		return [
 			'type'       => 'object',
 			'properties' => [
-				'path'    => [ 'type' => 'string' ],
-				'message' => [ 'type' => 'string' ],
+				'path'              => [ 'type' => 'string' ],
+				'package_slug'      => [ 'type' => 'string' ],
+				'snapshotted_files' => [ 'type' => 'array' ],
+				'count'             => [ 'type' => 'integer' ],
+				'message'           => [ 'type' => 'string' ],
 			],
 		];
 	}
 
 	protected function execute_callback( $input ) {
 		/** @var array<string, mixed> $input */
-		$path = $input['path'] ?? null;
+		$path         = $input['path'] ?? null;
+		$package_slug = $input['package_slug'] ?? null;
+		$package_type = isset( $input['package_type'] ) ? (string) $input['package_type'] : 'plugin';
 
-		if ( ! is_string( $path ) || '' === $path ) {
-			return new WP_Error( 'sd_ai_agent_invalid_path', __( 'Path must be a non-empty string.', 'superdav-ai-agent' ) );
+		// Single-file mode (back-compat).
+		if ( is_string( $path ) && '' !== $path ) {
+			$result = GitTrackerManager::snapshot_before_modify( $path );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+			return [
+				'path'              => $path,
+				'snapshotted_files' => [ $path ],
+				'count'             => 1,
+				'message'           => sprintf(
+					/* translators: %s: file path */
+					__( 'File snapshotted successfully: %s', 'superdav-ai-agent' ),
+					$path
+				),
+			];
 		}
 
-		$result = GitTrackerManager::snapshot_before_modify( $path );
+		// Package-mode: resolve slug to a directory and snapshot its PHP files.
+		if ( ! is_string( $package_slug ) || '' === $package_slug ) {
+			return new WP_Error(
+				'sd_ai_agent_invalid_args',
+				__( 'Provide either `path` (absolute file) or `package_slug` (plugin/theme directory name).', 'superdav-ai-agent' )
+			);
+		}
 
-		if ( is_wp_error( $result ) ) {
-			return $result;
+		if ( 'theme' === $package_type ) {
+			$dir = get_theme_root() . '/' . $package_slug;
+		} else {
+			$dir = WP_PLUGIN_DIR . '/' . $package_slug;
+		}
+
+		if ( ! is_dir( $dir ) ) {
+			return new WP_Error(
+				'sd_ai_agent_package_not_found',
+				sprintf(
+					/* translators: 1: package type, 2: slug */
+					__( '%1$s "%2$s" not found.', 'superdav-ai-agent' ),
+					ucfirst( $package_type ),
+					$package_slug
+				)
+			);
+		}
+
+		$cap         = 200;
+		$snapshotted = [];
+		$failures    = [];
+
+		$iterator = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator( $dir, \FilesystemIterator::SKIP_DOTS )
+		);
+
+		foreach ( $iterator as $file ) {
+			if ( count( $snapshotted ) >= $cap ) {
+				break;
+			}
+			if ( ! $file->isFile() ) {
+				continue;
+			}
+			$ext = strtolower( $file->getExtension() );
+			if ( ! in_array( $ext, [ 'php', 'js', 'css', 'html', 'json' ], true ) ) {
+				continue;
+			}
+			$abs    = $file->getPathname();
+			$result = GitTrackerManager::snapshot_before_modify( $abs );
+			if ( is_wp_error( $result ) ) {
+				$failures[] = [
+					'path'  => $abs,
+					'error' => $result->get_error_message(),
+				];
+				continue;
+			}
+			$snapshotted[] = $abs;
 		}
 
 		return [
-			'path'    => $path,
-			'message' => sprintf(
-				/* translators: %s: file path */
-				__( 'File snapshotted successfully: %s', 'superdav-ai-agent' ),
-				$path
+			'package_slug'      => $package_slug,
+			'package_type'      => $package_type,
+			'snapshotted_files' => $snapshotted,
+			'count'             => count( $snapshotted ),
+			'failures'          => $failures,
+			'truncated'         => count( $snapshotted ) >= $cap,
+			'message'           => sprintf(
+				/* translators: 1: count, 2: slug */
+				__( 'Snapshotted %1$d files in package "%2$s".', 'superdav-ai-agent' ),
+				count( $snapshotted ),
+				$package_slug
 			),
 		];
 	}

--- a/includes/Abilities/OptionsAbilities.php
+++ b/includes/Abilities/OptionsAbilities.php
@@ -312,13 +312,16 @@ class UpdateOptionAbility extends AbstractAbility {
 
 		if ( $updated ) {
 			return [
-				'option_name' => $option_name,
-				'status'      => 'updated',
-				'message'     => sprintf(
+				'option_name'  => $option_name,
+				'status'       => 'updated',
+				'message'      => sprintf(
 					/* translators: %s: option name */
 					__( 'Option "%s" updated successfully.', 'superdav-ai-agent' ),
 					$option_name
 				),
+				'verification' => [
+					'persisted_value' => get_option( $option_name ),
+				],
 			];
 		}
 
@@ -332,13 +335,16 @@ class UpdateOptionAbility extends AbstractAbility {
 
 		if ( $exists ) {
 			return [
-				'option_name' => $option_name,
-				'status'      => 'unchanged',
-				'message'     => sprintf(
+				'option_name'  => $option_name,
+				'status'       => 'unchanged',
+				'message'      => sprintf(
 					/* translators: %s: option name */
 					__( 'Option "%s" already has the requested value — no change made.', 'superdav-ai-agent' ),
 					$option_name
 				),
+				'verification' => [
+					'persisted_value' => get_option( $option_name ),
+				],
 			];
 		}
 

--- a/includes/Abilities/ScanPluginHooksAbility.php
+++ b/includes/Abilities/ScanPluginHooksAbility.php
@@ -49,7 +49,7 @@ class ScanPluginHooksAbility extends AbstractAbility {
 		return [
 			'type'       => 'object',
 			'properties' => [
-				'hooks' => [
+				'hooks'   => [
 					'type'  => 'array',
 					'items' => [
 						'type'       => 'object',
@@ -59,6 +59,16 @@ class ScanPluginHooksAbility extends AbstractAbility {
 							'file' => [ 'type' => 'string' ],
 							'line' => [ 'type' => 'integer' ],
 						],
+					],
+				],
+				'count'   => [ 'type' => 'integer' ],
+				'summary' => [
+					'type'       => 'object',
+					'properties' => [
+						'actions_total'  => [ 'type' => 'integer' ],
+						'filters_total'  => [ 'type' => 'integer' ],
+						'unique_actions' => [ 'type' => 'array' ],
+						'unique_filters' => [ 'type' => 'array' ],
 					],
 				],
 			],

--- a/includes/Abilities/ScanThemeHooksAbility.php
+++ b/includes/Abilities/ScanThemeHooksAbility.php
@@ -49,7 +49,7 @@ class ScanThemeHooksAbility extends AbstractAbility {
 		return [
 			'type'       => 'object',
 			'properties' => [
-				'hooks' => [
+				'hooks'   => [
 					'type'  => 'array',
 					'items' => [
 						'type'       => 'object',
@@ -59,6 +59,16 @@ class ScanThemeHooksAbility extends AbstractAbility {
 							'file' => [ 'type' => 'string' ],
 							'line' => [ 'type' => 'integer' ],
 						],
+					],
+				],
+				'count'   => [ 'type' => 'integer' ],
+				'summary' => [
+					'type'       => 'object',
+					'properties' => [
+						'actions_total'  => [ 'type' => 'integer' ],
+						'filters_total'  => [ 'type' => 'integer' ],
+						'unique_actions' => [ 'type' => 'array' ],
+						'unique_filters' => [ 'type' => 'array' ],
 					],
 				],
 			],

--- a/includes/Abilities/WordPressAbilities.php
+++ b/includes/Abilities/WordPressAbilities.php
@@ -1117,12 +1117,15 @@ class RecommendPluginAbility extends AbstractAbility {
 	}
 
 	protected function input_schema(): array {
+		$categories = AbilityPluginRegistry::get_categories();
+		sort( $categories );
 		return [
 			'type'       => 'object',
 			'properties' => [
 				'category'        => [
 					'type'        => 'string',
-					'description' => 'The need category to search for (e.g. "ecommerce", "forms", "seo", "security", "backup", "events", "booking"). Use list-categories to see all available categories.',
+					'description' => 'The need category to search for. One of the values in `enum`. Set `list_categories: true` to enumerate them dynamically.',
+					'enum'        => $categories,
 				],
 				'limit'           => [
 					'type'        => 'integer',
@@ -1191,10 +1194,35 @@ class RecommendPluginAbility extends AbstractAbility {
 		$matches = AbilityPluginRegistry::get_by_category( $category );
 
 		if ( empty( $matches ) ) {
+			$all     = AbilityPluginRegistry::get_categories();
+			$cat_low = strtolower( trim( $category ) );
+			$near    = [];
+			foreach ( $all as $candidate ) {
+				$lev = levenshtein( $cat_low, strtolower( $candidate ) );
+				if ( $lev <= 4 || str_contains( strtolower( $candidate ), $cat_low ) || str_contains( $cat_low, strtolower( $candidate ) ) ) {
+					$near[] = [
+						'category' => $candidate,
+						'distance' => $lev,
+					];
+				}
+			}
+			usort(
+				$near,
+				static function ( array $a, array $b ): int {
+					return $a['distance'] - $b['distance'];
+				}
+			);
+			$suggestions = array_slice( array_column( $near, 'category' ), 0, 5 );
+			sort( $all );
 			return [
-				'recommendations' => [],
-				'total'           => 0,
-				'category'        => $category,
+				'recommendations'      => [],
+				'total'                => 0,
+				'category'             => $category,
+				'available_categories' => $all,
+				'suggested_categories' => $suggestions,
+				'hint'                 => empty( $suggestions )
+					? 'No close match. Choose a category from `available_categories` and call again.'
+					: 'No exact match. Closest categories are in `suggested_categories`.',
 			];
 		}
 
@@ -1466,14 +1494,17 @@ class ActivatePluginAbility extends AbstractAbility {
 		}
 
 		return [
-			'status'      => 'activated',
-			'message'     => sprintf(
+			'status'       => 'activated',
+			'message'      => sprintf(
 				/* translators: %s: plugin file */
 				__( 'Plugin "%s" activated successfully.', 'superdav-ai-agent' ),
 				$plugin_file
 			),
-			'plugin_file' => $plugin_file,
-			'active'      => true,
+			'plugin_file'  => $plugin_file,
+			'active'       => true,
+			'verification' => [
+				'active_plugins' => (array) get_option( 'active_plugins', [] ),
+			],
 		];
 	}
 
@@ -1587,14 +1618,17 @@ class DeactivatePluginAbility extends AbstractAbility {
 		deactivate_plugins( $plugin_file );
 
 		return [
-			'status'      => 'deactivated',
-			'message'     => sprintf(
+			'status'       => 'deactivated',
+			'message'      => sprintf(
 				/* translators: %s: plugin file */
 				__( 'Plugin "%s" deactivated successfully.', 'superdav-ai-agent' ),
 				$plugin_file
 			),
-			'plugin_file' => $plugin_file,
-			'active'      => false,
+			'plugin_file'  => $plugin_file,
+			'active'       => false,
+			'verification' => [
+				'active_plugins' => (array) get_option( 'active_plugins', [] ),
+			],
 		];
 	}
 

--- a/includes/Core/SkillAutoInjector.php
+++ b/includes/Core/SkillAutoInjector.php
@@ -163,6 +163,94 @@ class SkillAutoInjector {
 	}
 
 	/**
+	 * Per-request cache of skill slugs already auto-attached to ability
+	 * responses, so we attach each skill at most once per chat turn.
+	 *
+	 * @var array<string, true>
+	 */
+	private static array $attached_for_request = [];
+
+	/**
+	 * Map ability id prefix → skill slug. When an ability matching a prefix
+	 * is invoked via ability-call, the corresponding skill content is
+	 * attached to the response on first call only.
+	 *
+	 * @var array<string, string>
+	 */
+	private const ABILITY_PREFIX_TO_SKILL = [
+		'sd-ai-agent/seo-'                   => 'seo-optimization',
+		'sd-ai-agent/create-block-content'   => 'gutenberg-blocks',
+		'sd-ai-agent/parse-block-content'    => 'gutenberg-blocks',
+		'sd-ai-agent/review-block'           => 'gutenberg-blocks',
+		'sd-ai-agent/validate-block-content' => 'gutenberg-blocks',
+		'sd-ai-agent/markdown-to-blocks'     => 'gutenberg-blocks',
+		'sd-ai-agent/list-block-types'       => 'gutenberg-blocks',
+		'sd-ai-agent/list-block-templates'   => 'gutenberg-blocks',
+		'sd-ai-agent/list-block-patterns'    => 'gutenberg-blocks',
+		'sd-ai-agent/get-block-type'         => 'gutenberg-blocks',
+		'sd-ai-agent/get-theme-json'         => 'full-site-editing',
+		'sd-ai-agent/get-global-styles'      => 'full-site-editing',
+		'sd-ai-agent/update-global-styles'   => 'full-site-editing',
+		'sd-ai-agent/reset-global-styles'    => 'full-site-editing',
+	];
+
+	/**
+	 * Resolve the skill slug (if any) associated with a given ability id.
+	 *
+	 * @param string $ability_id Ability id to look up.
+	 * @return string Empty string when no skill applies.
+	 */
+	public static function skill_for_ability( string $ability_id ): string {
+		foreach ( self::ABILITY_PREFIX_TO_SKILL as $prefix => $slug ) {
+			if ( str_starts_with( $ability_id, $prefix ) ) {
+				return $slug;
+			}
+		}
+		return '';
+	}
+
+	/**
+	 * Return the auto-load skill content for an ability if it hasn't been
+	 * attached yet this request, marking it as attached for subsequent
+	 * calls. Returns null when no skill applies or when already attached.
+	 *
+	 * @param string $ability_id Ability id being invoked.
+	 * @return array{slug:string,name:string,content:string}|null
+	 */
+	public static function consume_skill_for_ability( string $ability_id ): ?array {
+		$slug = self::skill_for_ability( $ability_id );
+		if ( '' === $slug ) {
+			return null;
+		}
+		if ( isset( self::$attached_for_request[ $slug ] ) ) {
+			return null;
+		}
+
+		// @phpstan-ignore-next-line
+		$skill = Skill::get_by_slug( $slug );
+		if ( ! $skill || ! (int) $skill->enabled ) {
+			return null;
+		}
+
+		self::$attached_for_request[ $slug ] = true;
+
+		return [
+			'slug'    => $slug,
+			'name'    => (string) $skill->name,
+			'content' => (string) $skill->content,
+		];
+	}
+
+	/**
+	 * Reset per-request state. AgentLoop should call this between requests.
+	 *
+	 * @return void
+	 */
+	public static function reset_request_state(): void {
+		self::$attached_for_request = [];
+	}
+
+	/**
 	 * Record a skill auto-injection event to the usage table.
 	 *
 	 * Looks up the skill by slug to get its ID. Silently no-ops if the

--- a/includes/Models/GitTrackerManager.php
+++ b/includes/Models/GitTrackerManager.php
@@ -430,7 +430,7 @@ class GitTrackerManager {
 	 * @param string $plugin_dir_slug Plugin directory name (e.g. "akismet").
 	 * @return string|WP_Error Plugin file relative to plugins dir (e.g. "akismet/akismet.php"), or WP_Error.
 	 */
-	private static function resolve_plugin_file( string $plugin_dir_slug ) {
+	public static function resolve_plugin_file( string $plugin_dir_slug ) {
 		if ( ! function_exists( 'get_plugins' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}

--- a/includes/PluginBuilder/HookScanner.php
+++ b/includes/PluginBuilder/HookScanner.php
@@ -116,7 +116,43 @@ class HookScanner {
 			}
 		);
 
-		return [ 'hooks' => $hooks ];
+		// Summary buckets: distinct names by type so the agent can answer
+		// "what hooks does X invoke" without parsing the full positional
+		// list (which is often truncated for large plugins).
+		$action_names = [];
+		$filter_names = [];
+		foreach ( $hooks as $h ) {
+			if ( 'action' === $h['type'] || 'add_action' === $h['type'] ) {
+				$action_names[ $h['name'] ] = true;
+			} elseif ( 'filter' === $h['type'] || 'add_filter' === $h['type'] ) {
+				$filter_names[ $h['name'] ] = true;
+			}
+		}
+		$action_names = array_keys( $action_names );
+		$filter_names = array_keys( $filter_names );
+		sort( $action_names );
+		sort( $filter_names );
+
+		return [
+			'hooks'   => $hooks,
+			'count'   => count( $hooks ),
+			'summary' => [
+				'actions_total'  => count(
+					array_filter(
+						$hooks,
+						static fn( $h ) => 'action' === $h['type'] || 'add_action' === $h['type']
+					)
+				),
+				'filters_total'  => count(
+					array_filter(
+						$hooks,
+						static fn( $h ) => 'filter' === $h['type'] || 'add_filter' === $h['type']
+					)
+				),
+				'unique_actions' => $action_names,
+				'unique_filters' => $filter_names,
+			],
+		];
 	}
 
 	/**

--- a/includes/Tools/ToolDiscovery.php
+++ b/includes/Tools/ToolDiscovery.php
@@ -480,6 +480,7 @@ class ToolDiscovery {
 			$ids   = array_filter( array_map( 'trim', explode( ',', substr( $query_raw, 7 ) ) ) );
 			$found = array();
 			foreach ( $ids as $id ) {
+				$id = self::canonicalise_ability_id( $id );
 				foreach ( $candidates as $a ) {
 					if ( $a->get_name() === $id ) {
 						$found[] = $a;
@@ -655,17 +656,12 @@ class ToolDiscovery {
 			return new WP_Error( 'api_unavailable', __( 'Abilities API not available.', 'superdav-ai-agent' ) );
 		}
 
+		$ability_id = self::canonicalise_ability_id( $ability_id );
+
 		// @phpstan-ignore-next-line
 		$ability = wp_get_ability( $ability_id );
 		if ( ! $ability instanceof \WP_Ability ) {
-			return new WP_Error(
-				'ability_not_found',
-				sprintf(
-					/* translators: %s: ability id */
-					__( 'Ability "%s" not found.', 'superdav-ai-agent' ),
-					$ability_id
-				)
-			);
+			return self::format_unknown_ability_response( $ability_id );
 		}
 
 		$perms = self::tool_permissions();
@@ -796,11 +792,21 @@ class ToolDiscovery {
 		AbilityUsageTracker::record( $ability_id );
 		ModelHealthTracker::record_success();
 
-		return array(
+		$response = array(
 			'ability' => $ability_id,
 			'success' => true,
 			'result'  => $result,
 		);
+
+		// Auto-attach skill content for category-specific abilities the first
+		// time they're invoked this request. Saves the agent a round-trip to
+		// `skill-load`. Skill is silently omitted on subsequent calls.
+		$skill = \SdAiAgent\Core\SkillAutoInjector::consume_skill_for_ability( $ability_id );
+		if ( null !== $skill ) {
+			$response['_skill_context'] = $skill;
+		}
+
+		return $response;
 	}
 
 	// ─── Schema cache ────────────────────────────────────────────────────
@@ -855,6 +861,91 @@ class ToolDiscovery {
 	 */
 	public static function reset_schema_cache(): void {
 		self::$schema_cache = array();
+	}
+
+	// ─── Aliasing + unknown-ability self-heal ────────────────────────────
+
+	/**
+	 * Canonicalise an ability id, transparently rewriting the legacy
+	 * `ai-agent/` prefix that the model sometimes hallucinates back to the
+	 * canonical `sd-ai-agent/` namespace. Only rewrites when the rewritten
+	 * name resolves to a registered ability.
+	 *
+	 * @param string $ability_id Raw ability id from the model.
+	 * @return string Canonical id, or the original if no rewrite applied.
+	 */
+	public static function canonicalise_ability_id( string $ability_id ): string {
+		if ( '' === $ability_id ) {
+			return $ability_id;
+		}
+		if ( ! function_exists( 'wp_get_ability' ) ) {
+			return $ability_id;
+		}
+
+		// Rewrite the legacy `ai-agent/` prefix BEFORE probing, so we don't
+		// trigger WP's `doing_it_wrong` notice on the unknown name. Only
+		// keep the rewrite when the canonical name actually resolves.
+		if ( str_starts_with( $ability_id, 'ai-agent/' ) ) {
+			$rewritten = 'sd-' . $ability_id;
+			// @phpstan-ignore-next-line
+			if ( wp_get_ability( $rewritten ) instanceof \WP_Ability ) {
+				return $rewritten;
+			}
+		}
+
+		return $ability_id;
+	}
+
+	/**
+	 * Build a self-heal response when ability-call gets an unknown id.
+	 * Returns up to five fuzzy-ranked suggestions with their schemas inline
+	 * so the model can pick + retry in one turn instead of falling back to
+	 * ability-search.
+	 *
+	 * @param string $ability_id The original (post-canonicalisation) id.
+	 * @return array<string,mixed>
+	 */
+	private static function format_unknown_ability_response( string $ability_id ): array {
+		$payload = array(
+			'success' => false,
+			'ability' => $ability_id,
+			'error'   => sprintf(
+				/* translators: %s: ability id */
+				__( 'Ability "%s" not found.', 'superdav-ai-agent' ),
+				$ability_id
+			),
+			'code'    => 'ability_not_found',
+		);
+
+		$candidates = self::visible_abilities();
+
+		// Strip a known prefix when ranking so e.g. "ai-agent/foo-bar"
+		// matches "sd-ai-agent/foo-bar" cleanly even if the prefix rewrite
+		// didn't catch it (e.g. typo in slug).
+		$query = $ability_id;
+		if ( str_contains( $query, '/' ) ) {
+			[ , $tail ] = explode( '/', $query, 2 );
+			$query      = (string) $tail;
+		}
+
+		$ranked      = self::rank( $candidates, $query );
+		$top         = array_slice( $ranked, 0, 5 );
+		$suggestions = array();
+		foreach ( $top as $ability ) {
+			$suggestions[] = array(
+				'id'           => $ability->get_name(),
+				'description'  => $ability->get_description(),
+				// @phpstan-ignore-next-line
+				'input_schema' => self::serialise_schema( $ability->get_input_schema() ),
+			);
+		}
+
+		$payload['suggestions'] = $suggestions;
+		$payload['hint']        = empty( $suggestions )
+			? 'Call sd-ai-agent/ability-search with a keyword query to discover available abilities.'
+			: 'Pick the closest match from `suggestions`, copy its `input_schema`, and call sd-ai-agent/ability-call again.';
+
+		return $payload;
 	}
 
 	// ─── Helpers ─────────────────────────────────────────────────────────

--- a/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
+++ b/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
@@ -144,14 +144,46 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 		$this->assertContains( 'sd-ai-agent/get-plugins', $top );
 	}
 
-	public function test_ability_call_returns_error_for_unknown_ability(): void {
+	public function test_ability_call_returns_self_heal_payload_for_unknown_ability(): void {
 		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::get_registered' );
 
 		$result = ToolDiscovery::handle_ability_call(
 			[ 'ability' => 'no-such/ability' ]
 		);
 
-		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertIsArray( $result );
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'ability_not_found', $result['code'] );
+		$this->assertArrayHasKey( 'suggestions', $result );
+		$this->assertArrayHasKey( 'hint', $result );
+	}
+
+	public function test_ability_call_aliases_legacy_ai_agent_prefix(): void {
+		$result = ToolDiscovery::handle_ability_call(
+			[
+				'ability'   => 'ai-agent/get-plugins',
+				'arguments' => [],
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'sd-ai-agent/get-plugins', $result['ability'] );
+	}
+
+	public function test_ability_search_select_aliases_legacy_prefix(): void {
+		$result = ToolDiscovery::handle_ability_search(
+			[ 'query' => 'select:ai-agent/get-plugins' ]
+		);
+
+		$ids = array_map(
+			static function ( $r ) {
+				return $r['id'];
+			},
+			$result['results']
+		);
+
+		$this->assertContains( 'sd-ai-agent/get-plugins', $ids );
 	}
 
 	public function test_ability_call_returns_error_for_malformed_json_arguments(): void {


### PR DESCRIPTION
## Summary

Eight changes derived from analysing recent benchmark logs across the ac/ad/adev/apm/au/acr suites. Each one targets a specific, observed pattern of agent inefficiency.

1. **Alias legacy `ai-agent/` prefix** — server-side rewrite to `sd-ai-agent/` in `ability-call` + `ability-search`. Post-rename the model still hallucinated the old prefix on ~20 distinct ability names.
2. **Self-heal on unknown ability** — `ability-call` now returns ranked suggestions with inline schemas instead of a hard `WP_Error`, eliminating the search round.
3. **`recommend-plugin` category enum** — bake the valid category vocabulary into the JSON schema, plus nearest-match suggestions on empty results (was: 5+ guess turns).
4. **`git-snapshot` accepts `package_slug`** — snapshot a plugin/theme by name without filesystem-path discovery (recursive, capped at 200 files). `git-list` gains an optional `package_slug` filter.
5. **Hook-scan summary** — `scan-plugin-hooks` / `scan-theme-hooks` now include a `summary` block with distinct action/filter names so the agent can answer "list hooks" without parsing a possibly-truncated positional list.
6. **`file-edit` defensive decode** — accept stringified-JSON `edits` as a fallback, plus a worked example in the description.
7. **Verification block on mutators** — `update-option`, `activate-plugin`, `deactivate-plugin` now include `verification.{persisted_value, active_plugins}` so the agent stops following up with `wp-cli` to confirm.
8. **Auto-attach skill content** — when `ability-call` invokes an ability whose id prefix maps to a skill (`gutenberg-blocks`, `seo-optimization`, `full-site-editing`), the skill content rides along on the response. Per-request de-duplicated.

## Test plan

- [x] `vendor/bin/phpunit tests/SdAiAgent/Tools/ToolDiscoveryTest.php` — 19 tests / 51 assertions, including 3 new (legacy-prefix alias on `ability-call`, on `ability-search` `select:`, and self-heal payload shape).
- [x] Full suite: 1839 tests / 4893 assertions / 5 failures — same pre-existing `DatabaseSchemaTest` + `PluginBuilder` set; no new regressions.
- [ ] Re-run benchmark suites against this branch to confirm reduced turn-counts on `apm-013` (recommend-plugin), `au-011/012` (git), `adev-007` (hook-scan), and `adev-006` (file-edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)