### PR TITLE
fix(agent-loop): detect preamble-only truncations + add Synthetic model caps

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -77,6 +77,19 @@ class AgentLoop {
 	/** Default exponential backoff schedule in seconds, capped at 60 seconds. */
 	private const PROVIDER_RETRY_DELAYS = array( 1, 2, 4, 8, 16, 32, 60, 60, 60, 60 );
 
+	/**
+	 * Maximum consecutive preamble-only truncations before we abort the loop.
+	 *
+	 * A preamble-only truncation happens when the model emits text up to its
+	 * output cap without ever opening a tool call. We inject guidance and
+	 * retry once; if it happens again immediately the model is stuck (model
+	 * cap is genuinely too small, or the task is too large) and burning more
+	 * iterations is wasteful. Abort with a structured WP_Error so the
+	 * session ends cleanly and the UI can surface a real failure to the
+	 * user instead of an idle session with a half-sentence reply.
+	 */
+	private const PREAMBLE_TRUNCATION_MAX_RETRIES = 2;
+
 	/** @var string */
 	private $user_message;
 
@@ -148,6 +161,9 @@ class AgentLoop {
 
 	/** @var list<string> Per-agent Tier 1 tool override (empty = use global default). */
 	private array $agent_tier_1_tools = array();
+
+	/** @var int Consecutive preamble-only truncations observed this run. */
+	private int $preamble_truncation_retries = 0;
 
 	/**
 	 * Client-side ability descriptors validated against JsAbilityCatalog.
@@ -628,9 +644,32 @@ class AgentLoop {
 			$this->accumulate_tokens( $result );
 
 			if ( $this->is_truncated_tool_call_result( $result, $assistant_message ) ) {
+				// Partial tool call cut at the cap — discard the unsafe call,
+				// inject guidance, retry. This is the long-standing branch.
+				$this->preamble_truncation_retries = 0;
 				$this->inject_truncated_tool_call_guidance( $assistant_message );
 				continue;
 			}
+
+			if ( $this->is_truncated_before_tool_call_result( $result, $assistant_message ) ) {
+				// Model wrote a preamble, then hit the cap before opening any
+				// tool call. Without intervention the loop would treat the
+				// preamble as a final answer and silently exit, leaving the
+				// session idle. Inject distinct guidance and retry — but cap
+				// the retries so a genuinely undersized model doesn't burn
+				// every iteration on the same stall (see
+				// PREAMBLE_TRUNCATION_MAX_RETRIES).
+				++$this->preamble_truncation_retries;
+				if ( $this->preamble_truncation_retries > self::PREAMBLE_TRUNCATION_MAX_RETRIES ) {
+					return $this->abort_on_repeated_preamble_truncation();
+				}
+				$this->inject_pre_tool_call_truncation_guidance();
+				continue;
+			}
+
+			// Normal (non-truncated) turn — reset the preamble retry counter
+			// so an unrelated later truncation doesn't inherit prior state.
+			$this->preamble_truncation_retries = 0;
 
 			$this->history[] = $assistant_message;
 
@@ -1554,6 +1593,44 @@ class AgentLoop {
 			return false;
 		}
 
+		return $this->finish_reason_is_length_cap( $result );
+	}
+
+	/**
+	 * Detect provider length-cap finishes that never opened a tool call.
+	 *
+	 * This is the "preamble-only truncation" case: the model emitted assistant
+	 * text (typically a one-line lead-in like "Now I'll create the full landing
+	 * page...") and then hit its output cap before producing the JSON for a
+	 * tool call. Without intervention the agent loop would treat the partial
+	 * text as a final answer and silently exit the loop, leaving the session
+	 * idle with a half-sentence reply.
+	 *
+	 * We only flag this when the assistant *did* emit non-empty text — an
+	 * empty response that happens to report finish=length is almost always a
+	 * provider bug and should not enter the guidance-retry path.
+	 *
+	 * @param mixed   $result  Provider result object.
+	 * @param Message $message Assistant message converted from the result.
+	 */
+	private function is_truncated_before_tool_call_result( $result, Message $message ): bool {
+		if ( $this->get_ability_resolver()->has_ability_calls( $message ) ) {
+			return false;
+		}
+
+		if ( ! $this->message_has_assistant_text( $message ) ) {
+			return false;
+		}
+
+		return $this->finish_reason_is_length_cap( $result );
+	}
+
+	/**
+	 * Whether the provider's normalized finish reason indicates an output-cap hit.
+	 *
+	 * @param mixed $result Provider result object.
+	 */
+	private function finish_reason_is_length_cap( $result ): bool {
 		$reason = $this->get_result_finish_reason( $result );
 		if ( '' === $reason ) {
 			return false;
@@ -1561,6 +1638,22 @@ class AgentLoop {
 
 		$normalized = strtolower( str_replace( [ '-', ' ' ], '_', $reason ) );
 		return in_array( $normalized, [ 'max_tokens', 'length', 'max_output_tokens' ], true );
+	}
+
+	/**
+	 * Whether a Message contains any non-empty assistant text part.
+	 *
+	 * @param Message $message Assistant message converted from the result.
+	 */
+	private function message_has_assistant_text( Message $message ): bool {
+		foreach ( $message->getParts() as $part ) {
+			$text = $part->getText();
+			if ( is_string( $text ) && '' !== trim( $text ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**
@@ -1627,6 +1720,87 @@ class AgentLoop {
 
 		$this->history[] = new UserMessage( [ new MessagePart( $guidance ) ] );
 		$this->fire_progress();
+	}
+
+	/**
+	 * Inject guidance after a preamble-only truncation and retry the turn.
+	 *
+	 * Distinct from {@see inject_truncated_tool_call_guidance()} because no
+	 * tool call was actually started — the previous wording ("the tool call
+	 * you started (X) was discarded") would be a lie. This message tells the
+	 * model exactly what happened (it wrote a lead-in and ran out of room)
+	 * and points it at the concrete decomposition path that
+	 * `sd-ai-agent/create-post` + `sd-ai-agent/append-post-content` enables
+	 * for long content on small-cap models.
+	 */
+	private function inject_pre_tool_call_truncation_guidance(): void {
+		$cap      = $this->get_effective_max_output_tokens();
+		$guidance = sprintf(
+			/* translators: %d: max token cap. */
+			__( 'Your previous response hit the max_tokens cap (current cap: %d) before you opened a tool call. The text-only reply has been discarded. Skip any lead-in narration and call a tool immediately. For long content like landing pages, articles, or multi-section copy: call sd-ai-agent/create-post with only the hero and intro, then call sd-ai-agent/append-post-content once per remaining section. Never attempt to emit a complete long page in a single sd-ai-agent/create-post call when your output budget is this small.', 'superdav-ai-agent' ),
+			$cap
+		);
+
+		$this->tool_call_log[] = array(
+			'type'       => 'event',
+			'reason'     => 'truncated_before_tool_call',
+			'max_tokens' => $cap,
+			'message'    => $guidance,
+		);
+
+		AgentEventLog::log(
+			'truncated_before_tool_call',
+			AgentEventLog::SEVERITY_WARNING,
+			array(
+				'session_id'  => $this->session_id,
+				'max_tokens'  => $cap,
+				'model_id'    => (string) $this->model_id,
+				'provider_id' => (string) $this->provider_id,
+				'retry'       => $this->preamble_truncation_retries,
+			)
+		);
+
+		$this->history[] = new UserMessage( [ new MessagePart( $guidance ) ] );
+		$this->fire_progress();
+	}
+
+	/**
+	 * Abort the loop after repeated preamble-only truncations.
+	 *
+	 * Returns a structured WP_Error so the calling code in {@see run()} can
+	 * end the session cleanly and surface a real failure to the UI instead
+	 * of leaving the session idle with a half-sentence assistant reply.
+	 */
+	private function abort_on_repeated_preamble_truncation(): WP_Error {
+		$cap = $this->get_effective_max_output_tokens();
+
+		AgentEventLog::log(
+			'agent_loop_aborted',
+			AgentEventLog::SEVERITY_ERROR,
+			array(
+				'session_id'      => $this->session_id,
+				'reason'          => 'preamble_truncation_loop',
+				'iterations_used' => $this->iterations_used,
+				'iterations_max'  => (int) $this->max_iterations,
+				'model_id'        => (string) $this->model_id,
+				'provider_id'     => (string) $this->provider_id,
+				'max_tokens'      => $cap,
+				'retries'         => $this->preamble_truncation_retries,
+			)
+		);
+
+		return new WP_Error(
+			'preamble_truncation_loop',
+			sprintf(
+				/* translators: %d: max token cap. */
+				__( 'The model repeatedly hit its output cap (%d tokens) before opening a tool call. The current model or output cap is too small for this task. Try a model with a larger output budget, or break the request into smaller steps.', 'superdav-ai-agent' ),
+				$cap
+			),
+			array(
+				'cap'     => $cap,
+				'retries' => $this->preamble_truncation_retries,
+			)
+		);
 	}
 
 	/**

--- a/includes/Core/ProviderTraceLogger.php
+++ b/includes/Core/ProviderTraceLogger.php
@@ -222,8 +222,11 @@ class ProviderTraceLogger {
 			if ( '' === $error ) {
 				$error = "HTTP {$status_code}";
 			}
-		} elseif ( self::is_truncated_tool_call_response( $decoded_response ) ) {
-			$error = 'truncated_tool_call';
+		} else {
+			$classification = self::classify_truncation( $decoded_response );
+			if ( '' !== $classification ) {
+				$error = $classification;
+			}
 		}
 
 		// Format response headers as JSON.
@@ -428,13 +431,23 @@ class ProviderTraceLogger {
 	}
 
 	/**
-	 * Detect successful provider responses that ended at the output cap mid tool call.
+	 * Classify a successful provider response that ended at the output cap.
+	 *
+	 * Returns one of:
+	 *   - 'truncated_tool_call'        : finish=length AND a tool call had started
+	 *                                    (its JSON arguments are incomplete and unsafe).
+	 *   - 'truncated_before_tool_call' : finish=length AND no tool call AND the
+	 *                                    assistant emitted some text (a preamble
+	 *                                    that exhausted the cap before a tool
+	 *                                    call could begin — the model wanted to
+	 *                                    continue but couldn't).
+	 *   - ''                           : no truncation event of interest.
 	 *
 	 * @param mixed $decoded Decoded JSON response body.
 	 */
-	private static function is_truncated_tool_call_response( $decoded ): bool {
+	public static function classify_truncation( $decoded ): string {
 		if ( ! is_array( $decoded ) ) {
-			return false;
+			return '';
 		}
 
 		$candidates = [];
@@ -446,6 +459,8 @@ class ProviderTraceLogger {
 			$candidates = [ $decoded ];
 		}
 
+		$saw_preamble_truncation = false;
+
 		foreach ( $candidates as $candidate ) {
 			if ( ! is_array( $candidate ) ) {
 				continue;
@@ -456,12 +471,20 @@ class ProviderTraceLogger {
 				continue;
 			}
 
+			// Partial tool call wins outright — its arguments JSON is unsafe to execute.
 			if ( self::candidate_has_tool_call( $candidate ) ) {
-				return true;
+				return 'truncated_tool_call';
+			}
+
+			// No tool call, but the model emitted *some* text before hitting the cap.
+			// This is the Kimi-style preamble-only stall: model wanted to continue
+			// but ran out of output budget before opening a tool call.
+			if ( self::candidate_has_text( $candidate ) ) {
+				$saw_preamble_truncation = true;
 			}
 		}
 
-		return false;
+		return $saw_preamble_truncation ? 'truncated_before_tool_call' : '';
 	}
 
 	/**
@@ -504,6 +527,64 @@ class ProviderTraceLogger {
 		if ( is_array( $parts ) ) {
 			foreach ( $parts as $part ) {
 				if ( is_array( $part ) && isset( $part['functionCall'] ) ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Detect whether a response candidate contains any non-empty assistant text.
+	 *
+	 * Used by {@see classify_truncation()} to distinguish "model wrote a
+	 * preamble then ran out of tokens" from "empty/garbage response that
+	 * happened to report finish=length". An empty response with a length
+	 * finish is almost always a provider bug and should not trigger the
+	 * preamble-truncation guidance path.
+	 *
+	 * Handles OpenAI (`message.content` string), Anthropic
+	 * (`content[].type === 'text'` parts), and Gemini
+	 * (`content.parts[].text` parts) shapes.
+	 *
+	 * @param array<string, mixed> $candidate Provider response candidate.
+	 */
+	private static function candidate_has_text( array $candidate ): bool {
+		// OpenAI-compatible: choices[].message.content as a string.
+		$message = $candidate['message'] ?? null;
+		if ( is_array( $message ) ) {
+			$content = $message['content'] ?? null;
+			if ( is_string( $content ) && '' !== trim( $content ) ) {
+				return true;
+			}
+		}
+
+		// Anthropic: content[] array with type=text blocks.
+		$content = $candidate['content'] ?? null;
+		if ( is_array( $content ) ) {
+			foreach ( $content as $part ) {
+				if ( ! is_array( $part ) ) {
+					continue;
+				}
+				if ( ( $part['type'] ?? '' ) === 'text' ) {
+					$text = $part['text'] ?? '';
+					if ( is_string( $text ) && '' !== trim( $text ) ) {
+						return true;
+					}
+				}
+			}
+		}
+
+		// Gemini: candidate.content.parts[].text.
+		$parts = $candidate['content']['parts'] ?? $candidate['parts'] ?? [];
+		if ( is_array( $parts ) ) {
+			foreach ( $parts as $part ) {
+				if ( ! is_array( $part ) ) {
+					continue;
+				}
+				$text = $part['text'] ?? '';
+				if ( is_string( $text ) && '' !== trim( $text ) ) {
 					return true;
 				}
 			}

--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -136,6 +136,7 @@ class Settings {
 	 *   - https://docs.anthropic.com/en/docs/about-claude/models/overview
 	 *   - https://platform.openai.com/docs/models
 	 *   - https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini
+	 *   - Synthetic AI /openai/v1/models (live response — `max_output_length`)
 	 *
 	 * @var array<string, int>
 	 */
@@ -145,44 +146,74 @@ class Settings {
 		// and Opus 4 document 32K. Newer point releases have higher caps
 		// than older ones in the same family, which is why these are not
 		// collapsed into a single `claude-opus-4` entry.
-		'claude-opus-4-7'   => 128000,
-		'claude-opus-4-6'   => 128000,
-		'claude-opus-4-5'   => 64000,
-		'claude-opus-4-1'   => 32000,
-		'claude-opus-4'     => 32000,
+		'claude-opus-4-7'                => 128000,
+		'claude-opus-4-6'                => 128000,
+		'claude-opus-4-5'                => 64000,
+		'claude-opus-4-1'                => 32000,
+		'claude-opus-4'                  => 32000,
 		// Sonnet 4 / 4.5 / 4.6 all document 64K output.
-		'claude-sonnet-4'   => 64000,
+		'claude-sonnet-4'                => 64000,
 		// Haiku 4.5 documents 64K output (matches Sonnet 4.x).
-		'claude-haiku-4-5'  => 64000,
-		'claude-haiku-4'    => 64000,
+		'claude-haiku-4-5'               => 64000,
+		'claude-haiku-4'                 => 64000,
 		// Legacy 3.x models retain older lower caps.
-		'claude-3-5-sonnet' => 8192,
-		'claude-3-5-haiku'  => 8192,
-		'claude-3-opus'     => 4096,
-		'claude-3-sonnet'   => 4096,
-		'claude-3-haiku'    => 4096,
+		'claude-3-5-sonnet'              => 8192,
+		'claude-3-5-haiku'               => 8192,
+		'claude-3-opus'                  => 4096,
+		'claude-3-sonnet'                => 4096,
+		'claude-3-haiku'                 => 4096,
 		// ── OpenAI ─────────────────────────────────────────────────────
 		// GPT-5 family (5, 5.4, 5.5) and o-series reasoning models all
 		// document 128K output. o1/o3 budgets include reasoning tokens.
-		'gpt-5'             => 128000,
+		'gpt-5'                          => 128000,
 		// GPT-4.1 documents 32,768; GPT-4o documents 16,384.
-		'gpt-4.1'           => 32768,
-		'gpt-4o'            => 16384,
-		'gpt-4-turbo'       => 4096,
-		'gpt-4'             => 8192,
-		'gpt-3.5-turbo'     => 4096,
+		'gpt-4.1'                        => 32768,
+		'gpt-4o'                         => 16384,
+		'gpt-4-turbo'                    => 4096,
+		'gpt-4'                          => 8192,
+		'gpt-3.5-turbo'                  => 4096,
 		// o-series reasoning models: o1 and o3 document 100K; o4 family
 		// (o4-mini etc.) inherits the same envelope.
-		'o1'                => 100000,
-		'o3'                => 100000,
-		'o4'                => 100000,
+		'o1'                             => 100000,
+		'o3'                             => 100000,
+		'o4'                             => 100000,
 		// ── Google Gemini ──────────────────────────────────────────────
 		// Gemini 2.5 Pro and Flash both document 65,535 max output.
 		// Older 2.0 and 1.5 families cap at 8K.
-		'gemini-2.5-pro'    => 65535,
-		'gemini-2.5-flash'  => 65535,
-		'gemini-2.0'        => 8192,
-		'gemini-1.5'        => 8192,
+		'gemini-2.5-pro'                 => 65535,
+		'gemini-2.5-flash'               => 65535,
+		'gemini-2.0'                     => 8192,
+		'gemini-1.5'                     => 8192,
+		// ── HuggingFace-served via OpenAI-compatible connectors ────────
+		// These IDs come from providers like Synthetic AI that proxy
+		// HuggingFace-hosted models through an OpenAI-compatible API and
+		// report `max_output_length` in their /models response. Specific
+		// entries override the generic `hf:` prefix below via longest-
+		// prefix match. Verified against Synthetic's live /models endpoint
+		// (`https://api.synthetic.new/openai/v1/models`).
+		//
+		// Without these entries, model IDs prefixed `hf:` fall through to
+		// the 8192 token fallback, which is far below the provider's
+		// actual cap (65,536 for the active Synthetic models). On a long
+		// single-shot tool call (e.g. emitting a full landing page in one
+		// `sd-ai-agent/create-post`) this caused the model to hit the
+		// 8192 cap *before* it could open the tool-call JSON, leaving
+		// the session idle with a preamble like "Now I'll create the full
+		// landing page..." and no follow-through. See PR description.
+		'hf:moonshotai/Kimi-K2.6'        => 65536,
+		'hf:moonshotai/Kimi-K2.5'        => 32768,
+		'hf:zai-org/GLM-5.1'             => 65536,
+		'hf:zai-org/GLM-5'               => 65536,
+		'hf:zai-org/GLM-4.7-Flash'       => 65536,
+		'hf:zai-org/GLM-4.7'             => 65536,
+		'hf:MiniMaxAI/MiniMax-M2.5'      => 65536,
+		'hf:nvidia/NVIDIA-Nemotron-3'    => 65536,
+		// Broad fallback for any other `hf:`-prefixed model served via
+		// OpenAI-compatible proxies. 32K is a generous but bounded value
+		// that's well under the WordPress AI Client SDK's request-body
+		// limits while being 4x the global 8192 fallback. Specific
+		// entries above take precedence via longest-prefix match.
+		'hf:'                            => 32768,
 	);
 
 	/**

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -864,6 +864,172 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertNotEmpty( $events, 'The truncation should be visible in the tool-call log.' );
 	}
 
+	/**
+	 * Regression test for the Kimi K2.6 stall: model emits a preamble, hits
+	 * finish=length before opening any tool call, agent loop must inject
+	 * distinct guidance and retry instead of silently exiting with the
+	 * preamble as the final reply.
+	 */
+	public function test_run_recovers_from_preamble_only_truncation(): void {
+		$this->skip_if_sdk_unavailable();
+		if ( ! class_exists( 'WP_AI_Client_Ability_Function_Resolver' ) ) {
+			$this->markTestSkipped( 'WP_AI_Client_Ability_Function_Resolver not available.' );
+		}
+
+		$call_count          = 0;
+		$second_request_body = '';
+
+		// Turn 1: preamble-only with length finish (the Kimi K2.6 stall shape).
+		$preamble_body = wp_json_encode(
+			[
+				'id'      => 'chatcmpl-preamble',
+				'object'  => 'chat.completion',
+				'choices' => [
+					[
+						'index'         => 0,
+						'message'       => [
+							'role'    => 'assistant',
+							'content' => "Now I'll create the full landing page with professional Gutenberg block markup:",
+						],
+						'finish_reason' => 'length',
+					],
+				],
+				'usage'   => [ 'prompt_tokens' => 10, 'completion_tokens' => 8192, 'total_tokens' => 8202 ],
+			]
+		);
+
+		// Turn 2: model takes the guidance and ends with a normal reply.
+		$reply_body = wp_json_encode(
+			[
+				'id'      => 'chatcmpl-recovered',
+				'object'  => 'chat.completion',
+				'choices' => [
+					[
+						'index'         => 0,
+						'message'       => [ 'role' => 'assistant', 'content' => 'Created hero. Will append rest now.' ],
+						'finish_reason' => 'stop',
+					],
+				],
+				'usage'   => [ 'prompt_tokens' => 50, 'completion_tokens' => 8, 'total_tokens' => 58 ],
+			]
+		);
+
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( &$call_count, &$second_request_body, $preamble_body, $reply_body ) {
+				if ( false !== strpos( $url, 'fake-ai-proxy.test' ) ) {
+					++$call_count;
+					if ( 2 === $call_count ) {
+						$second_request_body = is_string( $args['body'] ?? null ) ? $args['body'] : (string) wp_json_encode( $args['body'] ?? [] );
+					}
+
+					return [
+						'headers'  => [ 'content-type' => 'application/json' ],
+						'body'     => ( 1 === $call_count ) ? $preamble_body : $reply_body,
+						'response' => [ 'code' => 200, 'message' => 'OK' ],
+						'cookies'  => [],
+						'filename' => '',
+					];
+				}
+
+				return $preempt;
+			},
+			10,
+			3
+		);
+
+		$loop   = new AgentLoop( 'Build me a landing page', [], [], [ 'max_iterations' => 3 ] );
+		$result = $loop->run();
+
+		$this->assertIsArray( $result, 'Loop must recover, not return WP_Error after a single preamble truncation.' );
+		$this->assertSame( 'Created hero. Will append rest now.', $result['reply'] );
+		$this->assertSame( 2, $call_count, 'Loop must retry once after preamble truncation.' );
+
+		// Verify the guidance was injected into the next request body so the
+		// model actually receives the steering signal.
+		$this->assertStringContainsString( 'hit the max_tokens cap', $second_request_body );
+		$this->assertStringContainsString( 'before you opened a tool call', $second_request_body );
+		$this->assertStringContainsString( 'sd-ai-agent/append-post-content', $second_request_body );
+
+		// The preamble must not be returned as the final reply.
+		$this->assertNotEquals(
+			"Now I'll create the full landing page with professional Gutenberg block markup:",
+			$result['reply'],
+			'The truncated preamble must not leak through as the final reply.'
+		);
+
+		// And the event should be visible in the tool-call log.
+		$events = array_filter(
+			$result['tool_calls'],
+			static fn( $entry ) => 'truncated_before_tool_call' === ( $entry['reason'] ?? '' )
+		);
+		$this->assertNotEmpty( $events, 'The preamble truncation should be visible in the tool-call log.' );
+	}
+
+	/**
+	 * Test that repeated preamble-only truncations abort cleanly with a
+	 * WP_Error instead of burning every iteration on the same stall.
+	 */
+	public function test_run_aborts_on_repeated_preamble_truncation(): void {
+		$this->skip_if_sdk_unavailable();
+		if ( ! class_exists( 'WP_AI_Client_Ability_Function_Resolver' ) ) {
+			$this->markTestSkipped( 'WP_AI_Client_Ability_Function_Resolver not available.' );
+		}
+
+		$call_count    = 0;
+		$preamble_body = wp_json_encode(
+			[
+				'id'      => 'chatcmpl-stuck',
+				'object'  => 'chat.completion',
+				'choices' => [
+					[
+						'index'         => 0,
+						'message'       => [
+							'role'    => 'assistant',
+							'content' => 'Working on it now.',
+						],
+						'finish_reason' => 'length',
+					],
+				],
+				'usage'   => [ 'prompt_tokens' => 10, 'completion_tokens' => 8192, 'total_tokens' => 8202 ],
+			]
+		);
+
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( &$call_count, $preamble_body ) {
+				if ( false !== strpos( $url, 'fake-ai-proxy.test' ) ) {
+					++$call_count;
+					return [
+						'headers'  => [ 'content-type' => 'application/json' ],
+						'body'     => $preamble_body,
+						'response' => [ 'code' => 200, 'message' => 'OK' ],
+						'cookies'  => [],
+						'filename' => '',
+					];
+				}
+
+				return $preempt;
+			},
+			10,
+			3
+		);
+
+		// Allow plenty of iterations — we want to prove the abort, not max_iterations.
+		$loop   = new AgentLoop( 'Build me a landing page', [], [], [ 'max_iterations' => 10 ] );
+		$result = $loop->run();
+
+		$this->assertInstanceOf( \WP_Error::class, $result, 'Repeated preamble truncations must abort with a WP_Error.' );
+		$this->assertSame( 'preamble_truncation_loop', $result->get_error_code() );
+		$this->assertStringContainsString( 'output cap', $result->get_error_message() );
+
+		// PREAMBLE_TRUNCATION_MAX_RETRIES = 2 → after the first stall we retry
+		// twice more (3 total provider calls) and then abort. Not all 10
+		// iterations should have burned.
+		$this->assertLessThanOrEqual( 4, $call_count, 'Loop must abort early, not burn every iteration.' );
+		$this->assertGreaterThanOrEqual( 3, $call_count, 'Loop must allow at least one retry before aborting.' );
+	}
+
 	// -------------------------------------------------------------------------
 	// Max iterations
 	// -------------------------------------------------------------------------

--- a/tests/SdAiAgent/Core/ProviderTraceLoggerTruncationTest.php
+++ b/tests/SdAiAgent/Core/ProviderTraceLoggerTruncationTest.php
@@ -1,0 +1,340 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Test case for ProviderTraceLogger::classify_truncation().
+ *
+ * Covers the three classification outcomes:
+ *   - 'truncated_tool_call'        : finish=length AND a partial tool call.
+ *   - 'truncated_before_tool_call' : finish=length AND non-empty text AND no tool call.
+ *   - ''                           : everything else.
+ *
+ * Provider response shapes covered: OpenAI-compatible (`choices[].message`),
+ * Anthropic (`content[]` with type-tagged blocks), and Gemini (`candidates[]`
+ * with `content.parts[]`).
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\ProviderTraceLogger;
+use WP_UnitTestCase;
+
+/**
+ * @covers \SdAiAgent\Core\ProviderTraceLogger::classify_truncation
+ */
+class ProviderTraceLoggerTruncationTest extends WP_UnitTestCase {
+
+	// --- OpenAI-compatible shape (choices[].message) ---------------------
+
+	public function test_openai_length_with_partial_tool_call_returns_truncated_tool_call(): void {
+		$decoded = [
+			'choices' => [
+				[
+					'finish_reason' => 'length',
+					'message'       => [
+						'role'       => 'assistant',
+						'content'    => null,
+						'tool_calls' => [
+							[
+								'id'       => 'call_1',
+								'type'     => 'function',
+								'function' => [
+									'name'      => 'sd-ai-agent/create-post',
+									// Truncated mid-JSON.
+									'arguments' => '{"title":"Landing Page","content":"<!-- wp:heading -->',
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$this->assertSame(
+			'truncated_tool_call',
+			ProviderTraceLogger::classify_truncation( $decoded )
+		);
+	}
+
+	public function test_openai_length_with_preamble_only_returns_before_tool_call(): void {
+		// The actual Kimi K2.6 stall: model emitted a one-line lead-in, hit
+		// finish=length, never produced a tool call.
+		$decoded = [
+			'choices' => [
+				[
+					'finish_reason' => 'length',
+					'message'       => [
+						'role'    => 'assistant',
+						'content' => "Now I'll create the full landing page with professional Gutenberg block markup:",
+					],
+				],
+			],
+		];
+
+		$this->assertSame(
+			'truncated_before_tool_call',
+			ProviderTraceLogger::classify_truncation( $decoded )
+		);
+	}
+
+	public function test_openai_length_with_empty_content_returns_empty(): void {
+		// Empty response with length finish is almost always a provider bug,
+		// not a recoverable preamble truncation — must not trigger the
+		// retry guidance path.
+		$decoded = [
+			'choices' => [
+				[
+					'finish_reason' => 'length',
+					'message'       => [
+						'role'    => 'assistant',
+						'content' => '',
+					],
+				],
+			],
+		];
+
+		$this->assertSame( '', ProviderTraceLogger::classify_truncation( $decoded ) );
+	}
+
+	public function test_openai_length_with_whitespace_only_content_returns_empty(): void {
+		$decoded = [
+			'choices' => [
+				[
+					'finish_reason' => 'length',
+					'message'       => [
+						'role'    => 'assistant',
+						'content' => "   \n\t  ",
+					],
+				],
+			],
+		];
+
+		$this->assertSame( '', ProviderTraceLogger::classify_truncation( $decoded ) );
+	}
+
+	public function test_openai_stop_finish_with_text_returns_empty(): void {
+		// Normal completion — model wanted to stop here.
+		$decoded = [
+			'choices' => [
+				[
+					'finish_reason' => 'stop',
+					'message'       => [
+						'role'    => 'assistant',
+						'content' => 'Here is your answer.',
+					],
+				],
+			],
+		];
+
+		$this->assertSame( '', ProviderTraceLogger::classify_truncation( $decoded ) );
+	}
+
+	public function test_openai_max_tokens_alias_treated_as_length(): void {
+		$decoded = [
+			'choices' => [
+				[
+					'finish_reason' => 'max_tokens',
+					'message'       => [
+						'role'    => 'assistant',
+						'content' => 'Working on it now.',
+					],
+				],
+			],
+		];
+
+		$this->assertSame(
+			'truncated_before_tool_call',
+			ProviderTraceLogger::classify_truncation( $decoded )
+		);
+	}
+
+	// --- Anthropic shape (content[] with type-tagged blocks) -------------
+
+	public function test_anthropic_max_tokens_with_partial_tool_use_returns_truncated_tool_call(): void {
+		$decoded = [
+			'stop_reason' => 'max_tokens',
+			'content'     => [
+				[
+					'type' => 'text',
+					'text' => 'Calling the create-post tool now.',
+				],
+				[
+					'type'  => 'tool_use',
+					'id'    => 'toolu_1',
+					'name'  => 'sd-ai-agent/create-post',
+					'input' => [ 'title' => 'Page' ],
+				],
+			],
+		];
+
+		$this->assertSame(
+			'truncated_tool_call',
+			ProviderTraceLogger::classify_truncation( $decoded )
+		);
+	}
+
+	public function test_anthropic_max_tokens_text_only_returns_before_tool_call(): void {
+		$decoded = [
+			'stop_reason' => 'max_tokens',
+			'content'     => [
+				[
+					'type' => 'text',
+					'text' => "Let me create that landing page for you.",
+				],
+			],
+		];
+
+		$this->assertSame(
+			'truncated_before_tool_call',
+			ProviderTraceLogger::classify_truncation( $decoded )
+		);
+	}
+
+	public function test_anthropic_end_turn_with_text_returns_empty(): void {
+		$decoded = [
+			'stop_reason' => 'end_turn',
+			'content'     => [
+				[
+					'type' => 'text',
+					'text' => 'Done.',
+				],
+			],
+		];
+
+		$this->assertSame( '', ProviderTraceLogger::classify_truncation( $decoded ) );
+	}
+
+	// --- Gemini shape (candidates[] with content.parts[]) ----------------
+
+	public function test_gemini_max_tokens_with_partial_function_call_returns_truncated_tool_call(): void {
+		$decoded = [
+			'candidates' => [
+				[
+					'finishReason' => 'MAX_TOKENS',
+					'content'      => [
+						'parts' => [
+							[ 'text' => 'Calling the tool.' ],
+							[
+								'functionCall' => [
+									'name' => 'sd-ai-agent/create-post',
+									'args' => [ 'title' => 'Hi' ],
+								],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$this->assertSame(
+			'truncated_tool_call',
+			ProviderTraceLogger::classify_truncation( $decoded )
+		);
+	}
+
+	public function test_gemini_max_tokens_text_only_returns_before_tool_call(): void {
+		$decoded = [
+			'candidates' => [
+				[
+					'finishReason' => 'MAX_TOKENS',
+					'content'      => [
+						'parts' => [
+							[ 'text' => 'I will now build the page section by section.' ],
+						],
+					],
+				],
+			],
+		];
+
+		$this->assertSame(
+			'truncated_before_tool_call',
+			ProviderTraceLogger::classify_truncation( $decoded )
+		);
+	}
+
+	// --- Edge cases ------------------------------------------------------
+
+	public function test_non_array_input_returns_empty(): void {
+		$this->assertSame( '', ProviderTraceLogger::classify_truncation( null ) );
+		$this->assertSame( '', ProviderTraceLogger::classify_truncation( 'string' ) );
+		$this->assertSame( '', ProviderTraceLogger::classify_truncation( 42 ) );
+	}
+
+	public function test_empty_array_returns_empty(): void {
+		$this->assertSame( '', ProviderTraceLogger::classify_truncation( [] ) );
+	}
+
+	public function test_missing_finish_reason_returns_empty(): void {
+		$decoded = [
+			'choices' => [
+				[
+					'message' => [
+						'role'    => 'assistant',
+						'content' => "Now I'll write the page:",
+					],
+				],
+			],
+		];
+
+		$this->assertSame( '', ProviderTraceLogger::classify_truncation( $decoded ) );
+	}
+
+	public function test_finish_reason_case_and_hyphens_normalized(): void {
+		// "MAX-TOKENS" → "max_tokens" via the strtolower + replace pipeline.
+		$decoded = [
+			'choices' => [
+				[
+					'finish_reason' => 'MAX-TOKENS',
+					'message'       => [
+						'role'    => 'assistant',
+						'content' => 'Some preamble text.',
+					],
+				],
+			],
+		];
+
+		$this->assertSame(
+			'truncated_before_tool_call',
+			ProviderTraceLogger::classify_truncation( $decoded )
+		);
+	}
+
+	public function test_multiple_candidates_partial_tool_call_takes_precedence(): void {
+		// If any candidate has a partial tool call, that's the higher-risk
+		// classification and should win over a sibling preamble-only one.
+		$decoded = [
+			'choices' => [
+				[
+					'finish_reason' => 'length',
+					'message'       => [
+						'role'    => 'assistant',
+						'content' => 'Preamble only.',
+					],
+				],
+				[
+					'finish_reason' => 'length',
+					'message'       => [
+						'role'       => 'assistant',
+						'content'    => null,
+						'tool_calls' => [
+							[
+								'id'       => 'call_1',
+								'type'     => 'function',
+								'function' => [ 'name' => 'foo', 'arguments' => '{"x":' ],
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$this->assertSame(
+			'truncated_tool_call',
+			ProviderTraceLogger::classify_truncation( $decoded )
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Resolves the Kimi K2.6 stall where sessions go idle mid-task with a half-sentence reply ("Now I'll create the full landing page with professional Gutenberg block markup:") and no follow-through. Bundles two complementary fixes:

- **(A)** Detect "preamble-only truncation" in `AgentLoop` and `ProviderTraceLogger` so the loop recovers with guidance instead of silently exiting on `finish=length` when no tool call was started.
- **(C)** Add explicit `max_output_tokens` entries for Synthetic-hosted `hf:` models (Kimi K2.6 → 65,536) plus a broad `hf:` fallback so these don't fall through to the 8,192 global fallback.

## Root cause

Two compounding issues, both visible in `wp_sd_ai_agent_provider_trace.id=636`:

1. **Wrong output cap.** Model ID `hf:moonshotai/Kimi-K2.6` had no entry in `Settings::MODEL_MAX_OUTPUT_TOKENS`, fell through to the 8,192-token fallback. Synthetic's live `/openai/v1/models` response reports `max_output_length: 65536` for that model — we were artificially capping at one eighth of the actual provider cap.

2. **Silent stall on length-cap without tool call.** `AgentLoop::is_truncated_tool_call_result()` only flagged truncation when the response *already contained* a partial tool call. When the model exhausted its 8,192 token budget on a preamble *before* opening a tool call, no detection fired, the preamble was treated as the final assistant reply, and the session went to idle without surfacing any error.

## What changed

### Settings catalog (`includes/Core/Settings.php`)

Verified against the live `https://api.synthetic.new/openai/v1/models` response:

| Model | New cap | Source |
| --- | --- | --- |
| `hf:moonshotai/Kimi-K2.6` | 65,536 | live `max_output_length` |
| `hf:moonshotai/Kimi-K2.5` | 32,768 | conservative (lib reports 0) |
| `hf:zai-org/GLM-5.1` | 65,536 | live `max_output_length` |
| `hf:zai-org/GLM-5` | 65,536 | live `max_output_length` |
| `hf:zai-org/GLM-4.7-Flash` | 65,536 | live `max_output_length` |
| `hf:zai-org/GLM-4.7` | 65,536 | live `max_output_length` |
| `hf:MiniMaxAI/MiniMax-M2.5` | 65,536 | live `max_output_length` |
| `hf:nvidia/NVIDIA-Nemotron-3` | 65,536 | live `max_output_length` |
| `hf:` (broad fallback) | 32,768 | conservative default |

Longest-prefix match means specific entries win over the broad `hf:` fallback.

### Agent loop (`includes/Core/AgentLoop.php`)

- `is_truncated_before_tool_call_result()` — mirrors the existing detector but for `finish=length` AND zero tool calls AND non-empty assistant text.
- `inject_pre_tool_call_truncation_guidance()` — distinct wording from the existing partial-tool-call branch; points the model at `sd-ai-agent/append-post-content` for decomposing long content rather than retrying the same monolithic tool call.
- `abort_on_repeated_preamble_truncation()` — returns a structured `WP_Error` after `PREAMBLE_TRUNCATION_MAX_RETRIES` (2) consecutive preamble stalls, so an undersized model doesn't burn every iteration on the same loop.
- Extracted `finish_reason_is_length_cap()` and `message_has_assistant_text()` helpers to keep the two detectors symmetrical.

### HTTP trace logger (`includes/Core/ProviderTraceLogger.php`)

- Replaced the boolean `is_truncated_tool_call_response()` with `classify_truncation()` returning `'truncated_tool_call'`, `'truncated_before_tool_call'`, or `''`.
- The trace's `error` column now carries the precise classification so dashboards can distinguish partial-tool-call from preamble-only truncation.
- New `candidate_has_text()` covering OpenAI / Anthropic / Gemini response shapes.

### Tests

- **`ProviderTraceLoggerTruncationTest`** (16 cases) — all three provider shapes, finish_reason aliases (`length` / `max_tokens` / `max_output_tokens` / `MAX-TOKENS`), empty-content edge cases, missing finish_reason, multiple-candidate precedence.
- **`AgentLoopTest::test_run_recovers_from_preamble_only_truncation`** — reproduces the exact Kimi K2.6 wire payload, asserts recovery in one retry with the correct guidance string in the next request body.
- **`AgentLoopTest::test_run_aborts_on_repeated_preamble_truncation`** — proves the retry cap kicks in before `max_iterations` is exhausted.

## Verification

- PHP syntax check: clean on all four modified files.
- PHPCS: clean (production files; tests are excluded by project config).
- PHPStan: 13 pre-existing errors on `includes/Core/AiClientEventTraceLogger.php` from PR #1459 remain unchanged; this change adds **0** new errors.
- Live verification against `https://api.synthetic.new/openai/v1/models`: Kimi K2.6 confirmed `max_output_length: 65536`.
- Manual `wp eval` smoke test: longest-prefix lookup resolves `hf:moonshotai/Kimi-K2.6` → 65536, `hf:unknown/foo` → 32768, `totally-unknown` → 8192.

## Risk

- Existing partial-tool-call branch is untouched semantically — same detector, same guidance, just refactored to share helpers.
- The new branch only activates on `finish=length` with no tool call, which today silently terminates the loop. Behaviour for every other path is unchanged.
- The retry cap (2) is conservative; combined with the bigger `hf:` cap, most Kimi-class stalls should resolve on the first retry without ever hitting the abort.

## Follow-ups (separate PRs / issues, not in scope here)

- **Parse `max_output_length` from `/models` responses directly** so we don't have to hand-curate the catalog for every new HuggingFace-served model. Would ideally land as a `php-ai-client` ModelMetadata extension. Filed as separate work.
- Per-model UI override in Settings so users can tune individual models without touching the global cap.

Resolves the original stall reproduced at `wp_sd_ai_agent_sessions.id=39` / `wp_sd_ai_agent_provider_trace.id=636`.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with claude-sonnet-4-6 spent 1d 4h and 383 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved recovery when AI models reach output limits during response generation through automatic retry with optimized guidance.

* **Bug Fixes**
  * Enhanced detection of incomplete responses when models hit token capacity.
  * Added safeguards to prevent excessive retry loops on persistent truncation issues.

* **Chores**
  * Extended model-specific token limit configuration for additional providers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1463?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->