### PR TITLE
fix(build): exclude .playwright-mcp/ and vendor .codex from distribution (sd-ai-ee4)

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -43,6 +43,11 @@ phpstan.neon.dist
 .cursorrules
 .clinerules
 .windsurfrules
+.codex
+
+# Transient AI / browser-automation session artefacts
+# (Playwright MCP writes console logs and screenshots here during E2E runs.)
+.playwright-mcp
 
 # WordPress local dev environment
 .wp-env.json

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ coverage-html/
 playwright-report/
 test-results/
 blob-report/
+.playwright-mcp/
 # Benchmark results (contain API-specific data, regenerated on demand)
 tests/benchmark/results/
 # Local AI tooling artifacts

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -78,7 +78,7 @@ echo "    Done."
 # plugin-check never re-flags non-permitted files such as .codex,
 # .cursorrules, etc., shipped *inside* a vendor package). Also strips any
 # transient playwright-mcp directory left over from a local E2E run.
-echo "==> Pruning stray dev-metadata files inside vendor/..."
+echo "==> Pruning stray dev-metadata and AI-session artefacts across distribution (incl. .playwright-mcp)..."
 find "$DEST" \
 	\( -name '.codex' \
 	-o -name '.cursorrules' \

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -72,6 +72,26 @@ rsync -a --delete \
 	"$PLUGIN_DIR/" "$DEST/"
 echo "    Done."
 
+# ── 4a. Post-copy sweep: prune dev-metadata files that vendor packages may
+# carry inside their own directories (rsync excludes are gitignore-style and
+# should match at any depth, but we belt-and-brace this so the WP.org
+# plugin-check never re-flags non-permitted files such as .codex,
+# .cursorrules, etc., shipped *inside* a vendor package). Also strips any
+# transient playwright-mcp directory left over from a local E2E run.
+echo "==> Pruning stray dev-metadata files inside vendor/..."
+find "$DEST" \
+	\( -name '.codex' \
+	-o -name '.cursorrules' \
+	-o -name '.clinerules' \
+	-o -name '.windsurfrules' \
+	-o -name '.editorconfig' \
+	-o -name '.eslintrc*' \
+	-o -name '.prettierrc*' \
+	-o -name '.stylelintrc*' \
+	-o -name '.playwright-mcp' \
+	\) -print -exec rm -rf {} + 2>/dev/null || true
+echo "    Done."
+
 # ── 5. Create zip ──
 ZIP_NAME="superdav-ai-agent-${VERSION}.zip"
 ZIP_PATH="${PLUGIN_DIR}/${ZIP_NAME}"


### PR DESCRIPTION
## Summary

Fixes WP.org plugin-check failures reporting non-permitted files in the submitted zip:

- `.playwright-mcp/console-*.log` — transient Playwright MCP session logs created during local E2E runs
- `vendor/x-wp/di/.codex` — dev metadata file shipped inside a vendor package

## Changes

- **`.gitignore`** — ignore `.playwright-mcp/` so transient E2E session output is never committed in the first place.
- **`.distignore`** — exclude `.codex` (matches at any depth, catches the nested vendor file) and `.playwright-mcp` from production zips.
- **`bin/build.sh`** — add a defence-in-depth post-rsync sweep that strips common dev-metadata filenames from the staged distribution tree, so a future vendor package shipping any of these will not silently re-introduce a WP.org plugin-check failure:
  - `.codex`, `.cursorrules`, `.clinerules`, `.windsurfrules`
  - `.editorconfig`, `.eslintrc*`, `.prettierrc*`, `.stylelintrc*`
  - `.playwright-mcp`

## Verification

Simulated the build's rsync stage against the current working tree (which contained a synthetic `.playwright-mcp/console-test.log` and the real `vendor/x-wp/di/.codex`):

```
=== Post-rsync check ===
playwright-mcp count: 0
.codex count: 0
```

Both files are excluded by the new `.distignore` patterns alone; the post-sweep is belt-and-braces for future vendor regressions.

## Notes

- No code, naming, or namespace changes — purely build/distribution exclusions.
- Does not touch `sd-ai-agent` ↔ `superdav-ai-agent` boundaries called out in `AGENTS.md`.

Resolves sd-ai-ee4

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.15 plugin for [OpenCode](https://opencode.ai) v1.14.41 with claude-sonnet-4-6 spent 17h 3m and 40 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated ignore and distribution-exclusion patterns to omit transient AI/browser-automation artifacts.
  * Enhanced build process to automatically remove stray development/AI-session metadata from packaged distributions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1303)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->