### PR TITLE
test: guard canonical naming after PR 1290

### DIFF
--- a/tests/SdAiAgent/CanonicalNamingTest.php
+++ b/tests/SdAiAgent/CanonicalNamingTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Tests for canonical plugin naming boundaries.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests;
+
+use WP_UnitTestCase;
+
+/**
+ * Guard the deliberately different public slug and internal ability namespace.
+ */
+class CanonicalNamingTest extends WP_UnitTestCase {
+
+	/**
+	 * Return the repository root path.
+	 *
+	 * @return string Repository root path.
+	 */
+	private function root_dir(): string {
+		return dirname( __DIR__, 2 );
+	}
+
+	/**
+	 * AbstractAbility must keep internal ability IDs separate from the text domain.
+	 */
+	public function test_abstract_ability_keeps_sd_ai_agent_ability_namespace(): void {
+		$contents = (string) file_get_contents( $this->root_dir() . '/includes/Abilities/AbstractAbility.php' );
+
+		$this->assertStringContainsString( "wp_register_ability( 'sd-ai-agent/my-ability'", $contents );
+		$this->assertStringContainsString( "return 'sd-ai-agent';", $contents );
+		$this->assertStringContainsString( "__( 'My Ability', 'superdav-ai-agent' )", $contents );
+		$this->assertStringNotContainsString( "wp_register_ability( 'superdav-ai-agent/", $contents );
+		$this->assertStringNotContainsString( "return 'superdav-ai-agent';", $contents );
+		$this->assertStringNotContainsString( 'gratis-ai-agent', $contents );
+	}
+
+	/**
+	 * The WordPress.org-facing plugin header must keep the public slug text domain.
+	 */
+	public function test_plugin_header_uses_superdav_text_domain(): void {
+		$contents = (string) file_get_contents( $this->root_dir() . '/superdav-ai-agent.php' );
+
+		$this->assertStringContainsString( 'Text Domain: superdav-ai-agent', $contents );
+		$this->assertStringNotContainsString( 'Text Domain: sd-ai-agent', $contents );
+		$this->assertStringNotContainsString( 'Text Domain: gratis-ai-agent', $contents );
+	}
+}


### PR DESCRIPTION
## Summary
- Salvages PR #1290 as a regression guard rather than reopening or cherry-picking its rename.
- Adds a focused PHPUnit test that documents the safe boundary: `sd-ai-agent/` remains the ability namespace/category while `superdav-ai-agent` remains the WordPress.org text domain.
- Confirms the old `gratis-ai-agent` identifier is not present in `AbstractAbility` or the plugin header.

## Source PR assessment
- Source: #1290 (`t235-fix-ability-discoverability`) was closed unmerged after it attempted broad historical slug renames.
- Decision: do not reopen or cherry-pick; the recoverable value is the naming confusion it exposed, now captured as a regression test.

## Verification
- `prework-discovery-helper.sh --keywords "PR 1290 canonical naming ability namespace text domain regression" --files "tests/SdAiAgent/CanonicalNamingTest.php includes/Abilities/AbstractAbility.php AGENTS.md"`
- `php -l tests/SdAiAgent/CanonicalNamingTest.php`
- `composer install --no-interaction --no-progress`
- `composer phpcs -- tests/SdAiAgent/CanonicalNamingTest.php`
- `vendor/bin/phpunit --filter CanonicalNamingTest` (blocked: missing WordPress PHPUnit test suite at `WP_TESTS_DIR` / `/wordpress-phpunit` / temp `wordpress-tests-lib`)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 5m and 81,235 tokens on this as a headless worker.
