### PR TITLE
feat(t226b): expand block-themes skill with theme.json presets, animation, and editor-visibility CSS

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -343,7 +343,7 @@ Goal: clean, minimal design that matches wp-admin conventions. Replace custom da
   - Closes the PLANS.md "AI site generation from prompt" P0 gap on the visual-container side (t060-t062 cover pages)
   - Renumbered from t170 in PR; t170 was already used (PR #848, completed 2026-04-09)
 
-- [ ] t226a Site-specification skill — markdown + memory category #enhancement #auto-dispatch ~3h For #t226 logged:2026-05-13
+- [x] t226a Site-specification skill — markdown + memory category #enhancement #auto-dispatch ~3h For #t226 logged:2026-05-13 pr:#1371 completed:2026-05-13
   - NEW: includes/Models/skills/site-specification.md — site-type inference patterns, worked examples, presentation format
   - EDIT: includes/Models/Skill.php — register in BUILTIN_META (enabled by default)
   - EDIT: includes/Enums/MemoryCategory.php — add SiteBrief = 'site_brief'
@@ -351,6 +351,12 @@ Goal: clean, minimal design that matches wp-admin conventions. Replace custom da
   - EDIT: tests/SdAiAgent/Models/MemoryTest.php — assert new category accepted
   - EDIT: src/settings-page/memory-manager.js — add Site Brief category option
   - Verify: `composer phpcs && npm run lint:js && npm run test:php` (MemoryTest)
+
+- [ ] t226b Block-themes skill expansion — theme.json presets, animation classes, editor-visibility CSS #enhancement #auto-dispatch ~4h For #t226 logged:2026-05-13
+  - EDIT: includes/Models/skills/block-themes.md — expand from 150 → ~400 lines (target 350-450)
+  - Add: Absolute Rules (no html-blocks, no decorative comments, no stock images), theme.json color/typography presets, Landing Page Composition, Cover Block Pitfalls, Card layouts, Visual Richness Without Images, Animation & Motion (className pattern, entrance animations, staggered children, hover transitions, ambient motion), Scroll-triggered reveals (IntersectionObserver), prefers-reduced-motion (required), Editor Visibility / .editor-styles-wrapper override (required), functions.php essentials
+  - Source: Automattic wordpress-block-theming reference (29KB → ~280 lines added) at github.com/Automattic/wordpress-agent-skills/blob/trunk/claude-code/wp-site-creator/references/wordpress-block-theming.md
+  - Verify: `wc -l includes/Models/skills/block-themes.md` is 350-450, and `grep -E "Editor Visibility|editor-styles-wrapper|prefers-reduced-motion" includes/Models/skills/block-themes.md` returns matches
 
 - [ ] t232 Ability discovery investigation: why agent misses registered abilities #investigation #parent #plan → [todo/PLANS.md#ability-discovery-investigation] ~5h logged:2026-04-26
 - [x] t234 Audit ability injection pipeline and tool catalog (Phase 1) #investigation #auto-dispatch ~3h For #t232 logged:2026-04-26 pr:#1204 completed:2026-04-27

--- a/includes/Models/skills/block-themes.md
+++ b/includes/Models/skills/block-themes.md
@@ -6,6 +6,15 @@ This skill is auto-loaded when the active WordPress theme is a **block theme** (
 
 If the active theme is classic (no `templates/` directory, no `theme.json`), use the `classic-themes` skill instead — different concepts apply.
 
+## Absolute Rules
+
+These rules are hard constraints when generating or modifying block markup. They are surfaced at the top because the most common defects in agent-generated themes come from violating them.
+
+- **No HTML blocks.** Never use `<!-- wp:html -->` (the `core/html` block). HTML blocks are opaque blobs in the block editor — users cannot select, style, or rearrange individual elements inside them. Every piece of content must use a proper core block (`wp:group`, `wp:heading`, `wp:paragraph`, `wp:columns`, etc.). If you find yourself reaching for `wp:html`, stop and decompose the content into core blocks with `className` attributes and CSS instead.
+- **No decorative HTML comments.** Never insert non-block HTML comments like `<!-- Hero Section -->` or `<!-- Features -->` in templates, template parts, or patterns. The only HTML comments allowed are WordPress block delimiters (`<!-- wp:block-name -->` / `<!-- /wp:block-name -->`).
+- **No stock image URLs.** Only use image URLs the user has explicitly provided. Stock-image URLs (Unsplash, Pexels, etc.) often fail to load in the block editor and break the design. When no user imagery is available, create visual richness through CSS gradients, color blocks, typography, and decorative pseudo-elements (see "Creating Visual Richness Without Images" below).
+- **Validate before write.** Run `sd-ai-agent/validate-block-content` on every template, template part, and pattern body before saving. The validator catches the markup mistakes that produce silent "this block contains unexpected or invalid content" errors in the editor.
+
 ## How to confirm the active theme is a block theme
 
 Use `sd-ai-agent/site-info` (preferred) or wp-cli:
@@ -70,16 +79,43 @@ Template parts are referenced inside templates via `wp:template-part`:
 
 ## theme.json Overview
 
-`theme.json` controls global styles AND editor settings. Two top-level keys: `settings` (what users can do) and `styles` (default appearance).
+`theme.json` controls global styles AND editor settings. Two top-level keys: `settings` (what users can do) and `styles` (default appearance). Always declare `$schema` and `version: 3`.
+
+### Schema and Version
+
+```json
+{
+  "$schema": "https://schemas.wp.org/trunk/theme.json",
+  "version": 3
+}
+```
 
 ### Settings
+
+Recommended palette: 5–7 entries (`primary`, `secondary`, `accent`, `background`, `surface`, plus `light`/`dark` if needed). Set `defaultPalette: false` and `defaultGradients: false` to keep the editor focused on the brand colours. Spacing: 6-step scale slugs `20`–`70` from `0.5rem` to `4rem`. Always set `appearanceTools: true` and `fluid: true` on typography.
 
 ```json
 {
   "settings": {
-    "color": { "palette": [ { "slug": "primary", "color": "#1a1a1a", "name": "Primary" } ] },
-    "typography": { "fontFamilies": [ ], "fontSizes": [ ] },
-    "spacing": { "spacingSizes": [ { "slug": "50", "size": "1rem", "name": "1" } ] },
+    "appearanceTools": true,
+    "color": {
+      "palette": [
+        { "slug": "primary",    "color": "#1a1a1a", "name": "Primary" },
+        { "slug": "accent",     "color": "#e63946", "name": "Accent" },
+        { "slug": "background", "color": "#ffffff", "name": "Background" },
+        { "slug": "surface",    "color": "#f5f5f5", "name": "Surface" }
+      ],
+      "defaultPalette": false,
+      "defaultGradients": false
+    },
+    "typography": { "fluid": true, "fontFamilies": [], "fontSizes": [] },
+    "spacing": {
+      "units": ["px", "em", "rem", "%", "vw", "vh"],
+      "spacingSizes": [
+        { "slug": "40", "size": "1rem",   "name": "Regular" },
+        { "slug": "60", "size": "2.5rem", "name": "Looser" }
+      ]
+    },
     "layout": { "contentSize": "720px", "wideSize": "1200px" }
   }
 }
@@ -91,11 +127,27 @@ Template parts are referenced inside templates via `wp:template-part`:
 {
   "styles": {
     "color": { "background": "#ffffff", "text": "#1a1a1a" },
-    "typography": { "fontFamily": "var(--wp--preset--font-family--inter)" },
-    "elements": { "link": { "color": { "text": "var(--wp--preset--color--primary)" } } }
+    "typography": { "fontFamily": "var(--wp--preset--font-family--body)", "fontSize": "1rem", "lineHeight": "1.6" },
+    "elements": {
+      "heading": { "typography": { "fontFamily": "var(--wp--preset--font-family--heading)", "lineHeight": "1.2" } },
+      "link":    { "color": { "text": "var(--wp--preset--color--accent)" } },
+      "button":  { "color": { "background": "var(--wp--preset--color--accent)", "text": "var(--wp--preset--color--light)" }, "border": { "radius": "0.5rem" } }
+    }
   }
 }
 ```
+
+### Typography presets — choose distinctive fonts
+
+Avoid generic fonts (Arial, Inter when used as a default). Pair a **distinctive display font** with a **refined body font**. A workable 6-step size scale:
+
+```
+0.875rem  /  1rem  /  1.25rem  /  1.75rem  /  2.25rem  /  clamp(2.5rem, 4vw, 3.5rem)
+```
+
+- Body line-height `1.5`–`1.65`; headings `1.1`–`1.3`. Never go below `1.0`.
+- Cap display sizes around `3.5rem`. Sizes above `4rem` rarely improve design and often degrade it.
+- Use `clamp()` for fluid display headings but always cap the upper bound.
 
 ### Custom Templates
 
@@ -118,6 +170,247 @@ The corresponding `templates/blank.html` and `templates/landing.html` files must
 - Template patterns can be inserted in the Site Editor
 - Use `sd-ai-agent/list-block-patterns` to discover available patterns
 - Synced patterns (formerly "reusable blocks") are stored as `wp_block` post type
+- Pattern files live in `patterns/*.php` with a header docblock declaring `Title`, `Slug`, and `Categories`
+
+```php
+<?php
+/**
+ * Title: Hero Section
+ * Slug: theme-slug/hero
+ * Categories: featured
+ */
+?>
+<!-- wp:group {"backgroundColor":"primary","textColor":"light","layout":{"type":"constrained"}} -->
+...
+<!-- /wp:group -->
+```
+
+## Landing Page Composition
+
+When generating a homepage, think like a landing page designer, not a template assembler. Every section is a visually distinct, full-width band that creates rhythm and visual impact as the user scrolls.
+
+### Section Architecture
+
+- **Section margin reset.** Add `"style":{"spacing":{"margin":{"top":"0"}}}` to every top-level Group block that wraps a landing-page section. This overrides WordPress's default top margin on direct children of `.wp-site-blocks`.
+- **Full-bleed wrappers, constrained content.** Every major homepage section MUST be `"align":"full"` with `{"layout":{"type":"constrained"}}` inside. A bare `{"layout":{"type":"constrained"}}` without `align:full` renders at `contentSize` (~720–800px) and the page looks narrow and lifeless.
+- **Columns alignment.** Always set `"align":"wide"` on `wp:columns` blocks (and add `alignwide` on the wrapper div) unless explicitly instructed otherwise.
+- **No `<inner-blocks>`.** Output the full expanded markup inside each block.
+
+### Visual Rhythm
+
+Alternate visual treatments to avoid monotony:
+
+| Technique | WordPress implementation |
+|-----------|--------------------------|
+| Alternating backgrounds | Alternate `backgroundColor` between `background` and `surface` (or `primary`/`secondary` for bold sections) |
+| Full-bleed imagery | Cover blocks with `"align":"full"` and `overlayColor` from the brand palette |
+| Edge-to-edge media-text | `wp:media-text` with `"align":"full"` for alternating image/content sides |
+| Bold CTA bands | Full-width group with `primary` or `accent` background, centered text |
+| Spacer breaks | `wp:spacer` between sections for breathing room |
+
+If two adjacent sections share the same background and layout, the page feels monotonous — change the background, flip the image side, switch from grid to single-column, or insert a cover block break.
+
+### Cover Block Pitfalls
+
+- **Hero height.** Use `60vh` for hero covers as the default — `100vh` plus large padding leaves content floating in whitespace because cover blocks already vertically centre via flexbox.
+- **`minHeight` accepts a number + unit only.** No `clamp()` — pass `60` + `vh`.
+- **Centred badges inside covers.** Use `display: flex; justify-content: center` — `display: inline-flex` left-aligns because the cover's inner container has no `text-align: center`.
+
+### Card layouts in rows
+
+For equal-height, equal-width cards with optional bottom-aligned CTAs: wrap a `wp:columns` (`className: "equal-cards"`) around N columns with `verticalAlignment: "stretch"`, each containing a `wp:group` card wrapper. All column widths must be equal and sum to exactly 100% (3 cards = `33.33%`). Optionally add a buttons block with `className: "cta-bottom"` that pins to the bottom of each card.
+
+```css
+.equal-cards > .wp-block-column { display: flex; flex-direction: column; flex-grow: 0; }
+.equal-cards > .wp-block-column > .wp-block-group { display: flex; flex-direction: column; flex-grow: 1; }
+.equal-cards .cta-bottom { margin-top: auto; justify-content: center; }
+/* Reset the site footer top margin so it sits flush against the last section. */
+.wp-site-blocks > footer { margin-block-start: 0; }
+```
+
+### Creating Visual Richness Without Images
+
+When the user has not supplied imagery, convey atmosphere through:
+
+- **CSS gradients** — linear, radial, conic for depth and colour
+- **Bold colour blocks** — surface/accent backgrounds for hierarchy
+- **Typography as design** — large, distinctive headings; varied weights; creative pairings
+- **CSS patterns** — repeating gradients (stripes, dots, grids)
+- **Shadows and depth** — `box-shadow`, `text-shadow`, `drop-shadow`
+- **Decorative pseudo-elements** — `::before` / `::after` for shapes and accents
+- **Generous whitespace** or controlled density to set mood
+
+## Animation & Motion
+
+Animation brings life to block themes, but WordPress block markup requires a specific pattern to connect CSS animations to blocks.
+
+### The className pattern
+
+Add animation classes to blocks via the `className` JSON attribute. WordPress renders this as a class on the wrapper div:
+
+```html
+<!-- wp:group {"className":"fade-up","align":"full","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull fade-up">
+  <!-- content -->
+</div>
+<!-- /wp:group -->
+```
+
+This works on any block — groups, columns, headings, paragraphs, buttons, images.
+
+### Animation classes in style.css
+
+Generate animation classes in `style.css`. The set below is a starter — adapt names and timings to the design.
+
+**Entrance animations:**
+
+```css
+.fade-up      { opacity: 0; transform: translateY(30px); animation: fadeUp 0.6s ease forwards; }
+.fade-in      { opacity: 0; animation: fadeIn 0.6s ease forwards; }
+.slide-in-left  { opacity: 0; transform: translateX(-40px); animation: slideIn 0.7s ease forwards; }
+.slide-in-right { opacity: 0; transform: translateX(40px);  animation: slideIn 0.7s ease forwards; }
+
+@keyframes fadeUp  { to { opacity: 1; transform: translateY(0); } }
+@keyframes fadeIn  { to { opacity: 1; } }
+@keyframes slideIn { to { opacity: 1; transform: translateX(0); } }
+```
+
+**Staggered children** — apply the entrance animation to the container, delay each child via `nth-child`:
+
+```css
+.stagger-children > * { opacity: 0; transform: translateY(20px); animation: fadeUp 0.5s ease forwards; }
+.stagger-children > *:nth-child(1) { animation-delay: 0.1s; }
+.stagger-children > *:nth-child(2) { animation-delay: 0.2s; }
+.stagger-children > *:nth-child(3) { animation-delay: 0.3s; }
+.stagger-children > *:nth-child(4) { animation-delay: 0.4s; }
+```
+
+**Interactive transitions and ambient motion** — use sparingly (one or two ambient effects per page):
+
+```css
+.hover-lift { transition: transform 0.2s ease, box-shadow 0.2s ease; }
+.hover-lift:hover { transform: translateY(-4px); box-shadow: 0 12px 24px rgba(0,0,0,0.15); }
+
+.float       { animation: float 3s ease-in-out infinite; }
+@keyframes float { 0%,100% { transform: translateY(0); } 50% { transform: translateY(-10px); } }
+.pulse-subtle{ animation: pulse 2s ease-in-out infinite; }
+@keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.7; } }
+```
+
+### Scroll-triggered reveals (IntersectionObserver)
+
+The highest-impact pattern — sections revealing as the user scrolls. Add a small observer in `functions.php` and pair it with CSS that hides elements until the `.is-visible` class is added:
+
+```php
+function theme_slug_scroll_animations() { ?>
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        var els = document.querySelectorAll('.animate-on-scroll');
+        if (!els.length) return;
+        var observer = new IntersectionObserver(function(entries) {
+            entries.forEach(function(entry) {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('is-visible');
+                    observer.unobserve(entry.target);
+                }
+            });
+        }, { threshold: 0.15 });
+        els.forEach(function(el) { observer.observe(el); });
+    });
+    </script>
+<?php }
+add_action( 'wp_footer', 'theme_slug_scroll_animations' );
+```
+
+```css
+.animate-on-scroll { opacity: 0; transform: translateY(30px); transition: opacity 0.6s ease, transform 0.6s ease; }
+.animate-on-scroll.is-visible { opacity: 1; transform: translateY(0); }
+```
+
+Apply `className: "animate-on-scroll"` on section-level Group blocks.
+
+### prefers-reduced-motion (required)
+
+Every theme MUST include this in `style.css` to respect the user's motion preference:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    transition-duration: 0.01ms !important;
+  }
+  .animate-on-scroll,
+  .fade-up, .fade-in,
+  .slide-in-left, .slide-in-right,
+  .scale-up {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}
+```
+
+### Editor Visibility (required)
+
+The theme's `style.css` loads in both the front-end and the WordPress block editor (via `enqueue_block_assets`). The IntersectionObserver script that triggers scroll reveals, however, runs only on `wp_footer` — not inside the editor iframe. Any block with an entrance animation class that sets `opacity: 0` would be **invisible in the block editor** without an override.
+
+WordPress wraps all editor content inside `<div class="editor-styles-wrapper">`. That class does not exist on the front-end, so it is the correct selector for editor-only overrides:
+
+```css
+/* === Editor: keep animated content visible while editing === */
+.editor-styles-wrapper .fade-up,
+.editor-styles-wrapper .fade-in,
+.editor-styles-wrapper .slide-in-left,
+.editor-styles-wrapper .slide-in-right,
+.editor-styles-wrapper .scale-up,
+.editor-styles-wrapper .animate-on-scroll,
+.editor-styles-wrapper .stagger-children > * {
+  opacity: 1 !important;
+  transform: none !important;
+  animation: none !important;
+  transition: none !important;
+}
+```
+
+The rule is simple: **every custom class that sets `opacity: 0` or uses `transform` as an initial hidden state needs a matching `.editor-styles-wrapper` override that makes it visible while editing.** Skip this and the editor renders empty boxes where the animated sections should be — the most common bug in agent-generated themes.
+
+### How much animation
+
+Not every element needs animation. Prioritise:
+
+- Hero section entrance — the first impression (fade-up, scale, or slide)
+- Section reveals on scroll — major content blocks with `animate-on-scroll`
+- Interactive elements — cards with `hover-lift`, buttons with transitions
+- One or two decorative ambient animations — a floating shape, gradient shift, or pulsing accent
+
+Avoid animating every heading, paragraph, and button individually — it creates visual noise rather than delight.
+
+## functions.php essentials
+
+Keep `functions.php` minimal. Primary uses are font enqueuing and pattern registration. **Always** use the `enqueue_block_assets` hook (not `wp_enqueue_scripts`) so fonts load in both the front-end AND the block editor:
+
+```php
+function theme_slug_enqueue_assets() {
+    wp_enqueue_style(
+        'theme-slug-fonts',
+        'https://fonts.googleapis.com/css2?family=Clash+Display:wght@400;500;600;700&family=DM+Sans:wght@400;500;600&display=swap',
+        array(),
+        null
+    );
+    wp_enqueue_style(
+        'theme-slug-style',
+        get_stylesheet_uri(),
+        array( 'theme-slug-fonts' ),
+        wp_get_theme()->get( 'Version' )
+    );
+}
+add_action( 'enqueue_block_assets', 'theme_slug_enqueue_assets' );
+```
+
+Security notes:
+
+- When `functions.php` outputs any user-derived value, use the appropriate WordPress escaping function: `esc_html()`, `esc_attr()`, `esc_url()`.
+- Never use `eval()`, `create_function()`, `shell_exec()`, `exec()`, or `system()` in generated theme code.
+- Static block themes with hard-coded markup (the default for our generator) do not need escaping at render time — WordPress core blocks handle output safely.
 
 ## Typical Workflows
 
@@ -148,3 +441,5 @@ After editing templates or `theme.json`:
 2. Check the Site Editor (`/wp-admin/site-editor.php`) — it should reflect the saved state.
 3. If `theme.json` settings appear ignored, clear the WordPress object cache (`wp cache flush`) and hard-refresh.
 4. For child theme overrides, confirm the active stylesheet is the child (`wp option get stylesheet`).
+5. Open the block editor on any page that uses entrance-animation classes — every animated section should render visibly, not as an empty box. If a section is invisible, an `.editor-styles-wrapper` override is missing.
+6. Toggle the OS-level "Reduce motion" preference and reload the front-end — animations should collapse to near-zero duration without leaving content stuck at `opacity: 0`.

--- a/todo/PLANS.md
+++ b/todo/PLANS.md
@@ -1264,8 +1264,8 @@ Closes the PLANS.md "AI site generation from prompt" P0 gap on the visual-contai
 
 #### Progress
 
-- [ ] (2026-05-13) Phase 1: `site-specification` skill — markdown + new memory category `site_brief` ~3h — t226a (in progress)
-- [ ] (2026-05-13) Phase 2: `block-themes.md` skill expansion (theme.json presets, animation classes, editor-visibility CSS) ~4h — t226b (TBF)
+- [x] (2026-05-13) Phase 1: `site-specification` skill — markdown + new memory category `site_brief` ~3h — t226a (merged in PR #1371)
+- [ ] (2026-05-13) Phase 2: `block-themes.md` skill expansion (theme.json presets, animation classes, editor-visibility CSS) ~4h — t226b (in progress)
 - [ ] (2026-05-13) Phase 3: Theme-builder onboarding branch — new ThemeBuilderPrompt, REST endpoint, 2 abilities (scaffold-block-theme + activate-theme), wizard mode-picker, React component, E2E test ~12h — t226c (TBF)
 - [ ] (2026-05-13) Phase 4: `design-system-aesthetics.md` skill (topic-grounded visual worlds framework) ~5h — t226d (TBF)
 


### PR DESCRIPTION
## Summary

Phase 2 of **t226 (block theme generation in onboarding)**. Expands `includes/Models/skills/block-themes.md` from 150 to **445 lines**, distilling Automattic's [wordpress-block-theming reference](https://github.com/Automattic/wordpress-agent-skills/blob/trunk/claude-code/wp-site-creator/references/wordpress-block-theming.md) into the patterns that prevent the most common defects in agent-generated block themes.

This phase compounds for *all* theme-aware work (theme.json edits, template generation, animation classes, validate-block-content reviews), not just the future Phase 3 onboarding flow. If we shipped only Phases 1–2, the agent would already be measurably better at block themes.

## What changed

The existing 150-line spine (template hierarchy, tool references, typical workflows) is preserved unchanged. New sections added in natural order:

- **Absolute Rules** — no `wp:html` blocks, no decorative HTML comments, no stock-image URLs, always `validate-block-content` before write.
- **theme.json** — 5–7 colour palette, fluid typography, 6-step spacing scale, distinctive font pairing rules, font-size scale with `clamp()` cap, recommended line-height ranges.
- **Landing Page Composition** — section margin reset, full-bleed wrapper + constrained content, columns alignment, visual rhythm table.
- **Cover Block Pitfalls** — `60vh` hero default, `minHeight` number+unit-only constraint, badge centring pattern.
- **Card layouts in rows** — `equal-cards` structure with required flex CSS for equal-height cards and bottom-aligned CTAs.
- **Creating Visual Richness Without Images** — gradients, colour blocks, typography-as-design, pseudo-elements, generous whitespace.
- **Animation & Motion** — `className` pattern, entrance animations (`fade-up`, `fade-in`, `slide-in-left/right`), staggered children, hover transitions, ambient motion.
- **Scroll-triggered reveals** — `IntersectionObserver` in `functions.php` + `animate-on-scroll` CSS.
- **prefers-reduced-motion (required)** — collapses durations to `0.01ms` and resets hidden initial states.
- **Editor Visibility / `.editor-styles-wrapper` override (required)** — keeps animated blocks visible in the editor iframe where the front-end `IntersectionObserver` does not run. The single most common cause of "empty editor" bugs in generated themes.
- **functions.php essentials** — `enqueue_block_assets` hook (front-end + editor), security notes (`esc_html`/`esc_attr`/`esc_url`, no `eval`/`exec`/`system`).

## Acceptance criteria (from `todo/tasks/t226-brief.md`)

| Criterion | Status |
|---|---|
| `wc -l includes/Models/skills/block-themes.md` is 350-450 | **445** ✓ |
| `block-themes.md` contains `Editor Visibility \| editor-styles-wrapper \| prefers-reduced-motion` | **13 matches** ✓ |
| No regression to existing discovery onboarding (`bootstrap-start` in `onboarding-bootstrap.js`) | unchanged ✓ |
| Lint clean | markdown-only change; no PHP/JS files modified |

## Verification commands

```bash
wc -l includes/Models/skills/block-themes.md
# 445

rg -c "Editor Visibility|editor-styles-wrapper|prefers-reduced-motion" includes/Models/skills/block-themes.md
# 13

rg -c "bootstrap-start" src/components/onboarding-bootstrap.js
# 2  (regression guard intact)
```

## Scope discipline

- **Adopt the architecture, not the code.** No `.claude-plugin/` packaging, no `studio` CLI calls, no Node `block-fixer` script. Pulled only the structural guidance and CSS patterns into our skill markdown.
- **Markdown-only change.** No PHP, JS, or build artefacts modified. The only other touched files are `TODO.md` and `todo/PLANS.md` to mark Phase 1 complete (PR #1371) and Phase 2 in progress.
- **Naming conventions respected** per `AGENTS.md`: skill content references `sd-ai-agent/*` tool/ability names throughout, never the text-domain `superdav-ai-agent` form.

For #1373

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 1d 4h and 15,815 tokens on this as a headless worker.
