### PR TITLE
fix: pass provider_id to OpenAI-compatible connector's model-listing shim

### DIFF
--- a/includes/CLI/ModelsCommand.php
+++ b/includes/CLI/ModelsCommand.php
@@ -203,10 +203,19 @@ class ModelsCommand extends WP_CLI_Command {
 					$models   = array();
 
 					// OpenAI-compatible connectors expose a model list endpoint.
+					// Pass the SDK provider_id so the connector can resolve the
+					// correct per-provider endpoint URL and API key in
+					// multi-provider setups. Without provider_id, the connector
+					// always falls back to its primary configured provider and
+					// every OpenAI-compatible provider would return the same
+					// model list — see ai-provider-for-any-compatible-endpoint
+					// PR #127.
 					if ( str_starts_with( $provider_id, 'ai-provider-for-any-openai-compatible' )
 						&& function_exists( 'OpenAiCompatibleConnector\\rest_list_models' )
 					) {
-						$result = \OpenAiCompatibleConnector\rest_list_models( new \WP_REST_Request( 'GET' ) );
+						$req = new \WP_REST_Request( 'GET' );
+						$req->set_param( 'provider_id', $provider_id );
+						$result = \OpenAiCompatibleConnector\rest_list_models( $req );
 						if ( ! is_wp_error( $result ) ) {
 							$data = $result->get_data();
 							if ( is_array( $data ) ) {

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -774,10 +774,18 @@ final class SettingsController {
 					// directory (which can fail due to SDK transporter issues).
 					// Use str_starts_with to handle multi-endpoint setups where each
 					// endpoint gets a unique ID (e.g., ai-provider-for-any-openai-compatible-1).
+					//
+					// Pass the SDK provider_id so the connector can resolve the
+					// correct per-provider endpoint URL and API key. Without
+					// provider_id, the connector falls back to its primary
+					// configured provider and every OpenAI-compatible provider
+					// would return the same model list — see PR #127 on
+					// ai-provider-for-any-compatible-endpoint.
 					if ( str_starts_with( $provider_id, 'ai-provider-for-any-openai-compatible' )
 						&& function_exists( 'OpenAiCompatibleConnector\\rest_list_models' )
 					) {
 						$fake_request = new WP_REST_Request( 'GET' );
+						$fake_request->set_param( 'provider_id', $provider_id );
 						$result       = \OpenAiCompatibleConnector\rest_list_models( $fake_request );
 						if ( ! is_wp_error( $result ) ) {
 							$data = $result->get_data();


### PR DESCRIPTION
## Summary

Companion fix to [ai-provider-for-any-compatible-endpoint#127](https://github.com/Ultimate-Multisite/ultimate-ai-connector-compatible-endpoints/pull/127).

In multi-provider setups, every OpenAI-compatible provider in the agent's listing returned the same model set (the primary provider's). The connector PR adds a `provider_id` REST param so it can resolve the right per-provider endpoint; this PR is the matching agent-side change to actually send that param.

## Reproduction

On a host with one Ollama (primary) and one Synthetic (secondary) endpoint configured:

```
$ wp sd-ai-agent models --provider=ai-provider-for-any-openai-compatible
… 17 Ollama models …

$ wp sd-ai-agent models --provider=ai-provider-for-any-openai-compatible-2
… same 17 Ollama models …   ← bug: should be Synthetic's distinct list
```

## Cause

`includes/CLI/ModelsCommand.php` and `includes/REST/SettingsController.php` both call the connector's `\OpenAiCompatibleConnector\rest_list_models()` shim with a bare `WP_REST_Request('GET')`. The connector has no way to know which of its registered SDK provider IDs (`ai-provider-for-any-openai-compatible`, `…-2`, `…-3`, …) is being listed, so it always resolves to its primary configured provider.

## Fix

Forward the `$provider_id` already in scope into the shim request:

```php
$req = new \WP_REST_Request( 'GET' );
$req->set_param( 'provider_id', $provider_id );
$result = \OpenAiCompatibleConnector\rest_list_models( $req );
```

Two call sites updated identically:

- `includes/CLI/ModelsCommand.php` (line 209 area) — drives `wp sd-ai-agent models`.
- `includes/REST/SettingsController.php` (line 781 area) — drives the settings page model dropdown.

## Compatibility

Older versions of the connector that don't yet understand `provider_id` will just ignore the extra param and keep returning their primary-provider list, so this change is safe to roll out independently. With both PRs merged, per-provider listings start showing genuinely distinct model sets.

## Verification

Tested end-to-end against the same two-provider host above with both this branch and the connector branch checked out. After the fix:

```
$ wp sd-ai-agent models --provider=ai-provider-for-any-openai-compatible
deepseek-r1:32b, gemma3:latest, gemma4:e2b, gemma4:e4b, …          ← Ollama

$ wp sd-ai-agent models --provider=ai-provider-for-any-openai-compatible-2
hf:deepseek-ai/DeepSeek-R1-0528, hf:moonshotai/Kimi-K2.6, …        ← Synthetic
```

## Files changed

- `includes/CLI/ModelsCommand.php`
- `includes/REST/SettingsController.php`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.50 plugin for [OpenCode](https://opencode.ai) v1.14.50 with claude-sonnet-4-6 spent 10h 33m and 383 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model listing for multi-provider OpenAI-compatible connector setups. When using multiple OpenAI-compatible providers in parallel, each provider now correctly displays its own available models instead of showing duplicate or incorrect model lists. This ensures the correct models are available for selection when managing multiple provider configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1437)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->