### PR TITLE
feat(sd-ai-bjv): provider-aware prompt caching with cache-token telemetry

### DIFF
--- a/includes/Bootstrap/HttpTraceHandler.php
+++ b/includes/Bootstrap/HttpTraceHandler.php
@@ -18,7 +18,9 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Bootstrap;
 
+use SdAiAgent\Core\PromptCache\CacheStrategyResolver;
 use SdAiAgent\Core\ProviderTraceLogger;
+use SdAiAgent\Core\Settings;
 use SdAiAgent\Models\ProviderTrace;
 use XWP\DI\Decorators\Filter;
 use XWP\DI\Decorators\Handler;
@@ -28,15 +30,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Captures outgoing HTTP requests and responses for LLM provider tracing.
+ * Captures outgoing HTTP requests and responses for LLM provider tracing,
+ * and injects provider-specific prompt-cache markers into outgoing bodies.
  *
  * CTX_GLOBAL ensures the filters are active in every request context — AI
  * calls can originate from admin (manual runs), REST (webhook triggers), CLI,
  * and cron (scheduled tasks).
  *
- * Both filter callbacks are no-ops when WP_DEBUG is not active. The DI
- * container always instantiates this handler, but the actual recording never
- * happens on production sites where WP_DEBUG is false or undefined.
+ * The trace callbacks are no-ops when WP_DEBUG is not active; the cache
+ * marker injection is always active (cache hints are a runtime cost
+ * optimisation, not a debug feature) but is gated on the
+ * `prompt_caching_enabled` setting so operators can opt out.
  */
 #[Handler(
 	container: 'sd-ai-agent',
@@ -44,6 +48,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 	strategy: Handler::INIT_IMMEDIATELY,
 )]
 final class HttpTraceHandler {
+
+	/**
+	 * Resolves the prompt-cache strategy for a given URL. Lazily
+	 * instantiated on first use so unit tests can replace the wiring
+	 * via the `sd_ai_agent_resolve_cache_strategy` filter without
+	 * having to provide a constructor.
+	 *
+	 * @var CacheStrategyResolver|null
+	 */
+	private ?CacheStrategyResolver $cache_resolver = null;
 
 	/**
 	 * Capture outgoing request details before the HTTP call is made.
@@ -83,5 +97,73 @@ final class HttpTraceHandler {
 			return $response;
 		}
 		return ProviderTraceLogger::on_http_response( $response, $parsed_args, $url );
+	}
+
+	/**
+	 * Inject prompt-cache markers into outgoing LLM provider requests.
+	 *
+	 * Runs at priority 9 — one priority earlier than the trace logger's
+	 * `pre_http_request` so that traced requests reflect what is actually
+	 * sent on the wire. The resolver picks a strategy by URL host; if
+	 * no strategy matches (request is not an LLM endpoint, or
+	 * `prompt_caching_enabled` is off), the args pass through unchanged.
+	 *
+	 * Failures during JSON decode/encode degrade silently: any exception
+	 * or invalid body shape returns `$parsed_args` untouched so a
+	 * malformed cache hint never breaks a working request.
+	 *
+	 * @param array<string,mixed> $parsed_args HTTP request arguments.
+	 * @param string              $url         The request URL.
+	 * @return array<string,mixed> Possibly-mutated arguments.
+	 */
+	#[Filter( tag: 'http_request_args', priority: 9 )]
+	public function on_http_request_args( array $parsed_args, string $url ): array {
+		if ( ! Settings::is_prompt_caching_enabled() ) {
+			return $parsed_args;
+		}
+
+		$strategy = $this->resolver()->resolve( $url );
+		if ( null === $strategy ) {
+			return $parsed_args;
+		}
+
+		// Only mutate when there's a body shaped like JSON — we don't
+		// know how to decorate form-encoded or multipart bodies and
+		// shouldn't try.
+		$body = $parsed_args['body'] ?? null;
+		if ( ! is_string( $body ) || '' === $body ) {
+			return $parsed_args;
+		}
+
+		$decoded = json_decode( $body, true );
+		if ( ! is_array( $decoded ) ) {
+			return $parsed_args;
+		}
+
+		$mutated = $strategy->apply( $decoded );
+		if ( $mutated === $decoded ) {
+			// Strategy chose not to mutate — skip the re-encode.
+			return $parsed_args;
+		}
+
+		$encoded = wp_json_encode( $mutated );
+		if ( false === $encoded ) {
+			return $parsed_args;
+		}
+
+		$parsed_args['body'] = $encoded;
+		return $parsed_args;
+	}
+
+	/**
+	 * Lazily get (and cache) the strategy resolver.
+	 *
+	 * @return CacheStrategyResolver
+	 */
+	private function resolver(): CacheStrategyResolver {
+		if ( null === $this->cache_resolver ) {
+			$this->cache_resolver = new CacheStrategyResolver();
+		}
+		return $this->cache_resolver;
 	}
 }

--- a/includes/CLI/TraceCommand.php
+++ b/includes/CLI/TraceCommand.php
@@ -122,17 +122,23 @@ class TraceCommand extends \WP_CLI_Command {
 			}
 
 			$rows[] = [
-				'ID'       => $trace->id,
-				'Time'     => $trace->created_at,
-				'Provider' => $trace->provider_id,
-				'Model'    => $trace->model_id,
-				'Status'   => $status_display,
-				'Duration' => $trace->duration_ms . 'ms',
-				'Error'    => $trace->error ? substr( $trace->error, 0, 60 ) : '',
+				'ID'         => $trace->id,
+				'Time'       => $trace->created_at,
+				'Provider'   => $trace->provider_id,
+				'Model'      => $trace->model_id,
+				'Status'     => $status_display,
+				'Duration'   => $trace->duration_ms . 'ms',
+				'CacheRead'  => $trace->cache_read_tokens,
+				'CacheWrite' => $trace->cache_creation_tokens,
+				'Error'      => $trace->error ? substr( $trace->error, 0, 60 ) : '',
 			];
 		}
 
-		WP_CLI\Utils\format_items( $format, $rows, [ 'ID', 'Time', 'Provider', 'Model', 'Status', 'Duration', 'Error' ] );
+		WP_CLI\Utils\format_items(
+			$format,
+			$rows,
+			[ 'ID', 'Time', 'Provider', 'Model', 'Status', 'Duration', 'CacheRead', 'CacheWrite', 'Error' ]
+		);
 	}
 
 	/**
@@ -193,6 +199,8 @@ class TraceCommand extends \WP_CLI_Command {
 			'Method'           => $trace->method,
 			'Status'           => $trace->status_code,
 			'Duration'         => $trace->duration_ms . 'ms',
+			'Cache Read'       => $trace->cache_read_tokens . ' tokens',
+			'Cache Write'      => $trace->cache_creation_tokens . ' tokens',
 			'Error'            => $trace->error ?: '(none)',
 			'Request Headers'  => json_decode( $trace->request_headers ?? '{}', true ),
 			'Request Body'     => $request_body ?: $trace->request_body,

--- a/includes/Core/Database.php
+++ b/includes/Core/Database.php
@@ -36,7 +36,7 @@ use SdAiAgent\Tools\CustomTools;
 class Database {
 
 	const DB_VERSION_OPTION = 'sd_ai_agent_db_version';
-	const DB_VERSION        = '19.1.0';
+	const DB_VERSION        = '19.2.0';
 
 	// ─── Table Name Registry ──────────────────────────────────────────────────
 

--- a/includes/Core/PromptCache/AnthropicCacheStrategy.php
+++ b/includes/Core/PromptCache/AnthropicCacheStrategy.php
@@ -1,0 +1,252 @@
+<?php
+/**
+ * Anthropic prompt-cache strategy.
+ *
+ * Anthropic is the only major LLM provider that requires explicit
+ * `cache_control` markers in the request body to opt into prompt caching.
+ * (OpenAI, DeepSeek, xAI Grok, and most others cache automatically based
+ * on prefix stability.)
+ *
+ * This strategy adds `cache_control: { type: "ephemeral" }` markers at
+ * two stable-prefix boundaries:
+ *
+ *   1. End of the `tools` array — caches the full tools definition block.
+ *      Tools are byte-stable across turns of a single conversation as long
+ *      as the abilities don't change.
+ *
+ *   2. End of the `system` array — caches the system prompt. The
+ *      anthropic-max provider already builds `system` as a 2-block array
+ *      (Claude Code identifier + user system instruction); we mark the
+ *      LAST block so cache scope covers both blocks plus the tools above.
+ *      The vanilla anthropic provider sets `system` as a string; we
+ *      promote it to a one-block array in that case before marking.
+ *
+ * Anthropic's cache scope semantics: marking a block as `cache_control`
+ * caches everything from the start of the request up to and including
+ * that block. So a single marker at the end of `system` would already
+ * cache `tools` too (since `tools` precedes `system` in the canonical
+ * Anthropic message order). However, we mark BOTH boundaries because:
+ *
+ *   - Two markers give Anthropic two separate cache-breakpoint candidates,
+ *     so partial reuse is possible if (e.g.) tools change but system doesn't.
+ *   - Marking is free up to 4 breakpoints per request.
+ *
+ * We deliberately do NOT mark messages — the message history changes
+ * every turn, so the marginal cache value is lower and the marker
+ * placement is harder to keep correct as the conversation grows. Revisit
+ * if telemetry shows meaningful re-use of mid-conversation prefixes.
+ *
+ * @package SdAiAgent\Core\PromptCache
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Core\PromptCache;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Mutates Anthropic /v1/messages request bodies to enable prompt caching.
+ */
+final class AnthropicCacheStrategy implements CacheStrategyInterface {
+
+	/**
+	 * Anthropic's ephemeral cache control marker.
+	 *
+	 * `type: "ephemeral"` is the only supported value as of the 2025-10
+	 * messages API. The default TTL is 5 minutes; passing `ttl: "1h"`
+	 * extends it to one hour but is a separate pricing tier.
+	 *
+	 * @var array{type: string}
+	 */
+	private const MARKER = array( 'type' => 'ephemeral' );
+
+	/**
+	 * Minimum total tokens before applying cache markers.
+	 *
+	 * Anthropic only actually caches a region when it meets a minimum
+	 * token count (1024 for Sonnet/Opus, 2048 for Haiku). Sending the
+	 * marker below that threshold is harmless — Anthropic silently
+	 * ignores it — but counts against the per-request marker budget.
+	 *
+	 * We use a conservative estimate of `strlen / 3` as a token proxy
+	 * (Anthropic averages ~3.5 chars/token for English/code) to gate
+	 * marker injection. Sending markers on tiny requests would burn
+	 * marker budget without producing cache hits.
+	 *
+	 * @var int
+	 */
+	private const MIN_CHARS_FOR_CACHE = 4096;
+
+	/**
+	 * @inheritDoc
+	 */
+	public function matches( string $url ): bool {
+		$parsed = wp_parse_url( $url );
+		if ( ! is_array( $parsed ) || empty( $parsed['host'] ) ) {
+			return false;
+		}
+
+		$host = strtolower( (string) $parsed['host'] );
+		return 'api.anthropic.com' === $host || str_ends_with( $host, '.api.anthropic.com' );
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function apply( array $body ): array {
+		// Skip when the request is below the minimum cacheable size —
+		// caching tiny requests burns marker budget for no benefit.
+		if ( ! $this->is_large_enough( $body ) ) {
+			return $body;
+		}
+
+		$body = $this->mark_tools( $body );
+		$body = $this->mark_system( $body );
+
+		return $body;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function id(): string {
+		return 'anthropic';
+	}
+
+	/**
+	 * Estimate whether the request is large enough to benefit from caching.
+	 *
+	 * @param array<string,mixed> $body Decoded request body.
+	 * @return bool
+	 */
+	private function is_large_enough( array $body ): bool {
+		$char_count = 0;
+
+		// System is the bulk of the cacheable prefix in most cases.
+		$system = $body['system'] ?? null;
+		if ( is_string( $system ) ) {
+			$char_count += strlen( $system );
+		} elseif ( is_array( $system ) ) {
+			foreach ( $system as $block ) {
+				if ( is_array( $block ) && isset( $block['text'] ) && is_string( $block['text'] ) ) {
+					$char_count += strlen( $block['text'] );
+				}
+			}
+		}
+
+		// Tools also contribute heavily — descriptions and JSON schemas.
+		$tools = $body['tools'] ?? null;
+		if ( is_array( $tools ) ) {
+			foreach ( $tools as $tool ) {
+				if ( ! is_array( $tool ) ) {
+					continue;
+				}
+				$char_count += strlen( (string) ( $tool['name'] ?? '' ) );
+				$char_count += strlen( (string) ( $tool['description'] ?? '' ) );
+				if ( isset( $tool['input_schema'] ) ) {
+					$char_count += strlen( (string) wp_json_encode( $tool['input_schema'] ) );
+				}
+			}
+		}
+
+		return $char_count >= self::MIN_CHARS_FOR_CACHE;
+	}
+
+	/**
+	 * Add a cache marker to the last tool definition.
+	 *
+	 * Idempotent — if the last tool already has cache_control we leave
+	 * it alone.
+	 *
+	 * @param array<string,mixed> $body Decoded request body.
+	 * @return array<string,mixed>
+	 */
+	private function mark_tools( array $body ): array {
+		if ( ! isset( $body['tools'] ) || ! is_array( $body['tools'] ) || empty( $body['tools'] ) ) {
+			return $body;
+		}
+
+		// Reindex defensively — the array may have non-sequential keys.
+		$tools     = array_values( $body['tools'] );
+		$last_idx  = count( $tools ) - 1;
+		$last_tool = $tools[ $last_idx ];
+
+		if ( ! is_array( $last_tool ) ) {
+			return $body;
+		}
+
+		if ( isset( $last_tool['cache_control'] ) ) {
+			// Already marked — preserve caller intent.
+			return $body;
+		}
+
+		$last_tool['cache_control'] = self::MARKER;
+		$tools[ $last_idx ]         = $last_tool;
+		$body['tools']              = $tools;
+
+		return $body;
+	}
+
+	/**
+	 * Add a cache marker to the last system block.
+	 *
+	 * If `system` is a string, promote it to a single-block array first
+	 * so the marker has something to attach to.
+	 *
+	 * Idempotent — if the last block already has cache_control we leave
+	 * it alone.
+	 *
+	 * @param array<string,mixed> $body Decoded request body.
+	 * @return array<string,mixed>
+	 */
+	private function mark_system( array $body ): array {
+		if ( ! isset( $body['system'] ) ) {
+			return $body;
+		}
+
+		$system = $body['system'];
+
+		// String form: promote to single-block array so we can attach
+		// cache_control. Anthropic accepts both shapes.
+		if ( is_string( $system ) ) {
+			if ( '' === $system ) {
+				return $body;
+			}
+			$system         = array(
+				array(
+					'type'          => 'text',
+					'text'          => $system,
+					'cache_control' => self::MARKER,
+				),
+			);
+			$body['system'] = $system;
+			return $body;
+		}
+
+		if ( ! is_array( $system ) || empty( $system ) ) {
+			return $body;
+		}
+
+		$system     = array_values( $system );
+		$last_idx   = count( $system ) - 1;
+		$last_block = $system[ $last_idx ];
+
+		if ( ! is_array( $last_block ) ) {
+			return $body;
+		}
+
+		if ( isset( $last_block['cache_control'] ) ) {
+			return $body;
+		}
+
+		$last_block['cache_control'] = self::MARKER;
+		$system[ $last_idx ]         = $last_block;
+		$body['system']              = $system;
+
+		return $body;
+	}
+}

--- a/includes/Core/PromptCache/CacheStrategyInterface.php
+++ b/includes/Core/PromptCache/CacheStrategyInterface.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Prompt cache strategy contract — provider-aware mutation of outgoing
+ * LLM HTTP requests so that providers requiring explicit cache markers
+ * (currently only Anthropic) can opt into prompt caching.
+ *
+ * Strategies operate on the parsed JSON body of `$parsed_args['body']`
+ * via the `http_request_args` filter. Each provider has its own concrete
+ * strategy; the {@see CacheStrategyResolver} picks one per request.
+ *
+ * @package SdAiAgent\Core\PromptCache
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Core\PromptCache;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Contract for per-provider prompt cache strategies.
+ *
+ * Each strategy is responsible for:
+ *   1. Reporting whether it applies to a given URL (so the resolver can
+ *      hand off without parsing bodies unnecessarily).
+ *   2. Mutating the decoded request body in-place to add cache markers
+ *      in the shape that provider expects.
+ *
+ * Strategies MUST be deterministic for byte-stable inputs — any randomness
+ * (timestamps, random IDs) injected into cached regions would defeat the
+ * cache by changing the prefix hash on every turn.
+ */
+interface CacheStrategyInterface {
+
+	/**
+	 * Whether this strategy applies to a given outgoing HTTP request.
+	 *
+	 * Implementations should match on the host (e.g. `api.anthropic.com`)
+	 * and return false otherwise — the resolver iterates strategies and
+	 * uses the first match.
+	 *
+	 * @param string $url The fully-qualified request URL.
+	 * @return bool True when this strategy should be invoked.
+	 */
+	public function matches( string $url ): bool;
+
+	/**
+	 * Mutate a decoded request body to add cache markers.
+	 *
+	 * Implementations MUST NOT throw — they receive untrusted input shapes
+	 * and must degrade silently when fields they expect are missing. The
+	 * goal is to never break a working request; cache hints are advisory.
+	 *
+	 * Implementations MUST be idempotent — calling apply() twice on the
+	 * same body must produce the same result as one call. This protects
+	 * against the unlikely case of filter re-entry.
+	 *
+	 * @param array<string,mixed> $body Decoded request body (associative).
+	 * @return array<string,mixed> Mutated body. Returned by value; callers
+	 *                             re-encode to JSON and re-assign to
+	 *                             `$parsed_args['body']`.
+	 */
+	public function apply( array $body ): array;
+
+	/**
+	 * Stable identifier for telemetry/logging.
+	 *
+	 * @return string Lowercase ASCII slug (e.g. `anthropic`, `noop`).
+	 */
+	public function id(): string;
+}

--- a/includes/Core/PromptCache/CacheStrategyResolver.php
+++ b/includes/Core/PromptCache/CacheStrategyResolver.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Resolves the prompt-cache strategy to apply for a given outgoing
+ * HTTP request.
+ *
+ * Lookup order:
+ *   1. {@see CacheStrategyInterface::matches()} — strategies that need
+ *      explicit body mutation (currently only Anthropic).
+ *   2. Known automatic-cache hosts → {@see NoopCacheStrategy}.
+ *   3. Filter `sd_ai_agent_resolve_cache_strategy` for custom providers.
+ *   4. Null when no strategy applies (URL is not an LLM endpoint).
+ *
+ * @package SdAiAgent\Core\PromptCache
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Core\PromptCache;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Picks a {@see CacheStrategyInterface} for an outgoing request URL.
+ */
+final class CacheStrategyResolver {
+
+	/**
+	 * Hosts where the provider performs server-side caching automatically.
+	 *
+	 * These providers do not require client-side `cache_control` markers —
+	 * they cache prefixes server-side based on hash of the request and
+	 * apply discounts via the response usage block.
+	 *
+	 * Sources (verified 2026-05):
+	 *   - OpenAI: GPT-4o / 4.1 / o-series automatic caching for >=1024 tok.
+	 *   - DeepSeek: automatic context caching, discount on hit.
+	 *   - xAI Grok: automatic prompt caching since late 2025.
+	 *   - Groq / Cerebras / Together / Fireworks: most have automatic
+	 *     caching; surface in usage varies but no client opt-in needed.
+	 *
+	 * @var array<int,string>
+	 */
+	private const AUTO_CACHE_HOSTS = array(
+		'api.openai.com',
+		'api.deepseek.com',
+		'api.x.ai',
+		'api.groq.com',
+		'api.cerebras.ai',
+		'api.together.xyz',
+		'api.fireworks.ai',
+	);
+
+	/**
+	 * Ordered list of explicit-marker strategies.
+	 *
+	 * @var list<CacheStrategyInterface>
+	 */
+	private array $strategies;
+
+	/**
+	 * Fallback strategy when an LLM host is known to auto-cache.
+	 *
+	 * @var NoopCacheStrategy
+	 */
+	private NoopCacheStrategy $noop;
+
+	/**
+	 * @param list<CacheStrategyInterface>|null $strategies Optional
+	 *        explicit list — primarily for tests. Production code should
+	 *        leave this null so the default strategy set is used.
+	 */
+	public function __construct( ?array $strategies = null ) {
+		if ( null === $strategies ) {
+			$strategies = array(
+				new AnthropicCacheStrategy(),
+			);
+		}
+		$this->strategies = $strategies;
+		$this->noop       = new NoopCacheStrategy();
+	}
+
+	/**
+	 * Resolve a strategy for an outgoing HTTP request URL.
+	 *
+	 * @param string $url Fully-qualified URL.
+	 * @return CacheStrategyInterface|null Strategy to apply, or null when
+	 *                                     the URL is not a known LLM host.
+	 */
+	public function resolve( string $url ): ?CacheStrategyInterface {
+		foreach ( $this->strategies as $strategy ) {
+			if ( $strategy->matches( $url ) ) {
+				return $strategy;
+			}
+		}
+
+		if ( $this->is_auto_cache_host( $url ) ) {
+			return $this->noop;
+		}
+
+		/**
+		 * Filter to provide a custom cache strategy for an unknown URL.
+		 *
+		 * Return a {@see CacheStrategyInterface} instance to opt in,
+		 * or null/false to skip caching for this request.
+		 *
+		 * @param CacheStrategyInterface|null $strategy Default: null.
+		 * @param string                      $url      The request URL.
+		 */
+		$custom = apply_filters( 'sd_ai_agent_resolve_cache_strategy', null, $url );
+		if ( $custom instanceof CacheStrategyInterface ) {
+			return $custom;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Whether the URL's host is a known auto-caching LLM endpoint.
+	 *
+	 * @param string $url Fully-qualified URL.
+	 * @return bool
+	 */
+	private function is_auto_cache_host( string $url ): bool {
+		$parsed = wp_parse_url( $url );
+		if ( ! is_array( $parsed ) || empty( $parsed['host'] ) ) {
+			return false;
+		}
+
+		$host = strtolower( (string) $parsed['host'] );
+
+		foreach ( self::AUTO_CACHE_HOSTS as $known ) {
+			if ( $host === $known || str_ends_with( $host, '.' . $known ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+}

--- a/includes/Core/PromptCache/CacheUsageExtractor.php
+++ b/includes/Core/PromptCache/CacheUsageExtractor.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Universal cache-usage extractor for LLM provider responses.
+ *
+ * Each provider reports prompt cache hit/miss counts in a different shape:
+ *
+ *   Anthropic:
+ *     usage.cache_creation_input_tokens (write to cache)
+ *     usage.cache_read_input_tokens     (read from cache)
+ *
+ *   OpenAI (and most OpenAI-compatible providers):
+ *     usage.prompt_tokens_details.cached_tokens (read from cache only — write is implicit)
+ *
+ *   DeepSeek:
+ *     usage.prompt_cache_hit_tokens   (read)
+ *     usage.prompt_cache_miss_tokens  (write — fresh tokens added to cache)
+ *
+ *   Google Gemini:
+ *     usageMetadata.cachedContentTokenCount (read from explicit cache)
+ *
+ * This extractor normalises all of them to a `{creation, read}` pair so
+ * the rest of the plugin (DB schema, viewer, telemetry) can stay
+ * provider-agnostic.
+ *
+ * @package SdAiAgent\Core\PromptCache
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Core\PromptCache;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Parses provider-specific response usage blocks into normalised cache counts.
+ */
+final class CacheUsageExtractor {
+
+	/**
+	 * Extract normalised cache-token counts from a decoded response body.
+	 *
+	 * Returns zeroes when the response does not carry cache telemetry —
+	 * either because the provider doesn't report it, the request was an
+	 * error, or this URL isn't an LLM endpoint.
+	 *
+	 * @param string $provider_id Provider slug (e.g. `anthropic`, `openai`).
+	 * @param mixed  $response    Decoded response body. Typically array,
+	 *                            but defensively handles any input — this
+	 *                            is called from the HTTP filter chain
+	 *                            where shapes can be unusual.
+	 * @return array{creation:int, read:int}
+	 */
+	public static function extract( string $provider_id, $response ): array {
+		$zero = array(
+			'creation' => 0,
+			'read'     => 0,
+		);
+
+		if ( ! is_array( $response ) ) {
+			return $zero;
+		}
+
+		$usage = $response['usage'] ?? $response['usageMetadata'] ?? null;
+		if ( ! is_array( $usage ) ) {
+			return $zero;
+		}
+
+		switch ( $provider_id ) {
+			case 'anthropic':
+				return array(
+					'creation' => self::clamp_non_negative( $usage['cache_creation_input_tokens'] ?? 0 ),
+					'read'     => self::clamp_non_negative( $usage['cache_read_input_tokens'] ?? 0 ),
+				);
+
+			case 'deepseek':
+				return array(
+					'creation' => self::clamp_non_negative( $usage['prompt_cache_miss_tokens'] ?? 0 ),
+					'read'     => self::clamp_non_negative( $usage['prompt_cache_hit_tokens'] ?? 0 ),
+				);
+
+			case 'google':
+				return array(
+					'creation' => 0,
+					'read'     => self::clamp_non_negative( $usage['cachedContentTokenCount'] ?? 0 ),
+				);
+
+			case 'openai':
+			case 'xai':
+			case 'groq':
+			case 'cerebras':
+			case 'together':
+			case 'fireworks':
+			default:
+				// OpenAI shape — used by OpenAI itself and most
+				// OpenAI-compatible providers (DeepSeek's own API uses
+				// the non-standard prompt_cache_*_tokens fields, handled
+				// above). Fall through for unknown providers since the
+				// OpenAI shape is the de-facto standard.
+				$details = $usage['prompt_tokens_details'] ?? array();
+				if ( ! is_array( $details ) ) {
+					$details = array();
+				}
+				return array(
+					'creation' => 0,
+					'read'     => self::clamp_non_negative( $details['cached_tokens'] ?? 0 ),
+				);
+		}
+	}
+
+	/**
+	 * Coerce a mixed value to a non-negative int.
+	 *
+	 * Providers occasionally report bogus shapes (string, null, float).
+	 * Anything that doesn't cast cleanly to a positive int returns zero.
+	 *
+	 * @param mixed $value Raw value from response usage block.
+	 * @return int Non-negative integer.
+	 */
+	private static function clamp_non_negative( $value ): int {
+		if ( is_int( $value ) ) {
+			return $value > 0 ? $value : 0;
+		}
+		if ( is_numeric( $value ) ) {
+			$int = (int) $value;
+			return $int > 0 ? $int : 0;
+		}
+		return 0;
+	}
+}

--- a/includes/Core/PromptCache/NoopCacheStrategy.php
+++ b/includes/Core/PromptCache/NoopCacheStrategy.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * No-op prompt cache strategy.
+ *
+ * Used for providers that perform prompt caching automatically server-side
+ * (OpenAI, DeepSeek, xAI Grok, Groq, Cerebras, Together, Fireworks, and
+ * any OpenAI-compatible endpoint that implements the standard pricing tier
+ * for prompt caching). These providers do NOT require client-side cache
+ * markers — they hash the input prefix automatically and apply the cache
+ * discount when they see a known prefix within the cache TTL window.
+ *
+ * The strategy still exists (rather than returning null from the resolver)
+ * so that future server-side cache telemetry can be hooked in here without
+ * the caller having to special-case "no strategy" vs "strategy with no
+ * request-body mutation".
+ *
+ * @package SdAiAgent\Core\PromptCache
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Core\PromptCache;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Pass-through strategy for providers with automatic prompt caching.
+ */
+final class NoopCacheStrategy implements CacheStrategyInterface {
+
+	/**
+	 * The resolver matches NoopCacheStrategy explicitly via its own list
+	 * of "automatic-cache" providers, so this strategy never matches a
+	 * URL on its own — the resolver picks it as a fallback.
+	 *
+	 * @inheritDoc
+	 */
+	public function matches( string $url ): bool {
+		unset( $url ); // Unused — matching is delegated to the resolver.
+		return false;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function apply( array $body ): array {
+		return $body;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function id(): string {
+		return 'noop';
+	}
+}

--- a/includes/Core/ProviderTraceLogger.php
+++ b/includes/Core/ProviderTraceLogger.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Core;
 
 use SdAiAgent\Core\AgentEventLog;
+use SdAiAgent\Core\PromptCache\CacheUsageExtractor;
 use SdAiAgent\Models\ProviderTrace;
 
 /**
@@ -182,19 +183,37 @@ class ProviderTraceLogger {
 			$response_headers_json = (string) wp_json_encode( $response_headers );
 		}
 
+		// Extract provider-agnostic cache token counts from the response
+		// usage block (Anthropic / OpenAI / DeepSeek / Google all use
+		// different field names — see CacheUsageExtractor). Returns
+		// zeroes on error responses or providers that don't report.
+		$cache_tokens = array(
+			'creation' => 0,
+			'read'     => 0,
+		);
+		if ( $status_code >= 200 && $status_code < 300 ) {
+			$decoded_response = json_decode( $response_body, true );
+			$cache_tokens     = CacheUsageExtractor::extract(
+				(string) ( $inflight['provider_id'] ?? '' ),
+				$decoded_response
+			);
+		}
+
 		ProviderTrace::insert(
 			[
-				'provider_id'      => $inflight['provider_id'] ?? '',
-				'model_id'         => $model_id,
-				'url'              => $inflight['url'] ?? $url,
-				'method'           => $inflight['method'] ?? 'POST',
-				'status_code'      => $status_code,
-				'duration_ms'      => $duration_ms,
-				'request_headers'  => $inflight['request_headers'] ?? '{}',
-				'request_body'     => $inflight['request_body'] ?? '',
-				'response_headers' => $response_headers_json,
-				'response_body'    => $response_body,
-				'error'            => $error,
+				'provider_id'           => $inflight['provider_id'] ?? '',
+				'model_id'              => $model_id,
+				'url'                   => $inflight['url'] ?? $url,
+				'method'                => $inflight['method'] ?? 'POST',
+				'status_code'           => $status_code,
+				'duration_ms'           => $duration_ms,
+				'cache_creation_tokens' => $cache_tokens['creation'],
+				'cache_read_tokens'     => $cache_tokens['read'],
+				'request_headers'       => $inflight['request_headers'] ?? '{}',
+				'request_body'          => $inflight['request_body'] ?? '',
+				'response_headers'      => $response_headers_json,
+				'response_body'         => $response_body,
+				'error'                 => $error,
 			]
 		);
 

--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -312,10 +312,38 @@ class Settings {
 			// Provider trace / debug mode (GH#830).
 			'provider_trace_enabled'   => false,
 			'provider_trace_max_rows'  => 200,
+			// Prompt caching — provider-side KV-cache opt-in (sd-ai-bjv).
+			// When true, the HttpTraceHandler injects provider-specific
+			// cache markers into outgoing LLM requests (only Anthropic
+			// requires explicit markers today; OpenAI/DeepSeek/etc. cache
+			// automatically). Safe to leave on — workers without cache
+			// support ignore the markers.
+			'prompt_caching_enabled'   => true,
 			// Skill auto-update settings (t218).
 			'skill_auto_update'        => true,
 			'skill_manifest_url'       => '',
 		);
+	}
+
+	/**
+	 * Whether prompt caching is enabled for outgoing LLM requests.
+	 *
+	 * Provider-aware: Anthropic requests get explicit `cache_control`
+	 * markers; providers with automatic server-side caching (OpenAI,
+	 * DeepSeek, xAI, Groq, etc.) pass through unchanged. Disabling this
+	 * setting opts out entirely — markers are not injected.
+	 *
+	 * Static helper so HttpTraceHandler can consult the flag without
+	 * needing DI access to a Settings instance during filter execution.
+	 *
+	 * @return bool
+	 */
+	public static function is_prompt_caching_enabled(): bool {
+		$option = get_option( self::OPTION_NAME, array() );
+		if ( ! is_array( $option ) || ! array_key_exists( 'prompt_caching_enabled', $option ) ) {
+			return true; // Default-on.
+		}
+		return (bool) $option['prompt_caching_enabled'];
 	}
 
 	/**

--- a/includes/Models/DTO/ProviderTraceRow.php
+++ b/includes/Models/DTO/ProviderTraceRow.php
@@ -16,19 +16,25 @@ namespace SdAiAgent\Models\DTO;
 readonly class ProviderTraceRow {
 
 	/**
-	 * @param int    $id               Row ID (auto-increment PK).
-	 * @param string $created_at       MySQL datetime string (UTC).
-	 * @param string $provider_id      AI provider slug.
-	 * @param string $model_id         Model slug.
-	 * @param string $url              Request URL.
-	 * @param string $method           HTTP method (GET, POST, etc.).
-	 * @param int    $status_code      HTTP response status code.
-	 * @param int    $duration_ms      Round-trip duration in milliseconds.
-	 * @param string $request_headers  JSON-encoded request headers.
-	 * @param string $request_body     Raw request body.
-	 * @param string $response_headers JSON-encoded response headers.
-	 * @param string $response_body    Raw response body.
-	 * @param string $error            Error message, or empty string.
+	 * @param int    $id                    Row ID (auto-increment PK).
+	 * @param string $created_at            MySQL datetime string (UTC).
+	 * @param string $provider_id           AI provider slug.
+	 * @param string $model_id              Model slug.
+	 * @param string $url                   Request URL.
+	 * @param string $method                HTTP method (GET, POST, etc.).
+	 * @param int    $status_code           HTTP response status code.
+	 * @param int    $duration_ms           Round-trip duration in milliseconds.
+	 * @param int    $cache_creation_tokens Prompt-cache write tokens reported by the
+	 *                                      provider (Anthropic / DeepSeek). 0 when
+	 *                                      not reported or not applicable.
+	 * @param int    $cache_read_tokens     Prompt-cache read (hit) tokens reported by
+	 *                                      the provider (Anthropic / OpenAI / DeepSeek
+	 *                                      / Google / xAI / etc.). 0 on miss.
+	 * @param string $request_headers       JSON-encoded request headers.
+	 * @param string $request_body          Raw request body.
+	 * @param string $response_headers      JSON-encoded response headers.
+	 * @param string $response_body         Raw response body.
+	 * @param string $error                 Error message, or empty string.
 	 */
 	public function __construct(
 		public int $id,
@@ -39,6 +45,8 @@ readonly class ProviderTraceRow {
 		public string $method,
 		public int $status_code,
 		public int $duration_ms,
+		public int $cache_creation_tokens,
+		public int $cache_read_tokens,
 		public string $request_headers,
 		public string $request_body,
 		public string $response_headers,
@@ -54,19 +62,21 @@ readonly class ProviderTraceRow {
 	 */
 	public static function from_row( object $row ): self {
 		return new self(
-			id:               (int) $row->id,
-			created_at:       (string) ( $row->created_at ?? '' ),
-			provider_id:      (string) ( $row->provider_id ?? '' ),
-			model_id:         (string) ( $row->model_id ?? '' ),
-			url:              (string) ( $row->url ?? '' ),
-			method:           (string) ( $row->method ?? 'POST' ),
-			status_code:      (int) ( $row->status_code ?? 0 ),
-			duration_ms:      (int) ( $row->duration_ms ?? 0 ),
-			request_headers:  (string) ( $row->request_headers ?? '{}' ),
-			request_body:     (string) ( $row->request_body ?? '' ),
-			response_headers: (string) ( $row->response_headers ?? '{}' ),
-			response_body:    (string) ( $row->response_body ?? '' ),
-			error:            (string) ( $row->error ?? '' ),
+			id:                    (int) $row->id,
+			created_at:            (string) ( $row->created_at ?? '' ),
+			provider_id:           (string) ( $row->provider_id ?? '' ),
+			model_id:              (string) ( $row->model_id ?? '' ),
+			url:                   (string) ( $row->url ?? '' ),
+			method:                (string) ( $row->method ?? 'POST' ),
+			status_code:           (int) ( $row->status_code ?? 0 ),
+			duration_ms:           (int) ( $row->duration_ms ?? 0 ),
+			cache_creation_tokens: (int) ( $row->cache_creation_tokens ?? 0 ),
+			cache_read_tokens:     (int) ( $row->cache_read_tokens ?? 0 ),
+			request_headers:       (string) ( $row->request_headers ?? '{}' ),
+			request_body:          (string) ( $row->request_body ?? '' ),
+			response_headers:      (string) ( $row->response_headers ?? '{}' ),
+			response_body:         (string) ( $row->response_body ?? '' ),
+			error:                 (string) ( $row->error ?? '' ),
 		);
 	}
 }

--- a/includes/Models/ProviderTrace.php
+++ b/includes/Models/ProviderTrace.php
@@ -53,6 +53,12 @@ class ProviderTrace {
 	public static function get_schema( string $charset ): string {
 		$table = self::table_name();
 
+		// `cache_creation_tokens` / `cache_read_tokens` were added in
+		// DB version 19.2.0 (sd-ai-bjv). They are populated from the
+		// normalised provider response usage block — see
+		// {@see \SdAiAgent\Core\PromptCache\CacheUsageExtractor}. dbDelta
+		// adds the columns to existing tables on upgrade; pre-19.2.0 rows
+		// retain the default of 0.
 		return "\n\nCREATE TABLE {$table} (
 			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
 			created_at datetime NOT NULL,
@@ -62,6 +68,8 @@ class ProviderTrace {
 			method varchar(10) NOT NULL DEFAULT 'POST',
 			status_code int(11) NOT NULL DEFAULT 0,
 			duration_ms bigint(20) unsigned NOT NULL DEFAULT 0,
+			cache_creation_tokens bigint(20) unsigned NOT NULL DEFAULT 0,
+			cache_read_tokens bigint(20) unsigned NOT NULL DEFAULT 0,
 			request_headers longtext NOT NULL,
 			request_body longtext NOT NULL,
 			response_headers longtext NOT NULL,
@@ -183,20 +191,22 @@ class ProviderTrace {
 		$result = $wpdb->insert(
 			self::table_name(),
 			[
-				'created_at'       => current_time( 'mysql', true ),
-				'provider_id'      => $data['provider_id'] ?? '',
-				'model_id'         => $data['model_id'] ?? '',
-				'url'              => $data['url'] ?? '',
-				'method'           => $data['method'] ?? 'POST',
-				'status_code'      => $data['status_code'] ?? 0,
-				'duration_ms'      => $data['duration_ms'] ?? 0,
-				'request_headers'  => $request_headers,
-				'request_body'     => $request_body,
-				'response_headers' => $response_headers,
-				'response_body'    => $response_body,
-				'error'            => $data['error'] ?? '',
+				'created_at'            => current_time( 'mysql', true ),
+				'provider_id'           => $data['provider_id'] ?? '',
+				'model_id'              => $data['model_id'] ?? '',
+				'url'                   => $data['url'] ?? '',
+				'method'                => $data['method'] ?? 'POST',
+				'status_code'           => $data['status_code'] ?? 0,
+				'duration_ms'           => $data['duration_ms'] ?? 0,
+				'cache_creation_tokens' => max( 0, (int) ( $data['cache_creation_tokens'] ?? 0 ) ),
+				'cache_read_tokens'     => max( 0, (int) ( $data['cache_read_tokens'] ?? 0 ) ),
+				'request_headers'       => $request_headers,
+				'request_body'          => $request_body,
+				'response_headers'      => $response_headers,
+				'response_body'         => $response_body,
+				'error'                 => $data['error'] ?? '',
 			],
-			[ '%s', '%s', '%s', '%s', '%s', '%d', '%d', '%s', '%s', '%s', '%s', '%s' ]
+			[ '%s', '%s', '%s', '%s', '%s', '%d', '%d', '%d', '%d', '%s', '%s', '%s', '%s', '%s' ]
 		);
 
 		if ( ! $result ) {
@@ -302,7 +312,8 @@ class ProviderTrace {
 		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Custom table query; built from prepared fragments.
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT id, created_at, provider_id, model_id, url, method, status_code, duration_ms, error,
+				"SELECT id, created_at, provider_id, model_id, url, method, status_code, duration_ms,
+					cache_creation_tokens, cache_read_tokens, error,
 					LENGTH(request_body) AS request_body_size,
 					LENGTH(response_body) AS response_body_size
 				FROM {$table} {$where_sql}

--- a/src/settings-page/provider-trace-viewer.js
+++ b/src/settings-page/provider-trace-viewer.js
@@ -355,6 +355,14 @@ export default function ProviderTraceViewer() {
 								<th>{ __( 'Model', 'sd-ai-agent' ) }</th>
 								<th>{ __( 'Status', 'sd-ai-agent' ) }</th>
 								<th>{ __( 'Duration', 'sd-ai-agent' ) }</th>
+								<th
+									title={ __(
+										'Prompt cache read / write tokens reported by the provider.',
+										'sd-ai-agent'
+									) }
+								>
+									{ __( 'Cache R/W', 'sd-ai-agent' ) }
+								</th>
 								<th>{ __( 'Error', 'sd-ai-agent' ) }</th>
 								<th>{ __( 'Actions', 'sd-ai-agent' ) }</th>
 							</tr>
@@ -383,6 +391,20 @@ export default function ProviderTraceViewer() {
 										/>
 									</td>
 									<td>{ trace.duration_ms }ms</td>
+									<td
+										className="sdaa-trace-cache-cell"
+										title={ __(
+											'Read tokens (cache hits) / Write tokens (cache creation)',
+											'sd-ai-agent'
+										) }
+									>
+										{ ( trace.cache_read_tokens || 0 ) +
+											( trace.cache_creation_tokens ||
+												0 ) >
+										0
+											? `${ trace.cache_read_tokens || 0 } / ${ trace.cache_creation_tokens || 0 }`
+											: '—' }
+									</td>
 									<td
 										className="sdaa-trace-error-cell"
 										title={ trace.error || '' }
@@ -541,6 +563,36 @@ export default function ProviderTraceViewer() {
 											</th>
 											<td>
 												{ selectedTrace.error || '—' }
+											</td>
+										</tr>
+										<tr>
+											<th>
+												{ __(
+													'Cache read',
+													'sd-ai-agent'
+												) }
+											</th>
+											<td>
+												{ selectedTrace.cache_read_tokens ||
+													0 }{ ' ' }
+												{ __(
+													'tokens',
+													'sd-ai-agent'
+												) }
+											</td>
+											<th>
+												{ __(
+													'Cache write',
+													'sd-ai-agent'
+												) }
+											</th>
+											<td>
+												{ selectedTrace.cache_creation_tokens ||
+													0 }{ ' ' }
+												{ __(
+													'tokens',
+													'sd-ai-agent'
+												) }
 											</td>
 										</tr>
 									</tbody>

--- a/tests/SdAiAgent/Bootstrap/HttpTraceHandlerCacheTest.php
+++ b/tests/SdAiAgent/Bootstrap/HttpTraceHandlerCacheTest.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Test case for HttpTraceHandler::on_http_request_args (cache marker injection).
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Bootstrap;
+
+use SdAiAgent\Bootstrap\HttpTraceHandler;
+use SdAiAgent\Core\Settings;
+use WP_UnitTestCase;
+
+/**
+ * Verifies that the cache-strategy http_request_args filter mutates
+ * Anthropic request bodies and leaves everything else alone.
+ *
+ * @covers \SdAiAgent\Bootstrap\HttpTraceHandler::on_http_request_args
+ */
+class HttpTraceHandlerCacheTest extends WP_UnitTestCase {
+
+	private HttpTraceHandler $handler;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->handler = new HttpTraceHandler();
+
+		// Default-on for these tests — explicitly reset.
+		update_option(
+			Settings::OPTION_NAME,
+			array( 'prompt_caching_enabled' => true )
+		);
+	}
+
+	protected function tearDown(): void {
+		delete_option( Settings::OPTION_NAME );
+		parent::tearDown();
+	}
+
+	public function test_anthropic_request_body_gets_cache_markers(): void {
+		$body = $this->large_anthropic_body();
+
+		$args = array(
+			'method' => 'POST',
+			'body'   => (string) wp_json_encode( $body ),
+		);
+
+		$result = $this->handler->on_http_request_args( $args, 'https://api.anthropic.com/v1/messages' );
+
+		$this->assertNotSame( $args['body'], $result['body'], 'Body should be mutated.' );
+
+		$decoded = json_decode( (string) $result['body'], true );
+		$this->assertIsArray( $decoded );
+
+		// Last tool marker.
+		$last_tool = end( $decoded['tools'] );
+		$this->assertArrayHasKey( 'cache_control', $last_tool );
+
+		// Last system block marker.
+		$last_sys = end( $decoded['system'] );
+		$this->assertArrayHasKey( 'cache_control', $last_sys );
+	}
+
+	public function test_openai_request_body_is_unchanged(): void {
+		$body = array(
+			'model'    => 'gpt-4o',
+			'messages' => array( array( 'role' => 'user', 'content' => 'hi' ) ),
+		);
+
+		$args = array(
+			'method' => 'POST',
+			'body'   => (string) wp_json_encode( $body ),
+		);
+
+		$result = $this->handler->on_http_request_args( $args, 'https://api.openai.com/v1/chat/completions' );
+
+		$this->assertSame( $args['body'], $result['body'], 'OpenAI body must not be mutated — caching is automatic server-side.' );
+	}
+
+	public function test_unknown_host_passes_through(): void {
+		$body = array( 'anything' => 'goes' );
+		$args = array(
+			'method' => 'POST',
+			'body'   => (string) wp_json_encode( $body ),
+		);
+
+		$result = $this->handler->on_http_request_args( $args, 'https://example.com/api/anything' );
+
+		$this->assertSame( $args, $result );
+	}
+
+	public function test_disabled_setting_skips_mutation(): void {
+		update_option(
+			Settings::OPTION_NAME,
+			array( 'prompt_caching_enabled' => false )
+		);
+
+		$body = $this->large_anthropic_body();
+		$args = array(
+			'method' => 'POST',
+			'body'   => (string) wp_json_encode( $body ),
+		);
+
+		$result = $this->handler->on_http_request_args( $args, 'https://api.anthropic.com/v1/messages' );
+
+		$this->assertSame( $args['body'], $result['body'] );
+	}
+
+	public function test_non_string_body_passes_through(): void {
+		$args = array(
+			'method' => 'GET',
+			'body'   => null,
+		);
+
+		$result = $this->handler->on_http_request_args( $args, 'https://api.anthropic.com/v1/messages' );
+
+		$this->assertSame( $args, $result );
+	}
+
+	public function test_non_json_body_passes_through(): void {
+		$args = array(
+			'method' => 'POST',
+			'body'   => 'form-encoded=value&another=1',
+		);
+
+		$result = $this->handler->on_http_request_args( $args, 'https://api.anthropic.com/v1/messages' );
+
+		$this->assertSame( $args, $result );
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private function large_anthropic_body(): array {
+		return array(
+			'model'    => 'claude-opus-4-7',
+			'system'   => array(
+				array( 'type' => 'text', 'text' => "You are Claude Code." ),
+				array( 'type' => 'text', 'text' => str_repeat( 'long system prompt sentence. ', 200 ) ),
+			),
+			'tools'    => array(
+				array(
+					'name'         => 'tool_a',
+					'description'  => str_repeat( 'desc a ', 50 ),
+					'input_schema' => array( 'type' => 'object' ),
+				),
+				array(
+					'name'         => 'tool_b',
+					'description'  => str_repeat( 'desc b ', 50 ),
+					'input_schema' => array( 'type' => 'object' ),
+				),
+			),
+			'messages' => array(
+				array( 'role' => 'user', 'content' => 'hello' ),
+			),
+		);
+	}
+}

--- a/tests/SdAiAgent/Core/PromptCache/AnthropicCacheStrategyTest.php
+++ b/tests/SdAiAgent/Core/PromptCache/AnthropicCacheStrategyTest.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Test case for AnthropicCacheStrategy.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Core\PromptCache;
+
+use SdAiAgent\Core\PromptCache\AnthropicCacheStrategy;
+use WP_UnitTestCase;
+
+/**
+ * @covers \SdAiAgent\Core\PromptCache\AnthropicCacheStrategy
+ */
+class AnthropicCacheStrategyTest extends WP_UnitTestCase {
+
+	private AnthropicCacheStrategy $strategy;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->strategy = new AnthropicCacheStrategy();
+	}
+
+	public function test_id(): void {
+		$this->assertSame( 'anthropic', $this->strategy->id() );
+	}
+
+	public function test_matches_anthropic_api_host(): void {
+		$this->assertTrue( $this->strategy->matches( 'https://api.anthropic.com/v1/messages' ) );
+	}
+
+	public function test_matches_anthropic_api_subdomain(): void {
+		$this->assertTrue( $this->strategy->matches( 'https://eu.api.anthropic.com/v1/messages' ) );
+	}
+
+	public function test_does_not_match_openai(): void {
+		$this->assertFalse( $this->strategy->matches( 'https://api.openai.com/v1/chat/completions' ) );
+	}
+
+	public function test_does_not_match_malformed_url(): void {
+		$this->assertFalse( $this->strategy->matches( '' ) );
+		$this->assertFalse( $this->strategy->matches( 'not-a-url' ) );
+	}
+
+	/**
+	 * Below the minimum char threshold, no markers are added — they would
+	 * just burn marker budget without producing a cache hit.
+	 */
+	public function test_skips_small_requests(): void {
+		$body = array(
+			'model'    => 'claude-opus-4-7',
+			'system'   => 'short prompt',
+			'tools'    => array( array( 'name' => 'tool_a', 'description' => 'x' ) ),
+			'messages' => array( array( 'role' => 'user', 'content' => 'hi' ) ),
+		);
+
+		$result = $this->strategy->apply( $body );
+
+		$this->assertSame( $body, $result, 'Small requests should pass through untouched.' );
+	}
+
+	public function test_marks_last_tool_and_system_block_on_large_request(): void {
+		$body = $this->large_request_body();
+
+		$result = $this->strategy->apply( $body );
+
+		// Last tool gets a cache_control marker.
+		$tools_count = count( $result['tools'] );
+		$this->assertArrayHasKey( 'cache_control', $result['tools'][ $tools_count - 1 ] );
+		$this->assertSame(
+			array( 'type' => 'ephemeral' ),
+			$result['tools'][ $tools_count - 1 ]['cache_control']
+		);
+
+		// Earlier tools are NOT marked.
+		$this->assertArrayNotHasKey( 'cache_control', $result['tools'][0] );
+
+		// Last system block gets a marker.
+		$sys_count = count( $result['system'] );
+		$this->assertArrayHasKey( 'cache_control', $result['system'][ $sys_count - 1 ] );
+		$this->assertSame(
+			array( 'type' => 'ephemeral' ),
+			$result['system'][ $sys_count - 1 ]['cache_control']
+		);
+
+		// Earlier system blocks are NOT marked.
+		$this->assertArrayNotHasKey( 'cache_control', $result['system'][0] );
+	}
+
+	public function test_promotes_string_system_to_array(): void {
+		$body = array(
+			'model'  => 'claude-opus-4-7',
+			'system' => str_repeat( 'A very long system prompt sentence. ', 200 ),
+			'tools'  => array(),
+		);
+
+		$result = $this->strategy->apply( $body );
+
+		$this->assertIsArray( $result['system'] );
+		$this->assertCount( 1, $result['system'] );
+		$this->assertSame( 'text', $result['system'][0]['type'] );
+		$this->assertSame(
+			array( 'type' => 'ephemeral' ),
+			$result['system'][0]['cache_control']
+		);
+	}
+
+	public function test_idempotent(): void {
+		$body = $this->large_request_body();
+
+		$once  = $this->strategy->apply( $body );
+		$twice = $this->strategy->apply( $once );
+
+		$this->assertSame( $once, $twice );
+	}
+
+	public function test_preserves_caller_supplied_cache_control(): void {
+		$body                                = $this->large_request_body();
+		$body['system'][1]['cache_control']  = array( 'type' => 'ephemeral', 'ttl' => '1h' );
+
+		$result = $this->strategy->apply( $body );
+
+		// Existing marker is preserved (not overwritten with the default).
+		$this->assertSame(
+			array( 'type' => 'ephemeral', 'ttl' => '1h' ),
+			$result['system'][1]['cache_control']
+		);
+	}
+
+	public function test_missing_tools_does_not_break(): void {
+		$body = array(
+			'model'  => 'claude-opus-4-7',
+			'system' => array(
+				array( 'type' => 'text', 'text' => str_repeat( 'x', 5000 ) ),
+			),
+		);
+
+		$result = $this->strategy->apply( $body );
+
+		// System still gets marked.
+		$this->assertArrayHasKey( 'cache_control', $result['system'][0] );
+		// No tools field is fabricated.
+		$this->assertArrayNotHasKey( 'tools', $result );
+	}
+
+	public function test_missing_system_does_not_break(): void {
+		$body = array(
+			'model' => 'claude-opus-4-7',
+			'tools' => array(
+				array( 'name' => 'tool_a', 'description' => str_repeat( 'x', 5000 ) ),
+			),
+		);
+
+		$result = $this->strategy->apply( $body );
+
+		// Tool still gets marked.
+		$this->assertArrayHasKey( 'cache_control', $result['tools'][0] );
+	}
+
+	/**
+	 * Build a representative large request body — system prompt + tools
+	 * combined comfortably exceed the MIN_CHARS_FOR_CACHE threshold.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function large_request_body(): array {
+		return array(
+			'model'    => 'claude-opus-4-7',
+			'system'   => array(
+				array( 'type' => 'text', 'text' => "You are Claude Code, Anthropic's official CLI for Claude." ),
+				array( 'type' => 'text', 'text' => str_repeat( 'A long system prompt. ', 300 ) ),
+			),
+			'tools'    => array(
+				array(
+					'name'         => 'tool_a',
+					'description'  => str_repeat( 'desc a ', 50 ),
+					'input_schema' => array( 'type' => 'object', 'properties' => array() ),
+				),
+				array(
+					'name'         => 'tool_b',
+					'description'  => str_repeat( 'desc b ', 50 ),
+					'input_schema' => array( 'type' => 'object', 'properties' => array() ),
+				),
+			),
+			'messages' => array(
+				array( 'role' => 'user', 'content' => 'hello' ),
+			),
+		);
+	}
+}

--- a/tests/SdAiAgent/Core/PromptCache/CacheStrategyResolverTest.php
+++ b/tests/SdAiAgent/Core/PromptCache/CacheStrategyResolverTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Test case for CacheStrategyResolver.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Core\PromptCache;
+
+use SdAiAgent\Core\PromptCache\AnthropicCacheStrategy;
+use SdAiAgent\Core\PromptCache\CacheStrategyInterface;
+use SdAiAgent\Core\PromptCache\CacheStrategyResolver;
+use SdAiAgent\Core\PromptCache\NoopCacheStrategy;
+use WP_UnitTestCase;
+
+/**
+ * @covers \SdAiAgent\Core\PromptCache\CacheStrategyResolver
+ */
+class CacheStrategyResolverTest extends WP_UnitTestCase {
+
+	public function test_resolves_anthropic_for_anthropic_api(): void {
+		$resolver = new CacheStrategyResolver();
+		$strategy = $resolver->resolve( 'https://api.anthropic.com/v1/messages' );
+
+		$this->assertInstanceOf( AnthropicCacheStrategy::class, $strategy );
+	}
+
+	public function test_resolves_noop_for_openai(): void {
+		$resolver = new CacheStrategyResolver();
+		$strategy = $resolver->resolve( 'https://api.openai.com/v1/chat/completions' );
+
+		$this->assertInstanceOf( NoopCacheStrategy::class, $strategy );
+	}
+
+	public function test_resolves_noop_for_deepseek(): void {
+		$resolver = new CacheStrategyResolver();
+		$strategy = $resolver->resolve( 'https://api.deepseek.com/chat/completions' );
+
+		$this->assertInstanceOf( NoopCacheStrategy::class, $strategy );
+	}
+
+	public function test_resolves_noop_for_xai(): void {
+		$resolver = new CacheStrategyResolver();
+		$strategy = $resolver->resolve( 'https://api.x.ai/v1/chat/completions' );
+
+		$this->assertInstanceOf( NoopCacheStrategy::class, $strategy );
+	}
+
+	public function test_returns_null_for_unknown_host(): void {
+		$resolver = new CacheStrategyResolver();
+		$strategy = $resolver->resolve( 'https://example.com/api/something' );
+
+		$this->assertNull( $strategy );
+	}
+
+	public function test_filter_can_provide_custom_strategy(): void {
+		$resolver = new CacheStrategyResolver();
+		$stub     = new class() implements CacheStrategyInterface {
+			public function matches( string $url ): bool {
+				return false;
+			}
+			public function apply( array $body ): array {
+				return $body;
+			}
+			public function id(): string {
+				return 'stub';
+			}
+		};
+
+		$filter = static function ( $current, string $url ) use ( $stub ) {
+			if ( str_contains( $url, 'example.com' ) ) {
+				return $stub;
+			}
+			return $current;
+		};
+		add_filter( 'sd_ai_agent_resolve_cache_strategy', $filter, 10, 2 );
+
+		$resolved = $resolver->resolve( 'https://example.com/api/something' );
+		remove_filter( 'sd_ai_agent_resolve_cache_strategy', $filter, 10 );
+
+		$this->assertSame( $stub, $resolved );
+	}
+
+	public function test_noop_strategy_is_pass_through(): void {
+		$noop = new NoopCacheStrategy();
+		$body = array( 'model' => 'gpt-4o', 'messages' => array() );
+
+		$this->assertSame( $body, $noop->apply( $body ) );
+		$this->assertSame( 'noop', $noop->id() );
+	}
+}

--- a/tests/SdAiAgent/Core/PromptCache/CacheUsageExtractorTest.php
+++ b/tests/SdAiAgent/Core/PromptCache/CacheUsageExtractorTest.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Test case for CacheUsageExtractor.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Core\PromptCache;
+
+use SdAiAgent\Core\PromptCache\CacheUsageExtractor;
+use WP_UnitTestCase;
+
+/**
+ * @covers \SdAiAgent\Core\PromptCache\CacheUsageExtractor
+ */
+class CacheUsageExtractorTest extends WP_UnitTestCase {
+
+	public function test_extracts_anthropic_cache_tokens(): void {
+		$response = array(
+			'usage' => array(
+				'input_tokens'                 => 2000,
+				'cache_creation_input_tokens'  => 1500,
+				'cache_read_input_tokens'      => 18000,
+				'output_tokens'                => 200,
+			),
+		);
+
+		$result = CacheUsageExtractor::extract( 'anthropic', $response );
+
+		$this->assertSame( 1500, $result['creation'] );
+		$this->assertSame( 18000, $result['read'] );
+	}
+
+	public function test_extracts_openai_cached_tokens(): void {
+		$response = array(
+			'usage' => array(
+				'prompt_tokens'         => 20000,
+				'completion_tokens'     => 300,
+				'prompt_tokens_details' => array(
+					'cached_tokens' => 18000,
+				),
+			),
+		);
+
+		$result = CacheUsageExtractor::extract( 'openai', $response );
+
+		$this->assertSame( 0, $result['creation'] ); // OpenAI doesn't report writes.
+		$this->assertSame( 18000, $result['read'] );
+	}
+
+	public function test_extracts_deepseek_hit_miss_tokens(): void {
+		$response = array(
+			'usage' => array(
+				'prompt_tokens'            => 21000,
+				'prompt_cache_hit_tokens'  => 17000,
+				'prompt_cache_miss_tokens' => 4000,
+				'completion_tokens'        => 300,
+			),
+		);
+
+		$result = CacheUsageExtractor::extract( 'deepseek', $response );
+
+		$this->assertSame( 4000, $result['creation'] );
+		$this->assertSame( 17000, $result['read'] );
+	}
+
+	public function test_extracts_google_cached_content_tokens(): void {
+		$response = array(
+			'usageMetadata' => array(
+				'promptTokenCount'        => 12000,
+				'cachedContentTokenCount' => 9000,
+				'candidatesTokenCount'    => 200,
+			),
+		);
+
+		$result = CacheUsageExtractor::extract( 'google', $response );
+
+		$this->assertSame( 0, $result['creation'] );
+		$this->assertSame( 9000, $result['read'] );
+	}
+
+	public function test_returns_zero_for_missing_usage_block(): void {
+		$this->assertSame(
+			array( 'creation' => 0, 'read' => 0 ),
+			CacheUsageExtractor::extract( 'anthropic', array() )
+		);
+		$this->assertSame(
+			array( 'creation' => 0, 'read' => 0 ),
+			CacheUsageExtractor::extract( 'openai', array( 'error' => 'overloaded' ) )
+		);
+	}
+
+	public function test_returns_zero_for_non_array_response(): void {
+		$this->assertSame(
+			array( 'creation' => 0, 'read' => 0 ),
+			CacheUsageExtractor::extract( 'anthropic', null )
+		);
+		$this->assertSame(
+			array( 'creation' => 0, 'read' => 0 ),
+			CacheUsageExtractor::extract( 'anthropic', 'string-response' )
+		);
+	}
+
+	public function test_clamps_negative_values_to_zero(): void {
+		$response = array(
+			'usage' => array(
+				'cache_creation_input_tokens' => -5,
+				'cache_read_input_tokens'     => -100,
+			),
+		);
+
+		$result = CacheUsageExtractor::extract( 'anthropic', $response );
+
+		$this->assertSame( 0, $result['creation'] );
+		$this->assertSame( 0, $result['read'] );
+	}
+
+	public function test_handles_string_numeric_values(): void {
+		$response = array(
+			'usage' => array(
+				'cache_creation_input_tokens' => '1500',
+				'cache_read_input_tokens'     => '18000',
+			),
+		);
+
+		$result = CacheUsageExtractor::extract( 'anthropic', $response );
+
+		$this->assertSame( 1500, $result['creation'] );
+		$this->assertSame( 18000, $result['read'] );
+	}
+
+	public function test_unknown_provider_falls_back_to_openai_shape(): void {
+		$response = array(
+			'usage' => array(
+				'prompt_tokens_details' => array(
+					'cached_tokens' => 7000,
+				),
+			),
+		);
+
+		// xAI, Groq, Cerebras, Together, Fireworks, and any unknown
+		// provider all default to the OpenAI shape because that's the
+		// de-facto standard.
+		foreach ( array( 'xai', 'groq', 'cerebras', 'together', 'fireworks', 'unknown-provider' ) as $provider_id ) {
+			$result = CacheUsageExtractor::extract( $provider_id, $response );
+			$this->assertSame( 7000, $result['read'], "Failed for provider {$provider_id}." );
+			$this->assertSame( 0, $result['creation'], "Failed for provider {$provider_id}." );
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Implements provider-aware **prompt caching** for LLM HTTP calls with a strategy pattern keyed by URL host.
- Adds **universal cache-token telemetry** (`cache_creation_tokens`, `cache_read_tokens`) to provider traces across all providers.
- Default-on (`prompt_caching_enabled = true`); operators can opt out via setting.

Resolves sd-ai-bjv.

## Background

Baseline analysis of traces 122–128 in `wp_sd_ai_agent_provider_trace` (7-call Anthropic conversation):

- 158,636 cold input tokens per conversation (≈$2.38 on Claude Opus).
- `cache_creation_input_tokens=0` and `cache_read_input_tokens=0` on every turn — the WP AI Client SDK was not opting in to Anthropic's KV cache.
- System + tools section byte-stable across turns: the canonical KV-cache scenario.

Expected after this PR: ~66% cache-read ratio once warm, reducing per-turn input cost to ~$0.79.

## Design

### Strategy pattern keyed by URL host

Cache opt-in semantics differ per provider, but at the HTTP layer the only thing we know is the request URL and body. Routing by host (not provider_id) keeps the implementation decoupled from SDK internals and provider-plugin configuration.

- `CacheStrategyInterface` — `applies_to(string $url): bool` + `apply(array $request_args, string $url): array`.
- `AnthropicCacheStrategy` — injects two `cache_control: {"type":"ephemeral"}` markers:
  1. End of last `tools` block (caches tool schemas).
  2. End of last `system` block (caches system prompt).
  - Gated by `MIN_CHARS_FOR_CACHE = 4096` (cache breakpoints below this aren't economical).
  - **Preserves the Anthropic Max OAuth gateway's required first system block** (`"You are Claude Code, Anthropic's official CLI for Claude."`).
  - Does NOT mark message-history blocks in v1 (history changes every turn → cache miss churn).
- `NoopCacheStrategy` — pass-through for providers with automatic prompt caching: `api.openai.com`, `api.deepseek.com`, `api.x.ai`, `api.groq.com`, `api.cerebras.ai`, `api.together.xyz`, `api.fireworks.ai`.
- `CacheStrategyResolver` — routes URL → strategy with a `sd_ai_agent_resolve_cache_strategy` filter hook for tests/extensions.

### Wiring via `http_request_args`, not SDK `customOptions`

Both Anthropic connector plugins reject conflicting `customOptions` keys (ai-provider-for-anthropic `AnthropicTextGenerationModel.php:177–188`; ai-provider-for-anthropic-max `AnthropicMaxTextGenerationModel.php:275–283`). Using WordPress core's `http_request_args` filter avoids the conflict and works for any provider regardless of which connector plugin is in use.

`HttpTraceHandler` registers the cache-injection filter at **priority 9**, before `ProviderTraceLogger` at **priority 10**, so the trace captures the on-wire body (with markers).

### Universal cache-token telemetry

`CacheUsageExtractor` normalises per-provider response shapes:

- **Anthropic**: `usage.cache_creation_input_tokens`, `usage.cache_read_input_tokens`.
- **OpenAI / xAI / DeepSeek / Groq / Cerebras / Together / Fireworks**: `usage.prompt_tokens_details.cached_tokens` → `cache_read_tokens`; no creation count exposed (auto-caching).
- **Unknown providers**: default to the OpenAI shape (the de-facto standard).

### Schema migration

- `Database::DB_VERSION`: `19.1.0` → `19.2.0`.
- Adds `cache_creation_tokens BIGINT UNSIGNED NOT NULL DEFAULT 0` and `cache_read_tokens BIGINT UNSIGNED NOT NULL DEFAULT 0` to `wp_sd_ai_agent_provider_trace` via `dbDelta`.
- Pre-19.2.0 rows backfill to `0`; no destructive operation.

### Settings

- `prompt_caching_enabled` (default `true`) in `Settings::get_defaults()`.
- Static helper `Settings::is_prompt_caching_enabled()`.
- Cache filter is gated on this setting so operators can opt out without code changes.

### UI surfaces

- `TraceCommand` (WP-CLI) `list` and `show` render `CacheRead` / `CacheWrite` columns.
- `src/settings-page/provider-trace-viewer.js` adds a cache-tokens column to the table and a corresponding row in the detail modal.

## Tests

New test files:

- `tests/SdAiAgent/Core/PromptCache/AnthropicCacheStrategyTest.php` — marker injection at correct breakpoints, `MIN_CHARS_FOR_CACHE` gate, Anthropic Max prefix preservation, idempotency on already-marked bodies.
- `tests/SdAiAgent/Core/PromptCache/CacheStrategyResolverTest.php` — host routing, filter override hook, noop fallback for auto-cache hosts.
- `tests/SdAiAgent/Core/PromptCache/CacheUsageExtractorTest.php` — per-provider response shapes (Anthropic, OpenAI, xAI, Groq, unknown).
- `tests/SdAiAgent/Bootstrap/HttpTraceHandlerCacheTest.php` — end-to-end filter wiring: Anthropic mutation, OpenAI pass-through, unknown host pass-through, disabled-setting skip, non-string/non-JSON body pass-through.

## Local verification

- `composer phpcs` — clean (0 errors, 0 warnings across all changed paths).
- `composer phpstan` — clean (`No errors`, 204 files analysed).
- `composer dump-autoload` — clean.

PHP unit tests will be exercised by the existing GitHub Actions workflow on this PR (local `wp-env` was unavailable in the worktree).

## Manual verification (post-merge)

1. Activate plugin; verify schema migration runs (`wp_sd_ai_agent_provider_trace` gains the two new columns).
2. Run a 3-turn conversation against an Anthropic model with a non-trivial system prompt or tool set (> 4096 chars total).
3. In `wp_sd_ai_agent_provider_trace`:
   - Turn 1: `cache_creation_tokens > 0`, `cache_read_tokens = 0`.
   - Turn 2+: `cache_read_tokens > 0`.
4. Confirm Anthropic Max users (OAuth gateway) still succeed — the required `"You are Claude Code…"` first system block must remain at index 0 with no `cache_control` marker.
5. Confirm OpenAI traces show `cache_read_tokens` populated from `prompt_tokens_details.cached_tokens` (OpenAI auto-caches reused prefixes).

## Non-goals

- Message-history caching (would cause churn on every turn; revisit later if needed).
- Plugin-level model/provider metadata caching (rejected per `AGENTS.md` provider-credentials guidance).
- Backporting cache tokens onto pre-19.2.0 trace rows.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.38 plugin for [OpenCode](https://opencode.ai) v1.14.48 with gpt-5.5 spent 1d 5h and 15,815 tokens on this as a headless worker.
