### PR TITLE
fix(rest): break /chat/tool-result 409 loop on WP_Error and stale paused_state (sd-ai-9ip)

### DIFF
--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -377,6 +377,19 @@ Assistant: %s',
 		$paused_state = Database::load_and_clear_paused_state( $session_id );
 
 		if ( null === $paused_state ) {
+			// Sync the job transient/DB row to a terminal state so the
+			// browser's poll loop stops re-issuing the same pending client
+			// tool call. Without this, a poll → execute → POST → 409 cycle
+			// can loop indefinitely (the transient still says
+			// 'awaiting_client_tools' with the stale pending calls).
+			//
+			// We do NOT downgrade to 'error' here when the same session has
+			// already produced a 'complete' result on a prior POST — in that
+			// case the transient already reflects 'complete' and this call
+			// is a no-op. When the transient is missing (TTL expiry) the
+			// helper updates the DB row only.
+			self::clear_pending_client_tool_calls( $job_id );
+
 			return new WP_Error(
 				'sd_ai_agent_no_paused_state',
 				__( 'No paused agent state found for this session. The session may have already been resumed or expired.', 'superdav-ai-agent' ),
@@ -422,6 +435,13 @@ Assistant: %s',
 		$result             = $loop->resume_after_client_tools( $tool_results_typed, $iterations_remaining );
 
 		if ( is_wp_error( $result ) ) {
+			// Sync the job transient/DB row to 'error' so the browser's poll
+			// loop sees a terminal state and stops re-issuing the same
+			// pending client tool call. Without this, the transient still
+			// says 'awaiting_client_tools' and the next poll cycle produces
+			// an infinite 409 loop on /chat/tool-result.
+			self::mark_job_error_after_resume( $job_id, $result->get_error_message() );
+
 			return $result;
 		}
 
@@ -604,5 +624,102 @@ Assistant: %s',
 		// Update the DB row so the fallback path serves 'complete' (with from_db=true)
 		// if the transient expires before the browser polls.
 		ActiveJobRepository::update_status( $job_id, 'complete' );
+	}
+
+	/**
+	 * Mark a job as 'error' on both the transient and the DB row.
+	 *
+	 * Called from /chat/tool-result when resume_after_client_tools() returns
+	 * a WP_Error. Without this sync, the job transient/DB row still says
+	 * 'awaiting_client_tools' with the same pending_client_tool_calls, so the
+	 * browser's next poll re-executes the client tools and POSTs again,
+	 * producing an infinite 409 loop on the next /chat/tool-result attempt
+	 * (paused_state was already consumed before resume_after_client_tools
+	 * ran).
+	 *
+	 * @param string $job_id        Job UUID supplied by the browser. No-op when empty.
+	 * @param string $error_message Human-readable error from the WP_Error.
+	 */
+	private static function mark_job_error_after_resume( string $job_id, string $error_message ): void {
+		if ( '' === $job_id ) {
+			return;
+		}
+
+		$transient_key = self::JOB_PREFIX . $job_id;
+		$job           = get_transient( $transient_key );
+
+		if ( is_array( $job ) ) {
+			unset( $job['token'] );
+			$job['status'] = 'error';
+			$job['error']  = $error_message;
+
+			// Drop stale pending-call hints so a transient-served poll cannot
+			// re-emit 'awaiting_client_tools' for the next browser poll.
+			unset( $job['pending_client_tool_calls'] );
+
+			set_transient( $transient_key, $job, self::JOB_TTL );
+		}
+
+		// Update the DB row so the transient-expiry fallback also serves
+		// 'error' rather than the stale 'awaiting_client_tools'.
+		ActiveJobRepository::update_status( $job_id, 'error' );
+	}
+
+	/**
+	 * Clear pending client tool calls from the job transient/DB row.
+	 *
+	 * Called from /chat/tool-result when paused_state is null (a duplicate
+	 * POST after the original was already processed, or a TTL expiry). The
+	 * server has nothing to resume, so the job MUST NOT continue advertising
+	 * 'awaiting_client_tools' — otherwise the browser polls, re-executes the
+	 * same client tools, POSTs again, gets 409 again, and loops forever.
+	 *
+	 * Behaviour:
+	 *   - If the transient already says 'complete' or 'error', leave it
+	 *     alone (the prior POST or background job already produced the
+	 *     terminal state).
+	 *   - If the transient says 'awaiting_client_tools' (stale), downgrade
+	 *     to 'error' with a synthetic message so the browser surfaces it
+	 *     and stops polling.
+	 *   - If the transient is missing entirely, only update the DB row when
+	 *     it currently says 'awaiting_client_tools'.
+	 *
+	 * @param string $job_id Job UUID supplied by the browser. No-op when empty.
+	 */
+	private static function clear_pending_client_tool_calls( string $job_id ): void {
+		if ( '' === $job_id ) {
+			return;
+		}
+
+		$transient_key = self::JOB_PREFIX . $job_id;
+		$job           = get_transient( $transient_key );
+
+		if ( is_array( $job ) ) {
+			$current_status = (string) ( $job['status'] ?? '' );
+
+			// Only act on stale 'awaiting_client_tools' entries; do not stomp
+			// on 'complete' or 'error' that a prior POST already produced.
+			if ( 'awaiting_client_tools' === $current_status ) {
+				unset( $job['token'], $job['pending_client_tool_calls'] );
+				$job['status'] = 'error';
+				$job['error']  = __(
+					'Client tool result arrived after the agent state had already been resumed or expired.',
+					'superdav-ai-agent'
+				);
+
+				set_transient( $transient_key, $job, self::JOB_TTL );
+
+				ActiveJobRepository::update_status( $job_id, 'error' );
+			}
+
+			return;
+		}
+
+		// Transient is gone — only update the DB row when it still
+		// advertises the stale 'awaiting_client_tools' status.
+		$db_row = ActiveJobRepository::get_by_job_id( $job_id );
+		if ( null !== $db_row && 'awaiting_client_tools' === $db_row->status ) {
+			ActiveJobRepository::update_status( $job_id, 'error' );
+		}
 	}
 }

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -1418,4 +1418,170 @@ class RestControllerTest extends WP_UnitTestCase {
 		$response = $this->dispatch( 'GET', '/sd-ai-agent/v1/knowledge/collections' );
 		$this->assertStatus( 401, $response );
 	}
+
+	// ─── /chat/tool-result regression: 409 loop fix (sd-ai-9ip) ──────────────
+
+	/**
+	 * Test POST /chat/tool-result returns 409 when no paused_state exists AND
+	 * downgrades a stale 'awaiting_client_tools' job transient/DB row to
+	 * 'error'.
+	 *
+	 * Regression for the infinite 409 loop: before the fix, a duplicate POST
+	 * (or a TTL-expiry replay) would return 409 but leave the job transient
+	 * advertising 'awaiting_client_tools' with the same pending_client_tool_calls.
+	 * The browser would then poll, re-execute the screenshot ability,
+	 * POST again, get 409 again, and loop forever.
+	 *
+	 * @group t-409-loop
+	 */
+	public function test_tool_result_409_clears_stale_awaiting_client_tools_transient(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$session_id = Database::create_session( [
+			'user_id' => $this->admin_id,
+			'title'   => '409 loop regression session',
+		] );
+		$job_id = '11111111-2222-3333-4444-555555555555';
+
+		// Simulate a job that is mid-pause: transient + DB row both say
+		// 'awaiting_client_tools' with one pending screenshot call. The
+		// session has NO paused_state — that is the failure scenario.
+		ActiveJobRepository::create( $session_id, $job_id, $this->admin_id, 'awaiting_client_tools' );
+		set_transient(
+			RestController::JOB_PREFIX . $job_id,
+			[
+				'status'                    => 'awaiting_client_tools',
+				'pending_client_tool_calls' => [
+					[
+						'id'   => 'call_screenshot_1',
+						'name' => 'sd-ai-agent-js/screenshot-url',
+						'args' => [ 'url' => '/about/' ],
+					],
+				],
+				'tool_calls'                => [],
+			],
+			RestController::JOB_TTL
+		);
+
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/chat/tool-result' );
+		$request->set_body( wp_json_encode( [
+			'session_id'   => $session_id,
+			'job_id'       => $job_id,
+			'tool_results' => [
+				[
+					'id'     => 'call_screenshot_1',
+					'name'   => 'sd-ai-agent-js/screenshot-url',
+					'result' => [ 'success' => true, 'image' => 'data:image/jpeg;base64,/9j/...' ],
+				],
+			],
+		] ) );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$response = $this->server->dispatch( $request );
+
+		// Endpoint still returns 409 — the contract is unchanged for the
+		// browser's retry loop, which already treats 409 as "already done".
+		$this->assertStatus( 409, $response );
+
+		// The transient must be downgraded to 'error' so the next poll sees
+		// a terminal state and stops re-executing the pending call.
+		$transient_after = get_transient( RestController::JOB_PREFIX . $job_id );
+		$this->assertIsArray( $transient_after );
+		$this->assertSame( 'error', $transient_after['status'], 'Transient must be downgraded to error to break the 409 loop.' );
+		$this->assertArrayNotHasKey(
+			'pending_client_tool_calls',
+			$transient_after,
+			'Stale pending client tool calls must be cleared so the next poll cannot re-emit awaiting_client_tools.'
+		);
+
+		// And the DB row must match so that transient-expiry fallback also
+		// serves 'error' rather than the stale 'awaiting_client_tools'.
+		$db_row = ActiveJobRepository::get_by_job_id( $job_id );
+		$this->assertNotNull( $db_row );
+		$this->assertSame( 'error', $db_row->status );
+	}
+
+	/**
+	 * Test POST /chat/tool-result on a 'complete' transient does NOT
+	 * downgrade it to 'error'. A duplicate POST after the original already
+	 * succeeded must leave the prior result intact for the browser to read.
+	 *
+	 * @group t-409-loop
+	 */
+	public function test_tool_result_409_preserves_complete_transient(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$session_id = Database::create_session( [
+			'user_id' => $this->admin_id,
+			'title'   => '409 loop regression — complete preserved',
+		] );
+		$job_id = '22222222-3333-4444-5555-666666666666';
+
+		ActiveJobRepository::create( $session_id, $job_id, $this->admin_id, 'complete' );
+		set_transient(
+			RestController::JOB_PREFIX . $job_id,
+			[
+				'status' => 'complete',
+				'result' => [ 'reply' => 'Done.', 'history' => [], 'tool_calls' => [] ],
+			],
+			RestController::JOB_TTL
+		);
+
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/chat/tool-result' );
+		$request->set_body( wp_json_encode( [
+			'session_id'   => $session_id,
+			'job_id'       => $job_id,
+			'tool_results' => [
+				[
+					'id'     => 'call_x',
+					'name'   => 'sd-ai-agent-js/screenshot-url',
+					'result' => [ 'success' => true ],
+				],
+			],
+		] ) );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertStatus( 409, $response );
+
+		$transient_after = get_transient( RestController::JOB_PREFIX . $job_id );
+		$this->assertIsArray( $transient_after );
+		$this->assertSame(
+			'complete',
+			$transient_after['status'],
+			'A complete transient must not be stomped by a duplicate tool-result POST.'
+		);
+	}
+
+	/**
+	 * Test POST /chat/tool-result with an empty job_id still returns 409
+	 * without raising an error — the helper short-circuits when no job_id
+	 * is supplied (defence in depth for older clients).
+	 *
+	 * @group t-409-loop
+	 */
+	public function test_tool_result_409_no_job_id_is_safe(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$session_id = Database::create_session( [
+			'user_id' => $this->admin_id,
+			'title'   => '409 loop regression — no job_id',
+		] );
+
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/chat/tool-result' );
+		$request->set_body( wp_json_encode( [
+			'session_id'   => $session_id,
+			// job_id intentionally omitted.
+			'tool_results' => [
+				[
+					'id'     => 'call_x',
+					'name'   => 'sd-ai-agent-js/screenshot-url',
+					'result' => [ 'success' => true ],
+				],
+			],
+		] ) );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertStatus( 409, $response );
+	}
 }


### PR DESCRIPTION
## Summary

Fixes two remaining bug paths in `handle_tool_result()` that PR #1239 missed,
which caused an infinite 409 loop on the browser's poll → execute → POST cycle
(observed with the `screenshot-url` client ability on myshopmaker.ng).

- **WP_Error path** (`includes/REST/RestController.php:424`): when
  `resume_after_client_tools()` returns a `WP_Error` (e.g. provider failure
  during the model call after a screenshot is consumed), the function returned
  early without updating the job transient. The next poll re-emitted
  `awaiting_client_tools` with the stale `pending_client_tool_calls`; the
  browser re-executed the screenshot and POSTed again, hitting 409 because
  `paused_state` had already been consumed by the first POST.
- **`no_paused_state` 409 path** (`includes/REST/RestController.php:379`):
  duplicate POSTs (or TTL expiry replays) returned 409 but never touched the
  job transient/DB row. The browser treated 409 as "already processed",
  resumed polling, saw the same stale `awaiting_client_tools`, re-executed
  the screenshot, POSTed → 409 → infinite loop.

## Fix

Two private helpers added to `RestController`:

1. `mark_job_error_after_resume(string $job_id, string $message)` —
   downgrades the transient + DB row to `error` and clears stale
   `pending_client_tool_calls`. Called from the `WP_Error` path.
2. `clear_pending_client_tool_calls(string $job_id)` — downgrades to
   `error` **only** when the job currently advertises
   `awaiting_client_tools`. Preserves `complete` / `error` transients so a
   duplicate POST cannot stomp a prior successful result. Called from the
   409 path.

## Tests

Three regression tests in `tests/SdAiAgent/REST/RestControllerTest.php`
(group `t-409-loop`):

- `test_tool_result_409_clears_stale_awaiting_client_tools_transient` —
  proves the loop-breaking behaviour: stale `awaiting_client_tools` →
  `error` after a 409 response, with `pending_client_tool_calls` removed.
- `test_tool_result_409_preserves_complete_transient` — proves a
  duplicate POST after a successful one does NOT downgrade `complete`.
- `test_tool_result_409_no_job_id_is_safe` — proves the helpers
  short-circuit safely when `job_id` is omitted by older clients.

## Verification

- `composer phpcs` (file-scoped): clean.
- `composer phpstan` (level max, full project): no errors.
- PHPUnit: cannot run locally — `npx wp-env` build fails on this host
  due to a buildkit cachemounts issue. CI will run the new tests.

## Why this matters

Without this fix, **any** WP_Error during the model call that follows a
client tool (provider 5xx, payload size violation, model-API quota
hit, etc.) leaves the user stuck in a tool-result loop with the page
showing "Composing reply…" forever, hammering the server until the job
TTL expires (~10 minutes).

Resolves sd-ai-9ip

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.6 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gemma4:e4b spent 1d 10h and 263,673 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an infinite polling loop (409 errors) that occurred when resuming chat sessions with paused client tool requests. The system now properly synchronizes session state and handles recovery failures gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->