### PR TITLE
fix(post-abilities): replace oneOf with type-array union for Claude 2020-12 compliance (#1425)

### DIFF
--- a/includes/Abilities/PostAbilities.php
+++ b/includes/Abilities/PostAbilities.php
@@ -119,10 +119,7 @@ class PostAbilities {
 							'type'        => 'array',
 							'description' => 'Array of category IDs (integers) or names (strings) to assign.',
 							'items'       => [
-								'oneOf' => [
-									[ 'type' => 'string' ],
-									[ 'type' => 'integer' ],
-								],
+								'type' => [ 'string', 'integer' ],
 							],
 						],
 						'tags'              => [
@@ -207,10 +204,7 @@ class PostAbilities {
 							'type'        => 'array',
 							'description' => 'Replace categories with this array of IDs (integers) or names (strings).',
 							'items'       => [
-								'oneOf' => [
-									[ 'type' => 'string' ],
-									[ 'type' => 'integer' ],
-								],
+								'type' => [ 'string', 'integer' ],
 							],
 						],
 						'tags'              => [
@@ -397,10 +391,7 @@ class PostAbilities {
 										'type'        => 'array',
 										'description' => 'Array of category IDs (integers) or names (strings).',
 										'items'       => [
-											'oneOf' => [
-												[ 'type' => 'string' ],
-												[ 'type' => 'integer' ],
-											],
+											'type' => [ 'string', 'integer' ],
 										],
 									],
 									'tags'              => [

--- a/tests/SdAiAgent/Abilities/Tier1SchemaComplianceTest.php
+++ b/tests/SdAiAgent/Abilities/Tier1SchemaComplianceTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Tier-1 schema compliance regression guard.
+ *
+ * Anthropic's Claude tool-use API validates `input_schema` against JSON Schema
+ * draft 2020-12 and rejects keywords that are merely "valid JSON Schema" in
+ * older drafts but are not supported in its strict subset. In particular,
+ * `oneOf` / `anyOf` / `allOf` inside an `items` schema produces a 400
+ * "tools.N.custom.input_schema: JSON schema is invalid" response, which fails
+ * the cold-start `/v1/run` call before the LLM is ever invoked.
+ *
+ * See issue #1425 for the original incident: `oneOf: [string, integer]`
+ * inside `categories.items` in `create-post`, `update-post`, and
+ * `bulk-update-posts` schemas. The fix is to use the native type-array form:
+ *
+ *     'items' => [ 'type' => [ 'string', 'integer' ] ]
+ *
+ * This test is a source-level guard against any future regression that
+ * reintroduces a forbidden composition keyword inside an ability schema in
+ * `includes/Abilities/`. It runs without a WordPress bootstrap and is
+ * therefore cheap to keep in every PR pipeline.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Abilities;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pure-PHP source-scan test — no WP_UnitTestCase needed.
+ */
+final class Tier1SchemaComplianceTest extends TestCase {
+
+	/**
+	 * Forbidden top-level JSON Schema composition keywords.
+	 *
+	 * These are technically valid JSON Schema but are rejected by Claude's
+	 * draft 2020-12 validator when used inside tool input schemas.
+	 *
+	 * @var string[]
+	 */
+	private const FORBIDDEN_KEYWORDS = array( 'oneOf', 'anyOf', 'allOf' );
+
+	/**
+	 * Test that no ability source file in `includes/Abilities/` uses a
+	 * forbidden composition keyword.
+	 *
+	 * We do a simple textual scan rather than full AST parsing because the
+	 * keywords are highly specific JSON Schema identifiers — false positives
+	 * would have to be `'oneOf'` / `'anyOf'` / `'allOf'` written as PHP string
+	 * literals, which is almost certainly an ability schema.
+	 *
+	 * If a legitimate non-schema use ever appears, exclude that file by path.
+	 */
+	public function test_no_forbidden_keywords_in_ability_schemas(): void {
+		$abilities_dir = dirname( __DIR__, 3 ) . '/includes/Abilities';
+
+		$this->assertDirectoryExists( $abilities_dir );
+
+		$iterator = new \RecursiveIteratorIterator(
+			new \RecursiveDirectoryIterator( $abilities_dir, \FilesystemIterator::SKIP_DOTS )
+		);
+
+		$violations = array();
+
+		foreach ( $iterator as $file ) {
+			if ( ! $file->isFile() || 'php' !== $file->getExtension() ) {
+				continue;
+			}
+
+			$contents = (string) file_get_contents( $file->getPathname() );
+
+			foreach ( self::FORBIDDEN_KEYWORDS as $keyword ) {
+				// Match the keyword as a quoted PHP array key, which is the
+				// only form that appears in ability schema definitions.
+				$pattern = "/['\"]" . preg_quote( $keyword, '/' ) . "['\"]\s*=>/";
+				if ( preg_match( $pattern, $contents ) ) {
+					$violations[] = sprintf(
+						'%s contains forbidden JSON Schema keyword "%s" — Claude 2020-12 rejects this. Use a type-array union, e.g. [ "type" => [ "string", "integer" ] ].',
+						$file->getPathname(),
+						$keyword
+					);
+				}
+			}
+		}
+
+		$this->assertSame(
+			array(),
+			$violations,
+			"Ability schemas must remain Claude 2020-12 compliant:\n" . implode( "\n", $violations )
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #1425 — replaces the JSON Schema `oneOf` composition keyword with the native draft-2020-12 type-array union inside `categories.items` for three Tier-1 abilities. Anthropic's Claude tool-use API rejects `oneOf`/`anyOf`/`allOf` inside `items` with HTTP 400, breaking the cold-start `/v1/run` call for every Anthropic-backed install (`create-post` and `update-post` are in `ToolDiscovery::DEFAULT_TIER_1`).

## Changes

- `includes/Abilities/PostAbilities.php`
  - `sd-ai-agent/create-post` (was line 122)
  - `sd-ai-agent/update-post` (was line 210)
  - `sd-ai-agent/bulk-update-posts` items (was line 400)

  Before:
  ```php
  'items' => [
      'oneOf' => [
          [ 'type' => 'string' ],
          [ 'type' => 'integer' ],
      ],
  ],
  ```

  After:
  ```php
  'items' => [
      'type' => [ 'string', 'integer' ],
  ],
  ```

  Semantically identical, shorter, supported by both Anthropic and OpenAI tool APIs. Descriptions unchanged.

- `tests/SdAiAgent/Abilities/Tier1SchemaComplianceTest.php` — new pure-PHP source-scan regression guard. Iterates `includes/Abilities/**/*.php` and fails if any quoted `oneOf` / `anyOf` / `allOf` array-key appears, catching any future reintroduction across all abilities (not just `PostAbilities`).

## Verification

- `composer phpcs` — clean (full suite, 8 files).
- `composer phpstan` — `[OK] No errors` (213 files).
- New test passes via `vendor/bin/phpunit --bootstrap vendor/autoload.php --filter Tier1SchemaCompliance` (1 test, 2 assertions).
- Pre-commit hooks (PHPCS + PHPCBF) pass.
- Full WP-bootstrapped PHPUnit suite was not run locally because the active wp-env on port 8890 is bound to a different worktree; CI will exercise it on this PR. The change is schema-only (no runtime code path touched), so unit coverage of `handle_create_post` / `handle_update_post` is unaffected.

End-to-end manual verification per the issue's reproduction (POST `/wp-json/sd-ai-agent/v1/run` with a Claude model and default Tier-1 abilities) requires `ai-provider-for-anthropic-max` on a live install and is best run on staging after merge.

Resolves #1425

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.50 plugin for [OpenCode](https://opencode.ai) v1.14.50 with claude-opus-4-7 spent 7m and 15,342 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified JSON schema validation for post category inputs in create, update, and batch post operations.

* **Tests**
  * Added regression test to enforce schema validation best practices and prevent structural issues in ability schemas.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1426)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->