### PR TITLE
feat: generic chat-banner + chat-error-message extension points (#1299)

### DIFF
--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -43,6 +43,7 @@ use SdAiAgent\Infrastructure\WordPress\Abilities\AbilitySchemaFilter;
 use SdAiAgent\Infrastructure\WordPress\Abilities\UsageInstructionsFilter;
 use SdAiAgent\REST\AgentController;
 use SdAiAgent\REST\AutomationController;
+use SdAiAgent\REST\BannerController;
 use SdAiAgent\REST\ConnectorsController;
 use SdAiAgent\REST\ChangesController;
 use SdAiAgent\REST\FeedbackController;
@@ -100,6 +101,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		FrontendAssetsHandler::class,
 		MemoryController::class,
 		SkillController::class,
+		BannerController::class,
 		FeedbackController::class,
 		TraceController::class,
 		McpController::class,

--- a/includes/REST/BannerController.php
+++ b/includes/REST/BannerController.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * REST API controller for the generic chat banner extension point.
+ *
+ * Exposes a single read-only endpoint:
+ *
+ *   GET /sd-ai-agent/v1/chat-banners
+ *
+ * which returns whatever banner objects other plugins have contributed
+ * via the `sd_ai_agent_chat_banners` filter. The AI Agent itself never
+ * adds banners; the endpoint exists purely so companion plugins (usage
+ * caps, billing, compliance, onboarding nudges, etc.) have a single
+ * place to surface UI without each having to ship its own React mount.
+ *
+ * Producers are expected to return an array of objects with this shape:
+ *
+ *   [
+ *     'id'        => 'unique-banner-id',
+ *     'severity'  => 'info' | 'warning' | 'error',
+ *     'message'   => 'Plain text body — no HTML.',
+ *     'cta_label' => 'Optional call-to-action label',
+ *     'cta_url'   => 'https://example.test/...',
+ *   ]
+ *
+ * Unknown keys are passed through; the React renderer ignores them.
+ *
+ * @package SdAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\REST;
+
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+use XWP\DI\Decorators\REST_Handler;
+use XWP\DI\Decorators\REST_Route;
+use XWP_REST_Controller;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Generic chat-banner extension point.
+ *
+ * Companion plugins should hook into the `sd_ai_agent_chat_banners`
+ * filter rather than mounting their own React components into the chat
+ * panel. The contract is defined in this class' docblock above.
+ */
+#[REST_Handler(
+	namespace: RestController::NAMESPACE,
+	basename: 'chat-banners',
+	container: 'sd-ai-agent',
+)]
+final class BannerController extends XWP_REST_Controller {
+
+	use PermissionTrait;
+
+	/**
+	 * Handle GET /chat-banners — return banners contributed by other plugins.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response
+	 */
+	#[REST_Route(
+		route: '',
+		methods: WP_REST_Server::READABLE,
+		guard: 'check_chat_permission',
+	)]
+	public function handle_get( WP_REST_Request $request ): WP_REST_Response {
+		$context = array(
+			'user_id' => get_current_user_id(),
+			'site_id' => function_exists( 'get_current_blog_id' ) ? get_current_blog_id() : 0,
+		);
+
+		/**
+		 * Filter the list of banners to render at the top of the chat panel.
+		 *
+		 * Hook into this filter to surface a banner above the AI Agent chat
+		 * UI without having to ship your own React mount. Each entry must
+		 * have at minimum `severity` (`info`, `warning`, or `error`) and
+		 * `message` (plain text — no HTML). `id`, `cta_label`, and `cta_url`
+		 * are optional.
+		 *
+		 * @since 1.11.0
+		 *
+		 * @param array<int, array<string, mixed>> $banners Banners to render. Default empty.
+		 * @param array<string, mixed>             $context Request context: user_id, site_id.
+		 */
+		$banners = apply_filters( 'sd_ai_agent_chat_banners', array(), $context );
+
+		if ( ! is_array( $banners ) ) {
+			$banners = array();
+		}
+
+		// Coerce each entry to a plain associative array so non-array
+		// producers can't poison the response shape. The renderer drops
+		// entries missing severity/message client-side.
+		$normalised = array();
+		foreach ( $banners as $banner ) {
+			if ( is_array( $banner ) ) {
+				$normalised[] = $banner;
+			}
+		}
+
+		return new WP_REST_Response( array( 'banners' => $normalised ), 200 );
+	}
+}

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -1032,7 +1032,33 @@ final class SessionController {
 		}
 
 		if ( 'error' === $job['status'] && isset( $job['error'] ) ) {
-			$response['message'] = $job['error'];
+			$error_context = array(
+				'job_id'        => $job_id,
+				'session_id'    => isset( $job['session_id'] ) ? (int) $job['session_id'] : 0,
+				'error_context' => $job['error_context'] ?? null,
+			);
+
+			/**
+			 * Filter the error message returned to the chat client.
+			 *
+			 * Companion plugins that raise their own AI-related errors
+			 * (usage caps, billing, content-policy gates, etc.) can hook
+			 * here to rewrite the message into something more actionable
+			 * for the user — for example, by appending a Markdown link to
+			 * a checkout or settings page. The frontend renders the
+			 * returned string through its Markdown pipeline, so producers
+			 * may use Markdown syntax including links.
+			 *
+			 * @since 1.11.0
+			 *
+			 * @param string               $message       Raw error message from AgentLoop.
+			 * @param array<string, mixed> $error_context Context: job_id, session_id, error_context.
+			 */
+			$response['message'] = (string) apply_filters(
+				'sd_ai_agent_chat_error_message',
+				(string) $job['error'],
+				$error_context
+			);
 
 			// Forward backtrace context so the frontend can display
 			// actionable debugging details (file, line, abbreviated stack).

--- a/src/components/__tests__/ChatBanners.test.js
+++ b/src/components/__tests__/ChatBanners.test.js
@@ -1,0 +1,228 @@
+/**
+ * Unit tests for components/chat-banners.js
+ *
+ * Tests cover the generic chat-banner host:
+ * - Renders nothing while the status fetch is in flight
+ * - Renders nothing on apiFetch rejection (endpoint missing / 401)
+ * - Renders nothing when the producer list is empty
+ * - Renders a single banner with correct severity class and CTA
+ * - Renders multiple banners in producer order
+ * - Drops banners missing severity or message
+ * - Drops banners with an unknown severity value
+ * - CTA opens in a new tab with rel="noopener noreferrer"
+ * - Skips CTA element when cta_label/cta_url are missing
+ */
+
+import { createElement } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+import ChatBanners from '../chat-banners';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+// Mock @wordpress/api-fetch.
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+/**
+ * Configure the apiFetch mock.
+ *
+ * @param {Object|null} payload Payload to resolve with; if null, apiFetch rejects.
+ */
+function mockResponse( payload ) {
+	apiFetch.mockReset();
+	if ( payload === null ) {
+		apiFetch.mockReturnValue( Promise.reject( new Error( '404' ) ) );
+	} else {
+		apiFetch.mockReturnValue( Promise.resolve( payload ) );
+	}
+}
+
+describe( 'ChatBanners', () => {
+	let createRoot;
+	let act;
+	let container;
+	let root;
+
+	beforeAll( () => {
+		// eslint-disable-next-line global-require
+		( { createRoot } = require( 'react-dom/client' ) );
+		// eslint-disable-next-line global-require
+		( { act } = require( 'react' ) );
+	} );
+
+	beforeEach( () => {
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		root = createRoot( container );
+	} );
+
+	afterEach( () => {
+		act( () => {
+			root.unmount();
+		} );
+		document.body.removeChild( container );
+	} );
+
+	/**
+	 * Render the component and flush the apiFetch microtask so the
+	 * useEffect resolves and the second render runs.
+	 *
+	 * @param {Object|null} response Response payload, or null to reject.
+	 * @return {Promise<string>} container.innerHTML after settle.
+	 */
+	async function renderWith( response ) {
+		mockResponse( response );
+		await act( async () => {
+			root.render( createElement( ChatBanners, {} ) );
+		} );
+		await act( async () => {
+			await Promise.resolve();
+		} );
+		return container.innerHTML;
+	}
+
+	test( 'renders nothing on apiFetch rejection', async () => {
+		const html = await renderWith( null );
+		expect( html ).toBe( '' );
+	} );
+
+	test( 'renders nothing when banners array is empty', async () => {
+		const html = await renderWith( { banners: [] } );
+		expect( html ).toBe( '' );
+	} );
+
+	test( 'renders nothing when response shape is unexpected', async () => {
+		const html = await renderWith( { unrelated: 'shape' } );
+		expect( html ).toBe( '' );
+	} );
+
+	test( 'renders a single info banner', async () => {
+		const html = await renderWith( {
+			banners: [
+				{
+					id: 'demo-info',
+					severity: 'info',
+					message: 'Heads up!',
+				},
+			],
+		} );
+		expect( html ).toContain( 'sdaa-chat-banner--info' );
+		expect( html ).toContain( 'Heads up!' );
+		expect( html ).not.toContain( '<a' );
+	} );
+
+	test( 'renders a warning banner with a CTA', async () => {
+		const html = await renderWith( {
+			banners: [
+				{
+					id: 'demo-warn',
+					severity: 'warning',
+					message: 'Approaching limit',
+					cta_label: 'Upgrade →',
+					cta_url: 'https://example.test/upgrade',
+				},
+			],
+		} );
+		expect( html ).toContain( 'sdaa-chat-banner--warning' );
+		expect( html ).toContain( 'Approaching limit' );
+		expect( html ).toContain( 'href="https://example.test/upgrade"' );
+		expect( html ).toContain( 'target="_blank"' );
+		expect( html ).toContain( 'rel="noopener noreferrer"' );
+		expect( html ).toContain( 'Upgrade →' );
+	} );
+
+	test( 'renders an error banner with role="alert"', async () => {
+		const html = await renderWith( {
+			banners: [
+				{
+					id: 'demo-error',
+					severity: 'error',
+					message: 'Blocked',
+				},
+			],
+		} );
+		expect( html ).toContain( 'sdaa-chat-banner--error' );
+		expect( html ).toContain( 'role="alert"' );
+	} );
+
+	test( 'renders multiple banners in order', async () => {
+		const html = await renderWith( {
+			banners: [
+				{ id: 'a', severity: 'info', message: 'First' },
+				{ id: 'b', severity: 'warning', message: 'Second' },
+				{ id: 'c', severity: 'error', message: 'Third' },
+			],
+		} );
+		expect( html.indexOf( 'First' ) ).toBeGreaterThan( -1 );
+		expect( html.indexOf( 'Second' ) ).toBeGreaterThan(
+			html.indexOf( 'First' )
+		);
+		expect( html.indexOf( 'Third' ) ).toBeGreaterThan(
+			html.indexOf( 'Second' )
+		);
+	} );
+
+	test( 'drops banners missing severity', async () => {
+		const html = await renderWith( {
+			banners: [
+				{ id: 'no-severity', message: 'I should not render' },
+				{ id: 'ok', severity: 'info', message: 'Visible' },
+			],
+		} );
+		expect( html ).not.toContain( 'I should not render' );
+		expect( html ).toContain( 'Visible' );
+	} );
+
+	test( 'drops banners missing message', async () => {
+		const html = await renderWith( {
+			banners: [
+				{ id: 'no-msg', severity: 'warning' },
+				{ id: 'ok', severity: 'info', message: 'Visible' },
+			],
+		} );
+		expect( html ).toContain( 'Visible' );
+		// No second banner element rendered.
+		expect( html.match( /sdaa-chat-banner--/g ) ).toHaveLength( 1 );
+	} );
+
+	test( 'drops banners with an unknown severity', async () => {
+		const html = await renderWith( {
+			banners: [
+				{
+					id: 'bad-severity',
+					severity: 'critical',
+					message: 'Should not render',
+				},
+				{ id: 'ok', severity: 'info', message: 'Visible' },
+			],
+		} );
+		expect( html ).not.toContain( 'Should not render' );
+		expect( html ).toContain( 'Visible' );
+	} );
+
+	test( 'omits CTA when only one of label/url is set', async () => {
+		const htmlNoUrl = await renderWith( {
+			banners: [
+				{
+					id: 'no-url',
+					severity: 'info',
+					message: 'Hi',
+					cta_label: 'Click',
+				},
+			],
+		} );
+		expect( htmlNoUrl ).not.toContain( '<a' );
+
+		const htmlNoLabel = await renderWith( {
+			banners: [
+				{
+					id: 'no-label',
+					severity: 'info',
+					message: 'Hi',
+					cta_url: 'https://example.test/',
+				},
+			],
+		} );
+		expect( htmlNoLabel ).not.toContain( '<a' );
+	} );
+} );

--- a/src/components/chat-banners.js
+++ b/src/components/chat-banners.js
@@ -1,0 +1,165 @@
+/**
+ * Generic chat banner host.
+ *
+ * Renders an array of banners returned by `/sd-ai-agent/v1/chat-banners`
+ * at the top of the chat panel. Banners are produced by other plugins
+ * via the `sd_ai_agent_chat_banners` PHP filter — this component is
+ * intentionally domain-agnostic.
+ *
+ * Each banner contributed by a producer is expected to have the shape:
+ *
+ * ```
+ * {
+ *   id:          string  // stable identifier; used as React key
+ *   severity:    'info' | 'warning' | 'error'
+ *   message:     string  // plain-text body (no HTML)
+ *   cta_label?:  string  // optional; required if cta_url is set
+ *   cta_url?:    string  // optional; opened in a new tab when present
+ * }
+ * ```
+ *
+ * Behaviour:
+ *
+ * - Polls the endpoint every 5 minutes so producers (e.g. usage caps)
+ *   can change state between turns without a page reload.
+ * - Hides itself silently on 404, 401, or any network error so a
+ *   missing or unauthorised producer never blocks the chat UI.
+ * - Skips any banner that is missing a `severity` or `message` to keep
+ *   ill-formed producer output from crashing the renderer.
+ *
+ * Producers that need to surface live data should declare their own
+ * REST endpoint and filter into `sd_ai_agent_chat_banners` server-side.
+ * The AI Agent never inspects the banner payload beyond the schema
+ * documented above.
+ *
+ * @return {JSX.Element|null} The banner stack, or null when nothing to show.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Refresh interval for the chat-banners endpoint.
+ */
+const REFRESH_MS = 5 * 60 * 1000;
+
+/**
+ * Map a producer-supplied severity to a CSS modifier class.
+ *
+ * @param {string} severity One of 'info', 'warning', 'error'.
+ * @return {string} CSS modifier class, falling back to 'info'.
+ */
+function severityClass( severity ) {
+	if ( 'error' === severity ) {
+		return 'sdaa-chat-banner--error';
+	}
+	if ( 'warning' === severity ) {
+		return 'sdaa-chat-banner--warning';
+	}
+	return 'sdaa-chat-banner--info';
+}
+
+/**
+ * Validate that a banner payload has the minimum required fields.
+ *
+ * @param {Object} banner Banner object from the REST endpoint.
+ * @return {boolean} True if the banner is renderable.
+ */
+function isRenderable( banner ) {
+	if ( ! banner || 'object' !== typeof banner ) {
+		return false;
+	}
+	if ( ! banner.message || 'string' !== typeof banner.message ) {
+		return false;
+	}
+	const severity = banner.severity;
+	if (
+		'info' !== severity &&
+		'warning' !== severity &&
+		'error' !== severity
+	) {
+		return false;
+	}
+	return true;
+}
+
+/**
+ * Chat banners component.
+ *
+ * @return {JSX.Element|null} Banner stack, or null when nothing to render.
+ */
+export default function ChatBanners() {
+	const [ banners, setBanners ] = useState( [] );
+
+	useEffect( () => {
+		let cancelled = false;
+
+		const fetchBanners = () => {
+			apiFetch( { path: '/sd-ai-agent/v1/chat-banners' } )
+				.then( ( data ) => {
+					if ( cancelled ) {
+						return;
+					}
+					const list = Array.isArray( data?.banners )
+						? data.banners.filter( isRenderable )
+						: [];
+					setBanners( list );
+				} )
+				.catch( () => {
+					if ( ! cancelled ) {
+						setBanners( [] );
+					}
+				} );
+		};
+
+		fetchBanners();
+		const interval = setInterval( fetchBanners, REFRESH_MS );
+
+		return () => {
+			cancelled = true;
+			clearInterval( interval );
+		};
+	}, [] );
+
+	if ( banners.length === 0 ) {
+		return null;
+	}
+
+	return (
+		<div className="sdaa-chat-banners">
+			{ banners.map( ( banner, index ) => {
+				// Producers SHOULD supply a stable id; fall back to the
+				// array index so React doesn't warn when they don't.
+				const key =
+					banner.id && 'string' === typeof banner.id
+						? banner.id
+						: `banner-${ index }`;
+				const className = `sdaa-chat-banner ${ severityClass(
+					banner.severity
+				) }`;
+				const role = 'error' === banner.severity ? 'alert' : 'status';
+
+				return (
+					<div key={ key } className={ className } role={ role }>
+						<span className="sdaa-chat-banner__message">
+							{ banner.message }
+						</span>
+						{ banner.cta_url && banner.cta_label && (
+							<a
+								className="sdaa-chat-banner__cta"
+								href={ banner.cta_url }
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								{ banner.cta_label }
+							</a>
+						) }
+					</div>
+				);
+			} ) }
+		</div>
+	);
+}

--- a/src/components/chat-redesign/index.js
+++ b/src/components/chat-redesign/index.js
@@ -11,6 +11,7 @@ import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 
 import STORE_NAME from '../../store';
+import ChatBanners from '../chat-banners';
 import ErrorBoundary from '../error-boundary';
 import ToolConfirmationDialog from '../tool-confirmation-dialog';
 import Sidebar from './Sidebar';
@@ -133,6 +134,12 @@ export default function ChatRedesign() {
 						changesCount={ changesCount }
 						onShowChanges={ () => setShowChanges( true ) }
 					/>
+
+					<ErrorBoundary
+						label={ __( 'Chat banners', 'sd-ai-agent' ) }
+					>
+						<ChatBanners />
+					</ErrorBoundary>
 
 					{ showChanges && (
 						<ChangesDrawer

--- a/src/components/shared.css
+++ b/src/components/shared.css
@@ -804,3 +804,74 @@
 .is-compact .sdaa-changes-bar {
 	padding: 4px 10px;
 }
+
+/* ── Chat banners (generic) ──────────────────────────────────────────────── */
+
+/* Generic banner stack rendered at the top of the chat panel. Banners are
+   contributed by other plugins via the `sd_ai_agent_chat_banners` PHP filter
+   and the `/sd-ai-agent/v1/chat-banners` REST endpoint. */
+.sdaa-chat-banners {
+	display: flex;
+	flex-direction: column;
+	gap: 1px;
+}
+
+.sdaa-chat-banner {
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: 12px;
+	padding: 10px 16px;
+	border-left: 4px solid;
+	font-size: 13px;
+	line-height: 1.5;
+}
+
+.sdaa-chat-banner--info {
+	background: #f0f6fc;
+	border-left-color: #2271b1;
+	color: #1d2327;
+}
+
+.sdaa-chat-banner--warning {
+	background: #fcf9e8;
+	border-left-color: #dba617;
+	color: #674a00;
+}
+
+.sdaa-chat-banner--error {
+	background: #fcf0f1;
+	border-left-color: #cc1818;
+	color: #8a1f11;
+}
+
+.sdaa-chat-banner__message {
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.sdaa-chat-banner__cta {
+	display: inline-block;
+	padding: 4px 12px;
+	border-radius: 3px;
+	background: #2271b1;
+	color: #fff;
+	text-decoration: none;
+	font-weight: 500;
+	white-space: nowrap;
+}
+
+.sdaa-chat-banner__cta:hover,
+.sdaa-chat-banner__cta:focus {
+	background: #135e96;
+	color: #fff;
+}
+
+.sdaa-chat-banner--error .sdaa-chat-banner__cta {
+	background: #cc1818;
+}
+
+.sdaa-chat-banner--error .sdaa-chat-banner__cta:hover,
+.sdaa-chat-banner--error .sdaa-chat-banner__cta:focus {
+	background: #a00d0d;
+}


### PR DESCRIPTION
## Summary

Replaces the metered-plans-specific banner and inline-error logic from the prior revision of this PR with two **generic, data-driven extension points** that any plugin can hook into. Metered-plans rendering will live in a separate follow-up PR that consumes these hooks.

This keeps AI Agent core free of consumer-specific UI/messaging while giving any addon (metered-plans, future plugins) a stable contract for surfacing chat-side banners and rewriting AI error messages.

## What's exposed

### 1. Generic chat banners — data filter

```php
apply_filters( 'sd_ai_agent_chat_banners', [], $context );
// $context = [ 'user_id' => int, 'site_id' => int ]
// return [ [ 'id' => 'unique', 'severity' => 'info|warning|error',
//            'message' => 'text', 'cta_label' => 'optional',
//            'cta_url' => 'optional' ], ... ];
```

- New REST endpoint: `GET /sd-ai-agent/v1/chat-banners` (guarded by `check_chat_permission`).
- New `ChatBanners` React component renders the returned list inside an ErrorBoundary between ConvoHeader and MessageList.
- Drops malformed entries (missing `severity`/`message`, unknown `severity`) client-side.
- CTA renders only when both `cta_label` and `cta_url` are present, with `target="_blank" rel="noopener noreferrer"`.

### 2. Generic inline-error rewrite — message filter

```php
apply_filters( 'sd_ai_agent_chat_error_message', $message, $error_context );
// $error_context = [ 'job_id' => string, 'session_id' => string,
//                    'error_context' => array ]
```

- Applied at `SessionController` job-result serialization.
- Lets producer plugins rewrite their own exception messages (e.g. metered-plans `TokenLimitReachedException` → Markdown link), which `markdown-message.js` already turns into clickable CTAs with safe `rel` attributes.

## Why this design

- **Q1 (data filter)**: hook returns plain data, not HTML — keeps consumer freedom intact and matches existing AI Agent filter conventions.
- **Q3 (repurpose this PR)**: the metered-plans-specific banner code moves out of AI Agent core entirely.
- **Q4 (server-side error filter)**: producer plugins know their own exception classes/formats; rewriting at the source is more reliable than client-side string matching.

Severity vocabulary is `info | warning | error`. Renderer drops anything else, so adding new severities later is forward-compatible.

## Files changed

- `includes/REST/BannerController.php` — NEW; `GET /sd-ai-agent/v1/chat-banners`, exposes `sd_ai_agent_chat_banners` filter
- `includes/REST/SessionController.php` — wraps `$job['error']` via `sd_ai_agent_chat_error_message` filter
- `includes/Plugin.php` — registers `BannerController`
- `src/components/chat-banners.js` — NEW; generic banner renderer
- `src/components/__tests__/ChatBanners.test.js` — NEW; 11-test Jest suite
- `src/components/chat-redesign/index.js` — mounts `ChatBanners` inside ErrorBoundary
- `src/components/shared.css` — generic `.sdaa-chat-banner` + `--info`/`--warning`/`--error` modifiers

## Verification

- ✅ `npm run lint:js` clean
- ✅ `npm run lint:css` clean
- ✅ `vendor/bin/phpcs` clean on changed files
- ✅ `vendor/bin/phpstan` clean on changed files
- ✅ `npm run test:js` — **228 / 228 pass** (incl. 11 new ChatBanners tests covering empty/rejected fetch, single info banner, warning + CTA, error with `role="alert"`, multiple banners, drop-malformed branches, CTA link-safety)
- ✅ `npm run build` produces `superdav-ai-agent.zip`

## Follow-up PRs

- `ultimate-multisite-metered-plans` PR: hook `sd_ai_agent_chat_banners` to surface payment-method gate state, hook `sd_ai_agent_chat_error_message` to rewrite `TokenLimitReachedException` to a Markdown checkout link, extend `Model_Availability_Filter` for full provider/model gating.

Refs #1299
