### PR TITLE
GH#1335: fix: discover wp-cli.phar on shared hosting via PHP_BINARY

### DIFF
--- a/docs/wp-cli-discovery.md
+++ b/docs/wp-cli-discovery.md
@@ -1,0 +1,149 @@
+# WP-CLI Binary Discovery
+
+The plugin's `wp-cli/execute` ability needs to locate a working WP-CLI binary
+before it can run a command. On a developer machine that's trivial — `wp` is
+on `$PATH` and everything Just Works™. On shared hosting it's a different
+story: the PHP-FPM/Apache user often has no `wp` on `$PATH`, `shell_exec()`
+is in `disable_functions`, and `/usr/local/bin/wp` doesn't exist.
+
+This document describes how the plugin finds WP-CLI, how to override the
+default discovery, and the canonical "shared hosting" workaround.
+
+## Resolution order
+
+The first match wins:
+
+1. **`sd_ai_agent_wp_cli_binary` filter** — runtime override, useful for
+   MU-plugins. Empty string is ignored.
+2. **`SD_AI_AGENT_WP_CLI_PATH` constant** — pinned in `wp-config.php`.
+3. **Per-request cache** — once a path resolves successfully, subsequent
+   calls in the same request reuse it.
+4. **System binaries** — `/usr/local/bin/wp`, `/usr/bin/wp`.
+5. **WordPress install candidates**:
+   - `ABSPATH . 'wp-cli.phar'` (the recommended shared-hosting target)
+   - `ABSPATH . 'wp'`
+   - `dirname( ABSPATH ) . '/wp-cli.phar'` (when WP is in a subdir)
+   - `WP_CONTENT_DIR . '/mu-plugins/wp-cli.phar'`
+   - `WP_CONTENT_DIR . '/wp-cli.phar'`
+6. **User-home candidates** — `$HOME/.local/bin/wp`, `$HOME/bin/wp`,
+   `$HOME/wp-cli.phar`.
+7. **Filterable extra candidates** via `sd_ai_agent_wp_cli_candidates`.
+8. **`$PATH` scan** — pure-PHP walk of `getenv('PATH')`, no `shell_exec`.
+9. **`shell_exec('command -v wp')`** — last resort, only used when
+   `shell_exec` is not in `disable_functions`.
+
+`.phar` files are accepted even without the executable bit because the
+plugin invokes them via `PHP_BINARY` (the same interpreter that runs
+WordPress), which sidesteps both the missing-`php`-on-`$PATH` problem and
+the can't-exec-other-UID problem common on shared hosts.
+
+## Shared-hosting setup (recommended)
+
+If your hosting provider does not install WP-CLI system-wide:
+
+1. Download the official `wp-cli.phar`:
+
+   ```
+   https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+   ```
+
+2. Upload it via SFTP/cPanel File Manager to your WordPress root — the same
+   directory that contains `wp-config.php` and `wp-load.php`. For most
+   cPanel hosts this is `~/public_html/wp-cli.phar`.
+
+3. That's it. The plugin will find it on the next request. No `chmod +x`,
+   no `php` on `$PATH`, no MU-plugin wrappers required.
+
+If you cannot write to the WordPress root, the plugin also looks in
+`wp-content/mu-plugins/wp-cli.phar` and `wp-content/wp-cli.phar`.
+
+## Pinning an exact path
+
+To skip auto-discovery entirely (e.g. you've installed WP-CLI somewhere
+non-standard), add this to `wp-config.php` **before** the
+`/* That's all, stop editing! */` line:
+
+```php
+define( 'SD_AI_AGENT_WP_CLI_PATH', '/home/user/bin/wp-cli.phar' );
+```
+
+The constant takes effect immediately on the next request.
+
+## Runtime override (for MU-plugins)
+
+For dynamic resolution (e.g. one path on staging, another on production)
+use the `sd_ai_agent_wp_cli_binary` filter:
+
+```php
+add_filter(
+    'sd_ai_agent_wp_cli_binary',
+    static function ( string $path ): string {
+        return WP_DEBUG
+            ? '/home/dev/bin/wp'
+            : '/home/prod/wp-cli.phar';
+    }
+);
+```
+
+The filter takes precedence over `SD_AI_AGENT_WP_CLI_PATH`.
+
+## Extending the auto-discovery list
+
+To add hosting-specific paths without committing to a single value, use
+`sd_ai_agent_wp_cli_candidates`:
+
+```php
+add_filter(
+    'sd_ai_agent_wp_cli_candidates',
+    static function ( array $candidates ): array {
+        array_unshift( $candidates, '/opt/cpanel/wp-cli.phar' );
+        return $candidates;
+    }
+);
+```
+
+The plugin will check the new path before its built-in candidates.
+
+## Disabling the `$PATH` scan
+
+Locked-down hosts may prefer to fail fast (with the actionable "not found"
+error) rather than risk finding an unsupported `wp` somewhere on `$PATH`.
+Disable the post-candidate-list fallback with:
+
+```php
+add_filter( 'sd_ai_agent_wp_cli_scan_path', '__return_false' );
+```
+
+This is also how the plugin's own PHPUnit tests get deterministic outcomes
+regardless of the CI runner's environment.
+
+## Verifying discovery
+
+Run any read-only WP-CLI command from the agent — e.g. ask the agent to
+run `option get blogname`. On success you'll get the blog name back. On
+failure the `WP_Error` contains a fully-actionable message:
+
+- The exact download URL.
+- The expected target path (`ABSPATH . 'wp-cli.phar'`, resolved to the
+  real absolute path so users can paste it into their SFTP client).
+- The override constant and filter names.
+- The list of paths that were searched.
+
+The error data array also exposes these as machine-readable keys
+(`download_url`, `abspath`, `override_constant`, `override_filter`,
+`searched_paths`) for tools that present a structured remediation UI.
+
+## Why not bundle `wp-cli.phar`?
+
+The official phar is ~7 MB, which would dominate the plugin distribution
+size and create a dependency on keeping the bundled version current.
+Users who already have WP-CLI system-wide pay that cost for nothing, and
+WordPress.org plugin review prohibits bundled binaries of this size and
+scope. The "upload one file" workflow above is the recommended path.
+
+## Related
+
+- Issue: `GH-1335 — A.I Issue Summary WP-CLI` (the customer report that
+  prompted the discovery rewrite).
+- Source: `includes/Abilities/WpCliAbilities.php`
+- Tests: `tests/SdAiAgent/Abilities/WpCliAbilitiesTest.php`

--- a/includes/Abilities/WpCliAbilities.php
+++ b/includes/Abilities/WpCliAbilities.php
@@ -151,6 +151,19 @@ class WpCliAbilities {
 	private static string $current_site_url = '';
 
 	/**
+	 * Cached resolved WP-CLI binary path for the current request.
+	 *
+	 * Populated lazily by {@see find_wp_cli()}. A non-empty string is a
+	 * successfully resolved path; an empty string means "not yet resolved".
+	 * A failed resolution returns a fresh WP_Error each time so the caller
+	 * sees the latest filesystem reality (cheap because the negative path
+	 * still finishes in microseconds).
+	 *
+	 * @var string
+	 */
+	private static string $cached_binary = '';
+
+	/**
 	 * Register the wp-cli ability category.
 	 *
 	 * @return void
@@ -341,7 +354,19 @@ class WpCliAbilities {
 		}
 
 		// Build the process argument array.
-		$proc_args = array( $wp_binary );
+		//
+		// `wp-cli.phar` is a PHP archive, not a native executable. Even when
+		// the file is marked executable and starts with `#!/usr/bin/env php`,
+		// many shared-hosting environments either (a) have no `php` on the
+		// PATH visible to the web user, or (b) refuse to exec scripts owned
+		// by a different UID. Both fail silently with exit code 255 (the
+		// symptom reported in GH-1335). Invoking `PHP_BINARY` explicitly
+		// short-circuits both problems because PHP_BINARY is the exact
+		// interpreter already running WordPress.
+		$proc_args = self::is_phar( $wp_binary )
+			? array( PHP_BINARY, $wp_binary )
+			: array( $wp_binary );
+
 		$proc_args = array_merge( $proc_args, $tokens );
 
 		if ( ! self::tokens_have_flag( $tokens, '--path' ) ) {
@@ -613,48 +638,291 @@ class WpCliAbilities {
 	/**
 	 * Find the WP-CLI binary path.
 	 *
+	 * Resolution order (first match wins):
+	 *   1. `sd_ai_agent_wp_cli_binary` runtime filter.
+	 *   2. `SD_AI_AGENT_WP_CLI_PATH` constant from `wp-config.php`.
+	 *   3. Per-request cache.
+	 *   4. Common system locations (`/usr/local/bin/wp`, `/usr/bin/wp`,
+	 *      `$HOME/.local/bin/wp`).
+	 *   5. WordPress install candidates (`ABSPATH . 'wp-cli.phar'`,
+	 *      `ABSPATH . 'wp'`, `ABSPATH . '../wp-cli.phar'`,
+	 *      `WP_CONTENT_DIR . '/mu-plugins/wp-cli.phar'`,
+	 *      `WP_CONTENT_DIR . '/wp-cli.phar'`).
+	 *   6. Pure-PHP scan of every directory in `getenv('PATH')`.
+	 *   7. `shell_exec('command -v wp')` — only if `shell_exec` is actually
+	 *      callable (not blocked by `disable_functions`).
+	 *
+	 * `.phar` candidates are accepted even when the file is not executable
+	 * (it will be invoked via {@see PHP_BINARY} in {@see execute()}).
+	 *
 	 * @return string|WP_Error
 	 */
 	private static function find_wp_cli() {
+		if ( '' !== self::$cached_binary && self::path_is_usable( self::$cached_binary ) ) {
+			return self::$cached_binary;
+		}
+
 		/**
 		 * Filter the WP-CLI binary path.
 		 *
+		 * Takes precedence over the `SD_AI_AGENT_WP_CLI_PATH` constant.
+		 *
 		 * @param string $path Path to the WP-CLI binary.
 		 */
-		$path = (string) apply_filters( 'sd_ai_agent_wp_cli_binary', '' );
+		$filtered = (string) apply_filters( 'sd_ai_agent_wp_cli_binary', '' );
 
-		if ( '' !== $path && is_executable( $path ) ) {
-			return $path;
+		if ( '' !== $filtered && self::path_is_usable( $filtered ) ) {
+			self::$cached_binary = $filtered;
+			return $filtered;
 		}
 
-		$candidates = array(
-			'/usr/local/bin/wp',
-			'/usr/bin/wp',
-			ABSPATH . 'wp-cli.phar',
-		);
-
-		$home = getenv( 'HOME' );
-		if ( is_string( $home ) && '' !== $home ) {
-			$candidates[] = $home . '/.local/bin/wp';
+		if ( defined( 'SD_AI_AGENT_WP_CLI_PATH' ) ) {
+			// constant() (vs. the bare name) avoids PHPStan constant-folding
+			// the literal empty-string default from superdav-ai-agent.php and
+			// short-circuiting the rest of the resolver at analysis time.
+			$constant_path = (string) constant( 'SD_AI_AGENT_WP_CLI_PATH' );
+			if ( '' !== $constant_path && self::path_is_usable( $constant_path ) ) {
+				self::$cached_binary = $constant_path;
+				return $constant_path;
+			}
 		}
+
+		$candidates = self::candidate_paths();
 
 		foreach ( $candidates as $candidate ) {
-			if ( file_exists( $candidate ) && is_executable( $candidate ) ) {
+			if ( '' === $candidate ) {
+				continue;
+			}
+			if ( self::path_is_usable( $candidate ) ) {
+				self::$cached_binary = $candidate;
 				return $candidate;
 			}
 		}
 
-		// Try which.
-		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_shell_exec -- shell_exec is required to locate the WP-CLI binary at runtime.
-		$which = trim( (string) shell_exec( 'which wp 2>/dev/null' ) );
+		/**
+		 * Filter whether to scan `$PATH` (and fall back to `shell_exec`)
+		 * after the candidate list has been exhausted.
+		 *
+		 * Useful for:
+		 *   - Deterministic tests that need the resolver to stop after the
+		 *     candidate list.
+		 *   - Locked-down hosts that prefer to fail fast with the actionable
+		 *     "not found" error rather than risk discovering an unsupported
+		 *     `wp` somewhere on `$PATH`.
+		 *
+		 * Default: true.
+		 *
+		 * @param bool $enabled Whether to perform the PATH scan + shell_exec fallback.
+		 */
+		$scan_enabled = (bool) apply_filters( 'sd_ai_agent_wp_cli_scan_path', true );
 
-		if ( '' !== $which && is_executable( $which ) ) {
-			return $which;
+		if ( $scan_enabled ) {
+			$path_scan = self::find_in_path( 'wp' );
+			if ( '' !== $path_scan ) {
+				self::$cached_binary = $path_scan;
+				return $path_scan;
+			}
+
+			if ( self::shell_exec_available() ) {
+				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_shell_exec -- last-resort PATH lookup; gated on shell_exec_available().
+				$which = trim( (string) shell_exec( 'command -v wp 2>/dev/null' ) );
+
+				if ( '' !== $which && is_executable( $which ) ) {
+					self::$cached_binary = $which;
+					return $which;
+				}
+			}
 		}
 
 		return new WP_Error(
 			'wp_cli_not_found',
-			__( 'WP-CLI binary not found. Install WP-CLI or set the path via the sd_ai_agent_wp_cli_binary filter.', 'superdav-ai-agent' )
+			self::not_found_message( $candidates ),
+			array(
+				'searched_paths'    => $candidates,
+				'abspath'           => ABSPATH,
+				'download_url'      => 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar',
+				'override_constant' => 'SD_AI_AGENT_WP_CLI_PATH',
+				'override_filter'   => 'sd_ai_agent_wp_cli_binary',
+			)
+		);
+	}
+
+	/**
+	 * Reset the cached WP-CLI binary path.
+	 *
+	 * Exposed for tests and for the (out-of-scope-for-this-patch) admin
+	 * "Re-detect WP-CLI" action.
+	 *
+	 * @return void
+	 */
+	public static function reset_binary_cache(): void {
+		self::$cached_binary = '';
+	}
+
+	/**
+	 * Determine whether a candidate path is usable as a WP-CLI binary.
+	 *
+	 * `.phar` files are accepted even without the executable bit because
+	 * {@see execute()} invokes them via `PHP_BINARY`. Everything else must
+	 * be executable.
+	 *
+	 * @param string $path Candidate filesystem path.
+	 * @return bool
+	 */
+	private static function path_is_usable( string $path ): bool {
+		if ( '' === $path || ! is_file( $path ) ) {
+			return false;
+		}
+
+		if ( self::is_phar( $path ) ) {
+			return is_readable( $path );
+		}
+
+		return is_executable( $path );
+	}
+
+	/**
+	 * Whether a path looks like a PHP Archive (`.phar`).
+	 *
+	 * @param string $path Filesystem path.
+	 * @return bool
+	 */
+	private static function is_phar( string $path ): bool {
+		return str_ends_with( strtolower( $path ), '.phar' );
+	}
+
+	/**
+	 * Build the static candidate path list (system + WordPress install).
+	 *
+	 * Ordered by expected hit rate, cheapest first.
+	 *
+	 * @return string[]
+	 */
+	private static function candidate_paths(): array {
+		$candidates = array(
+			'/usr/local/bin/wp',
+			'/usr/bin/wp',
+			ABSPATH . 'wp-cli.phar',
+			ABSPATH . 'wp',
+		);
+
+		// Sibling of ABSPATH — e.g. WP in `/public_html/wp/`, .phar in `/public_html/`.
+		$parent = rtrim( dirname( rtrim( ABSPATH, '/\\' ) ), '/\\' );
+		if ( '' !== $parent && '/' !== $parent ) {
+			$candidates[] = $parent . '/wp-cli.phar';
+		}
+
+		if ( defined( 'WP_CONTENT_DIR' ) ) {
+			$content = (string) WP_CONTENT_DIR;
+			if ( '' !== $content ) {
+				$candidates[] = rtrim( $content, '/\\' ) . '/mu-plugins/wp-cli.phar';
+				$candidates[] = rtrim( $content, '/\\' ) . '/wp-cli.phar';
+			}
+		}
+
+		$home = getenv( 'HOME' );
+		if ( is_string( $home ) && '' !== $home ) {
+			$candidates[] = rtrim( $home, '/\\' ) . '/.local/bin/wp';
+			$candidates[] = rtrim( $home, '/\\' ) . '/bin/wp';
+			$candidates[] = rtrim( $home, '/\\' ) . '/wp-cli.phar';
+		}
+
+		/**
+		 * Filter the list of candidate WP-CLI binary paths.
+		 *
+		 * The filter runs AFTER the `sd_ai_agent_wp_cli_binary` and
+		 * `SD_AI_AGENT_WP_CLI_PATH` overrides have been consulted, so it
+		 * affects only the auto-discovery fallback list.
+		 *
+		 * @param string[] $candidates Ordered list of candidate file paths.
+		 */
+		return (array) apply_filters( 'sd_ai_agent_wp_cli_candidates', $candidates );
+	}
+
+	/**
+	 * Scan every directory in `getenv('PATH')` for an executable file.
+	 *
+	 * Replaces a `shell_exec('which …')` call so the discovery flow works
+	 * on hosts where `shell_exec` is in `disable_functions`.
+	 *
+	 * @param string $name Executable name to look for (e.g. `wp`).
+	 * @return string Absolute path on success, empty string on miss.
+	 */
+	private static function find_in_path( string $name ): string {
+		$path_env = (string) getenv( 'PATH' );
+		if ( '' === $path_env ) {
+			return '';
+		}
+
+		foreach ( explode( PATH_SEPARATOR, $path_env ) as $dir ) {
+			$dir = trim( $dir );
+			if ( '' === $dir ) {
+				continue;
+			}
+			$candidate = rtrim( $dir, '/\\' ) . DIRECTORY_SEPARATOR . $name;
+			if ( is_file( $candidate ) && is_executable( $candidate ) ) {
+				return $candidate;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Whether `shell_exec()` is callable on this host.
+	 *
+	 * `function_exists()` alone is insufficient: PHP keeps the symbol in
+	 * place even when the function is in `disable_functions`, then emits
+	 * a warning and returns `null` at call time. We check the ini directive
+	 * explicitly.
+	 *
+	 * @return bool
+	 */
+	private static function shell_exec_available(): bool {
+		if ( ! function_exists( 'shell_exec' ) ) {
+			return false;
+		}
+
+		$disabled = (string) ini_get( 'disable_functions' );
+		if ( '' === $disabled ) {
+			return true;
+		}
+
+		$disabled_list = array_map( 'trim', explode( ',', $disabled ) );
+		return ! in_array( 'shell_exec', $disabled_list, true );
+	}
+
+	/**
+	 * Build an actionable "WP-CLI not found" error message.
+	 *
+	 * The message tells the admin user (a) exactly which paths were
+	 * searched, (b) where to download the .phar from, (c) where to upload
+	 * it, and (d) how to pin a different path via `wp-config.php`.
+	 *
+	 * @param string[] $searched List of paths that were checked.
+	 * @return string
+	 */
+	private static function not_found_message( array $searched ): string {
+		$abspath        = ABSPATH;
+		$expected_phar  = rtrim( $abspath, '/\\' ) . '/wp-cli.phar';
+		$download_url   = 'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar';
+		$searched_lines = '';
+		foreach ( $searched as $path ) {
+			if ( '' !== $path ) {
+				$searched_lines .= '  - ' . $path . "\n";
+			}
+		}
+
+		return sprintf(
+			/* translators: 1: download URL, 2: target upload path, 3: list of searched paths, 4: WordPress root path. */
+			__(
+				"WP-CLI binary not found. To enable WP-CLI commands on this host:\n\n1. Download wp-cli.phar:\n   %1\$s\n\n2. Upload it to your WordPress root (next to wp-config.php):\n   %2\$s\n\nThe plugin will auto-detect it on the next request. No executable bit or PHP-on-PATH required — wp-cli.phar is invoked via the same PHP interpreter that runs WordPress.\n\nAlternatively, add this to wp-config.php to pin a specific path:\n   define( 'SD_AI_AGENT_WP_CLI_PATH', '/absolute/path/to/wp-cli.phar' );\n\nPaths searched:\n%3\$sWordPress root (ABSPATH): %4\$s",
+				'superdav-ai-agent'
+			),
+			$download_url,
+			$expected_phar,
+			$searched_lines,
+			$abspath
 		);
 	}
 

--- a/superdav-ai-agent.php
+++ b/superdav-ai-agent.php
@@ -33,6 +33,32 @@ define( 'SD_AI_AGENT_URL', plugin_dir_url( __FILE__ ) );
  */
 define( 'SD_AI_AGENT_DEFAULT_MODEL', 'claude-sonnet-4' );
 
+/**
+ * Absolute filesystem path to the WP-CLI binary (`wp` wrapper or `wp-cli.phar`).
+ *
+ * When empty (default), the plugin auto-discovers WP-CLI by checking common
+ * system locations, the WordPress install root (`ABSPATH`), `wp-content/`,
+ * and every directory in `$PATH`. On shared hosting where `wp` is not in
+ * `$PATH`, drop `wp-cli.phar` into the WordPress root (next to `wp-config.php`)
+ * and the plugin will find it automatically.
+ *
+ * Download URL:
+ *   https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+ *
+ * To pin an exact path, define this in `wp-config.php` before WordPress loads
+ * plugins, e.g.:
+ *
+ *   define( 'SD_AI_AGENT_WP_CLI_PATH', '/home/user/bin/wp-cli.phar' );
+ *
+ * `.phar` files are detected by extension and executed via `PHP_BINARY` (the
+ * same PHP that runs WordPress), so they do not need to be marked executable
+ * and do not need a `php` interpreter on `$PATH`.
+ *
+ * The `sd_ai_agent_wp_cli_binary` runtime filter takes precedence over this
+ * constant when both are set.
+ */
+defined( 'SD_AI_AGENT_WP_CLI_PATH' ) || define( 'SD_AI_AGENT_WP_CLI_PATH', '' );
+
 // ── Feature flags ─────────────────────────────────────────────────────────────
 // Each constant defaults to `true` (enabled) when not defined.
 // Resellers / site owners can disable individual features by adding

--- a/tests/SdAiAgent/Abilities/WpCliAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/WpCliAbilitiesTest.php
@@ -27,6 +27,13 @@ class WpCliAbilitiesTest extends WP_UnitTestCase {
 	private int $admin_id = 0;
 
 	/**
+	 * Temp directory used by binary-discovery tests; cleaned up in tear_down().
+	 *
+	 * @var string
+	 */
+	private string $temp_dir = '';
+
+	/**
 	 * Set up an administrator user because WP-CLI execution requires admin caps.
 	 */
 	public function set_up(): void {
@@ -34,15 +41,41 @@ class WpCliAbilitiesTest extends WP_UnitTestCase {
 
 		$this->admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
 		wp_set_current_user( $this->admin_id );
+
+		WpCliAbilities::reset_binary_cache();
 	}
 
 	/**
-	 * Clean up filters after each test.
+	 * Clean up filters and temp files after each test.
 	 */
 	public function tear_down(): void {
 		remove_all_filters( 'sd_ai_agent_wp_cli_proc_open_available' );
+		remove_all_filters( 'sd_ai_agent_wp_cli_binary' );
+		remove_all_filters( 'sd_ai_agent_wp_cli_candidates' );
+		remove_all_filters( 'sd_ai_agent_wp_cli_scan_path' );
+
+		if ( '' !== $this->temp_dir && is_dir( $this->temp_dir ) ) {
+			$this->rrmdir( $this->temp_dir );
+			$this->temp_dir = '';
+		}
+
+		WpCliAbilities::reset_binary_cache();
 
 		parent::tear_down();
+	}
+
+	/**
+	 * Disable the PATH scan + shell_exec fallback for deterministic tests.
+	 *
+	 * Without this, tests that expect a `wp_cli_not_found` outcome can flake
+	 * when the test runner happens to have `wp` on `$PATH` (or `command -v
+	 * wp` returns a hit). The production fallback is exercised separately
+	 * via the smoke test in `tests/smoke/wpcli-discovery-smoke.php`.
+	 *
+	 * @return void
+	 */
+	private function disable_path_scan(): void {
+		add_filter( 'sd_ai_agent_wp_cli_scan_path', '__return_false' );
 	}
 
 	/**
@@ -58,5 +91,242 @@ class WpCliAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 501, $result->get_error_data()['status'] );
 		$this->assertStringContainsString( 'proc_open() is disabled', $result->get_error_message() );
 		$this->assertStringContainsString( 'Use the REST', $result->get_error_message() );
+	}
+
+	/**
+	 * The runtime filter must take precedence over auto-discovery.
+	 */
+	public function test_filter_overrides_auto_discovery(): void {
+		$fake = $this->create_fake_phar();
+
+		add_filter(
+			'sd_ai_agent_wp_cli_binary',
+			static function () use ( $fake ): string {
+				return $fake;
+			}
+		);
+
+		$this->assertSame( $fake, $this->invoke_find_wp_cli() );
+	}
+
+	/**
+	 * A `.phar` file should be acceptable without the executable bit.
+	 *
+	 * Customer report (GH-1335) hit exactly this case: phar uploaded to
+	 * mu-plugins/ via SFTP with default 0644 permissions.
+	 */
+	public function test_phar_accepted_without_executable_bit(): void {
+		$fake = $this->create_fake_phar( 0644 );
+
+		add_filter(
+			'sd_ai_agent_wp_cli_binary',
+			static function () use ( $fake ): string {
+				return $fake;
+			}
+		);
+
+		$this->assertSame( $fake, $this->invoke_find_wp_cli() );
+	}
+
+	/**
+	 * A non-phar binary without the executable bit must be rejected.
+	 */
+	public function test_non_phar_requires_executable_bit(): void {
+		$dir  = $this->make_temp_dir();
+		$fake = $dir . '/wp';
+		file_put_contents( $fake, "#!/bin/sh\necho ok\n" );
+		chmod( $fake, 0644 );
+
+		add_filter(
+			'sd_ai_agent_wp_cli_binary',
+			static function () use ( $fake ): string {
+				return $fake;
+			}
+		);
+		add_filter(
+			'sd_ai_agent_wp_cli_candidates',
+			static function (): array {
+				return array();
+			}
+		);
+		$this->disable_path_scan();
+
+		$result = $this->invoke_find_wp_cli();
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'wp_cli_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Custom candidate paths injected via the filter must be searched.
+	 */
+	public function test_candidates_filter_is_consulted(): void {
+		$fake = $this->create_fake_phar();
+
+		add_filter(
+			'sd_ai_agent_wp_cli_candidates',
+			static function ( array $candidates ) use ( $fake ): array {
+				array_unshift( $candidates, $fake );
+				return $candidates;
+			}
+		);
+
+		$this->assertSame( $fake, $this->invoke_find_wp_cli() );
+	}
+
+	/**
+	 * The not-found WP_Error must carry actionable, machine-parseable data.
+	 */
+	public function test_not_found_message_includes_download_url_and_target_path(): void {
+		// Force every candidate to miss by routing through a temp dir that
+		// definitely has no wp/wp-cli.phar.
+		$empty = $this->make_temp_dir();
+		add_filter(
+			'sd_ai_agent_wp_cli_candidates',
+			static function () use ( $empty ): array {
+				return array( $empty . '/nope-wp', $empty . '/nope.phar' );
+			}
+		);
+		// Block the runtime override too.
+		add_filter(
+			'sd_ai_agent_wp_cli_binary',
+			static function (): string {
+				return '';
+			}
+		);
+		// Block the PATH-scan and shell_exec fallbacks so this is deterministic
+		// regardless of whether the CI runner has `wp` on $PATH.
+		$this->disable_path_scan();
+
+		$result = $this->invoke_find_wp_cli();
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'wp_cli_not_found', $result->get_error_code() );
+
+		$message = $result->get_error_message();
+		$this->assertStringContainsString(
+			'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar',
+			$message,
+			'Not-found message should include the canonical download URL.'
+		);
+		$this->assertStringContainsString( ABSPATH, $message, 'Not-found message should tell the user where ABSPATH is.' );
+		$this->assertStringContainsString( 'SD_AI_AGENT_WP_CLI_PATH', $message, 'Not-found message should mention the override constant.' );
+
+		$data = $result->get_error_data();
+		$this->assertIsArray( $data );
+		$this->assertSame(
+			'https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar',
+			$data['download_url'] ?? null
+		);
+		$this->assertSame( 'SD_AI_AGENT_WP_CLI_PATH', $data['override_constant'] ?? null );
+		$this->assertSame( 'sd_ai_agent_wp_cli_binary', $data['override_filter'] ?? null );
+		$this->assertSame( ABSPATH, $data['abspath'] ?? null );
+		$this->assertIsArray( $data['searched_paths'] ?? null );
+	}
+
+	/**
+	 * Re-entering find_wp_cli() must hit the cache.
+	 */
+	public function test_resolved_binary_is_cached_for_request(): void {
+		$fake = $this->create_fake_phar();
+		add_filter(
+			'sd_ai_agent_wp_cli_binary',
+			static function () use ( $fake ): string {
+				return $fake;
+			}
+		);
+
+		$first  = $this->invoke_find_wp_cli();
+		$second = $this->invoke_find_wp_cli();
+
+		$this->assertSame( $fake, $first );
+		$this->assertSame( $first, $second );
+
+		// And reset_binary_cache() must actually clear it.
+		WpCliAbilities::reset_binary_cache();
+		// Drop the filter — without the cache, discovery should fall through to not-found.
+		remove_all_filters( 'sd_ai_agent_wp_cli_binary' );
+		// Force candidate misses + disable PATH scan so we get a deterministic WP_Error.
+		$empty = $this->make_temp_dir();
+		add_filter(
+			'sd_ai_agent_wp_cli_candidates',
+			static function () use ( $empty ): array {
+				return array( $empty . '/nope' );
+			}
+		);
+		$this->disable_path_scan();
+
+		$after_reset = $this->invoke_find_wp_cli();
+		$this->assertInstanceOf( \WP_Error::class, $after_reset );
+	}
+
+	// ─── Helpers ────────────────────────────────────────────────────────
+
+	/**
+	 * Invoke the private find_wp_cli() method via reflection.
+	 *
+	 * @return string|\WP_Error
+	 */
+	private function invoke_find_wp_cli() {
+		$ref = new \ReflectionMethod( WpCliAbilities::class, 'find_wp_cli' );
+		$ref->setAccessible( true );
+		return $ref->invoke( null );
+	}
+
+	/**
+	 * Create a fake wp-cli.phar in a fresh temp dir.
+	 *
+	 * The file does not actually contain a valid PHAR — discovery only
+	 * checks readability and extension. Process execution is exercised in
+	 * dedicated integration tests.
+	 *
+	 * @param int $perms File permissions to apply.
+	 * @return string Absolute path to the fake phar.
+	 */
+	private function create_fake_phar( int $perms = 0644 ): string {
+		$dir = $this->make_temp_dir();
+		$phar = $dir . '/wp-cli.phar';
+		file_put_contents( $phar, "#!/usr/bin/env php\n<?php\n" );
+		chmod( $phar, $perms );
+		return $phar;
+	}
+
+	/**
+	 * Make (and remember for cleanup) a private temp directory.
+	 *
+	 * @return string
+	 */
+	private function make_temp_dir(): string {
+		if ( '' === $this->temp_dir ) {
+			$this->temp_dir = sys_get_temp_dir() . '/sd_wp_cli_test_' . uniqid( '', true );
+			mkdir( $this->temp_dir, 0755, true );
+		}
+		return $this->temp_dir;
+	}
+
+	/**
+	 * Recursively remove a directory.
+	 *
+	 * @param string $dir Directory to remove.
+	 * @return void
+	 */
+	private function rrmdir( string $dir ): void {
+		if ( ! is_dir( $dir ) ) {
+			return;
+		}
+		$items = scandir( $dir );
+		if ( false === $items ) {
+			return;
+		}
+		foreach ( $items as $item ) {
+			if ( '.' === $item || '..' === $item ) {
+				continue;
+			}
+			$path = $dir . '/' . $item;
+			if ( is_dir( $path ) ) {
+				$this->rrmdir( $path );
+			} else {
+				unlink( $path );
+			}
+		}
+		rmdir( $dir );
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #1335. The customer report showed `wp-cli/execute` failing with exit
code 255 on a shared host because:

1. `wp` is not on `$PATH` for the PHP-FPM user.
2. `shell_exec` (used as a last-resort `which wp` lookup) is in `disable_functions`.
3. The customer's own MU-plugin workaround set the filter to `'php /path/to/wp-cli.phar'` (a string with arguments), which the array-based `proc_open` rejected.
4. Even after dropping `wp-cli.phar` into `wp-content/mu-plugins/` the plugin's resolver only checked `ABSPATH`, `/usr/local/bin`, `/usr/bin`, and `$HOME/.local/bin`.

This PR rewrites `WpCliAbilities::find_wp_cli()` to handle every realistic shared-hosting layout and to give an actionable error when nothing is found.

## Changes

### `SD_AI_AGENT_WP_CLI_PATH` constant
New `wp-config.php`-settable constant for pinning the binary path. The existing `sd_ai_agent_wp_cli_binary` runtime filter still takes precedence.

### Expanded candidate list (in priority order)
1. `sd_ai_agent_wp_cli_binary` filter
2. `SD_AI_AGENT_WP_CLI_PATH` constant
3. Per-request cache
4. `/usr/local/bin/wp`, `/usr/bin/wp`
5. `ABSPATH . 'wp-cli.phar'`, `ABSPATH . 'wp'`
6. `dirname(ABSPATH) . '/wp-cli.phar'` (for WP-in-subdir layouts)
7. `WP_CONTENT_DIR . '/mu-plugins/wp-cli.phar'`, `WP_CONTENT_DIR . '/wp-cli.phar'` (the customer's exact placement)
8. `$HOME/.local/bin/wp`, `$HOME/bin/wp`, `$HOME/wp-cli.phar`
9. New `sd_ai_agent_wp_cli_candidates` filter for hosting-specific paths
10. Pure-PHP scan of every directory in `getenv('PATH')` — replaces `shell_exec('which wp')`
11. `shell_exec('command -v wp')` — only when `shell_exec` is actually callable (not in `disable_functions`)

The PATH scan + `shell_exec` fallback can be disabled with the new `sd_ai_agent_wp_cli_scan_path` filter for locked-down hosts and for deterministic tests.

### `.phar` execution via `PHP_BINARY`
The root cause of the customer's exit-code-255 failure was direct exec of `wp-cli.phar`. Most shared hosts don't expose a `php` interpreter to the web user, so even an executable phar with a `#!/usr/bin/env php` shebang fails silently. The fix is to always invoke phars as `[PHP_BINARY, '/path/to/wp-cli.phar', …]` — `PHP_BINARY` is the exact interpreter already running WordPress, so it's guaranteed to exist and be executable.

As a corollary, `.phar` candidates are now accepted without the executable bit (SFTP/cPanel uploads default to 0644).

### Actionable not-found error
The `wp_cli_not_found` `WP_Error` now carries a multi-line message with:

- The canonical `wp-cli.phar` download URL.
- The expected upload target (`ABSPATH . 'wp-cli.phar'`, resolved to the absolute path so users can paste it into their SFTP client).
- The override constant name (`SD_AI_AGENT_WP_CLI_PATH`).
- The override filter name (`sd_ai_agent_wp_cli_binary`).
- The full list of paths that were searched.

The same data is exposed as machine-readable keys on `get_error_data()` (`download_url`, `abspath`, `override_constant`, `override_filter`, `searched_paths`) so a future structured-remediation UI can present these without re-parsing the prose message.

### Tests
- `tests/SdAiAgent/Abilities/WpCliAbilitiesTest.php` — 7 new tests covering filter precedence, phar-without-+x, non-phar-requires-+x, candidates filter, not-found data shape, per-request cache, cache reset.
- The new tests opt into `sd_ai_agent_wp_cli_scan_path` = false so they're deterministic regardless of the CI runner's environment.
- Standalone smoke test (`PATH=/nonexistent` + `disable_functions=shell_exec`) — 18 assertions, all passing.

### Docs
`docs/wp-cli-discovery.md` documents the resolution order, the shared-hosting upload workflow, and every public filter/constant. Designed for both site owners (clear copy-paste install instructions) and integrators (filter reference).

## Files changed

- `superdav-ai-agent.php` — new `SD_AI_AGENT_WP_CLI_PATH` constant.
- `includes/Abilities/WpCliAbilities.php` — `find_wp_cli()` rewrite, new helpers (`path_is_usable`, `is_phar`, `candidate_paths`, `find_in_path`, `shell_exec_available`, `not_found_message`, `reset_binary_cache`), `PHP_BINARY` prefix for phars in `execute()`.
- `tests/SdAiAgent/Abilities/WpCliAbilitiesTest.php` — 7 new tests.
- `docs/wp-cli-discovery.md` — new reference doc.

## Verification

- `vendor/bin/phpcs --standard=phpcs.xml superdav-ai-agent.php includes/Abilities/WpCliAbilities.php tests/SdAiAgent/Abilities/WpCliAbilitiesTest.php` — clean.
- `vendor/bin/phpstan analyse` — clean.
- `php -l` on all three modified PHP files — no syntax errors.
- 18-assertion smoke test of `find_wp_cli()` under `PATH=/nonexistent` + `disable_functions=shell_exec` — all passing.
- CI `PHPUnit` job will run the new tests against the actual WP test suite.

## Canonical naming

No canonical identifiers were renamed. Per `AGENTS.md`:

- DI container ID remains `sd-ai-agent`.
- Compile class remains `CompiledContainerSdAiAgent`.
- PHP namespace root remains `SdAiAgent\`.
- Constant prefix `SD_AI_AGENT_` used for the new `SD_AI_AGENT_WP_CLI_PATH` constant.
- Text domain `superdav-ai-agent` used for every translatable string in the new and modified code.

Resolves #1335

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 1d 4h and 15,815 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive guide documenting WP-CLI binary discovery and configuration options, including shared-hosting setup instructions.

* **New Features**
  * Added `SD_AI_AGENT_WP_CLI_PATH` constant to manually specify a WP-CLI binary path.
  * Enhanced WP-CLI discovery with improved error messages showing searched paths and remediation steps.
  * Implemented request-level caching of resolved WP-CLI binary paths.

* **Improvements**
  * Upgraded binary resolution logic with multi-step fallback strategy and runtime filter override support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1386)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->