### PR TITLE
GH#1478: fix(trace): salvage PR #1465 — LIFO stack maintenance + regression tests

### DIFF
--- a/includes/Core/AiClientEventTraceLogger.php
+++ b/includes/Core/AiClientEventTraceLogger.php
@@ -95,12 +95,14 @@ class AiClientEventTraceLogger {
 	 * @return void
 	 */
 	public static function on_after_generate_result( AfterGenerateResultEvent $event ): void {
+		// Pop the matching Before from the LIFO stack, regardless of tracing state.
+		// This prevents stale entries from accumulating if tracing is toggled
+		// between Before and After events.
+		$inflight = array_pop( self::$inflight );
+
 		if ( ! ProviderTrace::is_enabled() ) {
 			return;
 		}
-
-		// Pop the matching Before from the LIFO stack.
-		$inflight = array_pop( self::$inflight );
 		if ( null === $inflight ) {
 			// No Before recorded (tracing toggled on between Before and After,
 			// or an unbalanced After fired).
@@ -201,12 +203,12 @@ class AiClientEventTraceLogger {
 	 * @return void
 	 */
 	public static function cleanup_stalled_events(): void {
-		if ( ! ProviderTrace::is_enabled() ) {
-			return;
-		}
-
-		foreach ( self::$inflight as $inflight ) {
-			self::write_stalled_trace( $inflight );
+		// Always clear the stack, regardless of tracing state. This prevents
+		// stale entries from accumulating if tracing is toggled off.
+		if ( ProviderTrace::is_enabled() ) {
+			foreach ( self::$inflight as $inflight ) {
+				self::write_stalled_trace( $inflight );
+			}
 		}
 
 		// Clear the stack.

--- a/stubs/wordpress-7-runtime.php
+++ b/stubs/wordpress-7-runtime.php
@@ -104,9 +104,42 @@ namespace WordPress\AiClient\Tools\DTO {
 	}
 }
 
+namespace WordPress\AiClient\Messages\Enums {
+
+	/**
+	 * Message part channel enum (stub).
+	 *
+	 * Represents the channel/type of a message part (e.g., "text", "thought").
+	 * Mirrors WordPress\AiClient\Messages\Enums\MessagePartChannelEnum shipped
+	 * in php-ai-client.
+	 */
+	class MessagePartChannelEnum {
+		/** @var string */
+		public string $value = '';
+
+		/** @return string */
+		public function getValue(): string {
+			return $this->value;
+		}
+
+		/** @return string */
+		public function __toString(): string {
+			return $this->value;
+		}
+
+		/** @return self */
+		public static function thought(): self {
+			$enum = new self();
+			$enum->value = 'thought';
+			return $enum;
+		}
+	}
+}
+
 namespace WordPress\AiClient\Messages\DTO {
 
 	use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
+	use WordPress\AiClient\Messages\Enums\MessagePartChannelEnum;
 	use WordPress\AiClient\Tools\DTO\FunctionCall;
 	use WordPress\AiClient\Tools\DTO\FunctionResponse;
 
@@ -148,8 +181,9 @@ namespace WordPress\AiClient\Messages\DTO {
 		 * Constructor.
 		 *
 		 * @param string|FunctionCall|\WordPress\AiClient\Tools\DTO\FunctionResponse $content Text, function call, or function response.
+		 * @param MessagePartChannelEnum|null $channel Optional channel (e.g., "thought").
 		 */
-		public function __construct( string|FunctionCall|\WordPress\AiClient\Tools\DTO\FunctionResponse $content = '' ) {}
+		public function __construct( string|FunctionCall|\WordPress\AiClient\Tools\DTO\FunctionResponse $content = '', ?MessagePartChannelEnum $channel = null ) {}
 
 		/** @return string */
 		public function getText(): string { return ''; }

--- a/tests/SdAiAgent/Bootstrap/AiClientEventTraceHandlerTest.php
+++ b/tests/SdAiAgent/Bootstrap/AiClientEventTraceHandlerTest.php
@@ -455,18 +455,25 @@ class AiClientEventTraceHandlerTest extends WP_UnitTestCase {
 
 		// ProviderTrace::list() returns rows in reverse insertion order (ORDER BY id DESC),
 		// so the most recent row (A) comes first, then B.
-		$row_a = $rows[0];
-		$row_b = $rows[1];
+		$row_a_summary = $rows[0];
+		$row_b_summary = $rows[1];
 
 		// Verify row A paired with model A.
-		$this->assertSame( 'anthropic', $row_a->provider_id );
-		$this->assertSame( 'claude-3-5-sonnet', $row_a->model_id );
-		$this->assertSame( 'result-a', json_decode( $row_a->response_body, true )['id'] );
+		$this->assertSame( 'anthropic', $row_a_summary->provider_id );
+		$this->assertSame( 'claude-3-5-sonnet', $row_a_summary->model_id );
 
 		// Verify row B paired with model B.
-		$this->assertSame( 'openai', $row_b->provider_id );
-		$this->assertSame( 'gpt-4o', $row_b->model_id );
-		$this->assertSame( 'result-b', json_decode( $row_b->response_body, true )['id'] );
+		$this->assertSame( 'openai', $row_b_summary->provider_id );
+		$this->assertSame( 'gpt-4o', $row_b_summary->model_id );
+
+		// Get full rows to verify response bodies (list() returns only sizes).
+		$row_a_full = ProviderTrace::get( $row_a_summary->id );
+		$row_b_full = ProviderTrace::get( $row_b_summary->id );
+		$this->assertNotNull( $row_a_full );
+		$this->assertNotNull( $row_b_full );
+
+		$this->assertSame( 'result-a', json_decode( $row_a_full->response_body, true )['id'] );
+		$this->assertSame( 'result-b', json_decode( $row_b_full->response_body, true )['id'] );
 	}
 
 	/**

--- a/tests/SdAiAgent/Bootstrap/AiClientEventTraceHandlerTest.php
+++ b/tests/SdAiAgent/Bootstrap/AiClientEventTraceHandlerTest.php
@@ -217,6 +217,52 @@ class AiClientEventTraceHandlerTest extends WP_UnitTestCase {
 		$this->assertCount( 0, ProviderTrace::list() );
 	}
 
+	public function test_stack_cleared_when_tracing_disabled_between_before_and_after(): void {
+		// Regression: CodeRabbit major fix. If tracing is toggled off between
+		// Before and After events, the stack must still be popped to prevent
+		// stale entries from accumulating. This test verifies that the After
+		// handler pops the stack even when tracing is disabled.
+		$model    = $this->create_model( 'anthropic', 'claude-3-5-sonnet' );
+		$messages = [ $this->create_user_message( 'Test' ) ];
+
+		// Enable tracing and push a Before event.
+		ProviderTrace::set_enabled( true );
+		$this->handler->on_before_generate_result(
+			new BeforeGenerateResultEvent( $messages, $model, null )
+		);
+
+		// Disable tracing before the After event.
+		ProviderTrace::set_enabled( false );
+
+		$result = $this->create_result( 'result-stale', $model, 'Response' );
+		$this->handler->on_after_generate_result(
+			new AfterGenerateResultEvent( $messages, $model, null, $result )
+		);
+
+		// Re-enable tracing and push another Before event. If the stack was
+		// not cleared, this Before would pair with the stale After from the
+		// previous call, causing incorrect trace rows.
+		ProviderTrace::set_enabled( true );
+		$model_2    = $this->create_model( 'openai', 'gpt-4o' );
+		$messages_2 = [ $this->create_user_message( 'Second call' ) ];
+
+		$this->handler->on_before_generate_result(
+			new BeforeGenerateResultEvent( $messages_2, $model_2, null )
+		);
+
+		$result_2 = $this->create_result( 'result-2', $model_2, 'Response 2' );
+		$this->handler->on_after_generate_result(
+			new AfterGenerateResultEvent( $messages_2, $model_2, null, $result_2 )
+		);
+
+		// Verify only one trace row was written (the second call), not two.
+		// If the stack was not cleared, we would have two rows.
+		$rows = ProviderTrace::list();
+		$this->assertCount( 1, $rows, 'Only the second call should be traced; the first was disabled.' );
+		$this->assertSame( 'openai', $rows[0]->provider_id );
+		$this->assertSame( 'gpt-4o', $rows[0]->model_id );
+	}
+
 	public function test_stalled_before_event_writes_synthetic_row(): void {
 		$model    = $this->create_model( 'anthropic', 'claude-3-5-sonnet' );
 		$messages = [ $this->create_user_message( 'Stalled' ) ];
@@ -237,6 +283,47 @@ class AiClientEventTraceHandlerTest extends WP_UnitTestCase {
 		$this->assertSame( 0, $row->status_code );
 		$this->assertSame( 'no_result_event', $row->error );
 		$this->assertGreaterThanOrEqual( 0, $row->duration_ms );
+	}
+
+	public function test_cleanup_clears_stack_even_when_tracing_disabled(): void {
+		// Regression: CodeRabbit major fix. The cleanup_stalled_events()
+		// watchdog must clear the stack even when tracing is disabled,
+		// to prevent stale entries from accumulating across requests.
+		$model    = $this->create_model( 'anthropic', 'claude-3-5-sonnet' );
+		$messages = [ $this->create_user_message( 'Stalled' ) ];
+
+		// Enable tracing and push a Before event.
+		ProviderTrace::set_enabled( true );
+		$this->handler->on_before_generate_result(
+			new BeforeGenerateResultEvent( $messages, $model, null )
+		);
+
+		// Disable tracing and call cleanup. The stack must still be cleared.
+		ProviderTrace::set_enabled( false );
+		AiClientEventTraceLogger::cleanup_stalled_events();
+
+		// Re-enable tracing and push another Before event. If the stack was
+		// not cleared, this Before would be the second entry, and a subsequent
+		// After would pop the wrong entry.
+		ProviderTrace::set_enabled( true );
+		$model_2    = $this->create_model( 'openai', 'gpt-4o' );
+		$messages_2 = [ $this->create_user_message( 'Second call' ) ];
+
+		$this->handler->on_before_generate_result(
+			new BeforeGenerateResultEvent( $messages_2, $model_2, null )
+		);
+
+		$result_2 = $this->create_result( 'result-2', $model_2, 'Response 2' );
+		$this->handler->on_after_generate_result(
+			new AfterGenerateResultEvent( $messages_2, $model_2, null, $result_2 )
+		);
+
+		// Verify the trace row pairs with model_2, not model_1 (which would
+		// indicate the stack was not cleared).
+		$rows = ProviderTrace::list();
+		$this->assertCount( 1, $rows, 'Only the second call should be traced.' );
+		$this->assertSame( 'openai', $rows[0]->provider_id );
+		$this->assertSame( 'gpt-4o', $rows[0]->model_id );
 	}
 
 	public function test_stalled_watchdog_serialises_messages_with_thought_parts(): void {
@@ -327,6 +414,59 @@ class AiClientEventTraceHandlerTest extends WP_UnitTestCase {
 		$full = ProviderTrace::get( $rows[0]->id );
 		$this->assertNotNull( $full );
 		$this->assertSame( 'sdk', $full->source, 'SDK traces should have source=sdk.' );
+	}
+
+	public function test_nested_lifo_correlation_before_a_before_b_after_b_after_a(): void {
+		// Regression: nested provider calls must pair Before/After correctly
+		// using LIFO stack semantics. This test verifies that when two Before
+		// events are pushed (A, then B), the After events pop in reverse order
+		// (B, then A), and each After pairs with its corresponding Before.
+		$model_a = $this->create_model( 'anthropic', 'claude-3-5-sonnet' );
+		$model_b = $this->create_model( 'openai', 'gpt-4o' );
+
+		$messages_a = [ $this->create_user_message( 'First call' ) ];
+		$messages_b = [ $this->create_user_message( 'Nested call' ) ];
+
+		// Push Before(A) onto the stack.
+		$this->handler->on_before_generate_result(
+			new BeforeGenerateResultEvent( $messages_a, $model_a, null )
+		);
+
+		// Push Before(B) onto the stack (now stack is [A, B]).
+		$this->handler->on_before_generate_result(
+			new BeforeGenerateResultEvent( $messages_b, $model_b, null )
+		);
+
+		// Pop and pair After(B) with Before(B).
+		$result_b = $this->create_result( 'result-b', $model_b, 'Nested response' );
+		$this->handler->on_after_generate_result(
+			new AfterGenerateResultEvent( $messages_b, $model_b, null, $result_b )
+		);
+
+		// Pop and pair After(A) with Before(A).
+		$result_a = $this->create_result( 'result-a', $model_a, 'First response' );
+		$this->handler->on_after_generate_result(
+			new AfterGenerateResultEvent( $messages_a, $model_a, null, $result_a )
+		);
+
+		// Verify two trace rows were written, one for each call.
+		$rows = ProviderTrace::list( [ 'limit' => 2 ] );
+		$this->assertCount( 2, $rows, 'Two nested calls should produce two trace rows.' );
+
+		// Verify the rows are in the correct order (B first, then A, since
+		// they were inserted in that order).
+		$row_b = $rows[0];
+		$row_a = $rows[1];
+
+		// Verify row B paired with model B.
+		$this->assertSame( 'openai', $row_b->provider_id );
+		$this->assertSame( 'gpt-4o', $row_b->model_id );
+		$this->assertSame( 'result-b', json_decode( $row_b->response_body, true )['id'] );
+
+		// Verify row A paired with model A.
+		$this->assertSame( 'anthropic', $row_a->provider_id );
+		$this->assertSame( 'claude-3-5-sonnet', $row_a->model_id );
+		$this->assertSame( 'result-a', json_decode( $row_a->response_body, true )['id'] );
 	}
 
 	/**

--- a/tests/SdAiAgent/Bootstrap/AiClientEventTraceHandlerTest.php
+++ b/tests/SdAiAgent/Bootstrap/AiClientEventTraceHandlerTest.php
@@ -453,20 +453,20 @@ class AiClientEventTraceHandlerTest extends WP_UnitTestCase {
 		$rows = ProviderTrace::list( [ 'limit' => 2 ] );
 		$this->assertCount( 2, $rows, 'Two nested calls should produce two trace rows.' );
 
-		// Verify the rows are in the correct order (B first, then A, since
-		// they were inserted in that order).
-		$row_b = $rows[0];
-		$row_a = $rows[1];
-
-		// Verify row B paired with model B.
-		$this->assertSame( 'openai', $row_b->provider_id );
-		$this->assertSame( 'gpt-4o', $row_b->model_id );
-		$this->assertSame( 'result-b', json_decode( $row_b->response_body, true )['id'] );
+		// ProviderTrace::list() returns rows in reverse insertion order (ORDER BY id DESC),
+		// so the most recent row (A) comes first, then B.
+		$row_a = $rows[0];
+		$row_b = $rows[1];
 
 		// Verify row A paired with model A.
 		$this->assertSame( 'anthropic', $row_a->provider_id );
 		$this->assertSame( 'claude-3-5-sonnet', $row_a->model_id );
 		$this->assertSame( 'result-a', json_decode( $row_a->response_body, true )['id'] );
+
+		// Verify row B paired with model B.
+		$this->assertSame( 'openai', $row_b->provider_id );
+		$this->assertSame( 'gpt-4o', $row_b->model_id );
+		$this->assertSame( 'result-b', json_decode( $row_b->response_body, true )['id'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Applied CodeRabbit major fix to pop/clear LIFO stack even when tracing disabled. Added nested LIFO regression test (before(A)→before(B)→after(B)→after(A)). Added MessagePartChannelEnum to stubs for thought-channel support.

## Files Changed

includes/Core/AiClientEventTraceLogger.php,stubs/wordpress-7-runtime.php,tests/SdAiAgent/Bootstrap/AiClientEventTraceHandlerTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PHP syntax check passed. Regression tests cover: nested LIFO correlation, stack clearing when tracing toggled, cleanup watchdog stack clearing.

Resolves #1478


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.58 plugin for [OpenCode](https://opencode.ai) v1.15.3 with claude-haiku-4-5 spent 2m and 2,794 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added channel support for message parts, enabling the designation of content types, including a new "thought" channel for structured message content

* **Bug Fixes**
  * Improved event tracing reliability to properly preserve trace data even when tracing settings are changed mid-operation
  * Enhanced event cleanup logic to prevent stale entries from accumulating, which could lead to mismatched event correlations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1480?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->