### PR TITLE
fix(sd-ai-5ws): unblock max_tokens/temperature reaching the AI provider

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -958,13 +958,19 @@ class AgentLoop {
 		// temperature=0 and disable parallel tool calls, making real model
 		// usage noticeably slower and lower-quality without surfacing why
 		// to the user. Restore once telemetry is reliable.
-		if ( method_exists( $builder, 'using_temperature' ) ) {
-			$builder->using_temperature( (float) $this->temperature );
-		}
-
-		if ( method_exists( $builder, 'using_max_tokens' ) ) {
-			$builder->using_max_tokens( $this->get_effective_max_output_tokens() );
-		}
+		//
+		// The builder is `WP_AI_Client_Prompt_Builder`, a thin wrapper that
+		// forwards snake_case calls (e.g. `using_max_tokens`) to the SDK's
+		// camelCase `usingMaxTokens` via PHP's `__call`. An earlier version
+		// of this block guarded both setters with `method_exists()`, which
+		// does NOT detect `__call`-routed methods and silently skipped them
+		// — leaving `max_tokens` unset (so the anthropic-max connector fell
+		// back to its hard-coded 4096 default) and `temperature` absent
+		// from the outgoing request body. The guards are removed because
+		// the wrapper's `__call` is guaranteed to exist and the `@method`
+		// declarations on the wrapper enumerate the supported API.
+		$builder->using_temperature( (float) $this->temperature );
+		$builder->using_max_tokens( $this->get_effective_max_output_tokens() );
 
 		$abilities = $this->resolve_abilities();
 		if ( ! empty( $abilities ) ) {

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -1189,6 +1189,162 @@ class AgentLoopTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Capture the next outgoing wp_remote_post() body for assertion.
+	 *
+	 * Used by the builder-config regression tests below so we can prove the
+	 * `max_tokens` and `temperature` values computed by AgentLoop actually
+	 * land in the outgoing request body. Without capture, those values are
+	 * unobservable from a passing/failing assertion on the parsed reply
+	 * alone — which is exactly what hid the
+	 * `method_exists()`-vs-`__call` bug for months.
+	 *
+	 * @param string|null &$captured_body Reference populated with the JSON body string.
+	 */
+	private function capture_next_request_body( ?string &$captured_body ): void {
+		$body = wp_json_encode(
+			[
+				'id'      => 'chatcmpl-capture',
+				'object'  => 'chat.completion',
+				'choices' => [
+					[
+						'index'         => 0,
+						'message'       => [ 'role' => 'assistant', 'content' => 'ok' ],
+						'finish_reason' => 'stop',
+					],
+				],
+				'usage'   => [ 'prompt_tokens' => 5, 'completion_tokens' => 1, 'total_tokens' => 6 ],
+			]
+		);
+
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( &$captured_body, $body ) {
+				if ( false !== strpos( $url, 'fake-ai-proxy.test' ) && null === $captured_body ) {
+					$captured_body = is_string( $args['body'] ?? null )
+						? $args['body']
+						: (string) wp_json_encode( $args['body'] ?? [] );
+				}
+
+				if ( false !== strpos( $url, 'fake-ai-proxy.test' ) ) {
+					return [
+						'headers'  => [ 'content-type' => 'application/json' ],
+						'body'     => $body,
+						'response' => [ 'code' => 200, 'message' => 'OK' ],
+						'cookies'  => [],
+						'filename' => '',
+					];
+				}
+
+				return $preempt;
+			},
+			10,
+			3
+		);
+	}
+
+	/**
+	 * Regression test: builder config calls must NOT be guarded by
+	 * `method_exists()`, because the underlying builder routes its
+	 * snake_case API (`using_max_tokens`, `using_temperature`) through
+	 * `__call` — which `method_exists()` does not detect.
+	 *
+	 * Before the fix:
+	 *   - `method_exists( $builder, 'using_max_tokens' )` returned false,
+	 *   - both `using_*` calls were silently skipped,
+	 *   - `$config->getMaxTokens()` was null at provider time,
+	 *   - the anthropic-max connector fell back to its hard-coded 4096
+	 *     default, causing frequent `stop_reason=max_tokens` truncations
+	 *     and slow retry-with-guidance round-trips.
+	 *
+	 * After the fix (`is_callable()` instead of `method_exists()`):
+	 *   - both setters are invoked,
+	 *   - the outgoing request body carries `max_tokens` and `temperature`.
+	 *
+	 * The fake endpoint is OpenAI-compatible (chat.completion), so the
+	 * body is JSON with `max_tokens` and `temperature` at the top level.
+	 */
+	public function test_builder_receives_max_tokens_and_temperature(): void {
+		$this->skip_if_sdk_unavailable();
+
+		// Pick an explicit, non-legacy value so the resolver short-circuits
+		// to the honoured-override branch and we can pin the exact number.
+		Settings::instance()->update(
+			[
+				'max_output_tokens' => 9999,
+				'temperature'       => 0.42,
+			]
+		);
+
+		$captured = null;
+		$this->capture_next_request_body( $captured );
+
+		$loop   = new AgentLoop( 'Reply succinctly' );
+		$result = $loop->run();
+
+		$this->assertIsArray( $result );
+		$this->assertIsString( $captured, 'Expected to capture an outgoing request body.' );
+
+		$decoded = json_decode( (string) $captured, true );
+		$this->assertIsArray( $decoded, 'Outgoing body should be JSON.' );
+
+		$this->assertArrayHasKey(
+			'max_tokens',
+			$decoded,
+			'max_tokens must reach the provider — the builder magic-method guard regressed.'
+		);
+		$this->assertSame(
+			9999,
+			(int) $decoded['max_tokens'],
+			'The configured max_output_tokens must reach the provider unchanged.'
+		);
+
+		$this->assertArrayHasKey(
+			'temperature',
+			$decoded,
+			'temperature must reach the provider — the builder magic-method guard regressed.'
+		);
+		$this->assertEqualsWithDelta(
+			0.42,
+			(float) $decoded['temperature'],
+			0.0001,
+			'The configured temperature must reach the provider unchanged.'
+		);
+	}
+
+	/**
+	 * Regression test: the legacy 4096 default must NOT reach the provider.
+	 *
+	 * Existing installs that upgraded from pre-7rl carry a saved
+	 * `max_output_tokens=4096` they never explicitly chose. AgentLoop's
+	 * resolver maps that exact value to AUTO so the per-model catalog
+	 * picks a sensible cap (64K for Sonnet 4). This test proves the
+	 * resolver's output actually reaches the outgoing request body — i.e.
+	 * that the builder's `using_max_tokens()` call is wired up.
+	 */
+	public function test_builder_emits_catalog_value_when_legacy_4096_saved(): void {
+		$this->skip_if_sdk_unavailable();
+
+		Settings::instance()->update( [ 'max_output_tokens' => 4096 ] );
+
+		$captured = null;
+		$this->capture_next_request_body( $captured );
+
+		$loop = new AgentLoop( 'Reply succinctly', [], [], [ 'model_id' => 'claude-sonnet-4-6' ] );
+		$loop->run();
+
+		$this->assertIsString( $captured, 'Expected to capture an outgoing request body.' );
+		$decoded = json_decode( (string) $captured, true );
+		$this->assertIsArray( $decoded );
+
+		$this->assertArrayHasKey( 'max_tokens', $decoded );
+		$this->assertGreaterThan(
+			4096,
+			(int) $decoded['max_tokens'],
+			'Saved 4096 must be remapped via the catalog (Sonnet 4 documents 64K), not honoured verbatim.'
+		);
+	}
+
+	/**
 	 * Resolve the private get_effective_max_output_tokens() with a given
 	 * saved value and model_id so we can exercise the legacy / AUTO / ceiling
 	 * branches without spinning up the full agent loop.


### PR DESCRIPTION
## Summary

`AgentLoop::build_prompt` guarded `using_max_tokens()` and `using_temperature()` with `method_exists()`, which does NOT detect `__call`-routed methods on `WP_AI_Client_Prompt_Builder`. Both setters were silently skipped on every request, so `max_tokens` and `temperature` never reached the AI provider.

The anthropic-max connector falls back to a hard-coded `4096` when `$config->getMaxTokens()` is null (`AnthropicMaxTextGenerationModel.php:237-238`), so every Sonnet/Opus call was capped at 4096 output tokens regardless of saved settings or the per-model catalog. The legacy-default treatment added in #1389 (commit 1e2f149) was correct but unreachable because its caller was dead code.

## Observed impact

Reviewed 59 successful Anthropic traces on the dev install (`wp_sd_ai_agent_provider_trace`):

- **10.2%** of turns finished with `stop_reason=max_tokens` (hit the 4096 cap)
- Truncated turns averaged **47,236 ms** (model used every one of 4096 tokens)
- Non-truncated turns averaged **11,694 ms**
- `inject_truncated_tool_call_guidance` then forced another round-trip, doubling user-visible wait

## Fix

Drop the `method_exists()` guards entirely. The wrapper's `__call` is guaranteed to exist, the `@method` declarations on the wrapper enumerate the snake_case API, and PHPStan correctly flags `is_callable()` as always-true here because `__call` is defined — so the cleanest change is to call the setters directly.

```diff
- if ( method_exists( $builder, 'using_temperature' ) ) {
-     $builder->using_temperature( (float) $this->temperature );
- }
- if ( method_exists( $builder, 'using_max_tokens' ) ) {
-     $builder->using_max_tokens( $this->get_effective_max_output_tokens() );
- }
+ $builder->using_temperature( (float) $this->temperature );
+ $builder->using_max_tokens( $this->get_effective_max_output_tokens() );
```

## Verification

A/B comparison on the live dev install:

| Stage | `max_tokens` | `temperature` |
| --- | --- | --- |
| **Before** | `4096` | `[unset]` |
| **After**  | `64000` (Sonnet 4 catalog value) | `0.2` (Settings default) |

(`AUTO`/legacy resolver picks 64000 for `claude-sonnet-4-6` via `Settings::MODEL_MAX_OUTPUT_TOKENS`.)

## Regression tests

Two new tests in `tests/SdAiAgent/Core/AgentLoopTest.php`:

- `test_builder_receives_max_tokens_and_temperature` — captures the outgoing request body and asserts an explicit non-legacy `max_output_tokens` value and the saved `temperature` value both reach the provider unchanged.
- `test_builder_emits_catalog_value_when_legacy_4096_saved` — proves the full chain (saved 4096 → legacy-default treatment → catalog lookup → outgoing body) is wired end-to-end. Without the fix, the body carries 4096; with the fix, it carries the Sonnet catalog cap.

## Local checks

- `vendor/bin/phpcs --standard=phpcs.xml includes/Core/AgentLoop.php tests/SdAiAgent/Core/AgentLoopTest.php` — clean
- `vendor/bin/phpstan analyse includes/Core/AgentLoop.php --memory-limit=512M` — clean
- `php -l` on both files — no syntax errors
- A/B verification with `wp sd-ai-agent prompt` against the dev install

PHPUnit could not run locally (wp-env Docker volume corruption unrelated to this change); CI will exercise the new tests on this PR.

Resolves #sd-ai-5ws

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with claude-sonnet-4-6 spent 23h 55m and 383 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured temperature and max_tokens configuration settings are consistently applied to all outbound AI provider requests.

* **Tests**
  * Added regression tests validating that temperature and max_tokens values are properly transmitted in AI requests, and that legacy model configurations are correctly remapped.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1450)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->