### PR TITLE
fix(e2e): correct stale CSS prefix in disabled-card assertions (sd-ai-24t)

### DIFF
--- a/tests/e2e/automations.spec.js
+++ b/tests/e2e/automations.spec.js
@@ -756,7 +756,7 @@ test.describe( 'Scheduled Automations (t080)', () => {
 			.locator( '.sdaa-skill-card' )
 			.filter( { hasText: disabledAutomation.name } );
 
-		await expect( card ).toHaveClass( /ai-agent-skill-card--disabled/ );
+		await expect( card ).toHaveClass( /sdaa-skill-card--disabled/ );
 	} );
 
 	test( 'Cancel button hides the creation form', async ( { page } ) => {
@@ -1179,7 +1179,7 @@ test.describe( 'Event-Driven Automations (t081)', () => {
 			.locator( '.sdaa-skill-card' )
 			.filter( { hasText: disabledEvent.name } );
 
-		await expect( card ).toHaveClass( /ai-agent-skill-card--disabled/ );
+		await expect( card ).toHaveClass( /sdaa-skill-card--disabled/ );
 	} );
 
 	test( 'empty state shows when no event automations exist', async ( {


### PR DESCRIPTION
## Summary

Fixes the perpetual `Playwright E2E (WP trunk shard 1)` failure caused by two stale CSS-prefix regex assertions in `tests/e2e/automations.spec.js`.

Resolves bd issue **sd-ai-24t**.

## What

Two assertions expected `/ai-agent-skill-card--disabled/` but the class actually shipped (and used by the locator on the same line) is `sdaa-skill-card--disabled`:

- `tests/e2e/automations.spec.js:759` — Scheduled Automations test
- `tests/e2e/automations.spec.js:1182` — Event-Driven Automations test

Verified the `sdaa-skill-card--disabled` class is the source of truth across 5 files in `src/settings-page/` plus the stylesheet — the locator `.sdaa-skill-card` already targets it correctly, only the regex was stale (likely from an incomplete rename when `ai-agent-` -> `sdaa-` happened in the React layer).

## Verified pre-existing

Confirmed by `gh pr list` that `Playwright E2E (WP trunk shard 1)` has failed on every recent PR:

- #1297 (just merged) - FAILURE
- #1296 - FAILURE
- #1294 - FAILURE
- #1292 (merged) - FAILURE
- #1291 (merged) - FAILURE

Restoring this to green will clear `mergeStateStatus=UNSTABLE` on all future PRs.

## Scope

Intentionally narrow:

- Test-only change matching what's already shipped.
- Not a `sdaa-` -> `sd-ai-agent-` normalisation. AGENTS.md lists `sd-ai-agent-` as the canonical CSS prefix, but `sdaa-` is the prefix actually used throughout `src/settings-page/`. That broader inconsistency is a separate concern and is **out of scope** here.

## Verification

- `npm run lint:js`: clean.
- Diff is exactly 2 lines (the regex characters in two `toHaveClass` calls).
- The matching `.sdaa-skill-card` locator is unchanged — proves the regex was the only stale piece.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.9 plugin for [OpenCode](https://opencode.ai) v1.14.41 with gemma4:e4b spent 1d 11h and 263,673 tokens on this with the user in an interactive session.
