### PR TITLE
fix(providers): SDK dynamic model list beats static DIRECT_PROVIDERS fallback (sd-ai-aem)

### DIFF
--- a/includes/CLI/ModelsCommand.php
+++ b/includes/CLI/ModelsCommand.php
@@ -147,9 +147,12 @@ class ModelsCommand extends WP_CLI_Command {
 	/**
 	 * Fetch configured providers and their model lists.
 	 *
-	 * Mirrors the logic of SettingsController::handle_providers() but runs
-	 * entirely in-process without needing REST routes to be registered
-	 * (REST handlers are not loaded in CLI context).
+	 * Mirrors the logic of SettingsController::handle_providers() in-process
+	 * without needing REST routes to be registered (REST handlers are not
+	 * loaded in CLI context). Two-pass: WP SDK providers first (dynamic
+	 * `/models` listing — picks up new model families like gpt-5.x the
+	 * moment the provider publishes them), then DIRECT_PROVIDERS as a
+	 * fallback when the SDK can't enumerate. See bd:sd-ai-aem.
 	 *
 	 * @return list<array<string, mixed>>
 	 */
@@ -157,25 +160,7 @@ class ModelsCommand extends WP_CLI_Command {
 		$settings  = new Settings();
 		$providers = array();
 
-		// Built-in providers (OpenAI, Anthropic, Google) — only include when a
-		// WP 7.0 Connectors API key is set.
-		foreach ( Settings::DIRECT_PROVIDERS as $provider_id => $meta ) {
-			if ( '' === $settings->get_connectors_api_key( $provider_id ) ) {
-				continue;
-			}
-
-			$providers[] = array(
-				'id'         => $provider_id,
-				'name'       => $meta['name'],
-				'type'       => 'direct',
-				'configured' => true,
-				'models'     => $meta['models'] ?? array(),
-			);
-		}
-
-		$added_ids = array_column( $providers, 'id' );
-
-		// WP SDK providers (registered connectors, compatible endpoints, etc.).
+		// Pass 1: WP SDK providers (registered connectors, compatible endpoints, etc.).
 		if ( class_exists( '\\WordPress\\AiClient\\AiClient' ) ) {
 			$registry     = null;
 			$provider_ids = array();
@@ -188,7 +173,7 @@ class ModelsCommand extends WP_CLI_Command {
 			}
 
 			foreach ( $provider_ids as $provider_id ) {
-				if ( in_array( $provider_id, $added_ids, true ) || null === $registry ) {
+				if ( null === $registry ) {
 					continue;
 				}
 
@@ -234,7 +219,10 @@ class ModelsCommand extends WP_CLI_Command {
 								);
 							}
 						} catch ( \Throwable $e ) {
-							// Model listing failed — include provider without models.
+							// Model listing failed — provider stays registered
+							// but with no models; the DIRECT_PROVIDERS fallback
+							// below replaces the empty list when a Connectors
+							// key is set.
 						}
 					}
 
@@ -248,6 +236,43 @@ class ModelsCommand extends WP_CLI_Command {
 				} catch ( \Throwable $e ) {
 					continue;
 				}
+			}
+		}
+
+		// Pass 2: Built-in DIRECT_PROVIDERS static catalogue as a fallback for
+		// OpenAI / Anthropic / Google when the SDK didn't provide a populated
+		// model list. Requires a WP 7.0 Connectors API key for the provider.
+		foreach ( Settings::DIRECT_PROVIDERS as $provider_id => $meta ) {
+			if ( '' === $settings->get_connectors_api_key( $provider_id ) ) {
+				continue;
+			}
+
+			$existing_index = null;
+			$has_sdk_models = false;
+			foreach ( $providers as $i => $existing ) {
+				if ( $existing['id'] === $provider_id ) {
+					$existing_index = $i;
+					$has_sdk_models = ! empty( $existing['models'] );
+					break;
+				}
+			}
+
+			if ( $has_sdk_models ) {
+				continue;
+			}
+
+			$entry = array(
+				'id'         => $provider_id,
+				'name'       => $meta['name'],
+				'type'       => 'direct',
+				'configured' => true,
+				'models'     => $meta['models'] ?? array(),
+			);
+
+			if ( null !== $existing_index ) {
+				$providers[ $existing_index ] = $entry;
+			} else {
+				$providers[] = $entry;
 			}
 		}
 

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -699,6 +699,28 @@ final class SettingsController {
 	/**
 	 * Handle the /providers endpoint — list registered AI providers and models.
 	 *
+	 * Two-pass resolution:
+	 *
+	 *   Pass 1 — WP AI Client SDK registry. Third-party provider plugins
+	 *   (`ai-provider-for-openai`, `ai-provider-for-anthropic-max`, the
+	 *   OpenAI-compatible-endpoint connector, etc.) register here. The SDK
+	 *   queries the live provider `/models` endpoint, so its catalogue is
+	 *   always current — e.g. it surfaces newly released families like
+	 *   `gpt-5`, `gpt-5.4`, and `gpt-5.5` the moment OpenAI publishes them
+	 *   without any plugin update on our side.
+	 *
+	 *   Pass 2 — Built-in {@see Settings::DIRECT_PROVIDERS} static catalogue.
+	 *   Used as a fallback when, for OpenAI / Anthropic / Google, the SDK
+	 *   either didn't register the provider at all (no third-party plugin
+	 *   installed) or registered it but couldn't enumerate models (auth
+	 *   missing, network error). When a WP 7.0 Connectors API key is set,
+	 *   this guarantees the chat UI always sees a usable model dropdown.
+	 *
+	 * Inverting the order — running the SDK pass first and treating the static
+	 * catalogue as a true fallback — is deliberate: the previous "static first,
+	 * skip SDK on collision" arrangement suppressed the SDK's much larger
+	 * dynamic list whenever a Connectors key was present. See bd:sd-ai-aem.
+	 *
 	 * No caching layer is needed here: the underlying WP AI Client SDK already
 	 * caches `listModelMetadata()` results for 24 hours via
 	 * `AbstractApiBasedModelMetadataDirectory::getModelMetadataMap()`. Adding a
@@ -713,27 +735,12 @@ final class SettingsController {
 	public function handle_providers(): WP_REST_Response {
 		$providers = array();
 
-		// Built-in providers (OpenAI, Anthropic, Google) — listed first when a
-		// WP 7.0 Connectors API key is set, so sites without a third-party
-		// AI provider plugin still have a usable provider/model list.
-		foreach ( Settings::DIRECT_PROVIDERS as $provider_id => $meta ) {
-			$key = $this->settings->get_connectors_api_key( $provider_id );
-			if ( '' === $key ) {
-				continue;
-			}
-			$providers[] = array(
-				'id'         => $provider_id,
-				'name'       => $meta['name'],
-				'type'       => 'direct',
-				'configured' => true,
-				'models'     => $meta['models'],
-			);
-		}
-
-		// Collect IDs already added to avoid duplicates from the WP SDK registry.
-		$added_ids = array_column( $providers, 'id' );
-
-		// WP SDK providers (AI Experiments plugin, OpenAI-compatible connector, etc.).
+		// ─────────────────────────────────────────────────────────────
+		// Pass 1: WP SDK providers (third-party provider plugins, the
+		// OpenAI-compatible connector, etc.). Runs first so when a
+		// matching SDK provider is registered AND has auth, its dynamic
+		// list wins over the static DIRECT_PROVIDERS fallback below.
+		// ─────────────────────────────────────────────────────────────
 		if ( class_exists( '\\WordPress\\AiClient\\AiClient' ) ) {
 			$registry     = null;
 			$provider_ids = array();
@@ -744,15 +751,10 @@ final class SettingsController {
 				$provider_ids = array();
 			}
 
-			// Ensure credentials are loaded
+			// Ensure credentials are loaded.
 			ProviderCredentialLoader::load();
 
 			foreach ( $provider_ids as $provider_id ) {
-				// Skip if already added as a direct provider.
-				if ( in_array( $provider_id, $added_ids, true ) ) {
-					continue;
-				}
-
 				if ( null === $registry ) {
 					continue;
 				}
@@ -807,7 +809,10 @@ final class SettingsController {
 								);
 							}
 						} catch ( \Throwable $e ) {
-							// Model listing failed — still include the provider.
+							// Model listing failed — provider still registered;
+							// DIRECT_PROVIDERS fallback below replaces an empty
+							// list when a Connectors key is set so the UI keeps
+							// a usable dropdown.
 						}
 					}
 
@@ -821,6 +826,55 @@ final class SettingsController {
 				} catch ( \Throwable $e ) {
 					continue;
 				}
+			}
+		}
+
+		// ─────────────────────────────────────────────────────────────
+		// Pass 2: Built-in DIRECT_PROVIDERS static catalogue.
+		//
+		// Acts as a fallback for OpenAI / Anthropic / Google when either
+		// no third-party SDK plugin is installed for that provider, or
+		// the SDK plugin is installed but enumeration returned an empty
+		// list (transient API failure, missing auth, etc.).
+		//
+		// Requires a WP 7.0 Connectors API key for the provider — the
+		// catalogue is metadata only, not a credential source, so without
+		// a key there is nothing usable to add.
+		// ─────────────────────────────────────────────────────────────
+		foreach ( Settings::DIRECT_PROVIDERS as $provider_id => $meta ) {
+			$key = $this->settings->get_connectors_api_key( $provider_id );
+			if ( '' === $key ) {
+				continue;
+			}
+
+			$existing_index = null;
+			$has_sdk_models = false;
+			foreach ( $providers as $i => $existing ) {
+				if ( $existing['id'] === $provider_id ) {
+					$existing_index = $i;
+					$has_sdk_models = ! empty( $existing['models'] );
+					break;
+				}
+			}
+
+			// SDK already returned a populated list — prefer it.
+			if ( $has_sdk_models ) {
+				continue;
+			}
+
+			$entry = array(
+				'id'         => $provider_id,
+				'name'       => $meta['name'],
+				'type'       => 'direct',
+				'configured' => true,
+				'models'     => $meta['models'],
+			);
+
+			if ( null !== $existing_index ) {
+				// Replace the empty SDK entry with the static catalogue.
+				$providers[ $existing_index ] = $entry;
+			} else {
+				$providers[] = $entry;
 			}
 		}
 


### PR DESCRIPTION
## Summary

`/providers` and `wp sd-ai-agent models` were exposing only the 11 static
entries from `Settings::DIRECT_PROVIDERS['openai']` whenever a WP 7.0
Connectors OpenAI key was set — hiding the entire `gpt-5`, `gpt-5.4`,
and `gpt-5.5` family (and 100+ other models) that the SDK already
surfaces via `ai-provider-for-openai`.

This PR inverts the precedence so the WP AI Client SDK runs first and
the static catalogue becomes a true fallback used only when the SDK
can't enumerate models.

Resolves bd:sd-ai-aem.

## Root cause

`SettingsController::handle_providers()` and the mirrored
`CLI/ModelsCommand::fetch_providers()` added `DIRECT_PROVIDERS` entries
first and then skipped any SDK provider whose id was already in
`$added_ids`:

```php
foreach ( Settings::DIRECT_PROVIDERS as $provider_id => $meta ) {
    if ( '' !== $this->settings->get_connectors_api_key( $provider_id ) ) {
        $providers[] = [ 'id' => $provider_id, 'models' => $meta['models'], ... ];
    }
}
$added_ids = array_column( $providers, 'id' );

foreach ( $registry->getRegisteredProviderIds() as $provider_id ) {
    if ( in_array( $provider_id, $added_ids, true ) ) {
        continue;   // SDK 'openai' suppressed by static entry
    }
    ...
}
```

`ai-provider-for-openai` registers its SDK provider as `id => 'openai'`
(matching the `DIRECT_PROVIDERS['openai']` key in `Settings.php`), so any
site with both a Connectors OpenAI key set and the plugin active sees
the SDK's dynamic catalogue suppressed entirely.

The regression slipped in after #1336 switched the DIRECT_PROVIDERS
guard from `get_provider_key()` (old `sd_ai_agent_provider_keys` option,
rarely populated) to `get_connectors_api_key()` (WP 7.0 Connectors
options, populated by the new built-in connectors admin UI). With the
new guard returning truthy on any site that has set up Connectors, the
suppression now fires routinely instead of being a rare edge case.

## Fix

Two-pass resolution:

1. **Pass 1 — WP AI Client SDK** (third-party provider plugins, the
   OpenAI-compatible connector, etc.). The SDK queries the live provider
   `/models` endpoint and gets the current catalogue, so it surfaces
   newly released families like `gpt-5.x` the moment they're published.

2. **Pass 2 — DIRECT_PROVIDERS static catalogue**. Used as a fallback
   for OpenAI / Anthropic / Google when either no third-party SDK plugin
   is installed for that provider, or the SDK plugin is installed but
   enumeration returned an empty list (auth missing, network error).
   Replaces an empty SDK entry when a Connectors key is set so the chat
   UI keeps a usable dropdown.

## Verification

End-to-end on a live install with `ai-provider-for-openai` active and
`connectors_ai_openai_api_key` set:

```
Before: openai provider type=direct models=11   (gpt-4.1*/gpt-4o*/o1-o4)
After:  openai provider type=cloud  models=128  (gpt-5.5, gpt-5.4, gpt-5,
        gpt-5-codex, gpt-5-pro, gpt-4.1*, gpt-4o*, o1-o4, ...)
```

Fallback path verified by simulating the SDK with no `openai`
registered (reflection-poke at `\WordPress\AiClient\AiClient::defaultRegistry()->registeredIdsToClassNames`):
returns the 11-entry DIRECT_PROVIDERS static list with `type=direct`,
exactly as before.

CLI mirror verified:

```
$ wp sd-ai-agent models --provider=openai
id                            name                          context_window
gpt-5.5                       gpt-5.5                       128,000
gpt-5.5-pro                   gpt-5.5-pro                   128,000
gpt-5.4                       gpt-5.4                       128,000
gpt-5.4-mini                  gpt-5.4-mini                  128,000
...
```

## Quality gates

- `composer phpcs -- includes/REST/SettingsController.php includes/CLI/ModelsCommand.php` — clean
- `vendor/bin/phpstan analyse --memory-limit=512M includes/REST/SettingsController.php includes/CLI/ModelsCommand.php` — no errors
- `vendor/bin/phpunit --filter ModelsCommandTest` — OK (1 test, 3 assertions)
- `vendor/bin/phpunit --filter SettingsTest` — OK (19 tests, 61 assertions)

## Files touched

- `includes/REST/SettingsController.php` — `handle_providers()`
- `includes/CLI/ModelsCommand.php` — `fetch_providers()`

No tests added: the new behaviour is verified end-to-end via `wp eval`
and `wp sd-ai-agent models`, and meaningfully unit-testing
`handle_providers()` requires bootstrapping the WP AI Client SDK
registry with mock providers — infrastructure the existing tests don't
have. The PR locks in the contract through detailed docblocks instead.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with claude-sonnet-4-6 spent 1d 9h and 383 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI provider discovery reliability with a two-pass mechanism: primary discovery attempts to fetch models from the WordPress AI SDK registry, with a fallback to built-in provider catalog when initial discovery fails or returns empty results.
  * Enhanced handling of OpenAI-compatible connectors and provider credentials validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1472?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->