### PR TITLE
fix(sd-ai-dam): preserve tri-state annotations in abilities explorer (#1407)

### DIFF
--- a/includes/Services/AbilityExplorerService.php
+++ b/includes/Services/AbilityExplorerService.php
@@ -149,18 +149,57 @@ final class AbilityExplorerService {
 			'category'        => $ability->get_category(),
 			'param_count'     => $param_count,
 			'required_params' => $required_params,
-			'annotations'     => array(
-				// @phpstan-ignore-next-line
-				'readonly'    => (bool) ( $annotations['readonly'] ?? false ),
-				// @phpstan-ignore-next-line
-				'destructive' => (bool) ( $annotations['destructive'] ?? false ),
-				// @phpstan-ignore-next-line
-				'idempotent'  => (bool) ( $annotations['idempotent'] ?? false ),
-			),
+			'annotations'     => self::normalise_annotations( $annotations ),
 			// @phpstan-ignore-next-line
 			'output_schema'   => $ability->get_output_schema(),
 			'show_in_rest'    => (bool) ( $meta['show_in_rest'] ?? false ),
 		);
+	}
+
+	/**
+	 * Normalise an ability's MCP annotation set to a strict tri-state shape.
+	 *
+	 * The MCP specification (and {@see \SdAiAgent\Abilities\AbstractAbility::meta()})
+	 * defines `readonly`, `destructive`, and `idempotent` as a tri-state where
+	 * `null` means "the ability author did not declare this hint, treat as
+	 * unknown". Coercing those nulls to `false` silently mis-classifies
+	 * unknown-destructive abilities as safe.
+	 *
+	 * This helper:
+	 *   - Returns `true`/`false` only when the source value is a real boolean.
+	 *   - Returns `null` for any other value (missing key, null, junk).
+	 *
+	 * Downstream consumers (e.g. the abilities-explorer React component) MUST
+	 * render the `null` state distinctly from `false` and treat it as
+	 * "assume destructive" for any safety decision.
+	 *
+	 * @since 1.9.0
+	 *
+	 * @param mixed $annotations Raw annotations slot from `WP_Ability::get_meta()`.
+	 * @return array{readonly: bool|null, destructive: bool|null, idempotent: bool|null}
+	 */
+	private static function normalise_annotations( $annotations ): array {
+		if ( ! is_array( $annotations ) ) {
+			$annotations = array();
+		}
+
+		return array(
+			'readonly'    => self::read_tristate( $annotations, 'readonly' ),
+			'destructive' => self::read_tristate( $annotations, 'destructive' ),
+			'idempotent'  => self::read_tristate( $annotations, 'idempotent' ),
+		);
+	}
+
+	/**
+	 * Read a single tri-state annotation slot.
+	 *
+	 * @param array<string,mixed> $annotations Annotations array.
+	 * @param string              $key         Slot to read.
+	 * @return bool|null
+	 */
+	private static function read_tristate( array $annotations, string $key ): ?bool {
+		$value = $annotations[ $key ] ?? null;
+		return is_bool( $value ) ? $value : null;
 	}
 
 	/**
@@ -182,11 +221,7 @@ final class AbilityExplorerService {
 			'category'        => $descriptor['category'],
 			'param_count'     => $param_count,
 			'required_params' => $required_params,
-			'annotations'     => array(
-				'readonly'    => (bool) ( $annotations['readonly'] ?? false ),
-				'destructive' => false,
-				'idempotent'  => false,
-			),
+			'annotations'     => self::normalise_annotations( $annotations ),
 			'output_schema'   => $descriptor['output_schema'] ?? array(),
 			'show_in_rest'    => false,
 		);

--- a/src/abilities-explorer/abilities-explorer-app.js
+++ b/src/abilities-explorer/abilities-explorer-app.js
@@ -80,18 +80,70 @@ function Badge( { intent = 'default', children } ) {
 }
 
 /**
- * Renders a badge only when the annotation is active.
+ * Renders a tri-state annotation badge.
  *
- * @param {Object}  props
- * @param {string}  props.label  Badge label text.
- * @param {boolean} props.active Whether to render the badge.
- * @param {string}  props.intent Badge colour intent.
+ * The MCP annotation slots (`readonly`, `destructive`, `idempotent`) are a
+ * tri-state where `null` means "the ability author did not declare this hint".
+ * Coercing `null` to `false` silently mis-classifies unknown-destructive
+ * abilities as safe, so this component renders three visually-distinct states:
+ *
+ *  - `true`  -> coloured badge with the supplied intent (e.g. `error` for
+ *               destructive abilities).
+ *  - `false` -> muted "not <label>" badge so reviewers can see the author
+ *               explicitly declared the hint as off.
+ *  - `null`/undefined -> warning-coloured "<label>?" badge with a tooltip
+ *               telling the operator to assume the worst (destructive).
+ *
+ * @param {Object}       props
+ * @param {string}       props.label  Annotation slot label (e.g. "destructive").
+ * @param {boolean|null} props.active Tri-state annotation value.
+ * @param {string}       props.intent Badge colour intent for the `true` state.
  */
 function AnnotationBadge( { label, active, intent } ) {
-	if ( ! active ) {
-		return null;
+	if ( true === active ) {
+		return <Badge intent={ intent }>{ label }</Badge>;
 	}
-	return <Badge intent={ intent }>{ label }</Badge>;
+
+	if ( false === active ) {
+		return (
+			<Badge intent="default">
+				<span
+					style={ { opacity: 0.7 } }
+					title={ sprintf(
+						/* translators: %s: annotation name (e.g. "destructive") */
+						__(
+							'Ability author declared this hint as off (not %s).',
+							'superdav-ai-agent'
+						),
+						label
+					) }
+				>
+					{ sprintf(
+						/* translators: %s: annotation name (e.g. "destructive") */
+						__( 'not %s', 'superdav-ai-agent' ),
+						label
+					) }
+				</span>
+			</Badge>
+		);
+	}
+
+	return (
+		<Badge intent="warning">
+			<span
+				title={ __(
+					'Not declared by ability author — assume destructive for safety.',
+					'superdav-ai-agent'
+				) }
+			>
+				{ sprintf(
+					/* translators: %s: annotation name (e.g. "destructive") */
+					__( '%s?', 'superdav-ai-agent' ),
+					label
+				) }
+			</span>
+		</Badge>
+	);
 }
 
 /**

--- a/tests/SdAiAgent/Services/AbilityExplorerServiceTest.php
+++ b/tests/SdAiAgent/Services/AbilityExplorerServiceTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Tests for AbilityExplorerService tri-state annotation handling.
+ *
+ * Covers the bug where missing/null MCP annotation hints were silently
+ * coerced to `false`, causing the Abilities Explorer UI to mis-classify
+ * unknown-destructive abilities as safe (see beads sd-ai-dam / GH #1407).
+ *
+ * The fix introduces two private helpers — `normalise_annotations()` and
+ * `read_tristate()` — that preserve `true`/`false`/`null` distinctly and
+ * are shared between the PHP-ability and JS-ability formatters.
+ *
+ * @package SdAiAgent\Tests\Services
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Services;
+
+use SdAiAgent\Services\AbilityExplorerService;
+use WP_UnitTestCase;
+
+/**
+ * Tests for AbilityExplorerService private tri-state helpers and formatters.
+ */
+class AbilityExplorerServiceTest extends WP_UnitTestCase {
+
+	/**
+	 * Invoke a private static method on AbilityExplorerService.
+	 *
+	 * @param string             $method Method name.
+	 * @param array<int, mixed>  $args   Positional arguments.
+	 * @return mixed Method return value.
+	 */
+	private function invoke_private( string $method, array $args ) {
+		$ref = new \ReflectionMethod( AbilityExplorerService::class, $method );
+		$ref->setAccessible( true );
+		return $ref->invokeArgs( null, $args );
+	}
+
+	/**
+	 * `true` and `false` booleans are preserved verbatim.
+	 */
+	public function test_normalise_annotations_preserves_real_booleans(): void {
+		$out = $this->invoke_private(
+			'normalise_annotations',
+			array(
+				array(
+					'readonly'    => true,
+					'destructive' => false,
+					'idempotent'  => true,
+				),
+			)
+		);
+
+		$this->assertSame(
+			array(
+				'readonly'    => true,
+				'destructive' => false,
+				'idempotent'  => true,
+			),
+			$out
+		);
+	}
+
+	/**
+	 * Missing keys and explicit nulls both map to null (not false).
+	 *
+	 * This is the core regression fix: previous `(bool) ( ... ?? false )`
+	 * coercion silently classified unknown-destructive abilities as safe.
+	 */
+	public function test_normalise_annotations_returns_null_for_missing_and_null(): void {
+		$out = $this->invoke_private(
+			'normalise_annotations',
+			array(
+				array(
+					// readonly omitted entirely.
+					'destructive' => null,
+					'idempotent'  => null,
+				),
+			)
+		);
+
+		$this->assertNull( $out['readonly'] );
+		$this->assertNull( $out['destructive'] );
+		$this->assertNull( $out['idempotent'] );
+	}
+
+	/**
+	 * Non-bool truthy values (1, "true", "yes", ["x"]) all map to null.
+	 *
+	 * The tri-state contract is strict: only real PHP booleans count as a
+	 * declared hint. Anything else is treated as "author did not declare".
+	 *
+	 * @dataProvider provide_non_bool_values
+	 *
+	 * @param mixed $value Junk annotation value.
+	 */
+	public function test_read_tristate_returns_null_for_non_bool( $value ): void {
+		$out = $this->invoke_private(
+			'read_tristate',
+			array(
+				array( 'destructive' => $value ),
+				'destructive',
+			)
+		);
+
+		$this->assertNull( $out );
+	}
+
+	/**
+	 * Provider of non-bool values that must be treated as undeclared.
+	 *
+	 * @return array<string, array{0: mixed}>
+	 */
+	public function provide_non_bool_values(): array {
+		return array(
+			'integer one'    => array( 1 ),
+			'integer zero'   => array( 0 ),
+			'string true'    => array( 'true' ),
+			'string false'   => array( 'false' ),
+			'string yes'     => array( 'yes' ),
+			'empty string'   => array( '' ),
+			'array'          => array( array( 'x' ) ),
+			'object'         => array( new \stdClass() ),
+			'explicit null'  => array( null ),
+		);
+	}
+
+	/**
+	 * When the annotations slot itself is not an array, all three slots
+	 * are null. Defends against malformed third-party meta payloads.
+	 */
+	public function test_normalise_annotations_handles_non_array_input(): void {
+		foreach ( array( null, 'string', 42, new \stdClass() ) as $junk ) {
+			$out = $this->invoke_private( 'normalise_annotations', array( $junk ) );
+
+			$this->assertSame(
+				array(
+					'readonly'    => null,
+					'destructive' => null,
+					'idempotent'  => null,
+				),
+				$out,
+				sprintf( 'Junk input of type %s should produce all-null annotations.', gettype( $junk ) )
+			);
+		}
+	}
+
+	/**
+	 * The JS-ability formatter delegates to the same tri-state helper.
+	 *
+	 * This guards against the historical regression where the JS code path
+	 * hard-coded `destructive => false` and `idempotent => false`, which
+	 * mis-classified every client-side ability as definitively safe.
+	 */
+	public function test_format_js_ability_for_explorer_preserves_tristate(): void {
+		$descriptor = array(
+			'name'         => 'sd-ai-agent/test-js-ability',
+			'label'        => 'Test JS Ability',
+			'description'  => 'JS ability used for tri-state coverage.',
+			'category'     => 'sd-ai-agent-js',
+			'input_schema' => array(
+				'properties' => array(
+					'foo' => array( 'type' => 'string' ),
+				),
+				'required'   => array( 'foo' ),
+			),
+			'annotations'  => array(
+				'readonly'    => true,
+				// destructive omitted on purpose -> must become null.
+				'idempotent'  => false,
+			),
+			'output_schema' => array( 'type' => 'object' ),
+		);
+
+		$formatted = $this->invoke_private(
+			'format_js_ability_for_explorer',
+			array( $descriptor )
+		);
+
+		$this->assertArrayHasKey( 'annotations', $formatted );
+		$this->assertSame( true, $formatted['annotations']['readonly'] );
+		$this->assertNull( $formatted['annotations']['destructive'] );
+		$this->assertSame( false, $formatted['annotations']['idempotent'] );
+
+		// Spot-check unrelated fields remain intact.
+		$this->assertSame( 'sd-ai-agent/test-js-ability', $formatted['name'] );
+		$this->assertSame( 1, $formatted['param_count'] );
+		$this->assertSame( array( 'foo' ), $formatted['required_params'] );
+		$this->assertFalse( $formatted['show_in_rest'] );
+	}
+
+	/**
+	 * The JS-ability formatter still produces a fully-populated annotations
+	 * key when the descriptor omits the slot entirely.
+	 */
+	public function test_format_js_ability_for_explorer_handles_missing_annotations(): void {
+		$descriptor = array(
+			'name'         => 'sd-ai-agent/no-annotations',
+			'label'        => 'No Annotations',
+			'description'  => '',
+			'category'     => 'sd-ai-agent-js',
+			'input_schema' => array(),
+			// annotations key omitted entirely.
+		);
+
+		$formatted = $this->invoke_private(
+			'format_js_ability_for_explorer',
+			array( $descriptor )
+		);
+
+		$this->assertSame(
+			array(
+				'readonly'    => null,
+				'destructive' => null,
+				'idempotent'  => null,
+			),
+			$formatted['annotations']
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Preserves tri-state MCP annotation hints (`readonly`, `destructive`, `idempotent`) in the Abilities Explorer service and UI. The previous code coerced missing/null values to `false`, silently mis-classifying every unknown-destructive ability as definitively safe. The JS-ability formatter also hard-coded `destructive => false` and `idempotent => false` regardless of descriptor content.

## Changes

- `includes/Services/AbilityExplorerService.php`
  - New private `normalise_annotations()` + `read_tristate()` helpers — return `bool|null`, only real PHP booleans count as declared.
  - Both `format_ability_for_explorer()` (PHP path) and `format_js_ability_for_explorer()` (JS path) now delegate to the helper.
- `src/abilities-explorer/abilities-explorer-app.js`
  - `AnnotationBadge` renders three visually-distinct states:
    - `true` → coloured badge with intent (e.g. red `destructive`)
    - `false` → muted `not <label>` badge so operators see explicit author declaration
    - `null` → warning `<label>?` badge with tooltip *"Not declared by ability author — assume destructive for safety."*
- `tests/SdAiAgent/Services/AbilityExplorerServiceTest.php` — new test class:
  - Real booleans preserved verbatim.
  - Missing keys + explicit nulls map to null (regression guard).
  - Non-bool junk (`1`, `"true"`, arrays, objects) maps to null via `@dataProvider`.
  - Non-array `annotations` payloads produce all-null shape.
  - `format_js_ability_for_explorer()` regression test exercises the JS path directly.

## Verification

- `composer phpcs -- includes/Services/AbilityExplorerService.php tests/SdAiAgent/Services/AbilityExplorerServiceTest.php` — clean.
- `composer phpstan` — `[OK] No errors`.
- `npx wp-scripts lint-js src/abilities-explorer/abilities-explorer-app.js` — clean.
- `npx wp-env run tests-cli vendor/bin/phpunit --filter AbilityExplorerServiceTest` — **14 tests / 26 assertions / 0 failures**.
- Full suite: `vendor/bin/phpunit` — **2004 tests / 5541 assertions / 76 skipped / 0 failures** (up from 1990/5511 in #1403 baseline; new test adds 14 tests / 30 assertions).
- `npx wp-scripts build` — succeeds (only pre-existing bundle-size warnings).

## Notes

Downstream consumers must treat `null` annotation slots as "assume destructive" for any safety decision — documented in the `normalise_annotations()` PHPDoc.

Resolves #1407

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.45 plugin for [OpenCode](https://opencode.ai) v1.14.49 with gpt-5.5 spent 1d 11h and 15,815 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ability annotations now display three distinct states (enabled, disabled, or unspecified) with visual indicators and guidance tooltips.

* **Tests**
  * Added comprehensive test coverage for annotation state validation and handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1408)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->