### PR TITLE
ci: scope canonical guard to runtime PHP

### DIFF
--- a/.github/workflows/canonical-naming-guard.yml
+++ b/.github/workflows/canonical-naming-guard.yml
@@ -67,6 +67,7 @@ jobs:
         run: |
           hits=$(grep -rEn 'SUPERDAV_AI_AGENT_[A-Z]+' \
             --include='*.php' \
+            --exclude-dir=tests \
             --exclude-dir=vendor \
             --exclude-dir=node_modules \
             --exclude-dir=build \
@@ -83,6 +84,7 @@ jobs:
         run: |
           hits=$(grep -rEn 'namespace\s+SuperdavAiAgent\\?|use\s+SuperdavAiAgent\\?' \
             --include='*.php' \
+            --exclude-dir=tests \
             --exclude-dir=vendor \
             --exclude-dir=node_modules \
             --exclude-dir=build \
@@ -98,6 +100,7 @@ jobs:
         run: |
           hits=$(grep -rEn 'CompiledContainerSuperdavAiAgent' \
             --include='*.php' \
+            --exclude-dir=tests \
             --exclude-dir=vendor \
             --exclude-dir=node_modules \
             --exclude-dir=build \
@@ -128,6 +131,7 @@ jobs:
         run: |
           hits=$(grep -rEn 'gratis-ai-agent' \
             --include='*.php' \
+            --exclude-dir=tests \
             --exclude-dir=vendor \
             --exclude-dir=node_modules \
             --exclude-dir=build \


### PR DESCRIPTION
## Summary
- Fixes the canonical naming guard merged in #1349 so recursive forbidden-pattern scans target runtime PHP only.
- Excludes `tests/` from those recursive scans because existing tests intentionally mention forbidden historical strings as assertions/fixtures, not runtime code.

## Verification
- `python3` YAML parse for `.github/workflows/canonical-naming-guard.yml` and `.github/workflows/worker-model-allowlist.yml`
- Local execution of the canonical guard assertions with the same `--exclude-dir=tests` scan scope now used by the workflow

Fixes the failed `Verify canonical identifiers` check observed after #1349 merged.

Ref #1349

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 14m and 102,595 tokens on this as a headless worker.
