### PR TITLE
GH#1322: fix: use canonical chat banner CSS prefix

### DIFF
--- a/src/components/__tests__/ChatBanners.test.js
+++ b/src/components/__tests__/ChatBanners.test.js
@@ -106,7 +106,7 @@ describe( 'ChatBanners', () => {
 				},
 			],
 		} );
-		expect( html ).toContain( 'sdaa-chat-banner--info' );
+		expect( html ).toContain( 'sd-ai-agent-chat-banner--info' );
 		expect( html ).toContain( 'Heads up!' );
 		expect( html ).not.toContain( '<a' );
 	} );
@@ -123,7 +123,7 @@ describe( 'ChatBanners', () => {
 				},
 			],
 		} );
-		expect( html ).toContain( 'sdaa-chat-banner--warning' );
+		expect( html ).toContain( 'sd-ai-agent-chat-banner--warning' );
 		expect( html ).toContain( 'Approaching limit' );
 		expect( html ).toContain( 'href="https://example.test/upgrade"' );
 		expect( html ).toContain( 'target="_blank"' );
@@ -141,7 +141,7 @@ describe( 'ChatBanners', () => {
 				},
 			],
 		} );
-		expect( html ).toContain( 'sdaa-chat-banner--error' );
+		expect( html ).toContain( 'sd-ai-agent-chat-banner--error' );
 		expect( html ).toContain( 'role="alert"' );
 	} );
 
@@ -182,7 +182,7 @@ describe( 'ChatBanners', () => {
 		} );
 		expect( html ).toContain( 'Visible' );
 		// No second banner element rendered.
-		expect( html.match( /sdaa-chat-banner--/g ) ).toHaveLength( 1 );
+		expect( html.match( /sd-ai-agent-chat-banner--/g ) ).toHaveLength( 1 );
 	} );
 
 	test( 'drops banners with an unknown severity', async () => {

--- a/src/components/chat-banners.js
+++ b/src/components/chat-banners.js
@@ -54,12 +54,12 @@ const REFRESH_MS = 5 * 60 * 1000;
  */
 function severityClass( severity ) {
 	if ( 'error' === severity ) {
-		return 'sdaa-chat-banner--error';
+		return 'sd-ai-agent-chat-banner--error';
 	}
 	if ( 'warning' === severity ) {
-		return 'sdaa-chat-banner--warning';
+		return 'sd-ai-agent-chat-banner--warning';
 	}
-	return 'sdaa-chat-banner--info';
+	return 'sd-ai-agent-chat-banner--info';
 }
 
 /**
@@ -129,7 +129,7 @@ export default function ChatBanners() {
 	}
 
 	return (
-		<div className="sdaa-chat-banners">
+		<div className="sd-ai-agent-chat-banners">
 			{ banners.map( ( banner, index ) => {
 				// Producers SHOULD supply a stable id; fall back to the
 				// array index so React doesn't warn when they don't.
@@ -137,19 +137,19 @@ export default function ChatBanners() {
 					banner.id && 'string' === typeof banner.id
 						? banner.id
 						: `banner-${ index }`;
-				const className = `sdaa-chat-banner ${ severityClass(
+				const className = `sd-ai-agent-chat-banner ${ severityClass(
 					banner.severity
 				) }`;
 				const role = 'error' === banner.severity ? 'alert' : 'status';
 
 				return (
 					<div key={ key } className={ className } role={ role }>
-						<span className="sdaa-chat-banner__message">
+						<span className="sd-ai-agent-chat-banner__message">
 							{ banner.message }
 						</span>
 						{ banner.cta_url && banner.cta_label && (
 							<a
-								className="sdaa-chat-banner__cta"
+								className="sd-ai-agent-chat-banner__cta"
 								href={ banner.cta_url }
 								target="_blank"
 								rel="noopener noreferrer"

--- a/src/components/shared.css
+++ b/src/components/shared.css
@@ -810,13 +810,13 @@
 /* Generic banner stack rendered at the top of the chat panel. Banners are
    contributed by other plugins via the `sd_ai_agent_chat_banners` PHP filter
    and the `/sd-ai-agent/v1/chat-banners` REST endpoint. */
-.sdaa-chat-banners {
+.sd-ai-agent-chat-banners {
 	display: flex;
 	flex-direction: column;
 	gap: 1px;
 }
 
-.sdaa-chat-banner {
+.sd-ai-agent-chat-banner {
 	display: flex;
 	align-items: center;
 	flex-wrap: wrap;
@@ -827,30 +827,30 @@
 	line-height: 1.5;
 }
 
-.sdaa-chat-banner--info {
+.sd-ai-agent-chat-banner--info {
 	background: #f0f6fc;
 	border-left-color: #2271b1;
 	color: #1d2327;
 }
 
-.sdaa-chat-banner--warning {
+.sd-ai-agent-chat-banner--warning {
 	background: #fcf9e8;
 	border-left-color: #dba617;
 	color: #674a00;
 }
 
-.sdaa-chat-banner--error {
+.sd-ai-agent-chat-banner--error {
 	background: #fcf0f1;
 	border-left-color: #cc1818;
 	color: #8a1f11;
 }
 
-.sdaa-chat-banner__message {
+.sd-ai-agent-chat-banner__message {
 	flex: 1 1 auto;
 	min-width: 0;
 }
 
-.sdaa-chat-banner__cta {
+.sd-ai-agent-chat-banner__cta {
 	display: inline-block;
 	padding: 4px 12px;
 	border-radius: 3px;
@@ -861,17 +861,17 @@
 	white-space: nowrap;
 }
 
-.sdaa-chat-banner__cta:hover,
-.sdaa-chat-banner__cta:focus {
+.sd-ai-agent-chat-banner__cta:hover,
+.sd-ai-agent-chat-banner__cta:focus {
 	background: #135e96;
 	color: #fff;
 }
 
-.sdaa-chat-banner--error .sdaa-chat-banner__cta {
+.sd-ai-agent-chat-banner--error .sd-ai-agent-chat-banner__cta {
 	background: #cc1818;
 }
 
-.sdaa-chat-banner--error .sdaa-chat-banner__cta:hover,
-.sdaa-chat-banner--error .sdaa-chat-banner__cta:focus {
+.sd-ai-agent-chat-banner--error .sd-ai-agent-chat-banner__cta:hover,
+.sd-ai-agent-chat-banner--error .sd-ai-agent-chat-banner__cta:focus {
 	background: #a00d0d;
 }


### PR DESCRIPTION
## Summary

Renamed the chat banner CSS selectors and matching React className/test expectations from the non-canonical sdaa-chat-banner prefix to sd-ai-agent-chat-banner so new banner styles follow the plugin CSS naming rules.

## Files Changed

src/components/__tests__/ChatBanners.test.js,src/components/chat-banners.js,src/components/shared.css

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run test:js -- --runTestsByPath src/components/__tests__/ChatBanners.test.js (passed: 11 tests); npm run lint:css -- src/components/shared.css (passed); npm run lint:js -- src/components/chat-banners.js src/components/__tests__/ChatBanners.test.js (blocked by unrelated existing ESLint runtime error in src/components/export-dialog.js when the package script expands to all src/); subsequent npm dependency reinstall attempts left node_modules incomplete (wp-scripts missing), so final rerun was unavailable

Resolves #1322


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.35 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 9m and 89,458 tokens on this with the user in an interactive session.