### PR TITLE
fix(test): ThirdPartyAbilityNoticeHandlerTest::test_namespace_decision_overrides_heuristic broken on main

### DIFF
--- a/tests/SdAiAgent/Admin/ThirdPartyAbilityNoticeHandlerTest.php
+++ b/tests/SdAiAgent/Admin/ThirdPartyAbilityNoticeHandlerTest.php
@@ -129,20 +129,27 @@ class ThirdPartyAbilityNoticeHandlerTest extends WP_UnitTestCase {
 	 * Test that namespace decisions override the heuristic.
 	 */
 	public function test_namespace_decision_overrides_heuristic(): void {
-		if ( ! function_exists( 'wp_register_ability' ) ) {
+		if ( ! class_exists( '\WP_Ability' ) ) {
 			$this->markTestSkipped( 'WordPress Abilities API not available.' );
 		}
 
-		// Register a test ability with no description or category (would be private-unknown).
-		global $wp_current_filter;
-		$wp_current_filter[] = 'wp_abilities_api_init';
+		// Set the mode to 'auto' so the heuristic applies.
+		$option = get_option( 'sd_ai_agent_settings', array() );
+		if ( ! is_array( $option ) ) {
+			$option = array();
+		}
+		$option['third_party_mode'] = 'auto';
+		update_option( 'sd_ai_agent_settings', $option );
 
-		wp_register_ability(
+		// Create a mock ability with a non-partner category and no explicit public flag.
+		// This simulates an ability that would be classified as private-unknown
+		// (no description+category heuristic match, no partner namespace/category).
+		$ability = new \WP_Ability(
 			'test-plugin/test-ability',
 			[
 				'label'               => 'Test Ability',
-				'description'         => '',
-				'category'            => '',
+				'description'         => 'A test ability',
+				'category'            => 'test-category',
 				'input_schema'        => [ 'type' => 'object', 'properties' => [] ],
 				'execute_callback'    => static function () {
 					return [];
@@ -153,15 +160,9 @@ class ThirdPartyAbilityNoticeHandlerTest extends WP_UnitTestCase {
 			]
 		);
 
-		array_pop( $wp_current_filter );
-
-		// Get the ability.
-		$ability = wp_get_ability( 'test-plugin/test-ability' );
-		$this->assertNotNull( $ability );
-
-		// Without a decision, it should be private-unknown.
+		// Without a decision, it should be public-heuristic (has description + category).
 		$this->assertSame(
-			AbilityVisibility::CLASSIFICATION_PRIVATE_UNKNOWN,
+			AbilityVisibility::CLASSIFICATION_PUBLIC_HEURISTIC,
 			AbilityVisibility::classify( $ability )
 		);
 
@@ -173,7 +174,7 @@ class ThirdPartyAbilityNoticeHandlerTest extends WP_UnitTestCase {
 		$option['third_party_namespace_decisions'] = [ 'test-plugin' => 'allow' ];
 		update_option( 'sd_ai_agent_settings', $option );
 
-		// Now it should be public-explicit.
+		// Now it should be public-explicit (namespace decision overrides heuristic).
 		$this->assertSame(
 			AbilityVisibility::CLASSIFICATION_PUBLIC_EXPLICIT,
 			AbilityVisibility::classify( $ability )
@@ -183,7 +184,7 @@ class ThirdPartyAbilityNoticeHandlerTest extends WP_UnitTestCase {
 		$option['third_party_namespace_decisions'] = [ 'test-plugin' => 'block' ];
 		update_option( 'sd_ai_agent_settings', $option );
 
-		// Now it should be private-explicit.
+		// Now it should be private-explicit (namespace decision overrides heuristic).
 		$this->assertSame(
 			AbilityVisibility::CLASSIFICATION_PRIVATE_EXPLICIT,
 			AbilityVisibility::classify( $ability )

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -140,29 +140,32 @@ if ( ! class_exists( 'WP_Ability' ) ) {
 	class WP_Ability {
 		/** @var string */
 		public string $name = '';
+		/** @var array<string, mixed> */
+		private array $args = array();
 		/**
 		 * @param string               $name Ability name.
 		 * @param array<string, mixed> $args Ability args.
 		 */
 		public function __construct( string $name, array $args = array() ) {
 			$this->name = $name;
+			$this->args = $args;
 		}
 		/** @return string */
 		public function get_name(): string { return $this->name; }
 		/** @return string */
-		public function get_label(): string { return ''; }
+		public function get_label(): string { return (string) ( $this->args['label'] ?? '' ); }
 		/** @return string */
-		public function get_description(): string { return ''; }
+		public function get_description(): string { return (string) ( $this->args['description'] ?? '' ); }
 		/** @return array<string, mixed> */
-		public function get_params(): array { return array(); }
+		public function get_params(): array { return (array) ( $this->args['params'] ?? array() ); }
 		/** @return array<string, mixed> */
-		public function get_input_schema(): array { return array(); }
+		public function get_input_schema(): array { return (array) ( $this->args['input_schema'] ?? array() ); }
 		/** @return array<string, mixed> */
-		public function get_output_schema(): array { return array(); }
+		public function get_output_schema(): array { return (array) ( $this->args['output_schema'] ?? array() ); }
 		/** @return string */
-		public function get_category(): string { return ''; }
+		public function get_category(): string { return (string) ( $this->args['category'] ?? '' ); }
 		/** @return array<string, mixed> */
-		public function get_meta(): array { return array(); }
+		public function get_meta(): array { return (array) ( $this->args['meta'] ?? array() ); }
 		/** @return mixed */
 		public function call( array $params ): mixed { return null; }
 		/** @return mixed|\WP_Error */


### PR DESCRIPTION
## Summary

Fixes the failing `test_namespace_decision_overrides_heuristic` test that was broken on main after PR #1433 merged.

## Changes

1. **Updated WP_Ability polyfill** (`tests/bootstrap.php`):
   - Store ability properties from constructor args in a private `$args` property
   - Return properties from getter methods instead of hardcoded empty strings
   - Allows test to create mock abilities with proper description and category

2. **Fixed test implementation** (`tests/SdAiAgent/Admin/ThirdPartyAbilityNoticeHandlerTest.php`):
   - Changed from dynamic ability registration (which WordPress Abilities API doesn't allow after bootstrap) to mock WP_Ability instances
   - Set `third_party_mode` to 'auto' so the heuristic classification applies
   - Updated assertions to match actual behavior with proper mode setting

## Root Cause

WordPress 6.9.4 has a real Abilities API that:
- Only allows ability registration during `wp_abilities_api_init` action
- Uses `doing_action()` to enforce this constraint
- Rejects abilities with empty descriptions

The test was trying to register abilities dynamically after bootstrap, which WordPress rejects.

## Verification

- ✅ `test_namespace_decision_overrides_heuristic` now passes
- ✅ All 2102 tests run successfully (6 pre-existing failures unrelated to this change)
- ✅ Closes #sd-ai-4l0

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with claude-haiku-4-5 spent 6m and 2,982 tokens on this as a headless worker.
