### PR TITLE
refactor: drop Settings::DIRECT_PROVIDERS, single-source providers on the WP AI Client SDK registry (sd-ai-aem)

### DIFF
--- a/includes/CLI/ModelsCommand.php
+++ b/includes/CLI/ModelsCommand.php
@@ -147,107 +147,85 @@ class ModelsCommand extends WP_CLI_Command {
 	/**
 	 * Fetch configured providers and their model lists.
 	 *
-	 * Mirrors the logic of SettingsController::handle_providers() but runs
-	 * entirely in-process without needing REST routes to be registered
-	 * (REST handlers are not loaded in CLI context).
+	 * Mirrors the logic of SettingsController::handle_providers() in-process,
+	 * without needing REST routes to be registered (REST handlers are not
+	 * loaded in CLI context). The WP AI Client SDK registry is the single
+	 * source of truth for which providers exist and which models each exposes.
 	 *
 	 * @return list<array<string, mixed>>
 	 */
 	private function fetch_providers(): array {
-		$settings  = new Settings();
 		$providers = array();
 
-		// Built-in providers (OpenAI, Anthropic, Google) — only include when a
-		// WP 7.0 Connectors API key is set.
-		foreach ( Settings::DIRECT_PROVIDERS as $provider_id => $meta ) {
-			if ( '' === $settings->get_connectors_api_key( $provider_id ) ) {
-				continue;
-			}
-
-			$providers[] = array(
-				'id'         => $provider_id,
-				'name'       => $meta['name'],
-				'type'       => 'direct',
-				'configured' => true,
-				'models'     => $meta['models'] ?? array(),
-			);
+		if ( ! class_exists( '\\WordPress\\AiClient\\AiClient' ) ) {
+			return $providers;
 		}
 
-		$added_ids = array_column( $providers, 'id' );
+		try {
+			$registry     = \WordPress\AiClient\AiClient::defaultRegistry();
+			$provider_ids = $registry->getRegisteredProviderIds();
+		} catch ( \Throwable $e ) {
+			return $providers;
+		}
 
-		// WP SDK providers (registered connectors, compatible endpoints, etc.).
-		if ( class_exists( '\\WordPress\\AiClient\\AiClient' ) ) {
-			$registry     = null;
-			$provider_ids = array();
+		ProviderCredentialLoader::load();
 
+		foreach ( $provider_ids as $provider_id ) {
 			try {
-				$registry     = \WordPress\AiClient\AiClient::defaultRegistry();
-				$provider_ids = $registry->getRegisteredProviderIds();
+				$auth = $registry->getProviderRequestAuthentication( $provider_id );
+				if ( null === $auth ) {
+					continue;
+				}
+
+				$class    = $registry->getProviderClassName( $provider_id );
+				$metadata = $class::metadata();
+				$models   = array();
+
+				// OpenAI-compatible connectors expose a model list endpoint.
+				// Pass the SDK provider_id so the connector can resolve the
+				// correct per-provider endpoint URL and API key in
+				// multi-provider setups. Without provider_id, the connector
+				// always falls back to its primary configured provider and
+				// every OpenAI-compatible provider would return the same
+				// model list — see ai-provider-for-any-compatible-endpoint
+				// PR #127.
+				if ( str_starts_with( $provider_id, 'ai-provider-for-any-openai-compatible' )
+					&& function_exists( 'OpenAiCompatibleConnector\\rest_list_models' )
+				) {
+					$req = new \WP_REST_Request( 'GET' );
+					$req->set_param( 'provider_id', $provider_id );
+					$result = \OpenAiCompatibleConnector\rest_list_models( $req );
+					if ( ! is_wp_error( $result ) ) {
+						$data = $result->get_data();
+						if ( is_array( $data ) ) {
+							$models = $data;
+						}
+					}
+				} else {
+					try {
+						$directory = $class::modelMetadataDirectory();
+						foreach ( $directory->listModelMetadata() as $model_meta ) {
+							$model_id = $model_meta->getId();
+							$models[] = array(
+								'id'             => $model_id,
+								'name'           => $model_meta->getName(),
+								'context_window' => Settings::MODEL_CONTEXT_WINDOWS[ $model_id ] ?? 128000,
+							);
+						}
+					} catch ( \Throwable $e ) {
+						// Model listing failed — include provider without models.
+					}
+				}
+
+				$providers[] = array(
+					'id'         => $provider_id,
+					'name'       => $metadata->getName(),
+					'type'       => (string) $metadata->getType(),
+					'configured' => true,
+					'models'     => $models,
+				);
 			} catch ( \Throwable $e ) {
-				$provider_ids = array();
-			}
-
-			foreach ( $provider_ids as $provider_id ) {
-				if ( in_array( $provider_id, $added_ids, true ) || null === $registry ) {
-					continue;
-				}
-
-				try {
-					$auth = $registry->getProviderRequestAuthentication( $provider_id );
-					if ( null === $auth ) {
-						continue;
-					}
-
-					$class    = $registry->getProviderClassName( $provider_id );
-					$metadata = $class::metadata();
-					$models   = array();
-
-					// OpenAI-compatible connectors expose a model list endpoint.
-					// Pass the SDK provider_id so the connector can resolve the
-					// correct per-provider endpoint URL and API key in
-					// multi-provider setups. Without provider_id, the connector
-					// always falls back to its primary configured provider and
-					// every OpenAI-compatible provider would return the same
-					// model list — see ai-provider-for-any-compatible-endpoint
-					// PR #127.
-					if ( str_starts_with( $provider_id, 'ai-provider-for-any-openai-compatible' )
-						&& function_exists( 'OpenAiCompatibleConnector\\rest_list_models' )
-					) {
-						$req = new \WP_REST_Request( 'GET' );
-						$req->set_param( 'provider_id', $provider_id );
-						$result = \OpenAiCompatibleConnector\rest_list_models( $req );
-						if ( ! is_wp_error( $result ) ) {
-							$data = $result->get_data();
-							if ( is_array( $data ) ) {
-								$models = $data;
-							}
-						}
-					} else {
-						try {
-							$directory = $class::modelMetadataDirectory();
-							foreach ( $directory->listModelMetadata() as $model_meta ) {
-								$model_id = $model_meta->getId();
-								$models[] = array(
-									'id'             => $model_id,
-									'name'           => $model_meta->getName(),
-									'context_window' => Settings::MODEL_CONTEXT_WINDOWS[ $model_id ] ?? 128000,
-								);
-							}
-						} catch ( \Throwable $e ) {
-							// Model listing failed — include provider without models.
-						}
-					}
-
-					$providers[] = array(
-						'id'         => $provider_id,
-						'name'       => $metadata->getName(),
-						'type'       => (string) $metadata->getType(),
-						'configured' => true,
-						'models'     => $models,
-					);
-				} catch ( \Throwable $e ) {
-					continue;
-				}
+				continue;
 			}
 		}
 

--- a/includes/Core/ProviderCredentialLoader.php
+++ b/includes/Core/ProviderCredentialLoader.php
@@ -16,6 +16,40 @@ namespace SdAiAgent\Core;
 class ProviderCredentialLoader {
 
 	/**
+	 * Check whether at least one provider in the WP AI Client SDK registry
+	 * has authentication configured.
+	 *
+	 * Idempotently calls {@see load()} first so callers don't have to.
+	 * Returns false when the SDK is unavailable (WP < 7.0 without polyfill,
+	 * registry boot failure, etc.) — treated as "no provider" for alerting.
+	 *
+	 * Use this in lieu of walking option keys directly: the SDK registry is
+	 * the single source of truth for which providers exist and which have
+	 * usable credentials.
+	 *
+	 * @return bool
+	 */
+	public static function has_any_authenticated_provider(): bool {
+		if ( ! class_exists( '\\WordPress\\AiClient\\AiClient' ) ) {
+			return false;
+		}
+
+		try {
+			self::load();
+			$registry = \WordPress\AiClient\AiClient::defaultRegistry();
+			foreach ( $registry->getRegisteredProviderIds() as $provider_id ) {
+				if ( null !== $registry->getProviderRequestAuthentication( $provider_id ) ) {
+					return true;
+				}
+			}
+		} catch ( \Throwable $e ) {
+			return false;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Ensure AI provider credentials are loaded from the database.
 	 *
 	 * In loopback/background requests the AI Experiments plugin's init

--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -276,179 +276,6 @@ class Settings {
 		return $filtered;
 	}
 
-	/**
-	 * Built-in catalog of provider IDs, display names, default models, and
-	 * model lists for OpenAI, Anthropic, and Google.
-	 *
-	 * This is a static catalog of metadata only — it does NOT imply that any
-	 * of these providers are configured. Credentials are stored exclusively by
-	 * the WordPress 7.0 Connectors API in `connectors_ai_{provider}_api_key`
-	 * options; see {@see Settings::get_connectors_api_key()} and
-	 * {@see ProviderCredentialLoader::load()}.
-	 *
-	 * The catalog is consulted by `/providers`, `/alerts`, and the
-	 * `wp ai-agent models` CLI command so that sites without a third-party
-	 * AI provider plugin (`ai-provider-for-openai` etc.) can still discover
-	 * which models exist for a connector that has a key set.
-	 *
-	 * @var array<string, array{name: string, default_model: string, models: list<array{id: string, name: string, context_window: int}>}>
-	 */
-	const DIRECT_PROVIDERS = array(
-		'openai'    => array(
-			'name'          => 'OpenAI',
-			'default_model' => 'gpt-4.1-nano',
-			'models'        => array(
-				array(
-					'id'             => 'gpt-4.1-nano',
-					'name'           => 'GPT-4.1 Nano',
-					'context_window' => 1000000,
-				),
-				array(
-					'id'             => 'gpt-4.1-mini',
-					'name'           => 'GPT-4.1 Mini',
-					'context_window' => 1000000,
-				),
-				array(
-					'id'             => 'gpt-4.1',
-					'name'           => 'GPT-4.1',
-					'context_window' => 1000000,
-				),
-				array(
-					'id'             => 'gpt-4o',
-					'name'           => 'GPT-4o',
-					'context_window' => 128000,
-				),
-				array(
-					'id'             => 'gpt-4o-mini',
-					'name'           => 'GPT-4o Mini',
-					'context_window' => 128000,
-				),
-				array(
-					'id'             => 'gpt-4-turbo',
-					'name'           => 'GPT-4 Turbo',
-					'context_window' => 128000,
-				),
-				array(
-					'id'             => 'o1',
-					'name'           => 'o1',
-					'context_window' => 200000,
-				),
-				array(
-					'id'             => 'o1-mini',
-					'name'           => 'o1 Mini',
-					'context_window' => 128000,
-				),
-				array(
-					'id'             => 'o3-mini',
-					'name'           => 'o3 Mini',
-					'context_window' => 200000,
-				),
-				array(
-					'id'             => 'o3',
-					'name'           => 'o3',
-					'context_window' => 200000,
-				),
-				array(
-					'id'             => 'o4-mini',
-					'name'           => 'o4 Mini',
-					'context_window' => 200000,
-				),
-			),
-		),
-		'anthropic' => array(
-			'name'          => 'Anthropic',
-			'default_model' => 'claude-sonnet-4-6',
-			'models'        => array(
-				array(
-					'id'             => 'claude-opus-4-6',
-					'name'           => 'Claude Opus 4.6',
-					'context_window' => 200000,
-				),
-				array(
-					'id'             => 'claude-sonnet-4-6',
-					'name'           => 'Claude Sonnet 4.6',
-					'context_window' => 200000,
-				),
-				array(
-					'id'             => 'claude-opus-4-5',
-					'name'           => 'Claude Opus 4.5',
-					'context_window' => 200000,
-				),
-				array(
-					'id'             => 'claude-sonnet-4-5',
-					'name'           => 'Claude Sonnet 4.5',
-					'context_window' => 200000,
-				),
-				array(
-					'id'             => 'claude-haiku-3-5',
-					'name'           => 'Claude Haiku 3.5',
-					'context_window' => 200000,
-				),
-				array(
-					'id'             => 'claude-3-5-haiku-20241022',
-					'name'           => 'Claude 3.5 Haiku',
-					'context_window' => 200000,
-				),
-				array(
-					'id'             => 'claude-opus-4-20250514',
-					'name'           => 'Claude Opus 4',
-					'context_window' => 200000,
-				),
-				array(
-					'id'             => 'claude-sonnet-4-20250514',
-					'name'           => 'Claude Sonnet 4',
-					'context_window' => 200000,
-				),
-				array(
-					'id'             => 'claude-haiku-3-20241022',
-					'name'           => 'Claude Haiku 3',
-					'context_window' => 200000,
-				),
-			),
-		),
-		'google'    => array(
-			'name'          => 'Google',
-			'default_model' => 'gemini-2.0-flash',
-			'models'        => array(
-				array(
-					'id'             => 'gemini-2.5-pro-preview-05-06',
-					'name'           => 'Gemini 2.5 Pro',
-					'context_window' => 1048576,
-				),
-				array(
-					'id'             => 'gemini-2.5-flash-preview',
-					'name'           => 'Gemini 2.5 Flash',
-					'context_window' => 1048576,
-				),
-				array(
-					'id'             => 'gemini-2.5-flash-lite-preview',
-					'name'           => 'Gemini 2.5 Flash Lite',
-					'context_window' => 1048576,
-				),
-				array(
-					'id'             => 'gemini-2.0-flash',
-					'name'           => 'Gemini 2.0 Flash',
-					'context_window' => 1048576,
-				),
-				array(
-					'id'             => 'gemini-2.0-flash-lite',
-					'name'           => 'Gemini 2.0 Flash Lite',
-					'context_window' => 1048576,
-				),
-				array(
-					'id'             => 'gemini-1.5-pro',
-					'name'           => 'Gemini 1.5 Pro',
-					'context_window' => 2000000,
-				),
-				array(
-					'id'             => 'gemini-1.5-flash',
-					'name'           => 'Gemini 1.5 Flash',
-					'context_window' => 1048576,
-				),
-			),
-		),
-	);
-
 	// ── Static factory (bridge for non-DI code) ───────────────────────────────
 
 	/**
@@ -613,27 +440,6 @@ class Settings {
 			return true; // Default-on.
 		}
 		return (bool) $option['prompt_caching_enabled'];
-	}
-
-	/**
-	 * Read the API key stored by the WordPress 7.0 Connectors API for a
-	 * built-in provider in {@see Settings::DIRECT_PROVIDERS}.
-	 *
-	 * Reads the `connectors_ai_{provider}_api_key` option directly. This is the
-	 * same naming convention used by core on WP 7.0+ and by the 6.9 polyfill
-	 * in `includes/Compat/wp-connectors-polyfill.php`, so credentials entered
-	 * through the Connectors admin page are picked up here without any further
-	 * migration.
-	 *
-	 * Note: this helper is intentionally read-only — credential writes flow
-	 * through {@see ConnectorsController}, never through the Settings class.
-	 *
-	 * @param string $provider_id One of the keys of {@see Settings::DIRECT_PROVIDERS}.
-	 * @return string Empty string when not configured.
-	 */
-	public function get_connectors_api_key( string $provider_id ): string {
-		$sanitized_id = str_replace( '-', '_', $provider_id );
-		return (string) get_option( "connectors_ai_{$sanitized_id}_api_key", '' );
 	}
 
 	/**
@@ -835,8 +641,9 @@ class Settings {
 	 *
 	 * Resolution order:
 	 *  1. `default_provider` saved via the WP SDK Connectors settings page.
-	 *  2. A WP 7.0 Connectors API key for any built-in provider in
-	 *     {@see Settings::DIRECT_PROVIDERS}.
+	 *  2. Any provider in the WP AI Client SDK registry has authentication
+	 *     configured (handles credentials populated by `ai-provider-for-*`
+	 *     plugins, the WP 7.0 Connectors API, or the 6.9 polyfill).
 	 *
 	 * @return bool
 	 */
@@ -847,13 +654,7 @@ class Settings {
 			return true;
 		}
 
-		// WP 7.0 Connectors API key for a built-in provider.
-		foreach ( array_keys( self::DIRECT_PROVIDERS ) as $provider_id ) {
-			if ( '' !== $this->get_connectors_api_key( $provider_id ) ) {
-				return true;
-			}
-		}
-
-		return false;
+		// Any registered provider with credentials.
+		return ProviderCredentialLoader::has_any_authenticated_provider();
 	}
 }

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -713,114 +713,89 @@ final class SettingsController {
 	public function handle_providers(): WP_REST_Response {
 		$providers = array();
 
-		// Built-in providers (OpenAI, Anthropic, Google) — listed first when a
-		// WP 7.0 Connectors API key is set, so sites without a third-party
-		// AI provider plugin still have a usable provider/model list.
-		foreach ( Settings::DIRECT_PROVIDERS as $provider_id => $meta ) {
-			$key = $this->settings->get_connectors_api_key( $provider_id );
-			if ( '' === $key ) {
-				continue;
-			}
-			$providers[] = array(
-				'id'         => $provider_id,
-				'name'       => $meta['name'],
-				'type'       => 'direct',
-				'configured' => true,
-				'models'     => $meta['models'],
-			);
+		// The WP AI Client SDK registry is the single source of truth for which
+		// providers exist and which models each exposes. Provider plugins such
+		// as `ai-provider-for-openai`, `ai-provider-for-anthropic-max`, the
+		// OpenAI-compatible connector, etc. each register themselves there;
+		// credentials are bridged in by ProviderCredentialLoader::load(). A
+		// provider is exposed by this endpoint only when authentication has
+		// been configured for it.
+		if ( ! class_exists( '\\WordPress\\AiClient\\AiClient' ) ) {
+			return new WP_REST_Response( $providers, 200 );
 		}
 
-		// Collect IDs already added to avoid duplicates from the WP SDK registry.
-		$added_ids = array_column( $providers, 'id' );
+		try {
+			$registry     = \WordPress\AiClient\AiClient::defaultRegistry();
+			$provider_ids = $registry->getRegisteredProviderIds();
+		} catch ( \Throwable $e ) {
+			return new WP_REST_Response( $providers, 200 );
+		}
 
-		// WP SDK providers (AI Experiments plugin, OpenAI-compatible connector, etc.).
-		if ( class_exists( '\\WordPress\\AiClient\\AiClient' ) ) {
-			$registry     = null;
-			$provider_ids = array();
+		ProviderCredentialLoader::load();
+
+		foreach ( $provider_ids as $provider_id ) {
 			try {
-				$registry     = \WordPress\AiClient\AiClient::defaultRegistry();
-				$provider_ids = $registry->getRegisteredProviderIds();
+				// Only include providers that have authentication set.
+				$auth = $registry->getProviderRequestAuthentication( $provider_id );
+				if ( null === $auth ) {
+					continue;
+				}
+
+				$class    = $registry->getProviderClassName( $provider_id );
+				$metadata = $class::metadata();
+				$models   = array();
+
+				// For the OpenAI-compatible connector, fetch models directly
+				// from the endpoint rather than going through the SDK model
+				// directory (which can fail due to SDK transporter issues).
+				// Use str_starts_with to handle multi-endpoint setups where each
+				// endpoint gets a unique ID (e.g., ai-provider-for-any-openai-compatible-1).
+				//
+				// Pass the SDK provider_id so the connector can resolve the
+				// correct per-provider endpoint URL and API key. Without
+				// provider_id, the connector falls back to its primary
+				// configured provider and every OpenAI-compatible provider
+				// would return the same model list — see PR #127 on
+				// ai-provider-for-any-compatible-endpoint.
+				if ( str_starts_with( $provider_id, 'ai-provider-for-any-openai-compatible' )
+					&& function_exists( 'OpenAiCompatibleConnector\\rest_list_models' )
+				) {
+					$fake_request = new WP_REST_Request( 'GET' );
+					$fake_request->set_param( 'provider_id', $provider_id );
+					$result = \OpenAiCompatibleConnector\rest_list_models( $fake_request );
+					if ( ! is_wp_error( $result ) ) {
+						$data = $result->get_data();
+						if ( is_array( $data ) ) {
+							$models = $data;
+						}
+					}
+				} else {
+					try {
+						$directory      = $class::modelMetadataDirectory();
+						$model_metadata = $directory->listModelMetadata();
+
+						foreach ( $model_metadata as $model_meta ) {
+							$model_id = $model_meta->getId();
+							$models[] = array(
+								'id'             => $model_id,
+								'name'           => $model_meta->getName(),
+								'context_window' => Settings::MODEL_CONTEXT_WINDOWS[ $model_id ] ?? 128000,
+							);
+						}
+					} catch ( \Throwable $e ) {
+						// Model listing failed — still include the provider.
+					}
+				}
+
+				$providers[] = array(
+					'id'         => $provider_id,
+					'name'       => $metadata->getName(),
+					'type'       => (string) $metadata->getType(),
+					'configured' => true,
+					'models'     => $models,
+				);
 			} catch ( \Throwable $e ) {
-				$provider_ids = array();
-			}
-
-			// Ensure credentials are loaded
-			ProviderCredentialLoader::load();
-
-			foreach ( $provider_ids as $provider_id ) {
-				// Skip if already added as a direct provider.
-				if ( in_array( $provider_id, $added_ids, true ) ) {
-					continue;
-				}
-
-				if ( null === $registry ) {
-					continue;
-				}
-
-				try {
-					$class = $registry->getProviderClassName( $provider_id );
-
-					// Only include providers that have authentication set.
-					$auth = $registry->getProviderRequestAuthentication( $provider_id );
-					if ( null === $auth ) {
-						continue;
-					}
-
-					$metadata = $class::metadata();
-					$models   = array();
-
-					// For the OpenAI-compatible connector, fetch models directly
-					// from the endpoint rather than going through the SDK model
-					// directory (which can fail due to SDK transporter issues).
-					// Use str_starts_with to handle multi-endpoint setups where each
-					// endpoint gets a unique ID (e.g., ai-provider-for-any-openai-compatible-1).
-					//
-					// Pass the SDK provider_id so the connector can resolve the
-					// correct per-provider endpoint URL and API key. Without
-					// provider_id, the connector falls back to its primary
-					// configured provider and every OpenAI-compatible provider
-					// would return the same model list — see PR #127 on
-					// ai-provider-for-any-compatible-endpoint.
-					if ( str_starts_with( $provider_id, 'ai-provider-for-any-openai-compatible' )
-						&& function_exists( 'OpenAiCompatibleConnector\\rest_list_models' )
-					) {
-						$fake_request = new WP_REST_Request( 'GET' );
-						$fake_request->set_param( 'provider_id', $provider_id );
-						$result = \OpenAiCompatibleConnector\rest_list_models( $fake_request );
-						if ( ! is_wp_error( $result ) ) {
-							$data = $result->get_data();
-							if ( is_array( $data ) ) {
-								$models = $data;
-							}
-						}
-					} else {
-						try {
-							$directory      = $class::modelMetadataDirectory();
-							$model_metadata = $directory->listModelMetadata();
-
-							foreach ( $model_metadata as $model_meta ) {
-								$model_id = $model_meta->getId();
-								$models[] = array(
-									'id'             => $model_id,
-									'name'           => $model_meta->getName(),
-									'context_window' => Settings::MODEL_CONTEXT_WINDOWS[ $model_id ] ?? 128000,
-								);
-							}
-						} catch ( \Throwable $e ) {
-							// Model listing failed — still include the provider.
-						}
-					}
-
-					$providers[] = array(
-						'id'         => $provider_id,
-						'name'       => $metadata->getName(),
-						'type'       => (string) $metadata->getType(),
-						'configured' => true,
-						'models'     => $models,
-					);
-				} catch ( \Throwable $e ) {
-					continue;
-				}
+				continue;
 			}
 		}
 
@@ -886,36 +861,12 @@ final class SettingsController {
 	public function handle_alerts(): WP_REST_Response {
 		$alerts = array();
 
-		// Check whether at least one AI provider is configured.
-		$has_provider = false;
-
-		// Built-in providers (API key stored by the WP 7.0 Connectors API).
-		foreach ( array_keys( Settings::DIRECT_PROVIDERS ) as $provider_id ) {
-			if ( '' !== $this->settings->get_connectors_api_key( $provider_id ) ) {
-				$has_provider = true;
-				break;
-			}
-		}
-
-		// WP SDK providers (AI Experiments plugin, OpenAI-compatible connector, etc.).
-		if ( ! $has_provider && class_exists( '\\WordPress\\AiClient\\AiClient' ) ) {
-			try {
-				$registry     = \WordPress\AiClient\AiClient::defaultRegistry();
-				$provider_ids = $registry->getRegisteredProviderIds();
-				ProviderCredentialLoader::load();
-				foreach ( $provider_ids as $provider_id ) {
-					$auth = $registry->getProviderRequestAuthentication( $provider_id );
-					if ( null !== $auth ) {
-						$has_provider = true;
-						break;
-					}
-				}
-			} catch ( \Throwable $e ) {
-				// Registry unavailable — treat as no provider.
-			}
-		}
-
-		if ( ! $has_provider ) {
+		// A provider is considered configured iff some registered provider in
+		// the WP AI Client SDK registry has authentication set. Credentials are
+		// bridged from the WP 7.0 Connectors API (and 6.9 polyfill) by
+		// ProviderCredentialLoader::load(), so this single check covers both
+		// SDK-native plugins and the connector API.
+		if ( ! ProviderCredentialLoader::has_any_authenticated_provider() ) {
 			$alerts[] = array(
 				'type'           => 'no_provider',
 				'message'        => __( 'No AI provider configured. Add an API key on the Connectors page to get started.', 'superdav-ai-agent' ),

--- a/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
+++ b/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
@@ -18,6 +18,22 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 
 	private int $admin_id = 0;
 
+	/**
+	 * Ability ids registered via {@see self::register_test_ability()} during a
+	 * test, so tear_down can unregister them and prevent bleed-over.
+	 *
+	 * @var string[]
+	 */
+	private array $registered_test_abilities = [];
+
+	/**
+	 * Ability category slugs registered via {@see self::ensure_test_category()}
+	 * during a test, so tear_down can unregister them and prevent bleed-over.
+	 *
+	 * @var string[]
+	 */
+	private array $registered_test_categories = [];
+
 	public function set_up(): void {
 		parent::set_up();
 		AbilityUsageTracker::reset();
@@ -31,12 +47,111 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 	}
 
 	public function tear_down(): void {
+		// Clean up any abilities registered during the test BEFORE the parent
+		// teardown removes the user / filter context they depend on.
+		if ( function_exists( 'wp_unregister_ability' ) ) {
+			foreach ( $this->registered_test_abilities as $ability_id ) {
+				wp_unregister_ability( $ability_id );
+			}
+		}
+		$this->registered_test_abilities = [];
+
+		// Unregister any test categories we created, after the abilities that
+		// referenced them are gone.
+		if ( function_exists( 'wp_unregister_ability_category' ) ) {
+			foreach ( $this->registered_test_categories as $category_slug ) {
+				wp_unregister_ability_category( $category_slug );
+			}
+		}
+		$this->registered_test_categories = [];
+
 		parent::tear_down();
 		remove_all_filters( 'sd_ai_agent_ability_usage_instructions' );
 		remove_all_filters( 'sd_ai_agent_ability_usage_instructions_for' );
 		AbilityUsageTracker::reset();
 		ToolDiscovery::reset_schema_cache();
 		IdenticalFailureTracker::reset();
+	}
+
+	/**
+	 * Register a test ability under the `wp_abilities_api_init` hook context.
+	 *
+	 * WordPress 6.9+ requires {@see wp_register_ability()} to be called from
+	 * within `wp_abilities_api_init`. The registry init action fires lazily
+	 * and only once per request, so by the time set_up() runs it has already
+	 * fired and an add_action() callback would never be invoked. WP core's own
+	 * test suite (`tests/phpunit/tests/abilities-api/wpRegisterAbility.php`)
+	 * works around this by pushing the hook name onto $wp_current_filter to
+	 * satisfy the hook-context check, then popping it afterwards. We do the
+	 * same and remember the id so tear_down() can clean up.
+	 *
+	 * WP 6.9 also rejects an ability whose `category` slug is not registered
+	 * via {@see wp_register_ability_category()}, returning null silently from
+	 * the registry. The helper therefore lazy-registers the referenced
+	 * category before registering the ability.
+	 *
+	 * @param string              $name Ability id (namespaced or bare).
+	 * @param array<string,mixed> $args Ability registration args.
+	 */
+	private function register_test_ability( string $name, array $args ): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			$this->fail( 'wp_register_ability() is not available — Abilities API is not loaded.' );
+		}
+
+		if ( isset( $args['category'] ) && is_string( $args['category'] ) ) {
+			$this->ensure_test_category( $args['category'] );
+		}
+
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Standard WordPress hook stack global.
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_init';
+
+		try {
+			wp_register_ability( $name, $args );
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+
+		$this->registered_test_abilities[] = $name;
+	}
+
+	/**
+	 * Lazily register an ability category for the current test.
+	 *
+	 * WP 6.9 enforces that categories are registered on the
+	 * `wp_abilities_api_categories_init` hook, mirroring the constraint on
+	 * `wp_register_ability()`. We satisfy the hook-context check the same way
+	 * as {@see self::register_test_ability()} and track the slug so tear_down
+	 * can unregister it.
+	 *
+	 * @param string $slug Category slug used by a test ability.
+	 */
+	private function ensure_test_category( string $slug ): void {
+		if ( ! function_exists( 'wp_register_ability_category' ) || ! function_exists( 'wp_has_ability_category' ) ) {
+			return;
+		}
+
+		if ( wp_has_ability_category( $slug ) ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Standard WordPress hook stack global.
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_categories_init';
+
+		try {
+			wp_register_ability_category(
+				$slug,
+				[
+					'label'       => 'Test Category ' . $slug,
+					'description' => 'Auto-registered by ToolDiscoveryTest for ' . $slug,
+				]
+			);
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+
+		$this->registered_test_categories[] = $slug;
 	}
 
 	// ── tier_1_for_run ────────────────────────────────────────────────
@@ -255,8 +370,9 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 
 	public function test_manifest_includes_per_ability_usage_instructions(): void {
 		// Register a test ability with usage_instructions in meta.ai.
-		wp_register_ability(
-			'test-ability-with-instructions',
+		// WP 6.9 requires a namespaced id (`vendor/name`).
+		$this->register_test_ability(
+			'test-plugin/ability-with-instructions',
 			[
 				'label'       => 'Test Ability',
 				'description' => 'A test ability.',
@@ -283,8 +399,9 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 
 	public function test_ability_search_includes_usage_instructions_in_results(): void {
 		// Register a test ability with usage_instructions.
-		wp_register_ability(
-			'test-search-ability-with-instructions',
+		// WP 6.9 requires a namespaced id (`vendor/name`).
+		$this->register_test_ability(
+			'test-plugin/search-ability-with-instructions',
 			[
 				'label'       => 'Test Search Ability',
 				'description' => 'A test ability for search.',
@@ -304,7 +421,7 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 		);
 
 		$result = ToolDiscovery::handle_ability_search(
-			[ 'query' => 'select:test-search-ability-with-instructions' ]
+			[ 'query' => 'select:test-plugin/search-ability-with-instructions' ]
 		);
 
 		$this->assertIsArray( $result );
@@ -317,8 +434,9 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 
 	public function test_ability_search_omits_empty_usage_instructions(): void {
 		// Register a test ability without usage_instructions.
-		wp_register_ability(
-			'test-ability-no-instructions',
+		// WP 6.9 requires a namespaced id (`vendor/name`).
+		$this->register_test_ability(
+			'test-plugin/ability-no-instructions',
 			[
 				'label'       => 'Test No Instructions',
 				'description' => 'A test ability without instructions.',
@@ -333,7 +451,7 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 		);
 
 		$result = ToolDiscovery::handle_ability_search(
-			[ 'query' => 'select:test-ability-no-instructions' ]
+			[ 'query' => 'select:test-plugin/ability-no-instructions' ]
 		);
 
 		$this->assertIsArray( $result );
@@ -346,8 +464,9 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 
 	public function test_usage_instructions_filter_for_third_party_abilities(): void {
 		// Register a test ability without usage_instructions.
-		wp_register_ability(
-			'test-third-party-ability',
+		// WP 6.9 requires a namespaced id (`vendor/name`).
+		$this->register_test_ability(
+			'test-plugin/third-party-ability',
 			[
 				'label'       => 'Third Party Ability',
 				'description' => 'A third-party ability.',
@@ -365,7 +484,7 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 		add_filter(
 			'sd_ai_agent_ability_usage_instructions_for',
 			static function ( $instructions, $ability_name ) {
-				if ( 'test-third-party-ability' === $ability_name ) {
+				if ( 'test-plugin/third-party-ability' === $ability_name ) {
 					return 'Use this third-party ability when needed.';
 				}
 				return $instructions;
@@ -375,7 +494,7 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 		);
 
 		$result = ToolDiscovery::handle_ability_search(
-			[ 'query' => 'select:test-third-party-ability' ]
+			[ 'query' => 'select:test-plugin/third-party-ability' ]
 		);
 
 		$this->assertIsArray( $result );


### PR DESCRIPTION
## Summary

- Deletes `Settings::DIRECT_PROVIDERS` and `Settings::get_connectors_api_key()` — both are leftovers from when `AgentLoop` called provider REST APIs directly via `wp_remote_post()`. `AgentLoop` now uses `wp_ai_client_prompt()` exclusively, so the WP AI Client SDK registry is the single source of truth for "which providers exist" and "which models each exposes".
- Rewrites `SettingsController::handle_providers()` and `CLI\ModelsCommand::fetch_providers()` as pure SDK loops. The previous code listed `DIRECT_PROVIDERS` first, collected the resulting IDs in `$added_ids`, and `continue`d on any SDK provider whose id already appeared — which for `openai` is always the case. That dedup pass was silently suppressing the SDK's dynamic OpenAI list (gpt-5, gpt-5.5, gpt-5.5-pro, gpt-5.4, gpt-5.4-mini, gpt-5-codex, gpt-5-pro, …) in favour of an 11-model static catalog that hasn't been updated in months.
- Rewrites `Settings::has_provider_configured()` and `SettingsController::handle_alerts()` to call a new `ProviderCredentialLoader::has_any_authenticated_provider()` helper. The helper walks the registry once (after calling `ProviderCredentialLoader::load()`) and returns true iff any provider has authentication set. Credentials from the WP 7.0 Connectors API + 6.9 polyfill are already bridged into the registry by `load()`, so the second-pass option-key scan was both redundant and a maintenance hazard whenever a new provider plugin (`ai-provider-for-anthropic-max`, etc.) appeared.
- Also makes `CLI\ModelsCommand::fetch_providers()` call `ProviderCredentialLoader::load()` (previously missing in the CLI path — a latent bug where freshly-saved Connectors keys were invisible to `wp sd-ai-agent models` until the next non-CLI request loaded them).
- Preserves: `Settings::MODEL_CONTEXT_WINDOWS` (separate concern — context-window fallback for SDK models lacking metadata), `Compat/wp-connectors-polyfill.php` (WP 6.9 polyfill), `ConnectorsController` (credential writes), `ProviderCredentialLoader::load()` (credential bridge).

Resolves `sd-ai-aem` (Settings /providers: openai shows static 11-model list instead of SDK dynamic list).

Supersedes (closed) #1472.

## Verification

```text
# PHPCS — clean
$ composer phpcs -- includes/Core/Settings.php includes/Core/ProviderCredentialLoader.php \
                    includes/REST/SettingsController.php includes/CLI/ModelsCommand.php
.... 4 / 4 (100%)
Time: 733ms; Memory: 14MB

# PHPStan — clean
$ vendor/bin/phpstan analyse includes/Core/Settings.php includes/Core/ProviderCredentialLoader.php \
                              includes/REST/SettingsController.php includes/CLI/ModelsCommand.php \
                              --memory-limit=512M
 [OK] No errors

# PHPUnit (Settings + Models suites) — 20/20 pass, 64 assertions
$ vendor/bin/phpunit --filter 'SettingsTest|ModelsCommandTest'
....................                                              20 / 20 (100%)
OK (20 tests, 64 assertions)
```

**Live behaviour against dev install** (symlinked the plugin into the worktree and called the controller via the DI container — REST routes aren't registered in `wp eval` context, this is the same path REST handlers take):

```text
Providers: 5
- deepseek [cloud] models=2
- openai [cloud] models=128
  gpt-5:       YES
  gpt-5.5:     YES
  gpt-5.5-pro: YES
  First 8 ids: gpt-5.5, gpt-5.5-2026-04-23, gpt-5.5-pro, gpt-5.5-pro-2026-04-23,
               gpt-5.4, gpt-5.4-mini, gpt-5.4-2026-03-05, gpt-5.4-mini-2026-03-17
- ultimate-ai-connector-anthropic-max [cloud] models=9
- ai-provider-for-any-openai-compatible [server] models=17
- ai-provider-for-any-openai-compatible-2 [server] models=17

$ wp sd-ai-agent models --provider=openai --format=count
128
```

Zero `type=direct` entries — confirms the legacy path is fully gone, not just deprioritised.

## Behaviour change

- Sites that had **only** a Connectors API key set (no `ai-provider-for-*` plugin installed) previously got an 11-model static dropdown via the DIRECT_PROVIDERS fallback. After this change those sites see an empty provider list. This is strictly more honest than today — chat would fail at first send anyway because `wp_ai_client_prompt()` has no registered provider to dispatch to. The intended path on those sites is: install the matching provider plugin (e.g. `ai-provider-for-openai`), which both registers the SDK provider id and reads the Connectors key.

## Files

- `includes/Core/Settings.php` — delete `DIRECT_PROVIDERS` constant (172 lines), delete `get_connectors_api_key()`, rewrite `has_provider_configured()` to use the new helper.
- `includes/Core/ProviderCredentialLoader.php` — add `has_any_authenticated_provider(): bool` static helper.
- `includes/REST/SettingsController.php` — rewrite `handle_providers()` as a pure SDK loop; rewrite `handle_alerts()` to use the new helper.
- `includes/CLI/ModelsCommand.php` — rewrite `fetch_providers()` as a pure SDK loop; add the missing `ProviderCredentialLoader::load()` call.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with claude-sonnet-4-6 spent 1d 9h and 383 tokens on this as a headless worker.
