### PR TITLE
GH#1369: cover site specification phase acceptance

### DIFF
--- a/tests/SdAiAgent/Enums/MemoryCategoryTest.php
+++ b/tests/SdAiAgent/Enums/MemoryCategoryTest.php
@@ -23,8 +23,9 @@ class MemoryCategoryTest extends WP_UnitTestCase {
 	public function test_memory_category_cases_exist() {
 		$cases = MemoryCategory::cases();
 
-		$this->assertCount(5, $cases);
+		$this->assertCount(6, $cases);
 		$this->assertContains(MemoryCategory::SiteInfo, $cases);
+		$this->assertContains(MemoryCategory::SiteBrief, $cases);
 		$this->assertContains(MemoryCategory::UserPreferences, $cases);
 		$this->assertContains(MemoryCategory::TechnicalNotes, $cases);
 		$this->assertContains(MemoryCategory::Workflows, $cases);
@@ -36,6 +37,7 @@ class MemoryCategoryTest extends WP_UnitTestCase {
 	 */
 	public function test_memory_category_values() {
 		$this->assertSame('site_info', MemoryCategory::SiteInfo->value);
+		$this->assertSame('site_brief', MemoryCategory::SiteBrief->value);
 		$this->assertSame('user_preferences', MemoryCategory::UserPreferences->value);
 		$this->assertSame('technical_notes', MemoryCategory::TechnicalNotes->value);
 		$this->assertSame('workflows', MemoryCategory::Workflows->value);
@@ -49,8 +51,9 @@ class MemoryCategoryTest extends WP_UnitTestCase {
 		$values = MemoryCategory::values();
 
 		$this->assertIsArray($values);
-		$this->assertCount(5, $values);
+		$this->assertCount(6, $values);
 		$this->assertContains('site_info', $values);
+		$this->assertContains('site_brief', $values);
 		$this->assertContains('user_preferences', $values);
 		$this->assertContains('technical_notes', $values);
 		$this->assertContains('workflows', $values);
@@ -62,6 +65,7 @@ class MemoryCategoryTest extends WP_UnitTestCase {
 	 */
 	public function test_is_valid_with_valid_values() {
 		$this->assertTrue(MemoryCategory::isValid('site_info'));
+		$this->assertTrue(MemoryCategory::isValid('site_brief'));
 		$this->assertTrue(MemoryCategory::isValid('user_preferences'));
 		$this->assertTrue(MemoryCategory::isValid('technical_notes'));
 		$this->assertTrue(MemoryCategory::isValid('workflows'));
@@ -83,6 +87,7 @@ class MemoryCategoryTest extends WP_UnitTestCase {
 	 */
 	public function test_try_from_with_valid_values() {
 		$this->assertSame(MemoryCategory::SiteInfo, MemoryCategory::tryFrom('site_info'));
+		$this->assertSame(MemoryCategory::SiteBrief, MemoryCategory::tryFrom('site_brief'));
 		$this->assertSame(MemoryCategory::General, MemoryCategory::tryFrom('general'));
 	}
 
@@ -115,6 +120,7 @@ class MemoryCategoryTest extends WP_UnitTestCase {
 	 */
 	public function test_from_string_or_default_with_valid_values() {
 		$this->assertSame(MemoryCategory::SiteInfo, MemoryCategory::fromStringOrDefault('site_info'));
+		$this->assertSame(MemoryCategory::SiteBrief, MemoryCategory::fromStringOrDefault('site_brief'));
 		$this->assertSame(MemoryCategory::Workflows, MemoryCategory::fromStringOrDefault('workflows'));
 	}
 

--- a/tests/SdAiAgent/Models/SkillTest.php
+++ b/tests/SdAiAgent/Models/SkillTest.php
@@ -436,6 +436,29 @@ class SkillTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'wordpress-admin', $definitions );
 	}
 
+	/**
+	 * get_builtin_definitions() includes the site-specification skill with
+	 * the Phase 1 inference tables, worked examples, and site_brief guidance.
+	 */
+	public function test_get_builtin_definitions_includes_site_specification_acceptance_content(): void {
+		$definitions = Skill::get_builtin_definitions();
+
+		$this->assertArrayHasKey( 'site-specification', $definitions );
+
+		$content = $definitions['site-specification']['content'];
+
+		foreach ( [ 'SaaS', 'E-commerce', 'Professional Services', 'Restaurant', 'Portfolio', 'Blog', 'Non-profit' ] as $site_type ) {
+			$this->assertStringContainsString( $site_type, $content );
+		}
+
+		foreach ( [ 'Coffee Shop', 'Law Firm', 'Esports Team' ] as $example ) {
+			$this->assertStringContainsString( $example, $content );
+		}
+
+		$this->assertStringContainsString( 'category: site_brief', $content );
+		$this->assertStringContainsString( 'sd-ai-agent/memory-save', $content );
+	}
+
 	// ─── seed_builtins() ─────────────────────────────────────────────────────
 
 	/**
@@ -774,6 +797,7 @@ class SkillTest extends WP_UnitTestCase {
 			'site-troubleshooting' => [ 'site-troubleshooting', [ 'errors', 'debug', 'health', 'performance', 'diagnosis' ] ],
 			'multisite-management' => [ 'multisite-management', [ 'multisite', 'network' ] ],
 			'seo-optimization'     => [ 'seo-optimization', [ 'seo', 'meta', 'optimization', 'on-page' ] ],
+			'site-specification'   => [ 'site-specification', [ 'site spec', 'theme generation', 'audience', 'tone' ] ],
 			'content-marketing'    => [ 'content-marketing', [ 'strategy', 'editorial', 'content', 'audit' ] ],
 			'competitive-analysis' => [ 'competitive-analysis', [ 'competitor', 'analysis', 'tech stack' ] ],
 			'analytics-reporting'  => [ 'analytics-reporting', [ 'performance', 'metrics', 'analytics', 'reporting' ] ],


### PR DESCRIPTION
## Summary

Adds regression coverage for the Phase 1 site-specification deliverable, including the site_brief memory category and built-in skill acceptance content. For #1368.

## Files Changed

tests/SdAiAgent/Enums/MemoryCategoryTest.php,tests/SdAiAgent/Models/SkillTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified site-specification markdown acceptance content with a PHP assertion script; php -l passed for modified and related PHP files; composer phpcs passed for modified test files; targeted composer test filters were attempted but blocked by missing WordPress test library at the configured sandbox path.

Resolves #1369


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 4m and 76,175 tokens on this with the user in an interactive session.