### PR TITLE
ci: canonical-naming guard + weak-model PR allowlist (For #1293)

### DIFF
--- a/.github/workflows/canonical-naming-guard.yml
+++ b/.github/workflows/canonical-naming-guard.yml
@@ -1,0 +1,165 @@
+name: Canonical Naming Guard
+
+# Defence-in-depth against rogue rename PRs.
+#
+# History: PRs #1283, #1289, #1290, #1291 were headless-worker submissions
+# that renamed canonical sd-ai-agent / SdAiAgent / SD_AI_AGENT_ identifiers
+# to the WP.org slug 'superdav-ai-agent'. AGENTS.md documents the rules;
+# this workflow enforces them at PR-time so a future weak model can't slip
+# the same change through review.
+#
+# See AGENTS.md → "CANONICAL NAMING - DO NOT CHANGE".
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: canonical-naming-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  canonical-naming:
+    name: Verify canonical identifiers
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+
+      - name: Plugin DI container ID must be 'sd-ai-agent'
+        run: |
+          if ! grep -qE "'id'\s*=>\s*'sd-ai-agent'" superdav-ai-agent.php; then
+            echo "::error file=superdav-ai-agent.php::Missing required line: 'id' => 'sd-ai-agent'"
+            echo "::error::The DI container ID must remain 'sd-ai-agent'. AGENTS.md forbids renaming it to 'superdav-ai-agent' (that string is only the WP.org slug + text domain)."
+            exit 1
+          fi
+          echo "OK: DI container ID is 'sd-ai-agent'"
+
+      - name: Compile class must be 'CompiledContainerSdAiAgent'
+        run: |
+          if ! grep -qE "'compile_class'\s*=>\s*'CompiledContainerSdAiAgent'" superdav-ai-agent.php; then
+            echo "::error file=superdav-ai-agent.php::Missing required line: 'compile_class' => 'CompiledContainerSdAiAgent'"
+            echo "::error::See AGENTS.md → CANONICAL NAMING."
+            exit 1
+          fi
+          echo "OK: compile_class is 'CompiledContainerSdAiAgent'"
+
+      - name: Constants must use SD_AI_AGENT_ prefix
+        run: |
+          for c in SD_AI_AGENT_DIR SD_AI_AGENT_VERSION; do
+            if ! grep -q "$c" superdav-ai-agent.php; then
+              echo "::error file=superdav-ai-agent.php::Missing required constant: $c"
+              echo "::error::AGENTS.md requires the SD_AI_AGENT_ constant prefix. Do not rename to SUPERDAV_AI_AGENT_."
+              exit 1
+            fi
+          done
+          echo "OK: SD_AI_AGENT_DIR and SD_AI_AGENT_VERSION present"
+
+      - name: Forbid SUPERDAV_AI_AGENT_ constant prefix
+        # The plugin slug 'superdav-ai-agent' is correct for text-domain strings
+        # only. Renaming SD_AI_AGENT_ constants to SUPERDAV_AI_AGENT_ is exactly
+        # the rogue pattern from PR #1289 — block it explicitly.
+        run: |
+          hits=$(grep -rEn 'SUPERDAV_AI_AGENT_[A-Z]+' \
+            --include='*.php' \
+            --exclude-dir=vendor \
+            --exclude-dir=node_modules \
+            --exclude-dir=build \
+            . || true)
+          if [ -n "$hits" ]; then
+            echo "::error::Forbidden constant prefix SUPERDAV_AI_AGENT_ found:"
+            echo "$hits"
+            echo "::error::Use SD_AI_AGENT_ instead. See AGENTS.md → CANONICAL NAMING."
+            exit 1
+          fi
+          echo "OK: no SUPERDAV_AI_AGENT_ constant references"
+
+      - name: Forbid SuperdavAiAgent\\ namespace
+        run: |
+          hits=$(grep -rEn 'namespace\s+SuperdavAiAgent\\?|use\s+SuperdavAiAgent\\?' \
+            --include='*.php' \
+            --exclude-dir=vendor \
+            --exclude-dir=node_modules \
+            --exclude-dir=build \
+            . || true)
+          if [ -n "$hits" ]; then
+            echo "::error::Forbidden namespace SuperdavAiAgent\\ found (use SdAiAgent\\):"
+            echo "$hits"
+            exit 1
+          fi
+          echo "OK: no SuperdavAiAgent namespace references"
+
+      - name: Forbid CompiledContainerSuperdavAiAgent
+        run: |
+          hits=$(grep -rEn 'CompiledContainerSuperdavAiAgent' \
+            --include='*.php' \
+            --exclude-dir=vendor \
+            --exclude-dir=node_modules \
+            --exclude-dir=build \
+            . || true)
+          if [ -n "$hits" ]; then
+            echo "::error::Forbidden compile class name CompiledContainerSuperdavAiAgent found (use CompiledContainerSdAiAgent):"
+            echo "$hits"
+            echo "::error::This is the rogue pattern from PR #1289. See AGENTS.md."
+            exit 1
+          fi
+          echo "OK: no CompiledContainerSuperdavAiAgent references"
+
+      - name: Forbid 'id' => 'superdav-ai-agent' in xwp_load_app
+        # Specifically blocks the PR #1289 pattern. We can't blanket-ban the
+        # string 'superdav-ai-agent' (it's the legitimate text domain), so
+        # this catches the high-signal context.
+        run: |
+          if grep -qE "'id'\s*=>\s*'superdav-ai-agent'" superdav-ai-agent.php; then
+            echo "::error file=superdav-ai-agent.php::Forbidden: 'id' => 'superdav-ai-agent' (PR #1289 rogue pattern)"
+            echo "::error::The DI container ID must be 'sd-ai-agent'. See AGENTS.md."
+            exit 1
+          fi
+          echo "OK: no 'id' => 'superdav-ai-agent' in main plugin file"
+
+      - name: Forbid legacy ai-agent/ canonicalise migration code
+        # PR #1283 added auto-migration of legacy 'ai-agent/' keys. Per
+        # AGENTS.md rule 3, no legacy-name migrations are wanted.
+        run: |
+          hits=$(grep -rEn "str_starts_with\(\s*\\\$[a-zA-Z_]+\s*,\s*'ai-agent/'" \
+            --include='*.php' \
+            --exclude-dir=vendor \
+            --exclude-dir=node_modules \
+            --exclude-dir=build \
+            . || true)
+          if [ -n "$hits" ]; then
+            echo "::error::Forbidden legacy 'ai-agent/' migration code (PR #1283 rogue pattern):"
+            echo "$hits"
+            echo "::error::AGENTS.md rule 3: no legacy-name migrations."
+            exit 1
+          fi
+          echo "OK: no legacy ai-agent/ migration code"
+
+      - name: Forbid gratis-ai-agent rename code
+        # PR #1290 tried to rename gratis-ai-agent → superdav-ai-agent.
+        # The correct historical-name policy is "ignore", not "migrate".
+        run: |
+          hits=$(grep -rEn 'gratis-ai-agent' \
+            --include='*.php' \
+            --exclude-dir=vendor \
+            --exclude-dir=node_modules \
+            --exclude-dir=build \
+            . || true)
+          if [ -n "$hits" ]; then
+            echo "::error::Forbidden 'gratis-ai-agent' references found (PR #1290 rogue pattern):"
+            echo "$hits"
+            echo "::error::AGENTS.md rule 3: no legacy-name handling. Remove these references."
+            exit 1
+          fi
+          echo "OK: no gratis-ai-agent references"
+
+      - name: Summary
+        run: |
+          echo "All canonical naming checks passed."
+          echo "Plugin slug (text domain): superdav-ai-agent"
+          echo "Code prefixes / DI / namespace: sd-ai-agent / SdAiAgent / SD_AI_AGENT_"

--- a/.github/workflows/worker-model-allowlist.yml
+++ b/.github/workflows/worker-model-allowlist.yml
@@ -1,0 +1,89 @@
+name: Worker Model Allowlist
+
+# Inspects aidevops PR signature footers and fails the PR if the model that
+# produced it is on the denylist of weak/free-tier models.
+#
+# History: PRs #1283/#1289/#1290/#1291 were produced by free OpenCode meta
+# models (`nemotron-3-super-free`, `minimax-m2.5-free`) and renamed canonical
+# identifiers in violation of AGENTS.md. Those models are now blocked from
+# producing merged PRs in this repo.
+#
+# Signature format (from gh-signature-helper.sh):
+#   [aidevops.sh](https://aidevops.sh) v3.x.y plugin for [OpenCode](https://opencode.ai) v1.x.y with <model> spent ...
+#
+# Human-authored PRs (no aidevops:sig marker) are not affected — this only
+# fires when an aidevops signature is present.
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+concurrency:
+  group: worker-model-allowlist-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-signature-model:
+    name: Reject weak-model worker PRs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Inspect PR body for denylisted model
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -eu
+
+          if [ -z "${PR_BODY:-}" ]; then
+            echo "PR body is empty — nothing to check."
+            exit 0
+          fi
+
+          if ! printf '%s' "$PR_BODY" | grep -q 'aidevops:sig'; then
+            echo "No aidevops:sig marker — human-authored PR, skipping."
+            exit 0
+          fi
+
+          # Models that have demonstrably produced rogue rename PRs in this
+          # repo (#1283, #1289, #1290, #1291). DO NOT remove an entry without
+          # documented evidence the model has improved on naming/refactor
+          # tasks. ADD new entries when a future weak model misfires.
+          DENY_MODELS=(
+            "nemotron-3-super-free"
+            "nemotron-3-super"
+            "minimax-m2.5-free"
+            "minimax-m2.5"
+            "big-pickle"
+            "hy3-preview-free"
+            "gpt-5.4-mini"
+          )
+
+          # Extract the worker model from the canonical signature line.
+          # Format: "with <model-id> spent ..." — anchored on the framework
+          # signature so we don't false-positive on body prose.
+          model_line=$(printf '%s' "$PR_BODY" | grep -oE 'with [^ ]+ spent' | head -1 || true)
+          if [ -z "$model_line" ]; then
+            echo "::warning::aidevops:sig present but worker-model line not found — allowing through (fix gh-signature-helper if recurring)."
+            exit 0
+          fi
+
+          model=$(printf '%s' "$model_line" | sed -E 's/^with (.+) spent$/\1/')
+          echo "Detected worker model: $model"
+
+          for deny in "${DENY_MODELS[@]}"; do
+            if printf '%s' "$model" | grep -qF "$deny"; then
+              echo "::error::Worker model '$model' is on the denylist for this repo (matched '$deny')."
+              echo "::error::PRs #1283/#1289/#1290/#1291 demonstrated this model class cannot reliably handle naming/refactor briefs."
+              echo "::error::Re-dispatch with an Anthropic-tier model (sonnet/opus), or open the PR interactively after manual review."
+              echo "::error::See repo issue #1293 for the full incident analysis."
+              exit 1
+            fi
+          done
+
+          echo "OK: worker model '$model' is not on the denylist."


### PR DESCRIPTION
## Summary

Defence-in-depth following the rogue-rename incident (PRs #1283, #1289, #1290, #1291, see issue #1293). Two new GitHub Actions workflows make a future weak-model misfire fail at PR-time instead of slipping through review.

Resolves sd-ai-p8i (beads).
For #1293

## What's added

### `.github/workflows/canonical-naming-guard.yml`

Runs on every PR to `main`. Fails the PR if any of these are violated:

- `superdav-ai-agent.php` must contain `'id' => 'sd-ai-agent'` (PR #1289 broke this)
- `superdav-ai-agent.php` must contain `'compile_class' => 'CompiledContainerSdAiAgent'` (PR #1289 broke this)
- `SD_AI_AGENT_DIR` and `SD_AI_AGENT_VERSION` constants must be present
- No `SUPERDAV_AI_AGENT_` constant prefix anywhere in PHP (PR #1289 pattern)
- No `namespace SuperdavAiAgent\` or `use SuperdavAiAgent\` (PR #1289 pattern)
- No `CompiledContainerSuperdavAiAgent` (PR #1289 pattern)
- No `'id' => 'superdav-ai-agent'` in main plugin file (PR #1289 specific)
- No `str_starts_with($x, 'ai-agent/')` legacy migration code (PR #1283 pattern)
- No `gratis-ai-agent` references in PHP (PR #1290 pattern)

The blanket-ban approach of forbidding the *string* `superdav-ai-agent` won't work — that string is the legitimate WP.org slug + text domain and appears legitimately in headers, `__()` calls, and folder names. The guard targets the high-signal contexts only (constant prefixes, namespaces, compile-class names, `'id' =>` value).

### `.github/workflows/worker-model-allowlist.yml`

Runs on `pull_request_target` (so it sees the PR body, including the aidevops signature footer). Parses the worker model out of the canonical signature line:

```
[aidevops.sh](https://aidevops.sh) v3.x.y plugin for [OpenCode](https://opencode.ai) v1.x.y with <model> spent N tokens
```

Fails the PR if `<model>` matches any entry in `DENY_MODELS` (the four free-tier OpenCode meta models that produced the incident, plus close variants):

```
nemotron-3-super-free   nemotron-3-super
minimax-m2.5-free       minimax-m2.5
big-pickle              hy3-preview-free
gpt-5.4-mini
```

PRs without an `aidevops:sig` marker (i.e. human-authored) pass through with no check. PRs with the marker but no parseable model line emit a warning but pass — that's a signature-helper bug to fix separately, not a hard block.

## Why both layers

- **Naming guard** catches the *change* even if a stronger model produces it (regression guard).
- **Model allowlist** catches the *source* even if the change is novel (origin guard).

Either layer alone would have caught all four incident PRs. Together they make the failure mode require both (a) a stronger model AND (b) a novel rogue pattern, which is unlikely-to-impossible.

## Verification

```bash
# YAML validity
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/canonical-naming-guard.yml'))"
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/worker-model-allowlist.yml'))"

# After merge, verify CI runs by opening any PR
```

## Operational notes

- The denylist in `worker-model-allowlist.yml` should grow, never shrink, unless a model is documented as having improved on naming/refactor tasks. New rogue PRs identified in future incidents should add their producing model immediately.
- The `pull_request_target` permission is read-only (`pull-requests: read`, `contents: read`). It does not check out PR code.
- These workflows do not block on the existing checks (`code-quality`, `tests`, etc.) — they're independent gates.

## Follow-ups (separate work)

- ~~Audit `bd` issue prefix `gratis-ai-agent-*`~~ — **done**: prefix migrated from `gratis-ai-agent-` to `sd-ai-` via `bd rename-prefix sd-ai-`. All 13 historic issues renamed in place; new issues now get `sd-ai-` IDs. (Hence this PR's beads ID, originally created as `gratis-ai-agent-p8i`, is now `sd-ai-p8i`.)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.14.91 plugin for [OpenCode](https://opencode.ai) v1.14.40 with claude-opus-4-7 spent 35m and 38,140 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Introduced automated validation workflow to enforce canonical naming conventions across the repository. Pull requests that violate naming standards are automatically blocked with detailed error guidance
* Added validation workflow that validates pull requests against a restricted worker model allowlist, automatically preventing the merging of requests that use blocked or restricted worker models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
