### PR TITLE
fix(tests): guard temp-dir creation in WpCliAbilitiesTest (#1409)

### DIFF
--- a/tests/SdAiAgent/Abilities/WpCliAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/WpCliAbilitiesTest.php
@@ -297,7 +297,9 @@ class WpCliAbilitiesTest extends WP_UnitTestCase {
 	private function make_temp_dir(): string {
 		if ( '' === $this->temp_dir ) {
 			$this->temp_dir = sys_get_temp_dir() . '/sd_wp_cli_test_' . uniqid( '', true );
-			mkdir( $this->temp_dir, 0755, true );
+			$created        = mkdir( $this->temp_dir, 0755, true );
+			$this->assertTrue( $created || is_dir( $this->temp_dir ), "Failed to create temp directory: {$this->temp_dir}" );
+			$this->assertTrue( is_writable( $this->temp_dir ), "Temp directory is not writable: {$this->temp_dir}" );
 		}
 		return $this->temp_dir;
 	}


### PR DESCRIPTION
## Summary

- Capture the return value of `mkdir()` in `make_temp_dir()` instead of discarding it.
- Assert `$created || is_dir($this->temp_dir)` immediately after creation so a setup failure produces a clear, actionable error message rather than cascading filesystem assertion failures.
- Assert `is_writable($this->temp_dir)` to catch permission-related failures early with a helpful message referencing the directory path.

## Testing

No new test cases required — this is a test-helper hardening change. The assertions will fire during any PHPUnit run (`npm run test:php`) whenever temp-dir creation fails, giving an immediately diagnostic message.

Resolves #1409

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with claude-sonnet-4-6 spent 40s and 1,935 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced directory creation validation in test suite with explicit assertions to ensure proper setup and writeability, improving test reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1411)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->