### PR TITLE
fix: register plugin realpath so admin asset URLs resolve under symlinks

### DIFF
--- a/superdav-ai-agent.php
+++ b/superdav-ai-agent.php
@@ -22,6 +22,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 define( 'SD_AI_AGENT_VERSION', '1.11.1' );
 define( 'SD_AI_AGENT_DIR', __DIR__ );
+
+// Allow the plugin to load from a symlinked path. Without this, WordPress
+// resolves `__FILE__` to the realpath outside `WP_PLUGIN_DIR` and
+// `plugin_dir_url()` returns a malformed URL containing the absolute
+// filesystem path — admin asset URLs then 404 and the React chat panel
+// fails to mount. The function is a no-op when the plugin is not loaded
+// via a symlink (standard production installs).
+if ( function_exists( 'wp_register_plugin_realpath' ) ) {
+	wp_register_plugin_realpath( __FILE__ );
+}
+
 define( 'SD_AI_AGENT_URL', plugin_dir_url( __FILE__ ) );
 
 /**


### PR DESCRIPTION
## Summary

- WordPress core's `plugin_dir_url(__FILE__)` resolves `__FILE__` to the realpath when the plugin loads via a symlink in `wp-content/plugins/`. If the realpath is outside `WP_PLUGIN_DIR`, `plugins_url()` returns a malformed URL containing the absolute filesystem path.
- Admin asset URLs then 404 and the React chat panel never mounts.
- Standard WordPress idiom is `wp_register_plugin_realpath(__FILE__)`. This PR adds that one call before `SD_AI_AGENT_URL` is defined.

## Repro (before patch)

Following the `AGENTS.md` dev workflow ("This plugin: symlinked into `../wordpress/wp-content/plugins/$(basename $PWD)`"):

```
ln -s ~/Git/superdav-ai-agent ~/Git/wordpress/wp-content/plugins/superdav-ai-agent
```

Visit `/wp-admin/admin.php?page=sd-ai-agent`. Network shows:

```
http://wordpress.local:8080/wp-content/plugins/home/dave/Git/superdav-ai-agent/build/admin-page.js   404
http://wordpress.local:8080/wp-content/plugins/home/dave/Git/superdav-ai-agent/build/unified-admin.js   404
```

`#sdaa-root` stays empty.

## After patch

Same install, same symlink. Network shows:

```
http://wordpress.local:8080/wp-content/plugins/superdav-ai-agent/build/admin-page.js    200
http://wordpress.local:8080/wp-content/plugins/superdav-ai-agent/build/unified-admin.js 200
```

`#sdaa-root` mounts the React chat panel.

## Change

One conditional call to `wp_register_plugin_realpath(__FILE__)` immediately before the `SD_AI_AGENT_URL` constant is defined. The function is a no-op for plugins not loaded via symlink, so production installs are unaffected.

```php
if ( function_exists( 'wp_register_plugin_realpath' ) ) {
    wp_register_plugin_realpath( __FILE__ );
}

define( 'SD_AI_AGENT_URL', plugin_dir_url( __FILE__ ) );
```

## Verification

- `php -l superdav-ai-agent.php`: no syntax errors
- Manual browser test on dev install with symlinked plugin: admin asset URLs resolve to canonical `/wp-content/plugins/superdav-ai-agent/` path; React app mounts; chat panel visible
- No behaviour change for non-symlinked installs

## Scope

No canonical-identifier renames. Preserves all `sd-ai-agent/`, `SdAiAgent\`, `SD_AI_AGENT_`, and `superdav-ai-agent` usages exactly. Single file changed: `superdav-ai-agent.php` (+11 lines).

Resolves #1396

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.45 plugin for [OpenCode](https://opencode.ai) v1.14.49 with gpt-5.5 spent 1d 9h and 15,815 tokens on this as a headless worker.
