### PR TITLE
GH#1388: fix: handle truncated tool calls

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -622,10 +622,16 @@ class AgentLoop {
 
 			/** @var \WordPress\AiClient\Results\DTO\GenerativeAiResult $result */
 			$assistant_message = $result->toMessage();
-			$this->history[]   = $assistant_message;
 
 			// Accumulate token usage if available.
 			$this->accumulate_tokens( $result );
+
+			if ( $this->is_truncated_tool_call_result( $result, $assistant_message ) ) {
+				$this->inject_truncated_tool_call_guidance( $assistant_message );
+				continue;
+			}
+
+			$this->history[] = $assistant_message;
 
 			// Check if the model wants to call tools.
 			if ( ! $this->get_ability_resolver()->has_ability_calls( $assistant_message ) ) {
@@ -950,22 +956,7 @@ class AgentLoop {
 		}
 
 		if ( method_exists( $builder, 'using_max_tokens' ) ) {
-			// Resolve the effective max_tokens for this request.
-			//
-			// AUTO (0): consult the per-model catalog so each provider/model
-			// gets a sensible value (e.g. 32K for Claude 4.x, 16K for GPT-4o,
-			// 8K for Gemini Flash). The legacy 4096 default truncated tool_use
-			// input JSON for any non-trivial payload — see sd-ai-7rl.
-			//
-			// EXPLICIT (>0): honour the user's saved override but clamp at
-			// MAX_OUTPUT_TOKENS_CEILING to defend against runaway generations.
-			$max_tokens = $this->max_output_tokens;
-			if ( $max_tokens <= Settings::MAX_OUTPUT_TOKENS_AUTO ) {
-				$max_tokens = Settings::get_max_output_tokens_for_model( $this->model_id );
-			} elseif ( $max_tokens > Settings::MAX_OUTPUT_TOKENS_CEILING ) {
-				$max_tokens = Settings::MAX_OUTPUT_TOKENS_CEILING;
-			}
-			$builder->using_max_tokens( $max_tokens );
+			$builder->using_max_tokens( $this->get_effective_max_output_tokens() );
 		}
 
 		$abilities = $this->resolve_abilities();
@@ -1538,6 +1529,125 @@ class AgentLoop {
 		}
 
 		$this->fire_progress();
+	}
+
+	/**
+	 * Detect provider length-cap finishes that include tool calls.
+	 *
+	 * @param mixed   $result  Provider result object.
+	 * @param Message $message Assistant message converted from the result.
+	 */
+	private function is_truncated_tool_call_result( $result, Message $message ): bool {
+		if ( ! $this->get_ability_resolver()->has_ability_calls( $message ) ) {
+			return false;
+		}
+
+		$reason = $this->get_result_finish_reason( $result );
+		if ( '' === $reason ) {
+			return false;
+		}
+
+		$normalized = strtolower( str_replace( [ '-', ' ' ], '_', $reason ) );
+		return in_array( $normalized, [ 'max_tokens', 'length', 'max_output_tokens' ], true );
+	}
+
+	/**
+	 * Extract a provider-agnostic finish reason from SDK and direct-call results.
+	 *
+	 * @param mixed $result Provider result object.
+	 * @return string Finish reason or empty string when unavailable.
+	 */
+	private function get_result_finish_reason( $result ): string {
+		if ( is_object( $result ) && method_exists( $result, 'getFinishReason' ) ) {
+			$reason = $result->getFinishReason();
+			return is_string( $reason ) ? $reason : '';
+		}
+
+		if ( is_object( $result ) && method_exists( $result, 'getCandidates' ) ) {
+			$candidates = $result->getCandidates();
+			$candidate  = is_array( $candidates ) ? ( $candidates[0] ?? null ) : null;
+			if ( is_object( $candidate ) && method_exists( $candidate, 'getFinishReason' ) ) {
+				$reason = $candidate->getFinishReason();
+				if ( is_object( $reason ) && method_exists( $reason, '__toString' ) ) {
+					return (string) $reason;
+				}
+				if ( is_string( $reason ) ) {
+					return $reason;
+				}
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Replace an unsafe truncated tool-use turn with guidance for the next model turn.
+	 */
+	private function inject_truncated_tool_call_guidance( Message $message ): void {
+		$tool_name = $this->get_first_tool_call_name( $message );
+		$cap       = $this->get_effective_max_output_tokens();
+		$guidance  = sprintf(
+			/* translators: 1: max token cap, 2: tool/ability name. */
+			__( 'Your previous response was truncated because it hit the max_tokens cap (current cap: %1$d). The tool call you started (%2$s) was discarded because its input JSON was incomplete. Either split this work into smaller tool calls, reduce the payload size, or use a tool that accepts file/post references instead of inline content.', 'superdav-ai-agent' ),
+			$cap,
+			$tool_name
+		);
+
+		$this->tool_call_log[] = array(
+			'type'       => 'event',
+			'reason'     => 'truncated_tool_call',
+			'name'       => $tool_name,
+			'max_tokens' => $cap,
+			'message'    => $guidance,
+		);
+
+		AgentEventLog::log(
+			'truncated_tool_call',
+			AgentEventLog::SEVERITY_WARNING,
+			array(
+				'session_id'  => $this->session_id,
+				'ability'     => $tool_name,
+				'max_tokens'  => $cap,
+				'model_id'    => (string) $this->model_id,
+				'provider_id' => (string) $this->provider_id,
+			)
+		);
+
+		$this->history[] = new UserMessage( [ new MessagePart( $guidance ) ] );
+		$this->fire_progress();
+	}
+
+	/**
+	 * Get the first tool call name from a message.
+	 */
+	private function get_first_tool_call_name( Message $message ): string {
+		foreach ( $message->getParts() as $part ) {
+			$call = $part->getFunctionCall();
+			if ( $call ) {
+				return $call->getName();
+			}
+		}
+
+		return __( 'unknown tool', 'superdav-ai-agent' );
+	}
+
+	/**
+	 * Resolve the effective max output token cap used for provider requests.
+	 */
+	private function get_effective_max_output_tokens(): int {
+		// AUTO (0): consult the per-model catalog so each provider/model gets a
+		// sensible value. EXPLICIT (>0): honour the saved override but clamp at
+		// MAX_OUTPUT_TOKENS_CEILING to defend against runaway generations.
+		$max_tokens = $this->max_output_tokens;
+		if ( $max_tokens <= Settings::MAX_OUTPUT_TOKENS_AUTO ) {
+			return Settings::get_max_output_tokens_for_model( $this->model_id );
+		}
+
+		if ( $max_tokens > Settings::MAX_OUTPUT_TOKENS_CEILING ) {
+			return Settings::MAX_OUTPUT_TOKENS_CEILING;
+		}
+
+		return $max_tokens;
 	}
 
 	/**

--- a/includes/Core/ProviderTraceLogger.php
+++ b/includes/Core/ProviderTraceLogger.php
@@ -155,7 +155,12 @@ class ProviderTraceLogger {
 		// Extract model_id from request body if possible.
 		$model_id = self::extract_model_id( $inflight['request_body'] ?? '' );
 
-		// Detect errors.
+		$decoded_response = null;
+		if ( $status_code >= 200 && $status_code < 300 ) {
+			$decoded_response = json_decode( $response_body, true );
+		}
+
+		// Detect errors and provider-side truncation events.
 		$error = '';
 		if ( $status_code < 200 || $status_code >= 300 ) {
 			$decoded = json_decode( $response_body, true );
@@ -171,6 +176,8 @@ class ProviderTraceLogger {
 			if ( '' === $error ) {
 				$error = "HTTP {$status_code}";
 			}
+		} elseif ( self::is_truncated_tool_call_response( $decoded_response ) ) {
+			$error = 'truncated_tool_call';
 		}
 
 		// Format response headers as JSON.
@@ -192,8 +199,7 @@ class ProviderTraceLogger {
 			'read'     => 0,
 		);
 		if ( $status_code >= 200 && $status_code < 300 ) {
-			$decoded_response = json_decode( $response_body, true );
-			$cache_tokens     = CacheUsageExtractor::extract(
+			$cache_tokens = CacheUsageExtractor::extract(
 				(string) ( $inflight['provider_id'] ?? '' ),
 				$decoded_response
 			);
@@ -280,6 +286,91 @@ class ProviderTraceLogger {
 
 		$result = wp_json_encode( $headers );
 		return false !== $result ? $result : '{}';
+	}
+
+	/**
+	 * Detect successful provider responses that ended at the output cap mid tool call.
+	 *
+	 * @param mixed $decoded Decoded JSON response body.
+	 */
+	private static function is_truncated_tool_call_response( $decoded ): bool {
+		if ( ! is_array( $decoded ) ) {
+			return false;
+		}
+
+		$candidates = [];
+		if ( isset( $decoded['choices'] ) && is_array( $decoded['choices'] ) ) {
+			$candidates = $decoded['choices'];
+		} elseif ( isset( $decoded['candidates'] ) && is_array( $decoded['candidates'] ) ) {
+			$candidates = $decoded['candidates'];
+		} elseif ( isset( $decoded['content'] ) && is_array( $decoded['content'] ) ) {
+			$candidates = [ $decoded ];
+		}
+
+		foreach ( $candidates as $candidate ) {
+			if ( ! is_array( $candidate ) ) {
+				continue;
+			}
+
+			$reason = self::extract_finish_reason( $candidate );
+			if ( ! in_array( $reason, [ 'max_tokens', 'length', 'max_output_tokens' ], true ) ) {
+				continue;
+			}
+
+			if ( self::candidate_has_tool_call( $candidate ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Extract a normalized finish reason from a provider response candidate.
+	 *
+	 * @param array<string, mixed> $candidate Provider response candidate.
+	 */
+	private static function extract_finish_reason( array $candidate ): string {
+		foreach ( [ 'finish_reason', 'stop_reason', 'finishReason' ] as $key ) {
+			$reason = $candidate[ $key ] ?? null;
+			if ( is_string( $reason ) && '' !== $reason ) {
+				return strtolower( str_replace( [ '-', ' ' ], '_', $reason ) );
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Detect common OpenAI, Anthropic, and Gemini tool-call payload shapes.
+	 *
+	 * @param array<string, mixed> $candidate Provider response candidate.
+	 */
+	private static function candidate_has_tool_call( array $candidate ): bool {
+		$message = $candidate['message'] ?? [];
+		if ( is_array( $message ) && ! empty( $message['tool_calls'] ) ) {
+			return true;
+		}
+
+		$content = $candidate['content'] ?? ( is_array( $message ) ? ( $message['content'] ?? [] ) : [] );
+		if ( is_array( $content ) ) {
+			foreach ( $content as $part ) {
+				if ( is_array( $part ) && in_array( $part['type'] ?? '', [ 'tool_use', 'function_call' ], true ) ) {
+					return true;
+				}
+			}
+		}
+
+		$parts = $candidate['content']['parts'] ?? $candidate['parts'] ?? [];
+		if ( is_array( $parts ) ) {
+			foreach ( $parts as $part ) {
+				if ( is_array( $part ) && isset( $part['functionCall'] ) ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/Core/SimpleAiResult.php
+++ b/includes/Core/SimpleAiResult.php
@@ -50,6 +50,32 @@ class SimpleAiResult {
 	}
 
 	/**
+	 * Get the provider finish/stop reason from the raw response when available.
+	 *
+	 * @return string Finish reason or an empty string when unavailable.
+	 */
+	public function getFinishReason(): string {
+		$choice = $this->raw['choices'][0] ?? [];
+		if ( is_array( $choice ) ) {
+			foreach ( [ 'finish_reason', 'stop_reason', 'finishReason' ] as $key ) {
+				$reason = $choice[ $key ] ?? null;
+				if ( is_string( $reason ) && '' !== $reason ) {
+					return $reason;
+				}
+			}
+		}
+
+		foreach ( [ 'finish_reason', 'stop_reason', 'finishReason' ] as $key ) {
+			$reason = $this->raw[ $key ] ?? null;
+			if ( is_string( $reason ) && '' !== $reason ) {
+				return $reason;
+			}
+		}
+
+		return '';
+	}
+
+	/**
 	 * Convert the response to a Message object for the conversation history.
 	 *
 	 * Parses OpenAI-format tool_calls from the raw response and creates

--- a/src/settings-page/provider-trace-viewer.js
+++ b/src/settings-page/provider-trace-viewer.js
@@ -199,6 +199,29 @@ export default function ProviderTraceViewer() {
 		return <span className={ className }>{ code }</span>;
 	};
 
+	// Error/event badge.
+	const TraceEventBadge = ( { error } ) => {
+		if ( ! error ) {
+			return '—';
+		}
+
+		if ( error === 'truncated_tool_call' ) {
+			return (
+				<span
+					className="sdaa-trace-event-badge sdaa-trace-event-badge-truncated"
+					title={ __(
+						'The provider stopped at the output token cap while returning a tool call. The call was discarded before execution.',
+						'superdav-ai-agent'
+					) }
+				>
+					{ __( 'Truncated tool call', 'superdav-ai-agent' ) }
+				</span>
+			);
+		}
+
+		return error.substring( 0, 50 ) + ( error.length > 50 ? '...' : '' );
+	};
+
 	if ( ! traceSettings ) {
 		return (
 			<div className="sdaa-settings-loading">
@@ -402,19 +425,21 @@ export default function ProviderTraceViewer() {
 											( trace.cache_creation_tokens ||
 												0 ) >
 										0
-											? `${ trace.cache_read_tokens || 0 } / ${ trace.cache_creation_tokens || 0 }`
+											? `${
+													trace.cache_read_tokens || 0
+											  } / ${
+													trace.cache_creation_tokens ||
+													0
+											  }`
 											: '—' }
 									</td>
 									<td
 										className="sdaa-trace-error-cell"
 										title={ trace.error || '' }
 									>
-										{ trace.error
-											? trace.error.substring( 0, 50 ) +
-											  ( trace.error.length > 50
-													? '...'
-													: '' )
-											: '—' }
+										<TraceEventBadge
+											error={ trace.error }
+										/>
 									</td>
 									<td>
 										<Button

--- a/src/settings-page/style.css
+++ b/src/settings-page/style.css
@@ -1083,3 +1083,18 @@
 	z-index: 99999;
 }
 
+.sdaa-trace-event-badge {
+	display: inline-block;
+	padding: 2px 6px;
+	border-radius: 3px;
+	font-size: 11px;
+	font-weight: 600;
+	line-height: 1.4;
+	white-space: nowrap;
+}
+
+.sdaa-trace-event-badge-truncated {
+	border: 1px solid #dba617;
+	background: #fcf9e8;
+	color: #8a6500;
+}

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -770,6 +770,100 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertSame( 'wpab__sd-ai-agent__memory-list', $first_call['name'] );
 	}
 
+	/**
+	 * Test length-capped tool calls are discarded and converted to guidance.
+	 */
+	public function test_run_discards_truncated_tool_call_and_continues(): void {
+		$this->skip_if_sdk_unavailable();
+		if ( ! class_exists( 'WP_AI_Client_Ability_Function_Resolver' ) ) {
+			$this->markTestSkipped( 'WP_AI_Client_Ability_Function_Resolver not available.' );
+		}
+
+		$call_count          = 0;
+		$second_request_body = '';
+		$truncated_body      = wp_json_encode(
+			[
+				'id'      => 'chatcmpl-truncated',
+				'object'  => 'chat.completion',
+				'choices' => [
+					[
+						'index'         => 0,
+						'message'       => [
+							'role'       => 'assistant',
+							'content'    => null,
+							'tool_calls' => [
+								[
+									'id'       => 'call_truncated',
+									'type'     => 'function',
+									'function' => [
+										'name'      => 'wpab__sd-ai-agent__memory-list',
+										'arguments' => '{"arguments":{"query":"unterminated',
+									],
+								],
+							],
+						],
+						'finish_reason' => 'length',
+					],
+				],
+				'usage'   => [ 'prompt_tokens' => 10, 'completion_tokens' => 4096, 'total_tokens' => 4106 ],
+			]
+		);
+
+		$reply_body = wp_json_encode(
+			[
+				'id'      => 'chatcmpl-recovered',
+				'object'  => 'chat.completion',
+				'choices' => [
+					[
+						'index'         => 0,
+						'message'       => [ 'role' => 'assistant', 'content' => 'Recovered with smaller work.' ],
+						'finish_reason' => 'stop',
+					],
+				],
+				'usage'   => [ 'prompt_tokens' => 20, 'completion_tokens' => 8, 'total_tokens' => 28 ],
+			]
+		);
+
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( &$call_count, &$second_request_body, $truncated_body, $reply_body ) {
+				if ( false !== strpos( $url, 'fake-ai-proxy.test' ) ) {
+					++$call_count;
+					if ( 2 === $call_count ) {
+						$second_request_body = is_string( $args['body'] ?? null ) ? $args['body'] : (string) wp_json_encode( $args['body'] ?? [] );
+					}
+
+					return [
+						'headers'  => [ 'content-type' => 'application/json' ],
+						'body'     => ( 1 === $call_count ) ? $truncated_body : $reply_body,
+						'response' => [ 'code' => 200, 'message' => 'OK' ],
+						'cookies'  => [],
+						'filename' => '',
+					];
+				}
+
+				return $preempt;
+			},
+			10,
+			3
+		);
+
+		$loop   = new AgentLoop( 'List memories with a large filter', [], [], [ 'max_iterations' => 3 ] );
+		$result = $loop->run();
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'Recovered with smaller work.', $result['reply'] );
+		$this->assertSame( 2, $call_count );
+		$this->assertStringContainsString( 'previous response was truncated', $second_request_body );
+		$this->assertStringContainsString( 'max_tokens cap', $second_request_body );
+
+		$calls = array_filter( $result['tool_calls'], fn( $entry ) => 'call' === $entry['type'] );
+		$this->assertEmpty( $calls, 'The truncated tool call must not be dispatched or logged as a call.' );
+
+		$events = array_filter( $result['tool_calls'], fn( $entry ) => 'truncated_tool_call' === ( $entry['reason'] ?? '' ) );
+		$this->assertNotEmpty( $events, 'The truncation should be visible in the tool-call log.' );
+	}
+
 	// -------------------------------------------------------------------------
 	// Max iterations
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Detect max-token finishes that include tool calls, discard unsafe calls before ability dispatch, inject retry guidance into the next model turn, and surface provider-trace truncation events with a distinct badge.

## Files Changed

includes/Core/AgentLoop.php,includes/Core/ProviderTraceLogger.php,includes/Core/SimpleAiResult.php,src/settings-page/provider-trace-viewer.js,src/settings-page/style.css,tests/SdAiAgent/Core/AgentLoopTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PASS: php -l includes/Core/AgentLoop.php includes/Core/ProviderTraceLogger.php includes/Core/SimpleAiResult.php tests/SdAiAgent/Core/AgentLoopTest.php; PASS: vendor/bin/phpcs includes/Core/AgentLoop.php includes/Core/ProviderTraceLogger.php includes/Core/SimpleAiResult.php tests/SdAiAgent/Core/AgentLoopTest.php; PASS: npx wp-scripts lint-js src/settings-page/provider-trace-viewer.js && npx wp-scripts lint-style src/settings-page/style.css; BLOCKED: vendor/bin/phpunit --filter test_run_discards_truncated_tool_call_and_continues tests/SdAiAgent/Core/AgentLoopTest.php (missing wordpress-tests-lib/includes/functions.php); BLOCKED: npm run test:php -- --filter test_run_discards_truncated_tool_call_and_continues (missing ~/.wp-env docker-compose.yml for tests-wordpress container)

Resolves #1388


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.41 plugin for [OpenCode](https://opencode.ai) v1.14.49 with gpt-5.5 spent 19m and 506,433 tokens on this with the user in an interactive session.