### PR TITLE
GH#1370: fix: honor user-modified skill creation flag

### DIFF
--- a/includes/Models/Skill.php
+++ b/includes/Models/Skill.php
@@ -225,7 +225,7 @@ class Skill {
 	/**
 	 * Create a new skill.
 	 *
-	 * @param array<string, mixed> $data Skill data: slug, name, description, content, is_builtin, enabled, version, content_hash, source_url.
+	 * @param array<string, mixed> $data Skill data: slug, name, description, content, is_builtin, enabled, version, content_hash, source_url, user_modified.
 	 * @return int|false Inserted row ID or false on failure.
 	 */
 	public static function create( array $data ) {
@@ -257,7 +257,7 @@ class Skill {
 				'content_hash'  => '' !== $content ? hash( 'sha256', $content ) : (string) ( $data['content_hash'] ?? '' ),
 				// @phpstan-ignore-next-line
 				'source_url'    => esc_url_raw( (string) ( $data['source_url'] ?? '' ) ),
-				'user_modified' => 0,
+				'user_modified' => ! empty( $data['user_modified'] ) ? 1 : 0,
 				'created_at'    => $now,
 				'updated_at'    => $now,
 			],


### PR DESCRIPTION
## Summary

Updated Skill::create() to persist the user_modified flag supplied at creation time and documented the accepted create payload field, preserving admin-customized built-in skills from remote updates.

## Files Changed

includes/Models/Skill.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** composer phpcs -- includes/Models/Skill.php (passed); composer phpstan -- includes/Models/Skill.php (passed); vendor/bin/phpunit --filter test_apply_update_skips_user_modified_builtin_skill tests/SdAiAgent/Models/SkillTest.php (blocked: missing WordPress tests library at /home/dave/.aidevops/.agent-workspace/sandbox/tmp/1778707654-2293755/wordpress-tests-lib/includes/functions.php); npx wp-env start (blocked: Docker buildkit cachemount path missing /mnt/data/docker/buildkit/containerd-overlayfs/cachemounts)

Resolves #1370


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 3m and 42,864 tokens on this with the user in an interactive session.