### PR TITLE
refactor: remove sd_ai_agent_provider_keys + duplicate credential storage

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -187,16 +187,17 @@ jobs:
           npx wp-env run cli wp option update sd_ai_agent_settings \
             '{"onboarding_complete":true,"site_builder_mode":false}' --format=json
 
-          # Configure a fake OpenAI key so the /providers endpoint returns at
-          # least one provider. Without a provider the AdminPageApp renders the
-          # ConnectorGate instead of the chat layout, breaking all tests that
-          # look for .sd-ai-agent-layout or .sd-ai-agent-chat-panel.
+          # Configure a fake OpenAI key via the WP 7.0 Connectors API option
+          # so the /providers endpoint returns at least one provider. Without
+          # a provider the AdminPageApp renders the ConnectorGate instead of
+          # the chat layout, breaking all tests that look for
+          # .sd-ai-agent-layout or .sd-ai-agent-chat-panel.
           # The key is never used for real API calls — E2E specs mock the
-          # /stream endpoint — but its non-empty value is enough for the
+          # /stream endpoint — but its non-empty value is enough for
           # SettingsController::handle_providers() to include OpenAI in the
           # list returned to the React app.
-          npx wp-env run cli wp option update sd_ai_agent_provider_keys \
-            '{"openai":"sk-test-fake-key-for-e2e"}' --format=json
+          npx wp-env run cli wp option update connectors_ai_openai_api_key \
+            'sk-test-fake-key-for-e2e'
 
           # Prevent FreshInstallDetector from re-enabling site_builder_mode on
           # every page load. The wp-env environment is always a "fresh install"

--- a/includes/CLI/ModelsCommand.php
+++ b/includes/CLI/ModelsCommand.php
@@ -157,9 +157,10 @@ class ModelsCommand extends WP_CLI_Command {
 		$settings  = new Settings();
 		$providers = array();
 
-		// Direct providers (OpenAI, Anthropic, Google) — only include if a key is configured.
+		// Built-in providers (OpenAI, Anthropic, Google) — only include when a
+		// WP 7.0 Connectors API key is set.
 		foreach ( Settings::DIRECT_PROVIDERS as $provider_id => $meta ) {
-			if ( '' === $settings->get_provider_key( $provider_id ) ) {
+			if ( '' === $settings->get_connectors_api_key( $provider_id ) ) {
 				continue;
 			}
 

--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -37,22 +37,12 @@ class Settings {
 	const CLAUDE_MAX_TOKEN_OPTION = 'sd_ai_agent_claude_max_token';
 
 	/**
-	 * Option name for directly-configured provider API keys.
-	 * Stored separately from general settings to avoid leaking credentials
-	 * through the GET /settings endpoint.
-	 */
-	const PROVIDER_KEYS_OPTION = 'sd_ai_agent_provider_keys';
-
-	/**
 	 * Option name for Google Search Console credentials.
 	 * Stored separately from general settings to avoid leaking credentials
 	 * through the GET /settings endpoint.
 	 */
 	const GSC_CREDENTIALS_OPTION = 'sd_ai_agent_gsc_credentials';
 
-	/**
-	 * Supported direct providers with their metadata.
-	 */
 	/**
 	 * Known context window sizes per model (tokens).
 	 * Used as a fallback lookup for WP SDK provider models that do not carry
@@ -95,6 +85,23 @@ class Settings {
 		'gemini-1.5-flash'              => 1048576,
 	);
 
+	/**
+	 * Built-in catalog of provider IDs, display names, default models, and
+	 * model lists for OpenAI, Anthropic, and Google.
+	 *
+	 * This is a static catalog of metadata only — it does NOT imply that any
+	 * of these providers are configured. Credentials are stored exclusively by
+	 * the WordPress 7.0 Connectors API in `connectors_ai_{provider}_api_key`
+	 * options; see {@see Settings::get_connectors_api_key()} and
+	 * {@see ProviderCredentialLoader::load()}.
+	 *
+	 * The catalog is consulted by `/providers`, `/alerts`, and the
+	 * `wp ai-agent models` CLI command so that sites without a third-party
+	 * AI provider plugin (`ai-provider-for-openai` etc.) can still discover
+	 * which models exist for a connector that has a key set.
+	 *
+	 * @var array<string, array{name: string, default_model: string, models: list<array{id: string, name: string, context_window: int}>}>
+	 */
 	const DIRECT_PROVIDERS = array(
 		'openai'    => array(
 			'name'          => 'OpenAI',
@@ -322,68 +329,24 @@ class Settings {
 	}
 
 	/**
-	 * Get the API key for a directly-configured provider.
+	 * Read the API key stored by the WordPress 7.0 Connectors API for a
+	 * built-in provider in {@see Settings::DIRECT_PROVIDERS}.
 	 *
-	 * Keys are stored in a dedicated option, never in the general settings blob,
-	 * so they are not exposed through GET /settings.
+	 * Reads the `connectors_ai_{provider}_api_key` option directly. This is the
+	 * same naming convention used by core on WP 7.0+ and by the 6.9 polyfill
+	 * in `includes/Compat/wp-connectors-polyfill.php`, so credentials entered
+	 * through the Connectors admin page are picked up here without any further
+	 * migration.
 	 *
-	 * @param string $provider_id One of 'openai', 'anthropic', 'google'.
+	 * Note: this helper is intentionally read-only — credential writes flow
+	 * through {@see ConnectorsController}, never through the Settings class.
+	 *
+	 * @param string $provider_id One of the keys of {@see Settings::DIRECT_PROVIDERS}.
 	 * @return string Empty string when not configured.
 	 */
-	public function get_provider_key( string $provider_id ): string {
-		$keys = get_option( self::PROVIDER_KEYS_OPTION, array() );
-		// @phpstan-ignore-next-line
-		return isset( $keys[ $provider_id ] ) ? (string) $keys[ $provider_id ] : '';
-	}
-
-	/**
-	 * Persist an API key for a directly-configured provider.
-	 *
-	 * Pass an empty string to clear the credential.
-	 *
-	 * @param string $provider_id One of 'openai', 'anthropic', 'google'.
-	 * @param string $api_key     The API key value.
-	 * @return bool True on success.
-	 */
-	public function set_provider_key( string $provider_id, string $api_key ): bool {
-		if ( ! array_key_exists( $provider_id, self::DIRECT_PROVIDERS ) ) {
-			return false;
-		}
-
-		$keys = get_option( self::PROVIDER_KEYS_OPTION, array() );
-
-		if ( '' === $api_key ) {
-			// @phpstan-ignore-next-line
-			unset( $keys[ $provider_id ] );
-		} else {
-			// @phpstan-ignore-next-line
-			$keys[ $provider_id ] = $api_key;
-		}
-
-		return update_option( self::PROVIDER_KEYS_OPTION, $keys );
-	}
-
-	/**
-	 * Get all configured direct providers (those with a non-empty API key).
-	 *
-	 * Returns an array of provider metadata arrays, each with:
-	 *   - id, name, configured (bool), models (array), has_key (bool)
-	 *
-	 * @return array<int, array<string, mixed>>
-	 */
-	public function get_configured_direct_providers(): array {
-		$result = array();
-		foreach ( self::DIRECT_PROVIDERS as $id => $meta ) {
-			$key      = $this->get_provider_key( $id );
-			$result[] = array(
-				'id'         => $id,
-				'name'       => $meta['name'],
-				'configured' => '' !== $key,
-				'has_key'    => '' !== $key,
-				'models'     => $meta['models'],
-			);
-		}
-		return $result;
+	public function get_connectors_api_key( string $provider_id ): string {
+		$sanitized_id = str_replace( '-', '_', $provider_id );
+		return (string) get_option( "connectors_ai_{$sanitized_id}_api_key", '' );
 	}
 
 	/**
@@ -607,7 +570,8 @@ class Settings {
 	 *
 	 * Resolution order:
 	 *  1. `default_provider` saved via the WP SDK Connectors settings page.
-	 *  2. Any directly-configured provider API key (OpenAI, Anthropic, Google).
+	 *  2. A WP 7.0 Connectors API key for any built-in provider in
+	 *     {@see Settings::DIRECT_PROVIDERS}.
 	 *  3. Claude Max OAuth token.
 	 *
 	 * @return bool
@@ -619,9 +583,9 @@ class Settings {
 			return true;
 		}
 
-		// Direct API keys.
+		// WP 7.0 Connectors API key for a built-in provider.
 		foreach ( array_keys( self::DIRECT_PROVIDERS ) as $provider_id ) {
-			if ( '' !== $this->get_provider_key( $provider_id ) ) {
+			if ( '' !== $this->get_connectors_api_key( $provider_id ) ) {
 				return true;
 			}
 		}

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -143,56 +143,6 @@ final class SettingsController {
 			)
 		);
 
-		// Direct provider API key endpoint.
-		register_rest_route(
-			RestController::NAMESPACE,
-			'/settings/provider-key',
-			array(
-				array(
-					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $this, 'handle_set_provider_key' ),
-					'permission_callback' => array( __CLASS__, 'check_admin_permission' ),
-					'args'                => array(
-						'provider' => array(
-							'required'          => true,
-							'type'              => 'string',
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-						'api_key'  => array(
-							'required'          => true,
-							'type'              => 'string',
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-					),
-				),
-			)
-		);
-
-		// Direct provider API key test endpoint.
-		register_rest_route(
-			RestController::NAMESPACE,
-			'/settings/provider-key/test',
-			array(
-				array(
-					'methods'             => WP_REST_Server::CREATABLE,
-					'callback'            => array( $this, 'handle_test_provider_key' ),
-					'permission_callback' => array( __CLASS__, 'check_admin_permission' ),
-					'args'                => array(
-						'provider' => array(
-							'required'          => true,
-							'type'              => 'string',
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-						'api_key'  => array(
-							'required'          => false,
-							'type'              => 'string',
-							'sanitize_callback' => 'sanitize_text_field',
-						),
-					),
-				),
-			)
-		);
-
 		// Role permissions endpoints — only registered when access control feature is enabled.
 		if ( Features::is_enabled( Features::ACCESS_CONTROL ) ) {
 			register_rest_route(
@@ -422,14 +372,6 @@ final class SettingsController {
 		// @phpstan-ignore-next-line
 		$settings['_has_claude_max_token'] = '' !== $this->settings->get_claude_max_token();
 
-		// Indicate which direct provider keys are configured (boolean per provider, no values).
-		$provider_keys = array();
-		foreach ( array_keys( Settings::DIRECT_PROVIDERS ) as $provider_id ) {
-			$provider_keys[ $provider_id ] = '' !== $this->settings->get_provider_key( $provider_id );
-		}
-		// @phpstan-ignore-next-line
-		$settings['_provider_keys'] = $provider_keys;
-
 		// Indicate whether GSC credentials are configured (boolean + type only, no credential values).
 		$gsc_creds = $this->settings->get_gsc_credentials();
 		// @phpstan-ignore-next-line
@@ -557,189 +499,6 @@ final class SettingsController {
 				'saved'        => true,
 				'has_token'    => ! empty( $token ),
 				'token_prefix' => ! empty( $token ) ? substr( $token, 0, 20 ) . '…' : '',
-			),
-			200
-		);
-	}
-
-	/**
-	 * Handle POST /settings/provider-key — save or clear a direct provider API key.
-	 *
-	 * @param WP_REST_Request $request The request object.
-	 */
-	public function handle_set_provider_key( WP_REST_Request $request ): WP_REST_Response {
-		// @phpstan-ignore-next-line
-		$provider = (string) $request->get_param( 'provider' );
-		// @phpstan-ignore-next-line
-		$api_key = (string) $request->get_param( 'api_key' );
-		$api_key = trim( $api_key );
-
-		if ( ! array_key_exists( $provider, Settings::DIRECT_PROVIDERS ) ) {
-			return new WP_REST_Response( array( 'error' => 'Unknown provider.' ), 400 );
-		}
-
-		$success = $this->settings->set_provider_key( $provider, $api_key );
-
-		if ( ! $success && ! empty( $api_key ) ) {
-			return new WP_REST_Response( array( 'error' => 'Failed to save API key.' ), 500 );
-		}
-
-		// Credentials changed — the cached providers list is now stale.
-		self::flush_providers_cache();
-
-		return new WP_REST_Response(
-			array(
-				'saved'   => true,
-				'has_key' => ! empty( $api_key ),
-			),
-			200
-		);
-	}
-
-	/**
-	 * Handle POST /settings/provider-key/test — test a direct provider API key.
-	 *
-	 * @param WP_REST_Request $request The request object.
-	 */
-	public function handle_test_provider_key( WP_REST_Request $request ): WP_REST_Response {
-		// @phpstan-ignore-next-line
-		$provider = (string) $request->get_param( 'provider' );
-		// @phpstan-ignore-next-line
-		$api_key = (string) $request->get_param( 'api_key' );
-		$api_key = trim( $api_key );
-
-		if ( ! array_key_exists( $provider, Settings::DIRECT_PROVIDERS ) ) {
-			return new WP_REST_Response(
-				array(
-					'success' => false,
-					'error'   => 'Unknown provider.',
-				),
-				400
-			);
-		}
-
-		// Use the provided key or fall back to the stored key.
-		$key_to_test = '' !== $api_key ? $api_key : $this->settings->get_provider_key( $provider );
-
-		if ( '' === $key_to_test ) {
-			return new WP_REST_Response(
-				array(
-					'success' => false,
-					'error'   => 'No API key configured.',
-				),
-				400
-			);
-		}
-
-		$meta          = Settings::DIRECT_PROVIDERS[ $provider ];
-		$default_model = $meta['default_model'];
-
-		// Send a minimal test prompt.
-		$test_body = array(
-			'model'      => $default_model,
-			'max_tokens' => 16,
-			'messages'   => array(
-				array(
-					'role'    => 'user',
-					'content' => 'Say "ok".',
-				),
-			),
-		);
-
-		if ( 'anthropic' === $provider ) {
-			$response = wp_remote_post(
-				'https://api.anthropic.com/v1/messages',
-				[
-					'timeout' => 30,
-					'headers' => [
-						'Content-Type'      => 'application/json',
-						'x-api-key'         => $key_to_test,
-						'anthropic-version' => '2023-06-01',
-					],
-					'body'    => (string) wp_json_encode( $test_body ),
-				]
-			);
-		} elseif ( 'google' === $provider ) {
-			$openai_body = [
-				'model'      => $default_model,
-				'max_tokens' => 16,
-				'messages'   => [
-					[
-						'role'    => 'user',
-						'content' => 'Say "ok".',
-					],
-				],
-			];
-			$response    = wp_remote_post(
-				'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions',
-				[
-					'timeout' => 30,
-					'headers' => [
-						'Content-Type'  => 'application/json',
-						'Authorization' => 'Bearer ' . $key_to_test,
-					],
-					'body'    => (string) wp_json_encode( $openai_body ),
-				]
-			);
-		} else {
-			// OpenAI.
-			$openai_body = [
-				'model'      => $default_model,
-				'max_tokens' => 16,
-				'messages'   => [
-					[
-						'role'    => 'user',
-						'content' => 'Say "ok".',
-					],
-				],
-			];
-			$response    = wp_remote_post(
-				'https://api.openai.com/v1/chat/completions',
-				[
-					'timeout' => 30,
-					'headers' => [
-						'Content-Type'  => 'application/json',
-						'Authorization' => 'Bearer ' . $key_to_test,
-					],
-					'body'    => (string) wp_json_encode( $openai_body ),
-				]
-			);
-		}
-
-		if ( is_wp_error( $response ) ) {
-			return new WP_REST_Response(
-				[
-					'success' => false,
-					'error'   => $response->get_error_message(),
-				],
-				200
-			);
-		}
-
-		$code = wp_remote_retrieve_response_code( $response );
-		$body = wp_remote_retrieve_body( $response );
-		$data = json_decode( $body, true );
-
-		if ( 200 !== $code ) {
-			// @phpstan-ignore-next-line
-			$error_msg = isset( $data['error']['message'] ) ? $data['error']['message'] : "HTTP $code";
-			return new WP_REST_Response(
-				array(
-					'success' => false,
-					'error'   => $error_msg,
-				),
-				200
-			);
-		}
-
-		// Extract model name from response.
-		// @phpstan-ignore-next-line
-		$model_name = $data['model'] ?? $default_model;
-
-		return new WP_REST_Response(
-			array(
-				'success' => true,
-				'model'   => $model_name,
 			),
 			200
 		);
@@ -1080,9 +839,11 @@ final class SettingsController {
 
 		$providers = array();
 
-		// Direct providers (OpenAI, Anthropic, Google) — listed first, no WP SDK required.
+		// Built-in providers (OpenAI, Anthropic, Google) — listed first when a
+		// WP 7.0 Connectors API key is set, so sites without a third-party
+		// AI provider plugin still have a usable provider/model list.
 		foreach ( Settings::DIRECT_PROVIDERS as $provider_id => $meta ) {
-			$key = $this->settings->get_provider_key( $provider_id );
+			$key = $this->settings->get_connectors_api_key( $provider_id );
 			if ( '' === $key ) {
 				continue;
 			}
@@ -1250,9 +1011,9 @@ final class SettingsController {
 		// Check whether at least one AI provider is configured.
 		$has_provider = false;
 
-		// Direct providers (API key stored in plugin options).
-		foreach ( Settings::DIRECT_PROVIDERS as $provider_id => $meta ) {
-			if ( '' !== $this->settings->get_provider_key( $provider_id ) ) {
+		// Built-in providers (API key stored by the WP 7.0 Connectors API).
+		foreach ( array_keys( Settings::DIRECT_PROVIDERS ) as $provider_id ) {
+			if ( '' !== $this->settings->get_connectors_api_key( $provider_id ) ) {
 				$has_provider = true;
 				break;
 			}

--- a/tests/e2e/automations.spec.js
+++ b/tests/e2e/automations.spec.js
@@ -132,7 +132,6 @@ const MOCK_SETTINGS = {
 	image_generation_style: 'vivid',
 	tool_permissions: {},
 	_defaults: {},
-	_provider_keys: {},
 };
 
 /**

--- a/tests/e2e/spending-limits.spec.js
+++ b/tests/e2e/spending-limits.spec.js
@@ -57,7 +57,6 @@ const MOCK_SETTINGS = {
 	image_generation_style: 'vivid',
 	tool_permissions: {},
 	_defaults: {},
-	_provider_keys: {},
 };
 
 /**

--- a/todo/tasks/tasks-wp70-cleanup.md
+++ b/todo/tasks/tasks-wp70-cleanup.md
@@ -59,14 +59,14 @@ Update after completing each sub-task, not just parent tasks.
   - [ ] 3.3 Remove the "Providers" tab from `settings-app.js` tab list and its `case 'providers':` switch branch
   - [ ] 3.4 Remove provider key entry from `src/components/onboarding-wizard.js` — replace with a notice linking to Settings > Connectors
   - [ ] 3.5 Remove provider key entry from `src/floating-widget/site-builder-overlay.js` — replace with a notice linking to Settings > Connectors
-  - [ ] 3.6 Remove `Settings::DIRECT_PROVIDERS` constant and `get_provider_key()`/`set_provider_key()` methods from `includes/Core/Settings.php`
-  - [ ] 3.7 Remove REST endpoints: `POST /settings/provider-key`, `POST /settings/provider-key/test`, `GET /settings/provider-keys` from `includes/REST/RestController.php`
-  - [ ] 3.8 Remove `_provider_keys` from the settings REST response
-  - [ ] 3.9 Update `handle_providers()` REST endpoint to read exclusively from `ProviderRegistry::getRegisteredProviderIds()` — remove the `DIRECT_PROVIDERS` loop
+  - [x] 3.6 Remove `get_provider_key()` / `set_provider_key()` / `get_configured_direct_providers()` from `includes/Core/Settings.php` and remove the `PROVIDER_KEYS_OPTION` constant. **Scope deviation:** keep `Settings::DIRECT_PROVIDERS` as a static catalog of provider IDs and model lists — without it, bare-WP installs (no third-party AI provider plugin) cannot enumerate available models. Add `Settings::get_connectors_api_key()` to read the WP 7.0 Connectors API option (`connectors_ai_{provider}_api_key`).
+  - [x] 3.7 Remove REST endpoints `POST /settings/provider-key` and `POST /settings/provider-key/test` from `includes/REST/SettingsController.php`. (There was never a `GET /settings/provider-keys` route — the original plan was wrong; presence flags were carried inside `GET /settings`.)
+  - [x] 3.8 Remove `_provider_keys` from the `GET /settings` REST response.
+  - [x] 3.9 Update `handle_providers()` and `handle_alerts()` to read keys via `Settings::get_connectors_api_key()` instead of `get_provider_key()`. The `DIRECT_PROVIDERS` loop stays as the provider catalog when no third-party AI provider plugin is active.
   - [ ] 3.10 Remove or simplify `CredentialResolver` — remove `openai_compat_*` options and `AI_EXPERIMENTS_CREDENTIALS_OPTION`; keep only `getClaudeMaxToken()`/`setClaudeMaxToken()` if Claude Max OAuth is still needed
   - [ ] 3.11 Update `AgentLoop::ensure_provider_credentials_static()` — remove Source 2 (AI Experiments) and Source 3 (OpenAI compat); keep Source 1 (WP 7.0 Connectors API)
   - [ ] 3.12 Remove provider key tests from `tests/SdAiAgent/Core/CredentialResolverTest.php` (openai_compat tests)
-  - [ ] 3.13 Update `src/store/index.js` — simplify `fetchProviders` to only read from the `/providers` REST endpoint (no more `_provider_keys` state)
+  - [x] 3.13 Update `src/store/index.js` — simplify `fetchProviders` to only read from the `/providers` REST endpoint (no more `_provider_keys` state). Confirmed already done in a prior JS cleanup; no `_provider_keys` references remain in `src/`.
   - [ ] 3.14 Build and verify: no provider key UI in settings, onboarding points to Connectors, chat still shows available providers from registry
 
 - [ ] 4.0 Remove direct provider HTTP paths ~3h (ai:2.5h test:30m)

--- a/uninstall.php
+++ b/uninstall.php
@@ -48,6 +48,8 @@ $sd_ai_agent_options = [
 	'sd_ai_agent_settings',
 	'sd_ai_agent_db_version',
 	'sd_ai_agent_claude_max_token',
+	// Legacy option removed in v1.x — kept here so uninstall cleans up rows on
+	// sites that upgraded from before the WP 7.0 Connectors API migration.
 	'sd_ai_agent_provider_keys',
 	'sd_ai_agent_gsc_credentials',
 	'sd_ai_agent_tool_profiles',


### PR DESCRIPTION
## Summary

Completes the final dropped slice of [WP 7.0 cleanup task t144 section 3](todo/tasks/tasks-wp70-cleanup.md) — section 3.6-3.9. This work was deferred in April 2026 (around PR #738) and never resumed; it's the reason the user-visible question "are we still using `sd_ai_agent_provider_keys`?" had to be answered "yes, but it shouldn't be".

The plugin was storing AI provider API keys in **two** places:

1. `sd_ai_agent_provider_keys` option + `Settings::get_provider_key()` / `set_provider_key()` + `POST /settings/provider-key` REST endpoint
2. `connectors_ai_{provider}_api_key` options (WP 7.0 Connectors API, also polyfilled for WP 6.9)

Path 1 is now removed. Credential storage flows exclusively through the WP Connectors API.

## What changed

### Removed
- `Settings::PROVIDER_KEYS_OPTION` constant (`sd_ai_agent_provider_keys`)
- `Settings::get_provider_key()` / `set_provider_key()` / `get_configured_direct_providers()`
- `POST /settings/provider-key` REST endpoint + `handle_set_provider_key()` handler
- `POST /settings/provider-key/test` REST endpoint + `handle_test_provider_key()` handler (~150 lines of duplicate provider HTTP code)
- `_provider_keys` array from `GET /settings` REST response
- `_provider_keys` fixtures from `tests/e2e/automations.spec.js` and `tests/e2e/spending-limits.spec.js`

### Kept (scope deviation from original t144 plan)
- `Settings::DIRECT_PROVIDERS` constant — repurposed as a **static catalog** of OpenAI/Anthropic/Google model metadata. The original [task t144 section 3.6](todo/tasks/tasks-wp70-cleanup.md) called for removing it, but discovery showed that's wrong: without the catalog, `/providers` returns `[]` on any site that doesn't have a third-party AI provider plugin (e.g. `ai-provider-for-openai`) installed, because the SDK registry (`AiClient::defaultRegistry()`) only contains providers registered by such plugins. The catalog now ships purely as model metadata with no credential implications. Docblock updated to make this explicit.

### Rewired
- New `Settings::get_connectors_api_key( string $provider_id ): string` helper reads `connectors_ai_{provider}_api_key` directly.
- `Settings::has_provider_configured()`, `SettingsController::handle_providers()`, `SettingsController::handle_alerts()`, and `ModelsCommand::fetch_providers()` now read keys via `get_connectors_api_key()` instead of the removed `get_provider_key()`.
- `.github/workflows/e2e.yml` seeds `connectors_ai_openai_api_key` instead of the removed `sd_ai_agent_provider_keys` option, so `/providers` still returns OpenAI for the bare wp-env environment that has no AI provider plugin.

### Legacy install cleanup retained
`uninstall.php` still lists `'sd_ai_agent_provider_keys'` (as a literal string) so that sites upgrading from earlier versions still get the row cleaned up on uninstall. Annotated with a comment for future maintainers.

## Why now

The duplicate storage was the only unfinished slice of t144. It became a security/UX smell because:

- Two places to enter the same key (Settings > Connectors **and** the plugin's own provider-key endpoints)
- Credentials in the plugin's own option leaked through `_provider_keys` boolean flags in `GET /settings`
- 150+ lines of duplicate HTTP code for the test-key endpoint that re-implemented what the WP AI Client SDK does

## Verification

| Check | Result |
|---|---|
| `vendor/bin/phpcs --standard=phpcs.xml ...` on all 4 changed PHP files | Clean (0 errors, 0 warnings) |
| `composer phpstan` | No new errors. 1 pre-existing error in `WpCliAbilities.php:601` unrelated to this change |
| `php -l` on all 4 changed PHP files | OK |
| YAML parse of `e2e.yml` | OK |
| `grep` for removed APIs in `tests/` | No references found (no PHPUnit test rewrites needed) |
| `grep` for `_provider_keys` in `src/` | No references found (JS side already clean) |

CI will run the full PHPUnit + Playwright suites — particularly important for the e2e workflow change (the seed-line swap). Watching for `/providers` returning OpenAI when seeded via `connectors_ai_openai_api_key`.

## Stats

- **Net: -273 lines** (8 files changed, 60 insertions, 333 deletions)

## Refs

- Beads: `bd-sd-ai-9je` — Complete WP 7.0 cleanup section 3
- Task plan: `todo/tasks/tasks-wp70-cleanup.md` § 3.6, 3.7, 3.8, 3.9, 3.13 (all now checked off)
- Original cleanup batch: PR #738 (April 2026, marked t144 complete but left section 3 PHP work behind)
- Connectors API option naming source: `includes/Compat/wp-connectors-polyfill.php`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 14h 34m and 15,815 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated provider API key configuration to integrate with WordPress 7.0 standards.
  * Removed direct provider key management endpoints; provider configuration now handled through WordPress 7.0 Connectors API.
  * Updated settings structure and provider availability detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1336)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->