### PR TITLE
GH#1481: fix: stabilize order-dependent assertions in AiClientEventTraceHandlerTest

### DIFF
--- a/tests/SdAiAgent/Bootstrap/AiClientEventTraceHandlerTest.php
+++ b/tests/SdAiAgent/Bootstrap/AiClientEventTraceHandlerTest.php
@@ -453,27 +453,29 @@ class AiClientEventTraceHandlerTest extends WP_UnitTestCase {
 		$rows = ProviderTrace::list( [ 'limit' => 2 ] );
 		$this->assertCount( 2, $rows, 'Two nested calls should produce two trace rows.' );
 
-		// ProviderTrace::list() returns rows in reverse insertion order (ORDER BY id DESC),
-		// so the most recent row (A) comes first, then B.
-		$row_a_summary = $rows[0];
-		$row_b_summary = $rows[1];
+		// Build a map of rows by result ID to avoid order-dependent assertions.
+		$by_result_id = [];
+		foreach ( $rows as $row ) {
+			$row_full = ProviderTrace::get( $row->id );
+			$this->assertNotNull( $row_full );
+			$decoded = json_decode( $row_full->response_body, true );
+			$by_result_id[ $decoded['id'] ?? '' ] = [
+				'summary' => $row,
+				'full'    => $row_full,
+			];
+		}
+
+		// Verify both result IDs are present.
+		$this->assertArrayHasKey( 'result-a', $by_result_id );
+		$this->assertArrayHasKey( 'result-b', $by_result_id );
 
 		// Verify row A paired with model A.
-		$this->assertSame( 'anthropic', $row_a_summary->provider_id );
-		$this->assertSame( 'claude-3-5-sonnet', $row_a_summary->model_id );
+		$this->assertSame( 'anthropic', $by_result_id['result-a']['summary']->provider_id );
+		$this->assertSame( 'claude-3-5-sonnet', $by_result_id['result-a']['summary']->model_id );
 
 		// Verify row B paired with model B.
-		$this->assertSame( 'openai', $row_b_summary->provider_id );
-		$this->assertSame( 'gpt-4o', $row_b_summary->model_id );
-
-		// Get full rows to verify response bodies (list() returns only sizes).
-		$row_a_full = ProviderTrace::get( $row_a_summary->id );
-		$row_b_full = ProviderTrace::get( $row_b_summary->id );
-		$this->assertNotNull( $row_a_full );
-		$this->assertNotNull( $row_b_full );
-
-		$this->assertSame( 'result-a', json_decode( $row_a_full->response_body, true )['id'] );
-		$this->assertSame( 'result-b', json_decode( $row_b_full->response_body, true )['id'] );
+		$this->assertSame( 'openai', $by_result_id['result-b']['summary']->provider_id );
+		$this->assertSame( 'gpt-4o', $by_result_id['result-b']['summary']->model_id );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Refactored test_nested_calls_trace_both_calls to use result ID keying instead of array position indexing, making assertions order-independent and preventing flakiness if ProviderTrace::list() ordering changes.

## Files Changed

tests/SdAiAgent/Bootstrap/AiClientEventTraceHandlerTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PHP syntax verified; test logic unchanged, only assertion method refactored to be order-independent.

Resolves #1481


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.58 plugin for [OpenCode](https://opencode.ai) v1.15.3 with claude-haiku-4-5 spent 42s and 3,133 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of AI trace correlation tests by removing order-dependent assertions and implementing lookup-based result verification.

---

**Note:** This release contains internal testing improvements with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->