### PR TITLE
fix(security): tighten permission_callback on block-discovery + client stub abilities

### DIFF
--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -113,7 +113,9 @@ class BlockAbilities {
 					],
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_list_block_types' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => function () {
+					return current_user_can( 'edit_posts' );
+				},
 			]
 		);
 
@@ -155,7 +157,9 @@ class BlockAbilities {
 					],
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_get_block_type' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => function () {
+					return current_user_can( 'edit_posts' );
+				},
 			]
 		);
 

--- a/includes/Core/ClientAbilityRouter.php
+++ b/includes/Core/ClientAbilityRouter.php
@@ -114,15 +114,18 @@ final class ClientAbilityRouter {
 			wp_register_ability(
 				$name,
 				array(
-					'label'        => (string) ( $descriptor['label'] ?? $name ),
-					'description'  => (string) ( $descriptor['description'] ?? '' ),
-					'category'     => 'sd-ai-agent-js',
-					'callback'     => static function ( array $args ): array {
+					'label'               => (string) ( $descriptor['label'] ?? $name ),
+					'description'         => (string) ( $descriptor['description'] ?? '' ),
+					'category'            => 'sd-ai-agent-js',
+					'callback'            => static function ( array $args ): array {
 						// No-op: client-side abilities are never executed server-side.
 						return array( 'error' => 'Client-side ability cannot be executed server-side.' );
 					},
-					'input_schema' => $descriptor['input_schema'] ?? array(),
-					'annotations'  => array(
+					// Client-side stubs are never meant to execute server-side, so deny
+					// any server-side execution attempt at the permission layer.
+					'permission_callback' => '__return_false',
+					'input_schema'        => $descriptor['input_schema'] ?? array(),
+					'annotations'         => array(
 						'readonly' => (bool) ( $descriptor['annotations']['readonly'] ?? true ),
 					),
 				)


### PR DESCRIPTION
## Summary

WordPress.org plugin-check flagged abilities registered with `permission_callback => '__return_true'` that expose editor-oriented data publicly. This PR addresses the **two genuine issues** (`list-block-types`, `get-block-type`) plus one related missing-permission case in the client-ability stub registrar.

## Changes

- **`includes/Abilities/BlockAbilities.php`**
  - `sd-ai-agent/list-block-types`: was `__return_true` → now `current_user_can( 'edit_posts' )`. The block registry is editor metadata, not public site content.
  - `sd-ai-agent/get-block-type`: was `__return_true` → now `current_user_can( 'edit_posts' )`. Exposes attribute schemas, supports flags, styles, variations, example markup — all editor-oriented.
- **`includes/Core/ClientAbilityRouter.php`**
  - Server-side stubs for client-side (JS) abilities now register with `permission_callback => '__return_false'`. The callback is a no-op error response by design, so denying execution at the permission layer is correct (and silences the wp.org scanner).

## Why these (and not all 42 reported lines)

The original report listed 42 incidences but most are **false positives from the wp.org scanner**: it cannot follow the `ability_class => SomeAbility::class` indirection and assumes no permission_callback is set. In reality those abilities (e.g. `GetOptionAbility`, `UpdateOptionAbility`, `GetThemesAbility`, `UpdatePluginAbility`, `ScanThemeHooksAbility`, `ListModifiedPluginsAbility`) all implement `protected function permission_callback( $input ): bool` on `AbstractAbility` (verified via `rg -n 'permission_callback' includes/Abilities/`).

The only registrations that genuinely lacked a check were the two `__return_true` entries above, plus the `ClientAbilityRouter` stub which was missing the key entirely.

## Verification

- `composer phpcs -- includes/Abilities/BlockAbilities.php includes/Core/ClientAbilityRouter.php` → clean.
- `composer phpstan` → no errors.
- Capability chosen (`edit_posts`) matches the rest of `BlockAbilities.php` (`list-block-patterns`, `list-block-templates`, `parse-block-content`, `validate-block-content`, `create-block-content` all use `edit_posts`).

## Out of scope

- No legacy ability-name renames or `sd-ai-agent` → `superdav-ai-agent` refactors (would violate canonical-naming rules in `AGENTS.md`).
- The 40 false-positive flags from the wp.org tool are not actionable in code; if WP.org reviewers ask, the response is "ability_class hides permission_callback from static scanners — see `AbstractAbility::__construct` line 83 which wires the protected method into the registration array."

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.15 plugin for [OpenCode](https://opencode.ai) v1.14.41 with claude-sonnet-4-6 spent 17h 51m and 40 tokens on this as a headless worker.
