### PR TITLE
ci: salvage canonical naming guard from PR #1294

### DIFF
--- a/.github/workflows/canonical-naming-guard.yml
+++ b/.github/workflows/canonical-naming-guard.yml
@@ -1,0 +1,147 @@
+name: Canonical Naming Guard
+
+# Defence-in-depth against rogue rename PRs.
+#
+# History: PRs #1289, #1290, #1291 were headless-worker submissions that
+# renamed canonical sd-ai-agent / SdAiAgent / SD_AI_AGENT_ identifiers to the
+# WP.org slug 'superdav-ai-agent'. AGENTS.md documents the rules; this workflow
+# enforces the high-signal rename checks at PR-time so a future weak model can't
+# slip the same change through review.
+#
+# See AGENTS.md → "CANONICAL NAMING - DO NOT CHANGE".
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: canonical-naming-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  canonical-naming:
+    name: Verify canonical identifiers
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v6
+
+      - name: Plugin DI container ID must be 'sd-ai-agent'
+        run: |
+          if ! grep -qE "'id'\s*=>\s*'sd-ai-agent'" superdav-ai-agent.php; then
+            echo "::error file=superdav-ai-agent.php::Missing required line: 'id' => 'sd-ai-agent'"
+            echo "::error::The DI container ID must remain 'sd-ai-agent'. AGENTS.md forbids renaming it to 'superdav-ai-agent' (that string is only the WP.org slug + text domain)."
+            exit 1
+          fi
+          echo "OK: DI container ID is 'sd-ai-agent'"
+
+      - name: Compile class must be 'CompiledContainerSdAiAgent'
+        run: |
+          if ! grep -qE "'compile_class'\s*=>\s*'CompiledContainerSdAiAgent'" superdav-ai-agent.php; then
+            echo "::error file=superdav-ai-agent.php::Missing required line: 'compile_class' => 'CompiledContainerSdAiAgent'"
+            echo "::error::See AGENTS.md → CANONICAL NAMING."
+            exit 1
+          fi
+          echo "OK: compile_class is 'CompiledContainerSdAiAgent'"
+
+      - name: Constants must use SD_AI_AGENT_ prefix
+        run: |
+          for c in SD_AI_AGENT_DIR SD_AI_AGENT_VERSION; do
+            if ! grep -q "$c" superdav-ai-agent.php; then
+              echo "::error file=superdav-ai-agent.php::Missing required constant: $c"
+              echo "::error::AGENTS.md requires the SD_AI_AGENT_ constant prefix. Do not rename to SUPERDAV_AI_AGENT_."
+              exit 1
+            fi
+          done
+          echo "OK: SD_AI_AGENT_DIR and SD_AI_AGENT_VERSION present"
+
+      - name: Forbid SUPERDAV_AI_AGENT_ constant prefix
+        # The plugin slug 'superdav-ai-agent' is correct for text-domain strings
+        # only. Renaming SD_AI_AGENT_ constants to SUPERDAV_AI_AGENT_ is exactly
+        # the rogue pattern from PR #1289 — block it explicitly.
+        run: |
+          hits=$(grep -rEn 'SUPERDAV_AI_AGENT_[A-Z]+' \
+            --include='*.php' \
+            --exclude-dir=vendor \
+            --exclude-dir=node_modules \
+            --exclude-dir=build \
+            . || true)
+          if [ -n "$hits" ]; then
+            echo "::error::Forbidden constant prefix SUPERDAV_AI_AGENT_ found:"
+            echo "$hits"
+            echo "::error::Use SD_AI_AGENT_ instead. See AGENTS.md → CANONICAL NAMING."
+            exit 1
+          fi
+          echo "OK: no SUPERDAV_AI_AGENT_ constant references"
+
+      - name: Forbid SuperdavAiAgent\\ namespace
+        run: |
+          hits=$(grep -rEn 'namespace\s+SuperdavAiAgent\\?|use\s+SuperdavAiAgent\\?' \
+            --include='*.php' \
+            --exclude-dir=vendor \
+            --exclude-dir=node_modules \
+            --exclude-dir=build \
+            . || true)
+          if [ -n "$hits" ]; then
+            echo "::error::Forbidden namespace SuperdavAiAgent\\ found (use SdAiAgent\\):"
+            echo "$hits"
+            exit 1
+          fi
+          echo "OK: no SuperdavAiAgent namespace references"
+
+      - name: Forbid CompiledContainerSuperdavAiAgent
+        run: |
+          hits=$(grep -rEn 'CompiledContainerSuperdavAiAgent' \
+            --include='*.php' \
+            --exclude-dir=vendor \
+            --exclude-dir=node_modules \
+            --exclude-dir=build \
+            . || true)
+          if [ -n "$hits" ]; then
+            echo "::error::Forbidden compile class name CompiledContainerSuperdavAiAgent found (use CompiledContainerSdAiAgent):"
+            echo "$hits"
+            echo "::error::This is the rogue pattern from PR #1289. See AGENTS.md."
+            exit 1
+          fi
+          echo "OK: no CompiledContainerSuperdavAiAgent references"
+
+      - name: Forbid 'id' => 'superdav-ai-agent' in xwp_load_app
+        # Specifically blocks the PR #1289 pattern. We can't blanket-ban the
+        # string 'superdav-ai-agent' (it's the legitimate text domain), so
+        # this catches the high-signal context.
+        run: |
+          if grep -qE "'id'\s*=>\s*'superdav-ai-agent'" superdav-ai-agent.php; then
+            echo "::error file=superdav-ai-agent.php::Forbidden: 'id' => 'superdav-ai-agent' (PR #1289 rogue pattern)"
+            echo "::error::The DI container ID must be 'sd-ai-agent'. See AGENTS.md."
+            exit 1
+          fi
+          echo "OK: no 'id' => 'superdav-ai-agent' in main plugin file"
+
+      - name: Forbid gratis-ai-agent rename code
+        # PR #1290 tried to rename gratis-ai-agent → superdav-ai-agent.
+        # The correct historical-name policy is "ignore", not "migrate".
+        run: |
+          hits=$(grep -rEn 'gratis-ai-agent' \
+            --include='*.php' \
+            --exclude-dir=vendor \
+            --exclude-dir=node_modules \
+            --exclude-dir=build \
+            . || true)
+          if [ -n "$hits" ]; then
+            echo "::error::Forbidden 'gratis-ai-agent' references found (PR #1290 rogue pattern):"
+            echo "$hits"
+            echo "::error::AGENTS.md rule 3: no legacy-name handling. Remove these references."
+            exit 1
+          fi
+          echo "OK: no gratis-ai-agent references"
+
+      - name: Summary
+        run: |
+          echo "All canonical naming checks passed."
+          echo "Plugin slug (text domain): superdav-ai-agent"
+          echo "Code prefixes / DI / namespace: sd-ai-agent / SdAiAgent / SD_AI_AGENT_"

--- a/.github/workflows/worker-model-allowlist.yml
+++ b/.github/workflows/worker-model-allowlist.yml
@@ -1,0 +1,89 @@
+name: Worker Model Allowlist
+
+# Inspects aidevops PR signature footers and fails the PR if the model that
+# produced it is on the denylist of weak/free-tier models.
+#
+# History: PRs #1283/#1289/#1290/#1291 were produced by free OpenCode meta
+# models (`nemotron-3-super-free`, `minimax-m2.5-free`) and renamed canonical
+# identifiers in violation of AGENTS.md. Those models are now blocked from
+# producing merged PRs in this repo.
+#
+# Signature format (from gh-signature-helper.sh):
+#   [aidevops.sh](https://aidevops.sh) v3.x.y plugin for [OpenCode](https://opencode.ai) v1.x.y with <model> spent ...
+#
+# Human-authored PRs (no aidevops:sig marker) are not affected — this only
+# fires when an aidevops signature is present.
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+concurrency:
+  group: worker-model-allowlist-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-signature-model:
+    name: Reject weak-model worker PRs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Inspect PR body for denylisted model
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: |
+          set -eu
+
+          if [ -z "${PR_BODY:-}" ]; then
+            echo "PR body is empty — nothing to check."
+            exit 0
+          fi
+
+          if ! printf '%s' "$PR_BODY" | grep -q 'aidevops:sig'; then
+            echo "No aidevops:sig marker — human-authored PR, skipping."
+            exit 0
+          fi
+
+          # Models that have demonstrably produced rogue rename PRs in this
+          # repo (#1283, #1289, #1290, #1291). DO NOT remove an entry without
+          # documented evidence the model has improved on naming/refactor
+          # tasks. ADD new entries when a future weak model misfires.
+          DENY_MODELS=(
+            "nemotron-3-super-free"
+            "nemotron-3-super"
+            "minimax-m2.5-free"
+            "minimax-m2.5"
+            "big-pickle"
+            "hy3-preview-free"
+            "gpt-5.4-mini"
+          )
+
+          # Extract the worker model from the canonical signature line.
+          # Format: "with <model-id> spent ..." — anchored on the framework
+          # signature so we don't false-positive on body prose.
+          model_line=$(printf '%s' "$PR_BODY" | grep -oE 'with [^ ]+ spent' | head -1 || true)
+          if [ -z "$model_line" ]; then
+            echo "::warning::aidevops:sig present but worker-model line not found — allowing through (fix gh-signature-helper if recurring)."
+            exit 0
+          fi
+
+          model=$(printf '%s' "$model_line" | sed -E 's/^with (.+) spent$/\1/')
+          echo "Detected worker model: $model"
+
+          for deny in "${DENY_MODELS[@]}"; do
+            if printf '%s' "$model" | grep -qF "$deny"; then
+              echo "::error::Worker model '$model' is on the denylist for this repo (matched '$deny')."
+              echo "::error::PRs #1283/#1289/#1290/#1291 demonstrated this model class cannot reliably handle naming/refactor briefs."
+              echo "::error::Re-dispatch with an Anthropic-tier model (sonnet/opus), or open the PR interactively after manual review."
+              echo "::error::See repo issue #1293 for the full incident analysis."
+              exit 1
+            fi
+          done
+
+          echo "OK: worker model '$model' is not on the denylist."


### PR DESCRIPTION
## Summary
- Salvages the still-valuable CI guardrails from closed-unmerged PR #1294 onto current `main` without carrying the stale branch unrelated drift.
- Adds a canonical-naming workflow that blocks high-signal rogue rename patterns from PRs #1289, #1290, and #1291: wrong DI id, wrong compile class, wrong constant prefix, wrong namespace, and `gratis-ai-agent` handling in PHP.
- Adds a `pull_request_target` worker-model gate that denies known weak/free model signatures while leaving human PRs without `aidevops:sig` unaffected.

## Source PR review
- Source: #1294 (`ci/canonical-naming-and-model-allowlist`), closed unmerged.
- Kept: the canonical-naming guard and weak-model denylist are still valuable defense-in-depth for the incident described in #1293.
- Adjusted: omitted the source PR `ai-agent/` legacy-migration grep because current `main` still contains tested alias behavior in `includes/Tools/ToolDiscovery.php`; adding that check here would make the new guard fail immediately. That policy cleanup should be handled separately from this salvage.

## Verification
- `python3` YAML parse for `.github/workflows/canonical-naming-guard.yml` and `.github/workflows/worker-model-allowlist.yml`
- Local execution of the salvaged canonical guard assertions against current tree
- Local simulation of worker-model gate: rejects `nemotron-3-super-free`, allows `openai/gpt-5.5`, and skips a human body without `aidevops:sig`

Ref #1293
Ref #1294

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 7m and 77,158 tokens on this as a headless worker.
