### PR TITLE
GH#1331: docs: add WordPress.org review response guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,20 @@ between the user-facing plugin slug and the code-level prefixes/namespaces.
 6. Headless agents that propose these renames are operating outside scope. File
    an issue describing the rogue behaviour rather than merging the PR.
 
+### WordPress.org Review Responses
+
+When drafting replies to WordPress.org plugin review emails, use a concise,
+professional, issue-by-issue format:
+
+- Acknowledge the review and state that each reported item was investigated.
+- For every reviewer finding, cite the exact fix or rationale, including file or
+  pattern references when available.
+- Include verification evidence such as `wp plugin check`, PHPCS, PHPUnit, build,
+  or manual review commands that were run.
+- Avoid defensive language, marketing copy, emojis, and broad claims that are not
+  backed by a concrete change or test.
+- Close with the resubmission status and any specific reviewer action requested.
+
 ## Build Commands
 - **Build**: `npm run build` or `npx wp-scripts build` (production)
 - **Dev**: `npm start` or `npx wp-scripts start` (watch mode)

--- a/docs/wordpress-org-submission.md
+++ b/docs/wordpress-org-submission.md
@@ -228,6 +228,20 @@ Client SDK, Abilities API).
 - The review team may request changes — respond promptly via the ticket system
 - Do not resubmit the same plugin while a review is pending
 
+### Responding to review requests
+
+Use a concise, evidence-backed reply when automated or manual review tools report
+that the plugin is not ready for approval:
+
+1. Thank the reviewer and confirm that each reported item was investigated.
+2. List each finding separately, with the fix or rationale and file/pattern
+   references where possible.
+3. Include the verification commands that passed, such as `wp plugin check`,
+   `composer phpcs`, `composer phpstan`, `npm run build`, or relevant tests.
+4. Avoid defensive wording, marketing language, emojis, or unsupported claims.
+5. State whether the updated ZIP has been resubmitted and whether any item needs
+   reviewer confirmation.
+
 ### Common rejection reasons to pre-empt
 
 | Issue | Our status |


### PR DESCRIPTION
## Summary

Added project agent guidance and submission documentation for drafting concise, evidence-backed WordPress.org plugin review responses.

## Files Changed

AGENTS.md,docs/wordpress-org-submission.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Documentation-only change; verified with git diff and file reads for AGENTS.md and docs/wordpress-org-submission.md.

Resolves #1331


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 1m and 47,017 tokens on this with the user in an interactive session.