### PR TITLE
fix(routines): rename r010 → r020 feedback triage; wire systemd launcher

### DIFF
--- a/.agents/scripts/commands/feedback-triage.md
+++ b/.agents/scripts/commands/feedback-triage.md
@@ -1,5 +1,5 @@
 ---
-description: Triage incoming feedback reports from the sd-ai-feedback plugin (r010 routine)
+description: Triage incoming feedback reports from the sd-ai-feedback plugin (r020 routine)
 agent: Build+
 mode: subagent
 tools:
@@ -16,13 +16,18 @@ tools:
 <!-- SPDX-License-Identifier: MIT -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Dave Stone -->
 
-# Feedback Triage — r010 Routine SOP
+# Feedback Triage — r020 Routine SOP
 
 Triage new feedback reports submitted via the sd-ai-agent feedback system. Fetch pending
 reports, judge each one, and either create a GitHub issue or dismiss with a reason.
 
-**Invocation**: Automated via aidevops routine r010 (`repeat:daily(@09:00)`). Can also be
+**Invocation**: Automated daily at 09:00 by the systemd timer
+`sh.aidevops.routine-feedback-triage-daily.timer` (aidevops routine slot `r020`;
+`repeat:persistent` so the pulse-wrapper does not also dispatch it). Can also be
 triggered manually with `/feedback-triage`.
+
+Slot history: previously labelled `r010` until 2026-05-18; renamed to `r020` to free
+`r010` for the framework GH Failure Miner reservation.
 
 **Required env vars** (sourced from `~/.config/aidevops/credentials.sh` or gopass):
 - `FEEDBACK_ENDPOINT` — Base URL of the sd-ai-feedback WordPress site
@@ -59,7 +64,7 @@ Output is a JSON array of report objects. Each object has at minimum:
 - `created_at` — submission timestamp
 - `status` — should be `new`
 
-If the array is empty, output: `r010: No new reports to triage.` and stop (success).
+If the array is empty, output: `r020: No new reports to triage.` and stop (success).
 
 ### Step 3: Check latest plugin version
 
@@ -196,7 +201,7 @@ Reason should be one concise sentence explaining why this is not actionable.
 After processing all reports, output a summary:
 
 ```
-r010 triage complete: <N> reports processed.
+r020 triage complete: <N> reports processed.
   - Issues created: <N>
   - Dismissed (duplicate): <N>
   - Dismissed (user error): <N>

--- a/.opencode/command/feedback-triage.md
+++ b/.opencode/command/feedback-triage.md
@@ -1,0 +1,1 @@
+../../.agents/scripts/commands/feedback-triage.md

--- a/TODO.md
+++ b/TODO.md
@@ -685,14 +685,14 @@ Phase 1 (receiving plugin) complete — shipped to Ultimate-Multisite/sd-ai-feed
 
 
 - [x] t187 AI-assisted triage automation for incoming feedback reports #feature ~6h logged:2026-04-14 blocked-by:t183 pr:#949 completed:2026-04-15
-  - Runs as an aidevops routine (r010) using deterministic script + AI agent split (modeled on /log-issue-aidevops pattern)
+  - Runs as an aidevops routine (r020) using deterministic script + AI agent split (modeled on /log-issue-aidevops pattern)
   - Deterministic script: `~/.aidevops/agents/custom/scripts/feedback-triage.sh` (already created) — `fetch` pulls new reports, `get <id>` pulls full payload, `dedup <keywords>` checks existing GitHub issues, `update <id> <status>` marks reports after triage
   - AI agent receives each report and judges: (1) real bug vs user error vs model limitation vs missing ability vs provider error, (2) checks dedup results — is this already reported?, (3) validates claims per log-issue-aidevops Step 3.6 (verify evidence, check data scale, detect template-driven findings), (4) composes structured GitHub issue body (Description, Expected Behavior, Steps to Reproduce from conversation, Environment, Report ID for backlink)
   - If real + not duplicate: `gh issue create -R Ultimate-Multisite/sd-ai-agent` then `feedback-triage.sh update <id> issue_created <url>`
   - If duplicate: `feedback-triage.sh update <id> dismissed` with link to existing issue
   - If not a bug: `feedback-triage.sh update <id> dismissed` with reason
   - Check plugin_version vs latest: if the report is from an outdated version where the issue is already fixed, dismiss with "fixed in vX.Y.Z"
-  - Routine entry: `r010 Triage incoming feedback reports repeat:daily(@09:00) ~15m agent:Build+`
+  - Routine entry: `r020 Triage incoming feedback reports repeat:persistent ~15m agent:Build+` (lifecycle managed by `sh.aidevops.routine-feedback-triage-daily.timer`; r010 reserved for framework GH Failure Miner)
 
 ### Complete Site Building Abilities (P0)
 
@@ -913,7 +913,7 @@ Full plan: [todo/PLANS.md#complete-site-building-abilities](PLANS.md#2026-04-09-
 
 ## Routines
 
-- [x] r010 Triage incoming feedback reports repeat:daily(@09:00) ~15m agent:Build+ ref:GH#944
+- [x] r020 Triage incoming feedback reports repeat:persistent ~15m agent:Build+ ref:GH#944 # systemd: sh.aidevops.routine-feedback-triage-daily.timer (renamed from r010 — that slot is reserved for the framework GH Failure Miner)
 
 ## Done
 


### PR DESCRIPTION
## Summary

The daily feedback-triage routine has been silently broken since at least 2026-05-12. This PR makes it actually run again and frees the `r010` slot for the framework's GH Failure Miner reservation.

## What was broken

1. **systemd timer ExecStart was unparseable.** The form was `bash -lc <backslash-escaped command string>`, which bash treated as a single command name and failed every day with `No such file or directory` (six identical entries in `routine-feedback-triage-daily.log`, never a successful launch).
2. **Pulse-wrapper was also dispatching r010** with a title-only prompt (`"Execute routine r010: Triage incoming feedback reports"`), which the model answered with only the session-start greeting. 38 output tokens, 0 tool calls.
3. **Routine slot collision.** Framework `workflows/routine.md` reserves `r010` for GH Failure Miner; this repo had overloaded it for feedback triage.

## What changed

### In this repo
- `TODO.md`: `r010` → `r020`, `repeat:daily(@09:00)` → `repeat:persistent` so pulse-wrapper skips it (lifecycle now owned by the systemd timer).
- `.agents/scripts/commands/feedback-triage.md`: routine ID, summary labels, invocation docs, and a slot-history note.
- `.opencode/command/feedback-triage.md`: new symlink so opencode actually discovers the slash command in the project (it doesn't read `.agents/scripts/commands/` natively).

### On the host (outside this repo, applied to the local install)
- `~/.config/systemd/user/sh.aidevops.routine-feedback-triage-daily.service` rewritten with a working `ExecStart` that calls a wrapper script.
- `~/.aidevops/agents/custom/scripts/run-feedback-triage-routine.sh` reads the SOP body, strips YAML frontmatter, and dispatches `opencode run -m anthropic/claude-haiku-4-5 --agent Build+`. The wrapper exists because (a) `opencode run` does not expand `/slash-commands` embedded in a positional message and (b) the dedicated `--command <name>` flag errors `Session not found` on a fresh headless run (opencode v1.15.4, tested 2026-05-18). The wrapper is the simplest workaround until opencode fixes one of those paths.

## Verification

Manual `systemctl --user start sh.aidevops.routine-feedback-triage-daily.service` on 2026-05-18:

- Completed in ~20s, exit 0.
- Model `claude-haiku-4-5` (tool-capable; earlier attempt with the local Ollama `gemma4:e4b` default produced narration only because that model has `tool_call: false`).
- Loaded credentials, called `feedback-triage.sh fetch`, and reported `No new reports to triage.`
- Archived broken log at `~/.aidevops/logs/routine-feedback-triage-daily.log.pre-r020-fix` for reference.

Next scheduled run: Mon 2026-05-18 09:00 MDT.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.60 plugin for [OpenCode](https://opencode.ai) v1.15.4 with claude-opus-4-7 spent 11h 23m and 69,818 tokens on this with the user in an interactive session.
