### PR TITLE
GH#1357: test: cover skill usage telemetry

### DIFF
--- a/tests/SdAiAgent/Abilities/SkillAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/SkillAbilitiesTest.php
@@ -11,6 +11,7 @@ namespace SdAiAgent\Tests\Abilities;
 
 use SdAiAgent\Abilities\SkillAbilities;
 use SdAiAgent\Models\Skill;
+use SdAiAgent\Repositories\SkillUsageRepository;
 use WP_UnitTestCase;
 
 /**
@@ -151,6 +152,27 @@ class SkillAbilitiesTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'content', $result );
 		$this->assertSame( 'enabled-load-test', $result['slug'] );
 		$this->assertSame( 'Skill content here', $result['content'] );
+	}
+
+	/**
+	 * Loading a skill through the ability records tool-call telemetry.
+	 */
+	public function test_handle_skill_load_records_tool_call_usage() {
+		$skill_id = Skill::create( [ 'slug' => 'telemetry-load-test', 'name' => 'Telemetry Load Test', 'description' => 'Description', 'content' => 'Skill content for telemetry', 'enabled' => true ] );
+		$this->assertIsInt( $skill_id );
+
+		$result = SkillAbilities::handle_skill_load( [
+			'slug' => 'telemetry-load-test',
+		] );
+
+		$this->assertIsArray( $result );
+
+		$rows = SkillUsageRepository::get_by_skill( $skill_id, 1 );
+		$this->assertNotEmpty( $rows );
+		$this->assertSame( $skill_id, $rows[0]->skill_id );
+		$this->assertSame( 'tool_call', $rows[0]->trigger_type );
+		$this->assertSame( 'unknown', $rows[0]->outcome );
+		$this->assertGreaterThan( 0, $rows[0]->injected_tokens );
 	}
 
 	// ─── Built-in Skill Loading ──────────────────────────────────────────────

--- a/tests/SdAiAgent/Core/DatabaseSchemaTest.php
+++ b/tests/SdAiAgent/Core/DatabaseSchemaTest.php
@@ -175,6 +175,28 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Skill usage telemetry table has the required columns and indexes.
+	 */
+	public function test_skill_usage_table_has_required_columns_and_indexes(): void {
+		global $wpdb;
+
+		Database::install();
+
+		$table   = Database::skill_usage_table_name();
+		$columns = $this->get_column_names( $table );
+
+		foreach ( [ 'id', 'skill_id', 'session_id', 'trigger_type', 'injected_tokens', 'outcome', 'model_id', 'created_at' ] as $col ) {
+			$this->assertContains( $col, $columns, "Skill usage table missing column '{$col}'." );
+		}
+
+		foreach ( [ 'skill_id', 'session_id', 'trigger_type', 'outcome', 'model_id', 'created_at' ] as $index ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test-only introspection query.
+			$index_exists = $wpdb->get_var( "SHOW INDEX FROM {$table} WHERE Key_name = '{$index}'" );
+			$this->assertNotNull( $index_exists, "Skill usage table missing index '{$index}'." );
+		}
+	}
+
+	/**
 	 * Custom tools table has a UNIQUE KEY on slug.
 	 */
 	public function test_custom_tools_table_has_unique_slug_index(): void {

--- a/tests/SdAiAgent/Core/SkillAutoInjectorTest.php
+++ b/tests/SdAiAgent/Core/SkillAutoInjectorTest.php
@@ -11,6 +11,7 @@ namespace SdAiAgent\Tests\Core;
 
 use SdAiAgent\Core\SkillAutoInjector;
 use SdAiAgent\Models\Skill;
+use SdAiAgent\Repositories\SkillUsageRepository;
 use WP_UnitTestCase;
 
 /**
@@ -60,6 +61,31 @@ class SkillAutoInjectorTest extends WP_UnitTestCase {
 		$result = SkillAutoInjector::inject_for_message( 'How do I add a product to my WooCommerce store?' );
 
 		$this->assertStringContainsString( 'Active Skill Guide', $result );
+	}
+
+	/**
+	 * Auto-injection records telemetry when model and session context are provided.
+	 */
+	public function test_inject_records_skill_usage_telemetry(): void {
+		$skill = Skill::get_by_slug( 'gutenberg-blocks' );
+		$this->assertNotNull( $skill );
+
+		$result = SkillAutoInjector::inject_for_message(
+			'Create a landing page with Gutenberg blocks',
+			'gpt-test-model',
+			123
+		);
+
+		$this->assertStringContainsString( 'Active Skill Guide', $result );
+
+		$rows = SkillUsageRepository::get_by_skill( (int) $skill->id, 1 );
+		$this->assertNotEmpty( $rows );
+		$this->assertSame( (int) $skill->id, $rows[0]->skill_id );
+		$this->assertSame( 123, $rows[0]->session_id );
+		$this->assertSame( 'auto', $rows[0]->trigger_type );
+		$this->assertSame( 'unknown', $rows[0]->outcome );
+		$this->assertSame( 'gpt-test-model', $rows[0]->model_id );
+		$this->assertGreaterThan( 0, $rows[0]->injected_tokens );
 	}
 
 	/**

--- a/tests/SdAiAgent/Repositories/SkillUsageRepositoryTest.php
+++ b/tests/SdAiAgent/Repositories/SkillUsageRepositoryTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Test case for SkillUsageRepository.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Repositories;
+
+use SdAiAgent\Core\Database;
+use SdAiAgent\Models\Skill;
+use SdAiAgent\Models\DTO\SkillUsageRow;
+use SdAiAgent\Repositories\SkillUsageRepository;
+use WP_UnitTestCase;
+
+/**
+ * Tests for skill usage telemetry persistence and aggregation.
+ */
+class SkillUsageRepositoryTest extends WP_UnitTestCase {
+
+	/**
+	 * Clean skill usage rows before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test-only cleanup.
+		$wpdb->query( $wpdb->prepare( 'DELETE FROM %i', Database::skill_usage_table_name() ) );
+	}
+
+	/**
+	 * create() persists telemetry and get_by_skill() returns typed DTOs.
+	 */
+	public function test_create_and_get_by_skill_returns_typed_rows(): void {
+		$skill_id = $this->create_test_skill( 'repository-telemetry' );
+
+		$usage_id = SkillUsageRepository::create(
+			[
+				'skill_id'        => $skill_id,
+				'session_id'      => 42,
+				'trigger_type'    => 'manual',
+				'injected_tokens' => 128,
+				'outcome'         => 'helpful',
+				'model_id'        => 'gpt-test',
+			]
+		);
+
+		$this->assertIsInt( $usage_id );
+
+		$rows = SkillUsageRepository::get_by_skill( $skill_id );
+		$this->assertCount( 1, $rows );
+		$this->assertInstanceOf( SkillUsageRow::class, $rows[0] );
+		$this->assertSame( $usage_id, $rows[0]->id );
+		$this->assertSame( $skill_id, $rows[0]->skill_id );
+		$this->assertSame( 42, $rows[0]->session_id );
+		$this->assertSame( 'manual', $rows[0]->trigger_type );
+		$this->assertSame( 128, $rows[0]->injected_tokens );
+		$this->assertSame( 'helpful', $rows[0]->outcome );
+		$this->assertSame( 'gpt-test', $rows[0]->model_id );
+	}
+
+	/**
+	 * Invalid enum-like values fall back to safe defaults.
+	 */
+	public function test_create_sanitizes_invalid_trigger_and_outcome(): void {
+		$skill_id = $this->create_test_skill( 'repository-sanitize' );
+
+		SkillUsageRepository::create(
+			[
+				'skill_id'     => $skill_id,
+				'trigger_type' => 'invalid-trigger',
+				'outcome'      => 'invalid-outcome',
+			]
+		);
+
+		$rows = SkillUsageRepository::get_by_skill( $skill_id );
+		$this->assertCount( 1, $rows );
+		$this->assertSame( 'auto', $rows[0]->trigger_type );
+		$this->assertSame( 'unknown', $rows[0]->outcome );
+	}
+
+	/**
+	 * get_stats() aggregates outcome counts and last-used timestamps per skill.
+	 */
+	public function test_get_stats_aggregates_usage_by_skill(): void {
+		$skill_id = $this->create_test_skill( 'repository-stats' );
+
+		SkillUsageRepository::create( [ 'skill_id' => $skill_id, 'outcome' => 'helpful' ] );
+		SkillUsageRepository::create( [ 'skill_id' => $skill_id, 'outcome' => 'neutral' ] );
+		SkillUsageRepository::create( [ 'skill_id' => $skill_id, 'outcome' => 'negative' ] );
+
+		$stats = SkillUsageRepository::get_stats();
+		$stat  = $this->find_stat_for_skill( $stats, $skill_id );
+
+		$this->assertNotNull( $stat );
+		$this->assertSame( '3', (string) $stat->total_loads );
+		$this->assertSame( '1', (string) $stat->helpful_count );
+		$this->assertSame( '1', (string) $stat->neutral_count );
+		$this->assertSame( '1', (string) $stat->negative_count );
+		$this->assertNotEmpty( $stat->last_used_at );
+	}
+
+	/**
+	 * update_outcome() updates a single usage row and rejects unknown outcomes.
+	 */
+	public function test_update_outcome_updates_single_row(): void {
+		$skill_id = $this->create_test_skill( 'repository-update' );
+		$usage_id = SkillUsageRepository::create( [ 'skill_id' => $skill_id ] );
+
+		$this->assertIsInt( $usage_id );
+		$this->assertTrue( SkillUsageRepository::update_outcome( $usage_id, 'negative' ) );
+		$this->assertFalse( SkillUsageRepository::update_outcome( $usage_id, 'invalid' ) );
+
+		$rows = SkillUsageRepository::get_by_skill( $skill_id );
+		$this->assertSame( 'negative', $rows[0]->outcome );
+	}
+
+	/**
+	 * update_session_outcomes() only updates unknown rows for the requested session.
+	 */
+	public function test_update_session_outcomes_only_updates_unknown_rows(): void {
+		$skill_id = $this->create_test_skill( 'repository-session-outcome' );
+
+		SkillUsageRepository::create( [ 'skill_id' => $skill_id, 'session_id' => 77, 'outcome' => 'unknown' ] );
+		SkillUsageRepository::create( [ 'skill_id' => $skill_id, 'session_id' => 77, 'outcome' => 'negative' ] );
+		SkillUsageRepository::create( [ 'skill_id' => $skill_id, 'session_id' => 78, 'outcome' => 'unknown' ] );
+
+		$this->assertSame( 1, SkillUsageRepository::update_session_outcomes( 77, 'helpful' ) );
+		$this->assertSame( 0, SkillUsageRepository::update_session_outcomes( 0, 'helpful' ) );
+		$this->assertSame( 0, SkillUsageRepository::update_session_outcomes( 77, 'unknown' ) );
+
+		$rows     = SkillUsageRepository::get_by_skill( $skill_id, 10 );
+		$outcomes = [];
+		foreach ( $rows as $row ) {
+			$outcomes[ $row->session_id ][] = $row->outcome;
+		}
+
+		$this->assertContains( 'helpful', $outcomes[77] );
+		$this->assertContains( 'negative', $outcomes[77] );
+		$this->assertSame( [ 'unknown' ], $outcomes[78] );
+	}
+
+	/**
+	 * estimate_tokens() uses the documented chars/4 approximation.
+	 */
+	public function test_estimate_tokens_uses_chars_divided_by_four(): void {
+		$this->assertSame( 0, SkillUsageRepository::estimate_tokens( '' ) );
+		$this->assertSame( 1, SkillUsageRepository::estimate_tokens( 'abcd' ) );
+		$this->assertSame( 2, SkillUsageRepository::estimate_tokens( 'abcde' ) );
+	}
+
+	/**
+	 * Create a simple enabled skill and return its ID.
+	 *
+	 * @param string $slug Skill slug.
+	 * @return int Skill ID.
+	 */
+	private function create_test_skill( string $slug ): int {
+		$skill_id = Skill::create(
+			[
+				'slug'        => $slug,
+				'name'        => 'Repository Telemetry',
+				'description' => 'Repository telemetry test skill',
+				'content'     => 'Repository telemetry content',
+				'enabled'     => true,
+			]
+		);
+
+		$this->assertIsInt( $skill_id );
+
+		return $skill_id;
+	}
+
+	/**
+	 * Find an aggregate row by skill ID.
+	 *
+	 * @param list<object> $stats Aggregate rows.
+	 * @param int          $skill_id Skill ID.
+	 * @return object|null Matching row.
+	 */
+	private function find_stat_for_skill( array $stats, int $skill_id ): ?object {
+		foreach ( $stats as $stat ) {
+			if ( $skill_id === (int) $stat->skill_id ) {
+				return $stat;
+			}
+		}
+
+		return null;
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -36,6 +36,7 @@ $sd_ai_agent_tables = [
 	$wpdb->prefix . 'sd_ai_agent_shared_sessions',
 	$wpdb->prefix . 'sd_ai_agent_benchmark_runs',
 	$wpdb->prefix . 'sd_ai_agent_benchmark_results',
+	$wpdb->prefix . 'sd_ai_agent_skill_usage',
 ];
 
 foreach ( $sd_ai_agent_tables as $sd_ai_agent_table ) {


### PR DESCRIPTION
## Summary

Added regression coverage for the skill usage telemetry table, repository persistence/aggregation/outcome updates, auto-injection telemetry, skill-load telemetry, and uninstall cleanup for sd_ai_agent_skill_usage.

## Files Changed

tests/SdAiAgent/Abilities/SkillAbilitiesTest.php,tests/SdAiAgent/Core/DatabaseSchemaTest.php,tests/SdAiAgent/Core/SkillAutoInjectorTest.php,tests/SdAiAgent/Repositories/SkillUsageRepositoryTest.php,uninstall.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** php -l uninstall.php tests/SdAiAgent/Repositories/SkillUsageRepositoryTest.php tests/SdAiAgent/Core/DatabaseSchemaTest.php tests/SdAiAgent/Core/SkillAutoInjectorTest.php tests/SdAiAgent/Abilities/SkillAbilitiesTest.php; vendor/bin/phpcs uninstall.php tests/SdAiAgent/Repositories/SkillUsageRepositoryTest.php tests/SdAiAgent/Core/DatabaseSchemaTest.php tests/SdAiAgent/Core/SkillAutoInjectorTest.php tests/SdAiAgent/Abilities/SkillAbilitiesTest.php; vendor/bin/phpunit tests/SdAiAgent/Repositories/SkillUsageRepositoryTest.php tests/SdAiAgent/Core/SkillAutoInjectorTest.php tests/SdAiAgent/Abilities/SkillAbilitiesTest.php tests/SdAiAgent/Core/DatabaseSchemaTest.php (blocked locally: WordPress test suite missing at wordpress-tests-lib/includes/functions.php)

Resolves #1357


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 7m and 102,597 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for skill usage tracking and telemetry recording across tool calls, auto-injection, and repository operations.
  * Added database schema validation tests to ensure the skill usage table maintains required columns and indexes.

* **Chores**
  * Updated plugin uninstall process to properly remove skill usage data during deletion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1362)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->