### PR TITLE
feat: per-model max_output_tokens from provider /models responses (sd-ai-2zf)

### DIFF
--- a/includes/Bootstrap/ModelCapabilityHandler.php
+++ b/includes/Bootstrap/ModelCapabilityHandler.php
@@ -148,7 +148,9 @@ final class ModelCapabilityHandler {
 
 		$host_ok = false;
 		foreach ( self::ALLOWED_HOST_SUFFIXES as $suffix ) {
-			if ( str_ends_with( $host, $suffix ) ) {
+			// Match exact host or host.suffix (dot-boundary) to prevent
+			// api.synthetic.new.evil.com from matching api.synthetic.new.
+			if ( $host === $suffix || str_ends_with( $host, '.' . $suffix ) ) {
 				$host_ok = true;
 				break;
 			}

--- a/includes/Bootstrap/ModelCapabilityHandler.php
+++ b/includes/Bootstrap/ModelCapabilityHandler.php
@@ -1,0 +1,246 @@
+<?php
+/**
+ * DI handler that captures `/models` HTTP responses and feeds the parsed
+ * `max_output_length` / `context_length` fields into
+ * {@see ModelCapabilityRegistry}.
+ *
+ * Background: OpenAI-compatible providers (Synthetic, OpenRouter, etc.)
+ * advertise per-model `max_output_length` in their `/models` payloads.
+ * The upstream `ai-provider-for-any-compatible-endpoint` connector
+ * strips this field when building its `ModelMetadata` DTO
+ * (see `buildModelMetadataMapFromRaw()` in that plugin's
+ * `class-model-directory.php`), so by the time the value reaches the
+ * SDK it is already gone. We intercept the raw HTTP response at
+ * `http_response` priority 9 — one slot ahead of
+ * {@see HttpTraceHandler} (priority 10) — so:
+ *
+ *   1. We see the body before the trace logger snapshots it.
+ *   2. The connector's `wp_remote_request()` call returns the same
+ *      payload we inspected; we never mutate it.
+ *
+ * This is the same trick {@see HttpTraceHandler} uses to observe the
+ * outgoing prompt body; matching their pattern keeps the registration
+ * footprint identical.
+ *
+ * @package SdAiAgent\Bootstrap
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Bootstrap;
+
+use SdAiAgent\Core\ModelCapabilityRegistry;
+use XWP\DI\Decorators\Filter;
+use XWP\DI\Decorators\Handler;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Captures `/models` responses from LLM providers and writes per-model
+ * caps into the {@see ModelCapabilityRegistry} transient store.
+ */
+#[Handler(
+	container: 'sd-ai-agent',
+	context: Handler::CTX_GLOBAL,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class ModelCapabilityHandler {
+
+	/**
+	 * Allowed host suffixes for `/models` capture.
+	 *
+	 * Restricts ingestion to LLM provider hosts so unrelated WordPress
+	 * HTTP traffic that happens to use a `/models` path (some REST APIs,
+	 * geo/mapping services) cannot poison the registry.
+	 *
+	 * Match is case-insensitive substring on the parsed host. Add new
+	 * providers here when a connector starts surfacing models data.
+	 */
+	private const ALLOWED_HOST_SUFFIXES = array(
+		'api.synthetic.new',
+		'api.openai.com',
+		'api.anthropic.com',
+		'openrouter.ai',
+		'api.deepinfra.com',
+		'api.together.xyz',
+		'api.fireworks.ai',
+		'api.groq.com',
+		'api.mistral.ai',
+		'generativelanguage.googleapis.com',
+	);
+
+	/**
+	 * Capture `/models` responses and persist per-model caps.
+	 *
+	 * Runs at priority 9 — strictly before {@see HttpTraceHandler}
+	 * (priority 10) so the trace log sees the same body we did. We do
+	 * not mutate `$response` under any condition.
+	 *
+	 * The full WordPress HTTP-API signature is (response, args, url) per
+	 * `WP_Http::request()`. We declare four positional parameters to
+	 * accommodate other plugins that have wrapped the filter; XWP/DI
+	 * forwards every argument WordPress passes through.
+	 *
+	 * @param mixed        $response Raw response from the HTTP transport.
+	 *                               Typically `array{response: array, body: string, ...}`
+	 *                               on success, `WP_Error` on transport failure.
+	 * @param array<mixed> $args    Request args. Unused — kept for signature parity.
+	 * @param string       $url      Endpoint URL.
+	 * @return mixed Unchanged response — this filter is read-only.
+	 */
+	#[Filter( tag: 'http_response', priority: 9, args: 3 )]
+	public function capture_models_response( $response, $args, $url ) {
+		unset( $args ); // Reserved for future per-request gating.
+
+		if ( ! is_array( $response ) || ! isset( $response['body'] ) ) {
+			return $response;
+		}
+
+		if ( ! is_string( $url ) || '' === $url ) {
+			return $response;
+		}
+
+		if ( ! self::is_models_endpoint( $url ) ) {
+			return $response;
+		}
+
+		$status = isset( $response['response']['code'] ) ? (int) $response['response']['code'] : 0;
+		if ( $status < 200 || $status >= 300 ) {
+			return $response;
+		}
+
+		$body = $response['body'];
+		if ( ! is_string( $body ) || '' === $body ) {
+			return $response;
+		}
+
+		$decoded = json_decode( $body, true );
+		if ( ! is_array( $decoded ) ) {
+			return $response;
+		}
+
+		self::ingest_models_payload( $decoded );
+
+		return $response;
+	}
+
+	/**
+	 * Decide whether a URL points at an LLM provider `/models` endpoint.
+	 *
+	 * Allow list is gated on host suffix; the path must end with `/models`
+	 * (with an optional trailing slash or query string). Public so tests
+	 * and CLI commands can reuse the gate when validating manual seeds.
+	 *
+	 * @param string $url Full request URL.
+	 * @return bool True when the URL is an allowed provider's models listing.
+	 */
+	public static function is_models_endpoint( string $url ): bool {
+		$parts = wp_parse_url( $url );
+		if ( ! is_array( $parts ) || empty( $parts['host'] ) || empty( $parts['path'] ) ) {
+			return false;
+		}
+
+		$host = strtolower( (string) $parts['host'] );
+		$path = (string) $parts['path'];
+
+		$host_ok = false;
+		foreach ( self::ALLOWED_HOST_SUFFIXES as $suffix ) {
+			if ( str_ends_with( $host, $suffix ) ) {
+				$host_ok = true;
+				break;
+			}
+		}
+		if ( ! $host_ok ) {
+			return false;
+		}
+
+		// Accept `/models` and `/v1/models` etc., with optional trailing slash.
+		$path = rtrim( $path, '/' );
+		return str_ends_with( $path, '/models' );
+	}
+
+	/**
+	 * Parse a decoded `/models` payload and write each entry to the registry.
+	 *
+	 * Accepts both the OpenAI-compatible `{data: [{id, max_output_length, context_length}]}`
+	 * shape and the Ollama-style `{models: [...]}` fallback (matching the
+	 * connector's own parser). Entries without an `id` are skipped.
+	 *
+	 * Public so the CLI manual-refresh command can reuse the same parser
+	 * after issuing its own `wp_remote_get()`.
+	 *
+	 * @param array<mixed> $payload Decoded JSON body.
+	 * @return int Number of model entries written.
+	 */
+	public static function ingest_models_payload( array $payload ): int {
+		$entries = array();
+		if ( isset( $payload['data'] ) && is_array( $payload['data'] ) ) {
+			$entries = $payload['data'];
+		} elseif ( isset( $payload['models'] ) && is_array( $payload['models'] ) ) {
+			$entries = $payload['models'];
+		}
+
+		if ( empty( $entries ) ) {
+			return 0;
+		}
+
+		$written = 0;
+		foreach ( $entries as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$model_id = isset( $entry['id'] ) ? trim( (string) $entry['id'] ) : '';
+			if ( '' === $model_id ) {
+				continue;
+			}
+
+			// Provider field names vary slightly between hosts; check the
+			// canonical OpenAI-compatible names first, then the Ollama
+			// fallbacks the connector also accepts upstream.
+			$max_output = self::pick_int(
+				$entry,
+				array( 'max_output_length', 'max_output_tokens', 'max_completion_tokens' )
+			);
+			$context    = self::pick_int(
+				$entry,
+				array( 'context_length', 'context_window', 'context_size' )
+			);
+
+			if ( $max_output <= 0 ) {
+				// Without a max-output value we have nothing to cache — the
+				// catalog/fallback path already handles unknown models.
+				continue;
+			}
+
+			if ( ModelCapabilityRegistry::set( $model_id, $max_output, $context ) ) {
+				++$written;
+			}
+		}
+
+		return $written;
+	}
+
+	/**
+	 * Pick the first positive integer found under any of the candidate keys.
+	 *
+	 * @param array<string, mixed> $entry Decoded model entry.
+	 * @param array<int, string>   $keys  Candidate field names in priority order.
+	 * @return int Resolved value, or 0 when no candidate has a positive int.
+	 */
+	private static function pick_int( array $entry, array $keys ): int {
+		foreach ( $keys as $key ) {
+			if ( ! isset( $entry[ $key ] ) ) {
+				continue;
+			}
+			$value = (int) $entry[ $key ];
+			if ( $value > 0 ) {
+				return $value;
+			}
+		}
+		return 0;
+	}
+}

--- a/includes/Core/ModelCapabilityRegistry.php
+++ b/includes/Core/ModelCapabilityRegistry.php
@@ -1,0 +1,230 @@
+<?php
+/**
+ * Per-model capability registry — transient-backed lookup with provider →
+ * static-catalog → fallback resolution.
+ *
+ * The static catalog in {@see Settings::MODEL_MAX_OUTPUT_TOKENS} works for the
+ * core OpenAI/Anthropic/Google families but cannot keep up with the long tail
+ * of Synthetic-hosted Hugging Face models (Kimi K2.6, GLM, Nemotron, etc.)
+ * whose advertised `max_output_length` drifts with every model bump.
+ *
+ * This registry caches per-model caps in a transient keyed by md5 of the
+ * model ID. The transient is populated by {@see ModelCapabilityHandler}
+ * which sniffs `/models` HTTP responses (where the connector strips the
+ * field before it reaches the SDK). Resolution order:
+ *
+ *   1. Live provider transient (TTL 7d) — set by the `http_response` filter.
+ *   2. Static catalog seed in {@see Settings::MODEL_MAX_OUTPUT_TOKENS} —
+ *      longest-prefix match. The exact-match path keeps the existing
+ *      regression coverage from sd-ai-7rl.
+ *   3. {@see Settings::MAX_OUTPUT_TOKENS_FALLBACK} (8192).
+ *
+ * The `sd_ai_agent_max_output_tokens_for_model` filter on the resolver
+ * output stays the final word — deployments can still pin a value
+ * regardless of provider claims.
+ *
+ * @package SdAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Stores and retrieves per-model capability data (max output tokens,
+ * context length) sourced from live provider `/models` responses.
+ */
+class ModelCapabilityRegistry {
+
+	/**
+	 * Transient key prefix for cached per-model capabilities. The full key
+	 * is `{PREFIX}{md5(model_id)}` to keep the option name length bounded
+	 * regardless of how exotic the model ID is (Synthetic models can carry
+	 * long org/name slashes).
+	 */
+	public const TRANSIENT_PREFIX = 'sd_ai_agent_model_caps_';
+
+	/**
+	 * Default TTL for provider-sourced entries — 7 days.
+	 *
+	 * Provider catalogs are stable across the day; refreshing weekly is
+	 * sufficient. Stale entries do not break anything (they just emit a
+	 * slightly outdated cap); a wrong value is preferred over an empty
+	 * cache miss because requests must succeed even when the provider
+	 * `/models` endpoint is unreachable.
+	 */
+	public const PROVIDER_TTL_SECONDS = 7 * DAY_IN_SECONDS;
+
+	/**
+	 * Source marker for entries populated from a live provider response.
+	 */
+	public const SOURCE_PROVIDER = 'provider';
+
+	/**
+	 * Source marker for entries derived from {@see Settings::MODEL_MAX_OUTPUT_TOKENS}.
+	 *
+	 * Returned by {@see get()} when no provider entry is cached so callers
+	 * can distinguish "we measured this live" from "this is the catalog".
+	 */
+	public const SOURCE_CATALOG = 'catalog';
+
+	/**
+	 * Source marker when neither a transient nor a catalog match exists
+	 * and the caller is given the global fallback.
+	 */
+	public const SOURCE_FALLBACK = 'fallback';
+
+	/**
+	 * Resolve the max-output-tokens cap for a model.
+	 *
+	 * Consults the transient first; falls back to the static catalog via
+	 * {@see Settings::resolve_max_output_tokens_from_catalog()}; finally
+	 * returns {@see Settings::MAX_OUTPUT_TOKENS_FALLBACK} (the
+	 * {@see Settings} resolver applies the user filter and ceiling clamp
+	 * on top of whichever value we return here).
+	 *
+	 * @param string $model_id Provider-advertised model identifier.
+	 * @return int Max output tokens. Always positive; never clamped to ceiling here.
+	 */
+	public static function get_max_output_tokens( string $model_id ): int {
+		$model_id = trim( $model_id );
+		if ( '' === $model_id ) {
+			return Settings::MAX_OUTPUT_TOKENS_FALLBACK;
+		}
+
+		$entry = self::get( $model_id );
+		$value = isset( $entry['max_output_tokens'] ) ? (int) $entry['max_output_tokens'] : 0;
+		if ( $value > 0 ) {
+			return $value;
+		}
+
+		return Settings::MAX_OUTPUT_TOKENS_FALLBACK;
+	}
+
+	/**
+	 * Read a single registry entry by model id.
+	 *
+	 * Returns a shape with deterministic keys regardless of source so
+	 * callers (CLI, REST) can introspect lookups without branching on
+	 * "is this a transient hit or a catalog entry".
+	 *
+	 * @param string $model_id Provider-advertised model identifier.
+	 * @return array{model_id: string, max_output_tokens: int, context_length: int, source: string, fetched_at: int}
+	 */
+	public static function get( string $model_id ): array {
+		$model_id = trim( $model_id );
+		if ( '' === $model_id ) {
+			return self::empty_entry( $model_id, self::SOURCE_FALLBACK );
+		}
+
+		$transient = get_transient( self::transient_key( $model_id ) );
+		if ( is_array( $transient ) && isset( $transient['max_output_tokens'] ) ) {
+			return array(
+				'model_id'          => $model_id,
+				'max_output_tokens' => max( 0, (int) $transient['max_output_tokens'] ),
+				'context_length'    => max( 0, (int) ( $transient['context_length'] ?? 0 ) ),
+				'source'            => (string) ( $transient['source'] ?? self::SOURCE_PROVIDER ),
+				'fetched_at'        => max( 0, (int) ( $transient['fetched_at'] ?? 0 ) ),
+			);
+		}
+
+		$catalog = Settings::resolve_max_output_tokens_from_catalog( $model_id );
+		if ( $catalog > 0 ) {
+			return array(
+				'model_id'          => $model_id,
+				'max_output_tokens' => $catalog,
+				'context_length'    => 0,
+				'source'            => self::SOURCE_CATALOG,
+				'fetched_at'        => 0,
+			);
+		}
+
+		return self::empty_entry( $model_id, self::SOURCE_FALLBACK );
+	}
+
+	/**
+	 * Persist a registry entry for a model.
+	 *
+	 * Called by {@see ModelCapabilityHandler} when parsing a `/models`
+	 * response. Callers may also use this from CLI commands to manually
+	 * seed a cap when the provider does not advertise one.
+	 *
+	 * @param string $model_id          Provider-advertised model identifier. Empty values are dropped.
+	 * @param int    $max_output_tokens Max output tokens the provider advertises. Must be > 0.
+	 * @param int    $context_length    Total context window the provider advertises. 0 if unknown.
+	 * @param string $source            Source marker (defaults to provider). One of the SOURCE_* constants.
+	 * @param int    $ttl_seconds       Override TTL. Defaults to PROVIDER_TTL_SECONDS.
+	 * @return bool True on successful write; false on bad inputs or transient failure.
+	 */
+	public static function set(
+		string $model_id,
+		int $max_output_tokens,
+		int $context_length = 0,
+		string $source = self::SOURCE_PROVIDER,
+		int $ttl_seconds = 0
+	): bool {
+		$model_id = trim( $model_id );
+		if ( '' === $model_id || $max_output_tokens <= 0 ) {
+			return false;
+		}
+		if ( $ttl_seconds <= 0 ) {
+			$ttl_seconds = self::PROVIDER_TTL_SECONDS;
+		}
+
+		$entry = array(
+			'model_id'          => $model_id,
+			'max_output_tokens' => $max_output_tokens,
+			'context_length'    => max( 0, $context_length ),
+			'source'            => $source,
+			'fetched_at'        => time(),
+		);
+
+		return (bool) set_transient( self::transient_key( $model_id ), $entry, $ttl_seconds );
+	}
+
+	/**
+	 * Forget a single cached entry.
+	 *
+	 * @param string $model_id Provider-advertised model identifier.
+	 * @return bool True if a transient was deleted; false if nothing to delete.
+	 */
+	public static function forget( string $model_id ): bool {
+		$model_id = trim( $model_id );
+		if ( '' === $model_id ) {
+			return false;
+		}
+		return (bool) delete_transient( self::transient_key( $model_id ) );
+	}
+
+	/**
+	 * Transient key for a model id. Exposed for tests + CLI introspection.
+	 *
+	 * @param string $model_id Provider-advertised model identifier.
+	 * @return string Transient key.
+	 */
+	public static function transient_key( string $model_id ): string {
+		return self::TRANSIENT_PREFIX . md5( trim( $model_id ) );
+	}
+
+	/**
+	 * Build an empty entry shape for cache-miss returns.
+	 *
+	 * @param string $model_id Model id (echoed back for diagnostics).
+	 * @param string $source   Source marker.
+	 * @return array{model_id: string, max_output_tokens: int, context_length: int, source: string, fetched_at: int}
+	 */
+	private static function empty_entry( string $model_id, string $source ): array {
+		return array(
+			'model_id'          => $model_id,
+			'max_output_tokens' => 0,
+			'context_length'    => 0,
+			'source'            => $source,
+			'fetched_at'        => 0,
+		);
+	}
+}

--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -220,13 +220,17 @@ class Settings {
 	 * Resolve the appropriate `max_tokens` value for a given model.
 	 *
 	 * Falls back through, in order:
-	 *   1. exact match in {@see MODEL_MAX_OUTPUT_TOKENS},
-	 *   2. longest prefix match (so dated/quantized variants resolve to
+	 *   1. live transient written by {@see ModelCapabilityRegistry} (populated
+	 *      from provider `/models` responses — keeps Synthetic-hosted HF
+	 *      models like Kimi K2.6 honest as their advertised caps move),
+	 *   2. exact match in {@see MODEL_MAX_OUTPUT_TOKENS},
+	 *   3. longest prefix match (so dated/quantized variants resolve to
 	 *      their family entry),
-	 *   3. {@see MAX_OUTPUT_TOKENS_FALLBACK} (8192).
+	 *   4. {@see MAX_OUTPUT_TOKENS_FALLBACK} (8192).
 	 *
-	 * Filterable via `sd_ai_agent_max_output_tokens_for_model` to let
-	 * deployments override the catalog for custom or self-hosted models.
+	 * Filterable via `sd_ai_agent_max_output_tokens_for_model` (applied last)
+	 * to let deployments override both the live registry and the catalog
+	 * for custom or self-hosted models.
 	 *
 	 * @param string $model_id Provider-advertised model identifier. May be
 	 *                         empty when no model has been selected yet, in
@@ -235,32 +239,21 @@ class Settings {
 	 */
 	public static function get_max_output_tokens_for_model( string $model_id ): int {
 		$model_id = trim( $model_id );
-		$resolved = self::MAX_OUTPUT_TOKENS_FALLBACK;
 
-		if ( '' !== $model_id ) {
-			if ( isset( self::MODEL_MAX_OUTPUT_TOKENS[ $model_id ] ) ) {
-				$resolved = self::MODEL_MAX_OUTPUT_TOKENS[ $model_id ];
-			} else {
-				// Longest-prefix match so e.g. `claude-opus-4-7-20260513`
-				// resolves to `claude-opus-4` and `gpt-4.1-mini` to `gpt-4.1`.
-				$best_len = 0;
-				foreach ( self::MODEL_MAX_OUTPUT_TOKENS as $prefix => $value ) {
-					$prefix_len = strlen( $prefix );
-					if (
-						$prefix_len > $best_len
-						&& 0 === strncmp( $model_id, $prefix, $prefix_len )
-					) {
-						$best_len = $prefix_len;
-						$resolved = $value;
-					}
-				}
-			}
-		}
+		// Registry consults transient → static catalog → fallback in order;
+		// returns the global fallback if nothing matches.
+		$resolved = '' !== $model_id
+			? ModelCapabilityRegistry::get_max_output_tokens( $model_id )
+			: self::MAX_OUTPUT_TOKENS_FALLBACK;
 
 		/**
 		 * Filter the resolved max-output-tokens value for a model.
 		 *
-		 * @param int    $resolved Tokens chosen from the catalog/fallback.
+		 * Applied AFTER the live registry and static catalog lookups so
+		 * deployments can pin a value regardless of what the provider
+		 * advertises.
+		 *
+		 * @param int    $resolved Tokens chosen from registry/catalog/fallback.
 		 * @param string $model_id Model identifier being resolved.
 		 */
 		$filtered = (int) apply_filters( 'sd_ai_agent_max_output_tokens_for_model', $resolved, $model_id );
@@ -274,6 +267,47 @@ class Settings {
 		}
 
 		return $filtered;
+	}
+
+	/**
+	 * Pure static-catalog lookup for max-output-tokens.
+	 *
+	 * Encapsulates the exact-match + longest-prefix-match logic against
+	 * {@see MODEL_MAX_OUTPUT_TOKENS} so {@see ModelCapabilityRegistry::get()}
+	 * can consult it without ricocheting back through the filterable resolver.
+	 *
+	 * Returns 0 when no catalog entry matches — the caller decides what to
+	 * fall back to (typically {@see MAX_OUTPUT_TOKENS_FALLBACK}).
+	 *
+	 * @param string $model_id Provider-advertised model identifier.
+	 * @return int Tokens from the catalog, or 0 if no match.
+	 */
+	public static function resolve_max_output_tokens_from_catalog( string $model_id ): int {
+		$model_id = trim( $model_id );
+		if ( '' === $model_id ) {
+			return 0;
+		}
+
+		if ( isset( self::MODEL_MAX_OUTPUT_TOKENS[ $model_id ] ) ) {
+			return (int) self::MODEL_MAX_OUTPUT_TOKENS[ $model_id ];
+		}
+
+		// Longest-prefix match so e.g. `claude-opus-4-7-20260513` resolves
+		// to `claude-opus-4-7` and `gpt-4.1-mini` to `gpt-4.1`.
+		$best_len = 0;
+		$resolved = 0;
+		foreach ( self::MODEL_MAX_OUTPUT_TOKENS as $prefix => $value ) {
+			$prefix_len = strlen( $prefix );
+			if (
+				$prefix_len > $best_len
+				&& 0 === strncmp( $model_id, $prefix, $prefix_len )
+			) {
+				$best_len = $prefix_len;
+				$resolved = (int) $value;
+			}
+		}
+
+		return $resolved;
 	}
 
 	// ── Static factory (bridge for non-DI code) ───────────────────────────────

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -28,6 +28,7 @@ use SdAiAgent\Bootstrap\CliHandler;
 use SdAiAgent\Bootstrap\FrontendAssetsHandler;
 use SdAiAgent\Bootstrap\GitTrackingHandler;
 use SdAiAgent\Bootstrap\HttpTraceHandler;
+use SdAiAgent\Bootstrap\ModelCapabilityHandler;
 use SdAiAgent\Bootstrap\KnowledgeHooksHandler;
 use SdAiAgent\Bootstrap\OnboardingHandler;
 use SdAiAgent\Bootstrap\ToolDiscoveryHandler;
@@ -92,6 +93,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		// Core background service handlers (replaced CoreServicesHandler).
 		ChangeLoggingHandler::class,
 		HttpTraceHandler::class,
+		ModelCapabilityHandler::class,
 		AiClientEventTraceHandler::class,
 		KnowledgeHooksHandler::class,
 		ToolDiscoveryHandler::class,

--- a/tests/SdAiAgent/Bootstrap/ModelCapabilityHandlerTest.php
+++ b/tests/SdAiAgent/Bootstrap/ModelCapabilityHandlerTest.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * Tests for SdAiAgent\Bootstrap\ModelCapabilityHandler — sd-ai-2zf.
+ *
+ * Covers URL gating, payload ingestion (OpenAI-compatible + Ollama shapes),
+ * and the read-only contract of the `http_response` filter.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Bootstrap;
+
+use SdAiAgent\Bootstrap\ModelCapabilityHandler;
+use SdAiAgent\Core\ModelCapabilityRegistry;
+use WP_UnitTestCase;
+
+/**
+ * Capture-and-ingest behaviour for provider /models responses.
+ */
+class ModelCapabilityHandlerTest extends WP_UnitTestCase {
+
+	private const TEST_MODELS = array(
+		'hf:moonshotai/Kimi-K2.6',
+		'hf:zai-org/GLM-5.1',
+		'kimi-k2.6',
+		'gpt-5',
+		'should-not-be-cached',
+	);
+
+	/**
+	 * Clear any registry entries written by individual test cases.
+	 */
+	public function tear_down(): void {
+		parent::tear_down();
+		foreach ( self::TEST_MODELS as $model_id ) {
+			ModelCapabilityRegistry::forget( $model_id );
+		}
+	}
+
+	/**
+	 * Synthetic-shaped payload populates the registry with the advertised
+	 * max_output_length and context_length for each model entry.
+	 */
+	public function test_ingest_models_payload_writes_entries(): void {
+		$payload = array(
+			'data' => array(
+				array(
+					'id'                => 'hf:moonshotai/Kimi-K2.6',
+					'max_output_length' => 131072,
+					'context_length'    => 200000,
+				),
+				array(
+					'id'                => 'hf:zai-org/GLM-5.1',
+					'max_output_length' => 65536,
+					'context_length'    => 128000,
+				),
+			),
+		);
+
+		$written = ModelCapabilityHandler::ingest_models_payload( $payload );
+
+		$this->assertSame( 2, $written );
+
+		$kimi = ModelCapabilityRegistry::get( 'hf:moonshotai/Kimi-K2.6' );
+		$this->assertSame( 131072, $kimi['max_output_tokens'] );
+		$this->assertSame( 200000, $kimi['context_length'] );
+		$this->assertSame( ModelCapabilityRegistry::SOURCE_PROVIDER, $kimi['source'] );
+
+		$glm = ModelCapabilityRegistry::get( 'hf:zai-org/GLM-5.1' );
+		$this->assertSame( 65536, $glm['max_output_tokens'] );
+		$this->assertSame( 128000, $glm['context_length'] );
+	}
+
+	/**
+	 * Ollama-style payload (`{models: [...]}`) is accepted as a fallback so
+	 * the handler stays aligned with the connector's own parser.
+	 */
+	public function test_ingest_models_payload_accepts_ollama_envelope(): void {
+		$payload = array(
+			'models' => array(
+				array(
+					'id'                  => 'kimi-k2.6',
+					'max_output_tokens'   => 65536,
+					'context_window'      => 200000,
+				),
+			),
+		);
+
+		$this->assertSame( 1, ModelCapabilityHandler::ingest_models_payload( $payload ) );
+
+		$entry = ModelCapabilityRegistry::get( 'kimi-k2.6' );
+		$this->assertSame( 65536, $entry['max_output_tokens'] );
+		$this->assertSame( 200000, $entry['context_length'] );
+	}
+
+	/**
+	 * Entries without an id or without a positive max-output value are
+	 * skipped — no zero-token rows poison the registry.
+	 */
+	public function test_ingest_models_payload_skips_invalid_entries(): void {
+		$payload = array(
+			'data' => array(
+				array( 'id' => '', 'max_output_length' => 1024 ),
+				array( 'id' => 'should-not-be-cached', 'max_output_length' => 0 ),
+				array( 'max_output_length' => 1024 ), // missing id
+				array( 'id' => 'gpt-5', 'max_output_length' => 128000 ),
+			),
+		);
+
+		$this->assertSame( 1, ModelCapabilityHandler::ingest_models_payload( $payload ) );
+		$this->assertSame( 128000, ModelCapabilityRegistry::get_max_output_tokens( 'gpt-5' ) );
+
+		// Confirm the bad entry was not written.
+		$entry = ModelCapabilityRegistry::get( 'should-not-be-cached' );
+		$this->assertSame( ModelCapabilityRegistry::SOURCE_FALLBACK, $entry['source'] );
+	}
+
+	/**
+	 * Empty / non-list payloads return zero writes and do not error.
+	 */
+	public function test_ingest_models_payload_handles_empty_payloads(): void {
+		$this->assertSame( 0, ModelCapabilityHandler::ingest_models_payload( array() ) );
+		$this->assertSame( 0, ModelCapabilityHandler::ingest_models_payload( array( 'data' => array() ) ) );
+		$this->assertSame( 0, ModelCapabilityHandler::ingest_models_payload( array( 'data' => 'not-an-array' ) ) );
+	}
+
+	/**
+	 * The URL gate only accepts known LLM provider hosts whose path ends
+	 * with `/models`.
+	 */
+	public function test_is_models_endpoint_url_gate(): void {
+		// Allowed.
+		$this->assertTrue( ModelCapabilityHandler::is_models_endpoint( 'https://api.synthetic.new/openai/v1/models' ) );
+		$this->assertTrue( ModelCapabilityHandler::is_models_endpoint( 'https://api.synthetic.new/openai/v1/models/' ) );
+		$this->assertTrue( ModelCapabilityHandler::is_models_endpoint( 'https://api.openai.com/v1/models' ) );
+		$this->assertTrue( ModelCapabilityHandler::is_models_endpoint( 'https://openrouter.ai/api/v1/models' ) );
+		$this->assertTrue( ModelCapabilityHandler::is_models_endpoint( 'https://generativelanguage.googleapis.com/v1beta/models' ) );
+
+		// Wrong host.
+		$this->assertFalse( ModelCapabilityHandler::is_models_endpoint( 'https://example.com/v1/models' ) );
+
+		// Right host, wrong path (no /models suffix).
+		$this->assertFalse( ModelCapabilityHandler::is_models_endpoint( 'https://api.synthetic.new/openai/v1/chat/completions' ) );
+
+		// Garbage.
+		$this->assertFalse( ModelCapabilityHandler::is_models_endpoint( '' ) );
+		$this->assertFalse( ModelCapabilityHandler::is_models_endpoint( 'not-a-url' ) );
+	}
+
+	/**
+	 * capture_models_response() is read-only — it returns the input response
+	 * verbatim whether or not it ingests the body, and even when the URL
+	 * matches.
+	 */
+	public function test_capture_models_response_is_read_only(): void {
+		$handler = new ModelCapabilityHandler();
+
+		$body     = wp_json_encode(
+			array(
+				'data' => array(
+					array(
+						'id'                => 'hf:moonshotai/Kimi-K2.6',
+						'max_output_length' => 131072,
+						'context_length'    => 200000,
+					),
+				),
+			)
+		);
+		$response = array(
+			'response' => array( 'code' => 200, 'message' => 'OK' ),
+			'body'     => $body,
+			'headers'  => array(),
+		);
+
+		$returned = $handler->capture_models_response(
+			$response,
+			array(),
+			'https://api.synthetic.new/openai/v1/models'
+		);
+
+		$this->assertSame( $response, $returned );
+
+		// Side effect did fire.
+		$this->assertSame(
+			131072,
+			ModelCapabilityRegistry::get_max_output_tokens( 'hf:moonshotai/Kimi-K2.6' )
+		);
+	}
+
+	/**
+	 * Non-2xx responses are ignored — a 500 from a provider must never
+	 * overwrite a known-good cap.
+	 */
+	public function test_capture_models_response_ignores_error_status(): void {
+		ModelCapabilityRegistry::set( 'hf:moonshotai/Kimi-K2.6', 131072, 200000 );
+
+		$handler = new ModelCapabilityHandler();
+
+		$response = array(
+			'response' => array( 'code' => 500, 'message' => 'Server Error' ),
+			'body'     => wp_json_encode(
+				array(
+					'data' => array(
+						array(
+							'id'                => 'hf:moonshotai/Kimi-K2.6',
+							'max_output_length' => 0, // would be invalid anyway
+						),
+					),
+				)
+			),
+		);
+
+		$handler->capture_models_response(
+			$response,
+			array(),
+			'https://api.synthetic.new/openai/v1/models'
+		);
+
+		// Original cached value is preserved.
+		$this->assertSame(
+			131072,
+			ModelCapabilityRegistry::get_max_output_tokens( 'hf:moonshotai/Kimi-K2.6' )
+		);
+	}
+
+	/**
+	 * Responses for non-/models URLs (e.g. /chat/completions) are skipped
+	 * even when they happen to carry a `data` array — the URL gate prevents
+	 * other provider endpoints from leaking into the registry.
+	 */
+	public function test_capture_models_response_ignores_non_models_url(): void {
+		$handler = new ModelCapabilityHandler();
+
+		$response = array(
+			'response' => array( 'code' => 200 ),
+			'body'     => wp_json_encode(
+				array(
+					'data' => array(
+						array(
+							'id'                => 'should-not-be-cached',
+							'max_output_length' => 999999,
+						),
+					),
+				)
+			),
+		);
+
+		$handler->capture_models_response(
+			$response,
+			array(),
+			'https://api.synthetic.new/openai/v1/chat/completions'
+		);
+
+		$entry = ModelCapabilityRegistry::get( 'should-not-be-cached' );
+		$this->assertSame( ModelCapabilityRegistry::SOURCE_FALLBACK, $entry['source'] );
+	}
+
+	/**
+	 * WP_Error responses pass through untouched.
+	 */
+	public function test_capture_models_response_passes_wp_error(): void {
+		$handler = new ModelCapabilityHandler();
+
+		$wp_error = new \WP_Error( 'http_request_failed', 'cURL error 28' );
+
+		$returned = $handler->capture_models_response(
+			$wp_error,
+			array(),
+			'https://api.synthetic.new/openai/v1/models'
+		);
+
+		$this->assertSame( $wp_error, $returned );
+	}
+}

--- a/tests/SdAiAgent/Core/ModelCapabilityRegistryTest.php
+++ b/tests/SdAiAgent/Core/ModelCapabilityRegistryTest.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Tests for SdAiAgent\Core\ModelCapabilityRegistry — sd-ai-2zf.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\ModelCapabilityRegistry;
+use SdAiAgent\Core\Settings;
+use WP_UnitTestCase;
+
+/**
+ * Per-model capability registry: transient store, catalog fallback, and
+ * source markers.
+ */
+class ModelCapabilityRegistryTest extends WP_UnitTestCase {
+
+	private const TEST_MODELS = array(
+		'hf:moonshotai/Kimi-K2.6',
+		'hf:moonshotai/Kimi-K2.7',
+		'gpt-4o',
+		'unknown-provider-model-zzz',
+	);
+
+	/**
+	 * Forget any per-test registry writes so cases stay independent.
+	 */
+	public function tear_down(): void {
+		parent::tear_down();
+		foreach ( self::TEST_MODELS as $model_id ) {
+			ModelCapabilityRegistry::forget( $model_id );
+		}
+	}
+
+	/**
+	 * set() round-trips through get() with the provider source marker and
+	 * a positive fetched_at timestamp.
+	 */
+	public function test_set_then_get_round_trip(): void {
+		$before = time();
+		$ok     = ModelCapabilityRegistry::set( 'hf:moonshotai/Kimi-K2.6', 131072, 200000 );
+		$this->assertTrue( $ok );
+
+		$entry = ModelCapabilityRegistry::get( 'hf:moonshotai/Kimi-K2.6' );
+
+		$this->assertSame( 'hf:moonshotai/Kimi-K2.6', $entry['model_id'] );
+		$this->assertSame( 131072, $entry['max_output_tokens'] );
+		$this->assertSame( 200000, $entry['context_length'] );
+		$this->assertSame( ModelCapabilityRegistry::SOURCE_PROVIDER, $entry['source'] );
+		$this->assertGreaterThanOrEqual( $before, $entry['fetched_at'] );
+	}
+
+	/**
+	 * Bad inputs (empty model id, zero/negative max_output) return false and
+	 * write nothing.
+	 */
+	public function test_set_rejects_bad_inputs(): void {
+		$this->assertFalse( ModelCapabilityRegistry::set( '', 100, 0 ) );
+		$this->assertFalse( ModelCapabilityRegistry::set( 'gpt-4o', 0, 0 ) );
+		$this->assertFalse( ModelCapabilityRegistry::set( 'gpt-4o', -1, 0 ) );
+
+		// get_max_output_tokens returns the fallback (no transient written).
+		$this->assertSame(
+			Settings::MAX_OUTPUT_TOKENS_FALLBACK,
+			ModelCapabilityRegistry::get_max_output_tokens( 'unknown-provider-model-zzz' )
+		);
+	}
+
+	/**
+	 * Empty model id is normalised to the fallback in both accessors.
+	 */
+	public function test_empty_model_id_uses_fallback(): void {
+		$this->assertSame(
+			Settings::MAX_OUTPUT_TOKENS_FALLBACK,
+			ModelCapabilityRegistry::get_max_output_tokens( '' )
+		);
+
+		$entry = ModelCapabilityRegistry::get( '' );
+		$this->assertSame( 0, $entry['max_output_tokens'] );
+		$this->assertSame( ModelCapabilityRegistry::SOURCE_FALLBACK, $entry['source'] );
+	}
+
+	/**
+	 * With no transient written, get() falls back to the static catalog and
+	 * reports SOURCE_CATALOG so callers can tell live data from seeded data.
+	 */
+	public function test_get_falls_through_to_catalog(): void {
+		// Ensure no transient exists.
+		ModelCapabilityRegistry::forget( 'gpt-4o' );
+
+		$entry = ModelCapabilityRegistry::get( 'gpt-4o' );
+
+		$this->assertSame( 16384, $entry['max_output_tokens'] );
+		$this->assertSame( ModelCapabilityRegistry::SOURCE_CATALOG, $entry['source'] );
+		$this->assertSame( 0, $entry['fetched_at'] );
+	}
+
+	/**
+	 * Unknown model id (no transient, no catalog match) reports
+	 * SOURCE_FALLBACK and zero tokens.
+	 */
+	public function test_get_returns_fallback_for_unknown_model(): void {
+		$entry = ModelCapabilityRegistry::get( 'unknown-provider-model-zzz' );
+
+		$this->assertSame( 'unknown-provider-model-zzz', $entry['model_id'] );
+		$this->assertSame( 0, $entry['max_output_tokens'] );
+		$this->assertSame( ModelCapabilityRegistry::SOURCE_FALLBACK, $entry['source'] );
+
+		// But the int accessor still gives callers a safe non-zero value.
+		$this->assertSame(
+			Settings::MAX_OUTPUT_TOKENS_FALLBACK,
+			ModelCapabilityRegistry::get_max_output_tokens( 'unknown-provider-model-zzz' )
+		);
+	}
+
+	/**
+	 * forget() removes a previously written entry and returns true; a second
+	 * forget() returns false because nothing is left to delete.
+	 */
+	public function test_forget_clears_entry(): void {
+		ModelCapabilityRegistry::set( 'gpt-4o', 32768, 128000 );
+		$this->assertSame( 32768, ModelCapabilityRegistry::get_max_output_tokens( 'gpt-4o' ) );
+
+		$this->assertTrue( ModelCapabilityRegistry::forget( 'gpt-4o' ) );
+		$this->assertFalse( ModelCapabilityRegistry::forget( 'gpt-4o' ) );
+
+		// After forget, lookup falls through to the catalog (gpt-4o catalog
+		// value is 16384).
+		$this->assertSame( 16384, ModelCapabilityRegistry::get_max_output_tokens( 'gpt-4o' ) );
+	}
+
+	/**
+	 * transient_key() produces the documented prefix + md5(model_id) shape.
+	 * Tests rely on this for invalidation and inspection.
+	 */
+	public function test_transient_key_shape(): void {
+		$key = ModelCapabilityRegistry::transient_key( 'hf:moonshotai/Kimi-K2.6' );
+		$this->assertSame(
+			ModelCapabilityRegistry::TRANSIENT_PREFIX . md5( 'hf:moonshotai/Kimi-K2.6' ),
+			$key
+		);
+	}
+}

--- a/tests/SdAiAgent/Core/SettingsTest.php
+++ b/tests/SdAiAgent/Core/SettingsTest.php
@@ -9,6 +9,7 @@
 
 namespace SdAiAgent\Tests\Core;
 
+use SdAiAgent\Core\ModelCapabilityRegistry;
 use SdAiAgent\Core\Settings;
 use WP_UnitTestCase;
 
@@ -29,6 +30,19 @@ class SettingsTest extends WP_UnitTestCase {
 		parent::tear_down();
 		delete_option( Settings::OPTION_NAME );
 		delete_option( Settings::WOO_AUTO_ENABLED_OPTION );
+
+		// ModelCapabilityRegistry writes transients keyed by md5(model_id);
+		// clear the handful this suite touches so cases stay independent.
+		foreach (
+			array(
+				'gpt-4o',
+				'hf:moonshotai/Kimi-K2.6',
+				'hf:moonshotai/Kimi-K2.7',
+				'wholly-made-up-model-9000',
+			) as $model_id
+		) {
+			ModelCapabilityRegistry::forget( $model_id );
+		}
 	}
 
 	/**
@@ -320,5 +334,106 @@ class SettingsTest extends WP_UnitTestCase {
 			Settings::get_max_output_tokens_for_model( 'gpt-4o' )
 		);
 		remove_all_filters( 'sd_ai_agent_max_output_tokens_for_model' );
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// ModelCapabilityRegistry precedence — sd-ai-2zf
+	// ─────────────────────────────────────────────────────────────────────
+
+	/**
+	 * A live provider entry overrides the static catalog. Kimi K2.6 is in
+	 * the catalog at 65536, but if Synthetic later raises the cap to 131072
+	 * the registry must reflect the new value without a code change.
+	 */
+	public function test_registry_entry_overrides_static_catalog(): void {
+		// Verify catalog baseline.
+		$this->assertSame(
+			65536,
+			Settings::get_max_output_tokens_for_model( 'hf:moonshotai/Kimi-K2.6' )
+		);
+
+		// Provider /models response says 131072 — that wins.
+		ModelCapabilityRegistry::set( 'hf:moonshotai/Kimi-K2.6', 131072, 200000 );
+
+		$this->assertSame(
+			131072,
+			Settings::get_max_output_tokens_for_model( 'hf:moonshotai/Kimi-K2.6' )
+		);
+	}
+
+	/**
+	 * A registry value above {@see Settings::MAX_OUTPUT_TOKENS_CEILING} is
+	 * still clamped by the resolver. Defends against a misreported provider
+	 * payload (e.g. context length surfaced as max_output_length).
+	 */
+	public function test_registry_value_above_ceiling_is_clamped(): void {
+		ModelCapabilityRegistry::set( 'gpt-4o', 999999, 0 );
+
+		$this->assertSame(
+			Settings::MAX_OUTPUT_TOKENS_CEILING,
+			Settings::get_max_output_tokens_for_model( 'gpt-4o' )
+		);
+	}
+
+	/**
+	 * A model not in the catalog gets the registry value when one is
+	 * cached, and falls back to {@see Settings::MAX_OUTPUT_TOKENS_FALLBACK}
+	 * only when there is neither a catalog match nor a registry entry.
+	 */
+	public function test_registry_promotes_unknown_model_above_fallback(): void {
+		// Baseline: unknown HF model resolves via the broad `hf:` prefix
+		// (32768) — confirming the catalog hit path is intact.
+		$this->assertSame(
+			32768,
+			Settings::get_max_output_tokens_for_model( 'hf:moonshotai/Kimi-K2.7' )
+		);
+
+		// Provider response advertises 200000 — registry wins.
+		ModelCapabilityRegistry::set( 'hf:moonshotai/Kimi-K2.7', 200000, 256000 );
+
+		// Resolver result is the registry value, clamped to ceiling.
+		$this->assertSame(
+			Settings::MAX_OUTPUT_TOKENS_CEILING,
+			Settings::get_max_output_tokens_for_model( 'hf:moonshotai/Kimi-K2.7' )
+		);
+	}
+
+	/**
+	 * The `sd_ai_agent_max_output_tokens_for_model` filter still wins over
+	 * the registry — deployments must be able to pin a value no matter what
+	 * the provider advertises (e.g. cost control, output truncation tests).
+	 */
+	public function test_filter_overrides_registry(): void {
+		ModelCapabilityRegistry::set( 'hf:moonshotai/Kimi-K2.6', 131072, 200000 );
+
+		add_filter(
+			'sd_ai_agent_max_output_tokens_for_model',
+			static function ( $value, $model_id ) {
+				return 'hf:moonshotai/Kimi-K2.6' === $model_id ? 16384 : $value;
+			},
+			10,
+			2
+		);
+
+		$this->assertSame(
+			16384,
+			Settings::get_max_output_tokens_for_model( 'hf:moonshotai/Kimi-K2.6' )
+		);
+
+		remove_all_filters( 'sd_ai_agent_max_output_tokens_for_model' );
+	}
+
+	/**
+	 * resolve_max_output_tokens_from_catalog() is the pure static-catalog
+	 * lookup — used by the registry to consult the catalog without
+	 * re-entering the filterable resolver. Empty model id returns 0;
+	 * unknown model returns 0; known model returns the catalog value
+	 * unclamped (the resolver clamps).
+	 */
+	public function test_resolve_from_catalog_is_pure_lookup(): void {
+		$this->assertSame( 0, Settings::resolve_max_output_tokens_from_catalog( '' ) );
+		$this->assertSame( 0, Settings::resolve_max_output_tokens_from_catalog( 'wholly-made-up-model-9000' ) );
+		$this->assertSame( 16384, Settings::resolve_max_output_tokens_from_catalog( 'gpt-4o' ) );
+		$this->assertSame( 128000, Settings::resolve_max_output_tokens_from_catalog( 'claude-opus-4-7-20260513' ) );
 	}
 }


### PR DESCRIPTION
## Summary

Resolves the Kimi K2.6 (and broader Synthetic-hosted HF model) stall pattern by sourcing `max_output_tokens` from live provider `/models` responses instead of relying on the static catalog alone. Without this, the catalog drifts every time a provider bumps a model and stalls reappear (`finish_reason='length'` with empty content + zero tool_calls) until we ship a catalog update.

Resolves #sd-ai-2zf

## Architecture

New `SdAiAgent\Core\ModelCapabilityRegistry` is the per-model store. Transients keyed by `md5(model_id)` cache `{max_output_tokens, context_length, source, fetched_at}` for 7 days. Resolution order in the resolver:

1. **Live registry entry** (`SOURCE_PROVIDER`) — populated by the new HTTP handler.
2. **Static catalog** in `Settings::MODEL_MAX_OUTPUT_TOKENS` via the new `Settings::resolve_max_output_tokens_from_catalog()` pure helper (`SOURCE_CATALOG`).
3. **`Settings::MAX_OUTPUT_TOKENS_FALLBACK`** (8192, `SOURCE_FALLBACK`).

The `sd_ai_agent_max_output_tokens_for_model` filter still runs **last** so deployments retain the override they had before, and the ceiling clamp (`MAX_OUTPUT_TOKENS_CEILING = 131072`) defends against rogue payloads (e.g. a provider that surfaces context-length under the max-output key).

`SdAiAgent\Bootstrap\ModelCapabilityHandler` is a new DI handler that hooks `http_response` at **priority 9** — one slot ahead of `HttpTraceHandler` (priority 10) — so it captures the raw `/models` body **before** the upstream `ai-provider-for-any-compatible-endpoint` connector's `buildModelMetadataMapFromRaw()` strips `max_output_length` / `context_length` when constructing its `ModelMetadata` DTO. The filter is strictly read-only; `$response` is returned verbatim in every branch.

Host gating is an explicit allow list:

- `api.synthetic.new`, `api.openai.com`, `api.anthropic.com`
- `openrouter.ai`, `api.deepinfra.com`, `api.together.xyz`
- `api.fireworks.ai`, `api.groq.com`, `api.mistral.ai`
- `generativelanguage.googleapis.com`

Path match accepts any URL ending `/models` (after stripping a trailing slash), so `/v1/models`, `/openai/v1/models`, and `/v1beta/models` all qualify. Field resolution accepts:

- max-output: `max_output_length` → `max_output_tokens` → `max_completion_tokens`
- context: `context_length` → `context_window` → `context_size`

Both OpenAI-compatible `{data: [...]}` and Ollama `{models: [...]}` payload shapes are supported (matches the connector's own parser). Entries without an `id` or without a positive max-output value are **skipped** so zero-token rows cannot poison the registry.

## Why HTTP-response interception over connector patching

The connector strips the fields when constructing `ModelMetadata`. Extending the upstream DTO is deferred — that conversation belongs in `php-ai-client` proper, and we need a fix in this plugin today. Intercepting at `http_response` is the surgical fix: zero changes to upstream code, zero changes to the connector, the trace logger still sees the same body we did.

## Files

- `includes/Core/ModelCapabilityRegistry.php` (new)
- `includes/Bootstrap/ModelCapabilityHandler.php` (new)
- `includes/Core/Settings.php` — resolver now delegates to the registry; catalog logic extracted to `resolve_max_output_tokens_from_catalog()`.
- `includes/Plugin.php` — registers the handler immediately after `HttpTraceHandler`.

## Tests

- `tests/SdAiAgent/Core/SettingsTest.php` — new "ModelCapabilityRegistry precedence" block: registry overrides catalog, ceiling clamp still applies, registry promotes unknown models above fallback, filter wins last, pure-catalog helper.
- `tests/SdAiAgent/Core/ModelCapabilityRegistryTest.php` (new) — set/get round-trip, bad-input rejection, catalog/fallback source markers, `forget()` semantics, transient key shape.
- `tests/SdAiAgent/Bootstrap/ModelCapabilityHandlerTest.php` (new) — payload ingestion (Synthetic and Ollama shapes), invalid-entry skipping, URL gating (allowed/wrong host/wrong path/garbage), read-only filter contract, non-2xx ignored (a provider 500 cannot overwrite cached caps), non-`/models` URL skipped, `WP_Error` pass-through.

## Verification

- PHPCS clean (`vendor/bin/phpcs --standard=phpcs.xml` on all four changed `includes/` files).
- PHPStan level 10 clean (`composer phpstan` — `paths: includes + superdav-ai-agent.php`).
- Local PHPUnit skipped: wp-env is wedged in this worktree; CI runs PHPUnit on push.
- Commit-immediate workflow honored (three commits: registry foundation, handler + Plugin registration, tests).

## Backwards compatibility

Until a `/models` response is observed for a given model, every lookup falls through to the existing static catalog path. No behaviour change for catalog-known models; new behaviour kicks in only when a connector that hits an allow-listed host returns a payload with the right shape. The `sd_ai_agent_max_output_tokens_for_model` filter contract is unchanged.

## Follow-ups (separate issues)

- Manual-refresh: `wp sd-ai-agent model-caps {list,refresh,clear}` CLI to seed/inspect/invalidate entries without waiting for the next `/models` round-trip.
- Async refresh: `wp_schedule_single_event` on cache miss so the first request after expiry isn't blocked on a synchronous re-fetch.
- Upstream `php-ai-client` DTO extension to carry `maxOutputLength`/`contextLength` natively, replacing the `http_response` interception.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with claude-sonnet-4-6 spent 1d 9h and 383 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic detection and caching of language model capabilities (max output tokens, context length) from provider endpoints
  * Dynamic capability resolution with fallback to static configuration and sensible defaults
  * Improved model compatibility through intelligent capability validation

* **Tests**
  * Added comprehensive test coverage for capability detection, caching, and validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1471?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->