### PR TITLE
GH#1378: test: cover block themes skill expansion

### DIFF
--- a/includes/Models/skills/block-themes.md
+++ b/includes/Models/skills/block-themes.md
@@ -70,6 +70,35 @@ Template parts are referenced inside templates via `wp:template-part`:
 <!-- wp:template-part {"slug":"header","tagName":"header"} /-->
 ```
 
+### Template Part Composition
+
+Generate template parts as reusable, editor-friendly block assemblies. A part should provide the structural frame only; page-specific hero, content, and CTA sections belong in templates or patterns.
+
+**Header requirements:**
+
+- Use a constrained or wide Group wrapper with site-appropriate padding from the spacing scale.
+- Compose a flex Row or Group containing `wp:site-title` (usually level `0`, so it renders as non-heading text) and `wp:navigation`.
+- Add a `className` for design-specific styling (`site-header`, `sticky-header`, `transparent-header`) rather than inline HTML.
+- Keep menus editable through the Navigation block; do not hard-code link lists in HTML blocks.
+
+**Footer requirements:**
+
+- Use a Group wrapper whose background complements the header or final CTA band.
+- Include editor-editable core blocks: site title, paragraph copy, navigation, social links, or columns as needed for the site type.
+- Reset the default top margin with `.wp-site-blocks > footer { margin-block-start: 0; }` in `style.css` so the footer sits flush after full-bleed sections.
+
+**Page-title part:**
+
+For non-landing templates, create a reusable page-title part or pattern that uses the dynamic `wp:post-title` block. Matching its spacing, typography, and background treatment to the homepage hero makes generated pages feel cohesive instead of bolted on.
+
+```html
+<!-- wp:group {"className":"page-title-band","align":"full","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignfull page-title-band">
+  <!-- wp:post-title {"level":1,"textAlign":"center"} /-->
+</div>
+<!-- /wp:group -->
+```
+
 ## Available Tools
 
 - `sd-ai-agent/list-block-templates` — List all templates with slugs and descriptions

--- a/tests/SdAiAgent/Models/SkillTest.php
+++ b/tests/SdAiAgent/Models/SkillTest.php
@@ -740,6 +740,37 @@ class SkillTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Block themes skill covers the Phase 2 theme generation guidance.
+	 */
+	public function test_block_themes_skill_covers_phase_two_theme_generation_guidance(): void {
+		$definitions = Skill::get_builtin_definitions();
+
+		$this->assertArrayHasKey( 'block-themes', $definitions );
+
+		$content = $definitions['block-themes']['content'];
+		$lines   = preg_split( '/\R/', $content );
+
+		$this->assertIsArray( $lines );
+		$this->assertGreaterThanOrEqual( 350, count( $lines ) );
+		$this->assertLessThanOrEqual( 500, count( $lines ) );
+
+		foreach (
+			[
+				'theme.json Overview',
+				'Template Parts',
+				'wp:template-part',
+				'The className pattern',
+				'prefers-reduced-motion',
+				'Editor Visibility',
+				'editor-styles-wrapper',
+				'enqueue_block_assets',
+			] as $required_phrase
+		) {
+			$this->assertStringContainsString( $required_phrase, $content );
+		}
+	}
+
+	/**
 	 * Each built-in skill has a non-empty description.
 	 */
 	public function test_builtin_skills_have_non_empty_description(): void {


### PR DESCRIPTION
## Summary

Expanded the block-themes skill with concrete template-part composition guidance for headers, footers, and page-title parts, and added a SkillTest regression that locks Phase 2 acceptance content for theme.json, template parts, motion classes, reduced-motion handling, and editor visibility CSS.

## Files Changed

includes/Models/skills/block-themes.md,tests/SdAiAgent/Models/SkillTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** php -l tests/SdAiAgent/Models/SkillTest.php; php acceptance check for includes/Models/skills/block-themes.md required phrases and 350-500 line ratchet; git diff --check. composer phpcs -- tests/SdAiAgent/Models/SkillTest.php was attempted but blocked because vendor/bin/phpcs is not installed in this worktree.

Resolves #1378


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 4m and 71,238 tokens on this with the user in an interactive session.