### PR TITLE
fix(plugin-check): suppress core-hook prefix warnings and harden DESCRIBE query (sd-ai-bgz)

### DIFF
--- a/includes/Benchmark/AssertionEngine.php
+++ b/includes/Benchmark/AssertionEngine.php
@@ -309,7 +309,12 @@ class AssertionEngine {
 	 * @return array{pass: bool, expected: string, actual: string}
 	 */
 	private static function assert_rest_endpoint_registered( string $method, string $path ): array {
-		// Force REST route registration.
+		// Force REST route registration. `rest_api_init` is a WordPress core
+		// hook (not a plugin-owned hook), so the prefix rule does not apply —
+		// we are intentionally re-firing core's own hook in benchmark context
+		// because rest_get_server() may be called before the normal request
+		// lifecycle would have triggered it.
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WP core hook, not a custom plugin hook.
 		do_action( 'rest_api_init' );
 
 		$server = rest_get_server();
@@ -357,6 +362,8 @@ class AssertionEngine {
 		array $expected_body_keys,
 		?int $as_user = null
 	): array {
+		// `rest_api_init` is a WP core hook — not a plugin hook needing a prefix.
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WP core hook, not a custom plugin hook.
 		do_action( 'rest_api_init' );
 
 		$request = new \WP_REST_Request( $method, $path );
@@ -455,7 +462,30 @@ class AssertionEngine {
 			$table = $wpdb->prefix . $table;
 		}
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// Defence in depth: DESCRIBE cannot use prepared placeholders for the
+		// table identifier, so validate the name is a plain MySQL identifier
+		// (alphanumerics + underscore) and that it actually exists in this
+		// database before interpolating it into the query. This eliminates
+		// any path from a benchmark assertion definition to arbitrary SQL.
+		if ( ! preg_match( '/^[A-Za-z0-9_]+$/', $table ) ) {
+			return array(
+				'pass'     => false,
+				'expected' => 'table name to contain only [A-Za-z0-9_]',
+				'actual'   => "rejected unsafe table name: {$table}",
+			);
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+		$exists = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+		if ( $exists !== $table ) {
+			return array(
+				'pass'     => false,
+				'expected' => "table {$table} exists with columns: " . implode( ', ', $columns ),
+				'actual'   => "table {$table} does not exist",
+			);
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- $table is validated against /^[A-Za-z0-9_]+$/ AND confirmed to exist via SHOW TABLES above; DESCRIBE does not accept prepared placeholders for identifiers.
 		$rows = (array) $wpdb->get_results( "DESCRIBE `{$table}`", ARRAY_A );
 
 		if ( empty( $rows ) ) {

--- a/includes/CLI/BenchmarkCommand.php
+++ b/includes/CLI/BenchmarkCommand.php
@@ -386,7 +386,9 @@ class BenchmarkCommand extends WP_CLI_Command {
 				return $log;
 			}
 
-			// Run assertions against live WordPress state.
+			// Run assertions against live WordPress state. `rest_api_init` is
+			// a WP core hook — not a plugin hook needing a prefix.
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- WP core hook, not a custom plugin hook.
 			do_action( 'rest_api_init' );
 			$assertion_ctx['tool_call_log'] = $log['tool_call_log'] ?? array();
 			$log['assertions']              = AssertionEngine::run( $question['assertions'], $assertion_ctx );

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -141,4 +141,39 @@
         </properties>
     </rule>
 
+    <!--
+    ════════════════════════════════════════════════════════════════════════════
+    Re-firing WordPress core hooks (rest_api_init, etc.) in benchmark/CLI code
+    ════════════════════════════════════════════════════════════════════════════
+
+    `rest_api_init` is a WordPress *core* hook. The PrefixAllGlobals rule is
+    designed to flag custom hooks invented by a plugin that aren't prefixed —
+    not core hooks the plugin re-fires. WPCS's built-in $allowed_core_hooks
+    list only includes `widget_title` and `add_meta_boxes` and is `protected`
+    (not extensible from XML across all PHPCS versions), so we scope the
+    exclusion to the specific files where re-firing is intentional and
+    necessary:
+
+      - includes/Benchmark/AssertionEngine.php  — assertions inspect
+        rest_get_server() before the normal request lifecycle has fired
+        rest_api_init, so we re-fire it manually.
+      - includes/CLI/BenchmarkCommand.php       — same, in CLI context.
+
+    Do NOT add new files here without a similar justification — prefer
+    prefixing custom hooks correctly. See PR #1316 for the original context.
+
+    Note: WP.org Plugin Check has its own mirror of this rule
+    (PluginCheck.CodeAnalysis.Hook.NonPrefixedHooknameFound) and Plugin
+    Check's DB rule (PluginCheck.Security.DirectDB.UnescapedDBParameter).
+    Those standards are NOT installed in our local PHPCS sniffer pool —
+    they only run server-side when WP.org runs Plugin Check on submission.
+    The inline `phpcs:ignore PluginCheck.*` comments at the relevant call
+    sites are what suppress those server-side warnings; the XML rules below
+    are what suppress the equivalent WPCS warning in our CI. Both layers
+    are needed because they are evaluated by different tools. -->
+    <rule ref="WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound">
+        <exclude-pattern>*/includes/Benchmark/AssertionEngine\.php</exclude-pattern>
+        <exclude-pattern>*/includes/CLI/BenchmarkCommand\.php</exclude-pattern>
+    </rule>
+
 </ruleset>


### PR DESCRIPTION
## Summary

Fixes four WP.org Plugin Check warnings blocking submission approval:

- `includes/Benchmark/AssertionEngine.php:313` — `do_action('rest_api_init')` flagged as `NonPrefixedHooknameFound`
- `includes/Benchmark/AssertionEngine.php:360` — same
- `includes/CLI/BenchmarkCommand.php:390` — same
- `includes/Benchmark/AssertionEngine.php:459` — `$wpdb->get_results("DESCRIBE \`{$table}\`")` flagged as `PluginCheck.Security.DirectDB.UnescapedDBParameter`

## Why these are fixes, not renames

`rest_api_init` is a **WordPress core hook**, not a plugin-owned hook. The `PrefixAllGlobals` rule applies to hooks the plugin invents, not hooks it re-fires from core. We intentionally re-fire `rest_api_init` in benchmark/CLI context so REST routes are registered before `rest_get_server()` is queried. The correct remediation per WPCS docs is an inline `phpcs:ignore` with a justification — done in all three sites.

## DESCRIBE query hardening

`DESCRIBE` does not accept prepared placeholders for table identifiers, so the previous `phpcs:ignore` was the only mitigation. This PR adds **defence in depth**:

1. Reject any `$table` that does not match `/^[A-Za-z0-9_]+$/`.
2. Confirm the table actually exists via a prepared `SHOW TABLES LIKE %s` before interpolating into `DESCRIBE`.
3. Updated `phpcs:ignore` now documents both guards as the suppression rationale (matches the established style in `includes/Core/Database.php`).

After this, even a maliciously crafted benchmark assertion definition cannot reach arbitrary SQL through this code path.

## Verification

```
$ vendor/bin/phpcs includes/Benchmark/AssertionEngine.php includes/CLI/BenchmarkCommand.php
.. 2 / 2 (100%)
```

PHPCS clean on both files. PluginCheck runs server-side at WP.org submission, but the suppression comment style matches the existing pattern used in `includes/Core/Database.php:648,651` and `includes/Abilities/DatabaseAbilities.php:126`.

## Naming guard compliance

No identifier renames. `sd-ai-agent` container ID, namespaces, REST routes, and CSS prefixes are untouched. Only docblock prose, ignore comments, and the new validator block were added.

Resolves sd-ai-bgz

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.25 plugin for [OpenCode](https://opencode.ai) v1.14.41 with claude-sonnet-4-6 spent 1d 3h and 40 tokens on this as a headless worker.
