### PR TITLE
feat(sd-ai-xok): AbilityVisibility resolver + PartnerAllowlist

### DIFF
--- a/includes/Abilities/ThirdParty/PartnerAllowlist.php
+++ b/includes/Abilities/ThirdParty/PartnerAllowlist.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Curated allowlists of third-party ability namespaces and categories the
+ * plugin trusts as "intended for AI consumption" even when the ability author
+ * has not yet adopted the canonical `meta.mcp.public` flag.
+ *
+ * Why this exists
+ * ---------------
+ *
+ * The WordPress AI Building Blocks initiative defines `meta.mcp.public = true`
+ * (see WordPress/mcp-adapter) as the canonical signal that an ability is meant
+ * for AI / MCP consumption. The convention is new — most third-party plugins
+ * registered against the Abilities API today do not set it. {@see AbilityVisibility}
+ * uses the namespace/category entries here to keep those plugins working out of
+ * the box without forcing the site owner to triage every ability by hand.
+ *
+ * Editorial policy
+ * ----------------
+ *
+ * 1. Entries must be plugins/projects we have inspected and consider safe to
+ *    expose to the in-chat agent AND to external MCP clients on a default
+ *    install.
+ * 2. Prefer narrow prefixes that match a single plugin's namespace. Avoid
+ *    overly generic slugs (e.g. `core`) that could be hijacked by an
+ *    unrelated registrar.
+ * 3. Keep the lists short. The escape valve for end-users is the runtime
+ *    filter, not a sprawling default allowlist.
+ *
+ * @package SdAiAgent\Abilities\ThirdParty
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Abilities\ThirdParty;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Read-only registry of trusted third-party namespaces and categories.
+ *
+ * All accessors are static — the class is never instantiated. Runtime
+ * extension happens through the documented `sd_ai_agent_partner_namespaces`
+ * and `sd_ai_agent_partner_categories` filters, not by mutating the
+ * underlying constants.
+ *
+ * @since 1.9.0
+ */
+final class PartnerAllowlist {
+
+	/**
+	 * First-party ability namespaces. Abilities whose name (before the slash)
+	 * matches an entry here are always classified as `public-partner`.
+	 *
+	 * First-party namespaces are the ones this plugin ships or directly
+	 * integrates. They are listed here as a single source of truth so the
+	 * tests can guard them and downstream readers do not have to grep for
+	 * scattered `'sd-ai-agent/'` string literals.
+	 *
+	 * @var list<string>
+	 */
+	private const FIRST_PARTY_NAMESPACES = array(
+		'sd-ai-agent',
+		'wp-cli',
+		'sd-ai-agent-js',
+	);
+
+	/**
+	 * Verified third-party ability namespaces. Maintained by hand against the
+	 * plugin's docs entry on third-party support.
+	 *
+	 * @var list<string>
+	 */
+	private const PARTNER_NAMESPACES = array(
+		'woocommerce',
+		'woocommerce-rest',
+		'multisite-ultimate',
+		'mcp-adapter',
+	);
+
+	/**
+	 * Trusted category slugs. An ability registered under one of these
+	 * categories is classified as `public-partner` even when its namespace is
+	 * not on either allowlist above. These are categories shipped by core or
+	 * by upstream projects we have audited.
+	 *
+	 * @var list<string>
+	 */
+	private const PARTNER_CATEGORIES = array(
+		// Core ability categories (WordPress 6.9+).
+		'site',
+		'user',
+		'ai-experiments',
+		// First-party.
+		'sd-ai-agent',
+		'sd-ai-agent-js',
+		// Verified third-party.
+		'woocommerce-rest',
+		'multisite-ultimate',
+		'mcp-adapter',
+	);
+
+	/**
+	 * Return the full list of namespaces (first-party plus partner) that
+	 * should be classified as `public-partner`.
+	 *
+	 * The result is filterable so site operators can extend the list at
+	 * runtime without forking the plugin.
+	 *
+	 * @return list<string> Lowercased namespace slugs.
+	 */
+	public static function namespaces(): array {
+		$base = array_merge( self::FIRST_PARTY_NAMESPACES, self::PARTNER_NAMESPACES );
+
+		/**
+		 * Filter the list of trusted ability namespaces.
+		 *
+		 * Abilities whose name begins with `{namespace}/` are classified as
+		 * `public-partner` by {@see AbilityVisibility::classify()}.
+		 *
+		 * @since 1.9.0
+		 *
+		 * @param list<string> $namespaces Trusted namespace slugs.
+		 */
+		$filtered = apply_filters( 'sd_ai_agent_partner_namespaces', $base );
+
+		return self::normalise_string_list( $filtered, $base );
+	}
+
+	/**
+	 * Return the list of category slugs treated as trusted by default.
+	 *
+	 * @return list<string> Lowercased category slugs.
+	 */
+	public static function categories(): array {
+		/**
+		 * Filter the list of trusted ability categories.
+		 *
+		 * Abilities registered under one of these categories are classified
+		 * as `public-partner` by {@see AbilityVisibility::classify()} even
+		 * when their namespace is not on the namespace allowlist.
+		 *
+		 * @since 1.9.0
+		 *
+		 * @param list<string> $categories Trusted category slugs.
+		 */
+		$filtered = apply_filters( 'sd_ai_agent_partner_categories', self::PARTNER_CATEGORIES );
+
+		return self::normalise_string_list( $filtered, self::PARTNER_CATEGORIES );
+	}
+
+	/**
+	 * Whether the given ability name has a first-party or partner namespace.
+	 *
+	 * Comparison is case-insensitive on the namespace component (everything
+	 * before the first `/`). Abilities without a `/` separator never match.
+	 *
+	 * @param string $ability_name Fully-qualified ability id (`namespace/slug`).
+	 * @return bool
+	 */
+	public static function is_partner_namespace( string $ability_name ): bool {
+		if ( ! str_contains( $ability_name, '/' ) ) {
+			return false;
+		}
+
+		[ $namespace ] = explode( '/', $ability_name, 2 );
+		$namespace     = strtolower( trim( $namespace ) );
+
+		if ( '' === $namespace ) {
+			return false;
+		}
+
+		return in_array( $namespace, self::namespaces(), true );
+	}
+
+	/**
+	 * Whether the given category slug is on the trusted-categories list.
+	 *
+	 * @param string $category Category slug to test.
+	 * @return bool
+	 */
+	public static function is_partner_category( string $category ): bool {
+		$category = strtolower( trim( $category ) );
+
+		if ( '' === $category ) {
+			return false;
+		}
+
+		return in_array( $category, self::categories(), true );
+	}
+
+	/**
+	 * Whether the namespace is on the first-party portion of the allowlist.
+	 *
+	 * Kept separate from {@see is_partner_namespace()} so the classifier can
+	 * distinguish a first-party ability from a vetted third-party one when
+	 * surfacing diagnostics.
+	 *
+	 * @param string $ability_name Fully-qualified ability id.
+	 * @return bool
+	 */
+	public static function is_first_party_namespace( string $ability_name ): bool {
+		if ( ! str_contains( $ability_name, '/' ) ) {
+			return false;
+		}
+
+		[ $namespace ] = explode( '/', $ability_name, 2 );
+		$namespace     = strtolower( trim( $namespace ) );
+
+		if ( '' === $namespace ) {
+			return false;
+		}
+
+		return in_array( $namespace, self::FIRST_PARTY_NAMESPACES, true );
+	}
+
+	/**
+	 * Internal: coerce a filter result into a normalised, deduplicated
+	 * list of lowercased non-empty strings. Falls back to the supplied
+	 * default when the filtered value is not an array.
+	 *
+	 * @param mixed             $value    Raw filter return value.
+	 * @param array<int,string> $fallback List used when $value cannot be coerced.
+	 * @return list<string>
+	 */
+	private static function normalise_string_list( mixed $value, array $fallback ): array {
+		if ( ! is_array( $value ) ) {
+			$value = $fallback;
+		}
+
+		$out = array();
+		foreach ( $value as $entry ) {
+			if ( ! is_string( $entry ) ) {
+				continue;
+			}
+			$slug = strtolower( trim( $entry ) );
+			if ( '' === $slug ) {
+				continue;
+			}
+			$out[ $slug ] = true; // Dedup via assoc keys.
+		}
+
+		return array_keys( $out );
+	}
+}

--- a/includes/Core/AbilityVisibility.php
+++ b/includes/Core/AbilityVisibility.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Centralised visibility resolver for WordPress abilities.
+ *
+ * Why this exists
+ * ---------------
+ *
+ * Visibility of registered abilities to the AI agent and to the public MCP
+ * endpoint used to be enforced by four separate `! empty( $meta['ai_hidden'] )`
+ * checks scattered across the codebase. Every additional surface or rule risked
+ * drift. This class collapses the decision into one classifier and three
+ * surface-specific predicates, so every reader and writer shares the same
+ * answer.
+ *
+ * Visibility model
+ * ----------------
+ *
+ * Decision precedence — first match wins:
+ *
+ *   1. Explicit private:
+ *        - `meta.ai_hidden === true`
+ *        - `meta.mcp.public === false`
+ *   2. Explicit public:
+ *        - `meta.mcp.public === true`
+ *   3. First-party namespace (`sd-ai-agent/*`, `wp-cli/*`, …) → public-partner
+ *   4. Trusted partner namespace (woocommerce, multisite-ultimate, …) → public-partner
+ *   5. Trusted partner category (`site`, `user`, `ai-experiments`, …) → public-partner
+ *   6. Heuristic: ability has a non-empty `description` AND a non-empty
+ *      `category` → public-heuristic.
+ *   7. Otherwise → private-unknown.
+ *
+ * The `meta.mcp.public` flag is the canonical signal published by the
+ * WordPress AI Building Blocks initiative (see WordPress/mcp-adapter).
+ * Adopting it as the primary opt-in aligns the plugin with WooCommerce 10.3+
+ * and the broader ecosystem; the tier-3-onwards heuristics only kick in for
+ * abilities that pre-date the convention.
+ *
+ * Surface predicates
+ * ------------------
+ *
+ * Three call sites consume this class:
+ *
+ *   - `for_ai_chat()`   — Tier-1 FunctionDeclarations + Tier-2 system-prompt manifest.
+ *   - `for_mcp()`       — public `/sd-ai-agent/v1/mcp` `list_tools` response.
+ *   - `for_admin_picker()` — admin abilities list in the agent builder UI.
+ *
+ * They currently agree (everything `public-*` is exposed, everything `private-*`
+ * is hidden), but kept distinct so future policy (e.g. hiding write-capable
+ * abilities from the MCP endpoint by default) can land without re-touching the
+ * call sites.
+ *
+ * Pure functions, no side effects, no dependencies on the DI container.
+ *
+ * @package SdAiAgent\Core
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Core;
+
+use SdAiAgent\Abilities\ThirdParty\PartnerAllowlist;
+use WP_Ability;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Classify abilities and resolve per-surface visibility.
+ *
+ * @since 1.9.0
+ */
+final class AbilityVisibility {
+
+	/**
+	 * Classification result: declared public via `meta.mcp.public === true`.
+	 */
+	public const CLASSIFICATION_PUBLIC_EXPLICIT = 'public-explicit';
+
+	/**
+	 * Classification result: namespace or category is on the partner allowlist.
+	 */
+	public const CLASSIFICATION_PUBLIC_PARTNER = 'public-partner';
+
+	/**
+	 * Classification result: passes the description + category heuristic.
+	 */
+	public const CLASSIFICATION_PUBLIC_HEURISTIC = 'public-heuristic';
+
+	/**
+	 * Classification result: declared private via `ai_hidden` or `meta.mcp.public === false`.
+	 */
+	public const CLASSIFICATION_PRIVATE_EXPLICIT = 'private-explicit';
+
+	/**
+	 * Classification result: not declared public and fails every heuristic.
+	 *
+	 * The site owner has not opted this ability in; the ability author has
+	 * not flagged it. The admin notice in
+	 * {@see \SdAiAgent\Admin\ThirdPartyAbilityNoticeHandler} surfaces these.
+	 */
+	public const CLASSIFICATION_PRIVATE_UNKNOWN = 'private-unknown';
+
+	/**
+	 * Determine whether an ability should be visible to the in-chat AI agent.
+	 *
+	 * @param WP_Ability $ability The ability under consideration.
+	 * @return bool True when the ability may be loaded as a tool or listed in
+	 *              the system-prompt manifest.
+	 */
+	public static function for_ai_chat( WP_Ability $ability ): bool {
+		return self::is_public_classification( self::classify( $ability ) );
+	}
+
+	/**
+	 * Determine whether an ability should be advertised on the public MCP
+	 * endpoint that external clients (Claude Desktop, Cursor, …) consume.
+	 *
+	 * @param WP_Ability $ability The ability under consideration.
+	 * @return bool True when the ability is safe to expose to external MCP
+	 *              clients.
+	 */
+	public static function for_mcp( WP_Ability $ability ): bool {
+		return self::is_public_classification( self::classify( $ability ) );
+	}
+
+	/**
+	 * Determine whether an ability should appear in the admin agent-builder
+	 * picker.
+	 *
+	 * The admin picker is more permissive than the runtime surfaces: it shows
+	 * partner and heuristic-public abilities, but excludes only the
+	 * explicit-private ones. The intent is that an administrator selecting
+	 * tier-1 tools can see every ability the plugin author declared
+	 * AI-callable, including those the heuristic might dismiss as low-signal.
+	 *
+	 * @param WP_Ability $ability The ability under consideration.
+	 * @return bool
+	 */
+	public static function for_admin_picker( WP_Ability $ability ): bool {
+		return self::classify( $ability ) !== self::CLASSIFICATION_PRIVATE_EXPLICIT;
+	}
+
+	/**
+	 * Return the classification tier for an ability.
+	 *
+	 * @param WP_Ability $ability The ability under consideration.
+	 * @return string One of the `CLASSIFICATION_*` constants.
+	 */
+	public static function classify( WP_Ability $ability ): string {
+		$meta = $ability->get_meta();
+		if ( ! is_array( $meta ) ) {
+			$meta = array();
+		}
+
+		// 1. Explicit private wins over everything else.
+		if ( ! empty( $meta['ai_hidden'] ) ) {
+			return self::CLASSIFICATION_PRIVATE_EXPLICIT;
+		}
+
+		$mcp_public = self::read_mcp_public( $meta );
+		if ( false === $mcp_public ) {
+			return self::CLASSIFICATION_PRIVATE_EXPLICIT;
+		}
+
+		// 2. Explicit public.
+		if ( true === $mcp_public ) {
+			return self::CLASSIFICATION_PUBLIC_EXPLICIT;
+		}
+
+		// 3. & 4. Partner-allowlist (first-party + verified partners).
+		$name = (string) $ability->get_name();
+		if ( PartnerAllowlist::is_partner_namespace( $name ) ) {
+			return self::CLASSIFICATION_PUBLIC_PARTNER;
+		}
+
+		// 5. Partner category.
+		$category = (string) $ability->get_category();
+		if ( '' !== $category && PartnerAllowlist::is_partner_category( $category ) ) {
+			return self::CLASSIFICATION_PUBLIC_PARTNER;
+		}
+
+		// 6. Heuristic: well-formed registration.
+		$description = trim( (string) $ability->get_description() );
+		if ( '' !== $description && '' !== $category ) {
+			return self::CLASSIFICATION_PUBLIC_HEURISTIC;
+		}
+
+		// 7. Fall-through.
+		return self::CLASSIFICATION_PRIVATE_UNKNOWN;
+	}
+
+	/**
+	 * Whether the classification represents a "publicly exposed" tier.
+	 *
+	 * @param string $classification Classification string.
+	 * @return bool
+	 */
+	public static function is_public_classification( string $classification ): bool {
+		return in_array(
+			$classification,
+			array(
+				self::CLASSIFICATION_PUBLIC_EXPLICIT,
+				self::CLASSIFICATION_PUBLIC_PARTNER,
+				self::CLASSIFICATION_PUBLIC_HEURISTIC,
+			),
+			true
+		);
+	}
+
+	/**
+	 * Extract the `meta.mcp.public` flag from an ability meta array.
+	 *
+	 * Returns a tri-state:
+	 *   - `true`  → explicitly public
+	 *   - `false` → explicitly private
+	 *   - `null`  → not declared (caller should fall through to heuristics)
+	 *
+	 * Accepts both the canonical nested form `meta.mcp.public` and the flat
+	 * `meta.mcp_public` form some early adopters used. Non-boolean values are
+	 * treated as "not declared" to avoid accidental positive classifications
+	 * when a registrar populates the slot with junk.
+	 *
+	 * @param array<string,mixed> $meta The ability's `meta` array.
+	 * @return bool|null
+	 */
+	private static function read_mcp_public( array $meta ): ?bool {
+		if ( isset( $meta['mcp'] ) && is_array( $meta['mcp'] ) && array_key_exists( 'public', $meta['mcp'] ) ) {
+			$flag = $meta['mcp']['public'];
+			if ( is_bool( $flag ) ) {
+				return $flag;
+			}
+		}
+
+		if ( array_key_exists( 'mcp_public', $meta ) && is_bool( $meta['mcp_public'] ) ) {
+			return $meta['mcp_public'];
+		}
+
+		return null;
+	}
+}

--- a/tests/SdAiAgent/Abilities/ThirdParty/PartnerAllowlistTest.php
+++ b/tests/SdAiAgent/Abilities/ThirdParty/PartnerAllowlistTest.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * Test case for the PartnerAllowlist registry.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Abilities\ThirdParty;
+
+use SdAiAgent\Abilities\ThirdParty\PartnerAllowlist;
+use WP_UnitTestCase;
+
+/**
+ * Covers the static accessors and the documented filter contracts.
+ */
+class PartnerAllowlistTest extends WP_UnitTestCase {
+
+	/**
+	 * Drop any test-registered filter callbacks between cases.
+	 */
+	public function tearDown(): void {
+		remove_all_filters( 'sd_ai_agent_partner_namespaces' );
+		remove_all_filters( 'sd_ai_agent_partner_categories' );
+		parent::tearDown();
+	}
+
+	// ─── namespaces() ────────────────────────────────────────────────────
+
+	/**
+	 * The default namespace list contains the first-party slugs we ship.
+	 */
+	public function test_namespaces_contain_first_party(): void {
+		$namespaces = PartnerAllowlist::namespaces();
+
+		$this->assertContains( 'sd-ai-agent', $namespaces );
+		$this->assertContains( 'wp-cli', $namespaces );
+	}
+
+	/**
+	 * The default namespace list contains the documented partner slugs.
+	 */
+	public function test_namespaces_contain_verified_partners(): void {
+		$namespaces = PartnerAllowlist::namespaces();
+
+		$this->assertContains( 'woocommerce', $namespaces );
+		$this->assertContains( 'multisite-ultimate', $namespaces );
+		$this->assertContains( 'mcp-adapter', $namespaces );
+	}
+
+	/**
+	 * The filter can add new entries without losing the defaults.
+	 */
+	public function test_namespaces_filter_can_append(): void {
+		add_filter(
+			'sd_ai_agent_partner_namespaces',
+			static function ( array $existing ): array {
+				$existing[] = 'my-trusted-plugin';
+				return $existing;
+			}
+		);
+
+		$namespaces = PartnerAllowlist::namespaces();
+
+		$this->assertContains( 'my-trusted-plugin', $namespaces );
+		$this->assertContains( 'sd-ai-agent', $namespaces, 'Defaults must be retained alongside additions.' );
+	}
+
+	/**
+	 * Non-string entries returned by the filter are dropped silently.
+	 */
+	public function test_namespaces_filter_strips_non_strings(): void {
+		add_filter(
+			'sd_ai_agent_partner_namespaces',
+			static function (): array {
+				return array( 'good', 42, null, '', new \stdClass(), 'also-good' );
+			}
+		);
+
+		$namespaces = PartnerAllowlist::namespaces();
+
+		$this->assertSame( array( 'good', 'also-good' ), $namespaces );
+	}
+
+	/**
+	 * A non-array filter return falls back to the documented defaults.
+	 */
+	public function test_namespaces_filter_non_array_falls_back_to_default(): void {
+		add_filter(
+			'sd_ai_agent_partner_namespaces',
+			static function () {
+				return 'not an array';
+			}
+		);
+
+		$namespaces = PartnerAllowlist::namespaces();
+
+		$this->assertContains( 'sd-ai-agent', $namespaces );
+		$this->assertContains( 'woocommerce', $namespaces );
+	}
+
+	/**
+	 * Duplicate entries (case-insensitive) collapse to a single slug.
+	 */
+	public function test_namespaces_dedup_case_insensitive(): void {
+		add_filter(
+			'sd_ai_agent_partner_namespaces',
+			static function (): array {
+				return array( 'TrustMe', 'trustme', 'TRUSTME', '  trustme  ' );
+			}
+		);
+
+		$namespaces = PartnerAllowlist::namespaces();
+
+		$this->assertSame( array( 'trustme' ), $namespaces );
+	}
+
+	// ─── categories() ────────────────────────────────────────────────────
+
+	/**
+	 * Core ability categories are present by default.
+	 */
+	public function test_categories_contain_core_slugs(): void {
+		$categories = PartnerAllowlist::categories();
+
+		$this->assertContains( 'site', $categories );
+		$this->assertContains( 'user', $categories );
+		$this->assertContains( 'ai-experiments', $categories );
+	}
+
+	/**
+	 * The categories filter is honoured.
+	 */
+	public function test_categories_filter_can_append(): void {
+		add_filter(
+			'sd_ai_agent_partner_categories',
+			static function ( array $existing ): array {
+				$existing[] = 'my-category';
+				return $existing;
+			}
+		);
+
+		$categories = PartnerAllowlist::categories();
+
+		$this->assertContains( 'my-category', $categories );
+		$this->assertContains( 'site', $categories );
+	}
+
+	// ─── is_partner_namespace() ──────────────────────────────────────────
+
+	/**
+	 * First-party namespaces match.
+	 */
+	public function test_is_partner_namespace_matches_first_party(): void {
+		$this->assertTrue( PartnerAllowlist::is_partner_namespace( 'sd-ai-agent/memory-save' ) );
+		$this->assertTrue( PartnerAllowlist::is_partner_namespace( 'wp-cli/execute' ) );
+	}
+
+	/**
+	 * Verified-partner namespaces match.
+	 */
+	public function test_is_partner_namespace_matches_partner(): void {
+		$this->assertTrue( PartnerAllowlist::is_partner_namespace( 'woocommerce/products-list' ) );
+		$this->assertTrue( PartnerAllowlist::is_partner_namespace( 'multisite-ultimate/site-create-item' ) );
+	}
+
+	/**
+	 * Unknown namespaces never match.
+	 */
+	public function test_is_partner_namespace_rejects_unknown(): void {
+		$this->assertFalse( PartnerAllowlist::is_partner_namespace( 'totally-random/foo' ) );
+		$this->assertFalse( PartnerAllowlist::is_partner_namespace( 'evil/exec' ) );
+	}
+
+	/**
+	 * Ability ids without a slash separator do not match.
+	 */
+	public function test_is_partner_namespace_rejects_unnamespaced(): void {
+		$this->assertFalse( PartnerAllowlist::is_partner_namespace( 'no-slash-here' ) );
+		$this->assertFalse( PartnerAllowlist::is_partner_namespace( '' ) );
+	}
+
+	/**
+	 * Matching is case-insensitive on the namespace component.
+	 */
+	public function test_is_partner_namespace_case_insensitive(): void {
+		$this->assertTrue( PartnerAllowlist::is_partner_namespace( 'SD-AI-AGENT/Memory-Save' ) );
+		$this->assertTrue( PartnerAllowlist::is_partner_namespace( 'WooCommerce/products-list' ) );
+	}
+
+	// ─── is_first_party_namespace() ──────────────────────────────────────
+
+	/**
+	 * First-party check excludes verified partners.
+	 */
+	public function test_is_first_party_namespace_only_matches_first_party(): void {
+		$this->assertTrue( PartnerAllowlist::is_first_party_namespace( 'sd-ai-agent/memory-save' ) );
+		$this->assertTrue( PartnerAllowlist::is_first_party_namespace( 'wp-cli/execute' ) );
+		$this->assertTrue( PartnerAllowlist::is_first_party_namespace( 'sd-ai-agent-js/screenshot' ) );
+
+		$this->assertFalse( PartnerAllowlist::is_first_party_namespace( 'woocommerce/orders-list' ) );
+		$this->assertFalse( PartnerAllowlist::is_first_party_namespace( 'random/foo' ) );
+	}
+
+	// ─── is_partner_category() ───────────────────────────────────────────
+
+	/**
+	 * Core categories match.
+	 */
+	public function test_is_partner_category_matches_core_slugs(): void {
+		$this->assertTrue( PartnerAllowlist::is_partner_category( 'site' ) );
+		$this->assertTrue( PartnerAllowlist::is_partner_category( 'user' ) );
+	}
+
+	/**
+	 * Unknown categories do not match.
+	 */
+	public function test_is_partner_category_rejects_unknown(): void {
+		$this->assertFalse( PartnerAllowlist::is_partner_category( 'unknown-cat' ) );
+		$this->assertFalse( PartnerAllowlist::is_partner_category( '' ) );
+		$this->assertFalse( PartnerAllowlist::is_partner_category( '   ' ) );
+	}
+
+	/**
+	 * Whitespace and casing are normalised.
+	 */
+	public function test_is_partner_category_normalises_input(): void {
+		$this->assertTrue( PartnerAllowlist::is_partner_category( '  SITE  ' ) );
+		$this->assertTrue( PartnerAllowlist::is_partner_category( 'WooCommerce-Rest' ) );
+	}
+}

--- a/tests/SdAiAgent/Core/AbilityVisibilityTest.php
+++ b/tests/SdAiAgent/Core/AbilityVisibilityTest.php
@@ -1,0 +1,390 @@
+<?php
+/**
+ * Test case for the AbilityVisibility resolver.
+ *
+ * Covers the full classification decision tree and the three surface
+ * predicates (`for_ai_chat()`, `for_mcp()`, `for_admin_picker()`).
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\AbilityVisibility;
+use WP_Ability;
+use WP_UnitTestCase;
+
+/**
+ * Behavioural tests for the visibility classifier.
+ */
+class AbilityVisibilityTest extends WP_UnitTestCase {
+
+	/**
+	 * Skip the suite when WP 7.0+ Abilities API is unavailable.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			$this->markTestSkipped( 'WP_Ability not available — requires WP 7.0+.' );
+		}
+	}
+
+	/**
+	 * Drop test-registered filters between cases.
+	 */
+	public function tearDown(): void {
+		remove_all_filters( 'sd_ai_agent_partner_namespaces' );
+		remove_all_filters( 'sd_ai_agent_partner_categories' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Construct an in-memory WP_Ability with optional overrides.
+	 *
+	 * Tests intentionally instantiate WP_Ability directly rather than going
+	 * through `wp_register_ability()` so the global registry state does not
+	 * leak between cases.
+	 *
+	 * @param string              $name     Ability id (defaults to a synthetic namespace).
+	 * @param array<string,mixed> $overrides Partial property overrides.
+	 * @return WP_Ability
+	 */
+	private function make_ability( string $name = 'random-plugin/example', array $overrides = array() ): WP_Ability {
+		$defaults = array(
+			'label'               => 'Example',
+			'description'         => 'An example ability.',
+			'category'            => 'random-plugin',
+			'execute_callback'    => '__return_true',
+			'permission_callback' => '__return_true',
+		);
+
+		$properties = array_replace( $defaults, $overrides );
+
+		return new WP_Ability( $name, $properties );
+	}
+
+	// ─── classify(): explicit private ────────────────────────────────────
+
+	/**
+	 * `ai_hidden === true` always wins, regardless of other meta.
+	 */
+	public function test_ai_hidden_true_classifies_private_explicit(): void {
+		$ability = $this->make_ability(
+			'sd-ai-agent/internal',
+			array(
+				'meta' => array(
+					'ai_hidden' => true,
+					// Even when paired with mcp.public = true, ai_hidden wins.
+					'mcp'       => array( 'public' => true ),
+				),
+			)
+		);
+
+		$this->assertSame(
+			AbilityVisibility::CLASSIFICATION_PRIVATE_EXPLICIT,
+			AbilityVisibility::classify( $ability )
+		);
+		$this->assertFalse( AbilityVisibility::for_ai_chat( $ability ) );
+		$this->assertFalse( AbilityVisibility::for_mcp( $ability ) );
+		$this->assertFalse( AbilityVisibility::for_admin_picker( $ability ) );
+	}
+
+	/**
+	 * `meta.mcp.public === false` is treated as explicit private.
+	 */
+	public function test_mcp_public_false_classifies_private_explicit(): void {
+		$ability = $this->make_ability(
+			'sd-ai-agent/internal',
+			array(
+				'meta' => array(
+					'mcp' => array( 'public' => false ),
+				),
+			)
+		);
+
+		$this->assertSame(
+			AbilityVisibility::CLASSIFICATION_PRIVATE_EXPLICIT,
+			AbilityVisibility::classify( $ability )
+		);
+	}
+
+	/**
+	 * Flat `meta.mcp_public === false` alias is honoured.
+	 */
+	public function test_flat_mcp_public_false_classifies_private_explicit(): void {
+		$ability = $this->make_ability(
+			'sd-ai-agent/legacy-shape',
+			array(
+				'meta' => array(
+					'mcp_public' => false,
+				),
+			)
+		);
+
+		$this->assertSame(
+			AbilityVisibility::CLASSIFICATION_PRIVATE_EXPLICIT,
+			AbilityVisibility::classify( $ability )
+		);
+	}
+
+	// ─── classify(): explicit public ─────────────────────────────────────
+
+	/**
+	 * `meta.mcp.public === true` from a stranger namespace still wins.
+	 *
+	 * This is the canonical signal — if the third-party author opts in, we
+	 * trust them.
+	 */
+	public function test_mcp_public_true_classifies_public_explicit(): void {
+		$ability = $this->make_ability(
+			'random-plugin/foo',
+			array(
+				'meta' => array(
+					'mcp' => array( 'public' => true ),
+				),
+			)
+		);
+
+		$this->assertSame(
+			AbilityVisibility::CLASSIFICATION_PUBLIC_EXPLICIT,
+			AbilityVisibility::classify( $ability )
+		);
+		$this->assertTrue( AbilityVisibility::for_ai_chat( $ability ) );
+		$this->assertTrue( AbilityVisibility::for_mcp( $ability ) );
+	}
+
+	/**
+	 * Non-boolean `meta.mcp.public` is ignored (falls through to heuristics).
+	 *
+	 * Junk values must not unlock either side of the gate.
+	 */
+	public function test_non_boolean_mcp_public_is_ignored(): void {
+		$ability = $this->make_ability(
+			'random-plugin/junk',
+			array(
+				'meta' => array(
+					'mcp' => array( 'public' => 'yes' ),
+				),
+			)
+		);
+
+		// `random-plugin` is unknown; ability still has description + category,
+		// so it should fall through to the heuristic tier rather than
+		// being treated as explicit-public from the malformed value.
+		$this->assertSame(
+			AbilityVisibility::CLASSIFICATION_PUBLIC_HEURISTIC,
+			AbilityVisibility::classify( $ability )
+		);
+	}
+
+	// ─── classify(): partner namespace ───────────────────────────────────
+
+	/**
+	 * Unflagged first-party abilities classify as partner-public.
+	 */
+	public function test_first_party_namespace_classifies_public_partner(): void {
+		$ability = $this->make_ability(
+			'sd-ai-agent/some-ability',
+			array(
+				'category' => 'sd-ai-agent',
+			)
+		);
+
+		$this->assertSame(
+			AbilityVisibility::CLASSIFICATION_PUBLIC_PARTNER,
+			AbilityVisibility::classify( $ability )
+		);
+	}
+
+	/**
+	 * Documented partner namespaces classify as partner-public.
+	 */
+	public function test_partner_namespace_classifies_public_partner(): void {
+		$ability = $this->make_ability(
+			'woocommerce/products-list',
+			array(
+				'category' => 'woocommerce-rest',
+			)
+		);
+
+		$this->assertSame(
+			AbilityVisibility::CLASSIFICATION_PUBLIC_PARTNER,
+			AbilityVisibility::classify( $ability )
+		);
+	}
+
+	/**
+	 * Runtime filter additions to the namespace list are honoured.
+	 */
+	public function test_runtime_partner_namespace_filter_promotes_to_partner(): void {
+		add_filter(
+			'sd_ai_agent_partner_namespaces',
+			static function ( array $existing ): array {
+				$existing[] = 'random-plugin';
+				return $existing;
+			}
+		);
+
+		$ability = $this->make_ability( 'random-plugin/foo' );
+
+		$this->assertSame(
+			AbilityVisibility::CLASSIFICATION_PUBLIC_PARTNER,
+			AbilityVisibility::classify( $ability )
+		);
+	}
+
+	// ─── classify(): partner category ────────────────────────────────────
+
+	/**
+	 * Trusted-category match wins even when the namespace is unknown.
+	 */
+	public function test_partner_category_classifies_public_partner(): void {
+		$ability = $this->make_ability(
+			'random-plugin/get-something',
+			array(
+				'category' => 'site', // Core ability category.
+			)
+		);
+
+		$this->assertSame(
+			AbilityVisibility::CLASSIFICATION_PUBLIC_PARTNER,
+			AbilityVisibility::classify( $ability )
+		);
+	}
+
+	// ─── classify(): heuristic ───────────────────────────────────────────
+
+	/**
+	 * Description + category present, no other signal → heuristic public.
+	 */
+	public function test_well_formed_unknown_namespace_classifies_heuristic(): void {
+		$ability = $this->make_ability(
+			'random-plugin/heuristic',
+			array(
+				'description' => 'A well-described ability with a category.',
+				'category'    => 'random-plugin',
+			)
+		);
+
+		$this->assertSame(
+			AbilityVisibility::CLASSIFICATION_PUBLIC_HEURISTIC,
+			AbilityVisibility::classify( $ability )
+		);
+	}
+
+	// ─── classify(): private-unknown ─────────────────────────────────────
+
+	/**
+	 * Whitespace-only description does not satisfy the heuristic.
+	 *
+	 * `WP_Ability::prepare_properties()` rejects truly empty descriptions
+	 * (`description => ''`) at construction time via `empty()`, so the
+	 * resolver only ever sees whitespace-or-better. This case ensures that
+	 * `trim()`-equivalent whitespace still falls through to private-unknown
+	 * rather than satisfying the heuristic.
+	 */
+	public function test_whitespace_only_description_classifies_private_unknown(): void {
+		$ability = $this->make_ability(
+			'random-plugin/whitespace-desc',
+			array(
+				'description' => "   \t\n  ",
+				'category'    => 'random-plugin',
+			)
+		);
+
+		$this->assertSame(
+			AbilityVisibility::CLASSIFICATION_PRIVATE_UNKNOWN,
+			AbilityVisibility::classify( $ability )
+		);
+	}
+
+	// ─── Admin picker leniency ───────────────────────────────────────────
+
+	/**
+	 * The admin picker shows everything except explicit-private classifications.
+	 *
+	 * This includes private-unknown abilities — the agent builder UI is
+	 * authoritative for surfacing the full registry to administrators so they
+	 * can opt-in unrecognised abilities.
+	 */
+	public function test_admin_picker_surfaces_private_unknown(): void {
+		$ability = $this->make_ability(
+			'random-plugin/blank-desc',
+			array(
+				// `WP_Ability` rejects truly empty descriptions, so we use
+				// whitespace — the resolver still classifies private-unknown
+				// because the heuristic trims before testing for emptiness.
+				'description' => "   \t  ",
+				'category'    => 'random-plugin',
+			)
+		);
+
+		$this->assertSame(
+			AbilityVisibility::CLASSIFICATION_PRIVATE_UNKNOWN,
+			AbilityVisibility::classify( $ability )
+		);
+		$this->assertTrue( AbilityVisibility::for_admin_picker( $ability ) );
+		$this->assertFalse( AbilityVisibility::for_ai_chat( $ability ) );
+	}
+
+	/**
+	 * Admin picker still hides explicit-private abilities.
+	 */
+	public function test_admin_picker_hides_ai_hidden(): void {
+		$ability = $this->make_ability(
+			'sd-ai-agent/internal',
+			array(
+				'meta' => array(
+					'ai_hidden' => true,
+				),
+			)
+		);
+
+		$this->assertFalse( AbilityVisibility::for_admin_picker( $ability ) );
+	}
+
+	// ─── Helper invariants ───────────────────────────────────────────────
+
+	/**
+	 * `is_public_classification()` agrees with itself for every constant.
+	 */
+	public function test_is_public_classification_constants(): void {
+		$this->assertTrue(
+			AbilityVisibility::is_public_classification( AbilityVisibility::CLASSIFICATION_PUBLIC_EXPLICIT )
+		);
+		$this->assertTrue(
+			AbilityVisibility::is_public_classification( AbilityVisibility::CLASSIFICATION_PUBLIC_PARTNER )
+		);
+		$this->assertTrue(
+			AbilityVisibility::is_public_classification( AbilityVisibility::CLASSIFICATION_PUBLIC_HEURISTIC )
+		);
+		$this->assertFalse(
+			AbilityVisibility::is_public_classification( AbilityVisibility::CLASSIFICATION_PRIVATE_EXPLICIT )
+		);
+		$this->assertFalse(
+			AbilityVisibility::is_public_classification( AbilityVisibility::CLASSIFICATION_PRIVATE_UNKNOWN )
+		);
+	}
+
+	/**
+	 * Missing `meta` entirely is handled gracefully (treated as no flags set).
+	 */
+	public function test_missing_meta_falls_through_to_heuristic(): void {
+		$ability = $this->make_ability(
+			'random-plugin/no-meta',
+			array(
+				'category' => 'random-plugin',
+				// meta not set at all.
+			)
+		);
+
+		$this->assertSame(
+			AbilityVisibility::CLASSIFICATION_PUBLIC_HEURISTIC,
+			AbilityVisibility::classify( $ability )
+		);
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `SdAiAgent\Core\AbilityVisibility` — single classifier + three surface predicates (`for_ai_chat()`, `for_mcp()`, `for_admin_picker()`) for third-party ability visibility decisions.
- Adds `SdAiAgent\Abilities\ThirdParty\PartnerAllowlist` — first-party namespaces, verified-partner namespaces (WooCommerce, Multisite Ultimate, etc.), and trusted categories, with `sd_ai_agent_partner_namespaces` / `sd_ai_agent_partner_categories` filters.
- Pure additive — no existing call site is rewired in this PR.

## Why

Today the same `! empty( $meta['ai_hidden'] )` check is duplicated in:

- `includes/Tools/ToolDiscovery.php:343, 993`
- `includes/Core/AgentLoop.php:1422`
- `includes/REST/AgentController.php:583`

And `includes/REST/McpController.php` lacks any gate at all, so the public MCP endpoint advertises every ability regardless of intent (tracked separately in beads `sd-ai-3ns`).

Centralising the decision once means future policy changes (e.g. hiding write-capable abilities from MCP by default) touch one file, not five.

## Visibility model

Decision precedence (first match wins):

1. `meta.ai_hidden === true` → `private-explicit`
2. `meta.mcp.public === false` → `private-explicit`
3. `meta.mcp.public === true` → `public-explicit`
4. First-party or partner namespace → `public-partner`
5. Partner category → `public-partner`
6. Non-empty description + non-empty category → `public-heuristic`
7. Otherwise → `private-unknown`

The `meta.mcp.public` flag is the canonical signal from [WordPress/mcp-adapter](https://github.com/WordPress/mcp-adapter) v0.5.0, also adopted by WooCommerce 10.3+. The flat `meta.mcp_public` alias is accepted to ease migration for early adopters.

The admin picker is intentionally more permissive than the runtime surfaces — it surfaces `private-unknown` abilities so administrators can opt-in unrecognised tools, while still hiding explicit-private ones.

## Verification

- `composer phpcs` — clean on all four new files.
- `composer phpstan` — `No errors` on the production classes.
- PHPUnit (just the new tests): **32 tests, 64 assertions, 0 failures**.
- PHPUnit (full suite): **1990 tests, 5511 assertions, 0 failures**, 78 environment-skipped (unchanged baseline).

## What this PR does NOT change

The four legacy `ai_hidden` call sites stay untouched. Migration of `ToolDiscovery`, `AgentLoop`, `AgentController`, and the new `McpController` gate is split out so each can be reviewed independently:

- `sd-ai-3ns` — gate `McpController::get_mcp_tools()` via `for_mcp()` and migrate the other three sites.
- `sd-ai-w7a` — migrate `AbilityExplorerService` to consume `for_admin_picker()`.
- `sd-ai-dam` — fix the tri-state `null → false` coercion at `AbilityExplorerService:152-159`.

## Refs

- Epic: `sd-ai-aey` (Standards-aligned third-party ability visibility).
- This PR: `sd-ai-xok` (foundation).

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.45 plugin for [OpenCode](https://opencode.ai) v1.14.49 with gpt-5.5 spent 1d 10h and 15,815 tokens on this as a headless worker.
