### PR TITLE
fix: update code examples in AbstractAbility to use superdav-ai-agent

### DIFF
--- a/includes/Abilities/AbstractAbility.php
+++ b/includes/Abilities/AbstractAbility.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  * Usage:
  *
  *     class MyAbility extends AbstractAbility {
- *         protected function category(): string { return 'sd-ai-agent'; }
+ *         protected function category(): string { return 'superdav-ai-agent'; }
  *         protected function input_schema(): array { return [...]; }
  *         protected function output_schema(): array { return [...]; }
  *         protected function execute_callback( $input ) { ... }
@@ -24,7 +24,7 @@ declare(strict_types=1);
  *     }
  *
  *     // Register via wp_register_ability() with ability_class:
- *     wp_register_ability( 'sd-ai-agent/my-ability', [
+ *     wp_register_ability( 'superdav-ai-agent/my-ability', [
  *         'label'         => __( 'My Ability', 'superdav-ai-agent' ),
  *         'description'   => __( 'Does something.', 'superdav-ai-agent' ),
  *         'ability_class' => MyAbility::class,
@@ -65,7 +65,7 @@ abstract class AbstractAbility extends \WP_Ability {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string              $name       The namespaced ability name (e.g. 'sd-ai-agent/memory-save').
+	 * @param string              $name       The namespaced ability name (e.g. 'superdav-ai-agent/memory-save').
 	 * @param array<string,mixed> $properties Optional overrides. Supports 'label' and 'description'.
 	 */
 	public function __construct( string $name, array $properties = array() ) {


### PR DESCRIPTION
## Summary

Updates docblock code examples in AbstractAbility.php to use `superdav-ai-agent` instead of `sd-ai-agent` for consistency with the WordPress.org plugin slug.

## What

- Updated `category()` return example: `'sd-ai-agent'` → `'superdav-ai-agent'`
- Updated `wp_register_ability()` call example: `'sd-ai-agent/my-ability'` → `'superdav-ai-agent/my-ability'`  
- Updated `\$name` param docblock example: `'sd-ai-agent/memory-save'` → `'superdav-ai-agent/memory-save'`

## Context

Follows up on issue #1288 to ensure the code examples match the canonical text domain (`superdav-ai-agent`) used throughout the plugin.

## Acceptance Criteria

- [x] Docblock examples use `superdav-ai-agent`
- [x] PR created and links to issue #1288

<!-- aidevops:sig -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal naming conventions for ability categorization to align with current standards. The ability management system now uses updated category identifiers for consistent organization and improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->