### PR TITLE
GH#1324: guard WP-CLI proc_open availability

### DIFF
--- a/includes/Abilities/WpCliAbilities.php
+++ b/includes/Abilities/WpCliAbilities.php
@@ -318,6 +318,14 @@ class WpCliAbilities {
 			return $perm_check;
 		}
 
+		if ( ! self::is_proc_open_available() ) {
+			return new WP_Error(
+				'proc_open_unavailable',
+				__( 'WP-CLI execution is unavailable because PHP proc_open() is disabled on this host. Use the REST, posts, options, media, or other WordPress abilities instead.', 'superdav-ai-agent' ),
+				array( 'status' => 501 )
+			);
+		}
+
 		// Find WP-CLI binary.
 		$wp_binary = self::find_wp_cli();
 
@@ -582,6 +590,24 @@ class WpCliAbilities {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Determine whether PHP can spawn a WP-CLI subprocess.
+	 *
+	 * @return bool
+	 */
+	private static function is_proc_open_available(): bool {
+		$available = function_exists( 'proc_open' ) && is_callable( 'proc_open' );
+
+		/**
+		 * Filter whether the WP-CLI ability may use proc_open().
+		 *
+		 * Primarily useful for tests and hosts that wrap proc_open availability.
+		 *
+		 * @param bool $available Whether proc_open() is available.
+		 */
+		return (bool) apply_filters( 'sd_ai_agent_wp_cli_proc_open_available', $available );
 	}
 
 	/**

--- a/tests/SdAiAgent/Abilities/WpCliAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/WpCliAbilitiesTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Test case for WpCliAbilities class.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Abilities;
+
+use SdAiAgent\Abilities\WpCliAbilities;
+use WP_UnitTestCase;
+
+/**
+ * Test WP-CLI ability guard behaviour.
+ */
+class WpCliAbilitiesTest extends WP_UnitTestCase {
+
+	/**
+	 * Administrator user ID.
+	 *
+	 * @var int
+	 */
+	private int $admin_id = 0;
+
+	/**
+	 * Set up an administrator user because WP-CLI execution requires admin caps.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $this->admin_id );
+	}
+
+	/**
+	 * Clean up filters after each test.
+	 */
+	public function tear_down(): void {
+		remove_all_filters( 'sd_ai_agent_wp_cli_proc_open_available' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Test proc_open-disabled hosts receive a clear actionable error before process setup.
+	 */
+	public function test_execute_returns_clear_error_when_proc_open_unavailable(): void {
+		add_filter( 'sd_ai_agent_wp_cli_proc_open_available', '__return_false' );
+
+		$result = WpCliAbilities::execute( 'post list --format=json' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'proc_open_unavailable', $result->get_error_code() );
+		$this->assertSame( 501, $result->get_error_data()['status'] );
+		$this->assertStringContainsString( 'proc_open() is disabled', $result->get_error_message() );
+		$this->assertStringContainsString( 'Use the REST', $result->get_error_message() );
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a preflight availability guard before `WpCliAbilities` calls `proc_open()`.
- Returns an actionable `proc_open_unavailable` error directing agents to REST/WordPress abilities when WP-CLI subprocesses are disabled.
- Adds a focused PHPUnit test that simulates restricted hosting via `sd_ai_agent_wp_cli_proc_open_available`.

Resolves #1324

## Verification
- `composer phpcs -- includes/Abilities/WpCliAbilities.php tests/SdAiAgent/Abilities/WpCliAbilitiesTest.php`
- `php -l includes/Abilities/WpCliAbilities.php`
- `php -l tests/SdAiAgent/Abilities/WpCliAbilitiesTest.php`
- Attempted `npm run test:php -- --filter WpCliAbilitiesTest` but wp-env was not initialized.
- Attempted `npx wp-env start` but Docker failed building cache mounts: `stat /mnt/data/docker/buildkit/containerd-overlayfs/cachemounts: no such file or directory`.
- Attempted local `vendor/bin/phpunit --filter WpCliAbilitiesTest` but the WordPress test library was missing.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 5m and 75,545 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling when PHP's `proc_open()` function is unavailable, now returning a clear error message with guidance to use an alternative approach instead of failing silently.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1333)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->