### PR TITLE
fix(agent-loop): strip temperature for OpenAI reasoning models (sd-ai-0qy)

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -1008,7 +1008,18 @@ class AgentLoop {
 		// from the outgoing request body. The guards are removed because
 		// the wrapper's `__call` is guaranteed to exist and the `@method`
 		// declarations on the wrapper enumerate the supported API.
-		$builder->using_temperature( (float) $this->temperature );
+		//
+		// Reasoning-model exception: OpenAI's reasoning families (gpt-5*,
+		// o1*, o3*, o4*) reject `temperature` outright with HTTP 400
+		// ("Unsupported parameter: 'temperature' is not supported with
+		// this model.") — they only run at the model's implicit sampling
+		// setting. Skip the setter for those model IDs so the request
+		// body omits the field entirely. `max_tokens` is still safe to
+		// send: the SDK translates it to `max_completion_tokens` for the
+		// OpenAI reasoning API.
+		if ( ! self::is_reasoning_model( $this->model_id ) ) {
+			$builder->using_temperature( (float) $this->temperature );
+		}
 		$builder->using_max_tokens( $this->get_effective_max_output_tokens() );
 
 		$abilities = $this->resolve_abilities();
@@ -1408,6 +1419,52 @@ class AgentLoop {
 	 */
 	private static function truncate_tool_results( Message $message ): Message {
 		return ConversationSerializer::truncate_tool_results( $message );
+	}
+
+	/**
+	 * Detect OpenAI reasoning models that reject the `temperature` parameter.
+	 *
+	 * Reasoning models from OpenAI (GPT-5 family + o-series) only run at the
+	 * model's implicit sampling setting and respond with HTTP 400 if
+	 * `temperature` is present in the request body:
+	 *
+	 *     Unsupported parameter: 'temperature' is not supported with this model.
+	 *
+	 * The check is prefix-based and intentionally broad — it covers current
+	 * variants (gpt-5, gpt-5.4, gpt-5.4-mini, gpt-5.5, gpt-5.5-pro,
+	 * gpt-5-codex, gpt-5-pro, o1, o1-mini, o3, o3-mini, o4, o4-mini) and any
+	 * future dated/sized snapshots from the same families that follow the
+	 * same naming convention (e.g. `gpt-5.5-2026-04-23`).
+	 *
+	 * Non-reasoning OpenAI models (gpt-4*, gpt-3.5*, gpt-4o, gpt-4.1) accept
+	 * `temperature` normally and are NOT matched here.
+	 *
+	 * @param string $model_id The provider-scoped model identifier.
+	 * @return bool True if the model rejects the `temperature` parameter.
+	 */
+	private static function is_reasoning_model( string $model_id ): bool {
+		$normalised = strtolower( trim( $model_id ) );
+
+		if ( '' === $normalised ) {
+			return false;
+		}
+
+		// GPT-5 family — all variants are reasoning models.
+		if ( str_starts_with( $normalised, 'gpt-5' ) ) {
+			return true;
+		}
+
+		// o-series reasoning models (o1, o3, o4 and their *-mini/*-pro/*-preview/dated snapshots).
+		// Match the exact prefix followed by `-` or end-of-string so we don't
+		// accidentally match a hypothetical non-reasoning model whose ID
+		// starts with `o1`/`o3`/`o4` (e.g. `o1magic`).
+		foreach ( array( 'o1', 'o3', 'o4' ) as $family ) {
+			if ( $normalised === $family || str_starts_with( $normalised, $family . '-' ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	// ── Resolve abilities ─────────────────────────────────────────────────

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -1511,6 +1511,151 @@ class AgentLoopTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Regression test: `temperature` MUST be omitted from the outgoing
+	 * request body for OpenAI reasoning models, because those endpoints
+	 * reject the field with HTTP 400 ("Unsupported parameter:
+	 * 'temperature' is not supported with this model.").
+	 *
+	 * Reproduction before the fix (2026-05-16, live OpenAI API):
+	 *
+	 *     wp sd-ai-agent prompt 'test' --provider=openai --model=gpt-5.5 \
+	 *         --skip-tools --verbose
+	 *     => Warning: Bad Request (400) - Unsupported parameter:
+	 *        'temperature' is not supported with this model.
+	 *
+	 * The fix adds {@see AgentLoop::is_reasoning_model()} and short-circuits
+	 * the `using_temperature()` call in send_prompt() for any matched ID.
+	 *
+	 * This test exercises the agent loop end-to-end against the fake OpenAI-
+	 * compatible endpoint with model_id = gpt-5.5 and asserts the captured
+	 * outgoing JSON body has NO `temperature` key. `max_tokens` is still
+	 * expected because reasoning models accept `max_completion_tokens` and
+	 * the SDK translates `max_tokens` for the OpenAI reasoning endpoint.
+	 *
+	 * @dataProvider reasoning_model_id_provider
+	 */
+	public function test_builder_omits_temperature_for_reasoning_models( string $model_id ): void {
+		$this->skip_if_sdk_unavailable();
+
+		// A non-default temperature so the assertion can distinguish "not
+		// sent" from "sent at the AgentLoop default of 0.7".
+		Settings::instance()->update(
+			[
+				'max_output_tokens' => 8192,
+				'temperature'       => 0.42,
+			]
+		);
+
+		$captured = null;
+		$this->capture_next_request_body( $captured );
+
+		$loop = new AgentLoop( 'Reply succinctly', [], [], [ 'model_id' => $model_id ] );
+		$loop->run();
+
+		$this->assertIsString( $captured, 'Expected to capture an outgoing request body for ' . $model_id );
+		$decoded = json_decode( (string) $captured, true );
+		$this->assertIsArray( $decoded, 'Outgoing body should be JSON for ' . $model_id );
+
+		$this->assertArrayNotHasKey(
+			'temperature',
+			$decoded,
+			sprintf(
+				'Reasoning model %s must not receive a `temperature` field — the OpenAI endpoint returns HTTP 400 when it is present.',
+				$model_id
+			)
+		);
+
+		// Sanity: max_tokens still goes through (SDK rewrites it to
+		// max_completion_tokens for the reasoning endpoint).
+		$this->assertArrayHasKey(
+			'max_tokens',
+			$decoded,
+			'max_tokens must still reach the provider for ' . $model_id
+		);
+	}
+
+	/**
+	 * Data provider covering the reasoning-model families enumerated by
+	 * {@see AgentLoop::is_reasoning_model()}.
+	 *
+	 * @return array<string, array{0:string}>
+	 */
+	public function reasoning_model_id_provider(): array {
+		return [
+			'gpt-5'              => [ 'gpt-5' ],
+			'gpt-5.4'            => [ 'gpt-5.4' ],
+			'gpt-5.4-mini'       => [ 'gpt-5.4-mini' ],
+			'gpt-5.5'            => [ 'gpt-5.5' ],
+			'gpt-5.5-pro'        => [ 'gpt-5.5-pro' ],
+			'gpt-5-codex'        => [ 'gpt-5-codex' ],
+			'gpt-5.5 dated snap' => [ 'gpt-5.5-2026-04-23' ],
+			'o1'                 => [ 'o1' ],
+			'o1-mini'            => [ 'o1-mini' ],
+			'o3'                 => [ 'o3' ],
+			'o3-mini'            => [ 'o3-mini' ],
+			'o4-mini'            => [ 'o4-mini' ],
+		];
+	}
+
+	/**
+	 * Counter-test: `temperature` MUST still reach non-reasoning OpenAI
+	 * models (gpt-4*, gpt-4o, gpt-4.1, gpt-3.5*) and other providers. This
+	 * guards against an over-broad reasoning-model detector accidentally
+	 * stripping temperature for models that accept it.
+	 *
+	 * @dataProvider non_reasoning_model_id_provider
+	 */
+	public function test_builder_keeps_temperature_for_non_reasoning_models( string $model_id ): void {
+		$this->skip_if_sdk_unavailable();
+
+		Settings::instance()->update(
+			[
+				'max_output_tokens' => 8192,
+				'temperature'       => 0.33,
+			]
+		);
+
+		$captured = null;
+		$this->capture_next_request_body( $captured );
+
+		$loop = new AgentLoop( 'Reply succinctly', [], [], [ 'model_id' => $model_id ] );
+		$loop->run();
+
+		$this->assertIsString( $captured, 'Expected to capture an outgoing request body for ' . $model_id );
+		$decoded = json_decode( (string) $captured, true );
+		$this->assertIsArray( $decoded );
+
+		$this->assertArrayHasKey(
+			'temperature',
+			$decoded,
+			'Non-reasoning model ' . $model_id . ' must still receive the `temperature` field.'
+		);
+		$this->assertEqualsWithDelta(
+			0.33,
+			(float) $decoded['temperature'],
+			0.0001,
+			'Configured temperature must reach non-reasoning model ' . $model_id . ' unchanged.'
+		);
+	}
+
+	/**
+	 * Data provider for models that MUST keep receiving `temperature`.
+	 *
+	 * @return array<string, array{0:string}>
+	 */
+	public function non_reasoning_model_id_provider(): array {
+		return [
+			'gpt-4'             => [ 'gpt-4' ],
+			'gpt-4-turbo'       => [ 'gpt-4-turbo' ],
+			'gpt-4o'            => [ 'gpt-4o' ],
+			'gpt-4.1'           => [ 'gpt-4.1' ],
+			'gpt-3.5-turbo'     => [ 'gpt-3.5-turbo' ],
+			'claude-sonnet-4-6' => [ 'claude-sonnet-4-6' ],
+			'gemini-2.5-pro'    => [ 'gemini-2.5-pro' ],
+		];
+	}
+
+	/**
 	 * Resolve the private get_effective_max_output_tokens() with a given
 	 * saved value and model_id so we can exercise the legacy / AUTO / ceiling
 	 * branches without spinning up the full agent loop.
@@ -2403,5 +2548,83 @@ class AgentLoopTest extends WP_UnitTestCase {
 			static fn( $entry ) => 'preamble' === ( $entry['type'] ?? '' )
 		);
 		$this->assertEmpty( $preamble_entries, 'Whitespace-only assistant text must not be logged as a preamble entry.' );
+	}
+
+	// -------------------------------------------------------------------------
+	// is_reasoning_model() direct unit tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Invoke the private static {@see AgentLoop::is_reasoning_model()} helper.
+	 *
+	 * @param string $model_id Model ID to classify.
+	 * @return bool Helper return value.
+	 */
+	private function invoke_is_reasoning_model( string $model_id ): bool {
+		$rc     = new \ReflectionClass( AgentLoop::class );
+		$method = $rc->getMethod( 'is_reasoning_model' );
+		$method->setAccessible( true );
+		return (bool) $method->invoke( null, $model_id );
+	}
+
+	/**
+	 * Direct (no-SDK) coverage of the reasoning-model classifier.
+	 *
+	 * @dataProvider reasoning_model_classification_provider
+	 */
+	public function test_is_reasoning_model_classification( string $model_id, bool $expected ): void {
+		$this->assertSame(
+			$expected,
+			$this->invoke_is_reasoning_model( $model_id ),
+			sprintf( 'is_reasoning_model(%s) should be %s', var_export( $model_id, true ), $expected ? 'true' : 'false' )
+		);
+	}
+
+	/**
+	 * Classification corpus. Keep the negative cases honest — `o1magic`
+	 * style IDs must NOT match (the helper guards against an over-broad
+	 * prefix match by requiring `o1-...` or exact `o1`).
+	 *
+	 * @return array<string, array{0:string, 1:bool}>
+	 */
+	public function reasoning_model_classification_provider(): array {
+		return [
+			// GPT-5 family — all reasoning.
+			'gpt-5'                       => [ 'gpt-5', true ],
+			'gpt-5-pro'                   => [ 'gpt-5-pro', true ],
+			'gpt-5-codex'                 => [ 'gpt-5-codex', true ],
+			'gpt-5.4'                     => [ 'gpt-5.4', true ],
+			'gpt-5.4-mini'                => [ 'gpt-5.4-mini', true ],
+			'gpt-5.5'                     => [ 'gpt-5.5', true ],
+			'gpt-5.5-pro'                 => [ 'gpt-5.5-pro', true ],
+			'gpt-5.5-dated'               => [ 'gpt-5.5-2026-04-23', true ],
+			'GPT-5.5 uppercase'           => [ 'GPT-5.5', true ],
+			'gpt-5 padded'                => [ '  gpt-5.5  ', true ],
+			// o-series reasoning.
+			'o1'                          => [ 'o1', true ],
+			'o1-mini'                     => [ 'o1-mini', true ],
+			'o3'                          => [ 'o3', true ],
+			'o3-mini'                     => [ 'o3-mini', true ],
+			'o3-preview'                  => [ 'o3-preview', true ],
+			'o4'                          => [ 'o4', true ],
+			'o4-mini'                     => [ 'o4-mini', true ],
+			// Non-reasoning OpenAI — must NOT match.
+			'gpt-4'                       => [ 'gpt-4', false ],
+			'gpt-4-turbo'                 => [ 'gpt-4-turbo', false ],
+			'gpt-4o'                      => [ 'gpt-4o', false ],
+			'gpt-4.1'                     => [ 'gpt-4.1', false ],
+			'gpt-3.5-turbo'               => [ 'gpt-3.5-turbo', false ],
+			// Other providers — must NOT match.
+			'claude-sonnet-4-6'           => [ 'claude-sonnet-4-6', false ],
+			'claude-opus-4-7'             => [ 'claude-opus-4-7', false ],
+			'gemini-2.5-pro'              => [ 'gemini-2.5-pro', false ],
+			'deepseek-chat'               => [ 'deepseek-chat', false ],
+			// Defensive negatives — must NOT match (no `-` separator).
+			'o1magic (no separator)'      => [ 'o1magic', false ],
+			'o3xyz (no separator)'        => [ 'o3xyz', false ],
+			'orion (starts with o but no o<digit>)' => [ 'orion', false ],
+			'empty string'                => [ '', false ],
+			'whitespace'                  => [ '   ', false ],
+		];
 	}
 }


### PR DESCRIPTION
## Summary

OpenAI's reasoning-model families (`gpt-5*`, `o1*`, `o3*`, `o4*`) reject the `temperature` parameter with HTTP 400 — *"Unsupported parameter: 'temperature' is not supported with this model."* — they only run at the model's implicit sampling setting. `AgentLoop::send_prompt()` previously called `$builder->using_temperature()` unconditionally, so every GPT-5 / GPT-5.5 / o-series request failed at the provider boundary in a single round-trip with no completion.

This PR adds `AgentLoop::is_reasoning_model()` (prefix-matched, case-insensitive, trim-safe) and short-circuits the temperature setter when it returns `true`. `max_tokens` is still sent — the WP AI Client SDK rewrites it to `max_completion_tokens` for the OpenAI reasoning endpoint.

Resolves `sd-ai-0qy`. Surfaced while verifying #1473 (which made `gpt-5.5` visible in the SDK-driven provider list); root cause is the unconditional `using_temperature()` call added by #1450 (`fix(sd-ai-5ws): unblock max_tokens/temperature reaching the AI provider`).

## Reproduction (before this PR, against main)

```text
$ wp sd-ai-agent prompt 'test' --provider=openai --model=gpt-5.5 --skip-tools --verbose
Model:          gpt-5.5
Sending prompt to AI agent...

Warning: Bad Request (400) - Unsupported parameter: 'temperature' is not supported with this model.

Iterations used: 0/25
Total time: 4.46s
```

## Verification (live OpenAI against this branch)

```text
$ wp sd-ai-agent prompt 'Reply with: GPT-5.5 OK' --provider=openai --model=gpt-5.5 --skip-tools --verbose
Model:          gpt-5.5
Sending prompt to AI agent...
GPT-5.5 OK
Iterations used: 1/25
Total time: 7.37s

$ wp sd-ai-agent prompt 'Reply with: GPT-5 OK' --provider=openai --model=gpt-5 --skip-tools
GPT-5 OK

$ wp sd-ai-agent prompt 'Reply with: gpt-4.1 OK' --provider=openai --model=gpt-4.1 --skip-tools
gpt-4.1 OK    # non-reasoning model still receives temperature unchanged
```

## Quality gates

```text
$ vendor/bin/phpcs includes/Core/AgentLoop.php
. 1 / 1 (100%)        # clean

$ vendor/bin/phpstan analyse includes/Core/AgentLoop.php --memory-limit=512M
 [OK] No errors
```

`npm run test:php` was attempted in this worktree but the wp-env stack on this host couldn't reach a fresh tests-mysql container during this session (existing port-8893 owners and a stale-volume init issue, unrelated to the diff). The added regression tests follow the same pattern as the passing `test_builder_receives_max_tokens_and_temperature` (PR #1450) and use the same `capture_next_request_body` helper — they will run in CI alongside the rest of `AgentLoopTest`.

## Tests added

`tests/SdAiAgent/Core/AgentLoopTest.php`:

- **`test_builder_omits_temperature_for_reasoning_models`** — 12-case data provider (`gpt-5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.5`, `gpt-5.5-pro`, `gpt-5-codex`, `gpt-5.5-2026-04-23` dated snapshot, `o1`, `o1-mini`, `o3`, `o3-mini`, `o4-mini`). Captures the outgoing request body and asserts no `temperature` key.
- **`test_builder_keeps_temperature_for_non_reasoning_models`** — 7-case data provider (`gpt-4`, `gpt-4-turbo`, `gpt-4o`, `gpt-4.1`, `gpt-3.5-turbo`, `claude-sonnet-4-6`, `gemini-2.5-pro`). Guards against an over-broad detector by asserting `temperature` IS present and equals the configured value.
- **`test_is_reasoning_model_classification`** — 28-case reflection-based unit test of the helper itself (no SDK dependency). Includes defensive negatives (`o1magic`, `o3xyz`, `orion`, empty, whitespace) to lock in the `o<digit>-` prefix-with-separator requirement.

## Behaviour change

Sites that explicitly chose a non-default `temperature` and a reasoning model will see the `temperature` setting silently ignored for that model. This is strictly more correct than today — the alternative is a 100% failure rate at first send. Non-reasoning models are unaffected.

## Files

- `includes/Core/AgentLoop.php` — wrap `using_temperature()` call in `is_reasoning_model()` guard; add the helper.
- `tests/SdAiAgent/Core/AgentLoopTest.php` — three new tests, two data providers, one reflection helper.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.1 with claude-opus-4-7 in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API request formatting for OpenAI reasoning models (o1, o3, o4, GPT-5) by intelligently adjusting request parameters based on model capabilities while maintaining token limits.

* **Tests**
  * Added comprehensive coverage for request parameter handling across reasoning and standard model variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1474?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->