### PR TITLE
fix: use exact prefix matching instead of ltrim character mask in GeminiCacheManager

### DIFF
--- a/includes/Core/PromptCache/GeminiCacheManager.php
+++ b/includes/Core/PromptCache/GeminiCacheManager.php
@@ -231,7 +231,7 @@ final class GeminiCacheManager implements GeminiCacheManagerInterface {
 		string $system
 	): ?string {
 		// Gemini requires the model in `models/{id}` form.
-		$model_uri = 'models/' . ltrim( $model, 'models/' );
+		$model_uri = 'models/' . ( str_starts_with( $model, 'models/' ) ? substr( $model, 7 ) : $model );
 
 		$body = array(
 			'model'    => $model_uri,


### PR DESCRIPTION
Fixed ltrim character mask bug in GeminiCacheManager by using str_starts_with() and substr() for exact prefix removal. Closes #1445

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gemini cache resource model URI construction to handle prefix removal more reliably, preventing unintended character stripping that could occur with the previous approach.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1446)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->