### PR TITLE
feat(t226c-3d): onboarding mode-picker + OnboardingThemeBuilder component

### DIFF
--- a/src/admin-page/index.js
+++ b/src/admin-page/index.js
@@ -5,6 +5,7 @@ import {
 	createRoot,
 	useEffect,
 	useMemo,
+	useState,
 	lazy,
 	Suspense,
 } from '@wordpress/element';
@@ -24,9 +25,11 @@ import '../components/shared.css';
 import './style.css';
 
 // These components are rendered only in specific, uncommon states:
-//  - ConnectorGate   → zero providers configured (first install)
-//  - OnboardingBootstrap → provider exists but onboarding not yet done (once per site)
-//  - ShortcutsHelp   → user presses Mod+/ (explicitly intentional)
+//  - ConnectorGate          → zero providers configured (first install)
+//  - OnboardingWizard       → provider exists but onboarding not yet done (once per site)
+//  - OnboardingBootstrap    → user chose "explore" in the mode picker
+//  - OnboardingThemeBuilder → user chose "theme-builder" in the mode picker
+//  - ShortcutsHelp          → user presses Mod+/ (explicitly intentional)
 // None of them appear during a normal chat session, so they are lazy-loaded.
 const ConnectorGate = lazy( () =>
 	import(
@@ -34,10 +37,22 @@ const ConnectorGate = lazy( () =>
 		'../components/connector-gate'
 	)
 );
+const OnboardingWizard = lazy( () =>
+	import(
+		/* webpackChunkName: "onboarding-wizard", webpackPrefetch: true */
+		'../components/onboarding-wizard'
+	)
+);
 const OnboardingBootstrap = lazy( () =>
 	import(
 		/* webpackChunkName: "onboarding-bootstrap", webpackPrefetch: true */
 		'../components/onboarding-bootstrap'
+	)
+);
+const OnboardingThemeBuilder = lazy( () =>
+	import(
+		/* webpackChunkName: "onboarding-theme-builder", webpackPrefetch: true */
+		'../components/onboarding-theme-builder'
 	)
 );
 const ShortcutsHelp = lazy( () =>
@@ -50,21 +65,33 @@ const ShortcutsHelp = lazy( () =>
 /**
  * Root admin page application component.
  *
- * Implements a two-state onboarding flow:
+ * Implements a three-state onboarding flow:
  *
  * 1. **Connector gate** — shown when no AI provider is configured. The user
  *    is directed to the WordPress Connectors page. The gate polls every 5 s
  *    so it disappears automatically once a provider becomes available.
  *
- * 2. **Onboarding bootstrap** — shown when a provider exists but onboarding
- *    has not yet completed. Auto-sends a kickoff message so the AI explores
- *    the site before asking any questions.
+ * 2. **Onboarding wizard** — shown when a provider exists but onboarding has
+ *    not yet completed. Guides the user through provider selection and a
+ *    mode picker:
+ *    - 'explore'       → OnboardingBootstrap (existing site exploration)
+ *    - 'theme-builder' → OnboardingThemeBuilder (custom theme design)
+ *    - 'skip'          → ChatRedesign directly (wizard marks onboarding done)
  *
- * After onboarding completes the full redesigned chat layout is shown.
+ * 3. After onboarding completes the full redesigned chat layout is shown.
  *
  * @return {JSX.Element|null} Admin page app element, or null while settings are loading.
  */
 function AdminPageApp() {
+	/**
+	 * The onboarding mode chosen by the user in the wizard.
+	 * null            = wizard not yet completed.
+	 * 'explore'       = mount OnboardingBootstrap.
+	 * 'theme-builder' = mount OnboardingThemeBuilder.
+	 * 'skip'          = wizard already marked onboarding done; fall through.
+	 */
+	const [ onboardingMode, setOnboardingMode ] = useState( null );
+
 	const {
 		fetchProviders,
 		fetchSessions,
@@ -180,14 +207,38 @@ function AdminPageApp() {
 		);
 	}
 
-	// Phase 2 gate: connector exists but onboarding not yet started → bootstrap.
+	// Phase 2 gate: connector exists but onboarding not yet complete.
 	const onboardingComplete = settings?.onboarding_complete !== false;
 	if ( ! onboardingComplete ) {
-		return (
-			<Suspense fallback={ null }>
-				<OnboardingBootstrap />
-			</Suspense>
-		);
+		// No mode chosen yet → show the onboarding wizard.
+		if ( onboardingMode === null ) {
+			return (
+				<Suspense fallback={ null }>
+					<OnboardingWizard onComplete={ setOnboardingMode } />
+				</Suspense>
+			);
+		}
+
+		// Mode chosen: mount the appropriate bootstrapper.
+		if ( onboardingMode === 'theme-builder' ) {
+			return (
+				<Suspense fallback={ null }>
+					<OnboardingThemeBuilder />
+				</Suspense>
+			);
+		}
+
+		if ( onboardingMode === 'explore' ) {
+			return (
+				<Suspense fallback={ null }>
+					<OnboardingBootstrap />
+				</Suspense>
+			);
+		}
+
+		// 'skip' mode: the wizard saved onboarding_complete=true, so the
+		// store settings will update and re-render with onboardingComplete=true.
+		// Fall through to ChatRedesign as a synchronous safety net.
 	}
 
 	// Normal chat layout — redesigned shell.

--- a/src/components/__tests__/OnboardingThemeBuilder.test.js
+++ b/src/components/__tests__/OnboardingThemeBuilder.test.js
@@ -1,0 +1,215 @@
+/**
+ * Unit tests for components/onboarding-theme-builder.js
+ *
+ * Tests cover:
+ * - Calls theme-builder-start endpoint on mount
+ * - Selects the Theme Builder agent returned by theme-builder-start
+ * - Opens the session returned by theme-builder-start
+ * - Sends the kickoff message returned by theme-builder-start
+ * - Falls back gracefully when theme-builder-start fails
+ * - Uses fallback kickoff message when none returned
+ * - Skips agent selection when no agent_id returned
+ * - Does not open a session when session_id is missing
+ * - Does not call theme-builder-start twice (React 18 strict-mode guard)
+ */
+
+import { createElement } from '@wordpress/element';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { useDispatch } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
+import OnboardingThemeBuilder from '../onboarding-theme-builder';
+
+// Configure React act() environment for jsdom.
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+// ─── Mock @wordpress/data ─────────────────────────────────────────────────────
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+} ) );
+
+// ─── Mock @wordpress/i18n ─────────────────────────────────────────────────────
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( str ) => str,
+} ) );
+
+// ─── Mock @wordpress/api-fetch ────────────────────────────────────────────────
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+// ─── Mock store ───────────────────────────────────────────────────────────────
+
+jest.mock( '../../store', () => 'sd-ai-agent' );
+
+// ─── Mock ChatRedesign ────────────────────────────────────────────────────────
+
+jest.mock( '../chat-redesign', () => {
+	const React = require( 'react' );
+	return () =>
+		React.createElement( 'div', { 'data-testid': 'chat-redesign' } );
+} );
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe( 'OnboardingThemeBuilder', () => {
+	let container;
+	let root;
+	let openSessionMock;
+	let sendMessageMock;
+	let setSelectedAgentIdMock;
+
+	beforeEach( () => {
+		openSessionMock = jest.fn().mockResolvedValue( undefined );
+		sendMessageMock = jest.fn().mockResolvedValue( undefined );
+		setSelectedAgentIdMock = jest.fn();
+
+		useDispatch.mockReturnValue( {
+			openSession: openSessionMock,
+			sendMessage: sendMessageMock,
+			setSelectedAgentId: setSelectedAgentIdMock,
+		} );
+
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		root = createRoot( container );
+	} );
+
+	afterEach( async () => {
+		await act( async () => {
+			root.unmount();
+		} );
+		document.body.removeChild( container );
+		jest.clearAllMocks();
+	} );
+
+	/**
+	 * Helper — render OnboardingThemeBuilder inside act().
+	 */
+	async function renderThemeBuilder() {
+		await act( async () => {
+			root.render( createElement( OnboardingThemeBuilder, {} ) );
+		} );
+	}
+
+	test( 'calls theme-builder-start endpoint on mount', async () => {
+		apiFetch.mockResolvedValue( {
+			session_id: 42,
+			agent_id: 7,
+			kickoff_message: 'Hi!',
+		} );
+		await renderThemeBuilder();
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/sd-ai-agent/v1/onboarding/theme-builder-start',
+			method: 'POST',
+		} );
+	} );
+
+	test( 'selects the Theme Builder agent returned by theme-builder-start', async () => {
+		apiFetch.mockResolvedValue( {
+			session_id: 42,
+			agent_id: 7,
+			kickoff_message: 'Hi!',
+		} );
+		await renderThemeBuilder();
+		expect( setSelectedAgentIdMock ).toHaveBeenCalledWith( 7 );
+	} );
+
+	test( 'opens the session returned by theme-builder-start', async () => {
+		apiFetch.mockResolvedValue( {
+			session_id: 99,
+			agent_id: 7,
+			kickoff_message: 'Hi!',
+		} );
+		await renderThemeBuilder();
+		expect( openSessionMock ).toHaveBeenCalledWith( 99 );
+	} );
+
+	test( 'sends the kickoff message after session opens', async () => {
+		apiFetch.mockResolvedValue( {
+			session_id: 42,
+			agent_id: 7,
+			kickoff_message: 'Hello from theme-builder kickoff',
+		} );
+		await renderThemeBuilder();
+		expect( sendMessageMock ).toHaveBeenCalledWith(
+			'Hello from theme-builder kickoff'
+		);
+	} );
+
+	test( 'skips agent selection when no agent_id returned', async () => {
+		apiFetch.mockResolvedValue( {
+			session_id: 42,
+			kickoff_message: 'Hello',
+		} );
+		await renderThemeBuilder();
+		expect( setSelectedAgentIdMock ).not.toHaveBeenCalled();
+		expect( openSessionMock ).toHaveBeenCalledWith( 42 );
+	} );
+
+	test( 'uses fallback kickoff message when none returned', async () => {
+		apiFetch.mockResolvedValue( {
+			session_id: 42,
+			agent_id: 7,
+			kickoff_message: null,
+		} );
+		await renderThemeBuilder();
+		const [ msg ] = sendMessageMock.mock.calls[ 0 ];
+		// Should contain a non-empty fallback string.
+		expect( msg ).toBeTruthy();
+		expect( typeof msg ).toBe( 'string' );
+	} );
+
+	test( 'does not throw when theme-builder-start fails', async () => {
+		apiFetch.mockRejectedValue( new Error( 'Network error' ) );
+		// Should render without throwing.
+		await expect( renderThemeBuilder() ).resolves.toBeUndefined();
+		// openSession and sendMessage should not be called on error.
+		expect( openSessionMock ).not.toHaveBeenCalled();
+		expect( sendMessageMock ).not.toHaveBeenCalled();
+		expect( setSelectedAgentIdMock ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does not open a session when session_id is missing', async () => {
+		apiFetch.mockResolvedValue( { success: true } ); // no session_id
+		await renderThemeBuilder();
+		// openSession should not be called without a session_id.
+		expect( openSessionMock ).not.toHaveBeenCalled();
+		expect( setSelectedAgentIdMock ).not.toHaveBeenCalled();
+	} );
+
+	test( 'renders the ChatRedesign component', async () => {
+		apiFetch.mockResolvedValue( {
+			session_id: 42,
+			agent_id: 7,
+			kickoff_message: 'Hi!',
+		} );
+		await renderThemeBuilder();
+		expect(
+			container.querySelector( '[data-testid="chat-redesign"]' )
+		).not.toBeNull();
+	} );
+
+	test( 'does not call theme-builder-start twice on double-mount (strict-mode guard)', async () => {
+		apiFetch.mockResolvedValue( {
+			session_id: 42,
+			agent_id: 7,
+			kickoff_message: 'Hi!',
+		} );
+
+		// Mount once.
+		await act( async () => {
+			root.render( createElement( OnboardingThemeBuilder, {} ) );
+		} );
+
+		// Re-render with the same element (simulates React 18 strict-mode double-invoke).
+		await act( async () => {
+			root.render( createElement( OnboardingThemeBuilder, {} ) );
+		} );
+
+		// apiFetch should have been called only once despite two renders
+		// because the ref guard prevents a second invocation.
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/src/components/onboarding-theme-builder.js
+++ b/src/components/onboarding-theme-builder.js
@@ -1,0 +1,80 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import STORE_NAME from '../store';
+import ChatRedesign from './chat-redesign';
+
+/**
+ * Onboarding theme-builder component — shown when the user chose
+ * "Design a custom theme" in the onboarding mode picker.
+ *
+ * Calls POST /onboarding/theme-builder-start to:
+ *  1. Mark onboarding as complete on the server.
+ *  2. Create a new session and resolve the Theme Builder agent_id.
+ *
+ * Once the session is ready the component selects the Theme Builder agent
+ * and auto-sends a kickoff message. The agent's stored system prompt drives
+ * the design-theme conversational flow — no parallel onboarding prompt exists.
+ *
+ * @return {JSX.Element} The onboarding theme-builder element.
+ */
+export default function OnboardingThemeBuilder() {
+	const { openSession, sendMessage, setSelectedAgentId } =
+		useDispatch( STORE_NAME );
+	const bootstrappedRef = useRef( false );
+
+	useEffect( () => {
+		// Guard against double-invocation in React 18 strict-mode or re-renders.
+		if ( bootstrappedRef.current ) {
+			return;
+		}
+		bootstrappedRef.current = true;
+
+		apiFetch( {
+			path: '/sd-ai-agent/v1/onboarding/theme-builder-start',
+			method: 'POST',
+		} )
+			.then( ( data ) => {
+				if ( ! data?.session_id ) {
+					// Fallback: if the endpoint doesn't return a session, the
+					// ChatRedesign will allow the user to start chatting manually.
+					return;
+				}
+
+				// Select the Theme Builder agent so streamMessage attaches
+				// agent_id to the /run call and AgentLoop applies the agent's
+				// system prompt + tool tier overrides for this session.
+				if ( data.agent_id ) {
+					setSelectedAgentId( data.agent_id );
+				}
+
+				// Activate the theme-builder session in the store.
+				openSession( data.session_id )
+					.then( () =>
+						sendMessage(
+							data.kickoff_message ||
+								__(
+									"Hello! I'm ready to help you design a custom theme for your WordPress site. Let's start by discussing your vision — what style, colours, and feel are you aiming for?",
+									'superdav-ai-agent'
+								)
+						)
+					)
+					.catch( () => {
+						// Non-fatal: user can continue manually from chat UI.
+					} );
+			} )
+			.catch( () => {
+				// Non-fatal: the user can start chatting manually.
+			} );
+	}, [ openSession, sendMessage, setSelectedAgentId ] );
+
+	return <ChatRedesign />;
+}

--- a/src/components/onboarding-wizard.js
+++ b/src/components/onboarding-wizard.js
@@ -94,17 +94,26 @@ function GutenbergInstallButton() {
 /**
  * Multi-step onboarding wizard shown on first activation.
  *
- * Steps: Welcome → Set Up AI Provider → Configure Abilities → All Set.
+ * Steps: Welcome → Set Up AI Provider → Choose Your Start →
+ *        Configure Abilities → WooCommerce Store → All Set.
  *
  * The provider step directs users to the WordPress Connectors page to
  * configure their API keys. Once at least one provider is available the
  * ProviderSelector appears to choose the default provider/model.
  *
- * Saves settings (default provider/model, disabled abilities,
- * onboarding_complete) on finish or skip.
+ * The "Choose your start" step lets the user pick between three modes:
+ * - 'explore'       → existing bootstrap flow (OnboardingBootstrap)
+ * - 'theme-builder' → new theme-builder flow (OnboardingThemeBuilder)
+ * - 'skip'          → skip onboarding, go straight to chat
+ *
+ * Saves settings (default provider/model, onboarding_complete for skip mode)
+ * on finish or skip. For explore/theme-builder modes, onboarding_complete is
+ * set by the bootstrapper REST endpoint rather than here.
  *
  * @param {Object}   props            - Component props.
- * @param {Function} props.onComplete - Called when the wizard is finished or skipped.
+ * @param {Function} props.onComplete - Called when the wizard is finished.
+ *                                    Receives the chosen mode string:
+ *                                    'explore' | 'theme-builder' | 'skip'.
  * @return {JSX.Element} The onboarding wizard element.
  */
 export default function OnboardingWizard( { onComplete } ) {
@@ -113,6 +122,24 @@ export default function OnboardingWizard( { onComplete } ) {
 	const [ wooStatus, setWooStatus ] = useState( null );
 	const [ wooLoading, setWooLoading ] = useState( false );
 	const [ wooOfferAccepted, setWooOfferAccepted ] = useState( false );
+
+	/**
+	 * The user's chosen onboarding mode.
+	 * 'explore'       — explore and bootstrap the existing site.
+	 * 'theme-builder' — design a custom theme with the Theme Builder agent.
+	 * 'skip'          — skip onboarding and go straight to chat.
+	 *
+	 * Initialised to 'explore'. Updated to 'theme-builder' when the mode-picker
+	 * step mounts and the site is found to have no published content.
+	 */
+	const [ onboardingMode, setOnboardingMode ] = useState( 'explore' );
+
+	/**
+	 * Whether the site has any published posts or pages.
+	 * null = still loading, true/false = resolved.
+	 * Used to pick the default mode in the mode-picker step.
+	 */
+	const [ siteHasPosts, setSiteHasPosts ] = useState( null );
 
 	const { saveSettings } = useDispatch( STORE_NAME );
 	const { providers, selectedProviderId, selectedModelId } = useSelect(
@@ -130,9 +157,9 @@ export default function OnboardingWizard( { onComplete } ) {
 			.catch( () => {} );
 	}, [] );
 
-	// Fetch WooCommerce status when we reach the WooCommerce step (step 3).
+	// Fetch WooCommerce status when we reach the WooCommerce step (step 4).
 	useEffect( () => {
-		if ( step !== 3 ) {
+		if ( step !== 4 ) {
 			return;
 		}
 		setWooLoading( true );
@@ -147,15 +174,66 @@ export default function OnboardingWizard( { onComplete } ) {
 			} );
 	}, [ step ] );
 
+	// Probe for published content when we reach the mode-picker step (step 2).
+	// Sets the default onboarding mode: 'theme-builder' for an empty install,
+	// 'explore' when the site already has content.
+	useEffect( () => {
+		if ( step !== 2 ) {
+			return;
+		}
+		apiFetch( { path: '/wp/v2/posts?per_page=1&status=publish' } )
+			.then( ( posts ) => {
+				const hasPosts = Array.isArray( posts ) && posts.length > 0;
+				setSiteHasPosts( hasPosts );
+				if ( ! hasPosts ) {
+					// Empty install — default to theme-builder.
+					setOnboardingMode( 'theme-builder' );
+				}
+			} )
+			.catch( () => {
+				// On error keep the 'explore' default.
+				setSiteHasPosts( true );
+			} );
+	}, [ step ] );
+
 	const hasAnyProvider = providers.length > 0;
 
+	/**
+	 * Finish the wizard for explore/theme-builder modes.
+	 *
+	 * Saves the default provider/model. Does NOT set onboarding_complete —
+	 * that is handled by the bootstrapper REST endpoint (bootstrap-start or
+	 * theme-builder-start). Calls onComplete with the chosen mode so the
+	 * parent can mount the correct bootstrapper component.
+	 */
 	const handleFinish = useCallback( async () => {
+		await saveSettings( {
+			default_provider: selectedProviderId,
+			default_model: selectedModelId,
+		} );
+		onComplete( onboardingMode );
+	}, [
+		saveSettings,
+		selectedProviderId,
+		selectedModelId,
+		onComplete,
+		onboardingMode,
+	] );
+
+	/**
+	 * Skip all remaining onboarding and go straight to chat.
+	 *
+	 * Sets onboarding_complete on the server so the wizard is not shown
+	 * again on the next visit. Calls onComplete('skip') so the parent can
+	 * proceed immediately to the ChatRedesign shell.
+	 */
+	const handleSkipAll = useCallback( async () => {
 		await saveSettings( {
 			onboarding_complete: true,
 			default_provider: selectedProviderId,
 			default_model: selectedModelId,
 		} );
-		onComplete();
+		onComplete( 'skip' );
 	}, [ saveSettings, selectedProviderId, selectedModelId, onComplete ] );
 
 	/**
@@ -323,6 +401,118 @@ export default function OnboardingWizard( { onComplete } ) {
 		);
 	};
 
+	/**
+	 * Render the mode-picker step content.
+	 *
+	 * Shows three option buttons. The recommended default is highlighted
+	 * based on whether the site has any published content:
+	 * - non-empty install → "Explore my existing site" pre-selected
+	 * - empty install     → "Design a custom theme" pre-selected
+	 *
+	 * Clicking "Explore" or "Design" stores the choice and advances to the
+	 * next step. Clicking "Skip — just chat" marks onboarding complete and
+	 * exits the wizard immediately.
+	 */
+	const renderModePickerStep = () => {
+		const isLoadingDefault = siteHasPosts === null;
+
+		return (
+			<div className="sd-ai-agent-onboarding-mode-picker">
+				<p>
+					{ __(
+						'How would you like to get started with Superdav AI Agent?',
+						'superdav-ai-agent'
+					) }
+				</p>
+
+				{ isLoadingDefault && (
+					<div className="sd-ai-agent-onboarding-mode-picker__loading">
+						<Spinner />
+					</div>
+				) }
+
+				<div className="sd-ai-agent-onboarding-mode-picker__options">
+					{ /* Explore option */ }
+					<button
+						type="button"
+						className={ [
+							'sd-ai-agent-onboarding-mode-picker__button',
+							onboardingMode === 'explore'
+								? 'sd-ai-agent-onboarding-mode-picker__button--selected'
+								: '',
+						]
+							.filter( Boolean )
+							.join( ' ' ) }
+						onClick={ () => {
+							setOnboardingMode( 'explore' );
+							setStep( step + 1 );
+						} }
+					>
+						<span className="sd-ai-agent-onboarding-mode-picker__button-title">
+							{ __(
+								'Explore my existing site',
+								'superdav-ai-agent'
+							) }
+						</span>
+						<span className="sd-ai-agent-onboarding-mode-picker__button-description">
+							{ __(
+								'The AI agent will analyse your site, introduce itself, and help you get the most out of your existing content.',
+								'superdav-ai-agent'
+							) }
+						</span>
+					</button>
+
+					{ /* Theme builder option */ }
+					<button
+						type="button"
+						className={ [
+							'sd-ai-agent-onboarding-mode-picker__button',
+							onboardingMode === 'theme-builder'
+								? 'sd-ai-agent-onboarding-mode-picker__button--selected'
+								: '',
+						]
+							.filter( Boolean )
+							.join( ' ' ) }
+						onClick={ () => {
+							setOnboardingMode( 'theme-builder' );
+							setStep( step + 1 );
+						} }
+					>
+						<span className="sd-ai-agent-onboarding-mode-picker__button-title">
+							{ __(
+								'Design a custom theme',
+								'superdav-ai-agent'
+							) }
+						</span>
+						<span className="sd-ai-agent-onboarding-mode-picker__button-description">
+							{ __(
+								'Work with the Theme Builder agent to design a WordPress theme that matches your vision, colours, and style.',
+								'superdav-ai-agent'
+							) }
+						</span>
+					</button>
+
+					{ /* Skip option */ }
+					<button
+						type="button"
+						className="sd-ai-agent-onboarding-mode-picker__button sd-ai-agent-onboarding-mode-picker__button--skip"
+						onClick={ handleSkipAll }
+					>
+						<span className="sd-ai-agent-onboarding-mode-picker__button-title">
+							{ __( 'Skip — just chat', 'superdav-ai-agent' ) }
+						</span>
+						<span className="sd-ai-agent-onboarding-mode-picker__button-description">
+							{ __(
+								'Go straight to the chat interface. You can always start a guided flow later from the chat.',
+								'superdav-ai-agent'
+							) }
+						</span>
+					</button>
+				</div>
+			</div>
+		);
+	};
+
 	const steps = [
 		// Step 0: Welcome
 		{
@@ -401,7 +591,15 @@ export default function OnboardingWizard( { onComplete } ) {
 				</div>
 			),
 		},
-		// Step 2: Abilities overview (auto-discovery — no curation needed).
+		// Step 2: Choose your start — mode picker (NEW).
+		// Inserted after Provider setup so the user only sees the picker once
+		// a provider is configured. Default selection follows site-content
+		// heuristic: non-empty install → explore, empty install → theme-builder.
+		{
+			title: __( 'Choose Your Start', 'superdav-ai-agent' ),
+			content: renderModePickerStep(),
+		},
+		// Step 3: Abilities overview (auto-discovery — no curation needed).
 		{
 			title: __( 'Abilities', 'sd-ai-agent' ),
 			content: (
@@ -427,12 +625,12 @@ export default function OnboardingWizard( { onComplete } ) {
 				</div>
 			),
 		},
-		// Step 3: WooCommerce (content adapts based on detection result)
+		// Step 4: WooCommerce (content adapts based on detection result)
 		{
 			title: __( 'WooCommerce Store', 'sd-ai-agent' ),
 			content: renderWooCommerceStep(),
 		},
-		// Step 4: Done
+		// Step 5: Done
 		{
 			title: __( 'All Set!', 'sd-ai-agent' ),
 			content: (
@@ -492,7 +690,7 @@ export default function OnboardingWizard( { onComplete } ) {
 				) }
 				<Button
 					variant="link"
-					onClick={ handleFinish }
+					onClick={ handleSkipAll }
 					className="sdaa-wizard-skip"
 				>
 					{ __( 'Skip', 'sd-ai-agent' ) }
@@ -502,12 +700,16 @@ export default function OnboardingWizard( { onComplete } ) {
 						{ __( 'Start Chatting', 'sd-ai-agent' ) }
 					</Button>
 				) : (
-					<Button
-						variant="primary"
-						onClick={ () => setStep( step + 1 ) }
-					>
-						{ __( 'Next', 'sd-ai-agent' ) }
-					</Button>
+					// Hide Next on the mode-picker step (step 2): the user
+					// advances by clicking one of the three mode buttons.
+					step !== 2 && (
+						<Button
+							variant="primary"
+							onClick={ () => setStep( step + 1 ) }
+						>
+							{ __( 'Next', 'sd-ai-agent' ) }
+						</Button>
+					)
 				) }
 			</div>
 		</div>


### PR DESCRIPTION
## Summary

- Adds `OnboardingThemeBuilder` React component (mirrors `OnboardingBootstrap`, POSTs to `/sd-ai-agent/v1/onboarding/theme-builder-start`)
- Inserts a "Choose Your Start" mode-picker step into `OnboardingWizard` (after Provider setup, index 2 of 6 steps)
- Wires `OnboardingWizard` into the admin-page Phase 2 gate: the wizard now shows first, then the chosen bootstrapper mounts (`explore` → `OnboardingBootstrap`, `theme-builder` → `OnboardingThemeBuilder`, `skip` → ChatRedesign)
- Adds 10 Jest tests for `OnboardingThemeBuilder`

## Mode-Picker Default Logic

On mount of step 2, the component probes `/wp/v2/posts?per_page=1&status=publish`:
- **Empty install** (no published posts): pre-selects "Design a custom theme"
- **Non-empty install**: pre-selects "Explore my existing site"

## Webpack Entry Decision

`onboarding-theme-builder.js` is imported by `src/admin-page/index.js` via a lazy chunk (`webpackChunkName: "onboarding-theme-builder"`) — no separate webpack entry was needed. Same pattern as `OnboardingBootstrap`.

## Verification

```
npm run lint:js    # 0 errors
npm run test:js    # 239 tests passed (11 suites)
npm run build      # compiled successfully
```

For #1385
Ref #1373

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.50 plugin for [OpenCode](https://opencode.ai) v1.14.50 with claude-sonnet-4-6 spent 13m and 36,882 tokens on this as a headless worker.
