### PR TITLE
fix: adjust plugin ID and compile class for WordPress.org compatibility

### DIFF
--- a/superdav-ai-agent.php
+++ b/superdav-ai-agent.php
@@ -112,13 +112,13 @@ register_deactivation_hook( __FILE__, [ LifecycleHandler::class, 'deactivate' ] 
 // `SdAiAgent\Plugin::$handlers`. Nothing else needs to live in this file.
 xwp_load_app(
 	[
-		'id'            => 'sd-ai-agent',
+		'id'            => 'superdav-ai-agent',
 		'module'        => Plugin::class,
 		'autowiring'    => true,
 		'compile'       => true,
 		// The default `compile_class` is `CompiledContainer` + uppercased ID,
 		// which produces invalid PHP class names when the ID contains hyphens.
-		'compile_class' => 'CompiledContainerSdAiAgent',
+		'compile_class' => 'CompiledContainerSuperdavAiAgent',
 		'compile_dir'   => SD_AI_AGENT_DIR . '/build/di-cache/' . SD_AI_AGENT_VERSION,
 	],
 );


### PR DESCRIPTION
This change adjusts the plugin ID and compile class to be compatible with WordPress.org plugin repository requirements. The ID is changed from 'sd-ai-agent' to 'superdav-ai-agent' and the compile class is adjusted accordingly to avoid invalid PHP class names due to hyphens.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.89 plugin for [OpenCode](https://opencode.ai) v1.14.40 with nemotron-3-super-free spent 3m and 97,014 tokens on this as a headless worker.
