### PR TITLE
fix(cli): allow 'wp sd-ai-agent prompt "text"' (drop double prompt)

### DIFF
--- a/includes/CLI/CliCommand.php
+++ b/includes/CLI/CliCommand.php
@@ -91,7 +91,7 @@ class CliCommand extends \WP_CLI_Command {
 	 * @param array $args       Positional arguments.
 	 * @param array $assoc_args Associative arguments.
 	 */
-	public function prompt( array $args, array $assoc_args ): void {
+	public function __invoke( array $args, array $assoc_args ): void {
 		$prompt     = $args[0];
 		$agent_slug = \WP_CLI\Utils\get_flag_value( $assoc_args, 'agent', '' );
 		$no_tools   = \WP_CLI\Utils\get_flag_value( $assoc_args, 'skip-tools', false );


### PR DESCRIPTION
## Summary
The `CliCommand` class is registered with WP-CLI as the command `sd-ai-agent prompt` by `CliHandler::register_commands()`. Naming the handler method `prompt()` made WP-CLI register a same-name subcommand under the parent, so the only working invocation was the awkward `wp sd-ai-agent prompt prompt "text"` — every existing docblock example (e.g. `CliCommand.php:32`, `:83`) showed the single-word form, which actually returned `'…' is not a registered subcommand of 'sd-ai-agent prompt'`.

Renaming the method to `__invoke()` makes the registered command directly callable, mirroring the pattern already used by `ModelsCommand::__invoke()` (`includes/CLI/ModelsCommand.php:66`).

## Verification
- PHPCS: `composer phpcs -- includes/CLI/CliCommand.php` → 0 violations.
- `php -l includes/CLI/CliCommand.php` → no syntax errors.
- Live dev install (`wp sd-ai-agent prompt 'Just say hi.' --skip-tools`) returns the expected reply with the simplified syntax.
- `wp help sd-ai-agent prompt` synopsis is now `wp sd-ai-agent prompt <prompt> [--agent=<slug>] …` instead of `wp sd-ai-agent prompt <command>` with a nested `prompt` subcommand.

## Notes
- No callers of `CliCommand::prompt()` exist outside `CliHandler` (registration uses the class, not the method name).
- All existing class- and method-level docblock examples already used the single-word form, so no docs needed updating.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.50 plugin for [OpenCode](https://opencode.ai) v1.14.50 with claude-sonnet-4-6 spent 8h 1m and 383 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code structure improvements to CLI command handling. No user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1430)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->