### PR TITLE
GH#1356: align WooCommerce auto-enable with native abilities

### DIFF
--- a/includes/Core/OnboardingManager.php
+++ b/includes/Core/OnboardingManager.php
@@ -50,22 +50,6 @@ class OnboardingManager {
 	 */
 	const BOOTSTRAP_SESSION_OPTION = 'sd_ai_agent_bootstrap_session_id';
 
-	// ── Bootstrap ─────────────────────────────────────────────────────────
-
-	/**
-	 * Register all hooks.
-	 */
-	public static function register(): void {
-		// Register the cron handler.
-		SiteScanner::register();
-
-		// On every admin_init, check whether we should trigger onboarding.
-		add_action( 'admin_init', [ __CLASS__, 'maybe_trigger' ] );
-
-		// REST endpoint for status polling.
-		add_action( 'rest_api_init', [ __CLASS__, 'register_rest_routes' ] );
-	}
-
 	/**
 	 * Called on plugin activation.
 	 *

--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -475,12 +475,15 @@ class Settings {
 	 * @var string[]
 	 */
 	const WOO_ABILITY_IDS = array(
-		'sd-ai-agent/woo-get-products',
-		'sd-ai-agent/woo-create-product',
-		'sd-ai-agent/woo-update-product',
-		'sd-ai-agent/woo-delete-product',
-		'sd-ai-agent/woo-get-orders',
-		'sd-ai-agent/woo-get-store-stats',
+		'woocommerce/products-list',
+		'woocommerce/products-get',
+		'woocommerce/products-create',
+		'woocommerce/products-update',
+		'woocommerce/products-delete',
+		'woocommerce/orders-list',
+		'woocommerce/orders-get',
+		'woocommerce/orders-create',
+		'woocommerce/orders-update',
 	);
 
 	/**

--- a/includes/Core/SystemInstructionBuilder.php
+++ b/includes/Core/SystemInstructionBuilder.php
@@ -201,7 +201,7 @@ class SystemInstructionBuilder {
 			. "- Include `categories` and `tags` arrays for blog posts.\n"
 			. "- Include `excerpt` for SEO meta descriptions.\n"
 			. "- To add a featured image: first call `sd-ai-agent/stock-image` or `sd-ai-agent/generate-image`, then pass the returned attachment_id as `featured_image_id` in create-post or update-post.\n"
-			. "- For WooCommerce products, use `sd-ai-agent/woo-create-product` instead.\n\n"
+			. "- For WooCommerce products, use WooCommerce's native `woocommerce/products-create` ability instead.\n\n"
 			. "## Tips\n"
 			. "- Chain operations: create content first, then configure settings.\n"
 			. "- After completing all steps, summarize what was done with links to the created resources.\n\n"

--- a/includes/Models/Agent.php
+++ b/includes/Models/Agent.php
@@ -624,7 +624,7 @@ class Agent {
 				. "- Include `categories` and `tags` arrays for blog posts.\n"
 				. "- Include `excerpt` for SEO meta descriptions.\n"
 				. "- To add a featured image: first call `sd-ai-agent/stock-image` or `sd-ai-agent/generate-image`, then pass the returned attachment_id as `featured_image_id`.\n"
-				. "- For WooCommerce products, search for a `woo-create-product` ability via `sd-ai-agent/ability-search` (only available when WooCommerce is active).\n\n"
+				. "- For WooCommerce products, search for `woocommerce/products-*` abilities via `sd-ai-agent/ability-search` (only available when WooCommerce is active).\n\n"
 				. "## Tips\n"
 				. "- Chain operations: create content first, then configure settings.\n"
 				. "- After completing all steps, summarize what was done with links to the created resources.\n\n"
@@ -853,9 +853,9 @@ class Agent {
 				. "3. **Sales-focused.** Write product descriptions that sell. Highlight benefits, not just features. Include calls to action.\n"
 				. "4. **Data-aware.** Check existing products and orders before making recommendations. Use actual store data, not assumptions.\n\n"
 				. "## Product Management\n"
-				. "- Use `sd-ai-agent/woo-create-product` to create new products.\n"
-				. "- Use `sd-ai-agent/woo-update-product` to modify existing products.\n"
-				. "- Use `sd-ai-agent/woo-get-products` to list and search products.\n"
+				. "- Use `woocommerce/products-create` to create new products.\n"
+				. "- Use `woocommerce/products-update` to modify existing products.\n"
+				. "- Use `woocommerce/products-list` and `woocommerce/products-get` to list, search, and inspect products.\n"
 				. "- Add product images using `sd-ai-agent/stock-image` first, then reference the attachment ID.\n"
 				. "- Set up product categories and tags for better organization.\n\n"
 				. "## Store Optimization\n"
@@ -864,7 +864,7 @@ class Agent {
 				. "- Review product categories and suggest a logical taxonomy.\n"
 				. "- Ensure all products have images, descriptions, and proper categorization.\n\n"
 				. "## Order & Customer Insights\n"
-				. "- Use `sd-ai-agent/woo-get-orders` to review recent orders.\n"
+				. "- Use `woocommerce/orders-list` and `woocommerce/orders-get` to review recent orders.\n"
 				. "- Analyze sales trends and top-performing products.\n"
 				. "- Identify products that might need attention (no sales, no reviews, incomplete listings).\n\n"
 				. "## Reporting\n"
@@ -878,10 +878,12 @@ class Agent {
 					array_merge(
 						$base_tools,
 						[
-							'sd-ai-agent/woo-create-product',
-							'sd-ai-agent/woo-update-product',
-							'sd-ai-agent/woo-get-products',
-							'sd-ai-agent/woo-get-orders',
+							'woocommerce/products-create',
+							'woocommerce/products-update',
+							'woocommerce/products-list',
+							'woocommerce/products-get',
+							'woocommerce/orders-list',
+							'woocommerce/orders-get',
 							'sd-ai-agent/stock-image',
 							'sd-ai-agent/get-plugins',
 						]

--- a/tests/SdAiAgent/Core/OnboardingManagerTest.php
+++ b/tests/SdAiAgent/Core/OnboardingManagerTest.php
@@ -59,26 +59,6 @@ class OnboardingManagerTest extends WP_UnitTestCase {
 		$this->assertSame( 'sd_ai_agent_onboarding_triggered', OnboardingManager::TRIGGERED_OPTION );
 	}
 
-	// ── register ──────────────────────────────────────────────────────────
-
-	/**
-	 * register() hooks maybe_trigger to admin_init.
-	 */
-	public function test_register_hooks_maybe_trigger_to_admin_init(): void {
-		OnboardingManager::register();
-
-		$this->assertNotFalse( has_action( 'admin_init', [ OnboardingManager::class, 'maybe_trigger' ] ) );
-	}
-
-	/**
-	 * register() hooks register_rest_routes to rest_api_init.
-	 */
-	public function test_register_hooks_rest_routes_to_rest_api_init(): void {
-		OnboardingManager::register();
-
-		$this->assertNotFalse( has_action( 'rest_api_init', [ OnboardingManager::class, 'register_rest_routes' ] ) );
-	}
-
 	// ── trigger ───────────────────────────────────────────────────────────
 
 	/**

--- a/tests/SdAiAgent/Core/SettingsTest.php
+++ b/tests/SdAiAgent/Core/SettingsTest.php
@@ -13,6 +13,11 @@ use SdAiAgent\Core\Settings;
 use WP_UnitTestCase;
 
 /**
+ * Test double used to satisfy Settings::maybe_auto_enable_woo_abilities().
+ */
+final class WooCommerceTestDouble {}
+
+/**
  * Test Settings functionality.
  */
 class SettingsTest extends WP_UnitTestCase {
@@ -23,6 +28,7 @@ class SettingsTest extends WP_UnitTestCase {
 	public function tear_down(): void {
 		parent::tear_down();
 		delete_option( Settings::OPTION_NAME );
+		delete_option( Settings::WOO_AUTO_ENABLED_OPTION );
 	}
 
 	/**
@@ -143,5 +149,31 @@ class SettingsTest extends WP_UnitTestCase {
 
 		$result = Settings::instance()->get( 'tool_permissions' );
 		$this->assertSame( $perms, $result );
+	}
+
+	/**
+	 * Test WooCommerce auto-enable grants native WooCommerce REST abilities.
+	 */
+	public function test_maybe_auto_enable_woo_abilities_grants_native_woocommerce_abilities(): void {
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			class_alias( WooCommerceTestDouble::class, 'WooCommerce' );
+		}
+
+		Settings::instance()->update(
+			[
+				'default_provider'  => 'openai',
+				'tool_permissions' => [ 'sd-ai-agent/create-post' => 'confirm' ],
+			]
+		);
+
+		Settings::instance()->maybe_auto_enable_woo_abilities();
+
+		$permissions = Settings::instance()->get( 'tool_permissions' );
+		$this->assertSame( 'confirm', $permissions['sd-ai-agent/create-post'] );
+		$this->assertSame( 'auto', $permissions['woocommerce/products-list'] );
+		$this->assertSame( 'auto', $permissions['woocommerce/products-create'] );
+		$this->assertSame( 'auto', $permissions['woocommerce/orders-list'] );
+		$this->assertArrayNotHasKey( 'sd-ai-agent/woo-get-products', $permissions );
+		$this->assertTrue( (bool) get_option( Settings::WOO_AUTO_ENABLED_OPTION ) );
 	}
 }


### PR DESCRIPTION
## Summary

Auto-enable now grants WooCommerce's native products/orders ability IDs, built-in prompts reference those native tools, and the obsolete OnboardingManager register shim/tests were removed now that DI owns onboarding hooks.

## Files Changed

includes/Core/OnboardingManager.php,includes/Core/Settings.php,includes/Core/SystemInstructionBuilder.php,includes/Models/Agent.php,tests/SdAiAgent/Core/OnboardingManagerTest.php,tests/SdAiAgent/Core/SettingsTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** composer phpcs -- modified PHP files; php -l modified PHP files; composer phpstan -- --memory-limit=2G; composer test -- --filter 'SettingsTest|OnboardingManagerTest' (blocked: missing WordPress test library at sandbox tmp wordpress-tests-lib/includes/functions.php)

Resolves #1356


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 7m and 86,604 tokens on this as a headless worker.