### PR TITLE
fix(http-trace): preserve tool_use.input as JSON object across cache decoder round-trip [sd-ai-mtu]

### DIFF
--- a/includes/Bootstrap/HttpTraceHandler.php
+++ b/includes/Bootstrap/HttpTraceHandler.php
@@ -22,6 +22,7 @@ use SdAiAgent\Core\PromptCache\CacheStrategyResolver;
 use SdAiAgent\Core\PromptCache\RequestContextAwareCacheStrategyInterface;
 use SdAiAgent\Core\ProviderTraceLogger;
 use SdAiAgent\Core\Settings;
+use SdAiAgent\Infrastructure\Schema\EmptyJsonObject;
 use SdAiAgent\Infrastructure\Schema\SchemaNormalizer;
 use SdAiAgent\Models\ProviderTrace;
 use XWP\DI\Decorators\Filter;
@@ -157,16 +158,22 @@ final class HttpTraceHandler {
 			return $parsed_args;
 		}
 
-		// Repair tool input schemas BEFORE re-encoding. The json_decode/
-		// json_encode round-trip above collapses every JSON `{}` (including
-		// the canonical empty `properties` / `items` objects required by
-		// JSON Schema draft-2020-12) into a PHP empty array, which then
-		// re-serialises as `[]` and triggers Anthropic 400 responses
-		// (`tools.N.custom.input_schema: JSON schema is invalid`).
-		// SchemaNormalizer::to_json_safe() restores `EmptyJsonObject`
-		// markers in the known schema-bearing positions so the re-encoded
-		// body matches the wire format the SDK originally produced.
+		// Repair empty JSON-object positions BEFORE re-encoding. The
+		// json_decode / json_encode round-trip above collapses every JSON
+		// `{}` into a PHP empty array, which then re-serialises as `[]` —
+		// a different JSON type that triggers Anthropic 400 responses.
+		//
+		// `repair_tool_schemas()` restores the canonical empty
+		// `properties` / `items` objects required by JSON Schema
+		// draft-2020-12 in tool *definitions* (sd-ai-0nm,
+		// `tools.N.custom.input_schema: JSON schema is invalid`).
+		//
+		// `repair_message_tool_uses()` restores the empty `tool_use.input`
+		// object required for parameterless tool calls in conversation
+		// history (sd-ai-mtu,
+		// `messages.N.content.M.tool_use.input: Input should be an object`).
 		$mutated = $this->repair_tool_schemas( $mutated );
+		$mutated = $this->repair_message_tool_uses( $mutated );
 
 		$encoded = wp_json_encode( $mutated );
 		if ( false === $encoded ) {
@@ -239,6 +246,86 @@ final class HttpTraceHandler {
 			}
 
 			$body['tools'][ $i ] = $tool;
+		}
+
+		return $body;
+	}
+
+	/**
+	 * Restore JSON-object encoding for `tool_use.input` across assistant
+	 * message history.
+	 *
+	 * Anthropic's API requires every `tool_use.input` to be a JSON object
+	 * (matching the corresponding tool's `input_schema`, which itself
+	 * must be a JSON Schema draft-2020-12 `object`). Even parameterless
+	 * tools must emit `"input": {}` and never `"input": []`.
+	 *
+	 * The text-generation models in both
+	 * `WordPress/ai-provider-for-anthropic` (PR #23) and
+	 * `Ultimate-Multisite/ai-provider-for-anthropic-max` already
+	 * normalise `null` / empty PHP arrays returned by
+	 * `FunctionCall::getArgs()` to `stdClass` when building the request
+	 * body, so the body that reaches WordPress's HTTP API correctly
+	 * encodes parameterless tool calls as `"input": {}`. When prompt
+	 * caching is enabled, however, this filter then decodes the body
+	 * with `json_decode($body, true)`, collapsing the empty object back
+	 * to a PHP `[]`, and re-encodes with `wp_json_encode()` which emits
+	 * `[]`. Anthropic rejects the next request with:
+	 *
+	 *   400 Bad Request — messages.N.content.M.tool_use.input: Input should be an object
+	 *
+	 * Reproduces deterministically on the second turn of any
+	 * conversation that previously invoked a parameterless ability
+	 * (`memory-list`, `ability-search`, `skill-list`, etc.) — the
+	 * assistant turn carrying the prior `tool_use` block is replayed
+	 * and the round-trip corruption fires.
+	 *
+	 * This walker visits every `messages[*].content[*]` block of type
+	 * `tool_use` and, if `input` is an empty PHP array, restores an
+	 * `EmptyJsonObject` placeholder so re-encoding produces `{}` on the
+	 * wire.
+	 *
+	 * Scope: only the top-level `input` is repaired here, matching the
+	 * single path Anthropic's API enforces as "must be an object".
+	 * Empty objects nested inside a non-empty input (e.g.
+	 * `{"filters": {}}`) would require a parallel-decode pass that
+	 * tracks the original JSON type of every empty container and are
+	 * out of scope here — they are not currently known to trigger
+	 * Anthropic 400s when nested inside a non-empty object.
+	 *
+	 * @param array<string,mixed> $body Decoded request body.
+	 * @return array<string,mixed> Body with empty `tool_use.input` placeholders restored.
+	 */
+	private function repair_message_tool_uses( array $body ): array {
+		if ( ! isset( $body['messages'] ) || ! is_array( $body['messages'] ) ) {
+			return $body;
+		}
+
+		foreach ( $body['messages'] as $mi => $msg ) {
+			if ( ! is_array( $msg ) || ! isset( $msg['content'] ) || ! is_array( $msg['content'] ) ) {
+				continue;
+			}
+
+			foreach ( $msg['content'] as $ci => $block ) {
+				if ( ! is_array( $block ) ) {
+					continue;
+				}
+
+				if ( 'tool_use' !== ( $block['type'] ?? '' ) ) {
+					continue;
+				}
+
+				if ( ! array_key_exists( 'input', $block ) ) {
+					continue;
+				}
+
+				$input = $block['input'];
+
+				if ( is_array( $input ) && array() === $input ) {
+					$block['input']                            = new EmptyJsonObject();
+					$body['messages'][ $mi ]['content'][ $ci ] = $block;
+				}
+			}
 		}
 
 		return $body;

--- a/tests/SdAiAgent/Bootstrap/HttpTraceHandlerCacheTest.php
+++ b/tests/SdAiAgent/Bootstrap/HttpTraceHandlerCacheTest.php
@@ -169,6 +169,106 @@ class HttpTraceHandlerCacheTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Regression for sd-ai-mtu: parameterless tool calls in the
+	 * conversation history must keep `tool_use.input` encoded as `{}`,
+	 * not `[]`, when the cache decorator's json_decode/encode round-trip
+	 * runs.
+	 *
+	 * Before the fix, an assistant turn carrying a `tool_use` block with
+	 * empty `input` was replayed on the second turn and Anthropic
+	 * returned:
+	 *
+	 *   400 messages.N.content.M.tool_use.input: Input should be an object
+	 *
+	 * The handler now restores EmptyJsonObject placeholders in
+	 * messages[*].content[*].tool_use.input before re-encoding so
+	 * parameterless tool calls survive the round-trip as `{}`.
+	 */
+	public function test_anthropic_empty_tool_use_input_survives_round_trip(): void {
+		$body = $this->anthropic_body_with_empty_tool_use_input();
+
+		$args = array(
+			'method' => 'POST',
+			'body'   => (string) wp_json_encode( $body ),
+		);
+
+		// Sanity: original bytes already encode `{}` (not `[]`) for the
+		// empty tool_use.input — the provider build site does the right
+		// thing; the cache filter is the only thing that can break it.
+		$this->assertStringContainsString( '"input":{}', $args['body'] );
+		$this->assertStringNotContainsString( '"input":[]', $args['body'] );
+
+		$result = $this->handler->on_http_request_args( $args, 'https://api.anthropic.com/v1/messages' );
+
+		// After cache marker injection, every empty `tool_use.input`
+		// must still encode `{}` and never `[]`.
+		$this->assertStringContainsString( '"input":{}', (string) $result['body'] );
+		$this->assertStringNotContainsString( '"input":[]', (string) $result['body'] );
+
+		// Cache markers should still be applied (verifies we didn't
+		// accidentally short-circuit the strategy).
+		$decoded   = json_decode( (string) $result['body'], true );
+		$last_tool = end( $decoded['tools'] );
+		$this->assertArrayHasKey( 'cache_control', $last_tool );
+	}
+
+	/**
+	 * Build a request body that mirrors the real wire shape produced by
+	 * the WP-AI-Client SDK when an assistant turn invokes a
+	 * parameterless ability and is replayed on the next turn. The
+	 * `tool_use.input` is an EmptyJsonObject (which serialises to `{}`)
+	 * — the same shape the provider models build at runtime.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function anthropic_body_with_empty_tool_use_input(): array {
+		$empty_obj = new \SdAiAgent\Infrastructure\Schema\EmptyJsonObject();
+
+		return array(
+			'model'    => 'claude-sonnet-4-6',
+			'system'   => array(
+				array( 'type' => 'text', 'text' => str_repeat( 'long system. ', 400 ) ),
+			),
+			'tools'    => array(
+				array(
+					'name'         => 'wpab__sd-ai-agent__memory-list',
+					'description'  => str_repeat( 'list memories ', 30 ),
+					'input_schema' => array(
+						'type'                 => 'object',
+						'properties'           => $empty_obj,
+						'additionalProperties' => false,
+						'$schema'              => 'http://json-schema.org/draft-07/schema#',
+					),
+				),
+			),
+			'messages' => array(
+				array( 'role' => 'user', 'content' => 'list my memories' ),
+				array(
+					'role'    => 'assistant',
+					'content' => array(
+						array(
+							'type'  => 'tool_use',
+							'id'    => 'toolu_test_1',
+							'name'  => 'wpab__sd-ai-agent__memory-list',
+							'input' => $empty_obj,
+						),
+					),
+				),
+				array(
+					'role'    => 'user',
+					'content' => array(
+						array(
+							'type'        => 'tool_result',
+							'tool_use_id' => 'toolu_test_1',
+							'content'     => '[]',
+						),
+					),
+				),
+			),
+		);
+	}
+
+	/**
 	 * Build a request body that mirrors the real wire shape produced by
 	 * the WP-AI-Client SDK polyfill: every tool's input_schema is a
 	 * JSON-Schema draft-2020-12 object with `properties` represented as


### PR DESCRIPTION
## Summary

When prompt caching is enabled, `HttpTraceHandler::on_http_request_args()` decodes the request body with `json_decode($body, true)` and re-encodes it with `wp_json_encode()`. For parameterless ability calls the provider models correctly emit `"input": {}` on the wire, but the assoc-array round-trip collapses the empty object to a PHP `[]` which re-encodes as `"input": []`. Anthropic rejects the next request with:

```
400 messages.N.content.M.tool_use.input: Input should be an object
```

The bug fires deterministically on the **second turn of any conversation that previously invoked a parameterless ability** (`memory-list`, `ability-search`, `skill-list`, `get-current-time`, etc.) — the assistant turn carrying the prior `tool_use` block is replayed and the round-trip corruption fires.

This PR adds a focused walker, `HttpTraceHandler::repair_message_tool_uses()`, that visits every `messages[*].content[*]` block of type `tool_use` and, if `input` is an empty PHP array, restores an `EmptyJsonObject` placeholder so re-encoding produces `{}` on the wire.

## Why this can't be fixed only in the provider

The text-generation models in [`WordPress/ai-provider-for-anthropic`](https://github.com/WordPress/ai-provider-for-anthropic) (PR #23) and [`Ultimate-Multisite/ai-provider-for-anthropic-max`](https://github.com/Ultimate-Multisite/ai-provider-for-anthropic-max) already normalise empty `FunctionCall::getArgs()` results to `stdClass` when building the request body, so the bytes that reach the WordPress HTTP API correctly encode parameterless tool calls as `"input": {}`. The provider-side fix is necessary — and remains valuable as defence in depth — but is **not sufficient on its own**, because the `pre_http_request_args` filter in this plugin then performs a destructive `json_decode($body, true)` / `wp_json_encode()` round-trip that erases the object/array distinction.

This walker pairs with those provider-side fixes; together they form defence in depth at every layer where the request body is materialised or transformed.

## Sibling fix

This is the same class of round-trip bug as #1436 (`repair_tool_schemas`, which fixed empty `properties` in `$body['tools'][*]['input_schema']`), in a different location of the request body:

| PR | Path repaired | Symptom |
|---|---|---|
| #1436 | `body.tools[*].input_schema.properties` (recursive) | 400 `tools.N.input_schema: Input tag 'object' …` |
| **This PR** | `body.messages[*].content[*].tool_use.input` (top level) | 400 `messages.N.content.M.tool_use.input: Input should be an object` |

## Scope and limitations

- **Top-level `tool_use.input` only.** This matches the single path Anthropic's API enforces as "must be an object". Empty objects nested *inside* a non-empty input (e.g. `{"filters": {}}`) would require a parallel-decode pass that tracks the original JSON type of every empty container, and are not currently known to trigger Anthropic 400s. Out of scope here; happy to follow up if a counter-example surfaces.
- **No structural changes to the cache pipeline.** The fix is additive: a new private walker called once between `repair_tool_schemas` and `wp_json_encode`. The rest of the strategy/marker logic is untouched.

## Reproduction

Run the failure case via wp-cli against any install with prompt caching enabled:

```bash
wp eval '
$body = ["messages" => [["role"=>"assistant","content"=>[
  ["type"=>"tool_use","id"=>"t1","name"=>"memory-list","input"=>new \stdClass()],
]]]];
$encoded = wp_json_encode($body);
echo "Before: $encoded\n";
$decoded = json_decode($encoded, true);
$reencoded = wp_json_encode($decoded);
echo "After:  $reencoded\n";
'
# Before: {"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"memory-list","input":{}}]}]}
# After:  {"messages":[{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"memory-list","input":[]}]}]}
```

The `Before` body is what the provider builds; the `After` body is what gets sent to Anthropic when this filter runs without the walker. Anthropic returns a 400 on the next turn.

In-situ verification on a production-shaped install (mygratis.site) confirms the deployed handler reproduces the corruption with stock code and that the patched handler emits `"input":{}` while leaving `cache_control` markers intact.

## Verification

Run from the worktree:

```bash
composer phpcs    # 8/8 files, 0 errors
composer phpstan  # 218/218 files, 0 errors
composer test -- --filter HttpTraceHandlerCacheTest
# OK (8 tests, 19 assertions) — 7 existing + 1 new regression
```

The new test, `test_anthropic_empty_tool_use_input_survives_round_trip`, asserts:

1. The inbound body contains `"input":{}` (provider builds it correctly).
2. After `on_http_request_args` runs, the outbound body still contains `"input":{}` and **never** contains `"input":[]`.
3. Cache markers (`cache_control`) are still injected on the last tool — i.e. the strategy didn't short-circuit.

## Files changed

- `includes/Bootstrap/HttpTraceHandler.php` — adds `use SdAiAgent\Infrastructure\Schema\EmptyJsonObject;`, inserts a call to `repair_message_tool_uses()` between `repair_tool_schemas` and `wp_json_encode`, defines the new walker.
- `tests/SdAiAgent/Bootstrap/HttpTraceHandlerCacheTest.php` — adds the regression test and a fixture (`anthropic_body_with_empty_tool_use_input()`) shaped like a real two-turn replay.

## Task

`sd-ai-mtu`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.61 plugin for [OpenCode](https://opencode.ai) v1.15.4 with claude-sonnet-4-6 spent 3d 22h and 383 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected JSON encoding of empty tool inputs in AI agent messages to use object notation instead of array notation.

* **Tests**
  * Added regression test to verify proper encoding of parameterless tool calls in message history.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1493?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->