### PR TITLE
fix(agents): align built-in agent tier_1_tools with their system prompts (#1295)

### DIFF
--- a/includes/Compat/ai-client/class-wp-ai-client-ability-function-resolver.php
+++ b/includes/Compat/ai-client/class-wp-ai-client-ability-function-resolver.php
@@ -123,6 +123,12 @@ class WP_AI_Client_Ability_Function_Resolver {
 		$ability_name = self::function_name_to_ability_name( $function_name );
 
 		if ( ! isset( $this->allowed_abilities[ $ability_name ] ) ) {
+			// Include the actual allowed list in the response so the model
+			// can self-correct instead of looping with ability-search and
+			// burning iterations against an unknown surface. See #1295.
+			$allowed_list = array_keys( $this->allowed_abilities );
+			sort( $allowed_list );
+
 			return new FunctionResponse(
 				$function_id,
 				$function_name,
@@ -130,6 +136,10 @@ class WP_AI_Client_Ability_Function_Resolver {
 					/* translators: %s: ability name */
 					'error' => sprintf( __( 'Ability "%s" was not specified in the allowed abilities list.', 'superdav-ai-agent' ), $ability_name ),
 					'code'  => 'ability_not_allowed',
+					'data'  => array(
+						'allowed_abilities' => $allowed_list,
+						'hint'              => __( 'Pick a different ability from allowed_abilities, or call sd-ai-agent/ability-search to discover others. Do not retry the same name.', 'superdav-ai-agent' ),
+					),
 				)
 			);
 		}

--- a/includes/Models/Agent.php
+++ b/includes/Models/Agent.php
@@ -457,6 +457,14 @@ class Agent {
 	 * The meta-tools (ability-search/ability-call) are always appended by
 	 * ToolDiscovery regardless, so they don't need to be listed here.
 	 *
+	 * The post-management abilities (create-post / update-post / list-posts)
+	 * and update-global-styles are intentionally part of the shared base:
+	 * the General agent's system prompt and SystemInstructionBuilder both
+	 * direct the model to chain create → update on the same page and to
+	 * apply theme colors via update-global-styles. Omitting them here causes
+	 * the resolver to reject the calls with `ability_not_allowed`, the model
+	 * loops, and `max_iterations` is depleted with an empty result. See #1295.
+	 *
 	 * @return list<string>
 	 */
 	public static function get_general_tier_1_tools(): array {
@@ -469,6 +477,9 @@ class Agent {
 			'sd-ai-agent/knowledge-search',
 			'wp-cli/execute',
 			'sd-ai-agent/create-post',
+			'sd-ai-agent/update-post',
+			'sd-ai-agent/list-posts',
+			'sd-ai-agent/update-global-styles',
 		];
 	}
 
@@ -611,7 +622,7 @@ class Agent {
 				. "- Include `categories` and `tags` arrays for blog posts.\n"
 				. "- Include `excerpt` for SEO meta descriptions.\n"
 				. "- To add a featured image: first call `sd-ai-agent/stock-image` or `sd-ai-agent/generate-image`, then pass the returned attachment_id as `featured_image_id`.\n"
-				. "- For WooCommerce products, use `sd-ai-agent/woo-create-product` instead.\n\n"
+				. "- For WooCommerce products, search for a `woo-create-product` ability via `sd-ai-agent/ability-search` (only available when WooCommerce is active).\n\n"
 				. "## Tips\n"
 				. "- Chain operations: create content first, then configure settings.\n"
 				. "- After completing all steps, summarize what was done with links to the created resources.\n\n"
@@ -625,7 +636,22 @@ class Agent {
 				. '- Always provide a helpful text response explaining what you tried before calling the ability.',
 			'greeting'      => __( 'What can I help you with?', 'superdav-ai-agent' ),
 			'avatar_icon'   => 'dashicons-admin-generic',
-			'tier_1_tools'  => $base_tools,
+			'tier_1_tools'  => array_values(
+				array_unique(
+					array_merge(
+						$base_tools,
+						[
+							// Mentioned in the "Content Creation" and
+							// "Reporting Inability" sections of this prompt;
+							// must be in tier_1 so the resolver does not
+							// reject them with `ability_not_allowed`. See #1295.
+							'sd-ai-agent/stock-image',
+							'sd-ai-agent/generate-image',
+							'sd-ai-agent/report-inability',
+						]
+					)
+				)
+			),
 			'suggestions'   => [
 				[
 					'title'       => __( 'Site health check', 'superdav-ai-agent' ),
@@ -698,6 +724,7 @@ class Agent {
 							'sd-ai-agent/list-posts',
 							'sd-ai-agent/update-post',
 							'sd-ai-agent/stock-image',
+							'sd-ai-agent/generate-image',
 						]
 					)
 				)
@@ -773,6 +800,7 @@ class Agent {
 							'sd-ai-agent/list-posts',
 							'sd-ai-agent/update-post',
 							'sd-ai-agent/list-options',
+							'sd-ai-agent/update-option',
 							'sd-ai-agent/get-plugins',
 						]
 					)
@@ -849,7 +877,9 @@ class Agent {
 						$base_tools,
 						[
 							'sd-ai-agent/woo-create-product',
+							'sd-ai-agent/woo-update-product',
 							'sd-ai-agent/woo-get-products',
+							'sd-ai-agent/woo-get-orders',
 							'sd-ai-agent/stock-image',
 							'sd-ai-agent/get-plugins',
 						]

--- a/tests/SdAiAgent/Models/AgentTest.php
+++ b/tests/SdAiAgent/Models/AgentTest.php
@@ -423,4 +423,69 @@ class AgentTest extends WP_UnitTestCase {
 		$this->assertNull( $arr['temperature'] );
 		$this->assertNull( $arr['max_iterations'] );
 	}
+
+	// ─── built-in definitions ───────────────────────────────────────────────
+
+	/**
+	 * General agent must include the post-iteration abilities its system
+	 * prompt directs the model to call.
+	 *
+	 * Regression test for #1295: General agent's prompt told the model to
+	 * iterate via update-post / update-global-styles, but those abilities
+	 * were absent from tier_1_tools. The resolver rejected the calls, the
+	 * model looped, max_iterations was depleted, and pages came out empty.
+	 */
+	public function test_general_tier_1_tools_includes_post_iteration_abilities(): void {
+		$tools = Agent::get_general_tier_1_tools();
+
+		$this->assertContains( 'sd-ai-agent/create-post', $tools );
+		$this->assertContains( 'sd-ai-agent/update-post', $tools );
+		$this->assertContains( 'sd-ai-agent/list-posts', $tools );
+		$this->assertContains( 'sd-ai-agent/update-global-styles', $tools );
+	}
+
+	/**
+	 * Every ability mentioned in a built-in agent's system prompt must be
+	 * present in that agent's tier_1_tools (or in the meta-tools that the
+	 * resolver always exposes). Catches drift between prompt and tool surface
+	 * — see #1295.
+	 */
+	public function test_builtin_agent_prompts_only_reference_their_own_tools(): void {
+		$reflection = new \ReflectionClass( Agent::class );
+		$method     = $reflection->getMethod( 'get_builtin_definitions' );
+		$method->setAccessible( true );
+		$definitions = $method->invoke( null );
+
+		$this->assertIsArray( $definitions );
+
+		foreach ( $definitions as $def ) {
+			$slug          = $def['slug'];
+			$prompt        = $def['system_prompt'];
+			$tier_1        = $def['tier_1_tools'];
+
+			// Extract every ability mentioned in the prompt: matches
+			// `sd-ai-agent/<name>` inside backticks, with optional trailing
+			// punctuation. Excludes plain words like "sd-ai-agent" alone.
+			preg_match_all(
+				'#`(sd-ai-agent/[a-z0-9-]+)`#',
+				$prompt,
+				$matches
+			);
+
+			$mentioned = array_values( array_unique( $matches[1] ) );
+
+			foreach ( $mentioned as $ability ) {
+				$this->assertContains(
+					$ability,
+					$tier_1,
+					sprintf(
+						"Built-in agent '%s' system prompt references `%s` but it is not in tier_1_tools. "
+						. 'Either add it to tier_1_tools or stop telling the model to call it (see #1295).',
+						$slug,
+						$ability
+					)
+				);
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Adds the post-iteration abilities (`update-post`, `list-posts`) and `update-global-styles` to the General agent's `tier_1_tools`, plus `stock-image`/`generate-image`/`report-inability`. Without these, the General agent's own prompt and `SystemInstructionBuilder` direct the model to call abilities the resolver then rejects with `ability_not_allowed`. The model loops, `max_iterations` (50) is depleted, and the user gets an empty published page after ~6 min — the failure mode reported in #1295.
- Brings SEO (`update-option`) and E-commerce (`woo-update-product`, `woo-get-orders`) tier_1 surfaces in line with their prompts as well.
- Resolver now includes the actual `allowed_abilities` list and a self-correction hint in the `ability_not_allowed` `FunctionResponse`, so the model can pivot immediately instead of burning iterations on `ability-search`.
- Reworded the General prompt's WooCommerce mention to point at `ability-search` (since `woo-create-product` is conditional on WooCommerce being installed and may not be present in tier_1 for the General agent).
- Added a regression test in `AgentTest` that scans every built-in agent's `system_prompt` for `` `sd-ai-agent/*` `` mentions and asserts each is in that agent's `tier_1_tools`. This catches the original drift permanently.

## Verification

- `vendor/bin/phpcs` on changed files: clean.
- `vendor/bin/phpstan analyse` (full project): no new errors (baseline 2 pre-existing in `GutenbergConnectorsBridge.php`, untouched).
- `vendor/bin/phpunit tests/SdAiAgent/Models/AgentTest.php`: **OK (25 tests, 103 assertions)** — including 2 new regression tests.

## Files changed

- `includes/Models/Agent.php` — tier_1 surface fixes for General/Content Creator/SEO/E-commerce + General prompt rewording.
- `includes/Compat/ai-client/class-wp-ai-client-ability-function-resolver.php` — include `allowed_abilities` + `hint` in `ability_not_allowed` response.
- `tests/SdAiAgent/Models/AgentTest.php` — 2 new regression tests.

Resolves #1295

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.25 plugin for [OpenCode](https://opencode.ai) v1.14.41 with claude-sonnet-4-6 spent 1d 3h and 40 tokens on this as a headless worker.
