### PR TITLE
fix(scaffold-block-theme): resolve realpath before wp_mkdir_p()

### DIFF
--- a/includes/Abilities/ScaffoldBlockThemeAbility.php
+++ b/includes/Abilities/ScaffoldBlockThemeAbility.php
@@ -148,6 +148,17 @@ class ScaffoldBlockThemeAbility extends AbstractAbility {
 			);
 		}
 
+		// Resolve any `..` segments from WP_CONTENT_DIR before passing the
+		// path to wp_mkdir_p(). WordPress core's wp_mkdir_p() refuses to
+		// create directories whose path contains unresolved parent-dir
+		// references even when the parent itself is writable — a real
+		// failure mode on dev installs and some shared-host configs where
+		// WP_CONTENT_DIR is defined with a relative ".." segment.
+		$resolved_root = realpath( $theme_root );
+		if ( false !== $resolved_root ) {
+			$theme_root = $resolved_root;
+		}
+
 		$theme_dir   = trailingslashit( $theme_root ) . $slug;
 		$existed     = is_dir( $theme_dir );
 		$overwritten = false;

--- a/tests/SdAiAgent/Abilities/ThemeBuilderAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/ThemeBuilderAbilitiesTest.php
@@ -260,6 +260,56 @@ class ThemeBuilderAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( '#abcdef', $decoded['settings']['color']['palette'][0]['color'] );
 	}
 
+	/**
+	 * ScaffoldBlockThemeAbility resolves `..` segments in WP_CONTENT_DIR
+	 * before passing the target path to wp_mkdir_p().
+	 *
+	 * Regression test for PR #1392 follow-up: dev installs where
+	 * WP_CONTENT_DIR is defined with a relative ".." segment (e.g. plugin
+	 * worktrees symlinked into the install) caused wp_mkdir_p() to refuse
+	 * the create even when the parent themes directory was writable and a
+	 * raw mkdir() on the same path succeeded.
+	 */
+	public function test_scaffold_handles_theme_root_with_parent_dir_segments(): void {
+		$canonical = untrailingslashit( get_theme_root() );
+
+		// Simulate a WP_CONTENT_DIR defined with a `..` segment by routing
+		// the theme_root filter through "<parent>/<basename>/../<basename>".
+		$dirname  = dirname( $canonical );
+		$basename = basename( $canonical );
+		$bouncy   = $dirname . '/../' . basename( $dirname ) . '/' . $basename;
+
+		$filter = static function () use ( $bouncy ) {
+			return $bouncy;
+		};
+		add_filter( 'theme_root', $filter );
+
+		try {
+			$slug    = $this->unique_slug( 'realpath-fix' );
+			$ability = new ScaffoldBlockThemeAbility( 'sd-ai-agent/scaffold-block-theme' );
+
+			$result = $ability->run(
+				[
+					'slug' => $slug,
+					'name' => 'Realpath Fix',
+				]
+			);
+
+			$this->assertIsArray(
+				$result,
+				is_wp_error( $result )
+					? 'Expected scaffold to succeed despite ".." segments in theme_root. Got: ' . $result->get_error_code() . ' / ' . $result->get_error_message()
+					: ''
+			);
+
+			$canonical_theme_dir = $canonical . '/' . $slug;
+			$this->assertDirectoryExists( $canonical_theme_dir );
+			$this->assertFileExists( $canonical_theme_dir . '/theme.json' );
+		} finally {
+			remove_filter( 'theme_root', $filter );
+		}
+	}
+
 	// ── ActivateThemeAbility ──────────────────────────────────────────────
 
 	/**


### PR DESCRIPTION
## Summary

- `ScaffoldBlockThemeAbility` returned `sd_ai_agent_mkdir_failed` on dev installs where `WP_CONTENT_DIR` contains a relative `..` segment, even though raw `mkdir()` on the same path succeeded.
- Root cause: WordPress core's `wp_mkdir_p()` refuses to create directories whose target path contains unresolved `..` segments, even when the parent is writable.
- Fix is one block: resolve `$theme_root` through `realpath()` after the existing `is_writable()` pre-check, before composing the target directory path. Harmless on already-canonical paths.

## Why this matters

Real-world dev environments and some shared-host configurations define `WP_CONTENT_DIR` with a `..` segment — for example a plugin checked out at `~/Git/superdav-ai-agent` symlinked into `~/Git/wordpress/wp-content/plugins/`. Without this fix the very first call to `sd-ai-agent/scaffold-block-theme` in those setups fails with no obvious diagnostic ("Could not create theme directory"), even though every filesystem permission is correct.

## Repro (before patch)

```php
wp_set_current_user( 1 );
$ability = wp_get_ability( 'sd-ai-agent/scaffold-block-theme' );
$ability->execute( [ 'slug' => 'demo', 'name' => 'Demo' ] );
// WP_Error: sd_ai_agent_mkdir_failed
//   "Could not create theme directory:
//    /path/to/plugin/../wordpress/wp-content/themes/demo"

mkdir( '/path/to/plugin/../wordpress/wp-content/themes/demo', 0755 );
// true  <-- raw mkdir works on the same path
```

## After patch

Functional check via wp-cli on the same install:

```
SCAFFOLD: OK theme_dir=/home/dave/Git/wordpress/wp-content/themes/realpath-fix-test files=4
```

Files written: `theme.json`, `style.css`, `functions.php`, `templates/index.html`.

## Test

Added regression test `test_scaffold_handles_theme_root_with_parent_dir_segments` that filters `theme_root` to inject a synthetic `..`-segmented path and confirms:

1. Scaffold completes without `WP_Error`.
2. Files land in the canonical (resolved) theme directory.

## Verification

- `composer phpcs` on the two changed files: 0 errors, 0 warnings
- `composer phpstan` (full project, level 10): 0 errors
- Functional wp-cli verification on a dev install with `..` in `WP_CONTENT_DIR`: scaffold succeeds and produces a valid block-theme skeleton (4 files, valid JSON, canonical headers)

## Scope

Single-purpose follow-up to PR #1392 (t226c-3a). Does not rename any canonical identifiers; preserves the `sd-ai-agent/` ability namespace, `SdAiAgent\` PHP namespace, and `superdav-ai-agent` text domain exactly as documented in `AGENTS.md`.

Ref #1385
Ref #1373

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.45 plugin for [OpenCode](https://opencode.ai) v1.14.49 with gpt-5.5 spent 1d 9h and 15,815 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved theme directory creation to handle paths with parent directory segments.

* **Tests**
  * Added test coverage for theme scaffold functionality with complex path configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1395)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->