### PR TITLE
fix: PHPCS alignment regression in SettingsController.php (resolves #1439)

### DIFF
--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -786,7 +786,7 @@ final class SettingsController {
 					) {
 						$fake_request = new WP_REST_Request( 'GET' );
 						$fake_request->set_param( 'provider_id', $provider_id );
-						$result       = \OpenAiCompatibleConnector\rest_list_models( $fake_request );
+						$result = \OpenAiCompatibleConnector\rest_list_models( $fake_request );
 						if ( ! is_wp_error( $result ) ) {
 							$data = $result->get_data();
 							if ( is_array( $data ) ) {


### PR DESCRIPTION
## Summary

- Fixes the `Generic.Formatting.MultipleStatementAlignment.IncorrectWarning` introduced by PR #1437 in `includes/REST/SettingsController.php` line 789.
- `$result` had 7 extra spaces before `=` trying to over-align with `$fake_request`; PHPCBF corrected it to a single space.

## Change

```diff
-						$result       = \OpenAiCompatibleConnector\rest_list_models( $fake_request );
+						$result = \OpenAiCompatibleConnector\rest_list_models( $fake_request );
```

## Verification

```bash
vendor/bin/phpcs includes/REST/SettingsController.php includes/CLI/ModelsCommand.php
# Result: 0 errors, 0 warnings for both files
```

Resolves #1439

<!-- aidevops:sig -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of OpenAI-compatible connector model list retrieval in settings.

---

**Note:** This release contains minimal changes with low user-facing impact. The update addresses provider configuration functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1441)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->