### PR TITLE
fix: use superdav-ai-agent i18n domain in chat-redesign ErrorBoundary labels (#1321)

### DIFF
--- a/src/components/chat-redesign/index.js
+++ b/src/components/chat-redesign/index.js
@@ -120,7 +120,7 @@ export default function ChatRedesign() {
 					sidebarCollapsed ? ' is-sidebar-collapsed' : ''
 				}` }
 			>
-				<ErrorBoundary label={ __( 'Sidebar', 'sd-ai-agent' ) }>
+				<ErrorBoundary label={ __( 'Sidebar', 'superdav-ai-agent' ) }>
 					<Sidebar
 						collapsed={ sidebarCollapsed }
 						onToggleCollapse={ toggleSidebar }
@@ -136,7 +136,7 @@ export default function ChatRedesign() {
 					/>
 
 					<ErrorBoundary
-						label={ __( 'Chat banners', 'sd-ai-agent' ) }
+						label={ __( 'Chat banners', 'superdav-ai-agent' ) }
 					>
 						<ChatBanners />
 					</ErrorBoundary>
@@ -150,13 +150,13 @@ export default function ChatRedesign() {
 					) }
 
 					<ErrorBoundary
-						label={ __( 'Message list', 'sd-ai-agent' ) }
+						label={ __( 'Message list', 'superdav-ai-agent' ) }
 					>
 						<MessageList />
 					</ErrorBoundary>
 
 					<ErrorBoundary
-						label={ __( 'Message input', 'sd-ai-agent' ) }
+						label={ __( 'Message input', 'superdav-ai-agent' ) }
 					>
 						<InputArea />
 					</ErrorBoundary>


### PR DESCRIPTION
## Summary

- Fixes 4 `__()` calls in `src/components/chat-redesign/index.js` that incorrectly used `'sd-ai-agent'` as the i18n text domain instead of the required `'superdav-ai-agent'`
- Affected labels: `'Sidebar'`, `'Chat banners'`, `'Message list'`, `'Message input'` (all wrapped in `<ErrorBoundary>`)
- Change is purely mechanical string substitution; no logic or indentation altered

## Verification

Confirmed with `git diff`: only the 4 text domain strings changed. The REST API path on line 98 (`/sd-ai-agent/v1/...`) is intentionally unchanged — that is the REST namespace, not a text domain.

Resolves #1321

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.34 plugin for [OpenCode](https://opencode.ai) v1.14.48 with claude-sonnet-4-6 spent 2m and 9,134 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal localization configuration for chat component error boundaries.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1327)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->