### PR TITLE
GH#1284: fix: resolve AI provider dynamically

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Core;
 
+use SdAiAgent\Admin\UnifiedAdminMenu;
 use SdAiAgent\Abilities\FeedbackAbilities;
 use SdAiAgent\Core\BudgetManager;
 use SdAiAgent\Core\ChangeLogger;
@@ -771,7 +772,18 @@ class AgentLoop {
 	 * @return \WordPress\AiClient\Results\DTO\GenerativeAiResult|WP_Error
 	 */
 	private function send_prompt() {
-		$provider_id = $this->provider_id ?: 'ai-provider-for-any-openai-compatible';
+		$provider_id = $this->resolve_provider_id();
+
+		if ( '' === $provider_id ) {
+			return new WP_Error(
+				'sd_ai_agent_no_provider',
+				sprintf(
+					/* translators: %s: URL to the Connectors admin page */
+					__( 'No AI provider is configured. Please add an API key on the <a href="%s">Connectors</a> settings page to get started.', 'superdav-ai-agent' ),
+					esc_url( UnifiedAdminMenu::getConnectorsUrl() )
+				)
+			);
+		}
 
 		try {
 			$registry = \WordPress\AiClient\AiClient::defaultRegistry();
@@ -779,9 +791,10 @@ class AgentLoop {
 				return new WP_Error(
 					'sd_ai_agent_provider_unavailable',
 					sprintf(
-						/* translators: %s: provider ID */
-						__( 'Provider "%s" is not available. Please select a different provider in the chat header.', 'superdav-ai-agent' ),
-						$provider_id
+						/* translators: 1: provider ID, 2: URL to the Connectors admin page */
+						__( 'Provider "%1$s" is no longer available. Please configure a provider on the <a href="%2$s">Connectors</a> settings page.', 'superdav-ai-agent' ),
+						$provider_id,
+						esc_url( UnifiedAdminMenu::getConnectorsUrl() )
 					)
 				);
 			}
@@ -843,15 +856,20 @@ class AgentLoop {
 	 * through ProviderRegistry::getProviderModel(). This avoids creating
 	 * model instances outside the registry which can miss auth binding.
 	 *
+	 * The provider ID is resolved by {@see resolve_provider_id()} before
+	 * this method is called — send_prompt() validates that a provider
+	 * exists and returns a WP_Error early if none is configured.
+	 *
 	 * @param \WP_AI_Client_Prompt_Builder $builder The prompt builder.
 	 */
 	private function configure_model( $builder ): void {
-		$provider_id = $this->provider_id;
+		$provider_id = $this->resolve_provider_id();
 		$model_id    = $this->model_id;
 
-		// Resolve provider — fall back to the OpenAI-compatible connector.
 		if ( empty( $provider_id ) ) {
-			$provider_id = 'ai-provider-for-any-openai-compatible';
+			// No provider available — send_prompt() will have already
+			// returned a WP_Error, so this is a defensive no-op.
+			return;
 		}
 
 		// Resolve model — fall back to the connector's configured default.
@@ -883,6 +901,44 @@ class AgentLoop {
 				// Both approaches failed — builder will use default.
 			}
 		}
+	}
+
+	/**
+	 * Resolve the provider ID to use for this request.
+	 *
+	 * Returns, in order of priority:
+	 *  1. The explicitly configured provider ID (from options or settings).
+	 *  2. The first authenticated provider found in the SDK registry.
+	 *  3. An empty string when no provider is available at all.
+	 *
+	 * @return string Provider ID, or '' if none is configured.
+	 */
+	private function resolve_provider_id(): string {
+		// Explicitly configured — use as-is.
+		if ( ! empty( $this->provider_id ) ) {
+			return $this->provider_id;
+		}
+
+		// Fall back to the first authenticated provider in the registry.
+		if ( ! class_exists( '\\WordPress\\AiClient\\AiClient' ) ) {
+			return '';
+		}
+
+		try {
+			$registry = \WordPress\AiClient\AiClient::defaultRegistry();
+			ProviderCredentialLoader::load();
+
+			foreach ( $registry->getRegisteredProviderIds() as $id ) {
+				$auth = $registry->getProviderRequestAuthentication( $id );
+				if ( null !== $auth ) {
+					return $id;
+				}
+			}
+		} catch ( \Throwable $e ) {
+			// Registry unavailable.
+		}
+
+		return '';
 	}
 
 	// ── Private delegation helpers ────────────────────────────────────────

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -13,6 +13,7 @@ namespace SdAiAgent\REST;
 
 use SdAiAgent\Abilities\GoogleAnalyticsAbilities;
 use SdAiAgent\Abilities\InternetSearchAbilities;
+use SdAiAgent\Admin\UnifiedAdminMenu;
 use SdAiAgent\Core\AgentLoop;
 use SdAiAgent\Core\BudgetManager;
 use SdAiAgent\Core\Database;
@@ -1277,8 +1278,9 @@ final class SettingsController {
 
 		if ( ! $has_provider ) {
 			$alerts[] = array(
-				'type'    => 'no_provider',
-				'message' => __( 'No AI provider configured. Add an API key in Settings.', 'superdav-ai-agent' ),
+				'type'           => 'no_provider',
+				'message'        => __( 'No AI provider configured. Add an API key on the Connectors page to get started.', 'superdav-ai-agent' ),
+				'connectors_url' => UnifiedAdminMenu::getConnectorsUrl(),
 			);
 		}
 

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -10,17 +10,14 @@ declare(strict_types=1);
  *
  * Strategy
  * --------
- * AgentLoop has two code paths for sending prompts:
+ * AgentLoop routes all prompts through the WordPress AI Client SDK
+ * (`wp_ai_client_prompt()`). The provider is resolved dynamically from
+ * the SDK registry — whichever authenticated provider is configured via
+ * the Connectors page.
  *
- * 1. WordPress AI SDK path  (`wp_ai_client_prompt()`)  — used when a
- *    registered provider is selected.
- * 2. Direct OpenAI-compat path (`wp_remote_post()`) — used when the
- *    provider is 'ai-provider-for-any-openai-compatible' or when the
- *    SDK registry doesn't have the requested provider.
- *
- * The direct path is the easiest to intercept in tests: we set the
- * `openai_compat_endpoint_url` option and use the `pre_http_request`
- * filter to return a fake HTTP response, bypassing the network entirely.
+ * In tests we set the `openai_compat_endpoint_url` option and use the
+ * `pre_http_request` filter to return a fake HTTP response, bypassing
+ * the network entirely.
  *
  * For the SDK-unavailable path we simply don't define `wp_ai_client_prompt`
  * (it may be absent in the test environment), which lets us test the
@@ -89,9 +86,9 @@ class AgentLoopTest extends WP_UnitTestCase {
 	 * registered in the SDK registry.
 	 *
 	 * run() now routes exclusively through the WordPress AI Client SDK. Tests
-	 * that call run() must skip when the SDK is absent or when no provider is
-	 * registered (the typical CI environment for WP trunk without a real
-	 * provider configured).
+	 * that call run() must skip when the SDK is absent or when no authenticated
+	 * provider is registered (the typical CI environment for WP trunk without
+	 * a real provider configured).
 	 */
 	private function skip_if_sdk_unavailable(): void {
 		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
@@ -103,10 +100,20 @@ class AgentLoopTest extends WP_UnitTestCase {
 		}
 
 		try {
-			$registry    = \WordPress\AiClient\AiClient::defaultRegistry();
-			$provider_id = 'ai-provider-for-any-openai-compatible';
-			if ( ! $registry->hasProvider( $provider_id ) ) {
-				$this->markTestSkipped( 'No AI provider registered in SDK registry — skipping run() test.' );
+			$registry     = \WordPress\AiClient\AiClient::defaultRegistry();
+			$provider_ids = $registry->getRegisteredProviderIds();
+			$has_provider = false;
+			ProviderCredentialLoader::load();
+
+			foreach ( $provider_ids as $id ) {
+				if ( null !== $registry->getProviderRequestAuthentication( $id ) ) {
+					$has_provider = true;
+					break;
+				}
+			}
+
+			if ( ! $has_provider ) {
+				$this->markTestSkipped( 'No authenticated AI provider registered in SDK registry — skipping run() test.' );
 			}
 		} catch ( \Throwable $e ) {
 			$this->markTestSkipped( 'SDK registry unavailable: ' . $e->getMessage() );
@@ -237,7 +244,7 @@ class AgentLoopTest extends WP_UnitTestCase {
 			[],
 			[],
 			[
-				'provider_id'        => 'ai-provider-for-any-openai-compatible',
+				'provider_id'        => 'test-provider',
 				'model_id'           => 'claude-sonnet-4',
 				'max_iterations'     => 5,
 				'temperature'        => 0.5,
@@ -464,6 +471,7 @@ class AgentLoopTest extends WP_UnitTestCase {
 	 * Test run() returns WP_Error with 401 Unauthorized response.
 	 */
 	public function test_run_returns_wp_error_on_unauthorized(): void {
+		$this->skip_if_sdk_unavailable();
 		$this->mock_ai_error_response( 401, 'Invalid API key' );
 
 		$loop   = new AgentLoop( 'Hello' );
@@ -962,8 +970,7 @@ class AgentLoopTest extends WP_UnitTestCase {
 			[],
 			[],
 			[
-				'provider_id' => 'ai-provider-for-any-openai-compatible',
-				'model_id'    => 'gpt-4o',
+				'model_id' => 'gpt-4o',
 			]
 		);
 		$result = $loop->run();


### PR DESCRIPTION
## Summary

Recovered the valuable provider-resolution changes from closed PR #1253 without the unrelated Tavily/search-provider changes. AgentLoop now resolves the configured provider or first authenticated SDK provider, returns Connectors-page guidance when none is available, and settings alerts expose connectors_url.

## Files Changed

includes/Core/AgentLoop.php,includes/REST/SettingsController.php,tests/SdAiAgent/Core/AgentLoopTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** php -l includes/Core/AgentLoop.php && php -l includes/REST/SettingsController.php && php -l tests/SdAiAgent/Core/AgentLoopTest.php; composer phpcs -- includes/Core/AgentLoop.php includes/REST/SettingsController.php tests/SdAiAgent/Core/AgentLoopTest.php; git diff --check. Attempted npm run test:php -- --filter AgentLoopTest, blocked by missing wp-env docker-compose.yml in this worker.

Resolves #1284


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.75 plugin for [OpenCode](https://opencode.ai) v1.14.33 with gpt-5.5 spent 8m and 116,428 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error messaging when no AI provider is configured, now with direct links to the Connectors page for easy setup.

* **Improvements**
  * Enhanced AI provider selection mechanism for more reliable model configuration and initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->