### PR TITLE
fix: respect saved max_iterations Settings instead of REST default of 10

### DIFF
--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -395,7 +395,14 @@ final class SessionController {
 					'max_iterations'     => array(
 						'required'          => false,
 						'type'              => 'integer',
-						'default'           => 10,
+						// No 'default' here: when the client omits this param,
+						// $request->get_param('max_iterations') returns null and
+						// handle_run()/handle_process() fall back to the saved
+						// Settings value (default 100). A REST default of 10
+						// would short-circuit that fallback and cap user-facing
+						// tool calls at ~10, surfacing as a spurious
+						// "maximum number of tool calls" exit after a handful
+						// of tool calls even when Settings is set to 100.
 						'sanitize_callback' => 'absint',
 					),
 					'session_id'         => array(
@@ -1421,9 +1428,16 @@ final class SessionController {
 			}
 		}
 
-		$options = array(
-			'max_iterations' => $params['max_iterations'] ?? 100,
-		);
+		// Only forward max_iterations when the client explicitly supplied one.
+		// Passing it unconditionally (with a hardcoded fallback) would override
+		// the saved Settings value inside AgentLoop, which already falls back
+		// to $settings['max_iterations'] (default 100). The /run endpoint
+		// schema deliberately has no REST default for this param so
+		// $request->get_param() returns null when omitted — see handle_run().
+		$options = array();
+		if ( null !== $params['max_iterations'] && '' !== $params['max_iterations'] ) {
+			$options['max_iterations'] = (int) $params['max_iterations'];
+		}
 
 		if ( ! empty( $params['system_instruction'] ) ) {
 			$options['system_instruction'] = $params['system_instruction'];


### PR DESCRIPTION
## Summary

The chat agent loop was bailing out with "You have reached the maximum number of tool calls" after ~10–13 tool calls, even though Settings → Max Iterations was 100.

## Root cause

`includes/REST/SessionController.php` declared the `/run` endpoint's `max_iterations` argument with `'default' => 10`. WordPress's REST API auto-fills missing params with this default, so `$request->get_param('max_iterations')` returned the literal `10` whenever the client omitted the param — which the chat UI (`src/store/slices/jobSlice.js`) always does. That `10` then flowed through `$job['params']` into `AgentLoop`'s options, short-circuiting:

- the `handle_process()` `$params['max_iterations'] ?? 100` fallback, and
- `AgentLoop::__construct()`'s `$options['max_iterations'] ?? ($settings['max_iterations'] ?: 25)` fallback.

So the user's saved Settings value never reached `AgentLoop`. The loop exhausted at 10 iterations, injected the "please summarize" prompt at `AgentLoop.php:829-832`, and surfaced as the tool-limit-reached UX after ~13 visible tool calls (each round can produce multiple tool calls, plus the summarization round).

## Fix

`includes/REST/SessionController.php`:

1. Drop the `'default' => 10` from the `/run` schema for `max_iterations` so `$request->get_param()` returns `null` on omit. Added an inline comment explaining why no REST default belongs here.
2. In `handle_process()`, only forward `max_iterations` to `AgentLoop` options when the client actually supplied a value. `AgentLoop` already reads `$settings['max_iterations']` (default 100 from `Settings::get_defaults()`) as its fallback, so the user's Settings value now takes effect end-to-end and explicit per-request overrides still work.

## Verification

- `php -l includes/REST/SessionController.php` — no syntax errors.
- Existing test coverage: `tests/SdAiAgent/REST/RestControllerTest.php` already sets `max_iterations => 5` explicitly; `tests/SdAiAgent/Core/SettingsTest.php` asserts the 100 default; `tests/SdAiAgent/Core/AgentLoopTest.php::test_constructor_reads_max_iterations_from_settings` covers the AgentLoop fallback path. No existing test depended on the REST default of 10.
- Manual verification recommended: hit `/wp-json/sd-ai-agent/v1/run` without `max_iterations` in the body and confirm `AgentLoop` is constructed with 100 (or whatever Settings says) rather than 10.

## Follow-ups (not in this PR)

- Add a regression test asserting `handle_process()` does not pass `max_iterations` into `AgentLoop` options when the REST request omits it, so this can't regress silently again.
- Audit other endpoints (e.g. `WebhookController` line 371 uses `$request->get_param('max_iterations') ?? 10`) for the same Settings-vs-default mismatch.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with claude-sonnet-4-6 spent 22h 20m and 383 tokens on this as a headless worker.
