### PR TITLE
fix(sd-ai-0nm): preserve empty JSON-Schema objects through prompt-cache decoder

### DIFF
--- a/includes/Bootstrap/HttpTraceHandler.php
+++ b/includes/Bootstrap/HttpTraceHandler.php
@@ -22,6 +22,7 @@ use SdAiAgent\Core\PromptCache\CacheStrategyResolver;
 use SdAiAgent\Core\PromptCache\RequestContextAwareCacheStrategyInterface;
 use SdAiAgent\Core\ProviderTraceLogger;
 use SdAiAgent\Core\Settings;
+use SdAiAgent\Infrastructure\Schema\SchemaNormalizer;
 use SdAiAgent\Models\ProviderTrace;
 use XWP\DI\Decorators\Filter;
 use XWP\DI\Decorators\Handler;
@@ -156,6 +157,17 @@ final class HttpTraceHandler {
 			return $parsed_args;
 		}
 
+		// Repair tool input schemas BEFORE re-encoding. The json_decode/
+		// json_encode round-trip above collapses every JSON `{}` (including
+		// the canonical empty `properties` / `items` objects required by
+		// JSON Schema draft-2020-12) into a PHP empty array, which then
+		// re-serialises as `[]` and triggers Anthropic 400 responses
+		// (`tools.N.custom.input_schema: JSON schema is invalid`).
+		// SchemaNormalizer::to_json_safe() restores `EmptyJsonObject`
+		// markers in the known schema-bearing positions so the re-encoded
+		// body matches the wire format the SDK originally produced.
+		$mutated = $this->repair_tool_schemas( $mutated );
+
 		$encoded = wp_json_encode( $mutated );
 		if ( false === $encoded ) {
 			return $parsed_args;
@@ -163,6 +175,73 @@ final class HttpTraceHandler {
 
 		$parsed_args['body'] = $encoded;
 		return $parsed_args;
+	}
+
+	/**
+	 * Restore JSON-Schema empty-object encoding in tool input schemas.
+	 *
+	 * The provider-cache decorator decodes the outgoing body with
+	 * `json_decode($body, true)`, mutates a few keys, and re-encodes via
+	 * `wp_json_encode()`. The decode step destroys every `{}` (empty
+	 * object) by collapsing it to a PHP `[]` (empty array), which then
+	 * re-encodes as `[]` — a different JSON type that breaks JSON Schema
+	 * draft-2020-12 validators in Anthropic and others.
+	 *
+	 * This walker reapplies {@see SchemaNormalizer::to_json_safe()} to the
+	 * known schema-bearing positions across all major provider body shapes:
+	 *
+	 *   - Anthropic: `tools[*].input_schema`
+	 *   - OpenAI:    `tools[*].function.parameters`
+	 *   - Gemini:    `tools[*].functionDeclarations[*].parameters`
+	 *
+	 * Other body regions are left untouched, so this is safe to call
+	 * regardless of which strategy ran (or whether one ran at all).
+	 *
+	 * @param array<string,mixed> $body Decoded request body.
+	 * @return array<string,mixed> Body with empty-object placeholders restored.
+	 */
+	private function repair_tool_schemas( array $body ): array {
+		if ( ! isset( $body['tools'] ) || ! is_array( $body['tools'] ) ) {
+			return $body;
+		}
+
+		foreach ( $body['tools'] as $i => $tool ) {
+			if ( ! is_array( $tool ) ) {
+				continue;
+			}
+
+			// Anthropic shape: tools[*].input_schema is a JSON Schema.
+			if ( isset( $tool['input_schema'] ) && is_array( $tool['input_schema'] ) ) {
+				$tool['input_schema'] = SchemaNormalizer::to_json_safe( $tool['input_schema'] );
+			}
+
+			// OpenAI shape: tools[*].function.parameters is a JSON Schema.
+			if (
+				isset( $tool['function'] ) && is_array( $tool['function'] ) &&
+				isset( $tool['function']['parameters'] ) && is_array( $tool['function']['parameters'] )
+			) {
+				$tool['function']['parameters'] = SchemaNormalizer::to_json_safe(
+					$tool['function']['parameters']
+				);
+			}
+
+			// Gemini shape: tools[*].functionDeclarations[*].parameters.
+			if ( isset( $tool['functionDeclarations'] ) && is_array( $tool['functionDeclarations'] ) ) {
+				foreach ( $tool['functionDeclarations'] as $j => $decl ) {
+					if (
+						is_array( $decl ) &&
+						isset( $decl['parameters'] ) && is_array( $decl['parameters'] )
+					) {
+						$decl['parameters']                 = SchemaNormalizer::to_json_safe( $decl['parameters'] );
+						$tool['functionDeclarations'][ $j ] = $decl;
+					}
+				}
+			}
+
+			$body['tools'][ $i ] = $tool;
+		}
+
+		return $body;
 	}
 
 	/**

--- a/tests/SdAiAgent/Bootstrap/HttpTraceHandlerCacheTest.php
+++ b/tests/SdAiAgent/Bootstrap/HttpTraceHandlerCacheTest.php
@@ -133,6 +133,92 @@ class HttpTraceHandlerCacheTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Regression for sd-ai-0nm: the cache decorator's json_decode/encode
+	 * round-trip used to collapse JSON Schema empty `{"properties":{}}`
+	 * into `[]`, triggering Anthropic 400
+	 * (`tools.N.custom.input_schema: JSON schema is invalid`).
+	 *
+	 * The handler now re-applies SchemaNormalizer::to_json_safe() to every
+	 * tool's input_schema before re-encoding so empty properties survive
+	 * as `{}`.
+	 */
+	public function test_anthropic_empty_input_schema_properties_survive_round_trip(): void {
+		$body = $this->anthropic_body_with_empty_properties();
+
+		$args = array(
+			'method' => 'POST',
+			'body'   => (string) wp_json_encode( $body ),
+		);
+
+		// Sanity: original bytes already encode `{}` (not `[]`).
+		$this->assertStringContainsString( '"properties":{}', $args['body'] );
+		$this->assertStringNotContainsString( '"properties":[]', $args['body'] );
+
+		$result = $this->handler->on_http_request_args( $args, 'https://api.anthropic.com/v1/messages' );
+
+		// After cache marker injection, body must still encode `{}` for
+		// every empty `properties` and never `[]`.
+		$this->assertStringContainsString( '"properties":{}', (string) $result['body'] );
+		$this->assertStringNotContainsString( '"properties":[]', (string) $result['body'] );
+
+		// Cache markers should still be applied (verifies we didn't
+		// accidentally short-circuit the strategy).
+		$decoded   = json_decode( (string) $result['body'], true );
+		$last_tool = end( $decoded['tools'] );
+		$this->assertArrayHasKey( 'cache_control', $last_tool );
+	}
+
+	/**
+	 * Build a request body that mirrors the real wire shape produced by
+	 * the WP-AI-Client SDK polyfill: every tool's input_schema is a
+	 * JSON-Schema draft-2020-12 object with `properties` represented as
+	 * an EmptyJsonObject (which serialises to `{}`).
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function anthropic_body_with_empty_properties(): array {
+		$empty_schema = array(
+			'type'                 => 'object',
+			'properties'           => new \SdAiAgent\Infrastructure\Schema\EmptyJsonObject(),
+			'additionalProperties' => false,
+			'$schema'              => 'http://json-schema.org/draft-07/schema#',
+		);
+
+		return array(
+			'model'    => 'claude-sonnet-4-6',
+			'system'   => array(
+				array( 'type' => 'text', 'text' => str_repeat( 'long system. ', 400 ) ),
+			),
+			'tools'    => array(
+				array(
+					'name'         => 'wpab__sd-ai-agent__memory-list',
+					'description'  => str_repeat( 'list memories ', 30 ),
+					'input_schema' => $empty_schema,
+				),
+				array(
+					'name'         => 'wpab__sd-ai-agent__ability-search',
+					'description'  => str_repeat( 'search abilities ', 30 ),
+					'input_schema' => array(
+						'type'       => 'object',
+						'properties' => array(
+							'query' => array( 'type' => 'string' ),
+						),
+						'required'   => array( 'query' ),
+					),
+				),
+				array(
+					'name'         => 'wpab__sd-ai-agent__skill-list',
+					'description'  => str_repeat( 'list skills ', 30 ),
+					'input_schema' => $empty_schema,
+				),
+			),
+			'messages' => array(
+				array( 'role' => 'user', 'content' => 'hi' ),
+			),
+		);
+	}
+
+	/**
 	 * @return array<string,mixed>
 	 */
 	private function large_anthropic_body(): array {


### PR DESCRIPTION
## Summary

- Fixes Anthropic 400 `tools.N.custom.input_schema: JSON schema is invalid (draft 2020-12)` cold-start failure on every `wp sd-ai-agent prompt` / chat call.
- Root cause: `HttpTraceHandler::on_http_request_args` decodes the outgoing body with `json_decode($body, true)` to inject cache markers, then re-encodes via `wp_json_encode`. The decode collapses every JSON `{}` to PHP `[]`; re-encode emits `[]` for the canonical empty `properties` / `items` objects required by JSON Schema draft-2020-12.
- Fix: walk the known schema-bearing positions (Anthropic `tools[*].input_schema`, OpenAI `tools[*].function.parameters`, Gemini `tools[*].functionDeclarations[*].parameters`) after the strategy mutation and re-apply `SchemaNormalizer::to_json_safe()` before re-encoding.

## Background

PR #1426 (sd-ai-0jh) addressed source-level `oneOf`/`anyOf` use in `PostAbilities` but did not fix this round-trip corruption. Tier-1 abilities like `ability-call`, `memory-list`, `skill-list` ship valid `{}` from the SDK builder; the cache-decorator destroyed it before the wire send. Reproducible only with `prompt_caching_enabled=true` (default).

## Verification

End-to-end:

```
wp sd-ai-agent prompt 'What is 2+2? Just the number.'
```

Before: `Warning: Bad Request (400) - tools.1.custom.input_schema: JSON schema is invalid…`
After: agent reply with suggestions, no 400.

Wire-body diff (PRE = before HttpTraceHandler, POST = after):

```
PRE  bytes=46994  properties:[]=0  properties:{}=6
POST bytes=47068  properties:[]=0  properties:{}=6   (was: properties:[]=6 / properties:{}=0)
```

Tests:

```
./vendor/bin/phpunit --filter HttpTraceHandlerCacheTest
OK (7 tests, 14 assertions)
```

`composer phpcs` clean on both files. PHPStan clean for changed files (one pre-existing error in `Settings.php:520` from `c93e936` is unrelated; will file follow-up).

## Test plan

- New `test_anthropic_empty_input_schema_properties_survive_round_trip` builds a body with `EmptyJsonObject` properties on multiple tools, runs through `on_http_request_args`, and asserts:
  - byte-level: `"properties":{}` present, `"properties":[]` absent
  - cache markers still applied (last tool has `cache_control`)
- Existing 6 cache tests still pass.

Refs #1425, follow-up to #1426.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.50 plugin for [OpenCode](https://opencode.ai) v1.14.50 with claude-sonnet-4-6 spent 9h 16m and 383 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JSON Schema encoding issues in AI provider tool definitions that could cause validation failures during request processing and caching operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1436)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->