### PR TITLE
fix(connectors): bust providers cache on first-time key save

### DIFF
--- a/includes/Bootstrap/AdminHandler.php
+++ b/includes/Bootstrap/AdminHandler.php
@@ -89,21 +89,35 @@ final class AdminHandler {
 	}
 
 	/**
-	 * Register update_option hooks for WP Connectors API option keys.
+	 * Register option-write hooks for WP Connectors API option keys.
 	 *
 	 * The native WP 7.0 Connectors page (options-connectors.php) writes
-	 * connectors_ai_{provider}_api_key options directly.  Hooking into
-	 * update_option_{key} ensures the site-wide providers transient cache is
-	 * invalidated whenever an external connector change is saved, so admins
-	 * see fresh provider data on the next GET /providers request.
+	 * connectors_ai_{provider}_api_key options directly.  Hooking into both
+	 * update_option_{key} and add_option_{key} ensures the site-wide providers
+	 * transient cache is invalidated whenever an external connector change is
+	 * saved, so admins see fresh provider data on the next GET /providers
+	 * request.
+	 *
+	 * The add_option_{key} hook is required because WordPress fires it (NOT
+	 * update_option_{key}) the very first time a connector key is saved on a
+	 * fresh install.  Without it, first-time users had to wait up to 5 minutes
+	 * for the providers transient to expire before the UI reflected their
+	 * newly added credentials.
 	 *
 	 * accepted_args=0 is intentional: flush_providers_cache() takes no
-	 * parameters, and update_option_{key} passes 3 args we do not need.
+	 * parameters, and update_option_{key} / add_option_{key} pass args we do
+	 * not need.
 	 */
 	private function register_connector_cache_hooks(): void {
 		foreach ( ConnectorsController::PROVIDERS as $meta ) {
 			add_action(
 				'update_option_' . $meta['option_key'],
+				[ SettingsController::class, 'flush_providers_cache' ],
+				10,
+				0
+			);
+			add_action(
+				'add_option_' . $meta['option_key'],
 				[ SettingsController::class, 'flush_providers_cache' ],
 				10,
 				0


### PR DESCRIPTION
## Summary

Hook `add_option_connectors_ai_{provider}_api_key` alongside the existing `update_option_*` hooks so the providers transient cache is busted on **first-time** key saves, not just subsequent updates.

## Why

WordPress fires `add_option_{key}` (NOT `update_option_{key}`) the very first time an option is written. The existing cache-invalidation logic in `AdminHandler::register_connector_cache_hooks()` only listened for `update_option_*`, so on a fresh install:

1. User saves their first Anthropic/OpenAI key via Connectors → `add_option_connectors_ai_anthropic_api_key` fires → no flush hook listening → providers transient stays empty.
2. User opens the plugin admin page → sees "Configure a provider" gate → still empty for up to **5 minutes** (transient TTL).

Subsequent edits to the same key fire `update_option_*` and DO flush correctly, so this only bites on initial setup. Symptom matches reports of "no providers configured" immediately after Connectors save on fresh installs.

## Change

`includes/Bootstrap/AdminHandler.php` — duplicate the existing `add_action()` loop body to also register on `add_option_{key}`. Mechanical change, mirrors the existing pattern exactly (priority 10, `accepted_args=0`).

## Verification

- `vendor/bin/phpcs includes/Bootstrap/AdminHandler.php` — clean (0 errors, 0 warnings).
- `vendor/bin/phpstan analyse includes/Bootstrap/AdminHandler.php` — `[OK] No errors`.
- Manual reproduction on JN site (`neat-web-saxophone`) confirmed the existing `update_option_*` hooks DO bust the cache (transient version bumps), and confirmed `add_option_*` was the missing first-save trigger.

## Files

- `includes/Bootstrap/AdminHandler.php` — added `add_option_*` hook registration in the existing foreach loop; expanded docblock.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.25 plugin for [OpenCode](https://opencode.ai) v1.14.41 with claude-opus-4-7 spent 6h 34m and 274,834 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where connector API key cache wasn't properly cleared when first added to a fresh installation, ensuring connector settings are correctly applied immediately.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1314)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->