### PR TITLE
refactor: drop /providers transient cache (-100 lines, fixes stale list for new provider plugins)

### DIFF
--- a/includes/Bootstrap/AdminHandler.php
+++ b/includes/Bootstrap/AdminHandler.php
@@ -18,8 +18,6 @@ use SdAiAgent\Admin\FloatingWidget;
 use SdAiAgent\Admin\UnifiedAdminMenu;
 use SdAiAgent\Compat\GutenbergConnectorsBridge;
 use SdAiAgent\Core\Database;
-use SdAiAgent\REST\ConnectorsController;
-use SdAiAgent\REST\SettingsController;
 use XWP\DI\Decorators\Action;
 use XWP\DI\Decorators\Filter;
 use XWP\DI\Decorators\Handler;
@@ -77,57 +75,12 @@ final class AdminHandler {
 	 * - DB schema safety-net (dbDelta is no-op when schema is current).
 	 * - Per-tool capabilities for role-management plugins.
 	 * - Legacy URL redirects to unified menu.
-	 * - Connector option update hooks to invalidate the providers cache when
-	 *   credentials are changed via the native WP 7.0 Connectors admin page.
 	 */
 	#[Action( tag: 'admin_init', priority: 10 )]
 	public function on_admin_init(): void {
 		Database::install();
 		ToolCapabilities::register_capabilities( ToolCapabilities::all_ability_ids() );
 		UnifiedAdminMenu::handleLegacyRedirects();
-		$this->register_connector_cache_hooks();
-	}
-
-	/**
-	 * Register option-write hooks for WP Connectors API option keys.
-	 *
-	 * The native WP 7.0 Connectors page (options-connectors.php) writes
-	 * connectors_ai_{provider}_api_key options directly.  Hooking into both
-	 * update_option_{key} and add_option_{key} ensures the site-wide providers
-	 * transient cache is invalidated whenever an external connector change is
-	 * saved, so admins see fresh provider data on the next GET /providers
-	 * request.
-	 *
-	 * The add_option_{key} hook is required because WordPress fires it (NOT
-	 * update_option_{key}) the very first time a connector key is saved on a
-	 * fresh install.  Without it, first-time users had to wait up to 5 minutes
-	 * for the providers transient to expire before the UI reflected their
-	 * newly added credentials.
-	 *
-	 * accepted_args=0 is intentional: flush_providers_cache() takes no
-	 * parameters, and update_option_{key} / add_option_{key} pass args we do
-	 * not need.
-	 */
-	private function register_connector_cache_hooks(): void {
-		foreach ( ConnectorsController::PROVIDERS as $meta ) {
-			add_action(
-				'update_option_' . $meta['option_key'],
-				[ SettingsController::class, 'flush_providers_cache' ],
-				10,
-				0
-			);
-			add_action(
-				'add_option_' . $meta['option_key'],
-				[ SettingsController::class, 'flush_providers_cache' ],
-				10,
-				0
-			);
-		}
-
-		// Flush when any provider plugin is activated or deactivated so the
-		// WP SDK registry change is immediately reflected in the chat UI.
-		add_action( 'activated_plugin', [ SettingsController::class, 'flush_providers_cache' ], 10, 0 );
-		add_action( 'deactivated_plugin', [ SettingsController::class, 'flush_providers_cache' ], 10, 0 );
 	}
 
 	/**

--- a/includes/REST/ConnectorsController.php
+++ b/includes/REST/ConnectorsController.php
@@ -196,10 +196,6 @@ final class ConnectorsController {
 		$option_key = self::PROVIDERS[ $provider_id ]['option_key'];
 		update_option( $option_key, $api_key, false );
 
-		// Connector credentials changed — invalidate the site-wide providers cache
-		// so every admin sees the updated list on the next /providers request.
-		SettingsController::flush_providers_cache();
-
 		return new WP_REST_Response(
 			array(
 				'success'    => true,
@@ -231,10 +227,6 @@ final class ConnectorsController {
 
 		$option_key = self::PROVIDERS[ $provider_id ]['option_key'];
 		delete_option( $option_key );
-
-		// Connector credentials removed — invalidate the site-wide providers cache
-		// so every admin sees the updated list on the next /providers request.
-		SettingsController::flush_providers_cache();
 
 		return new WP_REST_Response(
 			array(

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -728,64 +728,20 @@ final class SettingsController {
 	}
 
 	/**
-	 * Site option that stores the cache version counter.
-	 *
-	 * Bumping this value effectively orphans all existing per-user transients,
-	 * ensuring every admin sees a fresh providers list on the next request.
-	 */
-	const PROVIDERS_CACHE_VERSION_OPTION = 'sd_ai_providers_cache_version';
-
-	/**
-	 * Transient key for the cached providers list.
-	 *
-	 * Incorporates a site-wide version counter so that bumping the version in
-	 * flush_providers_cache() immediately invalidates every admin's cached copy
-	 * without needing to enumerate all user IDs.  The per-user suffix is
-	 * retained for compatibility with ProviderCredentialLoader, which may
-	 * resolve different credentials per user in future.
-	 *
-	 * @return string
-	 */
-	private static function providers_cache_key(): string {
-		$version = (int) get_option( self::PROVIDERS_CACHE_VERSION_OPTION, 0 );
-		return 'sd_ai_providers_' . $version . '_' . get_current_user_id();
-	}
-
-	/**
-	 * Flush the cached providers list for ALL admins.
-	 *
-	 * Increments the site-wide version counter so every existing per-user
-	 * transient (keyed on the previous version) is abandoned.  The orphaned
-	 * transients expire naturally within 5 minutes; no need to enumerate users.
-	 *
-	 * Call whenever provider credentials are added, changed, or removed so the
-	 * next GET /providers rebuilds the list from live data.
-	 */
-	public static function flush_providers_cache(): void {
-		update_option(
-			self::PROVIDERS_CACHE_VERSION_OPTION,
-			(int) get_option( self::PROVIDERS_CACHE_VERSION_OPTION, 0 ) + 1,
-			false
-		);
-	}
-
-	/**
 	 * Handle the /providers endpoint — list registered AI providers and models.
 	 *
-	 * The result is cached in a 5-minute transient because `listModelMetadata()`
-	 * on WP SDK providers can make a live HTTP call to the upstream API to
-	 * enumerate available models, adding ~1 s on every page load. The cache is
-	 * invalidated by flush_providers_cache() whenever credentials change.
+	 * No caching layer is needed here: the underlying WP AI Client SDK already
+	 * caches `listModelMetadata()` results for 24 hours via
+	 * `AbstractApiBasedModelMetadataDirectory::getModelMetadataMap()`. Adding a
+	 * second cache on top forced us to invent invalidation rules per provider
+	 * option key, which broke whenever a new third-party provider plugin
+	 * (e.g. `ai-provider-for-anthropic-max`) stored credentials under an
+	 * option we did not know about. Dropping the layer keeps `/providers`
+	 * fresh by construction and removes the entire stale-cache class of bugs.
 	 *
 	 * @return WP_REST_Response
 	 */
 	public function handle_providers(): WP_REST_Response {
-		$cache_key = self::providers_cache_key();
-		$cached    = get_transient( $cache_key );
-		if ( false !== $cached && is_array( $cached ) ) {
-			return new WP_REST_Response( $cached, 200 );
-		}
-
 		$providers = array();
 
 		// Built-in providers (OpenAI, Anthropic, Google) — listed first when a
@@ -890,10 +846,6 @@ final class SettingsController {
 				}
 			}
 		}
-
-		// Cache for 5 minutes. Provider lists rarely change during a session;
-		// flush_providers_cache() is called whenever credentials are updated.
-		set_transient( $cache_key, $providers, 5 * MINUTE_IN_SECONDS );
 
 		return new WP_REST_Response( $providers, 200 );
 	}

--- a/uninstall.php
+++ b/uninstall.php
@@ -56,6 +56,9 @@ $sd_ai_agent_options = [
 	'sd_ai_agent_tool_profiles',
 	'sd_ai_agent_custom_tools_seeded',
 	'sd_ai_agent_migrated_from_ai_agent',
+	// Removed when the /providers transient cache was dropped — kept so the
+	// stranded counter row is cleaned up on sites that ran earlier versions.
+	'sd_ai_providers_cache_version',
 ];
 
 foreach ( $sd_ai_agent_options as $sd_ai_agent_option ) {


### PR DESCRIPTION
## Summary

- Removes the `/providers` REST endpoint's 5-minute transient cache and all of its invalidation plumbing.
- Fixes the stale-cache class of bugs that surfaced whenever a new provider plugin (e.g. `ai-provider-for-anthropic-max`) stored credentials under an option key our hardcoded hook list didn't know about.
- Net **-100 lines**, four files touched, no behaviour change for the happy path because the WP AI Client SDK already caches the only expensive call here for 24 hours.

## Why

`SettingsController::handle_providers()` wrapped its response in a 5-minute site-wide transient and invalidated it via:

- `update_option_` / `add_option_` hooks on a hardcoded list of three `connectors_ai_*_api_key` option keys in `AdminHandler::register_connector_cache_hooks()`.
- `activated_plugin` / `deactivated_plugin` hooks calling `SettingsController::flush_providers_cache()`.

This forced us to know every provider plugin's credential option key ahead of time. The `ai-provider-for-anthropic-max` plugin stores its OAuth token under its own key, so the cache stayed stale after a token was set there until the 5-minute TTL expired or the plugin was activated/deactivated. Any future third-party connector would hit the same trap.

The cache was also unnecessary. The only expensive call inside `handle_providers()` is `listModelMetadata()`, which the WP AI Client SDK already caches for **86400 seconds** in `AbstractApiBasedModelMetadataDirectory::getModelMetadataMap()` via `WithDataCachingTrait`. Our 5-minute transient on top only saved a handful of `get_option()` reads and in-memory method calls per request, against an endpoint that is hit on admin page loads — not in any hot path.

## What's removed

- `SettingsController::PROVIDERS_CACHE_VERSION_OPTION`
- `SettingsController::providers_cache_key()`
- `SettingsController::flush_providers_cache()`
- All four `add_option_*` / `update_option_*` and both `activated_plugin` / `deactivated_plugin` hooks in `AdminHandler::register_connector_cache_hooks()` (the method itself, since it had no other purpose)
- Two `SettingsController::flush_providers_cache()` call sites in `ConnectorsController::handle_set_key()` and `handle_clear_key()`
- `SettingsController` and `ConnectorsController` `use` imports from `AdminHandler` that are no longer referenced

## What's added

- `uninstall.php` now removes the stranded `sd_ai_providers_cache_version` option row on sites that upgraded from earlier versions.

## Verification

| Check | Result |
| --- | --- |
| `php -l` on all four edited files | clean |
| `vendor/bin/phpcs --standard=phpcs.xml` on all four edited files | clean |
| `vendor/bin/phpstan analyse` on all four edited files | one error in `uninstall.php` is **pre-existing on `main`** (`$wpdb->usermeta` encapsed-string-part), not introduced by this change |

`tests/SdAiAgent/CLI/ModelsCommandTest.php` references the string `SettingsController::handle_providers()` in an unrelated docblock assertion — that method still exists, so the assertion still passes.

## Risk

Low. Removes code rather than adding it. The endpoint becomes fresh by construction. Cost of the lost cache layer is negligible (handful of cheap option reads and PHP method dispatches per `/providers` call) compared to the SDK's own 24-hour cache that does the real heavy lifting.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 23h 6m and 15,815 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined the providers caching mechanism to rely on the underlying SDK's built-in cache, removing redundant controller-level caching logic.
  * Simplified the initialization process by eliminating unnecessary cache management hooks.
  * Improved cleanup during plugin uninstallation to remove related legacy options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1351)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->