### PR TITLE
GH#1354: docs: add provider discovery guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,18 @@ Key gotchas: `compile_class` required for hyphenated IDs, `REST_Handler` support
 - Provider/model selection via WordPress Connectors API (Settings > Connectors)
 - Abilities extend `AbstractAbility` which extends core `WP_Ability`
 
+### Provider Credentials and Model Discovery
+- Do **not** add a plugin-level cache around provider/model discovery. The WP AI
+  Client SDK already caches model metadata, and an extra cache requires brittle
+  invalidation rules for unknown third-party provider option names.
+- When provider availability must reflect newly saved keys (for example,
+  `ai-provider-for-anthropic-max` or other connector plugins), reload credentials
+  from the registry/options at request time via `ProviderCredentialLoader::load()`
+  and let `/providers` build its response fresh.
+- If provider discovery appears stale, fix the credential-loading path or remove
+  redundant caching; do not whitelist individual option keys as a cache
+  invalidation strategy.
+
 ## Local Development Environment
 
 The shared WordPress dev install for testing this plugin is at `../wordpress` (relative to this repo root).


### PR DESCRIPTION
## Summary

Added provider credential/model discovery guidance to AGENTS.md so future changes avoid plugin-level provider caches and reload credentials from registry/options at request time.

## Files Changed

AGENTS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check

Resolves #1354


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 2m and 73,958 tokens on this with the user in an interactive session.