### PR TITLE
feat(t226c-3b): seed theme-builder built-in agent

### DIFF
--- a/includes/Models/Agent.php
+++ b/includes/Models/Agent.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
  * - tool_profile: legacy, no longer applied — kept on the row for backward compatibility
  * - temperature / max_iterations: per-agent inference settings
  *
- * Five built-in agents are seeded on first install (is_builtin=1):
- * onboarding, general, content-creator, seo, ecommerce.
+ * Six built-in agents are seeded on first install (is_builtin=1):
+ * onboarding, general, content-creator, seo, ecommerce, theme-builder.
  * The "general" agent cannot be deleted. All built-in agents can be reset
  * to factory defaults via reset_defaults().
  *
@@ -36,6 +36,11 @@ class Agent {
 	 * Slug of the onboarding agent (selected on first session).
 	 */
 	public const ONBOARDING_AGENT_SLUG = 'onboarding';
+
+	/**
+	 * Slug of the theme-builder agent (4-phase guided block theme creation).
+	 */
+	public const THEME_BUILDER_AGENT_SLUG = 'theme-builder';
 
 	/**
 	 * Get the agents table name.
@@ -497,6 +502,7 @@ class Agent {
 			self::get_content_creator_definition( $general_tools ),
 			self::get_seo_definition( $general_tools ),
 			self::get_ecommerce_definition( $general_tools ),
+			self::get_theme_builder_definition( $general_tools ),
 		];
 	}
 
@@ -580,6 +586,101 @@ class Agent {
 					'title'       => __( 'Import content ideas', 'superdav-ai-agent' ),
 					'description' => __( 'Get topic suggestions based on your niche', 'superdav-ai-agent' ),
 					'prompt'      => __( 'Suggest some blog post topics based on what my site is about.', 'superdav-ai-agent' ),
+				],
+			],
+			'is_builtin'    => true,
+			'enabled'       => true,
+		];
+	}
+
+	/**
+	 * Theme Builder agent definition.
+	 *
+	 * Guides users through a 4-phase process: interview (site-specification
+	 * skill), design directions (HTML previews), design selection, and block
+	 * theme scaffolding + activation.
+	 *
+	 * @param list<string> $base_tools Base tier 1 tools.
+	 * @return array<string, mixed>
+	 */
+	private static function get_theme_builder_definition( array $base_tools ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- list<string> is valid PHPStan but not a native PHP type.
+		return [
+			'slug'          => self::THEME_BUILDER_AGENT_SLUG,
+			'name'          => __( 'Theme Builder', 'superdav-ai-agent' ),
+			'description'   => __( 'Designs and builds a custom block theme through a guided 4-phase process: interview, design directions, selection, and build.', 'superdav-ai-agent' ),
+			'system_prompt' => "You are a WordPress Theme Builder. You guide users through a 4-phase process to design and build a custom block theme for their site.\n\n"
+				. "## Phase 1: Interview (Site Specification)\n\n"
+				. "Start every conversation by loading the site-specification skill:\n"
+				. "1. Call `sd-ai-agent/skill-load` with `skill_name: site-specification` to get the full specification template.\n"
+				. "2. Call `sd-ai-agent/skill-load` with `skill_name: block-themes` to load block theme guidance.\n"
+				. "3. Optionally call `sd-ai-agent/skill-load` with `skill_name: design-system-aesthetics` if available — gracefully skip and continue if it is absent.\n"
+				. "4. Interview the user using the site-specification framework. Ask **one question at a time**.\n"
+				. "5. Save gathered site information with `sd-ai-agent/memory-save` (category: site_brief).\n\n"
+				. "## Phase 2: Design Directions\n\n"
+				. "After completing the interview, propose 3 distinct topic-grounded design directions:\n"
+				. "1. Write each direction as a self-contained HTML preview via `sd-ai-agent/file-write`:\n"
+				. "   - `wp-content/uploads/sd-ai-agent/design-previews/{session}/design-1.html`\n"
+				. "   - `wp-content/uploads/sd-ai-agent/design-previews/{session}/design-2.html`\n"
+				. "   - `wp-content/uploads/sd-ai-agent/design-previews/{session}/design-3.html`\n"
+				. "2. Previews must use inline CSS only. **Never embed stock image URLs, external image URLs, or placeholder image services.** Use CSS gradients, solid color blocks, and typographic mockups instead.\n"
+				. "3. Summarize each direction with a distinctive name and a 2-sentence description.\n\n"
+				. "## Phase 3: Choose\n\n"
+				. "1. Present the three design directions and their preview file paths to the user.\n"
+				. "2. Ask the user to pick a direction, or to describe modifications they want.\n"
+				. "3. Fold any modifications back into the site specification.\n"
+				. "4. Save the chosen design direction with `sd-ai-agent/memory-save` (category: site_brief).\n\n"
+				. "## Phase 4: Build\n\n"
+				. "Once the user has chosen a design direction:\n"
+				. "1. Call `sd-ai-agent/scaffold-block-theme` to create the theme scaffold (slug and metadata from the site specification).\n"
+				. "2. Retrieve the current theme.json baseline with `sd-ai-agent/get-theme-json` to understand existing settings.\n"
+				. "3. Write custom template parts via `sd-ai-agent/file-write`:\n"
+				. "   - `parts/header.html` — header template part\n"
+				. "   - `parts/footer.html` — footer template part\n"
+				. "4. Write page templates via `sd-ai-agent/file-write`:\n"
+				. "   - `templates/index.html` — main index template\n"
+				. "   - `templates/page.html` — single page template\n"
+				. "5. Apply the chosen design system (colors, typography, spacing) via `sd-ai-agent/update-global-styles`.\n"
+				. "6. Validate every block markup file you write using `sd-ai-agent/validate-block-content`.\n"
+				. "7. Activate the new theme via `sd-ai-agent/activate-theme`.\n"
+				. "8. Confirm the result to the user.\n\n"
+				. "## Rules\n\n"
+				. "- **Never** embed stock image URLs, external image URLs, or placeholder image service URLs anywhere in previews, templates, or style output. Use CSS gradients and typographic layouts.\n"
+				. "- Load `sd-ai-agent/skill-load` for `site-specification` at the very start of every conversation.\n"
+				. "- Ask one question at a time during the interview phase.\n"
+				. "- Save the final site brief and chosen design direction with `sd-ai-agent/memory-save` (category: site_brief) before building.\n"
+				. "- If a tool call fails, try a different approach or skip and continue; never stop entirely after a single error.\n"
+				. '- After completing all build steps, summarize what was created and confirm the active theme.',
+			'greeting'      => __( "I'm your Theme Builder. I'll guide you through designing and building a custom WordPress block theme — from a quick interview about your site, through design concepts, to a fully activated theme. Ready to start?", 'superdav-ai-agent' ),
+			'avatar_icon'   => 'dashicons-art',
+			'tier_1_tools'  => array_values(
+				array_unique(
+					array_merge(
+						$base_tools,
+						[
+							'sd-ai-agent/scaffold-block-theme',
+							'sd-ai-agent/activate-theme',
+							'sd-ai-agent/file-write',
+							'sd-ai-agent/validate-block-content',
+							'sd-ai-agent/get-theme-json',
+						]
+					)
+				)
+			),
+			'suggestions'   => [
+				[
+					'title'       => __( 'Design a theme for a craft brewery', 'superdav-ai-agent' ),
+					'description' => __( 'Custom block theme with rustic, bold aesthetics', 'superdav-ai-agent' ),
+					'prompt'      => __( 'Design a theme for a craft brewery website.', 'superdav-ai-agent' ),
+				],
+				[
+					'title'       => __( 'Design a theme for a SaaS startup', 'superdav-ai-agent' ),
+					'description' => __( 'Clean, modern block theme for a software product', 'superdav-ai-agent' ),
+					'prompt'      => __( 'Design a theme for a SaaS startup website.', 'superdav-ai-agent' ),
+				],
+				[
+					'title'       => __( 'Design a theme for a personal portfolio', 'superdav-ai-agent' ),
+					'description' => __( 'Minimal, elegant block theme to showcase your work', 'superdav-ai-agent' ),
+					'prompt'      => __( 'Design a theme for my personal portfolio website.', 'superdav-ai-agent' ),
 				],
 			],
 			'is_builtin'    => true,

--- a/tests/SdAiAgent/Models/AgentThemeBuilderTest.php
+++ b/tests/SdAiAgent/Models/AgentThemeBuilderTest.php
@@ -1,0 +1,282 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Tests for the theme-builder built-in agent seeding.
+ *
+ * Covers: seed_defaults() creates the agent on fresh install; seed_defaults()
+ * is idempotent; reset_defaults() restores canonical fields after edits;
+ * tier_1_tools contains the required theme-builder abilities.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Models;
+
+use SdAiAgent\Models\Agent;
+use WP_UnitTestCase;
+
+/**
+ * Tests for the theme-builder built-in agent.
+ *
+ * @since 1.6.0
+ */
+class AgentThemeBuilderTest extends WP_UnitTestCase {
+
+	/**
+	 * Slug constant under test.
+	 */
+	private const SLUG = 'theme-builder';
+
+	/**
+	 * Remove the theme-builder agent row from the database (helper).
+	 */
+	private function delete_theme_builder_agent(): void {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test cleanup; caching not applicable.
+		$wpdb->delete( Agent::table_name(), [ 'slug' => self::SLUG ], [ '%s' ] );
+	}
+
+	/**
+	 * Set up: ensure no stale theme-builder row from a previous run.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->delete_theme_builder_agent();
+	}
+
+	/**
+	 * Tear down: remove any theme-builder agent rows created during the test
+	 * so they don't bleed into subsequent tests.
+	 */
+	public function tear_down(): void {
+		$this->delete_theme_builder_agent();
+		parent::tear_down();
+	}
+
+	// ─── THEME_BUILDER_AGENT_SLUG constant ───────────────────────────────────
+
+	/**
+	 * THEME_BUILDER_AGENT_SLUG constant has the expected value.
+	 */
+	public function test_theme_builder_agent_slug_constant(): void {
+		$this->assertSame( self::SLUG, Agent::THEME_BUILDER_AGENT_SLUG );
+	}
+
+	// ─── seed_defaults() ─────────────────────────────────────────────────────
+
+	/**
+	 * seed_defaults() creates the theme-builder agent when it does not exist.
+	 */
+	public function test_seed_defaults_creates_theme_builder_agent(): void {
+		// Ensure no pre-existing row.
+		$this->assertNull( Agent::get_by_slug( self::SLUG ) );
+
+		Agent::seed_defaults();
+
+		$agent = Agent::get_by_slug( self::SLUG );
+		$this->assertNotNull( $agent, 'theme-builder agent must exist after seed_defaults()' );
+		$this->assertSame( self::SLUG, $agent->slug );
+	}
+
+	/**
+	 * seed_defaults() is idempotent — running it twice does not create a duplicate.
+	 */
+	public function test_seed_defaults_is_idempotent(): void {
+		Agent::seed_defaults();
+		Agent::seed_defaults();
+
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test assertion; caching not applicable.
+		$count = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				'SELECT COUNT(*) FROM %i WHERE slug = %s',
+				Agent::table_name(),
+				self::SLUG
+			)
+		);
+
+		$this->assertSame( 1, $count, 'seed_defaults() must not create duplicate theme-builder rows' );
+	}
+
+	// ─── reset_defaults() ────────────────────────────────────────────────────
+
+	/**
+	 * reset_defaults() restores the canonical system_prompt after it has been edited.
+	 */
+	public function test_reset_defaults_restores_system_prompt(): void {
+		Agent::seed_defaults();
+
+		$agent = Agent::get_by_slug( self::SLUG );
+		$this->assertNotNull( $agent );
+
+		// Corrupt the system_prompt.
+		Agent::update( $agent->id, [ 'system_prompt' => 'CORRUPTED' ] );
+		$corrupted = Agent::get_by_slug( self::SLUG );
+		$this->assertNotNull( $corrupted );
+		$this->assertSame( 'CORRUPTED', $corrupted->system_prompt );
+
+		Agent::reset_defaults();
+
+		$restored = Agent::get_by_slug( self::SLUG );
+		$this->assertNotNull( $restored );
+		$this->assertNotSame(
+			'CORRUPTED',
+			$restored->system_prompt,
+			'reset_defaults() must restore the canonical system_prompt'
+		);
+		$this->assertStringContainsString(
+			'site-specification',
+			$restored->system_prompt,
+			'Restored system_prompt must reference the site-specification skill'
+		);
+	}
+
+	/**
+	 * reset_defaults() restores the canonical greeting after it has been edited.
+	 */
+	public function test_reset_defaults_restores_greeting(): void {
+		Agent::seed_defaults();
+
+		$agent = Agent::get_by_slug( self::SLUG );
+		$this->assertNotNull( $agent );
+
+		Agent::update( $agent->id, [ 'greeting' => 'CORRUPTED GREETING' ] );
+
+		Agent::reset_defaults();
+
+		$restored = Agent::get_by_slug( self::SLUG );
+		$this->assertNotNull( $restored );
+		$this->assertNotSame(
+			'CORRUPTED GREETING',
+			$restored->greeting,
+			'reset_defaults() must restore the canonical greeting'
+		);
+	}
+
+	/**
+	 * reset_defaults() restores the canonical tier_1_tools after they have been edited.
+	 */
+	public function test_reset_defaults_restores_tier_1_tools(): void {
+		Agent::seed_defaults();
+
+		$agent = Agent::get_by_slug( self::SLUG );
+		$this->assertNotNull( $agent );
+
+		Agent::update( $agent->id, [ 'tier_1_tools' => [] ] );
+
+		Agent::reset_defaults();
+
+		$restored = Agent::get_by_slug( self::SLUG );
+		$this->assertNotNull( $restored );
+
+		$tools = $restored->tier_1_tools;
+		$this->assertNotEmpty( $tools, 'reset_defaults() must restore tier_1_tools' );
+	}
+
+	// ─── tier_1_tools content ────────────────────────────────────────────────
+
+	/**
+	 * The seeded theme-builder agent includes all four core theme abilities
+	 * plus the required support tools in tier_1_tools.
+	 */
+	public function test_tier_1_tools_contains_required_theme_abilities(): void {
+		Agent::seed_defaults();
+
+		$agent = Agent::get_by_slug( self::SLUG );
+		$this->assertNotNull( $agent );
+
+		$tools = $agent->tier_1_tools;
+		$this->assertIsArray( $tools, 'tier_1_tools must be an array' );
+
+		$required = [
+			'sd-ai-agent/scaffold-block-theme',
+			'sd-ai-agent/activate-theme',
+			'sd-ai-agent/file-write',
+			'sd-ai-agent/validate-block-content',
+			'sd-ai-agent/memory-save',
+			'sd-ai-agent/skill-load',
+			'sd-ai-agent/get-theme-json',
+			'sd-ai-agent/update-global-styles',
+		];
+
+		foreach ( $required as $ability ) {
+			$this->assertContains(
+				$ability,
+				$tools,
+				sprintf( 'tier_1_tools must contain %s', $ability )
+			);
+		}
+	}
+
+	// ─── builtin definition fields ───────────────────────────────────────────
+
+	/**
+	 * The theme-builder definition in get_builtin_definitions() contains all
+	 * 8 required fields.
+	 */
+	public function test_builtin_definition_has_all_required_fields(): void {
+		$reflection = new \ReflectionClass( Agent::class );
+		$method     = $reflection->getMethod( 'get_builtin_definitions' );
+		$method->setAccessible( true );
+		/** @var list<array<string, mixed>> $definitions */
+		$definitions = $method->invoke( null );
+
+		$theme_builder_def = null;
+		foreach ( $definitions as $def ) {
+			if ( isset( $def['slug'] ) && $def['slug'] === self::SLUG ) {
+				$theme_builder_def = $def;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $theme_builder_def, 'get_builtin_definitions() must include a theme-builder entry' );
+
+		$required_fields = [ 'slug', 'name', 'description', 'system_prompt', 'greeting', 'tier_1_tools', 'suggestions', 'avatar_icon' ];
+		foreach ( $required_fields as $field ) {
+			$this->assertArrayHasKey( $field, $theme_builder_def, sprintf( 'theme-builder definition must have field: %s', $field ) );
+			$this->assertNotEmpty( $theme_builder_def[ $field ], sprintf( 'theme-builder definition field must not be empty: %s', $field ) );
+		}
+	}
+
+	/**
+	 * The system_prompt references the skills and contract keywords required
+	 * by the issue acceptance criteria.
+	 */
+	public function test_system_prompt_references_required_skills_and_contract(): void {
+		Agent::seed_defaults();
+
+		$agent = Agent::get_by_slug( self::SLUG );
+		$this->assertNotNull( $agent );
+
+		$prompt = $agent->system_prompt;
+
+		$this->assertStringContainsString(
+			'site-specification',
+			$prompt,
+			'system_prompt must reference the site-specification skill'
+		);
+		$this->assertStringContainsString(
+			'block-themes',
+			$prompt,
+			'system_prompt must reference the block-themes skill'
+		);
+		// The 4-phase contract: all four phase headings must appear.
+		$this->assertStringContainsString( 'Phase 1', $prompt, 'system_prompt must define Phase 1 (Interview)' );
+		$this->assertStringContainsString( 'Phase 2', $prompt, 'system_prompt must define Phase 2 (Designs)' );
+		$this->assertStringContainsString( 'Phase 3', $prompt, 'system_prompt must define Phase 3 (Choose)' );
+		$this->assertStringContainsString( 'Phase 4', $prompt, 'system_prompt must define Phase 4 (Build)' );
+		// No-stock-images rule.
+		$this->assertStringContainsString(
+			'stock image',
+			strtolower( $prompt ),
+			'system_prompt must include the no-stock-images rule'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `Agent::THEME_BUILDER_AGENT_SLUG = 'theme-builder'` constant next to existing slug constants.
- Adds `get_theme_builder_definition()` private static method and registers it in `get_builtin_definitions()`, seeding a sixth built-in agent via the existing `seed_defaults()` / `reset_defaults()` paths.
- Adds `tests/SdAiAgent/Models/AgentThemeBuilderTest.php` (9 tests, 52 assertions — all passing locally).

## 4-phase system prompt

| Phase | What happens |
|-------|-------------|
| 1 — Interview | Agent loads `site-specification` + `block-themes` skills via `sd-ai-agent/skill-load`; interviews user one question at a time; saves to `sd-ai-agent/memory-save` (category: `site_brief`) |
| 2 — Designs | Writes 3 HTML preview files via `sd-ai-agent/file-write` under `wp-content/uploads/sd-ai-agent/design-previews/{session}/`; no stock or external image URLs (CSS gradients only) |
| 3 — Choose | User picks a direction; choice is memo-saved; modifications fold back into spec |
| 4 — Build | `scaffold-block-theme` → template parts + page templates via `file-write` → `update-global-styles` → `validate-block-content` → `activate-theme` |

## Acceptance criteria

- [x] `Agent::THEME_BUILDER_AGENT_SLUG` constant defined with value `'theme-builder'`
- [x] `get_builtin_definitions()` includes the new entry with all 8 required fields
- [x] `seed_defaults()` creates the agent on fresh install and is idempotent on re-run
- [x] `reset_defaults()` restores canonical fields when edited
- [x] `tier_1_tools` includes `scaffold-block-theme`, `activate-theme`, `file-write`, `validate-block-content`, `skill-load`, `memory-save`, `get-theme-json`, `update-global-styles`
- [x] System prompt references `site-specification` and `block-themes` skills, the 4-phase contract, and the no-stock-images rule
- [x] No new PHP classes, REST routes, or JS changes
- [x] `composer phpcs` / `composer phpstan` / `npm run test:php --filter AgentThemeBuilderTest` all pass

## Verification

```bash
composer phpcs -- includes/Models/Agent.php tests/SdAiAgent/Models/AgentThemeBuilderTest.php
composer phpstan
npm run test:php -- --filter AgentThemeBuilderTest
```

For #1385
Ref #1373

---
Closes #1398

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with claude-sonnet-4-6 spent 9m and 25,382 tokens on this as a headless worker.
