### PR TITLE
fix(plugin-paths): use WP_PLUGIN_DIR / uploads basedir per wp.org guidelines (sd-ai-cis)

### DIFF
--- a/includes/Abilities/SandboxTestPluginAbility.php
+++ b/includes/Abilities/SandboxTestPluginAbility.php
@@ -78,7 +78,8 @@ class SandboxTestPluginAbility extends AbstractAbility {
 			return new WP_Error( 'sd_ai_agent_invalid_plugin_file', __( 'plugin_file is required.', 'superdav-ai-agent' ) );
 		}
 
-		$plugin_dir = WP_CONTENT_DIR . '/plugins/' . $slug . '/';
+		// Use WP_PLUGIN_DIR per wp.org guidelines for referencing other plugins.
+		$plugin_dir = trailingslashit( WP_PLUGIN_DIR ) . $slug . '/';
 
 		return PluginSandbox::run_all( $plugin_dir, $plugin_file );
 	}

--- a/includes/PluginBuilder/HookScanner.php
+++ b/includes/PluginBuilder/HookScanner.php
@@ -41,7 +41,9 @@ class HookScanner {
 			);
 		}
 
-		$plugin_dir = WP_CONTENT_DIR . '/plugins/' . $plugin_slug . '/';
+		// Use WP_PLUGIN_DIR per wp.org guidelines so this works when the
+		// plugins directory has been relocated.
+		$plugin_dir = trailingslashit( WP_PLUGIN_DIR ) . $plugin_slug . '/';
 
 		if ( ! is_dir( $plugin_dir ) ) {
 			return new WP_Error(
@@ -70,7 +72,9 @@ class HookScanner {
 			);
 		}
 
-		$theme_dir = WP_CONTENT_DIR . '/themes/' . $theme_slug . '/';
+		// Use get_theme_root() per wp.org guidelines so this works with
+		// custom theme roots and multisite theme directories.
+		$theme_dir = trailingslashit( get_theme_root( $theme_slug ) ) . $theme_slug . '/';
 
 		if ( ! is_dir( $theme_dir ) ) {
 			return new WP_Error(

--- a/includes/PluginBuilder/PluginInstaller.php
+++ b/includes/PluginBuilder/PluginInstaller.php
@@ -46,7 +46,7 @@ class PluginInstaller {
 	 *  - Path is not empty.
 	 *  - Path contains no null bytes.
 	 *  - Path does not contain traversal sequences (../).
-	 *  - Resolved absolute path starts with WP_CONTENT_DIR/plugins/{slug}/.
+	 *  - Resolved absolute path starts with WP_PLUGIN_DIR/{slug}/.
 	 *
 	 * @param string $slug          Validated plugin slug.
 	 * @param string $relative_path Relative file path (relative to the plugin directory).
@@ -92,7 +92,9 @@ class PluginInstaller {
 		}
 
 		// Build the expected plugin directory path for boundary validation.
-		$plugin_dir = WP_CONTENT_DIR . '/plugins/' . $slug . '/';
+		// Use WP_PLUGIN_DIR (not WP_CONTENT_DIR.'/plugins/') so this works on
+		// installs that relocate the plugins directory.
+		$plugin_dir = trailingslashit( WP_PLUGIN_DIR ) . $slug . '/';
 
 		// Ensure the plugin directory exists before using realpath.
 		if ( is_dir( $plugin_dir ) ) {
@@ -244,7 +246,7 @@ class PluginInstaller {
 			);
 		}
 
-		$plugin_dir = WP_CONTENT_DIR . '/plugins/' . $slug . '/';
+		$plugin_dir = trailingslashit( WP_PLUGIN_DIR ) . $slug . '/';
 		if ( ! is_dir( $plugin_dir ) ) {
 			return new WP_Error(
 				'sd_ai_agent_plugin_not_found',
@@ -355,7 +357,7 @@ class PluginInstaller {
 		}
 
 		// Remove directory from disk.
-		$plugin_dir = WP_CONTENT_DIR . '/plugins/' . $slug . '/';
+		$plugin_dir = trailingslashit( WP_PLUGIN_DIR ) . $slug . '/';
 		if ( is_dir( $plugin_dir ) ) {
 			require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
 			require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
@@ -412,7 +414,7 @@ class PluginInstaller {
 			);
 		}
 
-		$plugins_dir = WP_CONTENT_DIR . '/plugins/';
+		$plugins_dir = trailingslashit( WP_PLUGIN_DIR );
 		$plugin_dir  = $plugins_dir . $slug . '/';
 
 		// Validate paths to prevent directory traversal.
@@ -604,7 +606,7 @@ class PluginInstaller {
 		}
 
 		if ( $delete_files && ! empty( $record['slug'] ) ) {
-			$plugin_dir = WP_CONTENT_DIR . '/plugins/' . sanitize_title( $record['slug'] ) . '/';
+			$plugin_dir = trailingslashit( WP_PLUGIN_DIR ) . sanitize_title( $record['slug'] ) . '/';
 			if ( is_dir( $plugin_dir ) ) {
 				// Use WP Filesystem for safe deletion.
 				require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';

--- a/includes/PluginBuilder/PluginSandbox.php
+++ b/includes/PluginBuilder/PluginSandbox.php
@@ -310,12 +310,14 @@ class PluginSandbox {
 	 * @return string Path to wp binary, or empty string if not found.
 	 */
 	private static function find_wp_cli(): string {
-		// Check common locations.
+		// Check common locations. The ABSPATH-relative candidate covers the
+		// common composer-installed-WordPress layout (vendor/ as a sibling of
+		// the WordPress root) without depending on WP_CONTENT_DIR's location.
 		$candidates = [
 			'wp', // PATH
 			'/usr/local/bin/wp',
 			'/usr/bin/wp',
-			WP_CONTENT_DIR . '/../../../vendor/bin/wp',
+			ABSPATH . '../vendor/bin/wp',
 		];
 
 		foreach ( $candidates as $candidate ) {

--- a/includes/PluginBuilder/PluginUpdater.php
+++ b/includes/PluginBuilder/PluginUpdater.php
@@ -6,8 +6,10 @@ declare(strict_types=1);
  *
  * Flow: backup → stage → test → swap → verify → rollback on failure.
  *
- * Backups land in wp-content/sd-ai-backups/{slug}-{timestamp}/.
- * Staging uses    wp-content/sd-ai-staging/{slug}/.
+ * Backups and staging directories live inside the uploads basedir under
+ * `sd-ai-backups/` and `sd-ai-staging/` respectively, so they survive
+ * relocated wp-content / plugins directories and follow WordPress's
+ * recommended writeable-area convention.
  *
  * @package SdAiAgent\PluginBuilder
  * @license GPL-2.0-or-later
@@ -29,6 +31,43 @@ if ( ! defined( 'ABSPATH' ) ) {
 class PluginUpdater {
 
 	/**
+	 * Get the absolute path to the backups root directory.
+	 *
+	 * Uses uploads basedir per WP guidelines for plugin-managed writeable
+	 * locations, so it works on installs that relocate WP_CONTENT_DIR.
+	 *
+	 * @return string Trailing-slashed absolute path.
+	 */
+	private function backups_root(): string {
+		$uploads = wp_upload_dir( null, false );
+		$basedir = ! empty( $uploads['basedir'] ) ? (string) $uploads['basedir'] : WP_CONTENT_DIR . '/uploads';
+		return trailingslashit( $basedir ) . 'sd-ai-backups/';
+	}
+
+	/**
+	 * Get the absolute path to the staging root directory.
+	 *
+	 * @return string Trailing-slashed absolute path.
+	 */
+	private function staging_root(): string {
+		$uploads = wp_upload_dir( null, false );
+		$basedir = ! empty( $uploads['basedir'] ) ? (string) $uploads['basedir'] : WP_CONTENT_DIR . '/uploads';
+		return trailingslashit( $basedir ) . 'sd-ai-staging/';
+	}
+
+	/**
+	 * Get the trailing-slashed absolute path to an installed plugin's directory.
+	 *
+	 * Uses WP_PLUGIN_DIR per wp.org guidelines for referencing other plugins.
+	 *
+	 * @param string $slug Plugin slug (already validated by caller).
+	 * @return string
+	 */
+	private function plugin_dir_path( string $slug ): string {
+		return trailingslashit( WP_PLUGIN_DIR ) . $slug . '/';
+	}
+
+	/**
 	 * Backup an installed plugin to wp-content/sd-ai-backups/{slug}-{timestamp}/.
 	 *
 	 * @param string $slug Plugin slug (directory name under wp-content/plugins/).
@@ -43,7 +82,7 @@ class PluginUpdater {
 			);
 		}
 
-		$plugin_dir = WP_CONTENT_DIR . '/plugins/' . $slug . '/';
+		$plugin_dir = $this->plugin_dir_path( $slug );
 		if ( ! is_dir( $plugin_dir ) ) {
 			return new WP_Error(
 				'sd_ai_agent_plugin_not_found',
@@ -53,7 +92,7 @@ class PluginUpdater {
 		}
 
 		$timestamp  = gmdate( 'Y-m-d-His' );
-		$backup_dir = WP_CONTENT_DIR . '/sd-ai-backups/' . $slug . '-' . $timestamp . '/';
+		$backup_dir = $this->backups_root() . $slug . '-' . $timestamp . '/';
 
 		$result = $this->copy_directory( $plugin_dir, $backup_dir );
 		if ( is_wp_error( $result ) ) {
@@ -82,7 +121,7 @@ class PluginUpdater {
 			);
 		}
 
-		$plugin_dir = WP_CONTENT_DIR . '/plugins/' . $slug . '/';
+		$plugin_dir = $this->plugin_dir_path( $slug );
 		if ( ! is_dir( $plugin_dir ) ) {
 			return new WP_Error(
 				'sd_ai_agent_plugin_not_found',
@@ -91,7 +130,7 @@ class PluginUpdater {
 			);
 		}
 
-		$staging_dir = WP_CONTENT_DIR . '/sd-ai-staging/' . $slug . '/';
+		$staging_dir = $this->staging_root() . $slug . '/';
 
 		// Remove stale staging dir if it exists.
 		if ( is_dir( $staging_dir ) ) {
@@ -165,7 +204,7 @@ class PluginUpdater {
 		}
 
 		$plugin_file = $slug . '/' . $slug . '.php';
-		$plugin_dir  = WP_CONTENT_DIR . '/plugins/' . $slug . '/';
+		$plugin_dir  = $this->plugin_dir_path( $slug );
 
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
@@ -232,7 +271,7 @@ class PluginUpdater {
 			);
 		}
 
-		$plugin_dir = WP_CONTENT_DIR . '/plugins/' . sanitize_title( $slug ) . '/';
+		$plugin_dir = $this->plugin_dir_path( sanitize_title( $slug ) );
 
 		if ( is_dir( $plugin_dir ) ) {
 			$this->remove_directory( $plugin_dir );
@@ -266,7 +305,7 @@ class PluginUpdater {
 		 * @param int $max_age_days Default retention in days.
 		 */
 		$max_age_days = (int) apply_filters( 'sd_ai_agent_backup_retention_days', $max_age_days );
-		$backups_root = WP_CONTENT_DIR . '/sd-ai-backups/';
+		$backups_root = $this->backups_root();
 
 		if ( ! is_dir( $backups_root ) ) {
 			return 0;

--- a/tests/SdAiAgent/PluginBuilder/HookScannerTest.php
+++ b/tests/SdAiAgent/PluginBuilder/HookScannerTest.php
@@ -43,13 +43,13 @@ class HookScannerTest extends WP_UnitTestCase {
 	// ─── Helpers ────────────────────────────────────────────────────
 
 	/**
-	 * Create an isolated temp directory under WP_CONTENT_DIR/plugins/ and track for cleanup.
+	 * Create an isolated temp directory under WP_PLUGIN_DIR and track for cleanup.
 	 *
 	 * @param string $slug Plugin slug to use as the directory name.
 	 * @return string Absolute path to the plugin directory.
 	 */
 	private function make_temp_plugin( string $slug ): string {
-		$dir = WP_CONTENT_DIR . '/plugins/' . $slug . '/';
+		$dir = trailingslashit( WP_PLUGIN_DIR ) . $slug . '/';
 		if ( ! is_dir( $dir ) ) {
 			mkdir( $dir, 0755, true );
 		}
@@ -58,13 +58,13 @@ class HookScannerTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Create an isolated temp directory under WP_CONTENT_DIR/themes/ and track for cleanup.
+	 * Create an isolated temp directory under the active theme root and track for cleanup.
 	 *
 	 * @param string $slug Theme slug to use as the directory name.
 	 * @return string Absolute path to the theme directory.
 	 */
 	private function make_temp_theme( string $slug ): string {
-		$dir = WP_CONTENT_DIR . '/themes/' . $slug . '/';
+		$dir = trailingslashit( get_theme_root( $slug ) ) . $slug . '/';
 		if ( ! is_dir( $dir ) ) {
 			mkdir( $dir, 0755, true );
 		}

--- a/tests/SdAiAgent/PluginBuilder/PluginBuilderIntegrationTest.php
+++ b/tests/SdAiAgent/PluginBuilder/PluginBuilderIntegrationTest.php
@@ -90,7 +90,7 @@ class PluginBuilderIntegrationTest extends WP_UnitTestCase {
 		}
 
 		$src = trailingslashit( $this->fixtures_dir . $fixture_slug );
-		$dst = trailingslashit( WP_CONTENT_DIR . '/plugins/' . $target_slug );
+		$dst = trailingslashit( WP_PLUGIN_DIR . '/' . $target_slug );
 
 		$this->copy_dir( $src, $dst );
 		$this->created_dirs[] = $dst;
@@ -106,7 +106,7 @@ class PluginBuilderIntegrationTest extends WP_UnitTestCase {
 	 * @return string Absolute plugin directory path (with trailing slash).
 	 */
 	private function create_temp_plugin( string $slug, string $content ): string {
-		$plugin_dir = trailingslashit( WP_CONTENT_DIR . '/plugins/' . $slug );
+		$plugin_dir = trailingslashit( WP_PLUGIN_DIR . '/' . $slug );
 		wp_mkdir_p( $plugin_dir );
 		file_put_contents( $plugin_dir . $slug . '.php', $content );
 		$this->created_dirs[] = $plugin_dir;
@@ -353,7 +353,7 @@ class PluginBuilderIntegrationTest extends WP_UnitTestCase {
 		$files  = [
 			$slug . '.php' => '<?php' . PHP_EOL . '/* Plugin Name: Test Install */' . PHP_EOL,
 		];
-		$this->created_dirs[] = trailingslashit( WP_CONTENT_DIR . '/plugins/' . $slug );
+		$this->created_dirs[] = trailingslashit( WP_PLUGIN_DIR . '/' . $slug );
 
 		$result = PluginInstaller::install(
 			$slug,
@@ -371,7 +371,7 @@ class PluginBuilderIntegrationTest extends WP_UnitTestCase {
 		$this->created_ids[] = $result['id'];
 
 		// Verify file on disk.
-		$expected_path = trailingslashit( WP_CONTENT_DIR . '/plugins/' . $slug ) . $slug . '.php';
+		$expected_path = trailingslashit( WP_PLUGIN_DIR . '/' . $slug ) . $slug . '.php';
 		$this->assertFileExists( $expected_path );
 	}
 
@@ -401,7 +401,7 @@ class PluginBuilderIntegrationTest extends WP_UnitTestCase {
 	public function test_get_returns_record_created_by_install(): void {
 		$slug   = 'sd-pb-test-get-' . uniqid();
 		$files  = [ $slug . '.php' => '<?php /* Plugin Name: Test Get */' ];
-		$this->created_dirs[] = trailingslashit( WP_CONTENT_DIR . '/plugins/' . $slug );
+		$this->created_dirs[] = trailingslashit( WP_PLUGIN_DIR . '/' . $slug );
 
 		$install = PluginInstaller::install( $slug, $files, 'Desc', 'Plan', $slug . '/' . $slug . '.php' );
 		$this->assertIsArray( $install );
@@ -421,7 +421,7 @@ class PluginBuilderIntegrationTest extends WP_UnitTestCase {
 	public function test_update_status_changes_status_in_db(): void {
 		$slug   = 'sd-pb-test-status-' . uniqid();
 		$files  = [ $slug . '.php' => '<?php /* Plugin Name: Test Status */' ];
-		$this->created_dirs[] = trailingslashit( WP_CONTENT_DIR . '/plugins/' . $slug );
+		$this->created_dirs[] = trailingslashit( WP_PLUGIN_DIR . '/' . $slug );
 
 		$install = PluginInstaller::install( $slug, $files, 'Desc', 'Plan', $slug . '/' . $slug . '.php' );
 		$this->assertIsArray( $install );
@@ -443,7 +443,7 @@ class PluginBuilderIntegrationTest extends WP_UnitTestCase {
 	public function test_db_status_transitions_installed_to_active(): void {
 		$slug   = 'sd-pb-test-transitions-' . uniqid();
 		$files  = [ $slug . '.php' => '<?php /* Plugin Name: Test Transitions */' ];
-		$this->created_dirs[] = trailingslashit( WP_CONTENT_DIR . '/plugins/' . $slug );
+		$this->created_dirs[] = trailingslashit( WP_PLUGIN_DIR . '/' . $slug );
 
 		$install = PluginInstaller::install( $slug, $files, 'Desc', 'Plan', $slug . '/' . $slug . '.php' );
 		$this->assertIsArray( $install );
@@ -475,7 +475,7 @@ class PluginBuilderIntegrationTest extends WP_UnitTestCase {
 		];
 
 		foreach ( $slugs as $slug ) {
-			$this->created_dirs[] = trailingslashit( WP_CONTENT_DIR . '/plugins/' . $slug );
+			$this->created_dirs[] = trailingslashit( WP_PLUGIN_DIR . '/' . $slug );
 			$files                = [ $slug . '.php' => '<?php /* Plugin Name: ' . $slug . ' */' ];
 			$result               = PluginInstaller::install( $slug, $files, 'Desc', 'Plan', $slug . '/' . $slug . '.php' );
 			if ( is_array( $result ) ) {
@@ -494,7 +494,7 @@ class PluginBuilderIntegrationTest extends WP_UnitTestCase {
 	public function test_delete_removes_db_record(): void {
 		$slug   = 'sd-pb-test-delete-' . uniqid();
 		$files  = [ $slug . '.php' => '<?php /* Plugin Name: Test Delete */' ];
-		$this->created_dirs[] = trailingslashit( WP_CONTENT_DIR . '/plugins/' . $slug );
+		$this->created_dirs[] = trailingslashit( WP_PLUGIN_DIR . '/' . $slug );
 
 		$install = PluginInstaller::install( $slug, $files, 'Desc', 'Plan', $slug . '/' . $slug . '.php' );
 		$this->assertIsArray( $install );
@@ -647,7 +647,10 @@ PHP
 		$this->assertStringContainsString( '// original', (string) $current );
 
 		// Clean up any backup directory left by the updater (new path: sd-ai-backups/).
-		$backup_glob = glob( WP_CONTENT_DIR . '/sd-ai-backups/' . $slug . '-*', GLOB_ONLYDIR );
+		// Backups now live under uploads basedir per wp.org guidelines.
+		$uploads      = wp_upload_dir( null, false );
+		$basedir      = ! empty( $uploads['basedir'] ) ? (string) $uploads['basedir'] : WP_CONTENT_DIR . '/uploads';
+		$backup_glob  = glob( trailingslashit( $basedir ) . 'sd-ai-backups/' . $slug . '-*', GLOB_ONLYDIR );
 		if ( is_array( $backup_glob ) ) {
 			foreach ( $backup_glob as $backup_dir ) {
 				$this->rmdir_recursive( $backup_dir );
@@ -767,7 +770,7 @@ OUTPUT;
 		} else {
 			// If sanitize_title produced a safe non-empty slug, the install
 			// directory must still be confined inside WP_CONTENT_DIR/plugins/.
-			$this->assertStringStartsWith( WP_CONTENT_DIR . '/plugins/', $result['plugin_dir'] );
+			$this->assertStringStartsWith( trailingslashit( WP_PLUGIN_DIR ), $result['plugin_dir'] );
 			PluginInstaller::delete( $result['id'], true );
 		}
 	}
@@ -802,7 +805,7 @@ OUTPUT;
 			$this->assertSame( 'sd_ai_agent_invalid_slug', $result->get_error_code() );
 		} else {
 			// Must be inside plugins dir.
-			$this->assertStringStartsWith( WP_CONTENT_DIR . '/plugins/', $result['plugin_dir'] );
+			$this->assertStringStartsWith( trailingslashit( WP_PLUGIN_DIR ), $result['plugin_dir'] );
 			$this->created_dirs[] = $result['plugin_dir'];
 			$this->created_ids[]  = $result['id'];
 		}

--- a/tests/SdAiAgent/PluginBuilder/PluginInstallerTest.php
+++ b/tests/SdAiAgent/PluginBuilder/PluginInstallerTest.php
@@ -36,7 +36,7 @@ class PluginInstallerTest extends WP_UnitTestCase {
 	 */
 	public function setUp(): void {
 		parent::setUp();
-		$this->plugin_dir = WP_CONTENT_DIR . '/plugins/' . $this->test_slug . '/';
+		$this->plugin_dir = trailingslashit( WP_PLUGIN_DIR ) . $this->test_slug . '/';
 		$this->cleanup_plugin_dir();
 	}
 

--- a/tests/SdAiAgent/PluginBuilder/PluginUpdaterTest.php
+++ b/tests/SdAiAgent/PluginBuilder/PluginUpdaterTest.php
@@ -46,7 +46,7 @@ class PluginUpdaterTest extends WP_UnitTestCase {
 	 */
 	public function setUp(): void {
 		parent::setUp();
-		$this->plugin_dir = WP_CONTENT_DIR . '/plugins/' . $this->slug . '/';
+		$this->plugin_dir = trailingslashit( WP_PLUGIN_DIR ) . $this->slug . '/';
 		$this->updater    = new PluginUpdater();
 		$this->cleanup_all();
 		$this->create_minimal_plugin();
@@ -227,7 +227,7 @@ class PluginUpdaterTest extends WP_UnitTestCase {
 	 */
 	public function test_cleanup_old_backups_preserves_most_recent(): void {
 		// Create two backup directories for the slug.
-		$backups_root = WP_CONTENT_DIR . '/sd-ai-backups/';
+		$backups_root = $this->backups_root();
 		wp_mkdir_p( $backups_root );
 
 		$old_dir = $backups_root . $this->slug . '-2020-01-01-000001/';
@@ -307,9 +307,9 @@ class PluginUpdaterTest extends WP_UnitTestCase {
 	 */
 	private function cleanup_all(): void {
 		$dirs_to_clean = [
-			WP_CONTENT_DIR . '/plugins/' . $this->slug . '/',
-			WP_CONTENT_DIR . '/plugins/non-existent-plugin-phpunit/',
-			WP_CONTENT_DIR . '/sd-ai-staging/' . $this->slug . '/',
+			trailingslashit( WP_PLUGIN_DIR ) . $this->slug . '/',
+			trailingslashit( WP_PLUGIN_DIR ) . 'non-existent-plugin-phpunit/',
+			$this->staging_root() . $this->slug . '/',
 		];
 
 		foreach ( $dirs_to_clean as $dir ) {
@@ -317,7 +317,7 @@ class PluginUpdaterTest extends WP_UnitTestCase {
 		}
 
 		// Remove all backup directories for this slug.
-		$backups_root = WP_CONTENT_DIR . '/sd-ai-backups/';
+		$backups_root = $this->backups_root();
 		if ( is_dir( $backups_root ) ) {
 			$entries = glob( $backups_root . $this->slug . '-*', GLOB_ONLYDIR );
 			if ( false !== $entries ) {
@@ -326,6 +326,24 @@ class PluginUpdaterTest extends WP_UnitTestCase {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Mirror PluginUpdater::backups_root() so tests can locate backup dirs.
+	 */
+	private function backups_root(): string {
+		$uploads = wp_upload_dir( null, false );
+		$basedir = ! empty( $uploads['basedir'] ) ? (string) $uploads['basedir'] : WP_CONTENT_DIR . '/uploads';
+		return trailingslashit( $basedir ) . 'sd-ai-backups/';
+	}
+
+	/**
+	 * Mirror PluginUpdater::staging_root() so tests can locate staging dirs.
+	 */
+	private function staging_root(): string {
+		$uploads = wp_upload_dir( null, false );
+		$basedir = ! empty( $uploads['basedir'] ) ? (string) $uploads['basedir'] : WP_CONTENT_DIR . '/uploads';
+		return trailingslashit( $basedir ) . 'sd-ai-staging/';
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Resolves the WordPress.org plugin-check finding "Determine files and directories locations correctly" — 60+ flagged incidences of `WP_CONTENT_DIR . '/plugins/'` for referencing other plugins, and writing temp/staging files directly under wp-content root.

These patterns break on installs that relocate `WP_CONTENT_DIR` or the plugins directory (e.g. via `WP_PLUGIN_DIR` constant overrides or composer-installed WordPress layouts).

## Changes

### Production code

- **`PluginBuilder/PluginUpdater.php`** — Added private helpers `plugin_dir_path()`, `backups_root()`, `staging_root()`. Backups and staging directories now live under `wp_upload_dir()['basedir']/sd-ai-{backups,staging}/` instead of the wp-content root.
- **`PluginBuilder/PluginInstaller.php`** — Replaces `WP_CONTENT_DIR . '/plugins/'` with `trailingslashit( WP_PLUGIN_DIR )` for all plugin path constructions (5 sites).
- **`PluginBuilder/HookScanner.php`** — Plugins via `WP_PLUGIN_DIR`; themes via `get_theme_root( $slug )` (multisite/theme-root-aware).
- **`PluginBuilder/PluginSandbox.php`** — `find_wp_cli()` candidate switched from a brittle `WP_CONTENT_DIR.'/../../../vendor/bin/wp'` to `ABSPATH . '../vendor/bin/wp'` (composer-installed-WP layout).
- **`Abilities/SandboxTestPluginAbility.php`** — Plugin path via `WP_PLUGIN_DIR`.

### Tests

- `PluginUpdaterTest`, `PluginBuilderIntegrationTest`, `HookScannerTest`, `PluginInstallerTest` updated to mirror the new helpers and constants. Fixture creation continues to land in the same physical directory in CI (since `WP_PLUGIN_DIR` defaults to `WP_CONTENT_DIR/plugins`), but path expressions now match production code.

## Intentionally not changed

The remaining `WP_CONTENT_DIR` references in:

- **`FileAbilities`** — the entire feature is browsing wp-content (4 sites)
- **`SiteHealthAbilities`** — `WP_CONTENT_DIR . '/debug.log'` is WordPress's documented default debug.log path; `get_directory_size_mb( WP_CONTENT_DIR )` measures wp-content itself

…are the *correct* constant per the wp.org guideline (the references describe wp-content itself, not a relocatable subdirectory).

## Verification

- `composer phpcs` — passes (5 files lint clean)
- `composer phpstan` on `includes/PluginBuilder/` and `includes/Abilities/SandboxTestPluginAbility.php` — `[OK] No errors`
- `rg "WP_CONTENT_DIR \. '/plugins/'|WP_CONTENT_DIR \. '/themes/'|WP_CONTENT_DIR \. '/sd-ai-(backups|staging)"` returns no matches
- PHPUnit will run in CI (no local wp-env stack)

Resolves sd-ai-cis

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.15 plugin for [OpenCode](https://opencode.ai) v1.14.41 with claude-sonnet-4-6 spent 17h 11m and 40 tokens on this as a headless worker.
