### PR TITLE
GH#1301: fix: declare tool result schema type

### DIFF
--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -111,7 +111,9 @@ final class RestController {
 							'properties' => array(
 								'id'     => array( 'type' => 'string' ),
 								'name'   => array( 'type' => 'string' ),
-								'result' => array(),
+								'result' => array(
+									'type' => array( 'string', 'number', 'integer', 'boolean', 'array', 'object', 'null' ),
+								),
 								'error'  => array( 'type' => 'string' ),
 							),
 						),


### PR DESCRIPTION
## Summary

Declared the chat/tool-result REST schema type for tool_results[].result so WordPress trunk validation no longer encounters an undefined type key while preserving mixed JSON result payloads.

## Files Changed

includes/REST/RestController.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** php -l includes/REST/RestController.php (passes). composer phpcs -- includes/REST/RestController.php could not run because vendor/bin/phpcs is not installed. npm run test:php -- --filter test_tool_result_409 could not run because wp-env compose was missing; npm run wp-env:start failed with Docker BuildKit cachemount path error: stat /mnt/data/docker/buildkit/containerd-overlayfs/cachemounts: no such file or directory.

Resolves #1301


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.35 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 4m and 44,736 tokens on this with the user in an interactive session.