### PR TITLE
fix(sd-ai-86a): register client ability callbacks locally even when wp.abilities API is absent

### DIFF
--- a/src/abilities/__tests__/registry.test.js
+++ b/src/abilities/__tests__/registry.test.js
@@ -1,0 +1,145 @@
+/**
+ * Unit tests for src/abilities/registry.js
+ *
+ * Tests cover the sd-ai-86a regression: the local clientCallbacks map must
+ * be populated even when the WP 7.0 `@wordpress/abilities` script module has
+ * not loaded on the page, so that jobSlice's executeClientAbility() can still
+ * invoke screenshot-url, navigate-to, capture-screenshot, and insert-block
+ * when the chat job returns pending_client_tool_calls.
+ *
+ * Bug history:
+ *   - registerClientAbility() previously returned early (registry.js:189-192)
+ *     when abilitiesApiAvailable() was false, before storing the callback in
+ *     clientCallbacks. executeClientAbility() then threw
+ *     'Client ability "X" is not registered on this page' even though the
+ *     callback existed in the bundle.
+ *   - Fix: store the local callback first, then gate only the
+ *     wp.abilities.registerAbility() call on API availability.
+ */
+
+/**
+ * Each test loads a fresh registry module via jest.isolateModules so the
+ * module-scoped `registeredAbilityNames` and `clientCallbacks` Maps start
+ * empty. This avoids cross-test bleed while still exercising the real
+ * registry code (not a mock).
+ */
+function loadRegistry() {
+	let mod;
+	jest.isolateModules( () => {
+		// eslint-disable-next-line global-require
+		mod = require( '../registry' );
+	} );
+	return mod;
+}
+
+describe( 'registry — sd-ai-86a regression', () => {
+	let originalWp;
+
+	beforeEach( () => {
+		originalWp = global.wp;
+	} );
+
+	afterEach( () => {
+		global.wp = originalWp;
+	} );
+
+	test( 'registerClientAbility stores callback locally even when wp.abilities is undefined', async () => {
+		// Simulate a page where @wordpress/abilities never loaded.
+		delete global.wp;
+		const { registerClientAbility, executeClientAbility } = loadRegistry();
+
+		const callback = jest.fn().mockResolvedValue( { ok: true } );
+
+		await registerClientAbility( {
+			name: 'sd-ai-agent-js/test-no-api',
+			label: 'Test No API',
+			description: 'Test that callbacks register without the WP API',
+			inputSchema: { type: 'object' },
+			outputSchema: { type: 'object' },
+			annotations: { readonly: true },
+			callback,
+		} );
+
+		const result = await executeClientAbility(
+			'sd-ai-agent-js/test-no-api',
+			{ foo: 'bar' }
+		);
+		expect( callback ).toHaveBeenCalledWith( { foo: 'bar' } );
+		expect( result ).toEqual( { ok: true } );
+	} );
+
+	test( 'executeClientAbility throws for truly unknown abilities', async () => {
+		delete global.wp;
+		const { executeClientAbility } = loadRegistry();
+
+		await expect(
+			executeClientAbility( 'sd-ai-agent-js/never-registered', {} )
+		).rejects.toThrow( /is not registered on this page/ );
+	} );
+
+	test( 'executeClientAbility falls back to wp.abilities.executeAbility when the local map misses but WP API is present', async () => {
+		// Local map does NOT contain this ability (different module
+		// instance scenario), but wp.abilities.executeAbility is wired up.
+		global.wp = {
+			abilities: {
+				executeAbility: jest
+					.fn()
+					.mockResolvedValue( { fromWpApi: true } ),
+				registerAbility: jest.fn().mockResolvedValue( undefined ),
+				registerAbilityCategory: jest
+					.fn()
+					.mockResolvedValue( undefined ),
+				getAbilities: jest.fn().mockReturnValue( [] ),
+			},
+		};
+		const { executeClientAbility } = loadRegistry();
+
+		const result = await executeClientAbility(
+			'sd-ai-agent-js/only-in-wp-store',
+			{ key: 'value' }
+		);
+
+		expect( global.wp.abilities.executeAbility ).toHaveBeenCalledWith(
+			'sd-ai-agent-js/only-in-wp-store',
+			{ key: 'value' }
+		);
+		expect( result ).toEqual( { fromWpApi: true } );
+	} );
+
+	test( 'registerClientAbility writes to wp.abilities when API is available', async () => {
+		const registerAbility = jest.fn().mockResolvedValue( undefined );
+		global.wp = {
+			abilities: {
+				executeAbility: jest.fn(),
+				registerAbility,
+				registerAbilityCategory: jest
+					.fn()
+					.mockResolvedValue( undefined ),
+				getAbilities: jest.fn().mockReturnValue( [] ),
+			},
+		};
+		const { registerClientAbility, executeClientAbility } = loadRegistry();
+
+		const callback = jest.fn().mockResolvedValue( { wired: true } );
+		await registerClientAbility( {
+			name: 'sd-ai-agent-js/with-api',
+			label: 'With API',
+			description: 'Should also reach wp.abilities.registerAbility',
+			inputSchema: { type: 'object' },
+			outputSchema: { type: 'object' },
+			annotations: { readonly: true },
+			callback,
+		} );
+
+		expect( registerAbility ).toHaveBeenCalledTimes( 1 );
+		expect( registerAbility.mock.calls[ 0 ][ 0 ] ).toMatchObject( {
+			name: 'sd-ai-agent-js/with-api',
+			category: 'sd-ai-agent-js',
+			callback,
+		} );
+
+		// Local execution path still works alongside the WP store entry.
+		await executeClientAbility( 'sd-ai-agent-js/with-api', { x: 1 } );
+		expect( callback ).toHaveBeenCalledWith( { x: 1 } );
+	} );
+} );

--- a/src/abilities/registry.js
+++ b/src/abilities/registry.js
@@ -187,9 +187,6 @@ export async function registerCategory() {
  * @return {Promise<void>}
  */
 export async function registerClientAbility( def ) {
-	if ( ! abilitiesApiAvailable() ) {
-		return;
-	}
 	if ( ! def || typeof def.name !== 'string' || def.name === '' ) {
 		// eslint-disable-next-line no-console
 		console.warn(
@@ -205,8 +202,28 @@ export async function registerClientAbility( def ) {
 	// Store the callback so executeClientAbility() can invoke it by name
 	// without going through the WP abilities API (which may not expose the
 	// raw return value needed for tool-result forwarding).
+	//
+	// IMPORTANT (sd-ai-86a): this MUST happen BEFORE the
+	// abilitiesApiAvailable() guard. jobSlice's executeClientAbility()
+	// reads only from this local map, so even on pages where the WP 7.0
+	// `@wordpress/abilities` script module did not load in time (or at
+	// all — e.g. some frontend contexts in WP 7.0-RC2), the chat job's
+	// pending_client_tool_calls handler can still invoke
+	// screenshot-url, navigate-to, capture-screenshot, and insert-block.
+	// Without this ordering, executeClientAbility throws
+	// 'Client ability "..." is not registered on this page' even though
+	// the callback function is present in the bundle.
 	if ( typeof def.callback === 'function' ) {
 		clientCallbacks.set( def.name, def.callback );
+	}
+
+	// The WP 7.0 store is only updated when the abilities API is present
+	// on this page. If it is not, the local callback above is sufficient
+	// to keep client-side tool execution working; snapshotDescriptors()
+	// will fall back to an empty descriptor list and the server-side
+	// JsAbilityCatalog still advertises the abilities for tool calls.
+	if ( ! abilitiesApiAvailable() ) {
+		return;
 	}
 
 	try {
@@ -310,11 +327,33 @@ export async function snapshotDescriptors() {
  */
 export async function executeClientAbility( name, args ) {
 	const callback = clientCallbacks.get( name );
-	if ( ! callback ) {
-		throw new Error(
-			`Client ability "${ name }" is not registered on this page. ` +
-				'Ensure the ability was registered via registerClientAbility() before the job completed.'
-		);
+	if ( callback ) {
+		return callback( args );
 	}
-	return callback( args );
+
+	// Defensive fallback (sd-ai-86a): if the local callback map missed
+	// (e.g. another bundle on the same page registered the ability but
+	// this bundle's module scope did not), try the shared WP 7.0
+	// abilities API. This is rare in practice — both bundles import
+	// the same `src/abilities` tree — but keeps execution resilient
+	// when only the WP store has the ability.
+	if (
+		typeof wp !== 'undefined' &&
+		!! wp.abilities &&
+		typeof wp.abilities.executeAbility === 'function'
+	) {
+		try {
+			return await wp.abilities.executeAbility( name, args );
+		} catch ( err ) {
+			// Surface the WP error message rather than the generic
+			// "not registered" string so the model gets actionable
+			// feedback in the tool result.
+			throw err instanceof Error ? err : new Error( String( err ) );
+		}
+	}
+
+	throw new Error(
+		`Client ability "${ name }" is not registered on this page. ` +
+			'Ensure the ability was registered via registerClientAbility() before the job completed.'
+	);
 }


### PR DESCRIPTION
## Summary

Fixes the runtime error reported by the in-product agent when trying to invoke `screenshot-url` and `navigate-to` on a page where the `@wordpress/abilities` script module had not (yet) loaded:

> Client ability "sd-ai-agent-js/screenshot-url" is not registered on this page. Ensure the ability was registered via registerClientAbility() before the job completed.

> Client ability "sd-ai-agent-js/navigate-to" is not registered on this page. ...

These errors blocked `screenshot-url`, `navigate-to`, `capture-screenshot`, and `insert-block` from working whenever the WP 7.0 `wp.abilities` global was not present (e.g. some frontend post contexts in WP 7.0-RC2, or a slow script-module load).

## Root cause

`registerClientAbility()` in `src/abilities/registry.js` previously returned early at line 190 when `abilitiesApiAvailable()` was false — **before** populating the module-scoped `clientCallbacks` map. But `executeClientAbility()` (called by `jobSlice` when the server returns `pending_client_tool_calls`) only reads from `clientCallbacks`, so a miss there threw `"Client ability X is not registered on this page"` even though the callback function was present in the bundle.

## Fix

1. `registerClientAbility` now stores the callback in `clientCallbacks` **before** the `abilitiesApiAvailable()` guard. The `wp.abilities.registerAbility()` call remains gated (so we don't crash without the WP store), but the local execution path that jobSlice actually uses is always wired up.
2. `executeClientAbility` adds a defensive fallback to `wp.abilities.executeAbility()` when the local map misses but the WP API is present. Covers cross-bundle scenarios.

## Tests

New `src/abilities/__tests__/registry.test.js`:

- `registerClientAbility stores callback locally even when wp.abilities is undefined`
- `executeClientAbility throws for truly unknown abilities`
- `executeClientAbility falls back to wp.abilities.executeAbility when the local map misses but WP API is present`
- `registerClientAbility writes to wp.abilities when API is available`

```
PASS src/abilities/__tests__/registry.test.js
Tests:       243 passed, 243 total (full suite)
```

Build (`npm run build`) and lint (`npm run lint:js`) clean.

Refs: sd-ai-86a

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with claude-sonnet-4-6 spent 1d and 383 tokens on this as a headless worker.
