### PR TITLE
fix(sd-ai-34u): add missing cache_creation_tokens columns to provider_trace dbDelta

### DIFF
--- a/includes/Core/Database.php
+++ b/includes/Core/Database.php
@@ -36,7 +36,7 @@ use SdAiAgent\Tools\CustomTools;
 class Database {
 
 	const DB_VERSION_OPTION = 'sd_ai_agent_db_version';
-	const DB_VERSION        = '19.2.0';
+	const DB_VERSION        = '19.2.1';
 
 	// ─── Table Name Registry ──────────────────────────────────────────────────
 
@@ -578,6 +578,8 @@ class Database {
 			method varchar(10) NOT NULL DEFAULT 'POST',
 			status_code int(11) NOT NULL DEFAULT 0,
 			duration_ms bigint(20) unsigned NOT NULL DEFAULT 0,
+			cache_creation_tokens bigint(20) unsigned NOT NULL DEFAULT 0,
+			cache_read_tokens bigint(20) unsigned NOT NULL DEFAULT 0,
 			request_headers longtext NOT NULL,
 			request_body longtext NOT NULL,
 			response_headers longtext NOT NULL,

--- a/tests/SdAiAgent/Core/DatabaseSchemaTest.php
+++ b/tests/SdAiAgent/Core/DatabaseSchemaTest.php
@@ -312,6 +312,31 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Provider trace table has the cache-token columns introduced in DB 19.2.0.
+	 *
+	 * Regression for sd-ai-34u: PR #1387 added the columns to
+	 * {@see \SdAiAgent\Models\ProviderTrace::get_schema()} and bumped DB_VERSION
+	 * to 19.2.0, but the inline schema in {@see Database::install()} was not
+	 * updated, so dbDelta never created the columns on existing sites.
+	 * Inserts into the table then failed with "Unknown column
+	 * 'cache_creation_tokens' in 'INSERT INTO'". Asserting the columns exist
+	 * after install() guards against the same drift recurring.
+	 */
+	public function test_provider_trace_table_has_cache_token_columns(): void {
+		Database::install();
+
+		$columns = $this->get_column_names( Database::provider_trace_table_name() );
+
+		foreach ( [ 'cache_creation_tokens', 'cache_read_tokens' ] as $col ) {
+			$this->assertContains(
+				$col,
+				$columns,
+				"Provider trace table missing column '{$col}' — see sd-ai-34u."
+			);
+		}
+	}
+
+	/**
 	 * Knowledge tables are created with correct structure.
 	 */
 	public function test_knowledge_tables_have_required_columns(): void {


### PR DESCRIPTION
## Summary

- Provider trace inserts have been fataling with `Unknown column 'cache_creation_tokens' in 'INSERT INTO'` on every LLM HTTP call when WP_DEBUG + provider trace are enabled.
- Root cause: PR #1387 added `cache_creation_tokens` and `cache_read_tokens` to `ProviderTrace::get_schema()` and bumped `DB_VERSION` to 19.2.0, but the **inline** `CREATE TABLE` block inside `Database::install()` (the schema dbDelta actually runs — `ProviderTrace::get_schema()` is never called from the install path) was not updated. Sites already at 19.2.0 from an earlier deploy never gained the columns because the version-guard skips the install body.
- This PR adds the two columns to the inline schema in `Database::install()`, bumps `DB_VERSION` to 19.2.1 so already-upgraded sites re-enter the install body and let `dbDelta` ALTER the columns in, and adds a `DatabaseSchemaTest` regression assertion so future drift between the two schemas fails loudly in CI.

## Files changed

- `includes/Core/Database.php` — bump `DB_VERSION` to `19.2.1`; add `cache_creation_tokens` and `cache_read_tokens` columns to the inline `provider_trace` `CREATE TABLE` block.
- `tests/SdAiAgent/Core/DatabaseSchemaTest.php` — add `test_provider_trace_table_has_cache_token_columns` regression test that asserts both columns exist on the table after `Database::install()`.

## Verification (local, against the live wp-env site)

1. `wp db query "DESCRIBE wp_sd_ai_agent_provider_trace"` before fix → no `cache_creation_tokens` / `cache_read_tokens` columns despite `sd_ai_agent_db_version` already being `19.2.0`. Reproduces the reported fatal.
2. Deleted `sd_ai_agent_db_version`, swapped the live plugin symlink to this worktree, ran `wp eval 'SdAiAgent\Core\Database::install();'`. Option became `19.2.1`. `DESCRIBE` now shows both columns:
   ```
   cache_creation_tokens  bigint(20) unsigned  NO  0
   cache_read_tokens      bigint(20) unsigned  NO  0
   ```
3. Called `SdAiAgent\Models\ProviderTrace::insert()` with `cache_creation_tokens => 42`, `cache_read_tokens => 7`. Returned row id 177, no `Unknown column` error, values read back correctly via `ProviderTrace::get()`.
4. `vendor/bin/phpcs includes/Core/Database.php` — clean (auto-uses `phpcs.xml`).
5. `vendor/bin/phpstan analyse includes/Core/Database.php` — `[OK] No errors`.

CI will exercise the new `test_provider_trace_table_has_cache_token_columns` test (local PHPUnit blocked by a port collision on 8890 with another wp-env composition).

## Follow-up (out of scope)

The repeated drift between `ProviderTrace::get_schema()` and the inline schema in `Database::install()` (and the same risk for every other model that exposes a `get_schema()` static) is a maintenance hazard. A separate refactor task should make `Database::install()` call each model's `get_schema()` rather than duplicating SQL inline, eliminating the drift class.

Resolves sd-ai-34u

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.50 plugin for [OpenCode](https://opencode.ai) v1.14.50 with claude-sonnet-4-6 spent 8h 32m and 383 tokens on this as a headless worker.
