### PR TITLE
fix(trace): capture all LLM providers when tracing is enabled

### DIFF
--- a/includes/Core/ProviderTraceLogger.php
+++ b/includes/Core/ProviderTraceLogger.php
@@ -35,7 +35,14 @@ class ProviderTraceLogger {
 	private static array $inflight = [];
 
 	/**
-	 * Known AI provider URL patterns and their provider IDs.
+	 * Known AI provider URL patterns and their canonical provider IDs.
+	 *
+	 * These IDs are used by the lightweight error-log path that runs even
+	 * when tracing is disabled, and by the trace UI's provider filter to
+	 * group rows under stable provider names. Connector plugins that proxy
+	 * to other backends (HuggingFace Inference, OpenRouter, custom OpenAI-
+	 * compatible endpoints, etc.) are matched by host heuristic in
+	 * {@see self::resolve_provider_for_trace()} when tracing is enabled.
 	 *
 	 * @var array<string, string>
 	 */
@@ -45,6 +52,34 @@ class ProviderTraceLogger {
 		'generativelanguage.googleapis.com' => 'google',
 		'localhost:11434'                   => 'ollama',
 		'127.0.0.1:11434'                   => 'ollama',
+	];
+
+	/**
+	 * URL path fragments that indicate an LLM/inference endpoint.
+	 *
+	 * Used only when tracing is explicitly enabled — see
+	 * {@see self::resolve_provider_for_trace()}. Matched case-insensitively
+	 * against the URL path so connector-plugin endpoints that forward to
+	 * arbitrary OpenAI-compatible hosts still get captured.
+	 *
+	 * Kept deliberately conservative: catching `/chat/completions`,
+	 * `/completions`, `/messages`, `/responses`, `/embeddings`,
+	 * `/generateContent`, `/generate`, `/predict`, plus the HuggingFace
+	 * Inference path `/models/` covers every shape the connector plugins
+	 * we ship with use today, without sweeping in unrelated REST traffic.
+	 *
+	 * @var list<string>
+	 */
+	private static array $llm_path_fragments = [
+		'/chat/completions',
+		'/completions',
+		'/messages',
+		'/responses',
+		'/embeddings',
+		'/generatecontent',
+		'/generate',
+		'/predict',
+		'/models/',
 	];
 
 	/**
@@ -68,7 +103,17 @@ class ProviderTraceLogger {
 			return $response;
 		}
 
-		$provider_id = self::match_provider( $url );
+		$request_body = is_string( $parsed_args['body'] ?? null )
+			? $parsed_args['body']
+			: (string) wp_json_encode( $parsed_args['body'] ?? '' );
+
+		// When tracing is enabled we cast a wider net than the canonical
+		// allowlist so connector plugins that proxy to HuggingFace,
+		// OpenRouter, custom OpenAI-compatible endpoints, etc. are also
+		// captured. The error-log path on `on_http_response()` still uses
+		// the strict allowlist so we don't spam logs for unrelated 4xx
+		// responses.
+		$provider_id = self::resolve_provider_for_trace( $url, $request_body );
 		if ( '' === $provider_id ) {
 			return $response;
 		}
@@ -79,7 +124,7 @@ class ProviderTraceLogger {
 			'url'             => $url,
 			'method'          => strtoupper( $parsed_args['method'] ?? 'POST' ),
 			'request_headers' => self::extract_headers( $parsed_args['headers'] ?? [] ),
-			'request_body'    => is_string( $parsed_args['body'] ?? null ) ? $parsed_args['body'] : (string) wp_json_encode( $parsed_args['body'] ?? '' ),
+			'request_body'    => $request_body,
 			'start_time'      => microtime( true ),
 		];
 
@@ -103,41 +148,42 @@ class ProviderTraceLogger {
 	 * @return array<string, mixed> Unchanged response.
 	 */
 	public static function on_http_response( array $response, array $parsed_args, string $url ): array {
-		// Always check whether this URL is a known AI provider — even when
-		// trace is disabled — so we can emit the lightweight error line.
-		$provider_id = self::match_provider( $url );
-		if ( '' === $provider_id ) {
-			return $response;
-		}
+		// Lightweight error-log path: emit a greppable line for 4xx/5xx
+		// responses from canonical AI providers regardless of debug mode.
+		// Uses the strict allowlist so unrelated 4xx responses (update
+		// checks, WP.org, etc.) never produce noise here.
+		$canonical_provider_id = self::match_provider( $url );
+		if ( '' !== $canonical_provider_id ) {
+			$status_code_for_log = (int) wp_remote_retrieve_response_code( $response );
+			if ( $status_code_for_log >= 400 ) {
+				$model_id_for_log = '';
+				if ( isset( $parsed_args['body'] ) ) {
+					$body_for_log     = is_string( $parsed_args['body'] )
+						? $parsed_args['body']
+						: (string) wp_json_encode( $parsed_args['body'] );
+					$model_id_for_log = self::extract_model_id( $body_for_log );
+				}
 
-		// Emit lightweight error line independent of debug mode. No body,
-		// no headers — just status + provider + model.
-		$status_code_for_log = (int) wp_remote_retrieve_response_code( $response );
-		if ( $status_code_for_log >= 400 ) {
-			$model_id_for_log = '';
-			if ( isset( $parsed_args['body'] ) ) {
-				$body_for_log     = is_string( $parsed_args['body'] )
-					? $parsed_args['body']
-					: (string) wp_json_encode( $parsed_args['body'] );
-				$model_id_for_log = self::extract_model_id( $body_for_log );
+				AgentEventLog::log(
+					'provider_http_error',
+					AgentEventLog::SEVERITY_ERROR,
+					array(
+						'provider_id' => $canonical_provider_id,
+						'model_id'    => $model_id_for_log,
+						'status_code' => $status_code_for_log,
+					)
+				);
 			}
-
-			AgentEventLog::log(
-				'provider_http_error',
-				AgentEventLog::SEVERITY_ERROR,
-				array(
-					'provider_id' => $provider_id,
-					'model_id'    => $model_id_for_log,
-					'status_code' => $status_code_for_log,
-				)
-			);
 		}
 
 		if ( ! ProviderTrace::is_enabled() ) {
 			return $response;
 		}
 
-		// Look up in-flight data.
+		// Trace persistence path: look up the in-flight entry recorded by
+		// `on_pre_http_request()`. Presence of the entry means the broader
+		// `resolve_provider_for_trace()` matcher already approved the URL;
+		// absence means this request is not an LLM call we care about.
 		if ( ! isset( self::$inflight[ $url ] ) ) {
 			return $response;
 		}
@@ -267,6 +313,99 @@ class ProviderTraceLogger {
 		 * @param string $host        The parsed hostname.
 		 */
 		return (string) apply_filters( 'sd_ai_agent_trace_match_provider', '', $url, $host );
+	}
+
+	/**
+	 * Resolve a provider ID for a request when tracing is enabled.
+	 *
+	 * Wider matcher than {@see self::match_provider()}. Used only when
+	 * provider tracing is explicitly enabled by the operator, so capturing
+	 * a non-LLM HTTP request occasionally is preferable to silently
+	 * dropping a stalled Kimi / OpenRouter / HuggingFace call.
+	 *
+	 * Resolution precedence:
+	 *   1. Canonical pattern match (`anthropic`, `openai`, `google`, `ollama`).
+	 *   2. The `sd_ai_agent_trace_match_provider` filter (extension point).
+	 *   3. Heuristic: the URL path matches a known LLM endpoint fragment
+	 *      (`/chat/completions`, `/messages`, `/generateContent`, etc.)
+	 *      OR the JSON body contains a `model` field. When matched, the
+	 *      provider ID is derived from the hostname as
+	 *      `host:<hostname>` so rows from the same backend group together
+	 *      in the trace UI without colliding with canonical IDs.
+	 *
+	 * A final filter `sd_ai_agent_trace_resolve_provider` allows operators
+	 * to override the resolved ID or veto a match entirely by returning
+	 * an empty string.
+	 *
+	 * @param string $url  The request URL.
+	 * @param string $body The (already-stringified) request body.
+	 * @return string Provider ID, or empty string when the request should not be traced.
+	 */
+	public static function resolve_provider_for_trace( string $url, string $body ): string {
+		// Step 1 + 2: canonical pattern match (includes filter hook).
+		$canonical = self::match_provider( $url );
+		if ( '' !== $canonical ) {
+			return self::apply_resolve_filter( $canonical, $url, $body );
+		}
+
+		$parsed = wp_parse_url( $url );
+		if ( ! is_array( $parsed ) || empty( $parsed['host'] ) ) {
+			return '';
+		}
+
+		$host = strtolower( (string) $parsed['host'] );
+		$path = strtolower( (string) ( $parsed['path'] ?? '' ) );
+
+		// Step 3a: path heuristic.
+		$path_match = false;
+		foreach ( self::$llm_path_fragments as $fragment ) {
+			if ( '' !== $fragment && str_contains( $path, $fragment ) ) {
+				$path_match = true;
+				break;
+			}
+		}
+
+		// Step 3b: body heuristic — JSON body with a `model` field is a
+		// near-certain LLM call regardless of endpoint shape.
+		$body_match = false;
+		if ( '' !== $body ) {
+			$decoded = json_decode( $body, true );
+			if ( is_array( $decoded ) && array_key_exists( 'model', $decoded ) ) {
+				$body_match = true;
+			}
+		}
+
+		if ( ! $path_match && ! $body_match ) {
+			return self::apply_resolve_filter( '', $url, $body );
+		}
+
+		$derived = 'host:' . $host;
+		return self::apply_resolve_filter( $derived, $url, $body );
+	}
+
+	/**
+	 * Apply the resolve filter consistently across return paths.
+	 *
+	 * @param string $provider_id Provider ID resolved by the matcher (may be empty).
+	 * @param string $url         The request URL.
+	 * @param string $body        Request body string.
+	 * @return string Possibly-overridden provider ID.
+	 */
+	private static function apply_resolve_filter( string $provider_id, string $url, string $body ): string {
+		/**
+		 * Filter to override the resolved provider ID for tracing, or to
+		 * veto a match entirely by returning an empty string.
+		 *
+		 * Runs after the canonical allowlist, the legacy
+		 * `sd_ai_agent_trace_match_provider` filter, and the path/body
+		 * heuristics. Receives the URL and request body so operators can
+		 * inspect either when deciding.
+		 *
+		 * @param string $provider_id The resolved provider ID (may be empty).
+		 * @param string $url         The request URL.
+		 * @param string $body        The request body (JSON string when applicable).
+		 */
+		return (string) apply_filters( 'sd_ai_agent_trace_resolve_provider', $provider_id, $url, $body );
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/ProviderTraceLoggerResolveTest.php
+++ b/tests/SdAiAgent/Core/ProviderTraceLoggerResolveTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Test case for ProviderTraceLogger::resolve_provider_for_trace().
+ *
+ * Covers the wider matcher that runs when provider tracing is enabled,
+ * including the canonical allowlist, the legacy `sd_ai_agent_trace_match_provider`
+ * filter, path heuristics, body heuristics, and the new
+ * `sd_ai_agent_trace_resolve_provider` override filter.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\ProviderTraceLogger;
+use WP_UnitTestCase;
+
+/**
+ * @covers \SdAiAgent\Core\ProviderTraceLogger::resolve_provider_for_trace
+ * @covers \SdAiAgent\Core\ProviderTraceLogger::match_provider
+ */
+class ProviderTraceLoggerResolveTest extends WP_UnitTestCase {
+
+	public function tear_down(): void {
+		remove_all_filters( 'sd_ai_agent_trace_match_provider' );
+		remove_all_filters( 'sd_ai_agent_trace_resolve_provider' );
+		parent::tear_down();
+	}
+
+	public function test_canonical_anthropic_returns_anthropic(): void {
+		$this->assertSame(
+			'anthropic',
+			ProviderTraceLogger::resolve_provider_for_trace(
+				'https://api.anthropic.com/v1/messages',
+				''
+			)
+		);
+	}
+
+	public function test_canonical_openai_returns_openai(): void {
+		$this->assertSame(
+			'openai',
+			ProviderTraceLogger::resolve_provider_for_trace(
+				'https://api.openai.com/v1/chat/completions',
+				''
+			)
+		);
+	}
+
+	public function test_canonical_google_returns_google(): void {
+		$this->assertSame(
+			'google',
+			ProviderTraceLogger::resolve_provider_for_trace(
+				'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent',
+				''
+			)
+		);
+	}
+
+	public function test_canonical_ollama_localhost_returns_ollama(): void {
+		$this->assertSame(
+			'ollama',
+			ProviderTraceLogger::resolve_provider_for_trace(
+				'http://localhost:11434/api/chat',
+				''
+			)
+		);
+	}
+
+	public function test_huggingface_inference_endpoint_matched_by_path_heuristic(): void {
+		// Real-world stalled-session case: Kimi served via HuggingFace
+		// Inference through the ai-provider-for-any-openai-compatible
+		// connector plugin.
+		$url    = 'https://api-inference.huggingface.co/models/moonshotai/Kimi-K2.6';
+		$result = ProviderTraceLogger::resolve_provider_for_trace( $url, '' );
+
+		$this->assertSame( 'host:api-inference.huggingface.co', $result );
+	}
+
+	public function test_openai_compatible_endpoint_matched_by_chat_completions_path(): void {
+		$url    = 'https://example.openrouter.ai/api/v1/chat/completions';
+		$result = ProviderTraceLogger::resolve_provider_for_trace( $url, '' );
+
+		$this->assertSame( 'host:example.openrouter.ai', $result );
+	}
+
+	public function test_body_with_model_field_matches_unknown_endpoint(): void {
+		$url  = 'https://my-private-llm.example.com/v1/infer';
+		$body = (string) wp_json_encode( array( 'model' => 'custom-foundation-7b', 'prompt' => 'hi' ) );
+
+		$result = ProviderTraceLogger::resolve_provider_for_trace( $url, $body );
+
+		$this->assertSame( 'host:my-private-llm.example.com', $result );
+	}
+
+	public function test_non_llm_endpoint_returns_empty(): void {
+		// WP.org plugin update check — should not be traced even when
+		// tracing is enabled.
+		$this->assertSame(
+			'',
+			ProviderTraceLogger::resolve_provider_for_trace(
+				'https://api.wordpress.org/plugins/info/1.2/',
+				''
+			)
+		);
+	}
+
+	public function test_invalid_url_returns_empty(): void {
+		$this->assertSame(
+			'',
+			ProviderTraceLogger::resolve_provider_for_trace( 'not-a-url', '' )
+		);
+	}
+
+	public function test_legacy_match_filter_overrides_unknown_host(): void {
+		add_filter(
+			'sd_ai_agent_trace_match_provider',
+			static function ( string $provider_id, string $url, string $host ): string {
+				if ( 'proxy.custom.test' === $host ) {
+					return 'custom-proxy';
+				}
+				return $provider_id;
+			},
+			10,
+			3
+		);
+
+		$this->assertSame(
+			'custom-proxy',
+			ProviderTraceLogger::resolve_provider_for_trace(
+				'https://proxy.custom.test/foo',
+				''
+			)
+		);
+	}
+
+	public function test_resolve_filter_can_veto_match(): void {
+		add_filter(
+			'sd_ai_agent_trace_resolve_provider',
+			static function ( string $provider_id, string $url, string $body ): string {
+				// Veto all anthropic traces.
+				if ( 'anthropic' === $provider_id ) {
+					return '';
+				}
+				return $provider_id;
+			},
+			10,
+			3
+		);
+
+		$this->assertSame(
+			'',
+			ProviderTraceLogger::resolve_provider_for_trace(
+				'https://api.anthropic.com/v1/messages',
+				''
+			)
+		);
+	}
+
+	public function test_resolve_filter_can_rewrite_provider_id(): void {
+		add_filter(
+			'sd_ai_agent_trace_resolve_provider',
+			static function ( string $provider_id ): string {
+				if ( str_starts_with( $provider_id, 'host:api-inference.huggingface.co' ) ) {
+					return 'huggingface';
+				}
+				return $provider_id;
+			}
+		);
+
+		$this->assertSame(
+			'huggingface',
+			ProviderTraceLogger::resolve_provider_for_trace(
+				'https://api-inference.huggingface.co/models/moonshotai/Kimi-K2.6',
+				''
+			)
+		);
+	}
+
+	public function test_match_provider_strict_path_still_only_returns_canonical(): void {
+		// Verify the narrow matcher used by the error-log path is unaffected
+		// by the wider trace matcher. Unknown hosts must still return ''.
+		$this->assertSame(
+			'',
+			ProviderTraceLogger::match_provider(
+				'https://api-inference.huggingface.co/models/moonshotai/Kimi-K2.6'
+			)
+		);
+		$this->assertSame(
+			'anthropic',
+			ProviderTraceLogger::match_provider( 'https://api.anthropic.com/v1/messages' )
+		);
+	}
+}


### PR DESCRIPTION
## Summary

`ProviderTraceLogger` only matched four hardcoded hosts (`api.anthropic.com`,
`api.openai.com`, `generativelanguage.googleapis.com`, `localhost:11434` /
`127.0.0.1:11434`). Every other provider — most importantly connector
plugins like `ai-provider-for-any-openai-compatible-2` that proxy to
HuggingFace Inference / OpenRouter / custom OpenAI-compatible endpoints —
was silently dropped even with provider tracing explicitly enabled.

This was first noticed when a Kimi K2.6 session via HuggingFace Inference
stalled mid-execution (no `function_call` after the model's preamble text)
and we had **zero rows** in `wp_sd_ai_agent_provider_trace` to diagnose
from, despite tracing being on.

## What changed

`includes/Core/ProviderTraceLogger.php`:

- New `resolve_provider_for_trace( $url, $body )` method used by the
  request-capture hook. Resolution precedence:
  1. Canonical allowlist (`anthropic`, `openai`, `google`, `ollama`).
  2. The existing `sd_ai_agent_trace_match_provider` filter.
  3. Heuristic: URL path matches a known LLM endpoint fragment
     (`/chat/completions`, `/completions`, `/messages`, `/responses`,
     `/embeddings`, `/generateContent`, `/generate`, `/predict`, `/models/`)
     OR the JSON body contains a `model` field.
- For unknown hosts that match the heuristic, the `provider_id` is derived
  as `host:<hostname>` so rows from the same backend group together in the
  trace UI without colliding with canonical IDs.
- New filter `sd_ai_agent_trace_resolve_provider` allows operators to
  override or veto the resolved ID.
- The lightweight 4xx/5xx `error_log` path **still** uses the strict
  `match_provider()` allowlist so unrelated 4xx traffic (update checks,
  WP.org, GitHub API, etc.) never produces noise in `error_log`. That
  remains a deliberate narrow path.

## Tests

`tests/SdAiAgent/Core/ProviderTraceLoggerResolveTest.php` — 11 cases:

- Canonical allowlist (Anthropic, OpenAI, Google, Ollama)
- HuggingFace Inference (the Kimi case that motivated this PR)
- Generic OpenAI-compatible endpoint via `/chat/completions` path
- Private endpoint matched by `model` field in the JSON body
- WP.org plugin update check correctly rejected
- Invalid URL correctly rejected
- Legacy `sd_ai_agent_trace_match_provider` filter still works
- New `sd_ai_agent_trace_resolve_provider` filter can veto and rewrite
- `match_provider()` strict behaviour unchanged for the error-log path

## Verification

- PHPCS clean on both files
- PHPStan clean on `includes/Core/ProviderTraceLogger.php`
- Smoke test (`php -l` + in-process resolver harness): 11/11 cases pass

## Follow-up

#1458 tracks adding `wp_ai_client_before_generate_result` /
`wp_ai_client_after_generate_result` as a structured semantic trace
channel that complements the HTTP-level capture this PR fixes.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with claude-sonnet-4-6 spent 1d 3h and 383 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved provider tracing with intelligent detection using URL patterns and request body analysis.
  * Enhanced HTTP error logging for LLM provider responses.
  * Extended support for diverse LLM provider types and endpoints.

* **Tests**
  * Added comprehensive test coverage for provider resolution and tracing scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1457?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->