### PR TITLE
fix(tests): guard SdAiAgentPublicFlagTest against double-registration of sd-ai-agent/memory-save (#1421)

### DIFF
--- a/tests/SdAiAgent/Abilities/SdAiAgentPublicFlagTest.php
+++ b/tests/SdAiAgent/Abilities/SdAiAgentPublicFlagTest.php
@@ -61,8 +61,8 @@ class SdAiAgentPublicFlagTest extends WP_UnitTestCase {
 	public function set_up(): void {
 		parent::set_up();
 
-		if ( ! function_exists( 'wp_register_ability' ) || ! function_exists( 'wp_get_abilities' ) ) {
-			$this->markTestSkipped( 'WP 7.0+ Abilities API (wp_register_ability / wp_get_abilities) not available.' );
+		if ( ! function_exists( 'wp_register_ability' ) || ! function_exists( 'wp_get_abilities' ) || ! function_exists( 'wp_get_ability' ) ) {
+			$this->markTestSkipped( 'WP 7.0+ Abilities API (wp_register_ability / wp_get_ability / wp_get_abilities) not available.' );
 		}
 	}
 
@@ -71,63 +71,74 @@ class SdAiAgentPublicFlagTest extends WP_UnitTestCase {
 	 * it is explicitly hidden (meta.ai_hidden = true).
 	 *
 	 * Procedure:
-	 * 1. Temporarily push 'wp_abilities_api_init' onto $wp_current_filter so
-	 *    wp_register_ability() does not reject the calls.
-	 * 2. Call each abilities class register_abilities() / register() method
-	 *    directly (no DI container, no hook timing issues).
-	 * 3. Scan all registered abilities with a 'sd-ai-agent/' prefix.
-	 * 4. For each, assert meta.mcp.public === true (unless ai_hidden).
+	 * 1. If abilities are not yet registered (isolated test run), temporarily
+	 *    push 'wp_abilities_api_init' onto $wp_current_filter so
+	 *    wp_register_ability() does not reject the calls, then register all
+	 *    ability groups directly (no DI container, no hook timing issues).
+	 *    If abilities are already registered (full-suite run via AbilitiesHandler
+	 *    firing on wp_abilities_api_init during init), skip re-registration to
+	 *    avoid the "already registered" doing_it_wrong notice.
+	 * 2. Scan all registered abilities with a 'sd-ai-agent/' prefix.
+	 * 3. For each, assert meta.mcp.public === true (unless ai_hidden).
 	 */
 	public function test_all_sd_ai_agent_abilities_have_mcp_public_flag(): void {
-		// Push the hook onto $wp_current_filter so wp_register_ability()
-		// accepts calls made outside the normal hook callback context.
-		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Standard WordPress test global.
-		global $wp_current_filter;
-		$wp_current_filter[] = 'wp_abilities_api_init';
+		// Guard: if sd-ai-agent/memory-save is already in the registry (because
+		// AbilitiesHandler::register_all_abilities() fired during wp_abilities_api_init
+		// in the WP test bootstrap's init phase), skip inline registration to avoid
+		// triggering the "already registered" doing_it_wrong notice.
+		$already_registered = null !== wp_get_ability( 'sd-ai-agent/memory-save' );
 
-		// Register every sd-ai-agent/* ability group.
-		MemoryAbilities::register_abilities();
-		SkillAbilities::register_abilities();
-		KnowledgeAbilities::register_abilities();
-		PostAbilities::register_abilities();
-		BlockAbilities::register_abilities();
-		ContentAbilities::register_abilities();
-		FileAbilities::register_abilities();
-		MediaAbilities::register_abilities();
-		UserAbilities::register_abilities();
-		OptionsAbilities::register_abilities();
-		MenuAbilities::register_abilities();
-		SiteHealthAbilities::register_abilities();
-		EditorialAbilities::register_abilities();
-		SeoAbilities::register_abilities();
-		MarketingAbilities::register_abilities();
-		FeedbackAbilities::register_abilities();
-		NavigationAbilities::register_abilities();
-		CustomPostTypeAbilities::register_abilities();
-		CustomTaxonomyAbilities::register_abilities();
-		DatabaseAbilities::register_abilities();
-		DesignSystemAbilities::register_abilities();
-		GlobalStylesAbilities::register_abilities();
-		GoogleAnalyticsAbilities::register_abilities();
-		GscAbilities::register_abilities();
-		InternetSearchAbilities::register_abilities();
-		ImageAbilities::register_abilities();
-		WordPressAbilities::register_abilities();
-		GitAbilities::register_abilities();
+		if ( ! $already_registered ) {
+			// Push the hook onto $wp_current_filter so wp_register_ability()
+			// accepts calls made outside the normal hook callback context.
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Standard WordPress test global.
+			global $wp_current_filter;
+			$wp_current_filter[] = 'wp_abilities_api_init';
 
-		// Register the two meta-tools (ability-search and ability-call).
-		ToolDiscovery::register_abilities();
+			// Register every sd-ai-agent/* ability group.
+			MemoryAbilities::register_abilities();
+			SkillAbilities::register_abilities();
+			KnowledgeAbilities::register_abilities();
+			PostAbilities::register_abilities();
+			BlockAbilities::register_abilities();
+			ContentAbilities::register_abilities();
+			FileAbilities::register_abilities();
+			MediaAbilities::register_abilities();
+			UserAbilities::register_abilities();
+			OptionsAbilities::register_abilities();
+			MenuAbilities::register_abilities();
+			SiteHealthAbilities::register_abilities();
+			EditorialAbilities::register_abilities();
+			SeoAbilities::register_abilities();
+			MarketingAbilities::register_abilities();
+			FeedbackAbilities::register_abilities();
+			NavigationAbilities::register_abilities();
+			CustomPostTypeAbilities::register_abilities();
+			CustomTaxonomyAbilities::register_abilities();
+			DatabaseAbilities::register_abilities();
+			DesignSystemAbilities::register_abilities();
+			GlobalStylesAbilities::register_abilities();
+			GoogleAnalyticsAbilities::register_abilities();
+			GscAbilities::register_abilities();
+			InternetSearchAbilities::register_abilities();
+			ImageAbilities::register_abilities();
+			WordPressAbilities::register_abilities();
+			GitAbilities::register_abilities();
 
-		// Also register image abilities via their static register() methods.
-		if ( class_exists( \SdAiAgent\Abilities\ImageAbilities\StockImageAbility::class ) ) {
-			\SdAiAgent\Abilities\ImageAbilities\StockImageAbility::register();
+			// Register the two meta-tools (ability-search and ability-call).
+			ToolDiscovery::register_abilities();
+
+			// Also register image abilities via their static register() methods.
+			if ( class_exists( \SdAiAgent\Abilities\ImageAbilities\StockImageAbility::class ) ) {
+				\SdAiAgent\Abilities\ImageAbilities\StockImageAbility::register();
+			}
+			if ( class_exists( \SdAiAgent\Abilities\AiImageAbilities::class ) ) {
+				\SdAiAgent\Abilities\AiImageAbilities::register_abilities();
+			}
+
+			// Pop the hook filter entry we pushed.
+			array_pop( $wp_current_filter );
 		}
-		if ( class_exists( \SdAiAgent\Abilities\AiImageAbilities::class ) ) {
-			\SdAiAgent\Abilities\AiImageAbilities::register_abilities();
-		}
-
-		// Pop the hook filter entry we pushed.
-		array_pop( $wp_current_filter );
 
 		// Collect all registered sd-ai-agent/* abilities.
 		$missing_flag  = array();


### PR DESCRIPTION
## Summary

Fixes #1421 — PHPUnit regression where `test_all_sd_ai_agent_abilities_have_mcp_public_flag` fails after PR #1420 merge with:

```
Unexpected incorrect usage notice for WP_Abilities_Registry::register.
Ability "sd-ai-agent/memory-save" is already registered.
```

## Root Cause

`SdAiAgentPublicFlagTest::test_all_sd_ai_agent_abilities_have_mcp_public_flag` registers all `sd-ai-agent/*` abilities inline by calling `MemoryAbilities::register_abilities()` and siblings. When `AbilitiesHandler::register_all_abilities()` fires on `wp_abilities_api_init` during the WP test bootstrap's `init` phase (which happens in a full test-suite run), all abilities are already in the registry before this test method runs. The second call to `wp_register_ability('sd-ai-agent/memory-save', ...)` triggers the `doing_it_wrong` notice, which `WP_UnitTestCase` catches as a test failure.

## Fix

- Add a pre-registration guard in the test: if `wp_get_ability('sd-ai-agent/memory-save')` returns non-null, abilities are already registered (full-suite run via DI bootstrap) and the inline registration block is skipped.
- The existing registry scan always runs, so the test still verifies that every `sd-ai-agent/*` ability has `meta.mcp.public = true` regardless of which path populated the registry.
- Add `wp_get_ability` to the `set_up()` skip guard alongside `wp_register_ability` and `wp_get_abilities`.
- In an isolated `--filter` run (DI not yet fired), `wp_get_ability('sd-ai-agent/memory-save')` returns null and the original inline registration path runs unchanged.

## Verification

```bash
composer phpunit -- --filter=test_all_sd_ai_agent_abilities_have_mcp_public_flag
composer phpcs tests/SdAiAgent/Abilities/SdAiAgentPublicFlagTest.php
```

<!-- aidevops:sig -->