### PR TITLE
fix: canonicalise legacy ai-agent/ keys in usage tracker

### DIFF
--- a/includes/Tools/AbilityUsageTracker.php
+++ b/includes/Tools/AbilityUsageTracker.php
@@ -48,6 +48,8 @@ class AbilityUsageTracker {
 			return;
 		}
 
+		$ability_name = self::canonicalise( $ability_name );
+
 		$map = self::load();
 		$now = time();
 
@@ -120,18 +122,50 @@ class AbilityUsageTracker {
 			return array();
 		}
 
-		$out = array();
+		$out      = array();
+		$migrated = false;
 		foreach ( $raw as $name => $entry ) {
 			if ( ! is_string( $name ) || '' === $name || ! is_array( $entry ) ) {
 				continue;
 			}
-			$out[ $name ] = array(
-				'count'     => isset( $entry['count'] ) ? (int) $entry['count'] : 0,
-				'last_used' => isset( $entry['last_used'] ) ? (int) $entry['last_used'] : 0,
-			);
+			$canonical = self::canonicalise( $name );
+			if ( $canonical !== $name ) {
+				$migrated = true;
+			}
+			$count     = isset( $entry['count'] ) ? (int) $entry['count'] : 0;
+			$last_used = isset( $entry['last_used'] ) ? (int) $entry['last_used'] : 0;
+
+			if ( isset( $out[ $canonical ] ) ) {
+				$out[ $canonical ]['count']    += $count;
+				$out[ $canonical ]['last_used'] = max( $out[ $canonical ]['last_used'], $last_used );
+			} else {
+				$out[ $canonical ] = array(
+					'count'     => $count,
+					'last_used' => $last_used,
+				);
+			}
+		}
+
+		if ( $migrated ) {
+			update_option( self::OPTION_NAME, $out, false );
 		}
 
 		return $out;
+	}
+
+	/**
+	 * Rewrite the legacy `ai-agent/` namespace to the canonical
+	 * `sd-ai-agent/` form so historical entries (recorded before the plugin
+	 * rename) don't get probed against the abilities registry by name.
+	 *
+	 * @param string $ability_name Raw ability name as recorded.
+	 * @return string Canonicalised ability name.
+	 */
+	private static function canonicalise( string $ability_name ): string {
+		if ( str_starts_with( $ability_name, 'ai-agent/' ) ) {
+			return 'sd-' . $ability_name;
+		}
+		return $ability_name;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Auto-migrate persisted `sd_ai_agent_ability_usage` keys from the legacy `ai-agent/` namespace to `sd-ai-agent/` on read (counts merged on collision)
- Apply the same rewrite on `record()` so future writes are clean
- Eliminates the recurring `WP_Abilities_Registry::get_registered` _doing_it_wrong notice for `ai-agent/skill-load` (and any other legacy entry) seen on every benchmark turn

## Why

The persisted ability-usage option was populated before the plugin slug rename and still contained ~100 keys under the legacy `ai-agent/` namespace. `ToolDiscovery::tier_1_for_run` unions the curated cold-start list with `AbilityUsageTracker::top()` and probes each name via `wp_get_ability()`, which trips the `_doing_it_wrong` notice for any unknown id.

Backtrace captured live confirmed this was the only call path producing the warning.

## Test plan

- [x] PHPUnit `--filter AbilityUsageTracker` (6/6 passing)
- [x] Live benchmark run after fix: zero `ai-agent/skill-load` notices in `wp-content/debug.log` (was firing once per turn before)
- [x] Verified one-time auto-migration: 113 entries normalised, 0 legacy keys remain in stored option