### PR TITLE
GH#1374: fix: retry transient provider failures

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -67,6 +67,15 @@ class AgentLoop {
 	 */
 	const MAX_TOOL_RESULT_CHARS = 40000;
 
+	/** Maximum provider-call attempts for retryable transient failures. */
+	private const PROVIDER_RETRY_MAX_ATTEMPTS = 10;
+
+	/** Retryable upstream/network statuses. */
+	private const PROVIDER_RETRYABLE_STATUS_CODES = array( 408, 429, 500, 502, 503, 504 );
+
+	/** Default exponential backoff schedule in seconds, capped at 60 seconds. */
+	private const PROVIDER_RETRY_DELAYS = array( 1, 2, 4, 8, 16, 32, 60, 60, 60, 60 );
+
 	/** @var string */
 	private $user_message;
 
@@ -129,6 +138,12 @@ class AgentLoop {
 
 	/** @var int Session ID for change attribution (0 = no session). */
 	private int $session_id = 0;
+
+	/** @var int Maximum attempts for retryable provider failures. */
+	private int $provider_retry_max_attempts = self::PROVIDER_RETRY_MAX_ATTEMPTS;
+
+	/** @var list<int> Retry delay schedule in seconds. */
+	private array $provider_retry_delays = self::PROVIDER_RETRY_DELAYS;
 
 	/** @var list<string> Per-agent Tier 1 tool override (empty = use global default). */
 	private array $agent_tier_1_tools = array();
@@ -271,6 +286,16 @@ class AgentLoop {
 		$this->tool_call_log = $options['tool_call_log'] ?? array();
 		// @phpstan-ignore-next-line
 		$this->session_id = (int) ( $options['session_id'] ?? 0 );
+		// @phpstan-ignore-next-line -- Test/job callers may lower attempts or delays; production defaults remain 10 attempts.
+		$this->provider_retry_max_attempts = max( 1, (int) ( $options['provider_retry_max_attempts'] ?? self::PROVIDER_RETRY_MAX_ATTEMPTS ) );
+		// @phpstan-ignore-next-line -- Values are normalised below to non-negative integer seconds.
+		$retry_delays = $options['provider_retry_delays'] ?? self::PROVIDER_RETRY_DELAYS;
+		if ( is_array( $retry_delays ) ) {
+			$this->provider_retry_delays = array_map(
+				static fn( $delay ): int => max( 0, min( 60, (int) $delay ) ),
+				array_values( $retry_delays )
+			);
+		}
 		// @phpstan-ignore-next-line
 		$this->token_usage = $options['token_usage'] ?? array(
 			'prompt'     => 0,
@@ -952,7 +977,271 @@ class AgentLoop {
 			$builder->with_history( ...$this->history );
 		}
 
-		return $builder->generate_text_result();
+		$started_at = microtime( true );
+		$last_error = null;
+
+		for ( $attempt = 1; $attempt <= $this->provider_retry_max_attempts; ++$attempt ) {
+			try {
+				$result = $builder->generate_text_result();
+				if ( is_wp_error( $result ) ) {
+					/** @var WP_Error $result */
+					$last_error = $result;
+				} else {
+					return $result;
+				}
+			} catch ( \Throwable $e ) {
+				$last_error = $e;
+			}
+
+			$status_code = $this->extract_provider_error_status( $last_error );
+			if ( ! $this->is_retryable_provider_error( $last_error, $status_code ) ) {
+				return $this->provider_error_to_wp_error( $last_error, $status_code );
+			}
+
+			if ( $attempt >= $this->provider_retry_max_attempts ) {
+				break;
+			}
+
+			$delay = $this->get_provider_retry_delay( $attempt, $last_error );
+			$this->log_provider_retry_progress( $status_code, $attempt + 1, $delay );
+
+			if ( $delay > 0 ) {
+				sleep( $delay );
+			}
+		}
+
+		$elapsed_seconds = max( 0, (int) round( microtime( true ) - $started_at ) );
+		return $this->build_provider_retry_failed_error( $last_error, $elapsed_seconds );
+	}
+
+	/**
+	 * Determine whether a provider failure is retryable.
+	 *
+	 * @param WP_Error|\Throwable|null $error       Last provider error.
+	 * @param int                      $status_code HTTP status code, or 0 when unknown.
+	 */
+	private function is_retryable_provider_error( $error, int $status_code ): bool {
+		if ( in_array( $status_code, self::PROVIDER_RETRYABLE_STATUS_CODES, true ) ) {
+			return true;
+		}
+
+		if ( $status_code >= 400 ) {
+			return false;
+		}
+
+		$message = $this->get_provider_error_message( $error );
+		if ( '' === $message ) {
+			return false;
+		}
+
+		return (bool) preg_match( '/\b(timeout|timed out|connection reset|connection refused|network|cURL error|internal server error|bad gateway|service unavailable|gateway timeout|too many requests|rate limit)\b/i', $message );
+	}
+
+	/**
+	 * Extract an HTTP status code from provider errors produced by SDK layers.
+	 *
+	 * @param WP_Error|\Throwable|null $error Last provider error.
+	 */
+	private function extract_provider_error_status( $error ): int {
+		if ( $error instanceof WP_Error ) {
+			$code = $error->get_error_code();
+			if ( is_numeric( $code ) ) {
+				return (int) $code;
+			}
+
+			$data = $error->get_error_data();
+			if ( is_array( $data ) ) {
+				foreach ( [ 'status', 'status_code', 'code' ] as $key ) {
+					if ( isset( $data[ $key ] ) && is_numeric( $data[ $key ] ) ) {
+						return (int) $data[ $key ];
+					}
+				}
+			}
+		}
+
+		if ( $error instanceof \Throwable ) {
+			$code = $error->getCode();
+			if ( $code >= 400 && $code <= 599 ) {
+				return (int) $code;
+			}
+		}
+
+		$message = $this->get_provider_error_message( $error );
+		if ( preg_match( '/\((\d{3})\)|\bHTTP\s+(\d{3})\b|\bstatus\s*(?:code)?\s*[:=]?\s*(\d{3})\b/i', $message, $matches ) ) {
+			foreach ( array_slice( $matches, 1 ) as $match ) {
+				if ( '' !== $match ) {
+					return (int) $match;
+				}
+			}
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Build a user-facing message for a provider error.
+	 *
+	 * @param WP_Error|\Throwable|null $error Last provider error.
+	 */
+	private function get_provider_error_message( $error ): string {
+		if ( $error instanceof WP_Error ) {
+			return $error->get_error_message();
+		}
+
+		if ( $error instanceof \Throwable ) {
+			return $error->getMessage();
+		}
+
+		return '';
+	}
+
+	/**
+	 * Return retry delay in seconds, honouring Retry-After metadata when present.
+	 *
+	 * @param int                      $attempt Current one-based attempt number.
+	 * @param WP_Error|\Throwable|null $error   Last provider error.
+	 */
+	private function get_provider_retry_delay( int $attempt, $error ): int {
+		$retry_after = $this->extract_retry_after_seconds( $error );
+		if ( null !== $retry_after ) {
+			return min( 60, max( 0, $retry_after ) );
+		}
+
+		$index = max( 0, $attempt - 1 );
+		return (int) ( $this->provider_retry_delays[ $index ] ?? 60 );
+	}
+
+	/**
+	 * Extract Retry-After from WP_Error data when the SDK preserves headers.
+	 *
+	 * @param WP_Error|\Throwable|null $error Last provider error.
+	 */
+	private function extract_retry_after_seconds( $error ): ?int {
+		if ( ! $error instanceof WP_Error ) {
+			return null;
+		}
+
+		$data = $error->get_error_data();
+		if ( ! is_array( $data ) ) {
+			return null;
+		}
+
+		$headers = $data['headers'] ?? $data['response_headers'] ?? null;
+		if ( ! is_array( $headers ) ) {
+			return null;
+		}
+
+		foreach ( $headers as $name => $value ) {
+			if ( 'retry-after' !== strtolower( (string) $name ) ) {
+				continue;
+			}
+			if ( is_array( $value ) ) {
+				$value = reset( $value );
+			}
+			if ( is_numeric( $value ) ) {
+				return (int) $value;
+			}
+			$timestamp = strtotime( (string) $value );
+			if ( false !== $timestamp ) {
+				return max( 0, $timestamp - time() );
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Log provider retry progress so jobs and chat streams can render it.
+	 */
+	private function log_provider_retry_progress( int $status_code, int $next_attempt, int $delay ): void {
+		$status_label = $status_code > 0 ? (string) $status_code : __( 'a transient network error', 'superdav-ai-agent' );
+		$message      = sprintf(
+			/* translators: 1: status/error label, 2: delay seconds, 3: next attempt number, 4: maximum attempt number */
+			__( 'Provider returned %1$s. Retrying in %2$ds (attempt %3$d/%4$d)…', 'superdav-ai-agent' ),
+			$status_label,
+			$delay,
+			$next_attempt,
+			$this->provider_retry_max_attempts
+		);
+
+		$this->tool_call_log[] = [
+			'type'         => 'provider_retry',
+			'message'      => $message,
+			'status_code'  => $status_code,
+			'attempt'      => $next_attempt,
+			'max_attempts' => $this->provider_retry_max_attempts,
+			'delay'        => $delay,
+		];
+		$this->fire_progress();
+	}
+
+	/**
+	 * Convert a non-retryable provider failure into a WP_Error without retry noise.
+	 *
+	 * @param WP_Error|\Throwable|null $error       Last provider error.
+	 * @param int                      $status_code HTTP status code, or 0 when unknown.
+	 */
+	private function provider_error_to_wp_error( $error, int $status_code ): WP_Error {
+		if ( $error instanceof WP_Error ) {
+			return $error;
+		}
+
+		$message = $this->get_provider_error_message( $error );
+		if ( '' === $message ) {
+			$message = __( 'AI provider request failed.', 'superdav-ai-agent' );
+		}
+
+		return new WP_Error(
+			'sd_ai_agent_provider_error',
+			$message,
+			[
+				'status_code' => $status_code,
+			]
+		);
+	}
+
+	/**
+	 * Build the exhausted-retry WP_Error and persist resumable state if possible.
+	 *
+	 * @param WP_Error|\Throwable|null $error           Last provider error.
+	 * @param int                      $elapsed_seconds Total elapsed seconds.
+	 */
+	private function build_provider_retry_failed_error( $error, int $elapsed_seconds ): WP_Error {
+		$message = sprintf(
+			/* translators: 1: attempts, 2: elapsed seconds, 3: provider error message */
+			__( 'Provider retry failed after %1$d attempts over %2$ds — try resending your last message. Last error: %3$s', 'superdav-ai-agent' ),
+			$this->provider_retry_max_attempts,
+			$elapsed_seconds,
+			$this->get_provider_error_message( $error )
+		);
+
+		if ( $this->session_id > 0 ) {
+			Database::save_paused_state(
+				$this->session_id,
+				[
+					'history'          => $this->serialize_history(),
+					'tool_call_log'    => $this->tool_call_log,
+					'token_usage'      => $this->token_usage,
+					'model_id'         => $this->model_id,
+					'provider_id'      => $this->provider_id,
+					'client_abilities' => $this->client_abilities,
+					'exit_reason'      => 'provider_retry_failed',
+				]
+			);
+		}
+
+		return new WP_Error(
+			'sd_ai_agent_provider_retry_failed',
+			$message,
+			[
+				'tool_calls'      => $this->tool_call_log,
+				'token_usage'     => $this->token_usage,
+				'iterations_used' => $this->iterations_used,
+				'model_id'        => $this->model_id,
+				'history'         => $this->serialize_history(),
+				'elapsed_seconds' => $elapsed_seconds,
+			]
+		);
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -223,6 +223,73 @@ class AgentLoopTest extends WP_UnitTestCase {
 		);
 	}
 
+	/**
+	 * Options that keep retry tests fast by disabling sleep between attempts.
+	 *
+	 * @param int $max_attempts Maximum provider attempts.
+	 * @return array<string, mixed>
+	 */
+	private function no_sleep_retry_options( int $max_attempts = 4 ): array {
+		return [
+			'provider_retry_max_attempts' => $max_attempts,
+			'provider_retry_delays'       => array_fill( 0, $max_attempts, 0 ),
+		];
+	}
+
+	/**
+	 * Register a `pre_http_request` filter that returns queued responses.
+	 *
+	 * @param list<array<string,mixed>> $responses HTTP response specs.
+	 * @param int                       $call_count Number of intercepted provider calls.
+	 */
+	private function mock_ai_response_sequence( array $responses, int &$call_count ): void {
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( $responses, &$call_count ) {
+				if ( false === strpos( $url, 'fake-ai-proxy.test' ) ) {
+					return $preempt;
+				}
+
+				$index = min( $call_count, count( $responses ) - 1 );
+				++$call_count;
+				$spec = $responses[ $index ];
+
+				if ( isset( $spec['wp_error'] ) && $spec['wp_error'] instanceof \WP_Error ) {
+					return $spec['wp_error'];
+				}
+
+				$status = (int) ( $spec['status'] ?? 200 );
+				$body   = (string) ( $spec['body'] ?? '' );
+				if ( '' === $body ) {
+					$body = wp_json_encode(
+						[
+							'id'      => 'chatcmpl-sequence',
+							'object'  => 'chat.completion',
+							'choices' => [
+								[
+									'index'         => 0,
+									'message'       => [ 'role' => 'assistant', 'content' => (string) ( $spec['reply'] ?? 'Recovered' ) ],
+									'finish_reason' => 'stop',
+								],
+							],
+							'usage'   => [ 'prompt_tokens' => 10, 'completion_tokens' => 5, 'total_tokens' => 15 ],
+						]
+					);
+				}
+
+				return [
+					'headers'  => [ 'content-type' => 'application/json' ],
+					'body'     => $body,
+					'response' => [ 'code' => $status, 'message' => (string) ( $spec['message'] ?? 'OK' ) ],
+					'cookies'  => [],
+					'filename' => '',
+				];
+			},
+			10,
+			3
+		);
+	}
+
 	// -------------------------------------------------------------------------
 	// Constructor / configuration tests
 	// -------------------------------------------------------------------------
@@ -441,16 +508,89 @@ class AgentLoopTest extends WP_UnitTestCase {
 	/**
 	 * Test run() returns WP_Error when the AI proxy returns an HTTP error.
 	 */
-	public function test_run_returns_wp_error_on_http_error_response(): void {
+	public function test_run_retries_http_error_response_then_succeeds(): void {
 		$this->skip_if_sdk_unavailable();
-		$this->mock_ai_error_response( 500, 'Internal server error' );
+		$call_count = 0;
+		$progress   = [];
+		$this->mock_ai_response_sequence(
+			[
+				[
+					'status'  => 500,
+					'message' => 'Internal Server Error',
+					'body'    => wp_json_encode( [ 'error' => [ 'message' => 'Internal server error' ] ] ),
+				],
+				[
+					'status'  => 502,
+					'message' => 'Bad Gateway',
+					'body'    => wp_json_encode( [ 'error' => [ 'message' => 'Bad gateway' ] ] ),
+				],
+				[
+					'status'  => 503,
+					'message' => 'Service Unavailable',
+					'body'    => wp_json_encode( [ 'error' => [ 'message' => 'Unavailable' ] ] ),
+				],
+				[
+					'status' => 200,
+					'reply'  => 'Recovered after retry',
+				],
+			],
+			$call_count
+		);
 
-		$loop   = new AgentLoop( 'Hello' );
+		$options                      = $this->no_sleep_retry_options( 4 );
+		$options['progress_callback'] = static function ( array $tool_call_log ) use ( &$progress ): void {
+			$progress[] = $tool_call_log;
+		};
+
+		$loop   = new AgentLoop(
+			'Hello',
+			[],
+			[],
+			$options
+		);
+		$result = $loop->run();
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'Recovered after retry', $result['reply'] );
+		$this->assertSame( 4, $call_count );
+		$retry_entries = array_filter( $result['tool_calls'], static fn( $entry ) => 'provider_retry' === ( $entry['type'] ?? '' ) );
+		$this->assertCount( 3, $retry_entries );
+		$this->assertCount( 3, $progress );
+	}
+
+	/**
+	 * Test run() returns clear WP_Error after retry attempts are exhausted.
+	 */
+	public function test_run_returns_clear_wp_error_after_retry_exhaustion(): void {
+		$this->skip_if_sdk_unavailable();
+		$call_count = 0;
+		$this->mock_ai_response_sequence(
+			[
+				[
+					'status'  => 503,
+					'message' => 'Service Unavailable',
+					'body'    => wp_json_encode( [ 'error' => [ 'message' => 'Service unavailable' ] ] ),
+				],
+			],
+			$call_count
+		);
+
+		$loop   = new AgentLoop(
+			'Hello',
+			[],
+			[],
+			$this->no_sleep_retry_options( 3 )
+		);
 		$result = $loop->run();
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
-		$this->assertSame( 'sd_ai_agent_provider_unavailable', $result->get_error_code() );
-		$this->assertStringContainsString( 'Internal server error', $result->get_error_message() );
+		$this->assertSame( 'sd_ai_agent_provider_retry_failed', $result->get_error_code() );
+		$this->assertStringContainsString( 'Provider retry failed after 3 attempts', $result->get_error_message() );
+		$this->assertSame( 3, $call_count );
+		$data = $result->get_error_data();
+		$this->assertIsArray( $data );
+		$retry_entries = array_filter( $data['tool_calls'], static fn( $entry ) => 'provider_retry' === ( $entry['type'] ?? '' ) );
+		$this->assertCount( 2, $retry_entries );
 	}
 
 	/**
@@ -460,11 +600,11 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->skip_if_sdk_unavailable();
 		$this->mock_ai_network_failure();
 
-		$loop   = new AgentLoop( 'Hello' );
+		$loop   = new AgentLoop( 'Hello', [], [], $this->no_sleep_retry_options( 1 ) );
 		$result = $loop->run();
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
-		$this->assertSame( 'http_request_failed', $result->get_error_code() );
+		$this->assertSame( 'sd_ai_agent_provider_retry_failed', $result->get_error_code() );
 	}
 
 	/**
@@ -472,13 +612,24 @@ class AgentLoopTest extends WP_UnitTestCase {
 	 */
 	public function test_run_returns_wp_error_on_unauthorized(): void {
 		$this->skip_if_sdk_unavailable();
-		$this->mock_ai_error_response( 401, 'Invalid API key' );
+		$call_count = 0;
+		$this->mock_ai_response_sequence(
+			[
+				[
+					'status'  => 401,
+					'message' => 'Unauthorized',
+					'body'    => wp_json_encode( [ 'error' => [ 'message' => 'Invalid API key' ] ] ),
+				],
+			],
+			$call_count
+		);
 
 		$loop   = new AgentLoop( 'Hello' );
 		$result = $loop->run();
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'sd_ai_agent_provider_unavailable', $result->get_error_code() );
+		$this->assertSame( 1, $call_count );
 	}
 
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Added AgentLoop retry handling for transient provider failures with capped exponential backoff, progress entries in the existing tool-call stream, retry-exhausted errors that preserve paused session state, and regression coverage for retry success, retry exhaustion, network failure, and non-retryable 4xx errors.

## Files Changed

includes/Core/AgentLoop.php,tests/SdAiAgent/Core/AgentLoopTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** php -l includes/Core/AgentLoop.php && php -l tests/SdAiAgent/Core/AgentLoopTest.php; composer phpcs -- includes/Core/AgentLoop.php tests/SdAiAgent/Core/AgentLoopTest.php; composer phpstan -- includes/Core/AgentLoop.php. Attempted composer test -- --filter AgentLoopTest, blocked by missing WordPress test library path; attempted npm run test:php -- --filter AgentLoopTest, blocked by missing wp-env docker-compose.yml.

Resolves #1374


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.41 plugin for [OpenCode](https://opencode.ai) v1.14.49 with gpt-5.5 spent 10m and 230,137 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic retry mechanism for transient provider failures with configurable limits and delays
  * Session persistence to resume operations after provider connectivity issues

* **Improvements**
  * Enhanced error detection for network and rate-limiting scenarios
  * Support for Retry-After headers in rate-limited responses

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1393)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->