### PR TITLE
feat(sd-ai-u21): flip third_party_mode default from legacy to auto (#1407)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or chat sessions are flagged as onboarded so the bootstrap discovery UI
   never opens on plugin update.
 
+## [1.12.0] - 2026-05-15
+
+### Added
+
+- Admin notice for unclassified third-party abilities, grouped by namespace
+  with one decision per namespace (allow/block) rather than per-ability
+  toggling (#1406)
+- `ThirdPartyAbilityNoticeHandler` to surface and manage third-party ability
+  visibility decisions
+- `third_party_namespace_decisions` setting to store namespace-level visibility
+  overrides
+
+### Changed
+
+- Default `sd_ai_agent_third_party_mode` flipped from `legacy` to `auto`. The
+  tiered-trust model is now the default, requiring explicit namespace decisions
+  for unclassified third-party abilities. Site owners who want the previous
+  opt-out behaviour can set the mode back to `legacy` from settings.
+- `AbilityVisibility::classify()` now consults namespace-level decisions before
+  applying heuristics, allowing site owners to override the default
+  classification
+
 ## [1.3.0] - 2026-03-24
 
 ### Added

--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -457,16 +457,15 @@ class Settings {
 			// Skill auto-update settings (t218).
 			'skill_auto_update'        => true,
 			'skill_manifest_url'       => '',
-			// Third-party ability visibility mode (sd-ai-3ns / #1405).
+			// Third-party ability visibility mode (sd-ai-3ns / #1405, sd-ai-u21 / #1407).
 			// Controls which abilities are exposed to AI surfaces by AbilityVisibility.
-			// 'legacy'  — current behaviour: everything except ai_hidden is public.
+			// 'legacy'  — opt-out behaviour: everything except ai_hidden is public.
 			// The AbilityVisibility resolver is forced to allow regardless
-			// of namespace/category/heuristic tiers. Zero behavioural
-			// change for existing sites.
+			// of namespace/category/heuristic tiers.
 			// 'auto'    — full tiered-trust model: namespace allowlist + heuristics.
-			// Ships in a follow-up PR (sd-ai-u21).
+			// Default since 1.12.0.
 			// 'strict'  — only meta.mcp.public === true passes. Future use.
-			'third_party_mode'         => 'legacy',
+			'third_party_mode'         => 'auto',
 
 			// Third-party namespace visibility decisions (sd-ai-0zq / #1406).
 			// Maps namespace slugs to visibility decisions: 'allow', 'block', or 'pending'.

--- a/superdav-ai-agent.php
+++ b/superdav-ai-agent.php
@@ -3,7 +3,7 @@
  * Plugin Name: Superdav AI Agent
  * Plugin URI:  https://github.com/Ultimate-Multisite/superdav-ai-agent
  * Description: Agentic AI loop for WordPress — chat with an AI that can call WordPress abilities (tools) autonomously.
- * Version:     1.11.1
+ * Version:     1.12.0
  * Author:      superdav42
  * Author URI:  https://github.com/superdav42
  * License:     GPL-2.0-or-later
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'SD_AI_AGENT_VERSION', '1.11.1' );
+define( 'SD_AI_AGENT_VERSION', '1.12.0' );
 define( 'SD_AI_AGENT_DIR', __DIR__ );
 
 // Allow the plugin to load from a symlinked path. Without this, WordPress


### PR DESCRIPTION
## Summary

Flips the default `third_party_mode` setting from `legacy` (opt-out: everything except `ai_hidden` is public) to `auto` (full tiered-trust model: namespace allowlist + heuristics).

This is the second half of the sd-ai-3ns / sd-ai-u21 work. The first half (#1433) added the admin notice that lets site owners review and classify each third-party namespace as allow/block when running in `auto` mode.

## Changes

- Version bump: `1.11.1` → `1.12.0`
- Default `third_party_mode` flipped from `legacy` to `auto` in `includes/Core/Settings.php`
- Settings docblock updated to reflect that `auto` is now the default
- CHANGELOG entry for 1.12.0 covering both #1406 (admin notice, already merged) and this default flip

## No migration code

The plugin has no shipped install base that would need legacy-preservation behaviour, so no upgrade handler, no auto-allowlist scan, and no version-flag tracking is included. Anyone who explicitly wants the previous opt-out behaviour can set the mode back to `legacy` from settings.

## Verification

- `php -l` clean on both modified PHP files
- `vendor/bin/phpcs` runs clean for changes in this PR (35 alignment warnings on `Settings.php` are pre-existing across the file, unrelated to this change)
- `vendor/bin/phpstan analyse` shows the same 1 pre-existing error in `get_third_party_namespace_decisions()` (introduced in #1433) and no new errors

Resolves #1407