### PR TITLE
GH#1410: fix: add .catch() to openSession promise chain in onboarding bootstrap

### DIFF
--- a/src/components/onboarding-bootstrap.js
+++ b/src/components/onboarding-bootstrap.js
@@ -58,15 +58,19 @@ export default function OnboardingBootstrap() {
 				}
 
 				// Activate the bootstrap session in the store.
-				openSession( data.session_id ).then( () => {
-					sendMessage(
-						data.kickoff_message ||
-							__(
-								"Hello! I'm just getting set up. Please explore this WordPress site and introduce yourself — tell me what you notice and what you can help with.",
-								'superdav-ai-agent'
-							)
-					);
-				} );
+				openSession( data.session_id )
+					.then( () =>
+						sendMessage(
+							data.kickoff_message ||
+								__(
+									"Hello! I'm just getting set up. Please explore this WordPress site and introduce yourself — tell me what you notice and what you can help with.",
+									'superdav-ai-agent'
+								)
+						)
+					)
+					.catch( () => {
+						// Non-fatal: user can continue manually from chat UI.
+					} );
 			} )
 			.catch( () => {
 				// Non-fatal: the user can start chatting manually.


### PR DESCRIPTION
## Summary

Added a .catch() handler to the inner openSession().then() promise chain in onboarding-bootstrap.js to prevent unhandled promise rejections when session open or kickoff message fails. The outer apiFetch chain already had error handling, but the nested openSession chain did not.

## Files Changed

src/components/onboarding-bootstrap.js

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ESLint passes clean. Change is minimal — adds only a .catch() with a non-fatal comment, matching the existing error handling pattern at line 75-77.

Resolves #1410


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.46 plugin for [OpenCode](https://opencode.ai) v1.14.50 with claude-opus-4-6 spent 1m and 2,595 tokens on this as a headless worker.