### PR TITLE
feat(t226c-3c): /onboarding/theme-builder-start REST endpoint

### DIFF
--- a/includes/Core/OnboardingManager.php
+++ b/includes/Core/OnboardingManager.php
@@ -51,6 +51,13 @@ class OnboardingManager {
 	const BOOTSTRAP_SESSION_OPTION = 'sd_ai_agent_bootstrap_session_id';
 
 	/**
+	 * Option key that persists the theme-builder session ID.
+	 * Stored on first call to rest_theme_builder_start; reused on subsequent calls
+	 * to make the endpoint idempotent — repeat calls return the same session.
+	 */
+	const THEME_BUILDER_SESSION_OPTION = 'sd_ai_agent_theme_builder_session_id';
+
+	/**
 	 * Called on plugin activation.
 	 *
 	 * Two paths:
@@ -213,6 +220,16 @@ class OnboardingManager {
 			[
 				'methods'             => 'POST',
 				'callback'            => [ __CLASS__, 'rest_bootstrap_start' ],
+				'permission_callback' => [ __CLASS__, 'rest_permission' ],
+			]
+		);
+
+		register_rest_route(
+			'sd-ai-agent/v1',
+			'/onboarding/theme-builder-start',
+			[
+				'methods'             => 'POST',
+				'callback'            => [ __CLASS__, 'rest_theme_builder_start' ],
 				'permission_callback' => [ __CLASS__, 'rest_permission' ],
 			]
 		);
@@ -400,6 +417,104 @@ class OnboardingManager {
 				'agent_id'            => $onboarding_agent_id,
 				'kickoff_message'     => $kickoff_message,
 				'woo_detected'        => $woo_active,
+			],
+			200
+		);
+	}
+
+	// ── Theme-builder-start REST handler ──────────────────────────────────
+
+	/**
+	 * POST /sd-ai-agent/v1/onboarding/theme-builder-start
+	 *
+	 * Called by the frontend when a user chooses the theme-builder onboarding
+	 * path. This handler mirrors rest_bootstrap_start but:
+	 *
+	 *  1. Resolves the theme-builder agent instead of the onboarding agent.
+	 *  2. Does NOT mark onboarding complete (the user may still want the
+	 *     bootstrap discovery flow after building the theme).
+	 *  3. Does NOT auto-detect WooCommerce.
+	 *  4. Persists the session ID under THEME_BUILDER_SESSION_OPTION so
+	 *     repeat calls return the same session.
+	 *  5. Returns the same JSON shape as bootstrap-start so the React entry
+	 *     component can use a single helper.
+	 *
+	 * Idempotent: repeat calls return the originally-created session ID
+	 * instead of creating a duplicate session.
+	 *
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public static function rest_theme_builder_start(): \WP_REST_Response|\WP_Error {
+		$settings = Settings::instance();
+		$all      = $settings->get();
+
+		// Resolve the theme-builder agent so the frontend can attach it to
+		// the theme-builder session. The agent's stored system prompt is the
+		// canonical source of truth — no parallel theme-builder prompt is needed.
+		$theme_builder_agent    = Agent::get_by_slug( Agent::THEME_BUILDER_AGENT_SLUG );
+		$theme_builder_agent_id = $theme_builder_agent ? (int) $theme_builder_agent->id : 0;
+
+		$kickoff_message = __(
+			"I'd like to design a custom block theme for my site. Please start the interview.",
+			'superdav-ai-agent'
+		);
+
+		// Early-return if a theme-builder session was already created. Reuse the
+		// persisted session ID so the frontend can resume the same conversation.
+		$existing_session_id = get_option( self::THEME_BUILDER_SESSION_OPTION );
+		if ( ! empty( $existing_session_id ) ) {
+			return new \WP_REST_Response(
+				[
+					'success'         => true,
+					'session_id'      => $existing_session_id,
+					'agent_id'        => $theme_builder_agent_id,
+					'kickoff_message' => $kickoff_message,
+				],
+				200
+			);
+		}
+
+		// Create the theme-builder session, applying the theme-builder agent's
+		// provider/model overrides if present so the session starts with the
+		// right model for the first turn.
+		$session_data = [
+			'user_id'     => get_current_user_id(),
+			'title'       => __( 'Theme Builder', 'superdav-ai-agent' ),
+			'provider_id' => $all['default_provider'] ?? '',
+			'model_id'    => $all['default_model'] ?? '',
+		];
+
+		if ( $theme_builder_agent_id > 0 ) {
+			$agent_options = Agent::get_loop_options( $theme_builder_agent_id );
+			if ( ! empty( $agent_options['provider_id'] ) ) {
+				$session_data['provider_id'] = $agent_options['provider_id'];
+			}
+			if ( ! empty( $agent_options['model_id'] ) ) {
+				$session_data['model_id'] = $agent_options['model_id'];
+			}
+		}
+
+		$session_id = Database::create_session( $session_data );
+
+		if ( ! $session_id ) {
+			return new \WP_Error(
+				'theme_builder_session_failed',
+				__( 'Failed to create theme-builder session.', 'superdav-ai-agent' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		// Persist the session ID so repeat calls return the same session.
+		// Note: we do NOT mark onboarding complete — the user may still want
+		// the bootstrap discovery flow after building the theme.
+		update_option( self::THEME_BUILDER_SESSION_OPTION, $session_id, false );
+
+		return new \WP_REST_Response(
+			[
+				'success'         => true,
+				'session_id'      => $session_id,
+				'agent_id'        => $theme_builder_agent_id,
+				'kickoff_message' => $kickoff_message,
 			],
 			200
 		);

--- a/tests/SdAiAgent/Core/OnboardingManagerThemeBuilderTest.php
+++ b/tests/SdAiAgent/Core/OnboardingManagerThemeBuilderTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Test case for OnboardingManager theme-builder REST endpoint.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\Database;
+use SdAiAgent\Core\OnboardingManager;
+use SdAiAgent\Models\Agent;
+use WP_UnitTestCase;
+
+/**
+ * Test OnboardingManager::rest_theme_builder_start() functionality.
+ */
+class OnboardingManagerThemeBuilderTest extends WP_UnitTestCase {
+
+	/**
+	 * Reset onboarding state before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		OnboardingManager::reset();
+		delete_option( OnboardingManager::THEME_BUILDER_SESSION_OPTION );
+		global $wpdb;
+		$wpdb->query(
+			$wpdb->prepare(
+				'DELETE FROM %i',
+				$wpdb->prefix . 'sd_ai_agent_sessions'
+			)
+		);
+	}
+
+	/**
+	 * Reset onboarding state after each test.
+	 */
+	public function tear_down(): void {
+		OnboardingManager::reset();
+		delete_option( OnboardingManager::THEME_BUILDER_SESSION_OPTION );
+		global $wpdb;
+		$wpdb->query(
+			$wpdb->prepare(
+				'DELETE FROM %i',
+				$wpdb->prefix . 'sd_ai_agent_sessions'
+			)
+		);
+		parent::tear_down();
+	}
+
+	// ── register_rest_routes ──────────────────────────────────────────────
+
+	/**
+	 * register_rest_routes() registers the onboarding/theme-builder-start route.
+	 */
+	public function test_register_rest_routes_registers_theme_builder_start_route(): void {
+		do_action( 'rest_api_init' );
+		OnboardingManager::register_rest_routes();
+
+		$server = rest_get_server();
+		$routes = $server->get_routes();
+
+		$this->assertArrayHasKey( '/sd-ai-agent/v1/onboarding/theme-builder-start', $routes );
+	}
+
+	// ── rest_theme_builder_start ──────────────────────────────────────────
+
+	/**
+	 * rest_theme_builder_start() creates a session on first call.
+	 */
+	public function test_rest_theme_builder_start_creates_session_on_first_call(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$response = OnboardingManager::rest_theme_builder_start();
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertTrue( $data['success'] );
+		$this->assertIsInt( $data['session_id'] );
+		$this->assertGreaterThan( 0, $data['session_id'] );
+		$this->assertIsString( $data['kickoff_message'] );
+	}
+
+	/**
+	 * rest_theme_builder_start() returns the theme-builder agent ID.
+	 */
+	public function test_rest_theme_builder_start_returns_agent_id(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$response = OnboardingManager::rest_theme_builder_start();
+		$data     = $response->get_data();
+
+		// The agent ID should be present (may be 0 if the agent doesn't exist yet).
+		$this->assertArrayHasKey( 'agent_id', $data );
+		$this->assertIsInt( $data['agent_id'] );
+	}
+
+	/**
+	 * rest_theme_builder_start() persists the session ID.
+	 */
+	public function test_rest_theme_builder_start_persists_session_id(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$response = OnboardingManager::rest_theme_builder_start();
+		$data     = $response->get_data();
+
+		$persisted_id = get_option( OnboardingManager::THEME_BUILDER_SESSION_OPTION );
+		$this->assertSame( $data['session_id'], $persisted_id );
+	}
+
+	/**
+	 * rest_theme_builder_start() returns the same session ID on repeat calls.
+	 */
+	public function test_rest_theme_builder_start_returns_same_session_on_repeat(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$response1 = OnboardingManager::rest_theme_builder_start();
+		$data1     = $response1->get_data();
+
+		$response2 = OnboardingManager::rest_theme_builder_start();
+		$data2     = $response2->get_data();
+
+		$this->assertSame( $data1['session_id'], $data2['session_id'] );
+	}
+
+	/**
+	 * rest_theme_builder_start() does NOT mark onboarding complete.
+	 */
+	public function test_rest_theme_builder_start_does_not_mark_onboarding_complete(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		OnboardingManager::rest_theme_builder_start();
+
+		// The COMPLETE_OPTION should NOT be set.
+		$this->assertFalse( (bool) get_option( OnboardingManager::COMPLETE_OPTION ) );
+	}
+
+	/**
+	 * rest_theme_builder_start() does NOT set onboarding_complete in Settings.
+	 */
+	public function test_rest_theme_builder_start_does_not_set_settings_onboarding_complete(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		OnboardingManager::rest_theme_builder_start();
+
+		// The Settings store should NOT have onboarding_complete set.
+		$settings = \SdAiAgent\Core\Settings::instance();
+		$all      = $settings->get();
+		$this->assertEmpty( $all['onboarding_complete'] ?? null );
+	}
+
+	/**
+	 * rest_theme_builder_start() returns expected JSON shape.
+	 */
+	public function test_rest_theme_builder_start_returns_expected_shape(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$response = OnboardingManager::rest_theme_builder_start();
+		$data     = $response->get_data();
+
+		$this->assertArrayHasKey( 'success', $data );
+		$this->assertArrayHasKey( 'session_id', $data );
+		$this->assertArrayHasKey( 'agent_id', $data );
+		$this->assertArrayHasKey( 'kickoff_message', $data );
+
+		// Should NOT have these bootstrap-specific keys.
+		$this->assertArrayNotHasKey( 'onboarding_complete', $data );
+		$this->assertArrayNotHasKey( 'woo_detected', $data );
+		$this->assertArrayNotHasKey( 'already_complete', $data );
+	}
+
+	/**
+	 * rest_theme_builder_start() rejects unauthenticated requests.
+	 */
+	public function test_rest_theme_builder_start_rejects_unauthenticated(): void {
+		wp_set_current_user( 0 );
+
+		$result = OnboardingManager::rest_permission();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'rest_forbidden', $result->get_error_code() );
+	}
+
+	/**
+	 * rest_theme_builder_start() rejects non-admin users.
+	 */
+	public function test_rest_theme_builder_start_rejects_non_admin(): void {
+		$subscriber_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+
+		$result = OnboardingManager::rest_permission();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'rest_forbidden', $result->get_error_code() );
+	}
+
+	/**
+	 * rest_theme_builder_start() creates a session with the correct title.
+	 */
+	public function test_rest_theme_builder_start_creates_session_with_correct_title(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$response = OnboardingManager::rest_theme_builder_start();
+		$data     = $response->get_data();
+
+		// Verify the session was created with the expected title.
+		global $wpdb;
+		$session_row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE id = %d',
+				$wpdb->prefix . 'sd_ai_agent_sessions',
+				$data['session_id']
+			)
+		);
+
+		$this->assertNotNull( $session_row );
+		$this->assertStringContainsString( 'Theme Builder', $session_row->title );
+	}
+}


### PR DESCRIPTION
## Summary

Implements the `/sd-ai-agent/v1/onboarding/theme-builder-start` REST endpoint as Phase 3, subphase 3c of the theme-builder onboarding feature (#1373).

## Changes

- **OnboardingManager.php**:
  - Added `THEME_BUILDER_SESSION_OPTION` constant for persisting theme-builder session IDs
  - Registered new POST route `/sd-ai-agent/v1/onboarding/theme-builder-start`
  - Implemented `rest_theme_builder_start()` callback that mirrors `rest_bootstrap_start()` with key differences:
    - Resolves theme-builder agent via `Agent::THEME_BUILDER_AGENT_SLUG`
    - Creates session with "Theme Builder" title
    - Persists session ID for idempotent repeat calls
    - Returns same JSON shape as bootstrap-start for frontend compatibility
    - **Does NOT** mark onboarding complete (user may still want bootstrap discovery)
    - **Does NOT** auto-detect WooCommerce

- **OnboardingManagerThemeBuilderTest.php** (new):
  - Comprehensive test suite covering:
    - Route registration
    - Session creation on first call
    - Session ID persistence and idempotency
    - Correct agent ID resolution
    - Permission checks (rejects non-admin users)
    - Verification that onboarding_complete is NOT set
    - Expected JSON response shape

## Verification

✅ PHPCS: No violations
✅ PHPStan: No errors
✅ PHP Syntax: Valid
✅ Tests: Ready to run (requires wp-env)

## Dependencies

- Depends on #1385 (theme-builder agent must exist on main)
- Phase 3 of #1373 (onboarding feature)

## Acceptance Criteria

- [x] Route `/sd-ai-agent/v1/onboarding/theme-builder-start` is registered with method `POST`
- [x] Callback returns `{ success: true, session_id: int, agent_id: int, kickoff_message: string }` on first invocation
- [x] Repeat invocations return the same `session_id` without creating a new row
- [x] `onboarding_complete` is **not** flipped by this endpoint
- [x] WooCommerce detection is **not** triggered by this endpoint
- [x] Unauthenticated request returns HTTP 403
- [x] Tests pass PHPCS and PHPStan
- [x] No JS changes, no other PHP classes touched beyond `OnboardingManager.php`

For #1385
Ref #1373

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.50 plugin for [OpenCode](https://opencode.ai) v1.14.50 with claude-haiku-4-5 spent 5m and 2,585 tokens on this as a headless worker.
