### PR TITLE
chore: mark t217 complete

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -434,10 +434,10 @@ Goal: clean, minimal design that matches wp-admin conventions. Replace custom da
   - EDIT: includes/Core/AgentLoop.php — after loop completes, evaluate outcome heuristic (no exit_reason error + skill domain match = helpful)
   - Verify: `composer phpstan && composer phpcs`
 
-- [ ] t217 Model-aware tiered skill injection (Phase 2) #enhancement #auto-dispatch ~4h For #t215 blocked-by:t216 logged:2026-04-18
-  - EDIT: includes/Core/SystemInstructionBuilder.php:78-84 — wrap SkillAutoInjector::inject_for_message() in ModelHealthTracker::is_weak() check. Strong models get index only (~150 tokens), weak models get auto-injected content
-  - EDIT: includes/Core/SkillAutoInjector.php — reduce MAX_INJECTED_SKILLS from 2 to 1
-  - EDIT: includes/Abilities/SkillAbilities.php — record skill-load calls as ModelHealthTracker::record_success() signal
+- [x] t217 Model-aware tiered skill injection (Phase 2) #enhancement #auto-dispatch ~4h For #t215 blocked-by:t216 logged:2026-04-18 ref=GH#1358 pr:#1099 completed:2026-05-13
+  - Implemented: SystemInstructionBuilder now routes strong models to the lean skill index plus targeted skill-load hints and weak models to capped full skill auto-injection.
+  - Implemented: SkillAutoInjector caps auto-injection at one skill and exposes get_index_description() for the strong-model hint path.
+  - Implemented: SkillAbilities records voluntary skill-load calls through ModelHealthTracker::record_skill_load() so tier decisions can use model skill-loading telemetry.
   - Verify: `composer phpstan && composer phpcs`
 
 - [ ] t218 Skill versioning schema + remote update checker (Phase 3a) #feature #auto-dispatch ~4h For #t215 logged:2026-04-18

--- a/todo/PLANS.md
+++ b/todo/PLANS.md
@@ -797,7 +797,7 @@ so skill content can improve between plugin releases.
 #### Progress
 
 - [ ] (2026-04-18) Phase 1: Skill usage tracking table + telemetry ~4h
-- [ ] (2026-04-18) Phase 2: Model-aware tiered injection ~4h
+- [x] (2026-04-18) Phase 2: Model-aware tiered injection ~4h — completed via GH#1358 / PR #1099
 - [ ] (2026-04-18) Phase 3: Skill versioning + remote update channel ~8h
 - [ ] (2026-04-18) Phase 4: Settings UI + admin dashboard ~6h
 - [ ] (2026-04-18) Phase 5: Skill directory endpoint (server-side) ~8h


### PR DESCRIPTION
## Summary
- Mark t217 / GH#1358 as complete in TODO.md and todo/PLANS.md.
- Preserve evidence that the model-aware tiered skill injection code already landed via PR #1099.
- Correct the task note to reference ModelHealthTracker::record_skill_load().

## Testing
- `composer phpstan && composer phpcs` (blocked: `vendor/bin/phpstan: not found`, dependencies are not installed in this worker worktree)

Resolves #1358

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 3m and 73,707 tokens on this as a headless worker.
