### PR TITLE
fix: implement WP Ability stub registry so ThirdPartyAbilityNoticeHandlerTest passes (#1438)

### DIFF
--- a/includes/Admin/ThirdPartyAbilityNoticeHandler.php
+++ b/includes/Admin/ThirdPartyAbilityNoticeHandler.php
@@ -123,7 +123,7 @@ final class ThirdPartyAbilityNoticeHandler {
 			? __( 'plugin', 'superdav-ai-agent' )
 			: __( 'plugins', 'superdav-ai-agent' );
 
-		$review_url = admin_url( 'admin.php?page=sd-ai-agent#abilities/third-party-review' );
+		$review_url  = admin_url( 'admin.php?page=sd-ai-agent#abilities/third-party-review' );
 		$dismiss_url = wp_nonce_url(
 			add_query_arg( 'sd_ai_agent_dismiss_third_party_notice', '1' ),
 			'sd_ai_agent_dismiss_third_party_notice'
@@ -136,12 +136,14 @@ final class ThirdPartyAbilityNoticeHandler {
 				<?php
 				printf(
 					/* translators: %d is the number of plugins */
-					esc_html( _n(
-						'%d plugin has registered AI abilities that have not been classified.',
-						'%d plugins have registered AI abilities that have not been classified.',
-						$count,
-						'superdav-ai-agent'
-					) ),
+					esc_html(
+						_n(
+							'%d plugin has registered AI abilities that have not been classified.',
+							'%d plugins have registered AI abilities that have not been classified.',
+							$count,
+							'superdav-ai-agent'
+						)
+					),
 					intval( $count )
 				);
 				?>

--- a/stubs/wordpress-7-runtime.php
+++ b/stubs/wordpress-7-runtime.php
@@ -382,6 +382,18 @@ namespace {
 	}
 
 	/**
+	 * In-memory ability registry for PHPUnit test environments.
+	 *
+	 * Shared across wp_register_ability(), wp_get_ability(),
+	 * wp_unregister_ability(), and wp_get_abilities() via `global`.
+	 * Using a named global avoids the PHP `static`-per-function isolation
+	 * problem (PHP `static` variables are per-function, not shared).
+	 *
+	 * @var array<string, WP_Ability>
+	 */
+	$_wp_ability_registry = array();
+
+	/**
 	 * WordPress Ability class (stub).
 	 *
 	 * @since 7.0.0
@@ -400,7 +412,9 @@ namespace {
 		 * @param string               $name       The namespaced ability name.
 		 * @param array<string, mixed> $args       Ability configuration args.
 		 */
-		public function __construct( string $name, array $args = array() ) {}
+		public function __construct( string $name, array $args = array() ) {
+			$this->name = $name;
+		}
 
 		/**
 		 * Prepare and validate ability properties from args.
@@ -411,7 +425,7 @@ namespace {
 		protected function prepare_properties( array $args ): array { return $args; }
 
 		/** @return string */
-		public function get_name(): string { return ''; }
+		public function get_name(): string { return $this->name; }
 
 		/** @return string */
 		public function get_label(): string { return ''; }
@@ -540,7 +554,12 @@ namespace {
 	 * @param array<string, mixed> $args Ability configuration.
 	 * @return WP_Ability|null
 	 */
-	function wp_register_ability( string $name, array $args ): ?WP_Ability { return null; }
+	function wp_register_ability( string $name, array $args ): ?WP_Ability {
+		global $_wp_ability_registry;
+		$ability                       = new WP_Ability( $name, $args );
+		$_wp_ability_registry[ $name ] = $ability;
+		return $ability;
+	}
 
 	/**
 	 * Unregister a WordPress ability.
@@ -550,7 +569,12 @@ namespace {
 	 * @param string $name Namespaced ability name.
 	 * @return WP_Ability|null
 	 */
-	function wp_unregister_ability( string $name ): ?WP_Ability { return null; }
+	function wp_unregister_ability( string $name ): ?WP_Ability {
+		global $_wp_ability_registry;
+		$ability = $_wp_ability_registry[ $name ] ?? null;
+		unset( $_wp_ability_registry[ $name ] );
+		return $ability;
+	}
 
 	/**
 	 * Get a registered WordPress ability by name.
@@ -560,7 +584,10 @@ namespace {
 	 * @param string $name Namespaced ability name.
 	 * @return WP_Ability|null
 	 */
-	function wp_get_ability( string $name ): ?WP_Ability { return null; }
+	function wp_get_ability( string $name ): ?WP_Ability {
+		global $_wp_ability_registry;
+		return $_wp_ability_registry[ $name ] ?? null;
+	}
 
 	/**
 	 * Get all registered WordPress abilities.
@@ -569,7 +596,10 @@ namespace {
 	 *
 	 * @return WP_Ability[]
 	 */
-	function wp_get_abilities(): array { return array(); }
+	function wp_get_abilities(): array {
+		global $_wp_ability_registry;
+		return array_values( $_wp_ability_registry );
+	}
 
 	/**
 	 * Register a WordPress ability category.


### PR DESCRIPTION
## Summary

Fixes the PHPUnit CI failure in `ThirdPartyAbilityNoticeHandlerTest::test_namespace_decision_overrides_heuristic` and resolves 3 auto-fixable PHPCS violations.

### Root cause

`stubs/wordpress-7-runtime.php` had empty stub bodies for the WP 7.0 Abilities API. `wp_register_ability()` returned `null` without storing anything, so `wp_get_ability()` always returned `null` — causing the `assertNotNull($ability)` assertion to fail. Additionally, `WP_Ability::get_name()` returned `''` because the constructor never assigned `$this->name`.

### Changes

**`stubs/wordpress-7-runtime.php`**
- Added `$_wp_ability_registry` global array shared via `global` across all four registry functions (avoids PHP per-function `static` isolation)
- Added `$this->name = $name` to `WP_Ability::__construct()` so `get_name()` returns the correct namespaced name
- Implemented `wp_register_ability()`, `wp_get_ability()`, `wp_unregister_ability()`, `wp_get_abilities()` with real in-memory registry logic

**`includes/Admin/ThirdPartyAbilityNoticeHandler.php`**
- Fixed `Generic.Formatting.MultipleStatementAlignment` on `$review_url` (line 126)
- Fixed `PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket` — moved `_n(` to new line inside `esc_html(` (line 139)
- Fixed `PEAR.Functions.FunctionCallSignature.CloseBracketLine` — separated closing brackets onto their own lines (line 144)

### Verification

```bash
# PHPUnit: was 1 failure, must pass
vendor/bin/phpunit tests/SdAiAgent/Admin/ThirdPartyAbilityNoticeHandlerTest.php --no-coverage

# PHPCS: must exit 0
vendor/bin/phpcs includes/Admin/ThirdPartyAbilityNoticeHandler.php
vendor/bin/phpcs stubs/wordpress-7-runtime.php
```

### Out of scope (per issue)

- Pre-existing PHPCS warnings in `includes/Core/Settings.php` (35 warnings) and `includes/Core/AbilityVisibility.php` (1 warning)
- E2E shard-2 timeout in `changes-page.spec.js`

Resolves #1438
For #1404

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.50 plugin for [OpenCode](https://opencode.ai) v1.14.50 with claude-sonnet-4-6 spent 11m and 30,887 tokens on this as a headless worker.
