### PR TITLE
cleanup(trace): unbreak main after #1466 — LIFO correlation + phpcbf + SettingsTest + stubs

### DIFF
--- a/includes/Core/AiClientEventTraceLogger.php
+++ b/includes/Core/AiClientEventTraceLogger.php
@@ -6,8 +6,13 @@
  * to capture structured trace data including capability, provider, model, finish reason,
  * token usage, and result metadata.
  *
- * Correlates Before/After event pairs using spl_object_id() to compute duration and
- * handle nested/concurrent SDK calls safely.
+ * Correlates Before/After event pairs with a LIFO stack. The SDK constructs
+ * distinct event objects for Before vs After (lib/php-ai-client PromptBuilder.php
+ * dispatches `new BeforeGenerateResultEvent(...)` and `new AfterGenerateResultEvent(...)`
+ * on the same call), so spl_object_id() can never match. PHP is single-threaded
+ * and SDK calls nest Before→{request}→After in last-in-first-out order, so the
+ * After handler always pairs with the most recently pushed Before — even across
+ * nested provider calls.
  *
  * @package SdAiAgent
  * @license GPL-2.0-or-later
@@ -31,22 +36,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 class AiClientEventTraceLogger {
 
 	/**
-	 * In-flight event data keyed by spl_object_id for correlation.
+	 * In-flight Before-event data as a LIFO stack.
 	 *
 	 * Stores Before event metadata so the matching After event can compute
-	 * duration and write a complete trace row. Uses spl_object_id() as the
-	 * key to safely handle nested/concurrent SDK calls.
+	 * duration and write a complete trace row. Implemented as a LIFO stack
+	 * (`array_push` on Before, `array_pop` on After) because the SDK
+	 * dispatches distinct event objects for Before/After (so spl_object_id
+	 * cannot correlate them) and PHP is single-threaded (so nested calls
+	 * naturally pair LIFO).
 	 *
-	 * @var array<string, array<string, mixed>>
+	 * @var array<int, array<string, mixed>>
 	 */
 	private static array $inflight = [];
-
-	/**
-	 * Hook tag for the watchdog cleanup action.
-	 *
-	 * @var string
-	 */
-	private static string $watchdog_hook = 'sd_ai_agent_sdk_event_trace_watchdog';
 
 	/**
 	 * Hook: wp_ai_client_before_generate_result — capture request metadata.
@@ -62,8 +63,6 @@ class AiClientEventTraceLogger {
 			return;
 		}
 
-		$event_id = self::get_event_id( $event );
-
 		// Extract model and provider metadata.
 		$model       = $event->getModel();
 		$model_id    = $model->metadata()->getId();
@@ -73,8 +72,8 @@ class AiClientEventTraceLogger {
 		$capability       = $event->getCapability();
 		$capability_value = null !== $capability ? $capability->value : null;
 
-		// Store in-flight data for correlation with the After event.
-		self::$inflight[ $event_id ] = [
+		// Push onto the LIFO stack; the matching After will pop it.
+		self::$inflight[] = [
 			'model_id'    => $model_id,
 			'provider_id' => $provider_id,
 			'capability'  => $capability_value,
@@ -86,9 +85,11 @@ class AiClientEventTraceLogger {
 	/**
 	 * Hook: wp_ai_client_after_generate_result — capture response and write trace row.
 	 *
-	 * Correlates with the Before event via spl_object_id, computes duration,
+	 * Pops the most recent Before entry off the LIFO stack, computes duration,
 	 * extracts finish reason and token usage from the result, and writes a
-	 * structured trace row.
+	 * structured trace row. Pairing via LIFO is correct because PHP is
+	 * single-threaded and the SDK always dispatches Before→{request}→After
+	 * synchronously on the same call, even when calls nest.
 	 *
 	 * @param AfterGenerateResultEvent $event The after-generate event.
 	 * @return void
@@ -98,16 +99,13 @@ class AiClientEventTraceLogger {
 			return;
 		}
 
-		$event_id = self::get_event_id( $event );
-
-		// Look up the in-flight Before event data.
-		if ( ! isset( self::$inflight[ $event_id ] ) ) {
-			// Before event was not recorded (e.g., tracing was disabled at that time).
+		// Pop the matching Before from the LIFO stack.
+		$inflight = array_pop( self::$inflight );
+		if ( null === $inflight ) {
+			// No Before recorded (tracing toggled on between Before and After,
+			// or an unbalanced After fired).
 			return;
 		}
-
-		$inflight = self::$inflight[ $event_id ];
-		unset( self::$inflight[ $event_id ] );
 
 		$start_time  = (float) ( $inflight['start_time'] ?? microtime( true ) );
 		$duration_ms = (int) round( ( microtime( true ) - $start_time ) * 1000 );
@@ -129,9 +127,13 @@ class AiClientEventTraceLogger {
 		$cache_creation_tokens = 0;
 		$cache_read_tokens     = 0;
 
-		// Serialize messages and result for storage.
-		$messages_json = self::serialize_messages( $inflight['messages'] );
-		$result_json   = self::serialize_result( $result );
+		// Serialize messages and result for storage. Narrow the mixed
+		// $inflight['messages'] slot to array before passing —
+		// serialize_messages instanceof-filters non-Message entries
+		// defensively. serialize_result is similarly type-guarded.
+		$messages      = is_array( $inflight['messages'] ?? null ) ? $inflight['messages'] : [];
+		$messages_json = self::serialize_messages( $messages );
+		$result_json   = is_object( $result ) ? self::serialize_result( $result ) : '{}';
 
 		// Write the structured trace row.
 		ProviderTrace::insert(
@@ -160,13 +162,13 @@ class AiClientEventTraceLogger {
 	 * the SDK request was initiated but never completed (SDK exception, timeout,
 	 * malformed response, etc.).
 	 *
-	 * @param string               $event_id The event correlation ID.
 	 * @param array<string, mixed> $inflight The in-flight Before event data.
 	 * @return void
 	 */
-	private static function write_stalled_trace( string $event_id, array $inflight ): void {
-		// Serialize messages for storage.
-		$messages_json = self::serialize_messages( $inflight['messages'] ?? [] );
+	private static function write_stalled_trace( array $inflight ): void {
+		// Serialize messages for storage. Narrow the mixed slot to array.
+		$messages      = is_array( $inflight['messages'] ?? null ) ? $inflight['messages'] : [];
+		$messages_json = self::serialize_messages( $messages );
 
 		// Write a synthetic trace row with error='no_result_event'.
 		ProviderTrace::insert(
@@ -203,26 +205,25 @@ class AiClientEventTraceLogger {
 			return;
 		}
 
-		foreach ( self::$inflight as $event_id => $inflight ) {
-			self::write_stalled_trace( $event_id, $inflight );
+		foreach ( self::$inflight as $inflight ) {
+			self::write_stalled_trace( $inflight );
 		}
 
-		// Clear the in-flight map.
+		// Clear the stack.
 		self::$inflight = [];
 	}
 
 	/**
-	 * Get a stable correlation ID for an event object.
+	 * Reset the in-flight stack. Intended for tests only.
 	 *
-	 * Uses spl_object_id() to generate a unique ID for the event object,
-	 * allowing Before/After pairs to be correlated even when nested or
-	 * concurrent SDK calls occur.
+	 * Allows tests that exercise the LIFO stack across multiple cases to
+	 * start each case with a clean stack without relying on shutdown hooks.
 	 *
-	 * @param BeforeGenerateResultEvent|AfterGenerateResultEvent $event The event object.
-	 * @return string Stable correlation ID.
+	 * @internal
+	 * @return void
 	 */
-	private static function get_event_id( object $event ): string {
-		return 'sdk_event_' . spl_object_id( $event );
+	public static function reset_inflight_for_tests(): void {
+		self::$inflight = [];
 	}
 
 	/**
@@ -236,7 +237,7 @@ class AiClientEventTraceLogger {
 	 * Non-Message entries are skipped defensively so the watchdog cannot
 	 * crash on a malformed in-flight payload.
 	 *
-	 * @param array<int, mixed> $messages The messages array (expected: list<Message>).
+	 * @param array<array-key, mixed> $messages The messages array (expected: list<Message>; callers may pass an associative array if a Before payload was malformed).
 	 * @return string JSON-encoded messages.
 	 */
 	private static function serialize_messages( array $messages ): string {

--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -146,44 +146,44 @@ class Settings {
 		// and Opus 4 document 32K. Newer point releases have higher caps
 		// than older ones in the same family, which is why these are not
 		// collapsed into a single `claude-opus-4` entry.
-		'claude-opus-4-7'                => 128000,
-		'claude-opus-4-6'                => 128000,
-		'claude-opus-4-5'                => 64000,
-		'claude-opus-4-1'                => 32000,
-		'claude-opus-4'                  => 32000,
+		'claude-opus-4-7'             => 128000,
+		'claude-opus-4-6'             => 128000,
+		'claude-opus-4-5'             => 64000,
+		'claude-opus-4-1'             => 32000,
+		'claude-opus-4'               => 32000,
 		// Sonnet 4 / 4.5 / 4.6 all document 64K output.
-		'claude-sonnet-4'                => 64000,
+		'claude-sonnet-4'             => 64000,
 		// Haiku 4.5 documents 64K output (matches Sonnet 4.x).
-		'claude-haiku-4-5'               => 64000,
-		'claude-haiku-4'                 => 64000,
+		'claude-haiku-4-5'            => 64000,
+		'claude-haiku-4'              => 64000,
 		// Legacy 3.x models retain older lower caps.
-		'claude-3-5-sonnet'              => 8192,
-		'claude-3-5-haiku'               => 8192,
-		'claude-3-opus'                  => 4096,
-		'claude-3-sonnet'                => 4096,
-		'claude-3-haiku'                 => 4096,
+		'claude-3-5-sonnet'           => 8192,
+		'claude-3-5-haiku'            => 8192,
+		'claude-3-opus'               => 4096,
+		'claude-3-sonnet'             => 4096,
+		'claude-3-haiku'              => 4096,
 		// ── OpenAI ─────────────────────────────────────────────────────
 		// GPT-5 family (5, 5.4, 5.5) and o-series reasoning models all
 		// document 128K output. o1/o3 budgets include reasoning tokens.
-		'gpt-5'                          => 128000,
+		'gpt-5'                       => 128000,
 		// GPT-4.1 documents 32,768; GPT-4o documents 16,384.
-		'gpt-4.1'                        => 32768,
-		'gpt-4o'                         => 16384,
-		'gpt-4-turbo'                    => 4096,
-		'gpt-4'                          => 8192,
-		'gpt-3.5-turbo'                  => 4096,
+		'gpt-4.1'                     => 32768,
+		'gpt-4o'                      => 16384,
+		'gpt-4-turbo'                 => 4096,
+		'gpt-4'                       => 8192,
+		'gpt-3.5-turbo'               => 4096,
 		// o-series reasoning models: o1 and o3 document 100K; o4 family
 		// (o4-mini etc.) inherits the same envelope.
-		'o1'                             => 100000,
-		'o3'                             => 100000,
-		'o4'                             => 100000,
+		'o1'                          => 100000,
+		'o3'                          => 100000,
+		'o4'                          => 100000,
 		// ── Google Gemini ──────────────────────────────────────────────
 		// Gemini 2.5 Pro and Flash both document 65,535 max output.
 		// Older 2.0 and 1.5 families cap at 8K.
-		'gemini-2.5-pro'                 => 65535,
-		'gemini-2.5-flash'               => 65535,
-		'gemini-2.0'                     => 8192,
-		'gemini-1.5'                     => 8192,
+		'gemini-2.5-pro'              => 65535,
+		'gemini-2.5-flash'            => 65535,
+		'gemini-2.0'                  => 8192,
+		'gemini-1.5'                  => 8192,
 		// ── HuggingFace-served via OpenAI-compatible connectors ────────
 		// These IDs come from providers like Synthetic AI that proxy
 		// HuggingFace-hosted models through an OpenAI-compatible API and
@@ -200,20 +200,20 @@ class Settings {
 		// 8192 cap *before* it could open the tool-call JSON, leaving
 		// the session idle with a preamble like "Now I'll create the full
 		// landing page..." and no follow-through. See PR description.
-		'hf:moonshotai/Kimi-K2.6'        => 65536,
-		'hf:moonshotai/Kimi-K2.5'        => 32768,
-		'hf:zai-org/GLM-5.1'             => 65536,
-		'hf:zai-org/GLM-5'               => 65536,
-		'hf:zai-org/GLM-4.7-Flash'       => 65536,
-		'hf:zai-org/GLM-4.7'             => 65536,
-		'hf:MiniMaxAI/MiniMax-M2.5'      => 65536,
-		'hf:nvidia/NVIDIA-Nemotron-3'    => 65536,
+		'hf:moonshotai/Kimi-K2.6'     => 65536,
+		'hf:moonshotai/Kimi-K2.5'     => 32768,
+		'hf:zai-org/GLM-5.1'          => 65536,
+		'hf:zai-org/GLM-5'            => 65536,
+		'hf:zai-org/GLM-4.7-Flash'    => 65536,
+		'hf:zai-org/GLM-4.7'          => 65536,
+		'hf:MiniMaxAI/MiniMax-M2.5'   => 65536,
+		'hf:nvidia/NVIDIA-Nemotron-3' => 65536,
 		// Broad fallback for any other `hf:`-prefixed model served via
 		// OpenAI-compatible proxies. 32K is a generous but bounded value
 		// that's well under the WordPress AI Client SDK's request-body
 		// limits while being 4x the global 8192 fallback. Specific
 		// entries above take precedence via longest-prefix match.
-		'hf:'                            => 32768,
+		'hf:'                         => 32768,
 	);
 
 	/**

--- a/stubs/wordpress-7-runtime.php
+++ b/stubs/wordpress-7-runtime.php
@@ -112,8 +112,21 @@ namespace WordPress\AiClient\Messages\DTO {
 
 	/**
 	 * Represents the type of a message part (stub).
+	 *
+	 * Mirrors the WP 7.0 RC2 enum-style class shipped in
+	 * php-ai-client (WordPress\AiClient\Messages\Enums\MessagePartTypeEnum).
+	 * Real class extends AbstractEnum and exposes a magic ->value property
+	 * plus is*() helpers; this stub flattens that into a regular class so
+	 * PHPStan can verify property access without modelling the magic.
 	 */
 	class MessagePartType {
+		/**
+		 * Underlying enum value ("text", "file", "function_call", "function_response").
+		 *
+		 * @var string
+		 */
+		public string $value = '';
+
 		/** @return bool */
 		public function isFunctionCall(): bool { return false; }
 
@@ -122,6 +135,9 @@ namespace WordPress\AiClient\Messages\DTO {
 
 		/** @return bool */
 		public function isText(): bool { return false; }
+
+		/** @return bool */
+		public function isFile(): bool { return false; }
 	}
 
 	/**
@@ -207,9 +223,37 @@ namespace WordPress\AiClient\Messages\DTO {
 	}
 }
 
+namespace WordPress\AiClient\Results\Enums {
+
+	/**
+	 * Finish-reason enum for a Candidate (stub).
+	 *
+	 * Mirrors WordPress\AiClient\Results\Enums\FinishReasonEnum
+	 * shipped in php-ai-client; flattened from AbstractEnum into a plain
+	 * class so PHPStan can verify property access. Real values include
+	 * "stop", "length", "content_filter", "tool_calls".
+	 */
+	class FinishReasonEnum {
+		/** @var string */
+		public string $value = '';
+
+		/** @return string */
+		public function getValue(): string {
+			return $this->value;
+		}
+
+		/** @return string */
+		public function __toString(): string {
+			return $this->value;
+		}
+	}
+}
+
 namespace WordPress\AiClient\Results\DTO {
 
 	use WordPress\AiClient\Messages\DTO\Message;
+	use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+	use WordPress\AiClient\Results\Enums\FinishReasonEnum;
 
 	/**
 	 * Token usage data from a generative AI request (stub).
@@ -235,16 +279,46 @@ namespace WordPress\AiClient\Results\DTO {
 		 * @return int
 		 */
 		public function getTotalTokens(): int { return 0; }
+
+		/**
+		 * Get the number of thought tokens used (reasoning models only).
+		 *
+		 * Returns null when the provider does not report a thought-token count.
+		 *
+		 * @return int|null
+		 */
+		public function getThoughtTokens(): ?int { return null; }
+	}
+
+	/**
+	 * A single candidate response from a generative AI request (stub).
+	 *
+	 * Mirrors the WP 7.0 RC2 DTO shipped in php-ai-client. Each Candidate
+	 * pairs a Message (the candidate's content) with a FinishReasonEnum
+	 * (why the candidate stopped generating).
+	 */
+	class Candidate {
+		/** @return Message */
+		public function getMessage(): Message { return new Message(); }
+
+		/** @return FinishReasonEnum */
+		public function getFinishReason(): FinishReasonEnum { return new FinishReasonEnum(); }
 	}
 
 	/**
 	 * Result from a generative AI request (stub).
 	 */
 	class GenerativeAiResult {
+		/** @return string */
+		public function getId(): string { return ''; }
+
+		/** @return ModelMetadata */
+		public function getModelMetadata(): ModelMetadata { return new ModelMetadata(); }
+
 		/** @return Message */
 		public function getMessage(): Message { return new Message(); }
 
-		/** @return Message[] */
+		/** @return Candidate[] */
 		public function getCandidates(): array { return array(); }
 
 		/**
@@ -274,6 +348,90 @@ namespace WordPress\AiClient\Results\DTO {
 		 * @return TokenUsage
 		 */
 		public function getTokenUsage(): TokenUsage { return new TokenUsage(); }
+	}
+}
+
+namespace WordPress\AiClient\Providers\Models\DTO {
+
+	/**
+	 * Metadata describing a model exposed by a provider (stub).
+	 *
+	 * Mirrors WordPress\AiClient\Providers\Models\DTO\ModelMetadata shipped
+	 * in php-ai-client. Real DTO carries id, name, supportedCapabilities,
+	 * supportedOptions; this stub exposes only the methods the plugin reads.
+	 */
+	class ModelMetadata {
+		/**
+		 * Constructor.
+		 *
+		 * @param string             $id                    Model id.
+		 * @param string             $name                  Human-readable model name.
+		 * @param array<int, mixed>  $supported_capabilities Supported capability enums.
+		 * @param array<int, mixed>  $supported_options     Supported option enums.
+		 */
+		public function __construct(
+			string $id = '',
+			string $name = '',
+			array $supported_capabilities = array(),
+			array $supported_options = array()
+		) {}
+
+		/** @return string */
+		public function getId(): string { return ''; }
+
+		/** @return string */
+		public function getName(): string { return ''; }
+	}
+}
+
+namespace WordPress\AiClient\Providers\DTO {
+
+	use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
+
+	/**
+	 * Metadata describing an AI provider (stub).
+	 *
+	 * Mirrors WordPress\AiClient\Providers\DTO\ProviderMetadata shipped
+	 * in php-ai-client. Constructor takes (id, name, ProviderTypeEnum).
+	 */
+	class ProviderMetadata {
+		/**
+		 * Constructor.
+		 *
+		 * @param string                $id   Provider id.
+		 * @param string                $name Provider display name.
+		 * @param ProviderTypeEnum|null $type Provider type enum.
+		 */
+		public function __construct(
+			string $id = '',
+			string $name = '',
+			?ProviderTypeEnum $type = null
+		) {}
+
+		/** @return string */
+		public function getId(): string { return ''; }
+
+		/** @return string */
+		public function getName(): string { return ''; }
+	}
+}
+
+namespace WordPress\AiClient\Providers\Enums {
+
+	/**
+	 * Provider type enum (stub).
+	 *
+	 * Mirrors WordPress\AiClient\Providers\Enums\ProviderTypeEnum shipped
+	 * in php-ai-client. Real values include "cloud", "server", "client".
+	 */
+	class ProviderTypeEnum {
+		/** @var string */
+		public string $value = '';
+
+		/** @return string */
+		public function getValue(): string {
+			return $this->value;
+		}
 	}
 }
 

--- a/tests/SdAiAgent/Bootstrap/AiClientEventTraceHandlerTest.php
+++ b/tests/SdAiAgent/Bootstrap/AiClientEventTraceHandlerTest.php
@@ -59,9 +59,14 @@ class AiClientEventTraceHandlerTest extends WP_UnitTestCase {
 
 		ProviderTrace::set_enabled( true );
 		ProviderTrace::clear();
+		// Reset the LIFO inflight stack so a stalled Before from a prior
+		// test case (or a tearDown that didn't fire on_after) can't pair
+		// with this case's on_after.
+		AiClientEventTraceLogger::reset_inflight_for_tests();
 	}
 
 	protected function tearDown(): void {
+		AiClientEventTraceLogger::reset_inflight_for_tests();
 		ProviderTrace::clear();
 		ProviderTrace::set_enabled( false );
 		parent::tearDown();

--- a/tests/SdAiAgent/Core/SettingsTest.php
+++ b/tests/SdAiAgent/Core/SettingsTest.php
@@ -206,50 +206,89 @@ class SettingsTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Exact-match Claude Opus 4.x resolves to its 32K family entry.
+	 * Exact-match Claude Opus 4.x resolves to its documented family caps.
 	 *
-	 * Specifically guards the session-16 regression: claude-opus-4-7 was
-	 * silently using the 4096 default, which truncated tool_use input JSON
-	 * mid-payload and caused the agent loop to spin.
+	 * Originally guarded the session-16 regression (claude-opus-4-7 silently
+	 * using the 4096 default and truncating tool_use input JSON mid-payload).
+	 * Now also locks in the post-#1448 catalog values where newer Opus point
+	 * releases get the larger advertised caps (128K) and older 4.0/4.1 stay
+	 * at 32K. Newer point releases keep higher caps than older ones in the
+	 * same family, so the entries are NOT collapsed into a single
+	 * `claude-opus-4` entry.
 	 */
 	public function test_max_output_tokens_resolves_claude_opus_4_family(): void {
-		// Bare family prefix.
+		// Bare family prefix — still 32K (Opus 4.0).
 		$this->assertSame(
 			32000,
 			Settings::get_max_output_tokens_for_model( 'claude-opus-4' )
 		);
-		// Dated variant — longest-prefix match must still resolve.
+		// Opus 4.7 documents 128K output.
 		$this->assertSame(
-			32000,
+			128000,
 			Settings::get_max_output_tokens_for_model( 'claude-opus-4-7' )
 		);
+		// Dated variants must longest-prefix-match the 4.7 entry, not the
+		// bare `claude-opus-4` one.
+		$this->assertSame(
+			128000,
+			Settings::get_max_output_tokens_for_model( 'claude-opus-4-7-20260513' )
+		);
+		// Opus 4.5 sits between: 64K documented cap.
+		$this->assertSame(
+			64000,
+			Settings::get_max_output_tokens_for_model( 'claude-opus-4-5' )
+		);
+		// Opus 4.1 stayed at 32K.
 		$this->assertSame(
 			32000,
-			Settings::get_max_output_tokens_for_model( 'claude-opus-4-7-20260513' )
+			Settings::get_max_output_tokens_for_model( 'claude-opus-4-1' )
 		);
 	}
 
 	/**
-	 * GPT-4.1 family and o-series resolve via longest-prefix matching.
+	 * GPT-4.x and o-series resolve via longest-prefix matching.
+	 *
+	 * Locks in the post-#1448 catalog: GPT-5 documents 128K, GPT-4.1 32,768,
+	 * GPT-4o 16,384, o1/o3/o4 all document a 100K envelope (which includes
+	 * reasoning tokens).
 	 */
 	public function test_max_output_tokens_resolves_openai_families(): void {
-		$this->assertSame( 32000, Settings::get_max_output_tokens_for_model( 'gpt-4.1' ) );
-		$this->assertSame( 32000, Settings::get_max_output_tokens_for_model( 'gpt-4.1-mini' ) );
-		$this->assertSame( 32000, Settings::get_max_output_tokens_for_model( 'gpt-4.1-nano' ) );
-		$this->assertSame( 16000, Settings::get_max_output_tokens_for_model( 'gpt-4o' ) );
-		$this->assertSame( 16000, Settings::get_max_output_tokens_for_model( 'gpt-4o-mini' ) );
-		$this->assertSame( 32000, Settings::get_max_output_tokens_for_model( 'o3-mini' ) );
-		$this->assertSame( 32000, Settings::get_max_output_tokens_for_model( 'o4-mini' ) );
+		$this->assertSame( 128000, Settings::get_max_output_tokens_for_model( 'gpt-5' ) );
+		$this->assertSame( 128000, Settings::get_max_output_tokens_for_model( 'gpt-5-mini' ) );
+		$this->assertSame( 32768, Settings::get_max_output_tokens_for_model( 'gpt-4.1' ) );
+		$this->assertSame( 32768, Settings::get_max_output_tokens_for_model( 'gpt-4.1-mini' ) );
+		$this->assertSame( 32768, Settings::get_max_output_tokens_for_model( 'gpt-4.1-nano' ) );
+		$this->assertSame( 16384, Settings::get_max_output_tokens_for_model( 'gpt-4o' ) );
+		$this->assertSame( 16384, Settings::get_max_output_tokens_for_model( 'gpt-4o-mini' ) );
+		$this->assertSame( 100000, Settings::get_max_output_tokens_for_model( 'o3-mini' ) );
+		$this->assertSame( 100000, Settings::get_max_output_tokens_for_model( 'o4-mini' ) );
 	}
 
 	/**
-	 * Gemini Flash family is appropriately conservative at 8K.
+	 * Gemini families resolve to documented caps. Post-#1448, both 2.5 Pro
+	 * and 2.5 Flash document a 65,535 max output. Older 2.0 and 1.5 stay
+	 * conservatively at 8K.
 	 */
 	public function test_max_output_tokens_resolves_gemini_families(): void {
-		$this->assertSame( 32000, Settings::get_max_output_tokens_for_model( 'gemini-2.5-pro' ) );
-		$this->assertSame( 8192, Settings::get_max_output_tokens_for_model( 'gemini-2.5-flash' ) );
+		$this->assertSame( 65535, Settings::get_max_output_tokens_for_model( 'gemini-2.5-pro' ) );
+		$this->assertSame( 65535, Settings::get_max_output_tokens_for_model( 'gemini-2.5-flash' ) );
 		$this->assertSame( 8192, Settings::get_max_output_tokens_for_model( 'gemini-2.0-flash' ) );
 		$this->assertSame( 8192, Settings::get_max_output_tokens_for_model( 'gemini-1.5-pro' ) );
+	}
+
+	/**
+	 * Synthetic-hosted HuggingFace models resolve to their per-model caps,
+	 * verified against the live Synthetic `/openai/v1/models` payload. The
+	 * broad `hf:` fallback catches unknown models at 32K (conservative
+	 * relative to the Synthetic-typical 65K, but safe).
+	 */
+	public function test_max_output_tokens_resolves_synthetic_hf_models(): void {
+		// Explicit catalog entries.
+		$this->assertSame( 65536, Settings::get_max_output_tokens_for_model( 'hf:moonshotai/Kimi-K2.6' ) );
+		$this->assertSame( 32768, Settings::get_max_output_tokens_for_model( 'hf:moonshotai/Kimi-K2.5' ) );
+		$this->assertSame( 65536, Settings::get_max_output_tokens_for_model( 'hf:zai-org/GLM-5.1' ) );
+		// Unknown hf: model falls through to the broad prefix.
+		$this->assertSame( 32768, Settings::get_max_output_tokens_for_model( 'hf:unknown/random-model' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Unbreaks main after PR #1466 was merged with PHPUnit and PHPCS failing. Three orthogonal defects on the current `main`, four commits to address them:

1. **PHPCS — 35 alignment warnings in `Settings.php`** (lines ~199–216 around the `hf:` model catalog entries added in #1463). `phpcbf` auto-fix.
2. **PHPUnit — 3 `SettingsTest` failures** asserting pre-#1448 catalog values (`32000` / `8192` / etc.) where the catalog now ships `128000` / `32768` / `65535`. Test assertions updated; new `hf:` family coverage added.
3. **PHPUnit — 5 `AiClientEventTraceHandlerTest` failures** all surfacing as `"actual size 0 matches expected size 1"` on the After handler. Root cause:
   - PR #1466 fixed the SDK method names but kept the existing `spl_object_id($event)` keyed-map correlation. The php-ai-client SDK constructs **distinct event objects** for Before vs After (see `lib/php-ai-client/src/Builders/PromptBuilder.php` — `new BeforeGenerateResultEvent(...)` followed by `new AfterGenerateResultEvent(...)`), so `spl_object_id` on the After event never matches the Before's. The inflight lookup misses, the After returns early, no trace row is written.
   - Replace with a **LIFO stack** (`array_push` on Before, `array_pop` on After). Correct under PHP's single-threaded model: SDK always pairs Before→{request}→After synchronously on the same call, nested calls naturally pair LIFO.
4. **PHPStan — stub mismatch** for the methods PR #1466's logger now calls (`GenerativeAiResult::getId/getModelMetadata`, `TokenUsage::getThoughtTokens`, `Candidate` DTO, `FinishReasonEnum`). Stubs updated **additively**: no existing class renamed or methods removed, so the 18 other SDK consumers in `includes/` continue type-checking unchanged.

## Commits

| | |
|---|---|
| `5b7e5f9` | `style: align MODEL_MAX_OUTPUT_TOKENS double arrows (phpcbf)` |
| `64d353e` | `test: align SettingsTest with post-#1448 catalog values` |
| `381e365` | `fix(trace): LIFO correlation + stub alignment to unbreak PHPUnit/PHPStan post-#1466` |
| `dbdb63f` | `test(trace): reset LIFO inflight stack between cases` |

## Verification

```
composer phpcs   # 8/8 files clean
composer phpstan # 216 files, 0 errors
```

PHPUnit not run locally (wp-env wedged); relying on CI Tests workflow on this PR.

## Why not amend PR #1466

PR #1466 is already merged. The defects above only became visible after the merge made main red. This PR is the smallest scoped fix-forward.

## Files

- `includes/Core/Settings.php` — phpcbf alignment
- `includes/Core/AiClientEventTraceLogger.php` — LIFO stack + type narrowing + remove dead `$watchdog_hook`
- `stubs/wordpress-7-runtime.php` — additive: `Candidate`, `FinishReasonEnum`, `ModelMetadata`, `ProviderMetadata`, `ProviderTypeEnum`; `TokenUsage::getThoughtTokens`; `GenerativeAiResult::getId/getModelMetadata`; `MessagePartType::$value/isFile`; `getCandidates()` return type
- `tests/SdAiAgent/Core/SettingsTest.php` — post-#1448 catalog assertions + `hf:` family case
- `tests/SdAiAgent/Bootstrap/AiClientEventTraceHandlerTest.php` — `reset_inflight_for_tests()` in `setUp`/`tearDown`

Resolves the post-#1466 main breakage. Supersedes #1465 (which was rebased into this clean fix-forward branch).

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with claude-sonnet-4-6 spent 1d 7h and 383 tokens on this as a headless worker.
