### PR TITLE
fix(build): delete pre-existing zip before zip -qr to avoid stale-file leak

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -373,7 +373,17 @@ PYGUARD
 	fi
 	zip_path="${PLUGIN_DIR}/${zip_name}"
 
+	# Remove any pre-existing zip with the same name so `zip -qr` produces a
+	# fresh archive instead of UPDATING the old one. `zip` in update mode
+	# silently retains every file already in the archive even when it is no
+	# longer present in the source tree, which means stale paths added in
+	# earlier builds (e.g. before a new .distignore entry was added) leak
+	# into every subsequent zip until the file is manually deleted. This
+	# previously shipped /scripts, /playwright.config.js, and /.wordpress-org
+	# inside multiple WP.org submission attempts even after .distignore was
+	# updated to exclude them.
 	echo "==> [${variant}] Creating ${zip_name}..."
+	rm -f "$zip_path"
 	(cd "$build_dir" && zip -qr "$zip_path" superdav-ai-agent/)
 	echo "    Done."
 


### PR DESCRIPTION
## Summary

`bin/build.sh` was running `zip -qr` against any pre-existing zip with the target name. `zip` in update mode silently retains files already inside the archive even when they are no longer in the source tree. Every WP.org submission attempt to date has therefore shipped accumulated cruft from earlier builds.

## Concrete impact

`/scripts`, `/playwright.config.js`, and `/.wordpress-org` were added to `.distignore` in commit `4359aaf` (May 9). Verified just now: a fresh `bin/build.sh --target=wporg` build still produces a zip containing all three because the previous zip was being updated, not replaced. The rsync exclusion was working correctly all along — the stale entries just never got pruned from the archive.

This means the WP.org submission zip(s) sent for review have been carrying these dev-only artefacts even after the dedicated cleanup commit landed.

## Fix

Add `rm -f "$zip_path"` immediately before `zip -qr` so every build produces a from-scratch archive whose contents exactly match the post-rsync `build_dir`. Mechanical, 1-line change with explanatory comment block.

## Verification

End-to-end:

1. Pre-populated `superdav-ai-agent-1.11.1-wporg.zip` with sentinel files (`STALE.js`, `STALE.txt`) at `/scripts`, `/.wordpress-org`, and `/playwright.config.js`.
2. Ran `bin/build.sh --target=wporg`.
3. Confirmed the resulting zip contains **zero** STALE files and **zero** `/scripts`, `/playwright.config.js`, `/.wordpress-org` entries.

Commands:
```bash
bin/build.sh --target=wporg
unzip -l superdav-ai-agent-*-wporg.zip | grep -E "scripts/|playwright|wordpress-org"
# (no output = clean)
```

`shellcheck bin/build.sh` — clean.

## Files

- `bin/build.sh` — `rm -f "$zip_path"` before `zip -qr`, with comment explaining the update-vs-create gotcha.

## Recommendation

After merging, the next WP.org submission should be built from a clean state (`rm -f *.zip && bin/build.sh --target=wporg`) and re-uploaded — the previous submitted zip likely still contained the stripped paths.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.25 plugin for [OpenCode](https://opencode.ai) v1.14.41 with claude-opus-4-7 spent 6h 34m and 274,834 tokens on this with the user in an interactive session.
