### PR TITLE
GH#1359: test: cover skill remote update safeguards

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -440,12 +440,12 @@ Goal: clean, minimal design that matches wp-admin conventions. Replace custom da
   - Implemented: SkillAbilities records voluntary skill-load calls through ModelHealthTracker::record_skill_load() so tier decisions can use model skill-loading telemetry.
   - Verify: `composer phpstan && composer phpcs`
 
-- [ ] t218 Skill versioning schema + remote update checker (Phase 3a) #feature #auto-dispatch ~4h For #t215 logged:2026-04-18
+- [x] t218 Skill versioning schema + remote update checker (Phase 3a) #feature #auto-dispatch ~4h For #t215 logged:2026-04-18 ref=GH#1359 completed:2026-05-13
   - EDIT: includes/Core/Database.php — ALTER TABLE skills ADD version, content_hash, source_url, user_modified columns, bump DB_VERSION
   - EDIT: includes/Models/Skill.php — set user_modified=1 on update() when skill is_builtin, add check_for_updates() and apply_update() methods
   - EDIT: includes/Models/DTO/SkillRow.php — add version, content_hash, source_url, user_modified properties
   - EDIT: includes/Core/Settings.php — add skill_auto_update and skill_manifest_url settings
-  - Verify: `composer phpstan && composer phpcs`
+  - Verify: `composer phpstan && composer phpcs && composer phpunit -- --filter SkillTest`
 
 - [ ] t219 WP-Cron skill update checker + conditional HTTP (Phase 3b) #feature #auto-dispatch ~4h For #t215 blocked-by:t218 logged:2026-04-18
   - NEW: includes/Core/SkillUpdateChecker.php — WP-Cron callback: fetch manifest JSON from skill_manifest_url, compare content_hash per slug, update is_builtin=1 AND user_modified=0 skills. Use wp_remote_get with If-None-Match/If-Modified-Since headers. Model on Knowledge.php hash-comparison pattern (line 44)

--- a/tests/SdAiAgent/Models/SkillTest.php
+++ b/tests/SdAiAgent/Models/SkillTest.php
@@ -259,6 +259,97 @@ class SkillTest extends WP_UnitTestCase {
 		$this->assertFalse( $skill->enabled );
 	}
 
+	/**
+	 * update() tracks built-in skill edits as admin customisations.
+	 */
+	public function test_update_marks_builtin_content_as_user_modified(): void {
+		$id = $this->create_skill( [
+			'slug'       => 'builtin-update-marker',
+			'content'    => 'Original built-in content.',
+			'is_builtin' => true,
+		] );
+
+		$result = Skill::update( $id, [ 'content' => 'Admin customised content.' ] );
+
+		$this->assertTrue( $result );
+		$skill = Skill::get( $id );
+		$this->assertNotNull( $skill );
+		$this->assertTrue( $skill->user_modified );
+		$this->assertSame( hash( 'sha256', 'Admin customised content.' ), $skill->content_hash );
+	}
+
+	/**
+	 * check_for_updates() returns a manifest entry only when remote content differs.
+	 */
+	public function test_check_for_updates_compares_remote_content_hash(): void {
+		$id    = $this->create_skill( [ 'content' => 'Current content.' ] );
+		$skill = Skill::get( $id );
+		$this->assertNotNull( $skill );
+
+		$this->assertNull( Skill::check_for_updates( $skill, [ 'content' => 'Current content.' ] ) );
+
+		$update = [
+			'content'    => 'Remote content.',
+			'version'    => '1.2.3',
+			'source_url' => 'https://example.com/skills/test.md',
+		];
+
+		$this->assertSame( $update, Skill::check_for_updates( $skill, $update ) );
+	}
+
+	/**
+	 * apply_update() updates unmodified built-in skills without setting user_modified.
+	 */
+	public function test_apply_update_updates_unmodified_builtin_skill(): void {
+		$id = $this->create_skill( [
+			'slug'       => 'builtin-remote-update',
+			'content'    => 'Original remote-managed content.',
+			'is_builtin' => true,
+		] );
+
+		$result = Skill::apply_update(
+			$id,
+			[
+				'content'    => 'Updated remote content.',
+				'version'    => '2.0.0',
+				'source_url' => 'https://example.com/skills/builtin-remote-update.md',
+			]
+		);
+
+		$this->assertTrue( $result );
+		$skill = Skill::get( $id );
+		$this->assertNotNull( $skill );
+		$this->assertSame( 'Updated remote content.', $skill->content );
+		$this->assertSame( '2.0.0', $skill->version );
+		$this->assertFalse( $skill->user_modified );
+	}
+
+	/**
+	 * apply_update() does not overwrite admin-customised built-in skills.
+	 */
+	public function test_apply_update_skips_user_modified_builtin_skill(): void {
+		$id = $this->create_skill( [
+			'slug'          => 'builtin-customised-skip',
+			'content'       => 'Admin custom content.',
+			'is_builtin'    => true,
+			'user_modified' => true,
+		] );
+
+		$result = Skill::apply_update(
+			$id,
+			[
+				'content' => 'Remote replacement content.',
+				'version' => '3.0.0',
+			]
+		);
+
+		$this->assertFalse( $result );
+		$skill = Skill::get( $id );
+		$this->assertNotNull( $skill );
+		$this->assertSame( 'Admin custom content.', $skill->content );
+		$this->assertTrue( $skill->user_modified );
+	}
+
 	// ─── delete() ────────────────────────────────────────────────────────────
 
 	/**


### PR DESCRIPTION
## Summary

Added targeted SkillTest coverage for t218 skill versioning safeguards: built-in admin edits set user_modified and refresh content_hash, remote update detection compares content hashes, unmodified built-ins accept remote updates, and customised built-ins are protected from overwrite. Marked t218 complete in TODO with GH#1359 reference.

## Files Changed

TODO.md,tests/SdAiAgent/Models/SkillTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** composer phpstan (pass); composer phpcs (pass); vendor/bin/phpunit --filter SkillTest (blocked: missing WordPress test library at /home/dave/.aidevops/.agent-workspace/sandbox/tmp/1778700848-1297417/wordpress-tests-lib/includes/functions.php)

Resolves #1359


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 4m and 64,727 tokens on this with the user in an interactive session.