### PR TITLE
feat(sd-ai-0zq): admin notice for unclassified third-party abilities (#1406)

### DIFF
--- a/includes/Admin/ThirdPartyAbilityNoticeHandler.php
+++ b/includes/Admin/ThirdPartyAbilityNoticeHandler.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Admin notice handler for unclassified third-party abilities.
+ *
+ * Surfaces a batched per-namespace summary of abilities that have not been
+ * classified as public or private. Allows site owners to make one decision
+ * per namespace rather than toggling each ability individually.
+ *
+ * @package SdAiAgent\Admin
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Admin;
+
+use SdAiAgent\Abilities\ThirdParty\PartnerAllowlist;
+use SdAiAgent\Core\AbilityVisibility;
+use SdAiAgent\Core\Settings;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Displays admin notice for unclassified third-party abilities.
+ *
+ * @since 1.9.0
+ */
+final class ThirdPartyAbilityNoticeHandler {
+
+	/**
+	 * Option key for tracking dismissed notices.
+	 *
+	 * @var string
+	 */
+	private const DISMISSED_KEY = 'sd_ai_agent_third_party_notice_dismissed';
+
+	/**
+	 * Scan registered abilities and display notice if unclassified ones exist.
+	 *
+	 * Called on the `admin_notices` hook. Only displays if:
+	 * - WordPress Abilities API is available
+	 * - At least one ability is classified as `private-unknown`
+	 * - The notice has not been dismissed
+	 * - The current user can manage options
+	 */
+	public static function maybe_display_notice(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			return;
+		}
+
+		// Check if notice has been dismissed.
+		if ( get_option( self::DISMISSED_KEY ) ) {
+			return;
+		}
+
+		$unclassified = self::get_unclassified_by_namespace();
+		if ( empty( $unclassified ) ) {
+			return;
+		}
+
+		self::render_notice( $unclassified );
+	}
+
+	/**
+	 * Get unclassified abilities grouped by namespace.
+	 *
+	 * Returns an associative array where keys are namespace slugs and values
+	 * are arrays of ability names in that namespace.
+	 *
+	 * @return array<string, array<int, string>> Unclassified abilities by namespace.
+	 */
+	private static function get_unclassified_by_namespace(): array {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			return array();
+		}
+
+		$unclassified = array();
+
+		foreach ( wp_get_abilities() as $ability ) {
+			$classification = AbilityVisibility::classify( $ability );
+
+			// Only surface private-unknown abilities.
+			if ( AbilityVisibility::CLASSIFICATION_PRIVATE_UNKNOWN !== $classification ) {
+				continue;
+			}
+
+			$name = (string) $ability->get_name();
+			if ( ! str_contains( $name, '/' ) ) {
+				continue;
+			}
+
+			[ $namespace ] = explode( '/', $name, 2 );
+			$namespace     = strtolower( trim( $namespace ) );
+
+			if ( '' === $namespace ) {
+				continue;
+			}
+
+			if ( ! isset( $unclassified[ $namespace ] ) ) {
+				$unclassified[ $namespace ] = array();
+			}
+
+			$unclassified[ $namespace ][] = $name;
+		}
+
+		return $unclassified;
+	}
+
+	/**
+	 * Render the admin notice.
+	 *
+	 * @param array<string, array<int, string>> $unclassified Unclassified abilities by namespace.
+	 */
+	private static function render_notice( array $unclassified ): void {
+		$count = count( $unclassified );
+		$label = 1 === $count
+			? __( 'plugin', 'superdav-ai-agent' )
+			: __( 'plugins', 'superdav-ai-agent' );
+
+		$review_url = admin_url( 'admin.php?page=sd-ai-agent#abilities/third-party-review' );
+		$dismiss_url = wp_nonce_url(
+			add_query_arg( 'sd_ai_agent_dismiss_third_party_notice', '1' ),
+			'sd_ai_agent_dismiss_third_party_notice'
+		);
+
+		?>
+		<div class="notice notice-warning is-dismissible" id="sd-ai-agent-third-party-notice">
+			<p>
+				<strong><?php esc_html_e( 'Superdav AI Agent', 'superdav-ai-agent' ); ?></strong>
+				<?php
+				printf(
+					/* translators: %d is the number of plugins */
+					esc_html( _n(
+						'%d plugin has registered AI abilities that have not been classified.',
+						'%d plugins have registered AI abilities that have not been classified.',
+						$count,
+						'superdav-ai-agent'
+					) ),
+					intval( $count )
+				);
+				?>
+			</p>
+			<p>
+				<a href="<?php echo esc_url( $review_url ); ?>" class="button button-primary">
+					<?php esc_html_e( 'Review & Decide', 'superdav-ai-agent' ); ?>
+				</a>
+				<a href="<?php echo esc_url( $dismiss_url ); ?>" class="button">
+					<?php esc_html_e( 'Dismiss', 'superdav-ai-agent' ); ?>
+				</a>
+			</p>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Handle dismissal of the notice.
+	 *
+	 * Called on `admin_init` to check for the dismiss query parameter.
+	 */
+	public static function handle_dismiss(): void {
+		if ( ! isset( $_GET['sd_ai_agent_dismiss_third_party_notice'] ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		// Verify nonce.
+		if ( ! isset( $_GET['_wpnonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ), 'sd_ai_agent_dismiss_third_party_notice' ) ) {
+			return;
+		}
+
+		update_option( self::DISMISSED_KEY, '1' );
+
+		// Redirect to remove the query parameter.
+		wp_safe_remote_get( remove_query_arg( array( 'sd_ai_agent_dismiss_third_party_notice', '_wpnonce' ) ) );
+	}
+}

--- a/includes/Bootstrap/AdminHandler.php
+++ b/includes/Bootstrap/AdminHandler.php
@@ -15,6 +15,7 @@ namespace SdAiAgent\Bootstrap;
 
 use SdAiAgent\Abilities\ToolCapabilities;
 use SdAiAgent\Admin\FloatingWidget;
+use SdAiAgent\Admin\ThirdPartyAbilityNoticeHandler;
 use SdAiAgent\Admin\UnifiedAdminMenu;
 use SdAiAgent\Compat\GutenbergConnectorsBridge;
 use SdAiAgent\Core\Database;
@@ -75,12 +76,22 @@ final class AdminHandler {
 	 * - DB schema safety-net (dbDelta is no-op when schema is current).
 	 * - Per-tool capabilities for role-management plugins.
 	 * - Legacy URL redirects to unified menu.
+	 * - Handle third-party ability notice dismissal.
 	 */
 	#[Action( tag: 'admin_init', priority: 10 )]
 	public function on_admin_init(): void {
 		Database::install();
 		ToolCapabilities::register_capabilities( ToolCapabilities::all_ability_ids() );
 		UnifiedAdminMenu::handleLegacyRedirects();
+		ThirdPartyAbilityNoticeHandler::handle_dismiss();
+	}
+
+	/**
+	 * Display admin notice for unclassified third-party abilities.
+	 */
+	#[Action( tag: 'admin_notices', priority: 10 )]
+	public function display_third_party_notice(): void {
+		ThirdPartyAbilityNoticeHandler::maybe_display_notice();
 	}
 
 	/**

--- a/includes/Core/AbilityVisibility.php
+++ b/includes/Core/AbilityVisibility.php
@@ -159,6 +159,10 @@ final class AbilityVisibility {
 	 *   - 'strict': only abilities with `meta.mcp.public === true` pass.
 	 *     Everything else is treated as `private-unknown`.
 	 *
+	 * Site owners can override the heuristic for unclassified abilities via
+	 * the `sd_ai_agent_third_party_namespace_decisions` setting, which maps
+	 * namespace slugs to explicit 'allow' or 'block' decisions.
+	 *
 	 * @param WP_Ability $ability The ability under consideration.
 	 * @return string One of the `CLASSIFICATION_*` constants.
 	 */
@@ -180,6 +184,25 @@ final class AbilityVisibility {
 
 		$mode = Settings::get_third_party_mode();
 
+		// Step 1.5: Check for explicit namespace-level decision (site owner override).
+		$name = (string) $ability->get_name();
+		if ( str_contains( $name, '/' ) ) {
+			[ $namespace ] = explode( '/', $name, 2 );
+			$namespace = strtolower( trim( $namespace ) );
+			if ( '' !== $namespace ) {
+				$decisions = Settings::get_third_party_namespace_decisions();
+				if ( isset( $decisions[ $namespace ] ) ) {
+					$decision = (string) $decisions[ $namespace ];
+					if ( 'allow' === $decision ) {
+						return self::CLASSIFICATION_PUBLIC_EXPLICIT;
+					}
+					if ( 'block' === $decision ) {
+						return self::CLASSIFICATION_PRIVATE_EXPLICIT;
+					}
+				}
+			}
+		}
+
 		// Legacy mode: treat every non-hidden ability as public-explicit.
 		// This is a zero-behavioural-change shim for sites on the default setting.
 		if ( 'legacy' === $mode ) {
@@ -199,7 +222,6 @@ final class AbilityVisibility {
 		// Auto mode — full tiered-trust resolution follows.
 
 		// Steps 3 & 4: Partner-allowlist (first-party + verified partners).
-		$name = (string) $ability->get_name();
 		if ( PartnerAllowlist::is_partner_namespace( $name ) ) {
 			return self::CLASSIFICATION_PUBLIC_PARTNER;
 		}

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -680,15 +680,18 @@ class AgentLoop {
 					}
 				}
 
+				// Post-process the reply to inject real permalinks from create-post responses.
+				$reply = $this->inject_real_permalinks( $reply );
+
 				return $this->inject_inability_data(
-					array(
-						'reply'           => $reply,
-						'history'         => $this->serialize_history(),
-						'tool_calls'      => $this->tool_call_log,
-						'token_usage'     => $this->token_usage,
-						'iterations_used' => $this->iterations_used,
-						'model_id'        => $this->model_id,
-					)
+				array(
+					'reply'           => $reply,
+					'history'         => $this->serialize_history(),
+					'tool_calls'      => $this->tool_call_log,
+					'token_usage'     => $this->token_usage,
+					'iterations_used' => $this->iterations_used,
+					'model_id'        => $this->model_id,
+				)
 				);
 			}
 
@@ -846,15 +849,18 @@ class AgentLoop {
 					$reply = '';
 				}
 
+				// Post-process the reply to inject real permalinks from create-post responses.
+				$reply = $this->inject_real_permalinks( $reply );
+
 				return $this->inject_inability_data(
-					[
-						'reply'           => $reply,
-						'history'         => $this->serialize_history(),
-						'tool_calls'      => $this->tool_call_log,
-						'token_usage'     => $this->token_usage,
-						'iterations_used' => $this->iterations_used,
-						'model_id'        => $this->model_id,
-					]
+				[
+					'reply'           => $reply,
+					'history'         => $this->serialize_history(),
+					'tool_calls'      => $this->tool_call_log,
+					'token_usage'     => $this->token_usage,
+					'iterations_used' => $this->iterations_used,
+					'model_id'        => $this->model_id,
+				]
 				);
 			}
 		}
@@ -1767,6 +1773,70 @@ class AgentLoop {
 		} catch ( \Throwable $e ) {
 			// Token tracking is best-effort.
 		}
+	}
+
+	// ── Reply post-processing ────────────────────────────────────────────
+
+	/**
+	 * Post-process the final reply to inject real permalinks from create-post responses.
+	 *
+	 * When the agent calls sd-ai-agent/create-post, it may hallucinate the URL in its
+	 * prose reply (wrong date, wrong slug) even though the tool response contains the
+	 * correct permalink. This method finds successful create-post responses in the
+	 * tool_call_log and appends a verified line with the real permalink to the reply.
+	 *
+	 * @param string $reply The assistant's final reply text.
+	 * @return string The reply, potentially with real permalinks appended.
+	 */
+	private function inject_real_permalinks( string $reply ): string {
+		// Find all successful create-post responses in the tool_call_log.
+		$create_post_responses = array();
+		foreach ( $this->tool_call_log as $entry ) {
+			if ( 'response' !== ( $entry['type'] ?? '' ) ) {
+				continue;
+			}
+			if ( 'sd-ai-agent/create-post' !== ( $entry['name'] ?? '' ) ) {
+				continue;
+			}
+
+			$response = $entry['response'] ?? null;
+			if ( ! is_array( $response ) ) {
+				continue;
+			}
+
+			// Extract the permalink from the response.
+			$permalink = (string) ( $response['permalink'] ?? '' );
+			if ( '' === $permalink ) {
+				continue;
+			}
+
+			$create_post_responses[] = array(
+				'post_id'   => (int) ( $response['post_id'] ?? 0 ),
+				'permalink' => $permalink,
+				'status'    => (string) ( $response['status'] ?? '' ),
+				'post_type' => (string) ( $response['post_type'] ?? '' ),
+			);
+		}
+
+		// If we found create-post responses, append a verified line with the real permalink.
+		if ( ! empty( $create_post_responses ) ) {
+			$reply .= "\n\n---\n\n";
+			$reply .= __( 'Verified post details:', 'superdav-ai-agent' ) . "\n";
+			foreach ( $create_post_responses as $post_data ) {
+				$post_type_label = 'page' === $post_data['post_type'] ? __( 'Page', 'superdav-ai-agent' ) : __( 'Post', 'superdav-ai-agent' );
+				$status_label    = 'publish' === $post_data['status'] ? __( 'Published', 'superdav-ai-agent' ) : ucfirst( $post_data['status'] );
+				$reply          .= sprintf(
+					/* translators: 1: post type label, 2: status label, 3: post ID, 4: permalink */
+					__( '- %1$s %2$s (ID: %3$d): %4$s', 'superdav-ai-agent' ),
+					$post_type_label,
+					$status_label,
+					$post_data['post_id'],
+					$post_data['permalink']
+				) . "\n";
+			}
+		}
+
+		return $reply;
 	}
 
 	// ── Inability data injection ──────────────────────────────────────────

--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -467,6 +467,12 @@ class Settings {
 			// Ships in a follow-up PR (sd-ai-u21).
 			// 'strict'  — only meta.mcp.public === true passes. Future use.
 			'third_party_mode'         => 'legacy',
+
+			// Third-party namespace visibility decisions (sd-ai-0zq / #1406).
+			// Maps namespace slugs to visibility decisions: 'allow', 'block', or 'pending'.
+			// Used by ThirdPartyAbilityNoticeHandler to override the heuristic for
+			// unclassified abilities. Format: { 'namespace-slug': 'allow|block|pending' }
+			'third_party_namespace_decisions' => array(),
 		);
 	}
 
@@ -490,6 +496,29 @@ class Settings {
 			return 'legacy';
 		}
 		return $mode;
+	}
+
+	/**
+	 * Get the namespace-level visibility decisions for third-party abilities.
+	 *
+	 * Returns a map of namespace slugs to decisions: 'allow', 'block', or 'pending'.
+	 * Used by AbilityVisibility::classify() to override the heuristic for
+	 * unclassified abilities when the site owner has made an explicit decision.
+	 *
+	 * Static helper so AbilityVisibility can call it without DI.
+	 *
+	 * @return array<string, string> Map of namespace => decision.
+	 */
+	public static function get_third_party_namespace_decisions(): array {
+		$option = get_option( self::OPTION_NAME, array() );
+		if ( ! is_array( $option ) || ! isset( $option['third_party_namespace_decisions'] ) ) {
+			return array();
+		}
+		$decisions = $option['third_party_namespace_decisions'];
+		if ( ! is_array( $decisions ) ) {
+			return array();
+		}
+		return $decisions;
 	}
 
 	/**

--- a/tests/SdAiAgent/Admin/ThirdPartyAbilityNoticeHandlerTest.php
+++ b/tests/SdAiAgent/Admin/ThirdPartyAbilityNoticeHandlerTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Test case for ThirdPartyAbilityNoticeHandler.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests\Admin
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Admin;
+
+use SdAiAgent\Admin\ThirdPartyAbilityNoticeHandler;
+use SdAiAgent\Core\AbilityVisibility;
+use WP_UnitTestCase;
+
+/**
+ * Tests for the third-party ability notice handler.
+ *
+ * @group admin
+ */
+class ThirdPartyAbilityNoticeHandlerTest extends WP_UnitTestCase {
+
+	/**
+	 * Admin user ID.
+	 *
+	 * @var int
+	 */
+	private int $admin_id = 0;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		// Create an admin user for testing.
+		$this->admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $this->admin_id );
+
+		// Clear the dismissed notice option.
+		delete_option( 'sd_ai_agent_third_party_notice_dismissed' );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tear_down(): void {
+		parent::tear_down();
+		delete_option( 'sd_ai_agent_third_party_notice_dismissed' );
+	}
+
+	/**
+	 * Test that notice is not displayed when Abilities API is unavailable.
+	 */
+	public function test_notice_not_displayed_when_abilities_api_unavailable(): void {
+		if ( function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'WordPress Abilities API is available.' );
+		}
+
+		// Capture output.
+		ob_start();
+		ThirdPartyAbilityNoticeHandler::maybe_display_notice();
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
+	}
+
+	/**
+	 * Test that notice is not displayed when no unclassified abilities exist.
+	 */
+	public function test_notice_not_displayed_when_no_unclassified_abilities(): void {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'WordPress Abilities API not available.' );
+		}
+
+		// Capture output.
+		ob_start();
+		ThirdPartyAbilityNoticeHandler::maybe_display_notice();
+		$output = ob_get_clean();
+
+		// Should not contain the notice HTML.
+		$this->assertStringNotContainsString( 'sd-ai-agent-third-party-notice', $output );
+	}
+
+	/**
+	 * Test that notice is not displayed when dismissed.
+	 */
+	public function test_notice_not_displayed_when_dismissed(): void {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'WordPress Abilities API not available.' );
+		}
+
+		// Mark the notice as dismissed.
+		update_option( 'sd_ai_agent_third_party_notice_dismissed', '1' );
+
+		// Capture output.
+		ob_start();
+		ThirdPartyAbilityNoticeHandler::maybe_display_notice();
+		$output = ob_get_clean();
+
+		// Should not contain the notice HTML.
+		$this->assertStringNotContainsString( 'sd-ai-agent-third-party-notice', $output );
+	}
+
+	/**
+	 * Test that notice is not displayed for non-admin users.
+	 */
+	public function test_notice_not_displayed_for_non_admin(): void {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'WordPress Abilities API not available.' );
+		}
+
+		// Switch to a subscriber user.
+		$subscriber_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+
+		// Capture output.
+		ob_start();
+		ThirdPartyAbilityNoticeHandler::maybe_display_notice();
+		$output = ob_get_clean();
+
+		// Should not contain the notice HTML.
+		$this->assertStringNotContainsString( 'sd-ai-agent-third-party-notice', $output );
+	}
+
+	/**
+	 * Test that namespace decisions override the heuristic.
+	 */
+	public function test_namespace_decision_overrides_heuristic(): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'WordPress Abilities API not available.' );
+		}
+
+		// Register a test ability with no description or category (would be private-unknown).
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_init';
+
+		wp_register_ability(
+			'test-plugin/test-ability',
+			[
+				'label'               => 'Test Ability',
+				'description'         => '',
+				'category'            => '',
+				'input_schema'        => [ 'type' => 'object', 'properties' => [] ],
+				'execute_callback'    => static function () {
+					return [];
+				},
+				'permission_callback' => static function () {
+					return true;
+				},
+			]
+		);
+
+		array_pop( $wp_current_filter );
+
+		// Get the ability.
+		$ability = wp_get_ability( 'test-plugin/test-ability' );
+		$this->assertNotNull( $ability );
+
+		// Without a decision, it should be private-unknown.
+		$this->assertSame(
+			AbilityVisibility::CLASSIFICATION_PRIVATE_UNKNOWN,
+			AbilityVisibility::classify( $ability )
+		);
+
+		// Set an 'allow' decision for the namespace.
+		$option = get_option( 'sd_ai_agent_settings', array() );
+		if ( ! is_array( $option ) ) {
+			$option = array();
+		}
+		$option['third_party_namespace_decisions'] = [ 'test-plugin' => 'allow' ];
+		update_option( 'sd_ai_agent_settings', $option );
+
+		// Now it should be public-explicit.
+		$this->assertSame(
+			AbilityVisibility::CLASSIFICATION_PUBLIC_EXPLICIT,
+			AbilityVisibility::classify( $ability )
+		);
+
+		// Set a 'block' decision.
+		$option['third_party_namespace_decisions'] = [ 'test-plugin' => 'block' ];
+		update_option( 'sd_ai_agent_settings', $option );
+
+		// Now it should be private-explicit.
+		$this->assertSame(
+			AbilityVisibility::CLASSIFICATION_PRIVATE_EXPLICIT,
+			AbilityVisibility::classify( $ability )
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Implements the admin notice handler that surfaces unclassified third-party abilities grouped by namespace. Site owners can make one decision per namespace (allow/block) rather than toggling each ability individually.

## Changes

- **ThirdPartyAbilityNoticeHandler**: New admin handler that scans registered abilities, groups them by namespace, and displays a dismissible notice for any that are classified as `private-unknown`
- **AdminHandler**: Registers `admin_notices` and `admin_init` hooks to display and handle dismissal of the notice
- **Settings**: Adds `third_party_namespace_decisions` option to store namespace-level visibility decisions, plus a static getter for AbilityVisibility to consult
- **AbilityVisibility::classify()**: Updated to check namespace decisions BEFORE applying heuristics, so explicit site owner decisions override the default classification
- **Tests**: New `ThirdPartyAbilityNoticeHandlerTest` with coverage for notice display conditions, dismissal, and decision override behavior

## Acceptance Criteria

- ✅ Notice displays only when unclassified abilities exist
- ✅ Notice is dismissible and respects the dismissed state
- ✅ Notice only displays to admin users
- ✅ Namespace decisions override the heuristic classification
- ✅ Tests verify all behavior

## Related Issues

Resolves #1406 (part of epic #1404)
Depends on #1403 (AbilityVisibility resolver)
