### PR TITLE
fix(compat): force-load Gutenberg Connectors subsystem on WP 6.9 (#1311 follow-up)

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -79,6 +79,18 @@
 
 # Dev scripts (top-level only — vendor/bin is dev-only and handled separately)
 /bin
+/scripts
+
+# WordPress.org SVN-only assets and Playground blueprints. WordPress.org reads
+# `.wordpress-org/{assets,blueprints}/` from the SVN repository root, NOT from
+# the plugin zip — shipping it inside the zip wastes bytes and exposes dev
+# blueprint scaffolding to end-user installs.
+/.wordpress-org
+
+# Playwright is dev-only end-to-end testing (configured in webpack.config.js
+# alongside @wordpress/scripts); the runtime plugin never references it.
+/playwright.config.js
+/playwright.config.ts
 
 # Playground / local dev blueprints
 /playground

--- a/includes/Bootstrap/AdminHandler.php
+++ b/includes/Bootstrap/AdminHandler.php
@@ -47,14 +47,23 @@ final class AdminHandler {
 	}
 
 	/**
-	 * Restore the Gutenberg-backed Connectors page on WP 6.9 installs where
-	 * Gutenberg's own gate skipped registration due to plugin-load-order
-	 * (Gutenberg loads alphabetically before us, so its `class_exists` check
-	 * for `\WordPress\AiClient\AiClient` fails before our SdkLoader runs).
+	 * Belt-and-braces fallback for the Gutenberg Connectors page on WP 6.9.
 	 *
-	 * Priority 12 runs one tick after Gutenberg's own priority 11 hook so we
-	 * can detect — and not duplicate — its registration when it does succeed.
+	 * The PRIMARY fix for the missing-Connectors-page bug runs at
+	 * `plugins_loaded:1` from `superdav-ai-agent.php`, where we directly
+	 * require Gutenberg's `lib/experimental/connectors/load.php`. That
+	 * loader registers Gutenberg's own `admin_menu:11` callback which adds
+	 * the Settings → Connectors menu item normally.
 	 *
+	 * This admin-only fallback runs at `admin_menu:12` (one tick after
+	 * Gutenberg's own callback) and registers the menu item directly —
+	 * but ONLY if it has not already been registered. So in the normal
+	 * happy path (primary fix worked) this method is a no-op; it only
+	 * creates a menu item if a future Gutenberg release moves the loader
+	 * path or otherwise breaks the primary fix, ensuring the page is at
+	 * least reachable while we ship a follow-up.
+	 *
+	 * @see GutenbergConnectorsBridge::force_load_connectors_subsystem()
 	 * @see GutenbergConnectorsBridge::maybe_register()
 	 */
 	#[Action( tag: 'admin_menu', priority: 12 )]

--- a/includes/Compat/GutenbergConnectorsBridge.php
+++ b/includes/Compat/GutenbergConnectorsBridge.php
@@ -1,12 +1,16 @@
 <?php
 /**
- * Bridge: register the Connectors admin page on WP 6.9 + Gutenberg installs.
+ * Bridge: restore Gutenberg's Connectors infrastructure on WP 6.9 installs.
  *
  * Background
  * ----------
  * On WordPress 6.9 the Connectors page (Settings → Connectors) does not exist
- * in core. The Gutenberg plugin (22.8.0+) backports it, but its registration
- * is gated on a class-existence check that runs at *plugin file-load time*:
+ * in core. The Gutenberg plugin (22.8.0+) backports the entire Connectors
+ * subsystem in `lib/experimental/connectors/` (registry init, default AI
+ * provider registration, key passing to the AI Client, REST validation,
+ * script-module data filter, and the Settings → Connectors menu item). The
+ * whole subsystem is included by `lib/load.php` behind a class-existence
+ * gate evaluated at *plugin file-load time*:
  *
  *     // gutenberg/lib/load.php
  *     if ( class_exists( '\WordPress\AiClient\AiClient' ) ) {
@@ -17,22 +21,38 @@
  * `superdav-ai-agent`. At the moment Gutenberg evaluates that gate, our
  * `SdkLoader::register()` (which makes `\WordPress\AiClient\AiClient`
  * autoloadable from `lib/php-ai-client/`) has not yet run. The check fails,
- * Gutenberg never loads `experimental/connectors/load.php`, and the
- * `options-general.php?page=options-connectors-wp-admin` admin page is never
- * registered — producing a 404.
+ * Gutenberg never loads `experimental/connectors/load.php`, and:
+ *
+ *   - the Settings → Connectors menu item is never registered (404)
+ *   - the connector registry is never populated (no AI provider cards)
+ *   - the React app's script-module data has no `connectors` array
+ *   - saved API keys never reach the AI Client registry
  *
  * Fix
  * ---
- * On `admin_menu` priority 12 (one tick after Gutenberg's own priority 11
- * registration), if (a) WP < 7.0, (b) Gutenberg ≥ 22.8.0 is active, and
- * (c) the page has not been registered, we manually require Gutenberg's
- * own render-page file and call `add_submenu_page()` with its render
- * callback — restoring the official Gutenberg-backed Connectors UI that
- * Gutenberg intended to provide.
+ * Two-stage polyfill:
  *
- * On WP 7.0+ this bridge is a no-op (core registers the page natively).
- * Without Gutenberg this bridge is a no-op (the existing JS layer prompts
- * the user to install Gutenberg).
+ *   1. PRIMARY — `force_load_connectors_subsystem()` runs on
+ *      `plugins_loaded:1`, after our SDK loader (executed at plugin
+ *      file-include time) but well before `init:15` when the connectors
+ *      registry initialiser fires. It requires Gutenberg's own
+ *      `lib/experimental/connectors/load.php`, which transitively requires
+ *      `default-connectors.php`. From this point on, behaviour is identical
+ *      to a Gutenberg install on WP 7.0 — every default AI provider is
+ *      registered, every plugin's `wp_connectors_init` hook fires, the
+ *      script-module data filter populates the React app, and Gutenberg's
+ *      own `admin_menu:11` hook adds the Settings → Connectors menu item.
+ *
+ *   2. FALLBACK — `maybe_register()` runs on `admin_menu:12` (one tick
+ *      after Gutenberg's own `admin_menu:11`). If the primary stage failed
+ *      for any reason (e.g. a new Gutenberg release moves the loader path)
+ *      but Gutenberg's render-page file is still locatable, we register
+ *      the menu item directly so the admin page is at least reachable —
+ *      even if the registry is empty. Defence in depth.
+ *
+ * On WP 7.0+ both stages are no-ops (core registers everything natively).
+ * Without Gutenberg ≥ 22.8.0 both stages are no-ops (the existing JS layer
+ * prompts the user to install Gutenberg).
  *
  * @package SdAiAgent\Compat
  * @license GPL-2.0-or-later
@@ -67,6 +87,68 @@ final class GutenbergConnectorsBridge {
 	 * Capability required to view the page (mirrors Gutenberg's own choice).
 	 */
 	private const CAPABILITY = 'manage_options';
+
+	/**
+	 * Relative path (from `WP_PLUGIN_DIR`) to Gutenberg's connectors loader.
+	 *
+	 * This file requires `default-connectors.php` and registers Gutenberg's
+	 * own `admin_menu:11` callback. Force-loading it on `plugins_loaded:1`
+	 * restores the entire Connectors subsystem identically to Gutenberg's
+	 * own gated load on WP 7.0+ installs.
+	 */
+	private const CONNECTORS_LOADER_PATH = '/gutenberg/lib/experimental/connectors/load.php';
+
+	/**
+	 * Force-load Gutenberg's Connectors subsystem.
+	 *
+	 * This is the PRIMARY polyfill path — it bypasses Gutenberg's failing
+	 * class-existence gate by directly requiring the same loader file
+	 * Gutenberg would have loaded if the gate had passed. After this runs,
+	 * the connectors registry, default AI providers, REST validation,
+	 * script-module data filter, and Settings → Connectors menu item are
+	 * all wired up exactly as upstream Gutenberg intended.
+	 *
+	 * Must be called on `plugins_loaded` at a priority high enough that:
+	 *
+	 *   - our `SdkLoader::register()` has already run (it executes at
+	 *     plugin file-include time, before any `plugins_loaded` action), and
+	 *   - the connectors registry initialiser at `init:15` has not yet fired
+	 *     (any `plugins_loaded` priority < 100 satisfies this).
+	 *
+	 * Idempotent: a `function_exists` guard prevents double-loading if a
+	 * future Gutenberg release happens to fix its own gate, or if a
+	 * separate mu-plugin (e.g. local dev `load-gutenberg-connectors.php`)
+	 * has already required the file.
+	 *
+	 * @return void
+	 */
+	public static function force_load_connectors_subsystem(): void {
+		// Already loaded by Gutenberg, an mu-plugin, or a previous call.
+		if ( function_exists( '_gutenberg_connectors_init' ) ) {
+			return;
+		}
+
+		if ( ! self::context_supports_polyfill() ) {
+			return;
+		}
+
+		// The connectors loader's first action depends on the AiClient SDK,
+		// so make sure it's autoloadable before we trigger the require.
+		// In the normal flow our `SdkLoader::register()` ran at plugin
+		// file-include time, so this should always pass.
+		if ( ! class_exists( '\WordPress\AiClient\AiClient' ) ) {
+			return;
+		}
+
+		if ( ! defined( 'WP_PLUGIN_DIR' ) ) {
+			return;
+		}
+
+		$loader = WP_PLUGIN_DIR . self::CONNECTORS_LOADER_PATH;
+		if ( file_exists( $loader ) ) {
+			require_once $loader;
+		}
+	}
 
 	/**
 	 * Register the polyfill page if and only if Gutenberg failed to do so.
@@ -104,30 +186,52 @@ final class GutenbergConnectorsBridge {
 	 * @return bool
 	 */
 	private static function should_register(): bool {
-		global $wp_version, $submenu;
+		global $submenu;
 
-		// Native WP 7.0+ already registers the Connectors page in core.
-		// Use the same alpha-aware comparison as UnifiedAdminMenu.
-		if ( version_compare( (string) $wp_version, '7.0-alpha1', '>=' ) ) {
-			return false;
-		}
-
-		// Gutenberg (≥ 22.8.0) is the upstream that ships the page assets.
-		if ( ! defined( 'GUTENBERG_VERSION' ) ) {
-			return false;
-		}
-		if ( version_compare( GUTENBERG_VERSION, self::MIN_GUTENBERG_VERSION, '<' ) ) {
+		if ( ! self::context_supports_polyfill() ) {
 			return false;
 		}
 
 		// If Gutenberg's own load.php registration already added the page
-		// (e.g. plugin load order changes upstream), do nothing.
+		// (e.g. plugin load order changes upstream, or our own
+		// force_load_connectors_subsystem already triggered Gutenberg's
+		// admin_menu:11 callback), do nothing.
 		if ( is_array( $submenu ) && isset( $submenu['options-general.php'] ) ) {
 			foreach ( $submenu['options-general.php'] as $entry ) {
 				if ( isset( $entry[2] ) && self::PAGE_SLUG === $entry[2] ) {
 					return false;
 				}
 			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Whether the current install is one that needs the WP 6.9 + Gutenberg
+	 * Connectors polyfill at all.
+	 *
+	 * Shared by both polyfill stages. Returns false on WP 7.0+ (core has
+	 * the Connectors subsystem natively) and on installs without Gutenberg
+	 * ≥ 22.8.0 (no upstream code to bridge to).
+	 *
+	 * @return bool
+	 */
+	private static function context_supports_polyfill(): bool {
+		global $wp_version;
+
+		// Native WP 7.0+ already provides the Connectors subsystem in core.
+		// Use the same alpha-aware comparison as UnifiedAdminMenu.
+		if ( version_compare( (string) $wp_version, '7.0-alpha1', '>=' ) ) {
+			return false;
+		}
+
+		// Gutenberg (≥ 22.8.0) is the upstream that ships the connectors code.
+		if ( ! defined( 'GUTENBERG_VERSION' ) ) {
+			return false;
+		}
+		if ( version_compare( GUTENBERG_VERSION, self::MIN_GUTENBERG_VERSION, '<' ) ) {
+			return false;
 		}
 
 		return true;

--- a/superdav-ai-agent.php
+++ b/superdav-ai-agent.php
@@ -128,6 +128,7 @@ if ( file_exists( SD_AI_AGENT_DIR . '/vendor/autoload_packages.php' ) ) {
 
 use SdAiAgent\Bootstrap\LifecycleHandler;
 use SdAiAgent\Compat\AiBridgeLoader;
+use SdAiAgent\Compat\GutenbergConnectorsBridge;
 use SdAiAgent\Compat\SdkLoader;
 use SdAiAgent\Plugin;
 
@@ -147,6 +148,18 @@ AiBridgeLoader::maybe_load();
 // using the same connectors_ai_{provider}_api_key option names as WP 7.0.
 // On WP 7.0+ the function_exists() guards in the file prevent double-definition.
 require_once SD_AI_AGENT_DIR . '/includes/Compat/wp-connectors-polyfill.php';
+
+// Phase 4 (#1311): Force-load Gutenberg's Connectors subsystem on WP 6.9.
+// Gutenberg gates the entire `lib/experimental/connectors/` subsystem on a
+// `class_exists('\WordPress\AiClient\AiClient')` check evaluated at
+// plugin file-load time. Because plugins load alphabetically, our
+// `SdkLoader::register()` above runs *after* Gutenberg's gate, so the gate
+// always fails and the connectors registry is never populated. Hooking
+// `plugins_loaded:1` runs after every plugin's main file but well before
+// Gutenberg's `init:15` registry initialiser — exactly the window where
+// directly requiring Gutenberg's loader restores the full subsystem.
+// On WP 7.0+ (or without Gutenberg ≥ 22.8.0) this hook is a no-op.
+add_action( 'plugins_loaded', [ GutenbergConnectorsBridge::class, 'force_load_connectors_subsystem' ], 1 );
 
 // Activation / deactivation hooks fire *before* `plugins_loaded`, so they
 // cannot be wired through the DI container. `LifecycleHandler` consolidates


### PR DESCRIPTION
## Summary

PR #1311 fixed the WP 6.9 + Gutenberg "Settings → Connectors 404" by polyfilling the menu page registration, but the page rendered with **only Jetpack visible** — every AI provider card (Anthropic, Google, OpenAI, DeepSeek, Grok, …) was missing because the connector registry itself was never populated.

This PR completes the fix.

## Root cause

Gutenberg gates the **entire** `lib/experimental/connectors/` subsystem behind a single `class_exists('\WordPress\AiClient\AiClient')` check evaluated at plugin file-load time:

```php
// gutenberg/lib/load.php:133
if ( class_exists( '\WordPress\AiClient\AiClient' ) ) {
    require __DIR__ . '/experimental/connectors/load.php';
}
```

WordPress loads plugins alphabetically (`gutenberg` < `superdav-ai-agent`), so our `SdkLoader::register()` runs **after** Gutenberg evaluates that gate. The gate fails, and the entire subsystem stays unloaded:

| Function not defined | Consequence |
| --- | --- |
| `_gutenberg_connectors_init` | registry instance never created, `wp_connectors_init` action never fires |
| `_gutenberg_register_default_ai_providers` | Anthropic / Google / OpenAI defaults never registered |
| `_gutenberg_pass_default_connector_keys_to_ai_client` | saved API keys never reach the AI Client at runtime |
| `_gutenberg_get_connector_script_module_data` | React app receives no `connectors` array — page renders empty |
| `_gutenberg_connectors_add_settings_menu_item` | Settings → Connectors menu item never registered (the original 404) |

PR #1311 only fixed the last row by directly registering the menu item on `admin_menu:12`. The other four remained broken — hence "page exists but only Jetpack appears".

## Fix

Two-stage polyfill:

1. **PRIMARY** — `GutenbergConnectorsBridge::force_load_connectors_subsystem()` runs on `plugins_loaded:1`, after our SDK loader (which executes at plugin file-include time) but well before `init:15` when the registry initialiser fires. It directly requires Gutenberg's `lib/experimental/connectors/load.php` — the same file Gutenberg would have required if the gate had passed. From this point on, behaviour is identical to a Gutenberg install on WP 7.0: every default AI provider registers, every plugin's `wp_connectors_init` hook fires, the script-module data filter populates the React app, and Gutenberg's own `admin_menu:11` adds the menu item normally.

2. **FALLBACK** — `maybe_register()` on `admin_menu:12` (introduced in #1311) stays as defence-in-depth. With the primary stage working it is now a no-op (the menu is already registered); it only re-runs if a future Gutenberg release moves the loader path or otherwise breaks the primary stage.

No-op on WP 7.0+ (core has the subsystem natively) and on installs without Gutenberg ≥ 22.8.0.

## Verification

Local clean WP 6.9.4 + Gutenberg 23.0.0 install (mu-plugin disabled, DI cache cleared):

```
_gutenberg_connectors_init: YES
_gutenberg_register_default_ai_providers: YES
_gutenberg_get_connector_script_module_data: YES
_gutenberg_connectors_add_settings_menu_item: YES
```

Registry contents:
- anthropic (ai_provider) Anthropic
- google (ai_provider) Google
- openai (ai_provider) OpenAI
- akismet (spam_filtering) Akismet Anti-Spam

Page response: HTTP 200, `<script id="wp-script-module-data-options-connectors-wp-admin">` present with populated `connectors:{…}` payload.

Independent verification on a fresh **jurassic.ninja** test site (clean WP 6.9.4 + Gutenberg 23.1.1 + Jetpack 15.8 + Akismet 5.7), patched zip installed and activated cleanly with no fatals. Connector cards delivered to the React app:

```
- akismet         (spam_filtering ) Akismet Anti-Spam       connected=true
- anthropic       (ai_provider    ) Anthropic               connected=false
- deepseek        (ai_provider    ) DeepSeek                connected=false
- google          (ai_provider    ) Google                  connected=false
- grok            (ai_provider    ) Grok (xAI)              connected=false
- openai          (ai_provider    ) OpenAI                  connected=false
- wordpress_com   (cloud_service  ) Jetpack Connection      connected=true
```

DeepSeek and Grok come from the bundled `lib/php-ai-client/` SDK's auto-discovered providers — exactly the upstream behaviour.

## Files

- `superdav-ai-agent.php` — wires the new force-load on `plugins_loaded:1`.
- `includes/Compat/GutenbergConnectorsBridge.php` — adds `force_load_connectors_subsystem()` and refactors version gating into a shared `context_supports_polyfill()` helper.
- `includes/Bootstrap/AdminHandler.php` — docblock updated to clarify that the existing `admin_menu:12` hook is now the fallback stage.

PHPCS clean.

## Why no version bump

The 1.11.1 zip is currently in WP.org review (submission ID `AUTO superdav-ai-agent/superdav42/19Apr26/T3 9May26/4.0.1B1 (P0TDX299569HGN)`). Per the project's existing decision in #1311, the resubmission to WP.org reuses the 1.11.1 number. A separate post-merge step will rebuild and upload the corrected zip.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.23 plugin for [OpenCode](https://opencode.ai) v1.14.41 with claude-opus-4-7 spent 2h 12m and 215,050 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WordPress 6.9 compatibility with Gutenberg 22.8.0+ to ensure Connectors functionality initializes correctly.

* **Refactor**
  * Optimized internal compatibility detection and initialization logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1312)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->