### PR TITLE
feat(logging): add AgentEventLog for network-wide review of agent failures (sd-ai-3pc)

### DIFF
--- a/includes/Core/AbilityFunctionResolver.php
+++ b/includes/Core/AbilityFunctionResolver.php
@@ -140,6 +140,16 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 					. ' ' . ( $frame['function'] ?? '' ) . '()';
 			}
 
+			AgentEventLog::log(
+				'ability_failed',
+				AgentEventLog::SEVERITY_ERROR,
+				array(
+					'ability' => $ability_name,
+					'code'    => 'ability_exception',
+					'message' => $e->getMessage(),
+				)
+			);
+
 			return new FunctionResponse(
 				$function_id,
 				$function_name,
@@ -161,6 +171,19 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 			$response_data = array(
 				'error' => $result->get_error_message(),
 				'code'  => $error_code,
+			);
+
+			// Emit a single greppable line for operators reviewing failures
+			// across the network. Session attribution comes from
+			// AgentEventLog's thread-local set by AgentLoop::run().
+			AgentEventLog::log(
+				'ability_failed',
+				AgentEventLog::SEVERITY_ERROR,
+				array(
+					'ability' => $ability_name,
+					'code'    => $error_code,
+					'message' => (string) $result->get_error_message(),
+				)
 			);
 
 			// When our AbstractAbility::do_execute() catches an exception,

--- a/includes/Core/AgentEventLog.php
+++ b/includes/Core/AgentEventLog.php
@@ -1,0 +1,293 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Agent event log — emits a single greppable line to PHP `error_log` for
+ * agent-loop failure modes that today are otherwise invisible outside the
+ * per-subsite database.
+ *
+ * Goal: an operator running this plugin on a multisite install can
+ * `tail -f wp-content/debug.log | grep '[Superdav AI Agent]'` and see
+ * across every subsite where conversations went wrong (tool-iteration
+ * limit, ability failures, provider HTTP errors, agent-loop aborts).
+ *
+ * Design notes:
+ * - Static utility, mirrors {@see ChangeLogger}. No DI handler needed.
+ * - Output format is stable, single-line, contains no secrets, and is
+ *   independent of `WP_DEBUG` / `ProviderTrace::is_enabled()` so it works
+ *   on production.
+ * - Free-text fields are truncated; structured fields are caller-supplied.
+ * - Fires `sd_ai_agent_event_logged` so external sinks (Sentry, Loki,
+ *   syslog mu-plugin) can subscribe without us owning that integration.
+ *
+ * @package SdAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class AgentEventLog {
+
+	/**
+	 * Severity: error — agent failed in a way the user/operator should know about.
+	 */
+	const SEVERITY_ERROR = 'error';
+
+	/**
+	 * Severity: warning — abnormal but not fatal (e.g. iteration cap reached).
+	 */
+	const SEVERITY_WARNING = 'warning';
+
+	/**
+	 * Severity: info — diagnostic-only (default off; logged when callers ask for it).
+	 */
+	const SEVERITY_INFO = 'info';
+
+	/**
+	 * Maximum length of any free-text `message` field before truncation.
+	 *
+	 * Keeps log lines short and grep-friendly; full diagnostic context still
+	 * lives in {@see ProviderTrace} (gated by `WP_DEBUG`) and the session row.
+	 */
+	const MAX_MESSAGE_LENGTH = 200;
+
+	/**
+	 * Whitelisted scalar context keys that are safe to inline into the log line.
+	 *
+	 * Anything not listed here is dropped. This is the single defence against
+	 * accidentally logging request/response bodies, headers, or credentials.
+	 *
+	 * @var array<int, string>
+	 */
+	private const SAFE_CONTEXT_KEYS = array(
+		'session_id',
+		'agent_id',
+		'iterations',
+		'iterations_used',
+		'iterations_max',
+		'provider_id',
+		'model_id',
+		'ability',
+		'code',
+		'status_code',
+		'reason',
+		'duration_ms',
+	);
+
+	/**
+	 * Currently-active session ID for events emitted during a loop run.
+	 *
+	 * Set by {@see AgentLoop} at the start of `run()` / resume entry points
+	 * and cleared on exit, so call sites that don't have a session reference
+	 * (e.g. {@see AbilityFunctionResolver}, {@see ProviderTraceLogger})
+	 * can still attribute their events.
+	 *
+	 * @var int
+	 */
+	private static int $current_session_id = 0;
+
+	/**
+	 * Set the active session ID for subsequent {@see log()} calls.
+	 *
+	 * Mirrors the {@see ChangeLogger::begin()} pattern — paired with
+	 * {@see clear_session()} so nested resume paths don't leak across runs.
+	 *
+	 * @param int $session_id Session ID (0 = unknown).
+	 */
+	public static function set_session( int $session_id ): void {
+		self::$current_session_id = max( 0, $session_id );
+	}
+
+	/**
+	 * Clear the active session ID.
+	 */
+	public static function clear_session(): void {
+		self::$current_session_id = 0;
+	}
+
+	/**
+	 * Get the active session ID.
+	 *
+	 * Test-only helper; production code should use {@see log()}.
+	 *
+	 * @return int
+	 */
+	public static function get_current_session_id(): int {
+		return self::$current_session_id;
+	}
+
+	/**
+	 * Emit a single agent-event log line.
+	 *
+	 * Output shape (single line, no trailing newline — `error_log()` adds it):
+	 *
+	 *   [Superdav AI Agent][site:42][session:123] event=tool_limit_reached severity=warning iterations_used=10 iterations_max=10
+	 *
+	 * `[site:N]` is omitted on single-site installs.
+	 * `[session:N]` is omitted when no session context is available.
+	 *
+	 * @param string               $event    Event slug, e.g. `tool_limit_reached`.
+	 * @param string               $severity One of {@see self::SEVERITY_ERROR}, `_WARNING`, `_INFO`.
+	 * @param array<string, mixed> $context  Structured context. Only keys listed in
+	 *                                       {@see SAFE_CONTEXT_KEYS} are emitted; other
+	 *                                       keys (and any nested arrays) are dropped.
+	 *                                       A `message` key is allowed and truncated to
+	 *                                       {@see MAX_MESSAGE_LENGTH} chars.
+	 */
+	public static function log( string $event, string $severity, array $context = array() ): void {
+		$event    = self::sanitize_token( $event );
+		$severity = self::sanitize_severity( $severity );
+
+		if ( '' === $event ) {
+			return;
+		}
+
+		// Resolve session_id: explicit context wins, else thread-local default.
+		$session_id = isset( $context['session_id'] )
+			? (int) $context['session_id']
+			: self::$current_session_id;
+
+		// Build prefix: [Superdav AI Agent][site:N][session:N]
+		$prefix = '[Superdav AI Agent]';
+
+		if ( function_exists( 'is_multisite' ) && is_multisite() && function_exists( 'get_current_blog_id' ) ) {
+			$prefix .= '[site:' . (int) get_current_blog_id() . ']';
+		}
+
+		if ( $session_id > 0 ) {
+			$prefix .= '[session:' . $session_id . ']';
+		}
+
+		// Build key=value pairs from whitelisted context.
+		$pairs = array(
+			'event=' . $event,
+			'severity=' . $severity,
+		);
+
+		foreach ( self::SAFE_CONTEXT_KEYS as $key ) {
+			if ( 'session_id' === $key ) {
+				continue; // Already in prefix.
+			}
+			if ( ! array_key_exists( $key, $context ) ) {
+				continue;
+			}
+			$value = self::format_value( $context[ $key ] );
+			if ( '' === $value ) {
+				continue;
+			}
+			$pairs[] = $key . '=' . $value;
+		}
+
+		// Free-text message: truncated, sanitised to keep it on one line.
+		if ( isset( $context['message'] ) ) {
+			$message = (string) $context['message'];
+			if ( '' !== $message ) {
+				$message = self::truncate_and_flatten( $message, self::MAX_MESSAGE_LENGTH );
+				$pairs[] = 'message="' . $message . '"';
+			}
+		}
+
+		$line = $prefix . ' ' . implode( ' ', $pairs );
+
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Operational telemetry; this is the entire purpose of the class.
+		error_log( $line );
+
+		/**
+		 * Fires after an agent event is written to `error_log`.
+		 *
+		 * External sinks (Sentry, Loki, syslog mu-plugin) can subscribe to
+		 * forward events without us owning that integration.
+		 *
+		 * @param string               $event    Event slug.
+		 * @param string               $severity Event severity.
+		 * @param array<string, mixed> $context  Original (un-redacted) context as passed to log().
+		 */
+		do_action( 'sd_ai_agent_event_logged', $event, $severity, $context );
+	}
+
+	/**
+	 * Validate a severity string; falls back to `error` for unknown input
+	 * so a malformed call is still visible rather than silently dropped.
+	 *
+	 * @param string $severity Raw severity.
+	 * @return string Sanitised severity.
+	 */
+	private static function sanitize_severity( string $severity ): string {
+		$severity = strtolower( trim( $severity ) );
+		if ( in_array( $severity, array( self::SEVERITY_ERROR, self::SEVERITY_WARNING, self::SEVERITY_INFO ), true ) ) {
+			return $severity;
+		}
+		return self::SEVERITY_ERROR;
+	}
+
+	/**
+	 * Sanitise an event-name token: lowercase ASCII alnum + underscore + hyphen.
+	 *
+	 * Prevents log-injection if a caller mistakenly passes user input.
+	 *
+	 * @param string $token Raw token.
+	 * @return string Sanitised token (may be empty).
+	 */
+	private static function sanitize_token( string $token ): string {
+		$token = strtolower( trim( $token ) );
+		$token = preg_replace( '/[^a-z0-9_\-]/', '', $token );
+		return is_string( $token ) ? $token : '';
+	}
+
+	/**
+	 * Format a scalar context value for inclusion in the log line.
+	 *
+	 * Non-scalars are dropped (return ''). Strings have spaces and control
+	 * characters stripped so each `key=value` pair stays tokenised.
+	 *
+	 * @param mixed $value Raw value.
+	 * @return string Formatted value, or '' if unsuitable.
+	 */
+	private static function format_value( $value ): string {
+		if ( is_bool( $value ) ) {
+			return $value ? 'true' : 'false';
+		}
+		if ( is_int( $value ) || is_float( $value ) ) {
+			return (string) $value;
+		}
+		if ( ! is_string( $value ) ) {
+			return '';
+		}
+		// Collapse whitespace, strip control chars, trim. Keep printable ASCII
+		// + extended Latin so ability slugs (`sd-ai-agent/memory-save`),
+		// model IDs (`claude-opus-4-7`) and provider IDs survive intact.
+		$value = preg_replace( '/[\x00-\x1F\x7F]+/', ' ', $value );
+		$value = is_string( $value ) ? preg_replace( '/\s+/', ' ', $value ) : '';
+		$value = is_string( $value ) ? trim( $value ) : '';
+		// Cap at a sane length to keep log lines short.
+		if ( strlen( $value ) > 120 ) {
+			$value = substr( $value, 0, 120 );
+		}
+		return $value;
+	}
+
+	/**
+	 * Truncate a free-text message to a hard length and flatten newlines so
+	 * the emitted log line stays a single line.
+	 *
+	 * @param string $text Raw text.
+	 * @param int    $max  Maximum length.
+	 * @return string
+	 */
+	private static function truncate_and_flatten( string $text, int $max ): string {
+		// Replace embedded quotes so the `message="…"` token round-trips.
+		$text = str_replace( '"', "'", $text );
+		// Flatten newlines/control chars to spaces.
+		$text = preg_replace( '/[\x00-\x1F\x7F]+/', ' ', $text );
+		$text = is_string( $text ) ? preg_replace( '/\s+/', ' ', $text ) : '';
+		$text = is_string( $text ) ? trim( $text ) : '';
+		if ( strlen( $text ) > $max ) {
+			$text = substr( $text, 0, $max - 1 ) . '…';
+		}
+		return $text;
+	}
+}

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -338,18 +338,29 @@ class AgentLoop {
 		IdenticalFailureTracker::reset();
 		ModelHealthTracker::set_current_model( $this->model_id );
 
+		// Make session_id available to event-log emitters in sub-layers
+		// (AbilityFunctionResolver, ProviderTraceLogger) that don't carry
+		// a session reference through their call chain. Always cleared on exit
+		// via try/finally so a thrown exception cannot leak attribution into
+		// a subsequent unrelated run.
+		AgentEventLog::set_session( $this->session_id );
+
 		// Ensure provider auth is available (critical for loopback requests).
 		ProviderCredentialLoader::load();
 
 		// Append the new user message to history.
 		$this->history[] = new UserMessage( array( new MessagePart( $this->user_message ) ) );
 
-		$result = $this->run_loop( $this->max_iterations );
+		try {
+			$result = $this->run_loop( $this->max_iterations );
 
-		// Apply Phase-1 outcome heuristic to skill usage rows for this session.
-		$this->evaluate_skill_outcomes( $result );
+			// Apply Phase-1 outcome heuristic to skill usage rows for this session.
+			$this->evaluate_skill_outcomes( $result );
 
-		return $result;
+			return $result;
+		} finally {
+			AgentEventLog::clear_session();
+		}
 	}
 
 	/**
@@ -369,33 +380,39 @@ class AgentLoop {
 
 		ProviderCredentialLoader::load();
 
-		if ( $confirmed ) {
-			// The last message in history is the model's tool call message.
-			$assistant_message = end( $this->history );
-			ChangeLogger::begin( $this->session_id, 'confirmed-tool' );
-			try {
-				$response_message = $this->get_ability_resolver()->execute_abilities( $assistant_message );
-				/** @var \WordPress\AiClient\Messages\DTO\Message $response_message */
-			} finally {
-				ChangeLogger::end();
-			}
-			// Truncate then split for OpenAI-compatible providers.
-			$truncated_message = self::truncate_tool_results( $response_message );
-			$this->append_tool_response_to_history( $truncated_message );
-			$this->log_tool_responses( $response_message );
-		} else {
-			// Remove the model's tool call message and tell the model the call was rejected.
-			array_pop( $this->history );
-			$this->history[] = new UserMessage(
-				array(
-					new MessagePart(
-						'The user declined the requested tool calls. Please respond directly without using those tools.'
-					),
-				)
-			);
-		}
+		AgentEventLog::set_session( $this->session_id );
 
-		return $this->run_loop( $remaining_iterations );
+		try {
+			if ( $confirmed ) {
+				// The last message in history is the model's tool call message.
+				$assistant_message = end( $this->history );
+				ChangeLogger::begin( $this->session_id, 'confirmed-tool' );
+				try {
+					$response_message = $this->get_ability_resolver()->execute_abilities( $assistant_message );
+					/** @var \WordPress\AiClient\Messages\DTO\Message $response_message */
+				} finally {
+					ChangeLogger::end();
+				}
+				// Truncate then split for OpenAI-compatible providers.
+				$truncated_message = self::truncate_tool_results( $response_message );
+				$this->append_tool_response_to_history( $truncated_message );
+				$this->log_tool_responses( $response_message );
+			} else {
+				// Remove the model's tool call message and tell the model the call was rejected.
+				array_pop( $this->history );
+				$this->history[] = new UserMessage(
+					array(
+						new MessagePart(
+							'The user declined the requested tool calls. Please respond directly without using those tools.'
+						),
+					)
+				);
+			}
+
+			return $this->run_loop( $remaining_iterations );
+		} finally {
+			AgentEventLog::clear_session();
+		}
 	}
 
 	/**
@@ -418,6 +435,8 @@ class AgentLoop {
 		}
 
 		ProviderCredentialLoader::load();
+
+		AgentEventLog::set_session( $this->session_id );
 
 		// Build a tool-response message from the client results.
 		$parts = array();
@@ -463,7 +482,11 @@ class AgentLoop {
 			$this->fire_progress();
 		}
 
-		return $this->run_loop( $remaining_iterations );
+		try {
+			return $this->run_loop( $remaining_iterations );
+		} finally {
+			AgentEventLog::clear_session();
+		}
 	}
 
 	/**
@@ -486,6 +509,19 @@ class AgentLoop {
 
 			// Wall-clock timeout check.
 			if ( microtime( true ) >= $deadline ) {
+				AgentEventLog::log(
+					'agent_loop_aborted',
+					AgentEventLog::SEVERITY_WARNING,
+					array(
+						'session_id'      => $this->session_id,
+						'reason'          => 'timeout',
+						'iterations_used' => $this->iterations_used,
+						'iterations_max'  => (int) $this->max_iterations,
+						'model_id'        => (string) $this->model_id,
+						'provider_id'     => (string) $this->provider_id,
+					)
+				);
+
 				return array(
 					'reply'           => __(
 						'This request took longer than expected and was stopped to protect your usage budget. You can continue the conversation to pick up where it left off.',
@@ -521,6 +557,20 @@ class AgentLoop {
 			$result = $this->send_prompt();
 
 			if ( is_wp_error( $result ) ) {
+				/** @var WP_Error $result */
+				AgentEventLog::log(
+					'agent_loop_aborted',
+					AgentEventLog::SEVERITY_ERROR,
+					array(
+						'session_id'      => $this->session_id,
+						'reason'          => (string) $result->get_error_code(),
+						'iterations_used' => $this->iterations_used,
+						'iterations_max'  => (int) $this->max_iterations,
+						'model_id'        => (string) $this->model_id,
+						'provider_id'     => (string) $this->provider_id,
+						'message'         => (string) $result->get_error_message(),
+					)
+				);
 				return $result;
 			}
 
@@ -685,6 +735,19 @@ class AgentLoop {
 			// Spin detection: delegate to SpinDetector which encapsulates
 			// the idle-round state (last_tool_signature + idle_rounds counter).
 			if ( $this->spin_detector->record( $assistant_message, self::MAX_IDLE_ROUNDS ) ) {
+				AgentEventLog::log(
+					'agent_loop_aborted',
+					AgentEventLog::SEVERITY_WARNING,
+					array(
+						'session_id'      => $this->session_id,
+						'reason'          => 'spin_detected',
+						'iterations_used' => $this->iterations_used,
+						'iterations_max'  => (int) $this->max_iterations,
+						'model_id'        => (string) $this->model_id,
+						'provider_id'     => (string) $this->provider_id,
+					)
+				);
+
 				return array(
 					'reply'           => __(
 						'I\'ve been repeating the same operations without making progress. Here\'s what I found so far. Try rephrasing your request or providing more specifics.',
@@ -744,6 +807,18 @@ class AgentLoop {
 		}
 
 		// Exhausted iterations — return what we have so callers can inspect the log.
+		AgentEventLog::log(
+			'tool_limit_reached',
+			AgentEventLog::SEVERITY_WARNING,
+			array(
+				'session_id'      => $this->session_id,
+				'iterations_used' => $this->iterations_used,
+				'iterations_max'  => (int) $this->max_iterations,
+				'model_id'        => (string) $this->model_id,
+				'provider_id'     => (string) $this->provider_id,
+			)
+		);
+
 		return new WP_Error(
 			'sd_ai_agent_max_iterations',
 			sprintf(

--- a/includes/Core/ProviderTraceLogger.php
+++ b/includes/Core/ProviderTraceLogger.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Core;
 
+use SdAiAgent\Core\AgentEventLog;
 use SdAiAgent\Models\ProviderTrace;
 
 /**
@@ -87,12 +88,50 @@ class ProviderTraceLogger {
 	/**
 	 * Hook: http_response — capture response and write trace record.
 	 *
+	 * Two-tier logging:
+	 * - When {@see ProviderTrace::is_enabled()} (debug mode), the full
+	 *   request/response is written to the `provider_trace` DB table.
+	 * - When the response is a 4xx/5xx, a single greppable line is emitted
+	 *   to PHP `error_log` via {@see AgentEventLog} **regardless of debug
+	 *   mode**, so operators on production multisite installs can still
+	 *   diagnose provider issues without enabling `WP_DEBUG`.
+	 *
 	 * @param array<string, mixed> $response    HTTP response array.
 	 * @param array<string, mixed> $parsed_args HTTP request arguments.
 	 * @param string               $url         The request URL.
 	 * @return array<string, mixed> Unchanged response.
 	 */
 	public static function on_http_response( array $response, array $parsed_args, string $url ): array {
+		// Always check whether this URL is a known AI provider — even when
+		// trace is disabled — so we can emit the lightweight error line.
+		$provider_id = self::match_provider( $url );
+		if ( '' === $provider_id ) {
+			return $response;
+		}
+
+		// Emit lightweight error line independent of debug mode. No body,
+		// no headers — just status + provider + model.
+		$status_code_for_log = (int) wp_remote_retrieve_response_code( $response );
+		if ( $status_code_for_log >= 400 ) {
+			$model_id_for_log = '';
+			if ( isset( $parsed_args['body'] ) ) {
+				$body_for_log     = is_string( $parsed_args['body'] )
+					? $parsed_args['body']
+					: (string) wp_json_encode( $parsed_args['body'] );
+				$model_id_for_log = self::extract_model_id( $body_for_log );
+			}
+
+			AgentEventLog::log(
+				'provider_http_error',
+				AgentEventLog::SEVERITY_ERROR,
+				array(
+					'provider_id' => $provider_id,
+					'model_id'    => $model_id_for_log,
+					'status_code' => $status_code_for_log,
+				)
+			);
+		}
+
 		if ( ! ProviderTrace::is_enabled() ) {
 			return $response;
 		}

--- a/tests/SdAiAgent/Core/AgentEventLogTest.php
+++ b/tests/SdAiAgent/Core/AgentEventLogTest.php
@@ -1,0 +1,317 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Test case for AgentEventLog.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\AgentEventLog;
+use WP_UnitTestCase;
+
+/**
+ * Test AgentEventLog functionality.
+ *
+ * `error_log()` is captured by redirecting it to a temp file via the
+ * `error_log` ini directive, since PHPUnit's @ouputBuffer won't catch it.
+ */
+class AgentEventLogTest extends WP_UnitTestCase {
+
+	/**
+	 * Path to the temp file capturing error_log output.
+	 *
+	 * @var string
+	 */
+	private string $log_file = '';
+
+	/**
+	 * Captured do_action calls for sd_ai_agent_event_logged.
+	 *
+	 * @var list<array{event:string, severity:string, context:array<string,mixed>}>
+	 */
+	private array $captured_actions = array();
+
+	/**
+	 * Original error_log ini value, restored in tear_down.
+	 *
+	 * @var string
+	 */
+	private string $original_error_log = '';
+
+	public function set_up(): void {
+		parent::set_up();
+
+		AgentEventLog::clear_session();
+
+		$this->log_file = (string) tempnam( sys_get_temp_dir(), 'sdai-event-log-' );
+		// File must exist and be writable; tempnam creates it 0600.
+		$this->original_error_log = (string) ini_get( 'error_log' );
+		ini_set( 'error_log', $this->log_file );
+
+		$this->captured_actions = array();
+		add_action(
+			'sd_ai_agent_event_logged',
+			function ( $event, $severity, $context ): void {
+				$this->captured_actions[] = array(
+					'event'    => (string) $event,
+					'severity' => (string) $severity,
+					'context'  => is_array( $context ) ? $context : array(),
+				);
+			},
+			10,
+			3
+		);
+	}
+
+	public function tear_down(): void {
+		ini_set( 'error_log', $this->original_error_log );
+		if ( '' !== $this->log_file && file_exists( $this->log_file ) ) {
+			@unlink( $this->log_file );
+		}
+		AgentEventLog::clear_session();
+		remove_all_actions( 'sd_ai_agent_event_logged' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Read the contents of the captured error_log file.
+	 */
+	private function read_log(): string {
+		if ( ! file_exists( $this->log_file ) ) {
+			return '';
+		}
+		$contents = file_get_contents( $this->log_file );
+		return is_string( $contents ) ? $contents : '';
+	}
+
+	// ── tool_limit_reached ─────────────────────────────────────────────────
+
+	public function test_emits_tool_limit_reached_with_expected_shape(): void {
+		AgentEventLog::log(
+			'tool_limit_reached',
+			AgentEventLog::SEVERITY_WARNING,
+			array(
+				'session_id'      => 123,
+				'iterations_used' => 10,
+				'iterations_max'  => 10,
+				'model_id'        => 'claude-opus-4-7',
+				'provider_id'     => 'anthropic',
+			)
+		);
+
+		$contents = $this->read_log();
+
+		$this->assertStringContainsString( '[Superdav AI Agent]', $contents );
+		$this->assertStringContainsString( '[session:123]', $contents );
+		$this->assertStringContainsString( 'event=tool_limit_reached', $contents );
+		$this->assertStringContainsString( 'severity=warning', $contents );
+		$this->assertStringContainsString( 'iterations_used=10', $contents );
+		$this->assertStringContainsString( 'iterations_max=10', $contents );
+		$this->assertStringContainsString( 'model_id=claude-opus-4-7', $contents );
+		$this->assertStringContainsString( 'provider_id=anthropic', $contents );
+	}
+
+	// ── ability_failed ─────────────────────────────────────────────────────
+
+	public function test_emits_ability_failed_with_truncated_message(): void {
+		$long_message = str_repeat( 'x', 500 );
+
+		AgentEventLog::log(
+			'ability_failed',
+			AgentEventLog::SEVERITY_ERROR,
+			array(
+				'ability' => 'sd-ai-agent/memory-save',
+				'code'    => 'invalid_input',
+				'message' => $long_message,
+			)
+		);
+
+		$contents = $this->read_log();
+
+		$this->assertStringContainsString( 'event=ability_failed', $contents );
+		$this->assertStringContainsString( 'severity=error', $contents );
+		$this->assertStringContainsString( 'ability=sd-ai-agent/memory-save', $contents );
+		$this->assertStringContainsString( 'code=invalid_input', $contents );
+
+		// Message truncated to MAX_MESSAGE_LENGTH (200) — full 500-char string must NOT appear.
+		$this->assertStringNotContainsString( str_repeat( 'x', 250 ), $contents );
+		$this->assertStringContainsString( '…', $contents );
+	}
+
+	// ── provider_http_error ────────────────────────────────────────────────
+
+	public function test_emits_provider_http_error(): void {
+		AgentEventLog::log(
+			'provider_http_error',
+			AgentEventLog::SEVERITY_ERROR,
+			array(
+				'provider_id' => 'anthropic',
+				'model_id'    => 'claude-opus-4-7',
+				'status_code' => 529,
+			)
+		);
+
+		$contents = $this->read_log();
+
+		$this->assertStringContainsString( 'event=provider_http_error', $contents );
+		$this->assertStringContainsString( 'status_code=529', $contents );
+		$this->assertStringContainsString( 'provider_id=anthropic', $contents );
+	}
+
+	// ── agent_loop_aborted ─────────────────────────────────────────────────
+
+	public function test_emits_agent_loop_aborted_with_reason(): void {
+		AgentEventLog::log(
+			'agent_loop_aborted',
+			AgentEventLog::SEVERITY_ERROR,
+			array(
+				'session_id' => 7,
+				'reason'     => 'budget_exceeded',
+			)
+		);
+
+		$contents = $this->read_log();
+
+		$this->assertStringContainsString( '[session:7]', $contents );
+		$this->assertStringContainsString( 'event=agent_loop_aborted', $contents );
+		$this->assertStringContainsString( 'reason=budget_exceeded', $contents );
+	}
+
+	// ── thread-local session attribution ───────────────────────────────────
+
+	public function test_thread_local_session_id_is_used_when_context_omits_it(): void {
+		AgentEventLog::set_session( 42 );
+		AgentEventLog::log(
+			'ability_failed',
+			AgentEventLog::SEVERITY_ERROR,
+			array(
+				'ability' => 'sd-ai-agent/memory-save',
+				'code'    => 'invalid_input',
+			)
+		);
+
+		$contents = $this->read_log();
+		$this->assertStringContainsString( '[session:42]', $contents );
+	}
+
+	public function test_explicit_context_session_overrides_thread_local(): void {
+		AgentEventLog::set_session( 42 );
+		AgentEventLog::log(
+			'ability_failed',
+			AgentEventLog::SEVERITY_ERROR,
+			array(
+				'session_id' => 99,
+				'ability'    => 'sd-ai-agent/memory-save',
+				'code'       => 'invalid_input',
+			)
+		);
+
+		$contents = $this->read_log();
+		$this->assertStringContainsString( '[session:99]', $contents );
+		$this->assertStringNotContainsString( '[session:42]', $contents );
+	}
+
+	public function test_omits_session_when_unknown(): void {
+		AgentEventLog::clear_session();
+		AgentEventLog::log(
+			'tool_limit_reached',
+			AgentEventLog::SEVERITY_WARNING,
+			array( 'iterations_used' => 5 )
+		);
+
+		$contents = $this->read_log();
+		$this->assertStringNotContainsString( '[session:', $contents );
+	}
+
+	// ── action hook ─────────────────────────────────────────────────────────
+
+	public function test_fires_sd_ai_agent_event_logged_action(): void {
+		AgentEventLog::log(
+			'tool_limit_reached',
+			AgentEventLog::SEVERITY_WARNING,
+			array(
+				'session_id'      => 1,
+				'iterations_used' => 10,
+			)
+		);
+
+		$this->assertCount( 1, $this->captured_actions );
+		$this->assertSame( 'tool_limit_reached', $this->captured_actions[0]['event'] );
+		$this->assertSame( 'warning', $this->captured_actions[0]['severity'] );
+		$this->assertSame( 1, $this->captured_actions[0]['context']['session_id'] );
+		$this->assertSame( 10, $this->captured_actions[0]['context']['iterations_used'] );
+	}
+
+	// ── log-injection / sanitisation ───────────────────────────────────────
+
+	public function test_event_name_strips_unsafe_characters(): void {
+		// Newlines or shell metachars in the event name must not survive.
+		AgentEventLog::log(
+			"bad\nevent name; rm -rf /",
+			AgentEventLog::SEVERITY_ERROR
+		);
+
+		$contents = $this->read_log();
+		$this->assertStringNotContainsString( "rm -rf", $contents );
+		$this->assertStringNotContainsString( "\nevent", $contents );
+	}
+
+	public function test_message_field_collapses_newlines(): void {
+		AgentEventLog::log(
+			'ability_failed',
+			AgentEventLog::SEVERITY_ERROR,
+			array(
+				'ability' => 'x',
+				'code'    => 'y',
+				'message' => "line one\nline two\nline three",
+			)
+		);
+
+		$contents = $this->read_log();
+		// The error_log format itself appends a trailing newline; the
+		// message body must not introduce additional newlines.
+		$lines = array_filter(
+			explode( "\n", trim( $contents ) ),
+			static fn( string $l ): bool => '' !== $l
+		);
+		$this->assertCount( 1, $lines, 'Each emit must produce exactly one log line' );
+	}
+
+	// ── unknown severity defaults to error ─────────────────────────────────
+
+	public function test_unknown_severity_defaults_to_error(): void {
+		AgentEventLog::log( 'something', 'CRITICAL', array() );
+		$contents = $this->read_log();
+		$this->assertStringContainsString( 'severity=error', $contents );
+	}
+
+	// ── unsafe context keys are dropped ────────────────────────────────────
+
+	public function test_non_whitelisted_context_keys_are_dropped(): void {
+		AgentEventLog::log(
+			'tool_limit_reached',
+			AgentEventLog::SEVERITY_WARNING,
+			array(
+				'session_id'  => 1,
+				// Pretend a careless caller passed a body / API key — these
+				// keys are not in SAFE_CONTEXT_KEYS and must NOT appear.
+				'request_body' => '{"messages":[{"role":"user","content":"secret"}]}',
+				'authorization' => 'Bearer sk-very-secret-token-shhh',
+				'api_key'       => 'sk-shhh',
+			)
+		);
+
+		$contents = $this->read_log();
+		$this->assertStringNotContainsString( 'secret', $contents );
+		$this->assertStringNotContainsString( 'sk-shhh', $contents );
+		$this->assertStringNotContainsString( 'sk-very-secret-token', $contents );
+		$this->assertStringNotContainsString( 'Bearer', $contents );
+		$this->assertStringNotContainsString( 'request_body', $contents );
+		$this->assertStringNotContainsString( 'authorization', $contents );
+	}
+}


### PR DESCRIPTION
## Summary

Adds `SdAiAgent\Core\AgentEventLog` — a thin static utility that emits a single greppable line to PHP `error_log` for four agent-loop failure modes that today are invisible outside the per-subsite database. The goal is for an operator running this plugin on a multisite install to `tail -f wp-content/debug.log | grep '[Superdav AI Agent]'` and see across every subsite where conversations went wrong.

Resolves bd issue **sd-ai-3pc**.

## Why

Verified gaps before writing the brief:

- `ProviderTrace` (table `{prefix}sd_ai_agent_provider_trace`) is **gated by `WP_DEBUG`** (`includes/Models/ProviderTrace.php:87`) — never runs on production.
- `ChangeLogger` records *successful* AI writes only.
- Existing `error_log()` calls are inconsistent and don't cover four important branches:
  1. **Tool-iteration limit reached** — surfaced in the assistant message, not logged.
  2. **Ability returned `WP_Error`** (non-exception) — silent until now.
  3. **Provider HTTP 4xx/5xx** — captured to DB only when `WP_DEBUG`.
  4. **AgentLoop aborted** for non-exception reasons (timeout, spin, no provider, registry unavailable).

## What

### New file: `includes/Core/AgentEventLog.php`

- One public method: `log( string $event, string $severity, array $context = [] )`.
- Output format (stable, single-line, no secrets):
  ```
  [Superdav AI Agent][site:42][session:123] event=tool_limit_reached severity=warning iterations_used=10 iterations_max=10 model_id=claude-opus-4-7 provider_id=anthropic
  [Superdav AI Agent][site:42][session:123] event=ability_failed severity=error ability=sd-ai-agent/memory-save code=invalid_input message="…"
  [Superdav AI Agent][site:42] event=provider_http_error severity=error provider_id=anthropic model_id=claude-opus-4-7 status_code=529
  [Superdav AI Agent][site:42][session:123] event=agent_loop_aborted severity=error reason=timeout iterations_used=25 iterations_max=25
  ```
- `[site:N]` is omitted on single-site, `[session:N]` is omitted when unknown.
- Whitelist of safe context keys (`SAFE_CONTEXT_KEYS`) — anything else is dropped, so a careless caller passing `request_body` / `authorization` / `api_key` cannot leak secrets. Test asserts this directly.
- Free-text `message` is truncated to 200 chars and flattened to a single line.
- Fires `do_action( 'sd_ai_agent_event_logged', $event, $severity, $context )` so an external sink (Sentry, Loki, syslog mu-plugin) can subscribe without us owning that integration.
- Session attribution uses a thread-local (`set_session()` / `clear_session()`) mirroring `ChangeLogger`. `AgentLoop::run()` and both `resume_*()` entry points wrap the loop in `try/finally` so attribution can never leak across runs.

### Wire-in points

- `AgentLoop::run_loop()` — emits on iteration cap, wall-clock timeout, spin detection, and `send_prompt()` `WP_Error`.
- `AbilityFunctionResolver::execute_ability()` — emits on the `WP_Error` return path **and** the catch-all `Throwable` path.
- `ProviderTraceLogger::on_http_response()` — emits `provider_http_error` for any status ≥ 400 on a known AI-provider URL **independent of `ProviderTrace::is_enabled()`**, so production sites get the line without enabling `WP_DEBUG`. The body/header capture path remains gated by `WP_DEBUG` as before.

### Canonical naming compliance (per AGENTS.md)

- Namespace `SdAiAgent\Core\AgentEventLog`
- Action hook `sd_ai_agent_event_logged`
- No rename of `sd-ai-agent` <-> `superdav-ai-agent` boundaries
- Text domain `superdav-ai-agent` only used in user-facing strings

## Verification

- `vendor/bin/phpcs --standard=phpcs.xml`: **clean** across all 5 changed files.
- `composer phpstan`: **0 errors / 201 files**.
- `vendor/bin/phpunit --filter AgentEventLogTest`: **12/12 green, 39 assertions**.
- Full suite: 1868 tests, 5043 assertions. 3 failures in `PluginBuilder/*` are **pre-existing on `origin/main`** (verified by re-running on a clean checkout — same failures, missing `wp-config.php` in sandbox).
- Test coverage includes:
  - Each of the four event types emits the expected key=value tokens.
  - `[site:N]` omitted when not multisite.
  - `[session:N]` omitted when unknown.
  - Thread-local session vs explicit context override.
  - Action hook fires with correct args.
  - Long messages truncated.
  - Multi-line messages flattened to one line.
  - Unknown severity defaults to `error`.
  - **Sensitive keys (`request_body`, `authorization`, `api_key`) are dropped** even when callers pass them.
  - Event-name log-injection prevented (`bad\nevent name; rm -rf /` is sanitised).

## Out of scope (filed as bd sd-ai-mt8)

- Network Admin -> Recent agent events across all sites (DB table on main site, REST endpoint, React UI). Already filed as a separate bd brief blocked by this one.

## Manual verification (suggested before merge)

1. On the dev install (`http://wordpress.local:8080/wp-admin`), enable `WP_DEBUG_LOG` in `wp-config.php`.
2. Trigger a tool-limit conversation; `grep tool_limit_reached wp-content/debug.log`.
3. Trigger an ability validation failure; `grep ability_failed wp-content/debug.log`.
4. Both should appear with the expected single-line shape.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.8 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gemma4:e4b spent 1d 10h and 263,673 tokens on this with the user in an interactive session.
