### PR TITLE
GH#1325: scrub feedback session credentials

### DIFF
--- a/includes/Feedback/ReportSanitizer.php
+++ b/includes/Feedback/ReportSanitizer.php
@@ -25,13 +25,13 @@ class ReportSanitizer {
 	 * @var array<string, string>
 	 */
 	private const CREDENTIAL_PATTERNS = array(
-		'bearer_token'   => '/\bBearer\s+[A-Za-z0-9\-._~+\/]+=*/i',
+		'bearer_token'   => '/\bBearer\s+[A-Za-z0-9\-._~+\/]{20,}=*/i',
 		'basic_auth'     => '/\bBasic\s+[A-Za-z0-9+\/]+=*/i',
-		'api_key_param'  => '/\b(?:api[_-]?key|apikey|access[_-]?token|secret[_-]?key)\s*[=:]\s*[^\s&"\']{8,}/i',
+		'api_key_param'  => '/\b(?:api[_-]?key|apikey|access[_-]?token|auth[_-]?token|secret[_-]?key|token)\s*[=:]\s*[^\s&"\']{8,}/i',
 		'password_param' => '/\b(?:password|passwd|pwd)\s*[=:]\s*[^\s&"\']{3,}/i',
 		'aws_key_id'     => '/\bAKIA[0-9A-Z]{16}\b/',
-		'aws_secret'     => '/\b[A-Za-z0-9\/+]{40}\b/',
-		'openai_key'     => '/\bsk-[A-Za-z0-9]{20,}\b/',
+		'high_entropy'   => '/(?:(?<=[=:]\s)|\b)([A-Za-z0-9+\/_=-]{40,})(?=\b|\s|$)/',
+		'openai_key'     => '/\bsk-(?:proj-)?[A-Za-z0-9_\-]{20,}\b/',
 		'anthropic_key'  => '/\bsk-ant-[A-Za-z0-9\-]{20,}\b/',
 		'jwt_token'      => '/\beyJ[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+\.[A-Za-z0-9\-_]+\b/',
 	);
@@ -49,6 +49,12 @@ class ReportSanitizer {
 				/** @var array<int, array<string, mixed>> $messages */
 				$messages                            = $session_data['messages'];
 				$payload['session_data']['messages'] = self::sanitize_messages( $messages );
+			}
+
+			if ( isset( $session_data['session_messages'] ) && is_array( $session_data['session_messages'] ) ) {
+				/** @var array<int, array<string, mixed>> $session_messages */
+				$session_messages                            = $session_data['session_messages'];
+				$payload['session_data']['session_messages'] = self::sanitize_messages( $session_messages );
 			}
 
 			if ( isset( $session_data['tool_calls'] ) && is_array( $session_data['tool_calls'] ) ) {
@@ -111,8 +117,8 @@ class ReportSanitizer {
 				// Sanitize input arguments (may contain user-supplied data).
 				if ( is_array( $entry['input'] ?? null ) ) {
 					$entry['input'] = array_map(
-						static function ( $value ): mixed {
-							return is_string( $value ) ? self::sanitize_string( $value ) : $value;
+						static function ( mixed $value ): mixed {
+							return self::sanitize_value( $value );
 						},
 						$entry['input']
 					);
@@ -127,6 +133,29 @@ class ReportSanitizer {
 			},
 			$tool_calls
 		);
+	}
+
+	/**
+	 * Sanitize a mixed payload value recursively.
+	 *
+	 * @param mixed $value Value to sanitize.
+	 * @return mixed Sanitized value.
+	 */
+	private static function sanitize_value( mixed $value ): mixed {
+		if ( is_string( $value ) ) {
+			return self::sanitize_string( $value );
+		}
+
+		if ( is_array( $value ) ) {
+			return array_map(
+				static function ( mixed $nested_value ): mixed {
+					return self::sanitize_value( $nested_value );
+				},
+				$value
+			);
+		}
+
+		return $value;
 	}
 
 	/**

--- a/tests/SdAiAgent/Feedback/ReportSanitizerTest.php
+++ b/tests/SdAiAgent/Feedback/ReportSanitizerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Test case for feedback report sanitization.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Feedback;
+
+use SdAiAgent\Feedback\ReportSanitizer;
+use WP_UnitTestCase;
+
+/**
+ * Test ReportSanitizer credential scrubbing.
+ */
+class ReportSanitizerTest extends WP_UnitTestCase {
+
+	/**
+	 * Test chat session messages are scrubbed before feedback payload transmission.
+	 */
+	public function test_sanitize_redacts_credentials_from_session_messages(): void {
+		$openai_key         = 'sk-' . 'proj-' . str_repeat( 'a', 40 );
+		$high_entropy_value = str_repeat( 'b', 44 );
+
+		$payload = array(
+			'user_description' => 'Bearer bearer-token-value-abcdefghijklmnopqrstuvwxyz0123456789',
+			'session_data'     => array(
+				'messages'          => array(
+					array(
+						'role'    => 'user',
+						'content' => 'OpenAI key ' . $openai_key . ' should not leave this site.',
+					),
+					array(
+						'role'    => 'user',
+						'content' => 'token: ' . $high_entropy_value,
+					),
+				),
+				'session_messages' => array(
+					array(
+						'role'    => 'user',
+						'content' => array(
+							array(
+								'type' => 'text',
+								'text' => 'api_key=' . $high_entropy_value,
+							),
+						),
+					),
+				),
+				'tool_calls'        => array(
+					array(
+						'input'  => array(
+							'nested' => array(
+								'authorization' => 'Bearer nested-token-value-abcdefghijklmnopqrstuvwxyz0123456789',
+							),
+						),
+						'result' => 'password: secret-password-value',
+					),
+				),
+			),
+		);
+
+		$sanitized = ReportSanitizer::sanitize( $payload );
+		$encoded   = (string) wp_json_encode( $sanitized );
+
+		$this->assertStringNotContainsString( $openai_key, $encoded );
+		$this->assertStringNotContainsString( $high_entropy_value, $encoded );
+		$this->assertStringNotContainsString( 'bearer-token-value-abcdefghijklmnopqrstuvwxyz0123456789', $encoded );
+		$this->assertStringNotContainsString( 'secret-password-value', $encoded );
+		$this->assertStringContainsString( '[REDACTED:', $encoded );
+	}
+}


### PR DESCRIPTION
## Summary
- Redacts OpenAI project keys, bearer tokens, token assignments, and generic high-entropy values from feedback session message payloads before submission.
- Covers both `session_data.messages` and `session_data.session_messages`, and recursively sanitizes nested tool-call input values.
- Adds a focused PHPUnit regression test for feedback payload credential scrubbing.

Resolves #1325

## Verification
- `composer phpcs -- includes/Feedback/ReportSanitizer.php tests/SdAiAgent/Feedback/ReportSanitizerTest.php`
- `WP_TESTS_DIR="/tmp/wordpress-tests-lib" vendor/bin/phpunit tests/SdAiAgent/Feedback/ReportSanitizerTest.php` (passes; bootstrap prints pre-existing duplicate custom-tool seed warnings)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 4m and 77,160 tokens on this as a headless worker.
