### PR TITLE
fix(build): exclude .eslintignore from wporg zip (sd-ai-2gt)

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -53,6 +53,7 @@
 /.eslintrc
 /.eslintrc.json
 /.eslintrc.js
+/.eslintignore
 /.stylelintrc
 /.stylelintrc.json
 /.stylelintrc.js

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -157,6 +157,7 @@ build_variant() {
 	# repeating without a leading `/` would over-match (see GH#1310).
 	cat >>"$exclude_file" <<'EXTRA'
 **/.eslintrc*
+**/.eslintignore
 **/.prettierrc*
 **/.stylelintrc*
 EXTRA
@@ -187,6 +188,7 @@ EXTRA
 		-o -name '.windsurfrules' \
 		-o -name '.editorconfig' \
 		-o -name '.eslintrc*' \
+		-o -name '.eslintignore' \
 		-o -name '.prettierrc*' \
 		-o -name '.stylelintrc*' \
 		-o -name '.playwright-mcp' \


### PR DESCRIPTION
## Summary
- The wporg build target was shipping a top-level `.eslintignore` inside `superdav-ai-agent-{version}-wporg.zip` because `.distignore` only excluded `/.eslintrc*` and the always-applied tree-wide extras + post-copy `find` sweep in `bin/build.sh` also only matched `.eslintrc*`.
- WP.org plugin-check flags dev lint dotfiles shipped to end users.
- Mirrors how `.eslintrc*` is handled across all three layers.

## Changes
- `.distignore`: add `/.eslintignore` (top-level anchor) next to `/.eslintrc*`. Anchored intentionally — vendor packages don't ship `.eslintignore`, and the `GH#1310` rule documented in the file warns against unanchored patterns hitting identically named files deep inside `vendor/*`.
- `bin/build.sh` (always-applied extras heredoc): add `**/.eslintignore` to the tree-wide sweep so any future vendor copy is dropped at rsync time.
- `bin/build.sh` (post-copy `find`): add `-o -name '.eslintignore'` as belt-and-braces, matching the existing `.eslintrc*` treatment.

## Verification
- Replayed the `rsync --exclude-from=...` and post-copy `find` stages from `build.sh` against the live working tree (skipping the unrelated `wp-scripts build` step):
  - Staged build dir contains zero `.eslintignore` or `.eslintrc*` files at any depth.
  - Diff: 3 added lines, no behaviour change to existing exclusions.
- `shellcheck bin/build.sh` — no new findings.
- Repro before the fix: `bin/build.sh --target=wporg` then `unzip -l superdav-ai-agent-*-wporg.zip | grep eslintignore` showed `superdav-ai-agent/.eslintignore` at 1315 bytes.

Refs: sd-ai-2gt

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with claude-opus-4-7 spent 2m and 9,521 tokens on this with the user in an interactive session.
