### PR TITLE
GH#1337: fix: improve site builder ability discovery

### DIFF
--- a/includes/Core/SystemInstructionBuilder.php
+++ b/includes/Core/SystemInstructionBuilder.php
@@ -52,6 +52,15 @@ class SystemInstructionBuilder {
 				$base .= "\n\n" . $memory_text;
 			}
 
+			// Site builder mode still needs the discoverability manifest. Without
+			// it the bespoke prompt can mention tools by name, but the model cannot
+			// see the broader catalog or the ability-search/ability-call workflow for
+			// abilities that are not loaded as direct Tier-1 tools.
+			$manifest = ToolDiscovery::build_manifest_section();
+			if ( '' !== $manifest ) {
+				$base .= "\n\n" . $manifest;
+			}
+
 			return $base;
 		}
 

--- a/includes/Tools/ToolDiscovery.php
+++ b/includes/Tools/ToolDiscovery.php
@@ -55,12 +55,19 @@ class ToolDiscovery {
 	public const DEFAULT_TIER_1 = array(
 		'sd-ai-agent/ability-search',
 		'sd-ai-agent/ability-call',
-		// Memory + skill + knowledge are registered under the `sd-ai-agent/`
-		// prefix by their feature classes, not under `sd-ai-agent/`.
+		// Memory + skill + knowledge are registered under the canonical
+		// `sd-ai-agent/` ability prefix by their feature classes.
 		'sd-ai-agent/memory-save',
 		'sd-ai-agent/memory-list',
 		'sd-ai-agent/skill-load',
 		'sd-ai-agent/knowledge-search',
+		// Site-builder cold-start operations. These must be directly visible in
+		// fresh-site sessions so the agent updates existing generated pages,
+		// applies theme styles, and exits site-builder mode without falling back
+		// to WP-CLI or PHP snippets.
+		'sd-ai-agent/update-post',
+		'sd-ai-agent/update-global-styles',
+		'sd-ai-agent/complete-site-builder',
 		// WP-CLI is the proper tool for admin commands like `wp site list`,
 		// `wp plugin list`, etc. Registered by the cli-abilities-bridge plugin.
 		'wp-cli/execute',

--- a/tests/SdAiAgent/Abilities/PostAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/PostAbilitiesTest.php
@@ -17,6 +17,34 @@ use WP_UnitTestCase;
  */
 class PostAbilitiesTest extends WP_UnitTestCase {
 
+	public function set_up(): void {
+		parent::set_up();
+
+		add_filter( 'theme_page_templates', [ $this, 'register_test_page_templates' ] );
+	}
+
+	public function tear_down(): void {
+		remove_filter( 'theme_page_templates', [ $this, 'register_test_page_templates' ] );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Register synthetic page templates used by page-template assignment tests.
+	 *
+	 * WordPress trunk validates `page_template` during `wp_insert_post()` and
+	 * `wp_update_post()`, so tests must expose the template slugs they assign.
+	 *
+	 * @param array<string, string> $post_templates Existing template map.
+	 * @return array<string, string>
+	 */
+	public function register_test_page_templates( array $post_templates ): array {
+		$post_templates['templates/full-width.php'] = 'Full Width';
+		$post_templates['templates/landing.php']    = 'Landing';
+
+		return $post_templates;
+	}
+
 	// ─── handle_get_post ──────────────────────────────────────────
 
 	/**

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -836,6 +836,16 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'WordPress', $prompt );
 	}
 
+	public function test_site_builder_prompt_includes_ability_manifest(): void {
+		$builder = new SystemInstructionBuilder();
+		$prompt  = $builder->build( [ 'site_builder_mode' => true ] );
+
+		$this->assertStringContainsString( 'WordPress site builder assistant', $prompt );
+		$this->assertStringContainsString( '## Available Abilities', $prompt );
+		$this->assertStringContainsString( 'sd-ai-agent/ability-search', $prompt );
+		$this->assertStringContainsString( 'sd-ai-agent/ability-call', $prompt );
+	}
+
 	/**
 	 * Test custom system_instruction option is used when provided.
 	 */

--- a/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
+++ b/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
@@ -47,6 +47,14 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 		$this->assertContains( 'sd-ai-agent/ability-call', $tier_1 );
 	}
 
+	public function test_tier_1_includes_site_builder_cold_start_tools(): void {
+		$tier_1 = ToolDiscovery::tier_1_for_run();
+
+		$this->assertContains( 'sd-ai-agent/update-post', $tier_1 );
+		$this->assertContains( 'sd-ai-agent/update-global-styles', $tier_1 );
+		$this->assertContains( 'sd-ai-agent/complete-site-builder', $tier_1 );
+	}
+
 	public function test_tier_1_promotes_recently_used_abilities(): void {
 		// Pick an ability that exists in this install.
 		AbilityUsageTracker::record( 'sd-ai-agent/get-plugins' );


### PR DESCRIPTION
## Summary

Restored the ability discovery manifest in site-builder prompts and promoted update-post, update-global-styles, and complete-site-builder into cold-start Tier 1 so site-builder sessions can see and call them directly.

## Files Changed

includes/Core/SystemInstructionBuilder.php,includes/Tools/ToolDiscovery.php,tests/SdAiAgent/Core/AgentLoopTest.php,tests/SdAiAgent/Tools/ToolDiscoveryTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** php -l includes/Core/SystemInstructionBuilder.php && php -l includes/Tools/ToolDiscovery.php && php -l tests/SdAiAgent/Core/AgentLoopTest.php && php -l tests/SdAiAgent/Tools/ToolDiscoveryTest.php passed. composer phpcs and vendor/bin/phpunit could not run because vendor/bin/phpcs and vendor/bin/phpunit are unavailable in this worktree.

Resolves #1337


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 7m and 86,959 tokens on this with the user in an interactive session.