### PR TITLE
GH#1482: fix(agent-loop): resolve connector-default model before reasoning-model check

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -1017,7 +1017,15 @@ class AgentLoop {
 		// body omits the field entirely. `max_tokens` is still safe to
 		// send: the SDK translates it to `max_completion_tokens` for the
 		// OpenAI reasoning API.
-		if ( ! self::is_reasoning_model( $this->model_id ) ) {
+		//
+		// Resolve the effective model ID (including connector defaults)
+		// before checking if it's a reasoning model, since configure_model()
+		// may have resolved a default model from the connector.
+		$resolved_model_id = $this->model_id;
+		if ( empty( $resolved_model_id ) && function_exists( 'OpenAiCompatibleConnector\\get_default_model' ) ) {
+			$resolved_model_id = (string) \OpenAiCompatibleConnector\get_default_model();
+		}
+		if ( ! self::is_reasoning_model( $resolved_model_id ) ) {
 			$builder->using_temperature( (float) $this->temperature );
 		}
 		$builder->using_max_tokens( $this->get_effective_max_output_tokens() );


### PR DESCRIPTION
## Summary

Fixes reasoning-model check to use the effective model ID (including connector defaults) instead of only checking $this->model_id. This prevents HTTP 400 errors when temperature is sent for reasoning models that are resolved via connector defaults.

## Files Changed

includes/Core/AgentLoop.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PHP syntax validation passed; logic verified against configure_model() resolution pattern

Resolves #1482


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.58 plugin for [OpenCode](https://opencode.ai) v1.15.3 with claude-haiku-4-5 spent 1m and 2,684 tokens on this as a headless worker.