### PR TITLE
fix: gate generate-image ability and stock-image tip on provider availability

### DIFF
--- a/includes/Abilities/ImageAbilities/GenerateImageAbility.php
+++ b/includes/Abilities/ImageAbilities/GenerateImageAbility.php
@@ -29,9 +29,18 @@ class GenerateImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 
 	/**
 	 * Register this ability.
+	 *
+	 * Only registers when an image-capable AI provider is actually configured.
+	 * Without one, exposing the ability would mislead the model into calling a
+	 * tool that can only return an error.
 	 */
 	public static function register(): void {
 		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		if ( ! function_exists( 'wp_ai_client_prompt' )
+			|| ! wp_ai_client_prompt()->is_supported_for_image_generation() ) {
 			return;
 		}
 

--- a/includes/Abilities/ImageAbilities/StockImageAbility.php
+++ b/includes/Abilities/ImageAbilities/StockImageAbility.php
@@ -158,16 +158,26 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 			}
 		}
 
+		// Only suggest the AI-generation fallback when an image-capable
+		// provider is actually configured; otherwise the tip points at a
+		// dead end. Mirrors the gate used inside GenerateImageAbility itself.
+		$can_generate = function_exists( 'wp_ai_client_prompt' )
+			&& wp_ai_client_prompt()->is_supported_for_image_generation();
+		$generate_tip = 'Use sd-ai-agent/generate-image to create an AI-generated image instead.';
+
 		if ( ! $has_free ) {
-			return [
+			$response = [
 				'attachment_id' => 0,
 				'url'           => '',
 				'alt'           => '',
 				'title'         => '',
 				'source'        => '',
 				'error'         => 'No free stock image source is available. Configure Openverse or Pixabay.',
-				'tip'           => 'Use sd-ai-agent/generate-image to create an AI-generated image instead.',
 			];
+			if ( $can_generate ) {
+				$response['tip'] = $generate_tip;
+			}
+			return $response;
 		}
 
 		// Let the factory try all available free sources in priority order
@@ -181,7 +191,7 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 		$result = ImageSourceFactory::import_image( $keyword, '', $width, $height, $options );
 
 		if ( is_wp_error( $result ) ) {
-			return [
+			$response = [
 				'attachment_id' => 0,
 				'url'           => '',
 				'alt'           => '',
@@ -189,8 +199,11 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 				'source'        => '',
 				// Error message from the factory lists each source tried and why it failed.
 				'error'         => $result->get_error_message(),
-				'tip'           => 'Use sd-ai-agent/generate-image to create an AI-generated image instead.',
 			];
+			if ( $can_generate ) {
+				$response['tip'] = $generate_tip;
+			}
+			return $response;
 		}
 
 		$result['tip'] = 'Use attachment_id as featured_image_id when calling create-post or update-post.';


### PR DESCRIPTION
## Summary

- `GenerateImageAbility::register()` now returns early when no image-capable AI provider is connected, so `sd-ai-agent/generate-image` is never registered in that case and the model can't be told to call a tool that can only fail.
- `StockImageAbility::execute_callback()` only adds the "Use `sd-ai-agent/generate-image` instead" tip to its error responses when an image-capable provider is actually configured.

## Detail

The provider check mirrors the gate already used inside `GenerateImageAbility::execute_callback()`:

```php
function_exists( 'wp_ai_client_prompt' )
    && wp_ai_client_prompt()->is_supported_for_image_generation()
```

Registration runs on `wp_abilities_api_init` (during `init`), well after `plugins_loaded`, so the AI Client SDK and connector config are fully available.

The runtime guard inside `GenerateImageAbility::execute_callback()` is retained as defence-in-depth for the static proxy path (`AiImageAbilities::handle_generate`) that tests use, and for the edge case of a provider being removed mid-request.

## Files

- `includes/Abilities/ImageAbilities/GenerateImageAbility.php` — gate `register()`.
- `includes/Abilities/ImageAbilities/StockImageAbility.php` — conditionally emit the AI-generate tip in both error response branches; success-path tip (`attachment_id` -> `featured_image_id`) is unchanged.

## Verification

- `composer phpcs` on both files: clean.
- `composer phpstan --no-progress`: no errors.

## Behaviour

| Image-capable provider | Before | After |
| --- | --- | --- |
| Connected | `generate-image` registered, stock-image tip points at it | unchanged |
| Not connected | `generate-image` registered but only returns an error; stock-image tip pointed at a dead end | `generate-image` not registered; stock-image no longer mentions it |

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 23h 52m and 15,815 tokens on this as a headless worker.
