### PR TITLE
fix(file-abilities): remove error_reporting() calls from lint_php

### DIFF
--- a/includes/Abilities/FileAbilities.php
+++ b/includes/Abilities/FileAbilities.php
@@ -293,15 +293,23 @@ abstract class AbstractFileAbility extends AbstractAbility {
 	/**
 	 * Lint PHP content for syntax errors.
 	 *
+	 * Uses {@see token_get_all()} with `TOKEN_PARSE` to surface syntax errors as
+	 * `\ParseError`. A scoped `set_error_handler()` converts any notices/warnings
+	 * emitted by the tokeniser into `\ErrorException` so they do not leak to the
+	 * site-wide error log. The handler is always restored in a `finally` block.
+	 *
+	 * Note: this intentionally does NOT call `error_reporting()` — toggling the
+	 * global reporting level would interfere with the host site's debugging
+	 * configuration. The custom error handler already intercepts emitted errors
+	 * regardless of the configured reporting level.
+	 *
 	 * @param string $content PHP source code.
 	 * @return array{valid: bool, error?: string, line?: int}
 	 */
-	// phpcs:disable WordPress.PHP.DevelopmentFunctions, WordPress.PHP.DiscouragedPHPFunctions -- Intentional: error_reporting and set_error_handler used for PHP syntax validation.
 	protected function lint_php( string $content ): array {
-		$previous = error_reporting( 0 );
-
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Scoped error handler is required to convert tokeniser notices into exceptions; restored in finally.
 		set_error_handler(
-			function ( $severity, $message, $file, $line ) {
+			static function ( int $severity, string $message, string $file, int $line ): bool {
 				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- ErrorException constructor arguments are not output; PHPCS false positive.
 				throw new \ErrorException( $message, 0, $severity, $file, $line );
 			}
@@ -310,36 +318,23 @@ abstract class AbstractFileAbility extends AbstractAbility {
 		try {
 			$tokens = token_get_all( $content, TOKEN_PARSE );
 			unset( $tokens ); // Result unused — we only care about parse errors.
-			restore_error_handler();
-			error_reporting( $previous );
 			return [ 'valid' => true ];
-		} catch ( \ParseError $e ) {
-			restore_error_handler();
-			error_reporting( $previous );
-			return [
-				'valid' => false,
-				'error' => $e->getMessage(),
-				'line'  => $e->getLine(),
-			];
-		} catch ( \ErrorException $e ) {
-			restore_error_handler();
-			error_reporting( $previous );
+		} catch ( \ParseError | \ErrorException $e ) {
 			return [
 				'valid' => false,
 				'error' => $e->getMessage(),
 				'line'  => $e->getLine(),
 			];
 		} catch ( \Throwable $e ) {
-			restore_error_handler();
-			error_reporting( $previous );
 			return [
 				'valid' => false,
 				'error' => $e->getMessage(),
 				'line'  => $e->getLine(),
 			];
+		} finally {
+			restore_error_handler();
 		}
 	}
-	// phpcs:enable WordPress.PHP.DevelopmentFunctions, WordPress.PHP.DiscouragedPHPFunctions
 }
 
 /**


### PR DESCRIPTION
## Summary

Removes all `error_reporting()` calls from `AbstractFileAbility::lint_php()` in `includes/Abilities/FileAbilities.php` (lines 301, 314, 318, 326, 334 in `main`).

Plugins should never mutate the global `error_reporting` level — even briefly — because it interferes with the host site's debugging configuration. If a developer is trying to diagnose an issue while the agent happens to lint a PHP file, output gets silently suppressed for the duration of the call.

## Why the calls were redundant

The `set_error_handler()` callback registered immediately after `error_reporting(0)` already throws `\ErrorException` for any emitted notice/warning. Per PHP's documented behaviour, a custom error handler is invoked **regardless of the configured `error_reporting` level** (except for the small set of fatals that no handler can catch — `E_ERROR`, `E_PARSE`, `E_CORE_*`, `E_COMPILE_*`). Suppressing the level in addition to installing the handler did nothing useful.

`token_get_all($content, TOKEN_PARSE)` raises `\ParseError` for invalid syntax, which is caught directly. Notices emitted by the tokeniser become `\ErrorException` via the handler. Both cases produce the same `[ 'valid' => false, 'error' => ..., 'line' => ... ]` result.

## Behaviour change

None observable to callers. Verified by smoke-testing the new `lint_php` logic against:

- Valid PHP → `valid: true`
- `<?php function foo( {` → `valid: false, error: "syntax error, unexpected token \"{\", expecting variable", line: 1`
- `<?php $a = ;` → `valid: false, error: "syntax error, unexpected token \";\"", line: 1`

## Cleanups bundled with the fix

- Replace five repeated `restore_error_handler(); error_reporting($previous);` cleanup blocks with a single `finally { restore_error_handler(); }`.
- Combine `\ParseError` and `\ErrorException` into one catch arm.
- Type the error-handler closure (`int $severity, string $message, string $file, int $line): bool`) and declare it `static` — no `$this` capture needed.
- Narrow the previous `phpcs:disable WordPress.PHP.DevelopmentFunctions, WordPress.PHP.DiscouragedPHPFunctions` (which silenced the whole method) to a single `phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler` directly above the `set_error_handler` call.
- Add a docblock note explaining *why* `error_reporting()` is intentionally not used, so a future contributor doesn't reintroduce it.

## Verification

- `composer phpcs includes/Abilities/FileAbilities.php` → 0 errors, 0 warnings.
- `composer phpstan` (file-scoped) → no errors.
- Smoke-tested the standalone logic with the PHP CLI (see "Behaviour change" above).
- Existing unit tests in `tests/SdAiAgent/Abilities/FileAbilitiesTest.php` already cover the relevant paths:
  - `test_handle_write_file_rejects_invalid_php()` (line 119) — exercises the `\ParseError` path via `handle_write_file` with bad PHP content.
  - `handle_write_file` valid-PHP test at line 133 — exercises the success path.

## Reviewer reference

> "Don't Use Error Reporting in Production Code … if you set it permanently in your plugin, you mess things up for everyone who uses your code. Should they have a reason to try to debug their site which happens to use your code, they won't be able to get a clean test because you're messing with the output."

This applies even to *temporary* mutations — debugging sessions can overlap with the seconds-long window that `lint_php` was running, and there is no production benefit to suppressing the level while a custom handler is already installed.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.15 plugin for [OpenCode](https://opencode.ai) v1.14.41 with claude-opus-4-7 spent 3m and 12,315 tokens on this with the user in an interactive session.
