### PR TITLE
revert: undo unwanted naming PRs (#1289, #1291, #1283)

### DIFF
--- a/includes/Abilities/AbstractAbility.php
+++ b/includes/Abilities/AbstractAbility.php
@@ -15,7 +15,7 @@ declare(strict_types=1);
  * Usage:
  *
  *     class MyAbility extends AbstractAbility {
- *         protected function category(): string { return 'superdav-ai-agent'; }
+ *         protected function category(): string { return 'sd-ai-agent'; }
  *         protected function input_schema(): array { return [...]; }
  *         protected function output_schema(): array { return [...]; }
  *         protected function execute_callback( $input ) { ... }
@@ -24,7 +24,7 @@ declare(strict_types=1);
  *     }
  *
  *     // Register via wp_register_ability() with ability_class:
- *     wp_register_ability( 'superdav-ai-agent/my-ability', [
+ *     wp_register_ability( 'sd-ai-agent/my-ability', [
  *         'label'         => __( 'My Ability', 'superdav-ai-agent' ),
  *         'description'   => __( 'Does something.', 'superdav-ai-agent' ),
  *         'ability_class' => MyAbility::class,
@@ -65,7 +65,7 @@ abstract class AbstractAbility extends \WP_Ability {
 	 *
 	 * @since 1.0.0
 	 *
-	 * @param string              $name       The namespaced ability name (e.g. 'superdav-ai-agent/memory-save').
+	 * @param string              $name       The namespaced ability name (e.g. 'sd-ai-agent/memory-save').
 	 * @param array<string,mixed> $properties Optional overrides. Supports 'label' and 'description'.
 	 */
 	public function __construct( string $name, array $properties = array() ) {

--- a/includes/Tools/AbilityUsageTracker.php
+++ b/includes/Tools/AbilityUsageTracker.php
@@ -48,8 +48,6 @@ class AbilityUsageTracker {
 			return;
 		}
 
-		$ability_name = self::canonicalise( $ability_name );
-
 		$map = self::load();
 		$now = time();
 
@@ -122,50 +120,18 @@ class AbilityUsageTracker {
 			return array();
 		}
 
-		$out      = array();
-		$migrated = false;
+		$out = array();
 		foreach ( $raw as $name => $entry ) {
 			if ( ! is_string( $name ) || '' === $name || ! is_array( $entry ) ) {
 				continue;
 			}
-			$canonical = self::canonicalise( $name );
-			if ( $canonical !== $name ) {
-				$migrated = true;
-			}
-			$count     = isset( $entry['count'] ) ? (int) $entry['count'] : 0;
-			$last_used = isset( $entry['last_used'] ) ? (int) $entry['last_used'] : 0;
-
-			if ( isset( $out[ $canonical ] ) ) {
-				$out[ $canonical ]['count']    += $count;
-				$out[ $canonical ]['last_used'] = max( $out[ $canonical ]['last_used'], $last_used );
-			} else {
-				$out[ $canonical ] = array(
-					'count'     => $count,
-					'last_used' => $last_used,
-				);
-			}
-		}
-
-		if ( $migrated ) {
-			update_option( self::OPTION_NAME, $out, false );
+			$out[ $name ] = array(
+				'count'     => isset( $entry['count'] ) ? (int) $entry['count'] : 0,
+				'last_used' => isset( $entry['last_used'] ) ? (int) $entry['last_used'] : 0,
+			);
 		}
 
 		return $out;
-	}
-
-	/**
-	 * Rewrite the legacy `ai-agent/` namespace to the canonical
-	 * `sd-ai-agent/` form so historical entries (recorded before the plugin
-	 * rename) don't get probed against the abilities registry by name.
-	 *
-	 * @param string $ability_name Raw ability name as recorded.
-	 * @return string Canonicalised ability name.
-	 */
-	private static function canonicalise( string $ability_name ): string {
-		if ( str_starts_with( $ability_name, 'ai-agent/' ) ) {
-			return 'sd-' . $ability_name;
-		}
-		return $ability_name;
 	}
 
 	/**

--- a/superdav-ai-agent.php
+++ b/superdav-ai-agent.php
@@ -112,13 +112,13 @@ register_deactivation_hook( __FILE__, [ LifecycleHandler::class, 'deactivate' ] 
 // `SdAiAgent\Plugin::$handlers`. Nothing else needs to live in this file.
 xwp_load_app(
 	[
-		'id'            => 'superdav-ai-agent',
+		'id'            => 'sd-ai-agent',
 		'module'        => Plugin::class,
 		'autowiring'    => true,
 		'compile'       => true,
 		// The default `compile_class` is `CompiledContainer` + uppercased ID,
 		// which produces invalid PHP class names when the ID contains hyphens.
-		'compile_class' => 'CompiledContainerSuperdavAiAgent',
+		'compile_class' => 'CompiledContainerSdAiAgent',
 		'compile_dir'   => SD_AI_AGENT_DIR . '/build/di-cache/' . SD_AI_AGENT_VERSION,
 	],
 );


### PR DESCRIPTION
## Summary

Reverts three PRs that violated the canonical naming convention now documented in [AGENTS.md](https://github.com/Ultimate-Multisite/superdav-ai-agent/blob/main/AGENTS.md#canonical-naming---do-not-change) (commit 47cc5e3).

## Reverted commits

- **#1291** (merge `a720d88`) — "fix: update code examples in AbstractAbility to use superdav-ai-agent"
  - Changed docblock examples from `sd-ai-agent/...` to `superdav-ai-agent/...`
  - Wrong: `sd-ai-agent/` is the canonical ability namespace; `superdav-ai-agent` is **only** the WP.org slug + i18n text domain
- **#1289** (squash `cf3ef52`) — "fix: adjust plugin ID and compile class for WordPress.org compatibility"
  - Changed `'id' => 'sd-ai-agent'` to `'superdav-ai-agent'` and `CompiledContainerSdAiAgent` to `CompiledContainerSuperdavAiAgent`
  - Wrong: the WP.org plugin-check tool only inspects the text domain and slug; the internal x-wp/di container ID is private and unrelated
- **#1283** (squash `501a25e`) — "fix(usage-tracker): canonicalise legacy ai-agent/ keys"
  - Added auto-migration of legacy `ai-agent/` keys to `sd-ai-agent/`
  - Wrong: per AGENTS.md, no legacy-name migrations. Old names are not supported and we are not maintaining backward compatibility for them

## Post-revert canonical state (verified)

```
superdav-ai-agent.php:115:    'id'            => 'sd-ai-agent',
superdav-ai-agent.php:121:    'compile_class' => 'CompiledContainerSdAiAgent',
AbstractAbility.php:18:       category(): return 'sd-ai-agent';
AbstractAbility.php:27:       wp_register_ability( 'sd-ai-agent/my-ability', ...
AbilityUsageTracker.php:     (no canonicalise() / no legacy ai-agent/ migration)
```

Text-domain strings (`__( 'text', 'superdav-ai-agent' )`) are unchanged and correct.

## Why now

A headless agent merged each of these despite the rules they violate. The
canonical naming rules have now been added to [AGENTS.md on main](https://github.com/Ultimate-Multisite/superdav-ai-agent/blob/main/AGENTS.md#rules-for-agents) as a permanent
guardrail. Reverting these PRs aligns the codebase with that contract.

## Verification

- `grep "'id'" superdav-ai-agent.php` → `'sd-ai-agent'`
- `grep compile_class superdav-ai-agent.php` → `CompiledContainerSdAiAgent`
- `grep canonicalise includes/Tools/AbilityUsageTracker.php` → no matches
- All three reverts applied cleanly with no manual conflict resolution

## Follow-ups (separate work)

- Investigate how PR #1290 (the `gratis-ai-agent` → `superdav-ai-agent` rename) was generated and merged-attempted by a headless worker, despite contradicting the canonical convention. Closed unmerged but should not have been opened.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.91 plugin for [OpenCode](https://opencode.ai) v1.14.40 with gemma4:e4b spent 13h 26m and 263,673 tokens on this with the user in an interactive session.
