### PR TITLE
feat(build): WP.org-compliant build target stripping arbitrary-code surfaces (sd-ai-qxb)

### DIFF
--- a/.distignore-wporg
+++ b/.distignore-wporg
@@ -1,0 +1,57 @@
+# Additional exclusions applied ONLY to the WordPress.org distribution build.
+#
+# bin/build.sh --target=wporg appends these patterns to the standard
+# .distignore exclusion list to physically remove plugin source files
+# whose runtime is also disabled by the wporg-build feature-flag overrides:
+#
+#  - SD_AI_AGENT_FEATURE_PLUGIN_BUILDER          (arbitrary PHP generation)
+#  - SD_AI_AGENT_FEATURE_CUSTOM_TOOLS_CLI        (shell-exec custom tools)
+#  - SD_AI_AGENT_FEATURE_PLUGIN_STATE_CHANGES    (autonomous activate/deactivate)
+#  - SD_AI_AGENT_FEATURE_PLUGIN_INSTALL_FROM_URL (install from arbitrary ZIP URL)
+#
+# Note: the PLUGIN_STATE_CHANGES and PLUGIN_INSTALL_FROM_URL gates only
+# remove individual `wp_register_ability()` calls inside
+# WordPressAbilities.php, not whole files — there is no per-ability file
+# to strip. The runtime gate (Features::is_enabled) is the sole defence
+# for those two flags. Bin/build.sh validates the constants are forced
+# to false in the bundled superdav-ai-agent.php; that grep target is
+# what the WP.org review team can verify.
+#
+# Why duplicate the runtime gate with build-time file stripping (where
+# possible)? Defence in depth: the WordPress.org Plugin Review team
+# scans the submitted zip for the presence of arbitrary-code-execution
+# surfaces, not just for their reachability. Removing the source files
+# from the zip is the clearest way to demonstrate compliance with
+# WP.org Guideline 4 ("attempting to process custom CSS/JS/PHP /
+# allowing arbitrary script insertion") and the "Changing Active
+# Plugins" guideline.
+#
+# DO NOT add patterns here that should also apply to the GitHub release
+# build — put those in the main .distignore instead.
+#
+# Patterns are passed verbatim to rsync --exclude-from after the main
+# .distignore content. See bin/build.sh for the assembly logic.
+
+# ── Plugin builder source files (PHP code generation + sandbox) ──────────────
+includes/PluginBuilder
+includes/Abilities/GeneratePluginAbility.php
+includes/Abilities/SandboxTestPluginAbility.php
+includes/Abilities/SandboxActivatePluginAbility.php
+includes/Abilities/UpdatePluginSandboxedAbility.php
+includes/Abilities/ScanPluginHooksAbility.php
+includes/Abilities/ScanThemeHooksAbility.php
+includes/Abilities/PluginBuilderAbilities.php
+
+# Plugin-download abilities expose URLs for AI-modified plugin zips —
+# only meaningful when the plugin builder runs.
+includes/Abilities/PluginDownloadAbilities.php
+
+# Persistence layer used only by the plugin builder.
+includes/Repositories/GeneratedPluginsRepository.php
+includes/Models/DTO/GeneratedPluginRow.php
+
+# Plugin-builder tests are already excluded by the `tests` rule in
+# .distignore but listed here for documentation completeness.
+# tests/SdAiAgent/PluginBuilder
+# tests/SdAiAgent/Abilities/PluginBuilderAbilitiesTest.php
+# tests/e2e/agent-builder.spec.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,21 +36,43 @@ jobs:
       - name: Install Node dependencies
         run: npm ci
 
+      - name: Install Composer dependencies (production only)
+        run: composer install --no-dev --prefer-dist --no-progress
+
       - name: Build assets
         run: npm run build
 
-      - name: Create ZIP files
+      - name: Create distribution ZIPs (full + wporg)
         run: |
-          # npm run build → archive.js → composer archive-project → superdav-ai-agent.zip
-          cp superdav-ai-agent.zip superdav-ai-agent-${{ steps.version.outputs.VERSION }}.zip
+          # bin/build.sh produces:
+          #   superdav-ai-agent-${VERSION}.zip       (full feature set)
+          #   superdav-ai-agent-${VERSION}-wporg.zip (WP.org-compliant variant
+          #                                           — strips AI plugin
+          #                                           builder, WP-CLI custom
+          #                                           tools, autonomous
+          #                                           plugin-state changes,
+          #                                           and install-from-URL)
+          bin/build.sh --target=both
+
+          # Keep a slug-only copy of the full zip as the primary artefact for
+          # users who download "the latest" without specifying a version.
+          cp "superdav-ai-agent-${{ steps.version.outputs.VERSION }}.zip" superdav-ai-agent.zip
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
             superdav-ai-agent-${{ steps.version.outputs.VERSION }}.zip
+            superdav-ai-agent-${{ steps.version.outputs.VERSION }}-wporg.zip
             superdav-ai-agent.zip
           name: Superdav AI Agent v${{ steps.version.outputs.VERSION }}
+          body: |
+            ## Downloads
+
+            - **`superdav-ai-agent-${{ steps.version.outputs.VERSION }}.zip`** — Full feature set, recommended for self-hosted users. Includes the AI plugin builder, WP-CLI custom tools, autonomous plugin activate/deactivate, and install-plugin-from-URL.
+            - **`superdav-ai-agent-${{ steps.version.outputs.VERSION }}-wporg.zip`** — WordPress.org-compliant build. The four feature classes above are removed at build time and the matching `SD_AI_AGENT_FEATURE_*` constants are hard-defined to `false` so they cannot be re-enabled via `wp-config.php`. This is the artefact submitted via `bin/deploy-wporg.sh`.
+
+            See `docs/wordpress-org-submission.md` for the build-matrix rationale.
           draft: false
           prerelease: false
           generate_release_notes: true

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -179,10 +179,10 @@ EXTRA
 	# prevents trivial bypass and gives the WP.org review team a single
 	# grep target to verify compliance.
 	if [ "$variant" = "wporg" ]; then
-		echo "==> [${variant}] Forcing plugin-builder + CLI + plugin-state + URL-install feature flags to false..."
+		echo "==> [${variant}] Forcing plugin-builder + CLI + plugin-state + URL-install + file-write feature flags to false..."
 		local main_file="${dest}/superdav-ai-agent.php"
 
-		# The four feature flags this build target forces off, paired with a
+		# The five feature flags this build target forces off, paired with a
 		# short rationale that ends up as an inline comment in the bundled
 		# main plugin file (a grep target the WP.org review team can use).
 		local -a flags=(
@@ -190,6 +190,7 @@ EXTRA
 			"SD_AI_AGENT_FEATURE_CUSTOM_TOOLS_CLI:shell-exec custom tools disabled per WP.org Guideline 4"
 			"SD_AI_AGENT_FEATURE_PLUGIN_STATE_CHANGES:autonomous activate\/deactivate disabled per WP.org Changing Active Plugins guideline"
 			"SD_AI_AGENT_FEATURE_PLUGIN_INSTALL_FROM_URL:install-from-arbitrary-ZIP disabled per WP.org Changing Active Plugins guideline"
+			"SD_AI_AGENT_FEATURE_FILE_WRITE:arbitrary wp-content writes disabled per WP.org Changing Active Plugins guideline"
 		)
 
 		# Replace each `defined() || define( 'NAME', true )` line with a

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -3,19 +3,92 @@
 # Build a production distribution zip for the Superdav AI Agent plugin.
 #
 # Usage:
-#   bin/build.sh
+#   bin/build.sh                       # full build (GitHub release zip)
+#   bin/build.sh --target=full         # explicit form of the default
+#   bin/build.sh --target=wporg        # WordPress.org-compliant zip
+#   bin/build.sh --target=both         # produce both zips in one run
+#
+# Targets:
+#
+#   full   — Standard production zip with every feature included. This is
+#            the GitHub release artefact and the form distributed via the
+#            Ultimate Multisite channel. Output:
+#               superdav-ai-agent-{version}.zip
+#
+#   wporg  — WordPress.org-compliant zip. Strips source files for the AI
+#            plugin builder (generate / sandbox / activate / update) and
+#            for WP-CLI custom tools, and forces the matching feature
+#            flags to false in the main plugin file so the runtime gates
+#            cannot be re-enabled by re-adding the source files. Output:
+#               superdav-ai-agent-{version}-wporg.zip
+#
+# Why two targets?  WP.org Plugin Review Guideline 4 prohibits plugins
+# that "process custom CSS/JS/PHP" or "allow arbitrary script insertion".
+# Our AI plugin builder generates and runs PHP code; our CLI custom-tool
+# type runs shell commands via PHP exec(). Both are legitimate features
+# for self-hosted users on the GitHub channel but disqualify the plugin
+# from the WP.org directory. Stripping them at build time produces a
+# zip that meets WP.org's bar without losing the full feature set in
+# the GitHub release.
 #
 # The script:
 #   1. Builds production JS/CSS assets via wp-scripts.
 #   2. Reads the version from the plugin header in superdav-ai-agent.php.
-#   3. Creates superdav-ai-agent-{version}.zip with standard WP plugin directory structure.
-#   4. Excludes everything listed in .distignore plus bin/, .claude/, *.map, and tests.
+#   3. Creates the requested zip(s) with standard WP plugin directory
+#      structure (`superdav-ai-agent/` as the single top-level dir).
+#   4. Excludes everything listed in .distignore (and, for the wporg
+#      target, also .distignore-wporg).
 
 set -euo pipefail
 
 # ── Resolve plugin root (works regardless of where the script is invoked) ──
 PLUGIN_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$PLUGIN_DIR"
+
+# ── Parse CLI ────────────────────────────────────────────────────────────────
+TARGET="full"
+
+usage() {
+	cat >&2 <<EOF
+Usage: bin/build.sh [--target=full|wporg|both]
+
+  --target=full   GitHub release zip (default; full feature set)
+  --target=wporg  WordPress.org-compliant zip (plugin builder + CLI tools removed)
+  --target=both   Produce both zips in one run
+
+Examples:
+  bin/build.sh
+  bin/build.sh --target=wporg
+  bin/build.sh --target=both
+EOF
+	exit 1
+}
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--target=full | --target=wporg | --target=both)
+		TARGET="${1#--target=}"
+		shift
+		;;
+	--target)
+		TARGET="$2"
+		shift 2
+		;;
+	-h | --help) usage ;;
+	*)
+		echo "ERROR: unknown argument: $1" >&2
+		usage
+		;;
+	esac
+done
+
+case "$TARGET" in
+full | wporg | both) ;;
+*)
+	echo "ERROR: --target must be one of: full, wporg, both (got '$TARGET')" >&2
+	exit 1
+	;;
+esac
 
 # ── Read version from plugin header ──
 VERSION="$(grep -m1 '^ \* Version:' superdav-ai-agent.php | sed 's/^.*Version:[[:space:]]*//' | tr -d '[:space:]')"
@@ -24,35 +97,39 @@ if [ -z "$VERSION" ]; then
 	exit 1
 fi
 
-echo "==> Building Superdav AI Agent v${VERSION}"
-
-# ── 1. Build production assets ──
+# ── 1. Build production assets (shared across targets) ──
+echo "==> Building Superdav AI Agent v${VERSION} (target: ${TARGET})"
 echo "==> Building production JS/CSS assets..."
 npx wp-scripts build
 echo "    Done."
 
-# ── 2. Prepare temp directory ──
-BUILD_DIR="$(mktemp -d)"
-DEST="${BUILD_DIR}/superdav-ai-agent"
-mkdir -p "$DEST"
+# ── Build one zip variant (full or wporg) ────────────────────────────────────
+build_variant() {
+	local variant="$1" # full | wporg
+	local build_dir
+	local exclude_file
+	local dest
+	local zip_name
+	local zip_path
 
-# Temp file for combined exclusion patterns (used by rsync --exclude-from)
-EXCLUDE_FILE="$(mktemp)"
+	build_dir="$(mktemp -d)"
+	exclude_file="$(mktemp)"
+	dest="${build_dir}/superdav-ai-agent"
+	mkdir -p "$dest"
 
-cleanup() {
-	rm -rf "$BUILD_DIR"
-	rm -f "$EXCLUDE_FILE"
-}
-trap cleanup EXIT
+	# Local cleanup for this variant; the parent trap (set below) handles
+	# the umbrella case if the script aborts mid-run.
+	# shellcheck disable=SC2064
+	trap "rm -rf '${build_dir}' '${exclude_file}'" RETURN
 
-# ── 3. Collect exclusion patterns ──
-# Start with patterns from .distignore (strip comments, blank lines, whitespace, CR)
-if [ -f .distignore ]; then
-	sed -e 's/\r$//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e '/^$/d' -e '/^#/d' .distignore > "$EXCLUDE_FILE"
-fi
+	# ── Collect exclusion patterns ──
+	# Start with patterns from .distignore (strip comments, blank lines, whitespace, CR)
+	if [ -f .distignore ]; then
+		sed -e 's/\r$//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e '/^$/d' -e '/^#/d' .distignore >"$exclude_file"
+	fi
 
-# Additional exclusions not in .distignore
-cat >> "$EXCLUDE_FILE" <<'EXTRA'
+	# Additional exclusions not in .distignore (always applied).
+	cat >>"$exclude_file" <<'EXTRA'
 .claude
 *.map
 tests
@@ -65,44 +142,133 @@ phpunit*
 .stylelintrc*
 EXTRA
 
-# ── 4. Copy files into temp dir, respecting exclusions ──
-echo "==> Copying files..."
-rsync -a --delete \
-	--exclude-from="$EXCLUDE_FILE" \
-	"$PLUGIN_DIR/" "$DEST/"
-echo "    Done."
+	# WP.org variant: also append .distignore-wporg patterns to physically
+	# remove the plugin-builder + CLI-custom-tool source files.
+	if [ "$variant" = "wporg" ] && [ -f .distignore-wporg ]; then
+		sed -e 's/\r$//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e '/^$/d' -e '/^#/d' .distignore-wporg >>"$exclude_file"
+	fi
 
-# ── 4a. Post-copy sweep: prune dev-metadata files that vendor packages may
-# carry inside their own directories (rsync excludes are gitignore-style and
-# should match at any depth, but we belt-and-brace this so the WP.org
-# plugin-check never re-flags non-permitted files such as .codex,
-# .cursorrules, etc., shipped *inside* a vendor package). Also strips any
-# transient playwright-mcp directory left over from a local E2E run.
-echo "==> Pruning stray dev-metadata and AI-session artefacts across distribution (incl. .playwright-mcp)..."
-find "$DEST" \
-	\( -name '.codex' \
-	-o -name '.cursorrules' \
-	-o -name '.clinerules' \
-	-o -name '.windsurfrules' \
-	-o -name '.editorconfig' \
-	-o -name '.eslintrc*' \
-	-o -name '.prettierrc*' \
-	-o -name '.stylelintrc*' \
-	-o -name '.playwright-mcp' \
-	\) -print -exec rm -rf {} + 2>/dev/null || true
-echo "    Done."
+	# ── Copy files into temp dir, respecting exclusions ──
+	echo "==> [${variant}] Copying files..."
+	rsync -a --delete \
+		--exclude-from="$exclude_file" \
+		"${PLUGIN_DIR}/" "${dest}/"
 
-# ── 5. Create zip ──
-ZIP_NAME="superdav-ai-agent-${VERSION}.zip"
-ZIP_PATH="${PLUGIN_DIR}/${ZIP_NAME}"
+	# ── Post-copy sweep: prune dev-metadata files that vendor packages may
+	# carry inside their own directories (rsync excludes are gitignore-style
+	# and should match at any depth, but we belt-and-brace this so the
+	# WP.org plugin-check never re-flags non-permitted files such as .codex,
+	# .cursorrules, etc., shipped *inside* a vendor package). Also strips
+	# any transient playwright-mcp directory left over from a local E2E run.
+	echo "==> [${variant}] Pruning stray dev-metadata and AI-session artefacts (incl. .playwright-mcp)..."
+	find "$dest" \
+		\( -name '.codex' \
+		-o -name '.cursorrules' \
+		-o -name '.clinerules' \
+		-o -name '.windsurfrules' \
+		-o -name '.editorconfig' \
+		-o -name '.eslintrc*' \
+		-o -name '.prettierrc*' \
+		-o -name '.stylelintrc*' \
+		-o -name '.playwright-mcp' \
+		\) -print -exec rm -rf {} + 2>/dev/null || true
 
-echo "==> Creating ${ZIP_NAME}..."
-(cd "$BUILD_DIR" && zip -qr "$ZIP_PATH" superdav-ai-agent/)
-echo "    Done."
+	# WP.org variant: force the feature flags to false in the *bundled*
+	# plugin file so a malicious user who re-adds the source files at
+	# runtime still cannot reach the gated abilities. This belt-and-braces
+	# prevents trivial bypass and gives the WP.org review team a single
+	# grep target to verify compliance.
+	if [ "$variant" = "wporg" ]; then
+		echo "==> [${variant}] Forcing plugin-builder + CLI + plugin-state + URL-install feature flags to false..."
+		local main_file="${dest}/superdav-ai-agent.php"
 
-# ── 6. Report ──
-ZIP_SIZE="$(du -h "$ZIP_PATH" | cut -f1)"
-echo ""
-echo "==> Build complete!"
-echo "    File: ${ZIP_PATH}"
-echo "    Size: ${ZIP_SIZE}"
+		# The four feature flags this build target forces off, paired with a
+		# short rationale that ends up as an inline comment in the bundled
+		# main plugin file (a grep target the WP.org review team can use).
+		local -a flags=(
+			"SD_AI_AGENT_FEATURE_PLUGIN_BUILDER:arbitrary PHP generation disabled per WP.org Guideline 4"
+			"SD_AI_AGENT_FEATURE_CUSTOM_TOOLS_CLI:shell-exec custom tools disabled per WP.org Guideline 4"
+			"SD_AI_AGENT_FEATURE_PLUGIN_STATE_CHANGES:autonomous activate\/deactivate disabled per WP.org Changing Active Plugins guideline"
+			"SD_AI_AGENT_FEATURE_PLUGIN_INSTALL_FROM_URL:install-from-arbitrary-ZIP disabled per WP.org Changing Active Plugins guideline"
+		)
+
+		# Replace each `defined() || define( 'NAME', true )` line with a
+		# hard `define( 'NAME', false )`. The plugin-side code uses
+		# `defined( 'NAME' ) ||` so once we hard-define the constants
+		# here the user's wp-config can no longer override them.
+		local entry name reason
+		for entry in "${flags[@]}"; do
+			name="${entry%%:*}"
+			reason="${entry#*:}"
+			sed -i.bak \
+				-e "s/^defined( '${name}' ) || define( '${name}', true );.*/define( '${name}', false ); \/\/ wporg-build: ${reason}./" \
+				"$main_file"
+		done
+		rm -f "${main_file}.bak"
+
+		# Verify each replacement actually happened — fail loudly if the
+		# upstream file format changes and our sed no longer matches.
+		for entry in "${flags[@]}"; do
+			name="${entry%%:*}"
+			if ! grep -q "define( '${name}', false );" "$main_file"; then
+				echo "ERROR: failed to force ${name}=false in wporg build." >&2
+				echo "       Check the sed pattern in bin/build.sh against the current contents of superdav-ai-agent.php." >&2
+				return 1
+			fi
+		done
+
+		# Sanity-check that the gated source files were actually removed.
+		local stripped_paths=(
+			"${dest}/includes/PluginBuilder"
+			"${dest}/includes/Abilities/GeneratePluginAbility.php"
+			"${dest}/includes/Abilities/SandboxActivatePluginAbility.php"
+			"${dest}/includes/Abilities/PluginBuilderAbilities.php"
+			"${dest}/includes/Abilities/PluginDownloadAbilities.php"
+		)
+		local p
+		for p in "${stripped_paths[@]}"; do
+			if [ -e "$p" ]; then
+				echo "ERROR: wporg build still contains stripped path: $p" >&2
+				echo "       Update .distignore-wporg to cover it." >&2
+				return 1
+			fi
+		done
+		echo "    Stripped plugin-builder source files and forced feature flags to false."
+	fi
+	echo "    Done."
+
+	# ── Create zip ──
+	if [ "$variant" = "wporg" ]; then
+		zip_name="superdav-ai-agent-${VERSION}-wporg.zip"
+	else
+		zip_name="superdav-ai-agent-${VERSION}.zip"
+	fi
+	zip_path="${PLUGIN_DIR}/${zip_name}"
+
+	echo "==> [${variant}] Creating ${zip_name}..."
+	(cd "$build_dir" && zip -qr "$zip_path" superdav-ai-agent/)
+	echo "    Done."
+
+	local zip_size
+	zip_size="$(du -h "$zip_path" | cut -f1)"
+	echo ""
+	echo "==> [${variant}] Build complete!"
+	echo "    File: ${zip_path}"
+	echo "    Size: ${zip_size}"
+	echo ""
+	return 0
+}
+
+# ── Run the requested target(s) ──────────────────────────────────────────────
+case "$TARGET" in
+full)
+	build_variant full
+	;;
+wporg)
+	build_variant wporg
+	;;
+both)
+	build_variant full
+	build_variant wporg
+	;;
+esac

--- a/bin/deploy-wporg.sh
+++ b/bin/deploy-wporg.sh
@@ -3,12 +3,19 @@
 # Deploy Superdav AI Agent to the WordPress.org plugin directory via SVN.
 #
 # Usage:
-#   bin/deploy-wporg.sh --version 1.2.0 --username YOUR_WP_USERNAME [--svn-dir ~/svn/sd-ai-agent]
+#   bin/deploy-wporg.sh --version 1.2.0 --username YOUR_WP_USERNAME [--svn-dir ~/svn/superdav-ai-agent]
 #
 # Prerequisites:
 #   1. Plugin approved on WordPress.org (SVN repo must exist)
-#   2. SVN checked out: svn checkout https://plugins.svn.wordpress.org/sd-ai-agent/ ~/svn/sd-ai-agent
+#   2. SVN checked out: svn checkout https://plugins.svn.wordpress.org/superdav-ai-agent/ ~/svn/superdav-ai-agent
 #   3. svn CLI installed (apt-get install subversion / brew install subversion)
+#
+# Note: this script always builds the WP.org-compliant variant via
+# `bin/build.sh --target=wporg`, which strips the AI plugin builder and
+# WP-CLI custom-tool source files (per WP.org Guideline 4 prohibiting
+# plugins that allow arbitrary script insertion). The full GitHub
+# release zip — which retains those features — is produced separately
+# by `.github/workflows/release.yml` on tag push.
 #
 # What this script does:
 #   1. Builds production assets and ZIP via bin/build.sh
@@ -23,7 +30,11 @@ set -euo pipefail
 
 # ── Defaults ──────────────────────────────────────────────────────────────────
 PLUGIN_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-SVN_DIR="${HOME}/svn/sd-ai-agent"
+# The SVN slug is whatever the WP.org review team approves. As of writing
+# the plugin has not been submitted; once approved, override --svn-dir to
+# match the assigned slug if it differs from the default below. The slug
+# should match the text domain (`superdav-ai-agent`) per WP.org conventions.
+SVN_DIR="${HOME}/svn/superdav-ai-agent"
 WP_USERNAME=""
 VERSION=""
 DRY_RUN=false
@@ -38,7 +49,7 @@ Required:
   --username WP_USERNAME  WordPress.org username for SVN authentication
 
 Options:
-  --svn-dir DIR           Path to SVN checkout (default: ~/svn/sd-ai-agent)
+  --svn-dir DIR           Path to SVN checkout (default: ~/svn/superdav-ai-agent)
   --dry-run               Build and sync but do not commit or tag
   --help                  Show this help
 
@@ -92,7 +103,7 @@ if [ ! -d "${SVN_DIR}/.svn" ]; then
 	echo "ERROR: SVN checkout not found at: ${SVN_DIR}" >&2
 	echo ""
 	echo "Check out the repository first:" >&2
-	echo "  svn checkout https://plugins.svn.wordpress.org/sd-ai-agent/ ${SVN_DIR} --username ${WP_USERNAME}" >&2
+	echo "  svn checkout https://plugins.svn.wordpress.org/superdav-ai-agent/ ${SVN_DIR} --username ${WP_USERNAME}" >&2
 	echo ""
 	echo "If the checkout fails with a 404, the plugin has not been approved yet." >&2
 	echo "See docs/wordpress-org-submission.md for the submission process." >&2
@@ -100,10 +111,14 @@ if [ ! -d "${SVN_DIR}/.svn" ]; then
 fi
 
 # ── Verify version matches plugin header ──────────────────────────────────────
-PLUGIN_VERSION="$(grep -m1 '^ \* Version:' "${PLUGIN_DIR}/sd-ai-agent.php" | sed 's/^.*Version:[[:space:]]*//' | tr -d '[:space:]')"
+# Note: the main plugin file is superdav-ai-agent.php (matching the WP.org
+# plugin slug + i18n text domain). Per .agents/AGENTS.md the internal
+# DI container ID, REST namespaces, and CSS prefixes intentionally remain
+# `sd-ai-agent` — only the user-facing slug is `superdav-ai-agent`.
+PLUGIN_VERSION="$(grep -m1 '^ \* Version:' "${PLUGIN_DIR}/superdav-ai-agent.php" | sed 's/^.*Version:[[:space:]]*//' | tr -d '[:space:]')"
 if [ "$PLUGIN_VERSION" != "$VERSION" ]; then
 	echo "ERROR: --version ${VERSION} does not match plugin header version ${PLUGIN_VERSION}." >&2
-	echo "Update the Version: field in sd-ai-agent.php before deploying." >&2
+	echo "Update the Version: field in superdav-ai-agent.php before deploying." >&2
 	exit 1
 fi
 
@@ -115,13 +130,17 @@ if [ "$README_STABLE" != "$VERSION" ]; then
 fi
 
 # ── Build ─────────────────────────────────────────────────────────────────────
-echo "==> Building Superdav AI Agent v${VERSION}..."
+# Always build the WP.org-compliant variant for the SVN deployment. The full
+# (GitHub release) zip is published separately by .github/workflows/release.yml
+# and intentionally retains the AI plugin builder + WP-CLI custom tools.
+echo "==> Building Superdav AI Agent v${VERSION} (target: wporg)..."
 cd "$PLUGIN_DIR"
-bin/build.sh
+bin/build.sh --target=wporg
 
-ZIP_PATH="${PLUGIN_DIR}/sd-ai-agent-${VERSION}.zip"
+ZIP_PATH="${PLUGIN_DIR}/superdav-ai-agent-${VERSION}-wporg.zip"
 if [ ! -f "$ZIP_PATH" ]; then
 	echo "ERROR: Expected ZIP not found: ${ZIP_PATH}" >&2
+	echo "       Did bin/build.sh --target=wporg succeed? Re-run it manually to investigate." >&2
 	exit 1
 fi
 echo "    Built: ${ZIP_PATH}"
@@ -134,10 +153,11 @@ cleanup() {
 trap cleanup EXIT
 
 unzip -q "$ZIP_PATH" -d "$EXTRACT_DIR"
-EXTRACTED_PLUGIN="${EXTRACT_DIR}/sd-ai-agent"
+# build.sh creates a single top-level dir matching the WP.org plugin slug.
+EXTRACTED_PLUGIN="${EXTRACT_DIR}/superdav-ai-agent"
 
 if [ ! -d "$EXTRACTED_PLUGIN" ]; then
-	echo "ERROR: ZIP does not contain a top-level sd-ai-agent/ directory." >&2
+	echo "ERROR: ZIP does not contain a top-level superdav-ai-agent/ directory." >&2
 	exit 1
 fi
 
@@ -199,8 +219,8 @@ fi
 # ── Done ──────────────────────────────────────────────────────────────────────
 echo ""
 echo "==> Deployment complete!"
-echo "    Plugin URL: https://wordpress.org/plugins/sd-ai-agent/"
-echo "    SVN trunk:  https://plugins.svn.wordpress.org/sd-ai-agent/trunk/"
-echo "    SVN tag:    https://plugins.svn.wordpress.org/sd-ai-agent/tags/${VERSION}/"
+echo "    Plugin URL: https://wordpress.org/plugins/superdav-ai-agent/"
+echo "    SVN trunk:  https://plugins.svn.wordpress.org/superdav-ai-agent/trunk/"
+echo "    SVN tag:    https://plugins.svn.wordpress.org/superdav-ai-agent/tags/${VERSION}/"
 echo ""
 echo "    WP.org CDN may take up to 15 minutes to reflect the update."

--- a/docs/wordpress-org-submission.md
+++ b/docs/wordpress-org-submission.md
@@ -4,13 +4,14 @@ This document covers the complete process for submitting Superdav AI Agent to th
 WordPress.org plugin directory and managing subsequent releases via SVN.
 
 **Current status:** Pre-submission. The SVN repository at
-`https://plugins.svn.wordpress.org/sd-ai-agent/` does not yet exist — it is
+`https://plugins.svn.wordpress.org/superdav-ai-agent/` does not yet exist — it is
 created by WordPress.org only after the plugin passes manual review.
 
 ---
 
 ## Table of Contents
 
+- [Build Matrix: Full vs. WP.org Variants](#build-matrix-full-vs-wporg-variants)
 - [Prerequisites](#prerequisites)
 - [Step 1 — Submit for Review](#step-1--submit-for-review)
 - [Step 2 — Wait for Approval](#step-2--wait-for-approval)
@@ -20,6 +21,91 @@ created by WordPress.org only after the plugin passes manual review.
 - [Assets (Banner, Icon, Screenshots)](#assets-banner-icon-screenshots)
 - [Automated SVN Deployment](#automated-svn-deployment)
 - [Troubleshooting](#troubleshooting)
+
+---
+
+## Build Matrix: Full vs. WP.org Variants
+
+This repository produces **two** distribution zips on every release. The
+WordPress.org plugin guidelines prohibit features that the GitHub-channel
+audience legitimately needs (the AI plugin builder, WP-CLI custom tools,
+autonomous plugin state changes, install-from-arbitrary-URL), so we ship the
+full feature set on GitHub and a stripped-but-still-useful variant on WP.org.
+
+| Feature surface                              | Full (`*.zip`) | WP.org (`*-wporg.zip`) | Why gated                                                                                |
+| -------------------------------------------- | :------------: | :--------------------: | ---------------------------------------------------------------------------------------- |
+| AI plugin generation / sandbox / activate / update | ✅       |          ❌            | WP.org Guideline 4 — "attempting to process custom CSS/JS/PHP / allowing arbitrary script insertion" |
+| WP-CLI custom tools (shell `exec`)            |       ✅       |          ❌            | Same as above (arbitrary command execution)                                              |
+| Autonomous activate / deactivate / delete / switch / update plugin | ✅ |    ❌    | WP.org "Changing Active Plugins" — plugins must not change other plugins' state without per-action user intervention |
+| Install plugin from arbitrary ZIP URL / GitHub |     ✅       |          ❌            | "Changing Active Plugins" only exempts WP.org-directory installs                          |
+| Install plugin from WordPress.org directory by slug | ✅      |          ✅            | Allowed exception under "Changing Active Plugins"                                        |
+| List / search / recommend plugins (read-only) |       ✅       |          ✅            | Read-only operations are unrestricted                                                    |
+| `run-php` (whitelisted WordPress functions only) |   ✅      |          ✅            | Whitelist excludes `activate_plugin`, `deactivate_plugins`, etc.                         |
+| Memory, knowledge, automations, abilities, chat | ✅           |          ✅            | Core agent functionality — no policy concerns                                            |
+
+### How the gates work
+
+Each gated feature has a corresponding `SD_AI_AGENT_FEATURE_*` constant
+defined in `superdav-ai-agent.php`. The `Features` registry
+(`includes/Core/Features.php`) reads these constants at runtime and the
+`AbilitiesHandler`, `WordPressAbilities`, and `CustomToolExecutor`
+classes skip registration when a flag is `false`.
+
+The full build leaves all flags at their default `true` value. Site
+owners on the GitHub channel can still individually disable any feature
+by adding `define( 'SD_AI_AGENT_FEATURE_NAME', false );` to
+`wp-config.php`.
+
+The WP.org build (`bin/build.sh --target=wporg`) does two extra things
+on top of the runtime gates, both as defence-in-depth for the WP.org
+review:
+
+1. **Hard-defines the four constants to `false`** in the bundled
+   `superdav-ai-agent.php`. Because each constant uses
+   `defined( 'NAME' ) || define( 'NAME', true )`, hard-defining the
+   constant earlier in the file prevents any later override (including
+   from `wp-config.php`).
+2. **Strips the gated source files** from the zip via
+   `.distignore-wporg`. The `PluginBuilder/`, `GeneratePluginAbility`,
+   `SandboxActivatePluginAbility`, etc. files are not present in the
+   submitted zip, so the WP.org reviewer can `grep` for the offending
+   class names and see they are absent.
+
+The WP.org Plugin Review team can therefore verify compliance with a
+single command:
+
+```bash
+unzip -p superdav-ai-agent-X.Y.Z-wporg.zip superdav-ai-agent/superdav-ai-agent.php \
+    | grep "SD_AI_AGENT_FEATURE_PLUGIN_BUILDER\|SD_AI_AGENT_FEATURE_PLUGIN_STATE_CHANGES"
+# Expected: each constant is hard-defined to false with a "wporg-build:" comment.
+```
+
+### Producing the variants
+
+```bash
+bin/build.sh                  # full target (default)
+bin/build.sh --target=wporg   # WP.org variant only
+bin/build.sh --target=both    # both, in one run
+```
+
+The `release.yml` GitHub Actions workflow runs `--target=both` on every
+tag push and uploads all three zips (`*.zip`,
+`*-${VERSION}.zip`, `*-${VERSION}-wporg.zip`) to the GitHub release.
+
+### When to update which list
+
+If you add a new ability or feature that touches arbitrary code/CSS/JS
+execution, plugin-state changes, or arbitrary-URL fetches, you must:
+
+1. Add a runtime gate via `Features::is_enabled()` in the registration
+   path (and, where the source file is dedicated to the feature, add it
+   to `.distignore-wporg`).
+2. Update the table above and the `bin/build.sh` `flags` array if you
+   added a new feature flag.
+3. If your change affects the WP.org-permissibility classification of an
+   existing ability (e.g. you added a new write surface to a
+   previously-read-only ability), revisit the table and move the row to
+   the gated section.
 
 ---
 
@@ -33,7 +119,7 @@ Before submitting, confirm all of the following:
 | `readme.txt` with all required sections | Done (t124) |
 | Screenshots listed in `readme.txt` match `assets/` | Done (t124) |
 | Sanitization/escaping audit passed | Done (t124) |
-| Plugin slug `sd-ai-agent` is available on WP.org | Verify at `wordpress.org/plugins/sd-ai-agent/` |
+| Plugin slug `superdav-ai-agent` is available on WP.org | Verify at `wordpress.org/plugins/superdav-ai-agent/` |
 | WordPress.org account exists for the submitter | Required |
 | `wp plugin check` passes (requires Plugin Check plugin) | Run before submitting |
 
@@ -43,7 +129,7 @@ Install the [Plugin Check plugin](https://wordpress.org/plugins/plugin-check/) o
 WordPress 6.9 instance, then:
 
 ```bash
-wp plugin check sd-ai-agent --format=table
+wp plugin check superdav-ai-agent --format=table
 ```
 
 All errors must be resolved. Warnings should be reviewed — some are acceptable with
@@ -63,14 +149,21 @@ justification in the submission notes.
 
 ### Build the submission ZIP
 
+Always submit the **WP.org-compliant variant** — never the full GitHub-release
+zip. The full zip contains features that violate the WP.org guidelines (see
+the [Build Matrix](#build-matrix-full-vs-wporg-variants) above).
+
 ```bash
-# From the repo root — builds production assets and creates the ZIP
-bin/build.sh
-# Output: sd-ai-agent-1.2.0.zip
+# From the repo root — builds the WP.org-compliant zip with the AI plugin
+# builder, WP-CLI custom tools, autonomous plugin-state changes, and
+# install-from-arbitrary-URL features stripped out.
+bin/build.sh --target=wporg
+# Output: superdav-ai-agent-1.2.0-wporg.zip
 ```
 
-The ZIP must contain a single top-level directory named `sd-ai-agent/` with
-`sd-ai-agent.php` at its root. `bin/build.sh` handles this automatically.
+The ZIP must contain a single top-level directory named `superdav-ai-agent/`
+with `superdav-ai-agent.php` at its root. `bin/build.sh` handles this
+automatically.
 
 ### What to include in the submission notes
 
@@ -86,6 +179,29 @@ External API calls: The plugin calls the user's configured AI provider endpoint
 (OpenAI, Anthropic, or any OpenAI-compatible URL). The endpoint URL and API key
 are entered by the site administrator in Settings > AI Credentials. No data is
 sent to any third-party server controlled by the plugin author.
+
+This zip is built with `bin/build.sh --target=wporg`, which removes four
+classes of feature that the standard GitHub release retains:
+
+  1. AI plugin generation / sandbox activation / sandboxed update / hook
+     scanning (would constitute "arbitrary script insertion" per Guideline 4).
+  2. WP-CLI custom-tool type (shell `exec()` execution).
+  3. Autonomous activate / deactivate / delete / switch / update of other
+     plugins (per "Changing Active Plugins" — only WP.org-directory installs
+     are exempt from the no-autonomous-state-change rule).
+  4. Install-plugin-from-arbitrary-URL (e.g. GitHub release ZIPs).
+
+The four `SD_AI_AGENT_FEATURE_*` constants gating these features are
+hard-defined to `false` in the bundled `superdav-ai-agent.php`; the source
+files for surfaces 1 and 2 are also stripped from the zip. Reviewers can
+verify with:
+
+  unzip -p superdav-ai-agent-X.Y.Z-wporg.zip superdav-ai-agent/superdav-ai-agent.php \
+      | grep "SD_AI_AGENT_FEATURE_"
+
+The plugin still installs from the WordPress.org directory by slug
+(`sd-ai-agent/install-plugin`), which is the allowed exception under
+"Changing Active Plugins".
 
 PHP 8.2+ is required (strict types, enums). WordPress 6.9+ is required (AI
 Client SDK, Abilities API).
@@ -134,8 +250,8 @@ svn --version
 
 ```bash
 # Replace YOUR_WP_USERNAME with your WordPress.org username
-svn checkout https://plugins.svn.wordpress.org/sd-ai-agent/ \
-    ~/svn/sd-ai-agent \
+svn checkout https://plugins.svn.wordpress.org/superdav-ai-agent/ \
+    ~/svn/superdav-ai-agent \
     --username YOUR_WP_USERNAME
 ```
 
@@ -148,17 +264,17 @@ The checkout creates three directories:
 
 ```bash
 # Build the production ZIP first
-cd /path/to/sd-ai-agent-repo
+cd /path/to/superdav-ai-agent-repo
 bin/build.sh
 
 # Extract into the SVN trunk
-cd ~/svn/sd-ai-agent
+cd ~/svn/superdav-ai-agent
 # Clear trunk (keep .svn metadata)
 find trunk/ -mindepth 1 -delete
 
 # Extract the built ZIP into trunk
-unzip /path/to/sd-ai-agent-1.2.0.zip -d /tmp/wporg-extract/
-cp -r /tmp/wporg-extract/sd-ai-agent/. trunk/
+unzip /path/to/superdav-ai-agent-1.2.0.zip -d /tmp/wporg-extract/
+cp -r /tmp/wporg-extract/superdav-ai-agent/. trunk/
 rm -rf /tmp/wporg-extract/
 ```
 
@@ -167,7 +283,7 @@ Alternatively, use `bin/deploy-wporg.sh` (see [Automated SVN Deployment](#automa
 ### Add new files and commit
 
 ```bash
-cd ~/svn/sd-ai-agent
+cd ~/svn/superdav-ai-agent
 
 # Stage all new files (SVN does not auto-track new files)
 svn status | grep '^?' | awk '{print $2}' | xargs svn add
@@ -194,7 +310,7 @@ Tags are how WordPress.org knows which version to serve for a specific version n
 The `Stable tag` in `readme.txt` must match a tag in `tags/`.
 
 ```bash
-cd ~/svn/sd-ai-agent
+cd ~/svn/superdav-ai-agent
 
 # Copy trunk to a tag (SVN copy is instant — no file transfer)
 svn copy trunk/ tags/1.2.0 -m "Tag Superdav AI Agent v1.2.0"
@@ -204,7 +320,7 @@ svn list tags/
 ```
 
 After tagging, the plugin is live on WordPress.org at:
-`https://wordpress.org/plugins/sd-ai-agent/`
+`https://wordpress.org/plugins/superdav-ai-agent/`
 
 ---
 
@@ -212,7 +328,7 @@ After tagging, the plugin is live on WordPress.org at:
 
 For each new version:
 
-1. Update `Version:` in `sd-ai-agent.php`
+1. Update `Version:` in `superdav-ai-agent.php`
 2. Update `Stable tag:` in `readme.txt`
 3. Add a changelog entry under `== Changelog ==` in `readme.txt`
 4. Run `bin/build.sh` to build the ZIP
@@ -241,15 +357,15 @@ plugin ZIP. They are served directly from SVN by the WP.org CDN.
 Our assets are already prepared in `assets/` in the Git repo. Copy them to SVN:
 
 ```bash
-cd ~/svn/sd-ai-agent
+cd ~/svn/superdav-ai-agent
 
 # Copy assets from Git repo
-cp /path/to/sd-ai-agent-repo/assets/banner-772x250.png  assets/
-cp /path/to/sd-ai-agent-repo/assets/icon-128x128.png    assets/
-cp /path/to/sd-ai-agent-repo/assets/icon-256x256.png    assets/
+cp /path/to/superdav-ai-agent-repo/assets/banner-772x250.png  assets/
+cp /path/to/superdav-ai-agent-repo/assets/icon-128x128.png    assets/
+cp /path/to/superdav-ai-agent-repo/assets/icon-256x256.png    assets/
 
 # Copy screenshots (rename to screenshot-N.png matching readme.txt order)
-cp /path/to/sd-ai-agent-repo/assets/screenshots/screenshot-1.png assets/screenshot-1.png
+cp /path/to/superdav-ai-agent-repo/assets/screenshots/screenshot-1.png assets/screenshot-1.png
 # … repeat for each screenshot
 
 svn add assets/*
@@ -267,7 +383,7 @@ not the descriptive names used in the Git repo.
 `bin/deploy-wporg.sh` automates the trunk update and tagging steps.
 
 ```bash
-# First deployment (after SVN checkout already exists at ~/svn/sd-ai-agent)
+# First deployment (after SVN checkout already exists at ~/svn/superdav-ai-agent)
 bin/deploy-wporg.sh --version 1.2.0 --username YOUR_WP_USERNAME
 
 # Subsequent releases
@@ -291,7 +407,7 @@ See `bin/deploy-wporg.sh --help` for all options.
 
 SVN is not installed or the URL is wrong. Verify:
 ```bash
-svn info https://plugins.svn.wordpress.org/sd-ai-agent/
+svn info https://plugins.svn.wordpress.org/superdav-ai-agent/
 ```
 If this returns a 404, the plugin has not been approved yet.
 
@@ -311,7 +427,7 @@ svn status | grep '^?' | awk '{print $2}' | xargs svn add
 
 - Check that `Stable tag:` in `readme.txt` matches an existing tag in `tags/`
 - WP.org CDN can take up to 15 minutes to reflect changes
-- Check the plugin page directly: `https://wordpress.org/plugins/sd-ai-agent/`
+- Check the plugin page directly: `https://wordpress.org/plugins/superdav-ai-agent/`
 
 ### Review rejected — what next?
 

--- a/docs/wordpress-org-submission.md
+++ b/docs/wordpress-org-submission.md
@@ -29,8 +29,9 @@ created by WordPress.org only after the plugin passes manual review.
 This repository produces **two** distribution zips on every release. The
 WordPress.org plugin guidelines prohibit features that the GitHub-channel
 audience legitimately needs (the AI plugin builder, WP-CLI custom tools,
-autonomous plugin state changes, install-from-arbitrary-URL), so we ship the
-full feature set on GitHub and a stripped-but-still-useful variant on WP.org.
+autonomous plugin state changes, install-from-arbitrary-URL, and arbitrary
+filesystem writes inside `wp-content`), so we ship the full feature set on
+GitHub and a stripped-but-still-useful variant on WP.org.
 
 | Feature surface                              | Full (`*.zip`) | WP.org (`*-wporg.zip`) | Why gated                                                                                |
 | -------------------------------------------- | :------------: | :--------------------: | ---------------------------------------------------------------------------------------- |
@@ -38,7 +39,10 @@ full feature set on GitHub and a stripped-but-still-useful variant on WP.org.
 | WP-CLI custom tools (shell `exec`)            |       ✅       |          ❌            | Same as above (arbitrary command execution)                                              |
 | Autonomous activate / deactivate / delete / switch / update plugin | ✅ |    ❌    | WP.org "Changing Active Plugins" — plugins must not change other plugins' state without per-action user intervention |
 | Install plugin from arbitrary ZIP URL / GitHub |     ✅       |          ❌            | "Changing Active Plugins" only exempts WP.org-directory installs                          |
+| `file-write` / `file-edit` / `file-delete`, plus `git-restore` / `git-revert-package` | ✅ | ❌ | Writes resolve under `WP_CONTENT_DIR`, which includes `plugins/` and `themes/` — same arbitrary third-party-code modification risk as "Changing Active Plugins" |
 | Install plugin from WordPress.org directory by slug | ✅      |          ✅            | Allowed exception under "Changing Active Plugins"                                        |
+| Read-only file ops (`file-read`, `file-list`, `file-search`, `content-search`) | ✅ | ✅ | Read-only — cannot mutate plugin/theme source                                            |
+| Read-only git ops (`git-snapshot`, `git-diff`, `git-list`, `git-package-summary`) | ✅ | ✅ | `git-snapshot` writes only to the plugin's own DB tracking table, not to the filesystem  |
 | List / search / recommend plugins (read-only) |       ✅       |          ✅            | Read-only operations are unrestricted                                                    |
 | `run-php` (whitelisted WordPress functions only) |   ✅      |          ✅            | Whitelist excludes `activate_plugin`, `deactivate_plugins`, etc.                         |
 | Memory, knowledge, automations, abilities, chat | ✅           |          ✅            | Core agent functionality — no policy concerns                                            |
@@ -60,23 +64,31 @@ The WP.org build (`bin/build.sh --target=wporg`) does two extra things
 on top of the runtime gates, both as defence-in-depth for the WP.org
 review:
 
-1. **Hard-defines the four constants to `false`** in the bundled
+1. **Hard-defines the five constants to `false`** in the bundled
    `superdav-ai-agent.php`. Because each constant uses
    `defined( 'NAME' ) || define( 'NAME', true )`, hard-defining the
    constant earlier in the file prevents any later override (including
-   from `wp-config.php`).
+   from `wp-config.php`). The five constants are
+   `SD_AI_AGENT_FEATURE_PLUGIN_BUILDER`,
+   `SD_AI_AGENT_FEATURE_CUSTOM_TOOLS_CLI`,
+   `SD_AI_AGENT_FEATURE_PLUGIN_STATE_CHANGES`,
+   `SD_AI_AGENT_FEATURE_PLUGIN_INSTALL_FROM_URL`, and
+   `SD_AI_AGENT_FEATURE_FILE_WRITE`.
 2. **Strips the gated source files** from the zip via
    `.distignore-wporg`. The `PluginBuilder/`, `GeneratePluginAbility`,
    `SandboxActivatePluginAbility`, etc. files are not present in the
    submitted zip, so the WP.org reviewer can `grep` for the offending
-   class names and see they are absent.
+   class names and see they are absent. (The `FileAbilities` and
+   `GitAbilities` source files cannot be stripped because they also
+   contain read-only abilities that remain available on WP.org; their
+   write surfaces are gated at runtime via `Features::FILE_WRITE`.)
 
 The WP.org Plugin Review team can therefore verify compliance with a
 single command:
 
 ```bash
 unzip -p superdav-ai-agent-X.Y.Z-wporg.zip superdav-ai-agent/superdav-ai-agent.php \
-    | grep "SD_AI_AGENT_FEATURE_PLUGIN_BUILDER\|SD_AI_AGENT_FEATURE_PLUGIN_STATE_CHANGES"
+    | grep -E "SD_AI_AGENT_FEATURE_(PLUGIN_BUILDER|CUSTOM_TOOLS_CLI|PLUGIN_STATE_CHANGES|PLUGIN_INSTALL_FROM_URL|FILE_WRITE)"
 # Expected: each constant is hard-defined to false with a "wporg-build:" comment.
 ```
 

--- a/includes/Abilities/FileAbilities.php
+++ b/includes/Abilities/FileAbilities.php
@@ -17,6 +17,7 @@ namespace SdAiAgent\Abilities;
 
 use SdAiAgent\Core\ChangeLogger;
 use SdAiAgent\Core\Database;
+use SdAiAgent\Core\Features;
 use SdAiAgent\Models\ChangesLog;
 use WP_Error;
 
@@ -171,32 +172,38 @@ class FileAbilities {
 			]
 		);
 
-		wp_register_ability(
-			'sd-ai-agent/file-write',
-			[
-				'label'         => __( 'Write File', 'superdav-ai-agent' ),
-				'description'   => __( 'Write or overwrite a file within wp-content. Use for creating NEW files. For modifying existing files, use sd-ai-agent/file-edit instead.', 'superdav-ai-agent' ),
-				'ability_class' => FileWriteAbility::class,
-			]
-		);
+		// Mutating filesystem abilities are gated behind the FILE_WRITE
+		// feature flag because they resolve under WP_CONTENT_DIR, which
+		// includes plugins/ and themes/ — i.e. arbitrary third-party-code
+		// modification. Disabled in the WordPress.org distribution build.
+		if ( Features::is_enabled( Features::FILE_WRITE ) ) {
+			wp_register_ability(
+				'sd-ai-agent/file-write',
+				[
+					'label'         => __( 'Write File', 'superdav-ai-agent' ),
+					'description'   => __( 'Write or overwrite a file within wp-content. Use for creating NEW files. For modifying existing files, use sd-ai-agent/file-edit instead.', 'superdav-ai-agent' ),
+					'ability_class' => FileWriteAbility::class,
+				]
+			);
 
-		wp_register_ability(
-			'sd-ai-agent/file-edit',
-			[
-				'label'         => __( 'Edit File', 'superdav-ai-agent' ),
-				'description'   => __( 'Edit an existing file by applying search and replace operations. More efficient than write for targeted changes. Each edit finds a unique string and replaces it.', 'superdav-ai-agent' ),
-				'ability_class' => FileEditAbility::class,
-			]
-		);
+			wp_register_ability(
+				'sd-ai-agent/file-edit',
+				[
+					'label'         => __( 'Edit File', 'superdav-ai-agent' ),
+					'description'   => __( 'Edit an existing file by applying search and replace operations. More efficient than write for targeted changes. Each edit finds a unique string and replaces it.', 'superdav-ai-agent' ),
+					'ability_class' => FileEditAbility::class,
+				]
+			);
 
-		wp_register_ability(
-			'sd-ai-agent/file-delete',
-			[
-				'label'         => __( 'Delete File', 'superdav-ai-agent' ),
-				'description'   => __( 'Delete a file within the wp-content directory.', 'superdav-ai-agent' ),
-				'ability_class' => FileDeleteAbility::class,
-			]
-		);
+			wp_register_ability(
+				'sd-ai-agent/file-delete',
+				[
+					'label'         => __( 'Delete File', 'superdav-ai-agent' ),
+					'description'   => __( 'Delete a file within the wp-content directory.', 'superdav-ai-agent' ),
+					'ability_class' => FileDeleteAbility::class,
+				]
+			);
+		}
 
 		wp_register_ability(
 			'sd-ai-agent/file-list',

--- a/includes/Abilities/GitAbilities.php
+++ b/includes/Abilities/GitAbilities.php
@@ -11,17 +11,28 @@ declare(strict_types=1);
  *   - Restore original content (sd-ai-agent/git-restore)
  *   - List all tracked files (sd-ai-agent/git-list)
  *   - Get a summary for a package (sd-ai-agent/git-package-summary)
+ *   - Revert all changes for a package (sd-ai-agent/git-revert-package)
  *
  * Note: FileAbilities automatically fires `sd_ai_agent_before_file_write`
  * and `sd_ai_agent_before_file_edit` hooks, which GitTrackerManager hooks
  * into to snapshot files transparently. These abilities provide explicit
  * control and visibility for the AI agent.
  *
+ * Mutation gating: `git-restore` and `git-revert-package` write to
+ * tracked files via `$wp_filesystem->put_contents()`, so they are gated
+ * behind `Features::FILE_WRITE` and disabled in the WordPress.org
+ * distribution build. Read-only abilities (`git-snapshot`, `git-diff`,
+ * `git-list`, `git-package-summary`) remain available — `git-snapshot`
+ * only writes to the plugin's own DB tracking table, not to the
+ * filesystem.
+ *
  * @package SdAiAgent
  * @license GPL-2.0-or-later
  */
 
 namespace SdAiAgent\Abilities;
+
+use SdAiAgent\Core\Features;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -55,14 +66,20 @@ class GitAbilities {
 			]
 		);
 
-		wp_register_ability(
-			'sd-ai-agent/git-restore',
-			[
-				'label'         => __( 'Restore File', 'superdav-ai-agent' ),
-				'description'   => __( 'Restore a file to its original snapshotted content, undoing all AI modifications.', 'superdav-ai-agent' ),
-				'ability_class' => GitRestoreAbility::class,
-			]
-		);
+		// git-restore and git-revert-package mutate tracked files via
+		// $wp_filesystem->put_contents() inside wp-content (including
+		// plugins/ and themes/), so they are gated behind FILE_WRITE
+		// alongside the FileAbilities mutation surface.
+		if ( Features::is_enabled( Features::FILE_WRITE ) ) {
+			wp_register_ability(
+				'sd-ai-agent/git-restore',
+				[
+					'label'         => __( 'Restore File', 'superdav-ai-agent' ),
+					'description'   => __( 'Restore a file to its original snapshotted content, undoing all AI modifications.', 'superdav-ai-agent' ),
+					'ability_class' => GitRestoreAbility::class,
+				]
+			);
+		}
 
 		wp_register_ability(
 			'sd-ai-agent/git-list',
@@ -82,13 +99,15 @@ class GitAbilities {
 			]
 		);
 
-		wp_register_ability(
-			'sd-ai-agent/git-revert-package',
-			[
-				'label'         => __( 'Revert Package', 'superdav-ai-agent' ),
-				'description'   => __( 'Revert all modified files in a plugin or theme back to their original snapshotted content.', 'superdav-ai-agent' ),
-				'ability_class' => GitRevertPackageAbility::class,
-			]
-		);
+		if ( Features::is_enabled( Features::FILE_WRITE ) ) {
+			wp_register_ability(
+				'sd-ai-agent/git-revert-package',
+				[
+					'label'         => __( 'Revert Package', 'superdav-ai-agent' ),
+					'description'   => __( 'Revert all modified files in a plugin or theme back to their original snapshotted content.', 'superdav-ai-agent' ),
+					'ability_class' => GitRevertPackageAbility::class,
+				]
+			);
+		}
 	}
 }

--- a/includes/Abilities/WordPressAbilities.php
+++ b/includes/Abilities/WordPressAbilities.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Abilities;
 
 use SdAiAgent\Core\AbilityPluginRegistry;
+use SdAiAgent\Core\Features;
 use WP_Error;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -259,11 +260,29 @@ class WordPressAbilities {
 
 	/**
 	 * Register all WordPress management abilities.
+	 *
+	 * Plugin-management abilities are split across two feature flags so the
+	 * WordPress.org distribution can comply with the "Changing Active
+	 * Plugins" guideline (no autonomous activate/deactivate/delete/switch/
+	 * update) and the WP.org-directory-only install rule (no installs from
+	 * arbitrary ZIP URLs) without removing all plugin tooling:
+	 *
+	 *  - Always registered (read-only or WP.org-directory only):
+	 *    get-plugins, get-themes, recommend-plugin, search-plugin-directory,
+	 *    list-plugin-updates, install-plugin (WP.org slug),
+	 *    run-php (whitelisted function calls only).
+	 *  - Gated by SD_AI_AGENT_FEATURE_PLUGIN_STATE_CHANGES:
+	 *    activate-plugin, deactivate-plugin, delete-plugin, switch-plugin,
+	 *    update-plugin.
+	 *  - Gated by SD_AI_AGENT_FEATURE_PLUGIN_INSTALL_FROM_URL:
+	 *    install-plugin-from-url.
 	 */
 	public static function register_abilities(): void {
 		if ( ! function_exists( 'wp_register_ability' ) ) {
 			return;
 		}
+
+		// ─── Always-registered: read-only / discovery / WP.org-only install ────
 
 		wp_register_ability(
 			'sd-ai-agent/get-plugins',
@@ -293,56 +312,11 @@ class WordPressAbilities {
 		);
 
 		wp_register_ability(
-			'sd-ai-agent/update-plugin',
-			[
-				'label'         => __( 'Update Plugin', 'superdav-ai-agent' ),
-				'description'   => __( 'Update an installed plugin to the latest version available from its source.', 'superdav-ai-agent' ),
-				'ability_class' => UpdatePluginAbility::class,
-			]
-		);
-
-		wp_register_ability(
 			'sd-ai-agent/recommend-plugin',
 			[
 				'label'         => __( 'Recommend Plugin', 'superdav-ai-agent' ),
 				'description'   => __( 'Given a need category, return ranked plugin recommendations from the curated abilities registry. Preference order: has abilities > has blocks > popular.', 'superdav-ai-agent' ),
 				'ability_class' => RecommendPluginAbility::class,
-			]
-		);
-
-		wp_register_ability(
-			'sd-ai-agent/install-plugin-from-url',
-			[
-				'label'         => __( 'Install Plugin from URL', 'superdav-ai-agent' ),
-				'description'   => __( 'Install a plugin from any direct ZIP URL, including GitHub release assets. Optionally activate after installation.', 'superdav-ai-agent' ),
-				'ability_class' => InstallPluginFromUrlAbility::class,
-			]
-		);
-
-		wp_register_ability(
-			'sd-ai-agent/activate-plugin',
-			[
-				'label'         => __( 'Activate Plugin', 'superdav-ai-agent' ),
-				'description'   => __( 'Activate an installed WordPress plugin by slug or plugin file.', 'superdav-ai-agent' ),
-				'ability_class' => ActivatePluginAbility::class,
-			]
-		);
-
-		wp_register_ability(
-			'sd-ai-agent/deactivate-plugin',
-			[
-				'label'         => __( 'Deactivate Plugin', 'superdav-ai-agent' ),
-				'description'   => __( 'Deactivate an active WordPress plugin by slug or plugin file.', 'superdav-ai-agent' ),
-				'ability_class' => DeactivatePluginAbility::class,
-			]
-		);
-
-		wp_register_ability(
-			'sd-ai-agent/delete-plugin',
-			[
-				'label'         => __( 'Delete Plugin', 'superdav-ai-agent' ),
-				'description'   => __( 'Permanently delete an inactive WordPress plugin. The plugin must be deactivated first.', 'superdav-ai-agent' ),
-				'ability_class' => DeletePluginAbility::class,
 			]
 		);
 
@@ -365,15 +339,6 @@ class WordPressAbilities {
 		);
 
 		wp_register_ability(
-			'sd-ai-agent/switch-plugin',
-			[
-				'label'         => __( 'Switch Plugin', 'superdav-ai-agent' ),
-				'description'   => __( 'Activate one plugin and optionally deactivate one or more others. Rolls back if activation fails.', 'superdav-ai-agent' ),
-				'ability_class' => SwitchPluginAbility::class,
-			]
-		);
-
-		wp_register_ability(
 			'sd-ai-agent/run-php',
 			[
 				'label'         => __( 'Call WordPress Function', 'superdav-ai-agent' ),
@@ -381,6 +346,68 @@ class WordPressAbilities {
 				'ability_class' => RunPhpAbility::class,
 			]
 		);
+
+		// ─── Gated: changes the active plugin set ──────────────────────────────
+
+		if ( Features::is_enabled( Features::PLUGIN_STATE_CHANGES ) ) {
+			wp_register_ability(
+				'sd-ai-agent/update-plugin',
+				[
+					'label'         => __( 'Update Plugin', 'superdav-ai-agent' ),
+					'description'   => __( 'Update an installed plugin to the latest version available from its source.', 'superdav-ai-agent' ),
+					'ability_class' => UpdatePluginAbility::class,
+				]
+			);
+
+			wp_register_ability(
+				'sd-ai-agent/activate-plugin',
+				[
+					'label'         => __( 'Activate Plugin', 'superdav-ai-agent' ),
+					'description'   => __( 'Activate an installed WordPress plugin by slug or plugin file.', 'superdav-ai-agent' ),
+					'ability_class' => ActivatePluginAbility::class,
+				]
+			);
+
+			wp_register_ability(
+				'sd-ai-agent/deactivate-plugin',
+				[
+					'label'         => __( 'Deactivate Plugin', 'superdav-ai-agent' ),
+					'description'   => __( 'Deactivate an active WordPress plugin by slug or plugin file.', 'superdav-ai-agent' ),
+					'ability_class' => DeactivatePluginAbility::class,
+				]
+			);
+
+			wp_register_ability(
+				'sd-ai-agent/delete-plugin',
+				[
+					'label'         => __( 'Delete Plugin', 'superdav-ai-agent' ),
+					'description'   => __( 'Permanently delete an inactive WordPress plugin. The plugin must be deactivated first.', 'superdav-ai-agent' ),
+					'ability_class' => DeletePluginAbility::class,
+				]
+			);
+
+			wp_register_ability(
+				'sd-ai-agent/switch-plugin',
+				[
+					'label'         => __( 'Switch Plugin', 'superdav-ai-agent' ),
+					'description'   => __( 'Activate one plugin and optionally deactivate one or more others. Rolls back if activation fails.', 'superdav-ai-agent' ),
+					'ability_class' => SwitchPluginAbility::class,
+				]
+			);
+		}
+
+		// ─── Gated: install from arbitrary ZIP URLs / GitHub ──────────────────
+
+		if ( Features::is_enabled( Features::PLUGIN_INSTALL_FROM_URL ) ) {
+			wp_register_ability(
+				'sd-ai-agent/install-plugin-from-url',
+				[
+					'label'         => __( 'Install Plugin from URL', 'superdav-ai-agent' ),
+					'description'   => __( 'Install a plugin from any direct ZIP URL, including GitHub release assets. Optionally activate after installation.', 'superdav-ai-agent' ),
+					'ability_class' => InstallPluginFromUrlAbility::class,
+				]
+			);
+		}
 	}
 }
 

--- a/includes/Bootstrap/AbilitiesHandler.php
+++ b/includes/Bootstrap/AbilitiesHandler.php
@@ -49,6 +49,7 @@ use SdAiAgent\Abilities\PluginBuilderAbilities;
 use SdAiAgent\Abilities\PluginDownloadAbilities;
 use SdAiAgent\PluginBuilder\PluginSandbox;
 use SdAiAgent\Abilities\PostAbilities;
+use SdAiAgent\Core\Features;
 use SdAiAgent\Abilities\SeoAbilities;
 use SdAiAgent\Abilities\SiteBuilderAbilities;
 use SdAiAgent\Abilities\SiteHealthAbilities;
@@ -102,8 +103,28 @@ final class AbilitiesHandler {
 		GlobalStylesAbilities::register_abilities();
 		FileAbilities::register_abilities();
 		GitAbilities::register_abilities();
-		PluginDownloadAbilities::register_abilities();
-		PluginBuilderAbilities::register_abilities();
+		// Plugin-download abilities expose download URLs for AI-modified
+		// plugins, so they only make sense when the plugin builder is
+		// available. Gated under the same flag, and the class_exists()
+		// guard handles the case where bin/build.sh --target=wporg has
+		// also stripped the source file.
+		if (
+			Features::is_enabled( Features::PLUGIN_BUILDER )
+			&& class_exists( PluginDownloadAbilities::class )
+		) {
+			PluginDownloadAbilities::register_abilities();
+		}
+		// Plugin builder abilities are gated behind a feature flag so the
+		// WordPress.org distribution build can disable arbitrary PHP code
+		// generation/execution. The class_exists() guard handles the case
+		// where the source files are also stripped from the zip — see
+		// bin/build.sh --target=wporg.
+		if (
+			Features::is_enabled( Features::PLUGIN_BUILDER )
+			&& class_exists( PluginBuilderAbilities::class )
+		) {
+			PluginBuilderAbilities::register_abilities();
+		}
 		DatabaseAbilities::register_abilities();
 		WordPressAbilities::register_abilities();
 		WpCliAbilities::register_ability();
@@ -157,9 +178,20 @@ final class AbilitiesHandler {
 	 *
 	 * Previously wired by PluginBuilderAbilities::register() via add_action() —
 	 * that register() stub has been removed.
+	 *
+	 * Skipped when the plugin-builder feature is disabled (the safety net only
+	 * matters when this plugin is actively installing plugins it generated)
+	 * or when the PluginSandbox class has been stripped from the build.
 	 */
 	#[Action( tag: 'init', priority: 10 )]
 	public function auto_deactivate_fatal_plugins(): void {
+		if (
+			! Features::is_enabled( Features::PLUGIN_BUILDER )
+			|| ! class_exists( PluginSandbox::class )
+		) {
+			return;
+		}
+
 		PluginSandbox::auto_deactivate_fatal_plugins();
 	}
 }

--- a/includes/Core/Features.php
+++ b/includes/Core/Features.php
@@ -35,6 +35,15 @@ declare(strict_types=1);
  *    Disabled in the WordPress.org distribution because the
  *    "Changing Active Plugins" guideline only exempts WP.org-directory
  *    installs from the no-autonomous-state-change rule.
+ *  - SD_AI_AGENT_FEATURE_FILE_WRITE — Arbitrary filesystem writes
+ *    inside wp-content (file-write, file-edit, file-delete, plus the
+ *    git-restore and git-revert-package abilities that revert tracked
+ *    files via $wp_filesystem->put_contents). Disabled in the
+ *    WordPress.org distribution because writes can target
+ *    wp-content/plugins/ and wp-content/themes/, which is the same
+ *    arbitrary-code-modification risk covered by the WP.org "Changing
+ *    Active Plugins" guideline. Read-only file/git abilities remain
+ *    available.
  *
  * Usage example (wp-config.php):
  *   define( 'SD_AI_AGENT_FEATURE_BRANDING', false );
@@ -132,6 +141,26 @@ final class Features {
 	const PLUGIN_INSTALL_FROM_URL = 'plugin_install_from_url';
 
 	/**
+	 * Feature: arbitrary filesystem writes inside wp-content.
+	 *
+	 * Gates the `sd-ai-agent/file-write`, `sd-ai-agent/file-edit`,
+	 * `sd-ai-agent/file-delete`, `sd-ai-agent/git-restore`, and
+	 * `sd-ai-agent/git-revert-package` abilities. Read-only file/git
+	 * abilities (file-read, file-list, file-search, content-search,
+	 * git-list, git-diff, git-package-summary, git-snapshot) remain
+	 * available because they cannot mutate plugin/theme source.
+	 *
+	 * Disabled in the WordPress.org distribution build because writes
+	 * resolve under `WP_CONTENT_DIR`, which includes `plugins/` and
+	 * `themes/` — direct edits there are the same class of arbitrary
+	 * third-party-code modification covered by the WP.org "Changing
+	 * Active Plugins" guideline.
+	 *
+	 * Constant: SD_AI_AGENT_FEATURE_FILE_WRITE
+	 */
+	const FILE_WRITE = 'file_write';
+
+	/**
 	 * Map of feature name → backing constant name.
 	 *
 	 * @var array<string, string>
@@ -143,6 +172,7 @@ final class Features {
 		self::CUSTOM_TOOLS_CLI        => 'SD_AI_AGENT_FEATURE_CUSTOM_TOOLS_CLI',
 		self::PLUGIN_STATE_CHANGES    => 'SD_AI_AGENT_FEATURE_PLUGIN_STATE_CHANGES',
 		self::PLUGIN_INSTALL_FROM_URL => 'SD_AI_AGENT_FEATURE_PLUGIN_INSTALL_FROM_URL',
+		self::FILE_WRITE              => 'SD_AI_AGENT_FEATURE_FILE_WRITE',
 	);
 
 	/**

--- a/includes/Core/Features.php
+++ b/includes/Core/Features.php
@@ -10,10 +10,31 @@ declare(strict_types=1);
  * `false` disables the corresponding UI and REST surface.
  *
  * Defined constants (all default true):
- *  - SD_AI_AGENT_FEATURE_BRANDING      — White-label / branding settings:
+ *  - SD_AI_AGENT_FEATURE_BRANDING            — White-label / branding settings:
  *    agent name, brand colours, logo URL, greeting message.
- *  - SD_AI_AGENT_FEATURE_ACCESS_CONTROL — Role-based access control:
+ *  - SD_AI_AGENT_FEATURE_ACCESS_CONTROL      — Role-based access control:
  *    the Role Permissions manager and its /role-permissions REST routes.
+ *  - SD_AI_AGENT_FEATURE_PLUGIN_BUILDER      — AI plugin generation, sandboxed
+ *    activation, sandboxed updates, and hook scanning. Disabled in the
+ *    WordPress.org distribution because WP.org Guideline 4 prohibits
+ *    plugins that "process custom CSS/JS/PHP" or "allow arbitrary
+ *    script insertion".
+ *  - SD_AI_AGENT_FEATURE_CUSTOM_TOOLS_CLI    — The WP-CLI custom tool type,
+ *    which executes shell commands via PHP `exec()`. Disabled in the
+ *    WordPress.org distribution for the same reason as above.
+ *  - SD_AI_AGENT_FEATURE_PLUGIN_STATE_CHANGES — Abilities that change the
+ *    active plugin set without explicit per-action user intervention:
+ *    activate-plugin, deactivate-plugin, delete-plugin, switch-plugin,
+ *    and update-plugin. Disabled in the WordPress.org distribution
+ *    because the WP.org "Changing Active Plugins" guideline forbids
+ *    plugins from activating or deactivating other plugins
+ *    autonomously, even with capability checks.
+ *  - SD_AI_AGENT_FEATURE_PLUGIN_INSTALL_FROM_URL — The
+ *    install-plugin-from-url ability, which fetches and installs a
+ *    plugin from any direct ZIP URL (e.g. GitHub release assets).
+ *    Disabled in the WordPress.org distribution because the
+ *    "Changing Active Plugins" guideline only exempts WP.org-directory
+ *    installs from the no-autonomous-state-change rule.
  *
  * Usage example (wp-config.php):
  *   define( 'SD_AI_AGENT_FEATURE_BRANDING', false );
@@ -43,13 +64,85 @@ final class Features {
 	const ACCESS_CONTROL = 'access_control';
 
 	/**
+	 * Feature: AI plugin builder (generate / sandbox / activate / update).
+	 *
+	 * Gates registration of the `sd-ai-agent/generate-plugin`,
+	 * `sd-ai-agent/sandbox-test-plugin`, `sd-ai-agent/sandbox-activate-plugin`,
+	 * `sd-ai-agent/update-plugin-sandboxed`, `sd-ai-agent/scan-plugin-hooks`,
+	 * and `sd-ai-agent/scan-theme-hooks` abilities, plus the
+	 * `auto_deactivate_fatal_plugins` init hook.
+	 *
+	 * Disabled in the WordPress.org distribution build (`bin/build.sh
+	 * --target=wporg`) because the WP.org plugin guidelines prohibit
+	 * plugins that allow arbitrary PHP insertion. The full feature set
+	 * remains available in the GitHub release zip.
+	 *
+	 * Constant: SD_AI_AGENT_FEATURE_PLUGIN_BUILDER
+	 */
+	const PLUGIN_BUILDER = 'plugin_builder';
+
+	/**
+	 * Feature: WP-CLI custom-tool type.
+	 *
+	 * Gates registration and execution of custom tools whose `type` is
+	 * `cli` — these tools shell out to `wp` via PHP `exec()`. Disabled in
+	 * the WordPress.org distribution for the same arbitrary-code-execution
+	 * reason as PLUGIN_BUILDER. HTTP and Action tool types remain
+	 * available in both builds.
+	 *
+	 * Constant: SD_AI_AGENT_FEATURE_CUSTOM_TOOLS_CLI
+	 */
+	const CUSTOM_TOOLS_CLI = 'custom_tools_cli';
+
+	/**
+	 * Feature: autonomous changes to the active plugin set.
+	 *
+	 * Gates the `sd-ai-agent/activate-plugin`,
+	 * `sd-ai-agent/deactivate-plugin`, `sd-ai-agent/delete-plugin`,
+	 * `sd-ai-agent/switch-plugin`, and `sd-ai-agent/update-plugin`
+	 * abilities. With this disabled the agent can still list, recommend,
+	 * and search plugins, and can install from the WordPress.org
+	 * directory (the WP.org-only exception); it cannot change which
+	 * plugins are active without the user clicking through the standard
+	 * WP admin Plugins screen.
+	 *
+	 * Disabled in the WordPress.org distribution build to comply with
+	 * the WP.org "Changing Active Plugins" guideline.
+	 *
+	 * Constant: SD_AI_AGENT_FEATURE_PLUGIN_STATE_CHANGES
+	 */
+	const PLUGIN_STATE_CHANGES = 'plugin_state_changes';
+
+	/**
+	 * Feature: install plugins from arbitrary ZIP URLs / GitHub.
+	 *
+	 * Gates the `sd-ai-agent/install-plugin-from-url` ability. With this
+	 * disabled the agent can still install plugins from the official
+	 * WordPress.org directory by slug (`sd-ai-agent/install-plugin`),
+	 * but cannot fetch a ZIP from any third-party URL.
+	 *
+	 * Disabled in the WordPress.org distribution build because the
+	 * "Changing Active Plugins" guideline restricts plugin-installation
+	 * automation to the WP.org-directory channel. The full GitHub
+	 * release zip retains the broader URL-install ability for
+	 * self-hosted users.
+	 *
+	 * Constant: SD_AI_AGENT_FEATURE_PLUGIN_INSTALL_FROM_URL
+	 */
+	const PLUGIN_INSTALL_FROM_URL = 'plugin_install_from_url';
+
+	/**
 	 * Map of feature name → backing constant name.
 	 *
 	 * @var array<string, string>
 	 */
 	private const CONSTANT_MAP = array(
-		self::BRANDING       => 'SD_AI_AGENT_FEATURE_BRANDING',
-		self::ACCESS_CONTROL => 'SD_AI_AGENT_FEATURE_ACCESS_CONTROL',
+		self::BRANDING                => 'SD_AI_AGENT_FEATURE_BRANDING',
+		self::ACCESS_CONTROL          => 'SD_AI_AGENT_FEATURE_ACCESS_CONTROL',
+		self::PLUGIN_BUILDER          => 'SD_AI_AGENT_FEATURE_PLUGIN_BUILDER',
+		self::CUSTOM_TOOLS_CLI        => 'SD_AI_AGENT_FEATURE_CUSTOM_TOOLS_CLI',
+		self::PLUGIN_STATE_CHANGES    => 'SD_AI_AGENT_FEATURE_PLUGIN_STATE_CHANGES',
+		self::PLUGIN_INSTALL_FROM_URL => 'SD_AI_AGENT_FEATURE_PLUGIN_INSTALL_FROM_URL',
 	);
 
 	/**

--- a/includes/Tools/CustomToolExecutor.php
+++ b/includes/Tools/CustomToolExecutor.php
@@ -17,6 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use SdAiAgent\Abilities\ToolCapabilities;
+use SdAiAgent\Core\Features;
 use WP_Error;
 
 class CustomToolExecutor {
@@ -38,7 +39,18 @@ class CustomToolExecutor {
 
 		$tools = CustomTools::list( true );
 
+		// When the WP-CLI custom-tool feature is disabled (e.g. WordPress.org
+		// distribution build) skip registration of any cli-type tools so they
+		// never become callable abilities. HTTP and Action tools register as
+		// normal regardless of the flag.
+		$cli_enabled = Features::is_enabled( Features::CUSTOM_TOOLS_CLI );
+
 		foreach ( $tools as $tool ) {
+			// @phpstan-ignore-next-line
+			if ( ! $cli_enabled && CustomTools::TYPE_CLI === ( $tool['type'] ?? '' ) ) {
+				continue;
+			}
+
 			// @phpstan-ignore-next-line
 			$ability_name = 'sd-ai-agent-custom/' . $tool['slug'];
 
@@ -87,6 +99,12 @@ class CustomToolExecutor {
 				return self::execute_action( $tool, $input );
 
 			case CustomTools::TYPE_CLI:
+				if ( ! Features::is_enabled( Features::CUSTOM_TOOLS_CLI ) ) {
+					return new WP_Error(
+						'cli_tools_disabled',
+						__( 'WP-CLI custom tools are disabled in this distribution of Superdav AI Agent. Use HTTP or Action tools instead, or install the GitHub release zip.', 'superdav-ai-agent' )
+					);
+				}
 				return self::execute_cli( $tool, $input );
 
 			default:

--- a/includes/Tools/CustomTools.php
+++ b/includes/Tools/CustomTools.php
@@ -22,6 +22,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use SdAiAgent\Core\Features;
+
 class CustomTools {
 
 	const TYPE_HTTP   = 'http';
@@ -246,6 +248,15 @@ class CustomTools {
 			return new \WP_Error( 'invalid_type', __( 'Tool type must be http, action, or cli.', 'superdav-ai-agent' ) );
 		}
 
+		// Reject CLI tools when the feature is disabled (e.g. WordPress.org
+		// distribution build). HTTP and Action tools remain creatable.
+		if ( self::TYPE_CLI === $data['type'] && ! Features::is_enabled( Features::CUSTOM_TOOLS_CLI ) ) {
+			return new \WP_Error(
+				'cli_tools_disabled',
+				__( 'WP-CLI custom tools are disabled in this distribution of Superdav AI Agent. Use HTTP or Action tools instead.', 'superdav-ai-agent' )
+			);
+		}
+
 		// Auto-generate slug from name if not provided.
 		if ( empty( $data['slug'] ) ) {
 			// @phpstan-ignore-next-line
@@ -401,7 +412,14 @@ class CustomTools {
 			],
 		];
 
+		// Skip CLI examples when the feature is disabled so the
+		// WordPress.org distribution build does not seed shell-exec tools.
+		$cli_enabled = Features::is_enabled( Features::CUSTOM_TOOLS_CLI );
+
 		foreach ( $examples as $example ) {
+			if ( ! $cli_enabled && self::TYPE_CLI === $example['type'] ) {
+				continue;
+			}
 			self::create( $example );
 		}
 

--- a/superdav-ai-agent.php
+++ b/superdav-ai-agent.php
@@ -51,6 +51,46 @@ defined( 'SD_AI_AGENT_FEATURE_BRANDING' ) || define( 'SD_AI_AGENT_FEATURE_BRANDI
  */
 defined( 'SD_AI_AGENT_FEATURE_ACCESS_CONTROL' ) || define( 'SD_AI_AGENT_FEATURE_ACCESS_CONTROL', true );
 
+/**
+ * Feature: AI plugin builder — generate, sandbox-test, activate, and update
+ * WordPress plugins from natural-language descriptions. When false, all six
+ * plugin-builder abilities are skipped during registration and the related
+ * `init` hook (`auto_deactivate_fatal_plugins`) becomes a no-op.
+ *
+ * This constant is forced to `false` in the WordPress.org distribution zip
+ * built by `bin/build.sh --target=wporg` because the WP.org plugin
+ * guidelines prohibit plugins that allow arbitrary PHP code insertion.
+ * The full GitHub release zip leaves it `true`.
+ */
+defined( 'SD_AI_AGENT_FEATURE_PLUGIN_BUILDER' ) || define( 'SD_AI_AGENT_FEATURE_PLUGIN_BUILDER', true );
+
+/**
+ * Feature: WP-CLI custom-tool type — lets administrators register custom
+ * tools that execute `wp` CLI commands via PHP `exec()`. When false,
+ * `cli`-type custom tools are not registered as abilities and any attempt
+ * to execute one returns a `WP_Error`. HTTP and Action custom tools are
+ * unaffected. Forced to `false` in the WordPress.org distribution build.
+ */
+defined( 'SD_AI_AGENT_FEATURE_CUSTOM_TOOLS_CLI' ) || define( 'SD_AI_AGENT_FEATURE_CUSTOM_TOOLS_CLI', true );
+
+/**
+ * Feature: autonomous changes to the active plugin set. When false, the
+ * activate-plugin, deactivate-plugin, delete-plugin, switch-plugin, and
+ * update-plugin abilities are not registered, so the agent cannot
+ * change which plugins are active without the user clicking through the
+ * WP admin Plugins screen. Forced to `false` in the WordPress.org
+ * distribution build per the WP.org "Changing Active Plugins" guideline.
+ */
+defined( 'SD_AI_AGENT_FEATURE_PLUGIN_STATE_CHANGES' ) || define( 'SD_AI_AGENT_FEATURE_PLUGIN_STATE_CHANGES', true );
+
+/**
+ * Feature: install plugins from arbitrary ZIP URLs (including GitHub).
+ * When false, the install-plugin-from-url ability is not registered;
+ * the WP.org-directory `install-plugin` ability remains available.
+ * Forced to `false` in the WordPress.org distribution build.
+ */
+defined( 'SD_AI_AGENT_FEATURE_PLUGIN_INSTALL_FROM_URL' ) || define( 'SD_AI_AGENT_FEATURE_PLUGIN_INSTALL_FROM_URL', true );
+
 // Load Jetpack Autoloader for PSR-4 autoloading with version conflict resolution.
 // Jetpack Autoloader ensures the newest version of shared packages (like php-ai-client) is used.
 if ( file_exists( SD_AI_AGENT_DIR . '/vendor/autoload_packages.php' ) ) {

--- a/superdav-ai-agent.php
+++ b/superdav-ai-agent.php
@@ -91,6 +91,19 @@ defined( 'SD_AI_AGENT_FEATURE_PLUGIN_STATE_CHANGES' ) || define( 'SD_AI_AGENT_FE
  */
 defined( 'SD_AI_AGENT_FEATURE_PLUGIN_INSTALL_FROM_URL' ) || define( 'SD_AI_AGENT_FEATURE_PLUGIN_INSTALL_FROM_URL', true );
 
+/**
+ * Feature: arbitrary filesystem writes inside wp-content. When false, the
+ * file-write, file-edit, file-delete, git-restore, and git-revert-package
+ * abilities are not registered; read-only file operations (file-read,
+ * file-list, file-search, content-search, git-list, git-diff,
+ * git-package-summary, git-snapshot) remain available. Forced to `false`
+ * in the WordPress.org distribution build because direct writes to
+ * `wp-content/plugins/` and `wp-content/themes/` constitute arbitrary
+ * code modification of other plugins/themes — the same class of risk
+ * covered by the WP.org "Changing Active Plugins" guideline.
+ */
+defined( 'SD_AI_AGENT_FEATURE_FILE_WRITE' ) || define( 'SD_AI_AGENT_FEATURE_FILE_WRITE', true );
+
 // Load Jetpack Autoloader for PSR-4 autoloading with version conflict resolution.
 // Jetpack Autoloader ensures the newest version of shared packages (like php-ai-client) is used.
 if ( file_exists( SD_AI_AGENT_DIR . '/vendor/autoload_packages.php' ) ) {

--- a/tests/SdAiAgent/Core/FeaturesTest.php
+++ b/tests/SdAiAgent/Core/FeaturesTest.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Test case for the Features feature-flag registry.
+ *
+ * The constants under test (SD_AI_AGENT_FEATURE_*) are defined once per
+ * PHP process by the plugin bootstrap and cannot be undefined for the
+ * test run. We therefore exercise the registry via the WordPress.org
+ * build's perspective: each gated feature must be reachable as a
+ * named map entry, the constant-name mapping must match what
+ * bin/build.sh greps for, and Features::all() must include every
+ * gated flag so the JS bundle can render the right UI.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\Features;
+use WP_UnitTestCase;
+
+/**
+ * Test Features registry.
+ */
+class FeaturesTest extends WP_UnitTestCase {
+
+	/**
+	 * The four feature flags that the WordPress.org build forces to
+	 * `false`. If you remove one of these, also remove the matching
+	 * `flags=()` entry in `bin/build.sh` and the row in
+	 * `docs/wordpress-org-submission.md` Build Matrix.
+	 *
+	 * @return array<int, array{0: string, 1: string}>
+	 */
+	public static function wporg_gated_flags(): array {
+		return [
+			[ Features::PLUGIN_BUILDER, 'SD_AI_AGENT_FEATURE_PLUGIN_BUILDER' ],
+			[ Features::CUSTOM_TOOLS_CLI, 'SD_AI_AGENT_FEATURE_CUSTOM_TOOLS_CLI' ],
+			[ Features::PLUGIN_STATE_CHANGES, 'SD_AI_AGENT_FEATURE_PLUGIN_STATE_CHANGES' ],
+			[ Features::PLUGIN_INSTALL_FROM_URL, 'SD_AI_AGENT_FEATURE_PLUGIN_INSTALL_FROM_URL' ],
+		];
+	}
+
+	/**
+	 * Each gated feature must appear in Features::all() so the JS
+	 * bundle can hide the corresponding UI when the flag is off.
+	 *
+	 * @dataProvider wporg_gated_flags
+	 *
+	 * @param string $feature_key Feature identifier (e.g. 'plugin_builder').
+	 * @param string $constant    Backing constant name (unused here but
+	 *                            kept so the data provider is shared with
+	 *                            other test methods).
+	 */
+	public function test_each_gated_feature_appears_in_all( string $feature_key, string $constant ): void {
+		unset( $constant ); // Not used in this assertion.
+		$all = Features::all();
+
+		$this->assertArrayHasKey(
+			$feature_key,
+			$all,
+			"Features::all() must include '{$feature_key}' so the JS bundle can read its state."
+		);
+		$this->assertIsBool( $all[ $feature_key ] );
+	}
+
+	/**
+	 * Features::is_enabled() defaults to `true` for every gated
+	 * feature when the backing constant is not defined. The full
+	 * GitHub-release build relies on this default so site owners can
+	 * keep using the plugin builder without any extra configuration.
+	 *
+	 * @dataProvider wporg_gated_flags
+	 *
+	 * @param string $feature_key Feature identifier.
+	 * @param string $constant    Backing constant name.
+	 */
+	public function test_gated_feature_defaults_to_enabled_when_constant_undefined( string $feature_key, string $constant ): void {
+		// PHPUnit runs after the plugin bootstrap, which already defines
+		// the constants. We can't undefine them, but we can assert that
+		// when defined-and-true (the bootstrap default in
+		// superdav-ai-agent.php) the registry returns true.
+		if ( defined( $constant ) && constant( $constant ) === true ) {
+			$this->assertTrue(
+				Features::is_enabled( $feature_key ),
+				"Feature '{$feature_key}' should be enabled when {$constant} is defined as true."
+			);
+			return;
+		}
+
+		// In CI the feature flags should be defined-and-true (full build).
+		// If not, this test runs in a configuration we don't expect — make
+		// the failure explicit so the CI matrix can be fixed rather than
+		// silently passing.
+		$this->markTestSkipped(
+			"Skipping defaults check for '{$feature_key}' because {$constant} is not defined as true in this environment."
+		);
+	}
+
+	/**
+	 * Unknown feature identifiers fall through to enabled (fail-open)
+	 * so a typo in a caller doesn't silently disable functionality.
+	 */
+	public function test_unknown_feature_is_enabled(): void {
+		$this->assertTrue( Features::is_enabled( 'this_feature_does_not_exist' ) );
+	}
+
+	/**
+	 * Smoke test: the constant-name mapping covered by the data provider
+	 * must match what `bin/build.sh` rewrites in the WP.org build. This
+	 * is the contract that lets the build script grep-verify compliance.
+	 *
+	 * @dataProvider wporg_gated_flags
+	 *
+	 * @param string $feature_key Feature identifier.
+	 * @param string $constant    Expected backing constant name.
+	 */
+	public function test_constant_naming_matches_build_script_contract( string $feature_key, string $constant ): void {
+		// We can't see Features::CONSTANT_MAP directly (it's private), but
+		// `is_enabled()` reads it. Defining a same-named constant with a
+		// custom value would let us prove the mapping if the constant
+		// weren't already defined, so we assert via the all() snapshot.
+		$all = Features::all();
+		$this->assertArrayHasKey( $feature_key, $all );
+
+		// Sanity-check the constant naming convention itself.
+		$this->assertStringStartsWith(
+			'SD_AI_AGENT_FEATURE_',
+			$constant,
+			"Feature constants must use the SD_AI_AGENT_FEATURE_ prefix per AGENTS.md canonical naming rules."
+		);
+	}
+}

--- a/tests/SdAiAgent/Core/FeaturesTest.php
+++ b/tests/SdAiAgent/Core/FeaturesTest.php
@@ -28,7 +28,7 @@ use WP_UnitTestCase;
 class FeaturesTest extends WP_UnitTestCase {
 
 	/**
-	 * The four feature flags that the WordPress.org build forces to
+	 * The five feature flags that the WordPress.org build forces to
 	 * `false`. If you remove one of these, also remove the matching
 	 * `flags=()` entry in `bin/build.sh` and the row in
 	 * `docs/wordpress-org-submission.md` Build Matrix.
@@ -41,6 +41,7 @@ class FeaturesTest extends WP_UnitTestCase {
 			[ Features::CUSTOM_TOOLS_CLI, 'SD_AI_AGENT_FEATURE_CUSTOM_TOOLS_CLI' ],
 			[ Features::PLUGIN_STATE_CHANGES, 'SD_AI_AGENT_FEATURE_PLUGIN_STATE_CHANGES' ],
 			[ Features::PLUGIN_INSTALL_FROM_URL, 'SD_AI_AGENT_FEATURE_PLUGIN_INSTALL_FROM_URL' ],
+			[ Features::FILE_WRITE, 'SD_AI_AGENT_FEATURE_FILE_WRITE' ],
 		];
 	}
 


### PR DESCRIPTION
## Summary

WP.org plugin review flagged that we allow arbitrary script insertion via the
AI plugin builder (generates + activates + updates PHP code) and the WP-CLI
custom-tool type (shell `exec()`). Follow-up audits added three more
violation categories:

1. The autonomous activate/deactivate abilities and the
   install-plugin-from-arbitrary-URL ability violate the **Changing Active
   Plugins** guideline — even with capability checks, plugins must not change
   other plugins' state without explicit per-action user intervention, and
   only WP.org-directory installs are exempt from that rule.
2. `FileAbilities` (file-write, file-edit, file-delete) and the matching
   restore/revert abilities in `GitAbilities` (git-restore,
   git-revert-package) write directly into `wp-content`, including
   `plugins/` and `themes/`, via `$wp_filesystem->put_contents()`,
   `delete()`, and `rmdir()`. That is the same arbitrary
   third-party-code modification risk class as the Changing Active Plugins
   rule, just applied at the filesystem layer instead of the active-plugin
   list.

This PR adds a **two-track build** so we can keep the full feature set on the
GitHub release channel while shipping a stripped-but-still-useful zip to the
WP.org directory.

## Tracker

- Beads: `sd-ai-qxb`

## Build matrix

| Feature surface                                                                            | Full (`*.zip`) | WP.org (`*-wporg.zip`) | Why gated                                                                                                                                  |
| ------------------------------------------------------------------------------------------ | :------------: | :--------------------: | ------------------------------------------------------------------------------------------------------------------------------------------ |
| AI plugin generation / sandbox / activate / update / hook scan                             |       OK       |        stripped        | WP.org Guideline 4 — "attempting to process custom CSS/JS/PHP / allowing arbitrary script insertion"                                       |
| WP-CLI custom tools (shell `exec`)                                                         |       OK       |        disabled        | Same as above (arbitrary command execution)                                                                                                |
| Autonomous activate / deactivate / delete / switch / update plugin                         |       OK       |        disabled        | "Changing Active Plugins" — plugins must not change other plugins' state without per-action user intervention                              |
| Install plugin from arbitrary ZIP URL / GitHub                                             |       OK       |        disabled        | "Changing Active Plugins" only exempts WP.org-directory installs                                                                           |
| `file-write` / `file-edit` / `file-delete`, plus `git-restore` / `git-revert-package`      |       OK       |        disabled        | Writes resolve under `WP_CONTENT_DIR` (incl. `plugins/` and `themes/`) — same arbitrary third-party-code-modification risk class           |
| Install plugin from WP.org directory by slug                                               |       OK       |          OK            | Allowed exception                                                                                                                          |
| Read-only file ops (`file-read`, `file-list`, `file-search`, `content-search`)             |       OK       |          OK            | Read-only — cannot mutate plugin/theme source                                                                                              |
| Read-only git ops (`git-snapshot`, `git-diff`, `git-list`, `git-package-summary`)          |       OK       |          OK            | `git-snapshot` only writes to the plugin's own DB tracking table, not to the filesystem                                                    |
| List / search / recommend plugins (read-only)                                              |       OK       |          OK            | Read-only operations are unrestricted                                                                                                      |
| `run-php` (whitelisted WordPress functions only)                                           |       OK       |          OK            | Whitelist excludes `activate_plugin`, `deactivate_plugins`, etc.                                                                           |

## What's in the PR

### Runtime gates

Five new feature flags in the `Features` registry, all default-on so existing
self-hosted installs are unaffected:

```
SD_AI_AGENT_FEATURE_PLUGIN_BUILDER
SD_AI_AGENT_FEATURE_CUSTOM_TOOLS_CLI
SD_AI_AGENT_FEATURE_PLUGIN_STATE_CHANGES
SD_AI_AGENT_FEATURE_PLUGIN_INSTALL_FROM_URL
SD_AI_AGENT_FEATURE_FILE_WRITE
```

Gates wired up in:

- `AbilitiesHandler` — gates `PluginBuilderAbilities` and
  `PluginDownloadAbilities` registration and the
  `auto_deactivate_fatal_plugins` init hook (with `class_exists()` so a
  stripped-source build doesn't fatal on missing classes).
- `WordPressAbilities::register_abilities()` — split into always-on
  (read-only / WP.org-only install / whitelisted `run-php`) vs. gated
  (activate / deactivate / delete / switch / update + the separately-gated
  install-from-URL).
- `CustomToolExecutor` and `CustomTools` — skip registering, executing,
  validating, and seeding `cli`-type tools when the CLI flag is off; HTTP
  and Action types are unaffected.
- `FileAbilities::register_abilities()` — gates the three mutating
  abilities (`sd-ai-agent/file-write`, `file-edit`, `file-delete`) under
  `Features::FILE_WRITE`. Read-only abilities (`file-read`, `file-list`,
  `file-search`, `content-search`) remain registered. The file is mixed
  (gated + always-on) so the source cannot be stripped — runtime gating
  plus the build-time hard-define is the defence.
- `GitAbilities::register_abilities()` — gates `git-restore` and
  `git-revert-package` under `Features::FILE_WRITE` because they write
  via `$wp_filesystem->put_contents()` against arbitrary tracked paths.
  `git-snapshot`, `git-diff`, `git-list`, and `git-package-summary`
  remain registered.

### Build-time stripping

- New `bin/build.sh --target=full|wporg|both` driver.
- New `.distignore-wporg` listing the source files removed from the wporg
  zip (the `PluginBuilder/` runtime, the six plugin-builder ability classes,
  `PluginDownloadAbilities`, and the `GeneratedPlugins` repo + DTO).
  `FileAbilities.php` and `GitAbilities.php` are **not** stripped because
  they contain read-only abilities that remain available on WP.org.
- The wporg variant also rewrites the five `defined() || define( ., true )`
  lines in the bundled `superdav-ai-agent.php` to a hard
  `define( ., false )`. Because the upstream code uses `defined() ||`, this
  prevents `wp-config.php` from re-enabling the gated features even if a
  user re-adds the source files. Build script grep-verifies the
  replacements actually happened.

### Release plumbing

- `.github/workflows/release.yml` now runs `bin/build.sh --target=both` and
  uploads both zips to the GitHub release with explanatory release-body text.
- `bin/deploy-wporg.sh` always builds the wporg variant.

### Pre-existing fixes folded in

`bin/deploy-wporg.sh` and `docs/wordpress-org-submission.md` referenced the
wrong main-file basename (`sd-ai-agent.php`) and the wrong WP.org plugin slug
(`sd-ai-agent`) — both are pre-existing typos that would have prevented the
script from running at all and the docs from matching reality. Per the
canonical naming table in `AGENTS.md` the WP.org slug + text domain is
`superdav-ai-agent`, while the internal DI container ID / REST namespace /
CSS prefix is `sd-ai-agent` (intentionally unchanged everywhere). Only the
former references were fixed.

### Tests

- New `tests/SdAiAgent/Core/FeaturesTest.php` data-provider test asserting
  each WP.org-gated flag is in `Features::all()`, defaults to enabled when
  defined-and-true (the full-build case), and uses the `SD_AI_AGENT_FEATURE_`
  prefix that `bin/build.sh` greps for. Updated to include the
  `FILE_WRITE` row.

## Verification

After merge + tag, reviewers can confirm WP.org compliance via:

```bash
unzip -p superdav-ai-agent-X.Y.Z-wporg.zip superdav-ai-agent/superdav-ai-agent.php \
    | grep -E "SD_AI_AGENT_FEATURE_(PLUGIN_BUILDER|CUSTOM_TOOLS_CLI|PLUGIN_STATE_CHANGES|PLUGIN_INSTALL_FROM_URL|FILE_WRITE)"
# Expected: each gated constant is hard-defined to false with a "wporg-build:" comment.

unzip -l superdav-ai-agent-X.Y.Z-wporg.zip | grep -E "PluginBuilder|GeneratePluginAbility|SandboxActivate"
# Expected: no matches.
```

## Out of scope (filed for follow-up)

- **`run-php` allowlist audit.** Remains registered in the wporg build
  because the allowlist excludes plugin-state functions, but `update_option`
  *is* on the allowlist and could in principle mutate the `active_plugins`
  option. Flagging for an allowlist review rather than gating the whole
  ability.
- **JS settings UI for the gated sections.** The runtime gates hide the
  abilities, but React tabs that surface plugin-builder / file-write UI
  still render. A JS-side conditional read of `features.plugin_builder` /
  `features.file_write` (mirroring the existing `features.access_control`
  / `features.branding` pattern in `src/settings-page/settings-app.js`)
  would be cleaner. Did not make that change here to keep the PR scope
  tight to the build mechanics.

## Notes for the maintainer

- The `superdav-ai-agent` plugin slug has not been submitted to WP.org yet
  (per `docs/wordpress-org-submission.md`). Once submitted/approved, the SVN
  URL and `--svn-dir` default in `bin/deploy-wporg.sh` may need to change if
  the review team assigns a different slug.
