### PR TITLE
feat(agent-loop): stream model preamble text live alongside tool calls (sd-ai-x0o)

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -1564,10 +1564,37 @@ class AgentLoop {
 	// ── Tool call logging ─────────────────────────────────────────────────
 
 	/**
-	 * Log tool calls from an assistant message for transparency.
+	 * Log tool calls (and any preceding/interleaved assistant text) from an
+	 * assistant message for transparency.
+	 *
+	 * Some models — Claude in particular, but also many OpenAI- and
+	 * Anthropic-derived chat-completion responses — emit a short "preamble"
+	 * text part in the same message as their tool calls (for example
+	 * "Looking up your recent posts first…" immediately followed by a
+	 * function call for list-posts). Without surfacing this text in the live
+	 * progress stream the chat UI shows the tool card with no human-readable
+	 * context for why the model is making that call. Logging text parts here
+	 * — interleaved with call parts in original order — lets the polling
+	 * frontend render the assistant's running commentary above each tool
+	 * card while the loop is still executing.
+	 *
+	 * The text part also remains in `$this->history` via the assistant
+	 * message that is appended in the main run loop, so the final persisted
+	 * assistant message still owns the canonical text content. The frontend
+	 * filters preamble entries out of finalised messages via the function-
+	 * call id pairing in {@see associateToolCallsWithMessages}, so there is
+	 * no double-rendering on reload.
 	 */
 	private function log_tool_calls( Message $message ): void {
 		foreach ( $message->getParts() as $part ) {
+			$text = $part->getText();
+			if ( is_string( $text ) && '' !== trim( $text ) ) {
+				$this->tool_call_log[] = array(
+					'type' => 'preamble',
+					'text' => $text,
+				);
+			}
+
 			$call = $part->getFunctionCall();
 			if ( $call ) {
 				$this->tool_call_log[] = array(

--- a/src/components/chat-redesign/__tests__/message-helpers.test.js
+++ b/src/components/chat-redesign/__tests__/message-helpers.test.js
@@ -1,0 +1,191 @@
+/**
+ * Unit tests for chat-redesign/message-helpers.js
+ *
+ * Tests cover:
+ * - pairToolCalls() pairs calls with responses by id and ignores preamble entries.
+ * - pairToolCalls() falls back to one item per entry when no call types exist,
+ *   while still skipping preamble entries.
+ * - buildRunningItems() preserves original emission order across preamble and
+ *   call entries, suppresses whitespace-only preambles, and assigns stable keys.
+ * - getRunningToolName() ignores preamble entries when deciding what is in
+ *   flight.
+ * - extractText() concatenates only text parts.
+ */
+
+import {
+	buildRunningItems,
+	extractText,
+	getRunningToolName,
+	pairToolCalls,
+	parseSuggestions,
+} from '../message-helpers';
+
+describe( 'extractText', () => {
+	test( 'concatenates text parts in order', () => {
+		const msg = {
+			parts: [ { text: 'Hello ' }, { text: 'world' } ],
+		};
+		expect( extractText( msg ) ).toBe( 'Hello world' );
+	} );
+
+	test( 'ignores function-call parts', () => {
+		const msg = {
+			parts: [
+				{ text: 'Hi' },
+				{ functionCall: { id: 'a', name: 'x', args: {} } },
+				{ text: ' there' },
+			],
+		};
+		expect( extractText( msg ) ).toBe( 'Hi there' );
+	} );
+
+	test( 'returns empty string for missing/empty parts', () => {
+		expect( extractText( {} ) ).toBe( '' );
+		expect( extractText( { parts: [] } ) ).toBe( '' );
+	} );
+} );
+
+describe( 'pairToolCalls', () => {
+	test( 'returns empty array for empty or missing input', () => {
+		expect( pairToolCalls( null ) ).toEqual( [] );
+		expect( pairToolCalls( [] ) ).toEqual( [] );
+	} );
+
+	test( 'pairs calls to responses by id', () => {
+		const log = [
+			{ type: 'call', id: 'a', name: 'tool_a', args: {} },
+			{ type: 'response', id: 'a', response: { ok: true } },
+		];
+		const pairs = pairToolCalls( log );
+		expect( pairs ).toHaveLength( 1 );
+		expect( pairs[ 0 ].call.id ).toBe( 'a' );
+		expect( pairs[ 0 ].response.response ).toEqual( { ok: true } );
+	} );
+
+	test( 'ignores preamble entries entirely', () => {
+		const log = [
+			{ type: 'preamble', text: 'Looking that up...' },
+			{ type: 'call', id: 'a', name: 'tool_a', args: {} },
+		];
+		const pairs = pairToolCalls( log );
+		expect( pairs ).toHaveLength( 1 );
+		expect( pairs[ 0 ].call.id ).toBe( 'a' );
+	} );
+
+	test( 'fallback path still skips preamble entries', () => {
+		// No type='call' entries → fallback shows non-preamble entries as
+		// orphan cards. Preamble entries must not appear.
+		const log = [
+			{ type: 'preamble', text: 'Thinking…' },
+			{ type: 'misc', id: 'x', name: 'unknown' },
+		];
+		const pairs = pairToolCalls( log );
+		expect( pairs ).toHaveLength( 1 );
+		expect( pairs[ 0 ].call.type ).toBe( 'misc' );
+	} );
+} );
+
+describe( 'buildRunningItems', () => {
+	test( 'returns empty array for empty or missing input', () => {
+		expect( buildRunningItems( null ) ).toEqual( [] );
+		expect( buildRunningItems( [] ) ).toEqual( [] );
+	} );
+
+	test( 'preserves emission order across preamble and call entries', () => {
+		const log = [
+			{ type: 'preamble', text: 'First, let me look that up.' },
+			{ type: 'call', id: 'a', name: 'tool_a', args: {} },
+			{ type: 'response', id: 'a', response: { ok: true } },
+			{ type: 'preamble', text: 'Now updating the page.' },
+			{ type: 'call', id: 'b', name: 'tool_b', args: {} },
+		];
+		const items = buildRunningItems( log );
+		expect( items.map( ( i ) => i.kind ) ).toEqual( [
+			'preamble',
+			'pair',
+			'preamble',
+			'pair',
+		] );
+		expect( items[ 0 ].text ).toBe( 'First, let me look that up.' );
+		expect( items[ 1 ].call.id ).toBe( 'a' );
+		expect( items[ 1 ].response.response ).toEqual( { ok: true } );
+		expect( items[ 2 ].text ).toBe( 'Now updating the page.' );
+		expect( items[ 3 ].call.id ).toBe( 'b' );
+		expect( items[ 3 ].response ).toBeNull();
+	} );
+
+	test( 'suppresses whitespace-only preambles', () => {
+		const log = [
+			{ type: 'preamble', text: '  \n  ' },
+			{ type: 'preamble', text: '' },
+			{ type: 'call', id: 'a', name: 'tool_a', args: {} },
+		];
+		const items = buildRunningItems( log );
+		expect( items ).toHaveLength( 1 );
+		expect( items[ 0 ].kind ).toBe( 'pair' );
+	} );
+
+	test( 'assigns stable keys derived from call ids', () => {
+		const log = [
+			{ type: 'preamble', text: 'A' },
+			{ type: 'call', id: 'call-xyz', name: 'tool_a', args: {} },
+		];
+		const items = buildRunningItems( log );
+		expect( items[ 0 ].key ).toBe( 'preamble-0' );
+		expect( items[ 1 ].key ).toBe( 'call-xyz' );
+	} );
+
+	test( 'still works when responses arrive out of order', () => {
+		const log = [
+			{ type: 'call', id: 'a', name: 'tool_a', args: {} },
+			{ type: 'call', id: 'b', name: 'tool_b', args: {} },
+			{ type: 'response', id: 'b', response: { ok: 'b' } },
+			{ type: 'response', id: 'a', response: { ok: 'a' } },
+		];
+		const items = buildRunningItems( log );
+		expect( items ).toHaveLength( 2 );
+		expect( items[ 0 ].response.response ).toEqual( { ok: 'a' } );
+		expect( items[ 1 ].response.response ).toEqual( { ok: 'b' } );
+	} );
+} );
+
+describe( 'getRunningToolName', () => {
+	test( 'returns null when no calls are present', () => {
+		expect( getRunningToolName( [] ) ).toBeNull();
+		expect(
+			getRunningToolName( [ { type: 'preamble', text: 'thinking…' } ] )
+		).toBeNull();
+	} );
+
+	test( 'returns the running tool name when calls outnumber responses', () => {
+		const log = [
+			{ type: 'preamble', text: 'one sec' },
+			{ type: 'call', id: 'a', name: 'wpab__sd-ai-agent__memory-list' },
+		];
+		expect( getRunningToolName( log ) ).toBe( 'sd-ai-agent/memory-list' );
+	} );
+
+	test( 'returns null when every call has a response', () => {
+		const log = [
+			{ type: 'call', id: 'a', name: 'wpab__sd-ai-agent__memory-list' },
+			{ type: 'response', id: 'a', response: { ok: true } },
+		];
+		expect( getRunningToolName( log ) ).toBeNull();
+	} );
+} );
+
+describe( 'parseSuggestions', () => {
+	test( 'strips trailing [suggestion] lines and returns them separately', () => {
+		const { cleanText, suggestions } = parseSuggestions(
+			'Hello world.\n\n[suggestion] Try this\n[suggestion] Or that'
+		);
+		expect( cleanText ).toBe( 'Hello world.' );
+		expect( suggestions ).toEqual( [ 'Try this', 'Or that' ] );
+	} );
+
+	test( 'leaves text alone when no suggestions present', () => {
+		const { cleanText, suggestions } = parseSuggestions( 'Just text.' );
+		expect( cleanText ).toBe( 'Just text.' );
+		expect( suggestions ).toEqual( [] );
+	} );
+} );

--- a/src/components/chat-redesign/chat-redesign.css
+++ b/src/components/chat-redesign/chat-redesign.css
@@ -1110,6 +1110,28 @@ input[type="text"].sdaa-cr-search-input {
 	animation: sdaa-cr-pulse 1.2s ease-in-out infinite;
 }
 
+/*
+ * Preamble block — assistant narration the model emits in the same turn as
+ * a tool call (e.g. "Looking that up first…" immediately before a function
+ * call). Rendered above the tool card during live execution so the user
+ * sees the running commentary in context. Slightly muted vs. final reply
+ * text so it visually reads as in-flight progress rather than the answer.
+ */
+.sdaa-cr-running-preamble {
+	color: var(--sdaa-text-secondary);
+	font-size: 14px;
+	margin: 4px 0;
+	line-height: 1.5;
+}
+
+.sdaa-cr-running-preamble p {
+	margin: 0 0 6px;
+}
+
+.sdaa-cr-running-preamble p:last-child {
+	margin-bottom: 0;
+}
+
 /* Input area */
 .sdaa-cr-input-area {
 	border-top: 1px solid var(--sdaa-border-subtle);

--- a/src/components/chat-redesign/message-helpers.js
+++ b/src/components/chat-redesign/message-helpers.js
@@ -42,11 +42,73 @@ export function pairToolCalls( toolCalls ) {
 		}
 	}
 	if ( pairs.length === 0 ) {
+		// Defensive fallback: a log with no explicit type='call' entries
+		// (e.g. a free-form preamble-only stream) still renders one card per
+		// entry so the user sees something rather than an empty container.
+		// Preamble entries deliberately skip this path — they are surfaced by
+		// buildRunningItems() above text-friendly rendering.
 		for ( const t of toolCalls ) {
+			if ( t.type === 'preamble' ) {
+				continue;
+			}
 			pairs.push( { call: t, response: null } );
 		}
 	}
 	return pairs;
+}
+
+/**
+ * Build the ordered list of items to render inside a model message body,
+ * preserving the original emission order of preamble text blocks and tool
+ * call pairs.
+ *
+ * Returns a heterogeneous list of items shaped as either:
+ *   { kind: 'preamble', text: string, key: string }
+ *   { kind: 'pair', call: ToolCall, response: ToolResponse|null, key: string }
+ *
+ * The polling frontend uses this for the live RunningMessage so the user
+ * can see narration like "Looking that up first…" immediately above the
+ * tool card it precedes. Finalised assistant messages also use it so live
+ * and persisted views share the same layout pipeline.
+ *
+ * @param {Array} toolCalls Flat tool-call log entries.
+ * @return {Array} Ordered render items.
+ */
+export function buildRunningItems( toolCalls ) {
+	if ( ! toolCalls?.length ) {
+		return [];
+	}
+	const responses = {};
+	for ( const t of toolCalls ) {
+		if ( ( t.type === 'response' || t.type === 'result' ) && t.id ) {
+			responses[ t.id ] = t;
+		}
+	}
+	const items = [];
+	let preambleSeq = 0;
+	let pairSeq = 0;
+	for ( const t of toolCalls ) {
+		if ( t.type === 'preamble' && typeof t.text === 'string' ) {
+			const trimmed = t.text.trim();
+			if ( trimmed !== '' ) {
+				items.push( {
+					kind: 'preamble',
+					text: t.text,
+					key: `preamble-${ preambleSeq++ }`,
+				} );
+			}
+			continue;
+		}
+		if ( t.type === 'call' ) {
+			items.push( {
+				kind: 'pair',
+				call: t,
+				response: t.id ? responses[ t.id ] || null : null,
+				key: t.id || `pair-${ pairSeq++ }`,
+			} );
+		}
+	}
+	return items;
 }
 
 /**

--- a/src/components/chat-redesign/message-items.js
+++ b/src/components/chat-redesign/message-items.js
@@ -29,8 +29,8 @@ import MarkdownMessage from '../markdown-message';
 import { AiIcon } from './icons';
 import ToolCard from './ToolCard';
 import {
+	buildRunningItems,
 	extractText,
-	pairToolCalls,
 	parseSuggestions,
 } from './message-helpers';
 import { linkifyText } from '../../utils/linkify';
@@ -342,7 +342,15 @@ export function AssistantMessage( {
 
 	const rawText = extractText( msg );
 	const { cleanText, suggestions } = parseSuggestions( rawText );
-	const pairs = pairToolCalls( msg.toolCalls );
+	// Finalised assistant messages render only tool pairs here. Any preamble
+	// text the model emitted alongside its tool calls is already included in
+	// `cleanText` via the persisted assistant message parts, so we deliberately
+	// drop preamble entries from the persisted message body to avoid showing
+	// the same text twice. The live RunningMessage component below DOES show
+	// preamble entries because the assistant message is not yet in history.
+	const items = ( buildRunningItems( msg.toolCalls ) || [] ).filter(
+		( it ) => it.kind === 'pair'
+	);
 
 	const handleCopy = () => {
 		if ( ! cleanText ) {
@@ -360,11 +368,11 @@ export function AssistantMessage( {
 				<AiIcon />
 			</div>
 			<div className="sdaa-cr-msg-body">
-				{ pairs.map( ( pair, i ) => (
+				{ items.map( ( item ) => (
 					<ToolCard
-						key={ pair.call.id || i }
-						call={ pair.call }
-						response={ pair.response }
+						key={ item.key }
+						call={ item.call }
+						response={ item.response }
 					/>
 				) ) }
 				{ cleanText && <MarkdownMessage content={ cleanText } /> }
@@ -434,21 +442,37 @@ export function AssistantMessage( {
  * @param {*}      root0.liveToolCalls
  */
 export function RunningMessage( { step, liveToolCalls } ) {
-	const pairs = pairToolCalls( liveToolCalls );
+	// Render preamble narration and tool-call cards in original emission
+	// order so the user sees context like "Looking that up first…" directly
+	// above the tool card it precedes. buildRunningItems returns a flat list
+	// of { kind: 'preamble' | 'pair', ... } items.
+	const items = buildRunningItems( liveToolCalls );
 	return (
 		<div className="sdaa-cr-msg-row sdaa-cr-msg-assistant">
 			<div className="sdaa-cr-avatar" aria-hidden="true">
 				<AiIcon thinking={ true } />
 			</div>
 			<div className="sdaa-cr-msg-body">
-				{ pairs.map( ( pair, i ) => (
-					<ToolCard
-						key={ pair.call.id || i }
-						call={ pair.call }
-						response={ pair.response }
-						defaultOpen={ ! pair.response }
-					/>
-				) ) }
+				{ items.map( ( item ) => {
+					if ( item.kind === 'preamble' ) {
+						return (
+							<div
+								key={ item.key }
+								className="sdaa-cr-running-preamble"
+							>
+								<MarkdownMessage content={ item.text } />
+							</div>
+						);
+					}
+					return (
+						<ToolCard
+							key={ item.key }
+							call={ item.call }
+							response={ item.response }
+							defaultOpen={ ! item.response }
+						/>
+					);
+				} ) }
 				<div className="sdaa-cr-running-line">
 					<span className="sdaa-cr-running-dot" aria-hidden="true" />
 					<span>{ step }</span>

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -2193,4 +2193,215 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'awaiting_confirmation', $result );
 		$this->assertArrayHasKey( 'reply', $result );
 	}
+
+	/**
+	 * Regression test: preamble text emitted alongside a tool call must appear
+	 * in the live tool_call_log so the polling frontend can render it above
+	 * the tool card while the loop is still running.
+	 *
+	 * The mock turn returns an assistant message that contains both a text
+	 * preamble ("Let me look that up first.") and a function call in the same
+	 * choice — the chat-completion shape used by every model we support that
+	 * narrates before invoking tools. The first call returns the
+	 * preamble+tool-call payload; the second call returns the final text reply
+	 * so the loop terminates cleanly.
+	 */
+	public function test_run_logs_preamble_text_before_tool_call(): void {
+		$this->skip_if_sdk_unavailable();
+		if ( ! class_exists( 'WP_AI_Client_Ability_Function_Resolver' ) ) {
+			$this->markTestSkipped( 'WP_AI_Client_Ability_Function_Resolver not available.' );
+		}
+
+		$call_count           = 0;
+		$progress_snapshots   = [];
+		$preamble_text        = 'Let me look that up first.';
+		$preamble_and_call    = wp_json_encode(
+			[
+				'id'      => 'chatcmpl-preamble',
+				'object'  => 'chat.completion',
+				'choices' => [
+					[
+						'index'         => 0,
+						'message'       => [
+							'role'       => 'assistant',
+							'content'    => $preamble_text,
+							'tool_calls' => [
+								[
+									'id'       => 'call_preamble_1',
+									'type'     => 'function',
+									'function' => [
+										'name'      => 'wpab__sd-ai-agent__memory-list',
+										'arguments' => '{}',
+									],
+								],
+							],
+						],
+						'finish_reason' => 'tool_calls',
+					],
+				],
+				'usage'   => [ 'prompt_tokens' => 10, 'completion_tokens' => 5, 'total_tokens' => 15 ],
+			]
+		);
+		$final_reply_body     = wp_json_encode(
+			[
+				'id'      => 'chatcmpl-final',
+				'object'  => 'chat.completion',
+				'choices' => [
+					[
+						'index'         => 0,
+						'message'       => [ 'role' => 'assistant', 'content' => 'Done.' ],
+						'finish_reason' => 'stop',
+					],
+				],
+				'usage'   => [ 'prompt_tokens' => 20, 'completion_tokens' => 5, 'total_tokens' => 25 ],
+			]
+		);
+
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( &$call_count, $preamble_and_call, $final_reply_body ) {
+				if ( false !== strpos( $url, 'fake-ai-proxy.test' ) ) {
+					++$call_count;
+					$body = ( 1 === $call_count ) ? $preamble_and_call : $final_reply_body;
+					return [
+						'headers'  => [ 'content-type' => 'application/json' ],
+						'body'     => $body,
+						'response' => [ 'code' => 200, 'message' => 'OK' ],
+						'cookies'  => [],
+						'filename' => '',
+					];
+				}
+				return $preempt;
+			},
+			10,
+			3
+		);
+
+		$options                      = [];
+		$options['progress_callback'] = static function ( array $log ) use ( &$progress_snapshots ): void {
+			$progress_snapshots[] = $log;
+		};
+
+		$loop   = new AgentLoop( 'Find my notes', [], [], $options );
+		$result = $loop->run();
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'tool_calls', $result );
+
+		// The preamble entry must precede the call entry in original order.
+		$preamble_index = null;
+		$call_index     = null;
+		foreach ( $result['tool_calls'] as $i => $entry ) {
+			if ( null === $preamble_index && 'preamble' === ( $entry['type'] ?? '' ) ) {
+				$preamble_index = $i;
+			}
+			if ( null === $call_index && 'call' === ( $entry['type'] ?? '' ) ) {
+				$call_index = $i;
+			}
+		}
+
+		$this->assertNotNull( $preamble_index, 'A preamble entry must be present in tool_call_log when the model emits text alongside a tool call.' );
+		$this->assertNotNull( $call_index, 'The tool call entry must still be present.' );
+		$this->assertLessThan( $call_index, $preamble_index, 'Preamble must be logged before the tool call to match emission order.' );
+		$this->assertSame( $preamble_text, $result['tool_calls'][ $preamble_index ]['text'] );
+
+		// The progress callback must have observed the preamble in at least
+		// one snapshot so the polling frontend can render it incrementally.
+		$saw_preamble_in_progress = false;
+		foreach ( $progress_snapshots as $snapshot ) {
+			foreach ( $snapshot as $entry ) {
+				if ( 'preamble' === ( $entry['type'] ?? '' ) && ( $entry['text'] ?? '' ) === $preamble_text ) {
+					$saw_preamble_in_progress = true;
+					break 2;
+				}
+			}
+		}
+		$this->assertTrue( $saw_preamble_in_progress, 'progress_callback must surface preamble entries so live UI can show running commentary.' );
+	}
+
+	/**
+	 * Whitespace-only assistant text emitted alongside a tool call must NOT be
+	 * logged as a preamble. Some providers normalise null content to an empty
+	 * string or a stray newline; surfacing that as a "preamble" would render
+	 * blank speech bubbles in the running message.
+	 */
+	public function test_run_skips_whitespace_only_preamble(): void {
+		$this->skip_if_sdk_unavailable();
+		if ( ! class_exists( 'WP_AI_Client_Ability_Function_Resolver' ) ) {
+			$this->markTestSkipped( 'WP_AI_Client_Ability_Function_Resolver not available.' );
+		}
+
+		$call_count = 0;
+		$body_tool  = wp_json_encode(
+			[
+				'id'      => 'chatcmpl-blank',
+				'object'  => 'chat.completion',
+				'choices' => [
+					[
+						'index'         => 0,
+						'message'       => [
+							'role'       => 'assistant',
+							'content'    => "  \n  ",
+							'tool_calls' => [
+								[
+									'id'       => 'call_blank_1',
+									'type'     => 'function',
+									'function' => [
+										'name'      => 'wpab__sd-ai-agent__memory-list',
+										'arguments' => '{}',
+									],
+								],
+							],
+						],
+						'finish_reason' => 'tool_calls',
+					],
+				],
+				'usage'   => [ 'prompt_tokens' => 10, 'completion_tokens' => 0, 'total_tokens' => 10 ],
+			]
+		);
+		$body_reply = wp_json_encode(
+			[
+				'id'      => 'chatcmpl-final-blank',
+				'object'  => 'chat.completion',
+				'choices' => [
+					[
+						'index'         => 0,
+						'message'       => [ 'role' => 'assistant', 'content' => 'Here.' ],
+						'finish_reason' => 'stop',
+					],
+				],
+				'usage'   => [ 'prompt_tokens' => 12, 'completion_tokens' => 1, 'total_tokens' => 13 ],
+			]
+		);
+
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( &$call_count, $body_tool, $body_reply ) {
+				if ( false !== strpos( $url, 'fake-ai-proxy.test' ) ) {
+					++$call_count;
+					$body = ( 1 === $call_count ) ? $body_tool : $body_reply;
+					return [
+						'headers'  => [ 'content-type' => 'application/json' ],
+						'body'     => $body,
+						'response' => [ 'code' => 200, 'message' => 'OK' ],
+						'cookies'  => [],
+						'filename' => '',
+					];
+				}
+				return $preempt;
+			},
+			10,
+			3
+		);
+
+		$loop   = new AgentLoop( 'Find my notes' );
+		$result = $loop->run();
+
+		$this->assertIsArray( $result );
+		$preamble_entries = array_filter(
+			$result['tool_calls'],
+			static fn( $entry ) => 'preamble' === ( $entry['type'] ?? '' )
+		);
+		$this->assertEmpty( $preamble_entries, 'Whitespace-only assistant text must not be logged as a preamble entry.' );
+	}
 }


### PR DESCRIPTION
## Summary
- AgentLoop::log_tool_calls now emits `{type: 'preamble', text: ...}` entries alongside `{type: 'call', ...}` entries in their original emission order, so the polling frontend can render assistant narration (e.g. "Looking up your recent posts first…") above the tool card it precedes — instead of just the bare tool card with no human-readable context.
- New JS helper `buildRunningItems()` returns a flat ordered list of preamble blocks and tool-call pairs; `RunningMessage` renders both, and `AssistantMessage` filters preambles back out so persisted reloads aren't duplicated.
- New CSS `.sdaa-cr-running-preamble` styles narration as muted in-flight text.

## Why
Many providers (Claude in particular, plus most OpenAI- and Anthropic-derived chat completions) emit a short text "preamble" in the same message as their tool calls. The plugin already captured this text in `history` for the final persisted message but dropped it from the live `progress_callback` stream, so users saw a tool card running with no idea why the agent invoked it. Surfacing the preamble in order makes the running loop legible.

## Files changed
- `includes/Core/AgentLoop.php` — `log_tool_calls()` interleaves preamble entries with call entries.
- `src/components/chat-redesign/message-helpers.js` — new `buildRunningItems()` helper.
- `src/components/chat-redesign/message-items.js` — `RunningMessage` and `AssistantMessage` consume the helper.
- `src/components/chat-redesign/chat-redesign.css` — muted preamble styling.
- `tests/SdAiAgent/Core/AgentLoopTest.php` — two new PHPUnit tests: ordering + whitespace guard.
- `src/components/chat-redesign/__tests__/message-helpers.test.js` — 17 new Jest cases covering ordering, whitespace, key stability, out-of-order responses, and preamble-tolerance of `getRunningToolName`.

## Verification
- `npm run test:js -- --testPathPattern=chat-redesign` → 17 / 17 passing.
- `npm run lint:js` clean across `src/`.
- `npm run lint:css` clean.
- `composer phpcs` clean (`includes/Core/AgentLoop.php`).
- `composer phpstan` errors are pre-existing in `includes/Core/AiClientEventTraceLogger.php` — unrelated to this PR (identical count on `main`).
- `npm run build` produces the wporg archive without warnings.
- `php vendor/bin/phpunit tests/SdAiAgent/Core/AgentLoopTest.php` → 56 tests, 21 passing, 35 skipped (no SDK provider in `wp-env`). Zero failures, zero errors. The new tests follow the same `skip_if_sdk_unavailable()` pattern as the existing `test_run_logs_tool_calls` test.

## Backwards compatibility
- Existing `tool_call_log` consumers that filter by `type === 'call'` are unaffected — the new `preamble` entries do not satisfy that check.
- `pairToolCalls()` kept its old shape; callers expecting `{call, response}` pairs continue to work and explicitly skip preamble entries on the fallback path.
- Persisted assistant messages render unchanged because `associateToolCallsWithMessages()` matches by function-call id (which preambles do not have).

Resolves sd-ai-x0o

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with claude-sonnet-4-6 spent 1d 5h and 383 tokens on this as a headless worker.
