### PR TITLE
fix(settings): validate default model against registered providers (GH#1494)

### DIFF
--- a/includes/Admin/DefaultModelNoticeHandler.php
+++ b/includes/Admin/DefaultModelNoticeHandler.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Admin notice handler for rejected default-model values.
+ *
+ * Surfaces a one-time notice when the resolver in
+ * {@see \SdAiAgent\Core\Settings::get_default_model()} falls back because
+ * the saved `sd_ai_agent_settings.default_model` (or its paired
+ * `default_provider`) is no longer registered with any authenticated
+ * provider in the WP AI Client SDK registry.
+ *
+ * Historical context: the production `gemma4:e4b` regression (GH#1494) was
+ * caused by the saved default propagating into every new chat unchecked.
+ * The resolver now substitutes a working model and records the rejected
+ * value so this handler can explain the substitution to the site owner.
+ *
+ * @package SdAiAgent\Admin
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Admin;
+
+use SdAiAgent\Core\Settings;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Renders the one-time "default model substituted" admin notice.
+ *
+ * @since 1.13.1
+ */
+final class DefaultModelNoticeHandler {
+
+	/**
+	 * Dismiss-query parameter recognised by {@see handle_dismiss()}.
+	 */
+	private const DISMISS_QUERY_ARG = 'sd_ai_agent_dismiss_default_model_notice';
+
+	/**
+	 * Nonce action paired with {@see DISMISS_QUERY_ARG}.
+	 */
+	private const DISMISS_NONCE_ACTION = 'sd_ai_agent_dismiss_default_model_notice';
+
+	/**
+	 * Conditionally render the substitution notice on the current admin screen.
+	 *
+	 * Called on the `admin_notices` hook. The notice is shown when:
+	 *   - the current user can manage options (so connectors are reachable),
+	 *   - a substitution record exists in {@see Settings::INVALID_DEFAULT_NOTICE_OPTION}.
+	 *
+	 * Dismissal clears the option entirely; the notice will re-appear only
+	 * if the resolver records a fresh rejection.
+	 */
+	public static function maybe_display_notice(): void {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		$record = get_option( Settings::INVALID_DEFAULT_NOTICE_OPTION );
+		if ( ! is_array( $record ) || empty( $record['model'] ) ) {
+			return;
+		}
+
+		self::render_notice( $record );
+	}
+
+	/**
+	 * Handle dismissal of the notice via the query-string handshake.
+	 *
+	 * Wired on `admin_init` (mirroring
+	 * {@see ThirdPartyAbilityNoticeHandler::handle_dismiss()}). Verifies the
+	 * nonce, deletes the option, and redirects to drop the query args so a
+	 * page refresh does not re-trigger the handler.
+	 */
+	public static function handle_dismiss(): void {
+		if ( ! isset( $_GET[ self::DISMISS_QUERY_ARG ] ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+
+		if ( ! isset( $_GET['_wpnonce'] )
+			|| ! wp_verify_nonce(
+				sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) ),
+				self::DISMISS_NONCE_ACTION
+			)
+		) {
+			return;
+		}
+
+		delete_option( Settings::INVALID_DEFAULT_NOTICE_OPTION );
+
+		$redirect = remove_query_arg( array( self::DISMISS_QUERY_ARG, '_wpnonce' ) );
+		if ( is_string( $redirect ) && '' !== $redirect ) {
+			wp_safe_redirect( $redirect );
+			exit;
+		}
+	}
+
+	/**
+	 * Render the notice markup.
+	 *
+	 * @param array<string, mixed> $record Substitution record from the option.
+	 */
+	private static function render_notice( array $record ): void {
+		$provider          = isset( $record['provider'] ) ? (string) $record['provider'] : '';
+		$model             = isset( $record['model'] ) ? (string) $record['model'] : '';
+		$replacement_model = isset( $record['replacement_model'] ) ? (string) $record['replacement_model'] : '';
+
+		$settings_url = admin_url( 'admin.php?page=sd-ai-agent#settings' );
+		$dismiss_url  = wp_nonce_url(
+			add_query_arg( self::DISMISS_QUERY_ARG, '1' ),
+			self::DISMISS_NONCE_ACTION
+		);
+
+		?>
+		<div class="notice notice-warning is-dismissible" id="sd-ai-agent-default-model-notice">
+			<p>
+				<strong><?php esc_html_e( 'Superdav AI Agent', 'superdav-ai-agent' ); ?></strong>
+				<?php
+				if ( '' !== $replacement_model ) {
+					printf(
+						esc_html(
+							/* translators: 1: previously saved model ID, 2: substitute model ID currently in use */
+							__( 'Your saved default model "%1$s" is not advertised by any authenticated provider, so chats are using "%2$s" instead. Open the settings page to choose a model that matches the providers you have configured.', 'superdav-ai-agent' )
+						),
+						esc_html( '' !== $model ? $model : ( '' !== $provider ? $provider : __( '(unknown)', 'superdav-ai-agent' ) ) ),
+						esc_html( $replacement_model )
+					);
+				} else {
+					printf(
+						esc_html(
+							/* translators: %s: previously saved model ID */
+							__( 'Your saved default model "%s" is not advertised by any authenticated provider, and no fallback could be selected. Configure a provider on the Connectors page to restore chats.', 'superdav-ai-agent' )
+						),
+						esc_html( '' !== $model ? $model : ( '' !== $provider ? $provider : __( '(unknown)', 'superdav-ai-agent' ) ) )
+					);
+				}
+				?>
+			</p>
+			<p>
+				<a href="<?php echo esc_url( $settings_url ); ?>" class="button button-primary">
+					<?php esc_html_e( 'Open Settings', 'superdav-ai-agent' ); ?>
+				</a>
+				<a href="<?php echo esc_url( $dismiss_url ); ?>" class="button">
+					<?php esc_html_e( 'Dismiss', 'superdav-ai-agent' ); ?>
+				</a>
+			</p>
+		</div>
+		<?php
+	}
+}

--- a/includes/Bootstrap/AdminHandler.php
+++ b/includes/Bootstrap/AdminHandler.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Bootstrap;
 
 use SdAiAgent\Abilities\ToolCapabilities;
+use SdAiAgent\Admin\DefaultModelNoticeHandler;
 use SdAiAgent\Admin\FloatingWidget;
 use SdAiAgent\Admin\ThirdPartyAbilityNoticeHandler;
 use SdAiAgent\Admin\UnifiedAdminMenu;
@@ -77,6 +78,7 @@ final class AdminHandler {
 	 * - Per-tool capabilities for role-management plugins.
 	 * - Legacy URL redirects to unified menu.
 	 * - Handle third-party ability notice dismissal.
+	 * - Handle invalid-default-model notice dismissal (GH#1494).
 	 */
 	#[Action( tag: 'admin_init', priority: 10 )]
 	public function on_admin_init(): void {
@@ -84,6 +86,7 @@ final class AdminHandler {
 		ToolCapabilities::register_capabilities( ToolCapabilities::all_ability_ids() );
 		UnifiedAdminMenu::handleLegacyRedirects();
 		ThirdPartyAbilityNoticeHandler::handle_dismiss();
+		DefaultModelNoticeHandler::handle_dismiss();
 	}
 
 	/**
@@ -92,6 +95,16 @@ final class AdminHandler {
 	#[Action( tag: 'admin_notices', priority: 10 )]
 	public function display_third_party_notice(): void {
 		ThirdPartyAbilityNoticeHandler::maybe_display_notice();
+	}
+
+	/**
+	 * Display admin notice when the saved default model is no longer
+	 * advertised by any authenticated provider and the resolver had to
+	 * substitute (GH#1494).
+	 */
+	#[Action( tag: 'admin_notices', priority: 10 )]
+	public function display_default_model_notice(): void {
+		DefaultModelNoticeHandler::maybe_display_notice();
 	}
 
 	/**

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -230,10 +230,19 @@ class AgentLoop {
 		$raw_settings = $this->settings_service->get();
 		$settings     = is_array( $raw_settings ) ? $raw_settings : array();
 
+		// Default provider/model resolution flows through the Settings
+		// service so an out-of-date saved value (e.g. a model whose provider
+		// has been uninstalled) is validated against the live WP AI Client
+		// SDK registry and substituted before it reaches the SDK. Without
+		// this, every new chat against a broken default hits a top-level
+		// "model not available" error banner — see GH#1494 (the production
+		// `gemma4:e4b` demo regression). Explicit per-call overrides via
+		// $options bypass validation so callers can still pin arbitrary
+		// values (benchmarks, scheduled jobs, etc.).
 		// @phpstan-ignore-next-line
-		$this->provider_id = $options['provider_id'] ?? ( $settings['default_provider'] ?: '' );
+		$this->provider_id = $options['provider_id'] ?? $this->settings_service->get_default_provider();
 		// @phpstan-ignore-next-line
-		$this->model_id = $options['model_id'] ?? ( $settings['default_model'] ?: '' );
+		$this->model_id = $options['model_id'] ?? $this->settings_service->get_default_model();
 		// @phpstan-ignore-next-line
 		$this->max_iterations = $options['max_iterations'] ?? ( $settings['max_iterations'] ?: 25 );
 
@@ -1330,9 +1339,17 @@ class AgentLoop {
 			return;
 		}
 
-		// Resolve model — fall back to the connector's configured default.
+		// Resolve model — fall back to the connector's configured default
+		// when the agent loop was started without one. The connector default
+		// (`ultimate_ai_connector_default_model`) is what produced the
+		// production `gemma4:e4b` regression (GH#1494): it stored a model
+		// the endpoint did not actually serve and the SDK rejected every
+		// chat with a top-level error banner. Validate before adopting.
 		if ( empty( $model_id ) && function_exists( 'OpenAiCompatibleConnector\\get_default_model' ) ) {
-			$model_id = \OpenAiCompatibleConnector\get_default_model();
+			$candidate = (string) \OpenAiCompatibleConnector\get_default_model();
+			if ( '' !== $candidate && Settings::is_model_advertised( $provider_id, $candidate ) ) {
+				$model_id = $candidate;
+			}
 		}
 
 		try {

--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -36,6 +36,28 @@ class Settings {
 	const GSC_CREDENTIALS_OPTION = 'sd_ai_agent_gsc_credentials';
 
 	/**
+	 * Option name that records the most recent saved default-model value
+	 * which was rejected by {@see resolve_default_provider_and_model()}
+	 * because the configured provider/model was not advertised by any
+	 * authenticated provider in the WP AI Client SDK registry.
+	 *
+	 * Used by {@see \SdAiAgent\Admin\DefaultModelNoticeHandler} to render
+	 * a one-time admin notice describing the rejected value and the
+	 * substitute the plugin chose so the user knows why the dropdown
+	 * default no longer matches what they last saved.
+	 *
+	 * Shape:
+	 *   array{
+	 *     provider:           string, // saved (possibly invalid) provider ID
+	 *     model:              string, // saved (possibly invalid) model ID
+	 *     replacement_provider: string, // provider chosen by the resolver
+	 *     replacement_model:    string, // model chosen by the resolver
+	 *     recorded_at:        int,    // unix timestamp
+	 *   }
+	 */
+	const INVALID_DEFAULT_NOTICE_OPTION = 'sd_ai_agent_invalid_default_model_notice';
+
+	/**
 	 * Known context window sizes per model (tokens).
 	 * Used as a fallback lookup for WP SDK provider models that do not carry
 	 * context_window metadata from the provider registry.
@@ -525,11 +547,31 @@ class Settings {
 	/**
 	 * Resolve the effective default model ID.
 	 *
-	 * Resolution order (first non-empty value wins):
-	 *   1. `default_model` setting saved by the site administrator.
-	 *   2. Value returned by the `sd_ai_agent_default_model` filter (allows
-	 *      developers to override the default programmatically).
-	 *   3. The `SD_AI_AGENT_DEFAULT_MODEL` constant defined in the plugin root.
+	 * The resolver validates the saved (provider, model) pair against the
+	 * WP AI Client SDK registry before returning it. If the saved provider
+	 * has been uninstalled or no longer advertises the saved model, the
+	 * resolver falls through to safer candidates instead of letting the
+	 * SDK reject the request with a top-level error banner — the situation
+	 * that produced the production `gemma4:e4b` regression (GH#1494).
+	 *
+	 * Resolution order:
+	 *   1. The saved `default_model` from `sd_ai_agent_settings`, paired with
+	 *      `default_provider`, when an authenticated provider in the registry
+	 *      advertises that model.
+	 *   2. The `sd_ai_agent_default_model` filter override, when an
+	 *      authenticated provider in the registry advertises that model.
+	 *   3. The `SD_AI_AGENT_DEFAULT_MODEL` constant (factory default), when
+	 *      an authenticated provider in the registry advertises that model.
+	 *   4. The first model advertised by the first authenticated provider —
+	 *      so a fresh signup or an install that just rotated providers still
+	 *      gets a working chat instead of a hard error.
+	 *   5. The filtered/constant value as a last resort when the registry is
+	 *      not consultable (e.g. WP < 7.0 without the bundled polyfill) so
+	 *      historical behaviour is preserved on unsupported runtimes.
+	 *
+	 * When the saved value is rejected (path 1 fails because the saved pair
+	 * is not advertised), {@see record_invalid_default_notice()} stores a
+	 * one-time admin notice so the site owner is told what happened.
 	 *
 	 * Example — override the default model from a theme or mu-plugin:
 	 *
@@ -537,25 +579,438 @@ class Settings {
 	 *       return 'gpt-4o';
 	 *   } );
 	 *
-	 * @return string Non-empty model ID.
+	 * @return string Model ID. Non-empty in every path except when the
+	 *                registry is consultable and reports no authenticated
+	 *                providers at all — in which case `''` is returned so
+	 *                callers can short-circuit to the "no provider configured"
+	 *                error path instead of sending an unusable request.
 	 */
 	public function get_default_model(): string {
+		[ , $model ] = $this->resolve_default_provider_and_model();
+		return $model;
+	}
+
+	/**
+	 * Resolve the effective default provider ID.
+	 *
+	 * Co-resolves with {@see get_default_model()} so the returned provider
+	 * advertises the returned model. When the saved `default_provider` is
+	 * not registered or not authenticated, the resolver falls through to
+	 * the first authenticated provider in the WP AI Client SDK registry.
+	 *
+	 * @return string Provider ID, or `''` when no provider can be chosen
+	 *                (registry empty, or registry not consultable and no
+	 *                provider was saved).
+	 */
+	public function get_default_provider(): string {
+		[ $provider ] = $this->resolve_default_provider_and_model();
+		return $provider;
+	}
+
+	/**
+	 * Resolve the canonical (provider, model) pair used by the chat path.
+	 *
+	 * Resolution rules (in order):
+	 *   - When the registry cannot be consulted (WP < 7.0 without the SDK
+	 *     polyfill, SDK boot failure, etc.) the saved pair is returned
+	 *     verbatim without validation or notice recording.
+	 *   - When the saved `default_model` is **empty AND no
+	 *     `sd_ai_agent_default_model` filter pins a value**, the resolver
+	 *     returns `''` for the model so callers fall through to the SDK's
+	 *     built-in per-provider default (e.g. anthropic picks its newest
+	 *     Sonnet point release rather than being pinned to the constant).
+	 *     Only the provider hint is co-resolved.
+	 *   - Otherwise the **candidate** model is the filter-pinned value if
+	 *     the filter overrode the constant, else the saved model. The
+	 *     candidate is validated against the saved provider first, then
+	 *     against any other authenticated provider; when valid it is
+	 *     returned (with a notice only if the provider had to change).
+	 *   - When the candidate is not advertised anywhere, the resolver
+	 *     substitutes a working value (constant → first registered model)
+	 *     and records a one-time admin notice describing the substitution
+	 *     so site owners can investigate the rejected configuration.
+	 *
+	 * @see get_default_model()    for the public API and resolution order.
+	 * @see get_default_provider() for the paired provider semantics.
+	 *
+	 * @return array{0: string, 1: string} `[provider_id, model_id]`. The model
+	 *         may be `''` when the saved value was empty (intentional fall
+	 *         through to the SDK's per-provider default). Both may be `''`
+	 *         only when the registry is consultable but reports no
+	 *         authenticated providers.
+	 */
+	private function resolve_default_provider_and_model(): array {
 		$settings = $this->get();
 		// @phpstan-ignore-next-line
-		$model = (string) ( $settings['default_model'] ?? '' );
+		$saved_provider = (string) ( $settings['default_provider'] ?? '' );
+		// @phpstan-ignore-next-line
+		$saved_model = (string) ( $settings['default_model'] ?? '' );
 
-		if ( '' === $model ) {
-			$builtin = defined( 'SD_AI_AGENT_DEFAULT_MODEL' ) ? (string) SD_AI_AGENT_DEFAULT_MODEL : 'claude-sonnet-4';
+		$builtin = defined( 'SD_AI_AGENT_DEFAULT_MODEL' )
+			? (string) SD_AI_AGENT_DEFAULT_MODEL
+			: 'claude-sonnet-4';
 
-			/**
-			 * Filter the default model ID used when no model is configured in settings.
-			 *
-			 * @param string $model The built-in fallback model ID (SD_AI_AGENT_DEFAULT_MODEL).
-			 */
-			$model = (string) apply_filters( 'sd_ai_agent_default_model', $builtin );
+		/**
+		 * Filter the default model ID used when no model is configured in settings.
+		 *
+		 * Applied BEFORE the registry-validation step so the filter can pin
+		 * a value that will then be validated against the live providers.
+		 * Filters that pin a model the user does not actually have a provider
+		 * for will themselves fall through (with one-time notice) rather
+		 * than emit an unrecoverable error from the SDK.
+		 *
+		 * @param string $model The built-in fallback model ID (SD_AI_AGENT_DEFAULT_MODEL).
+		 */
+		$filtered_builtin = (string) apply_filters( 'sd_ai_agent_default_model', $builtin );
+		if ( '' === $filtered_builtin ) {
+			$filtered_builtin = $builtin;
 		}
 
-		return $model;
+		// If the registry is not consultable (WP < 7.0 without polyfill,
+		// SDK boot failure, etc.) we cannot validate — preserve historical
+		// behaviour and return the saved values verbatim.
+		if ( ! self::can_validate_against_registry() ) {
+			return array( $saved_provider, $saved_model );
+		}
+
+		$registered = self::collect_registered_provider_models();
+
+		// Empty saved model with no filter override — preserve the historical
+		// "let the SDK pick" behaviour. The chat path calls
+		// $builder->using_provider() (no explicit model) when this returns
+		// `''`, which lets each provider's adapter choose its own newest
+		// stable model. Returning the constant unconditionally would force
+		// every install onto a fixed ID even when the provider supports
+		// something newer in the same family.
+		//
+		// When a `sd_ai_agent_default_model` filter pins a concrete value,
+		// fall through to the regular validation/substitution flow so the
+		// pinned value either takes effect (when registered) or is
+		// substituted with a working model (when not). A broken filter
+		// must not silently degrade to "SDK picks something different".
+		$filter_pinned = ( $filtered_builtin !== $builtin );
+		if ( '' === $saved_model && ! $filter_pinned ) {
+			return array( self::resolve_provider_hint( $saved_provider, $registered ), '' );
+		}
+
+		// Candidate model = filter override if set, else saved. The saved
+		// provider stays the candidate provider unless we later swap it
+		// because the candidate model is registered under a different one.
+		$candidate_model = $filter_pinned ? $filtered_builtin : $saved_model;
+
+		// Path 1 — candidate (provider, model) pair, when the provider is
+		// authenticated and advertises the candidate model.
+		if ( '' !== $saved_provider
+			&& self::pair_is_registered( $saved_provider, $candidate_model, $registered )
+		) {
+			return array( $saved_provider, $candidate_model );
+		}
+
+		// Path 2 — candidate model advertised by some authenticated provider
+		// other than the saved one. Honour the candidate value but swap
+		// to a provider that actually serves it; record a notice only when
+		// we had a saved provider that just changed beneath the user.
+		$provider_for_candidate = self::find_provider_for_model( $candidate_model, $registered );
+		if ( null !== $provider_for_candidate ) {
+			if ( '' !== $saved_provider && $saved_provider !== $provider_for_candidate ) {
+				self::record_invalid_default_notice( $saved_provider, $saved_model, $provider_for_candidate, $candidate_model );
+			}
+			return array( $provider_for_candidate, $candidate_model );
+		}
+
+		// Candidate (filter result or saved model) is not advertised
+		// anywhere — substitute and record a notice. Every path below
+		// records a notice so the site owner is informed.
+		//
+		// Path 3 — the factory-default constant, when advertised by some
+		// authenticated provider. Distinct from path 2 only when the filter
+		// rewrote the value above; we still try the unfiltered constant
+		// before falling all the way through.
+		if ( $builtin !== $candidate_model ) {
+			$provider_for_builtin = self::find_provider_for_model( $builtin, $registered );
+			if ( null !== $provider_for_builtin ) {
+				$resolved = array( $provider_for_builtin, $builtin );
+				self::record_invalid_default_notice( $saved_provider, $saved_model, $resolved[0], $resolved[1] );
+				return $resolved;
+			}
+		}
+
+		// Path 4 — first advertised model from the first authenticated
+		// provider. Prefer the saved provider when it is still authenticated
+		// so the user does not see the provider switch out from under them
+		// just because the saved model is gone.
+		if ( ! empty( $registered ) ) {
+			$preferred_provider = ( '' !== $saved_provider && isset( $registered[ $saved_provider ] ) )
+				? $saved_provider
+				: array_key_first( $registered );
+
+			$models = $registered[ $preferred_provider ] ?? array();
+			if ( ! empty( $models ) ) {
+				$resolved = array( $preferred_provider, (string) $models[0] );
+				self::record_invalid_default_notice( $saved_provider, $saved_model, $resolved[0], $resolved[1] );
+				return $resolved;
+			}
+		}
+
+		// Path 5 — registry consultable but reports no authenticated
+		// providers at all. Return '' for both so the caller short-circuits
+		// to the "no provider configured" error path with a useful message.
+		self::record_invalid_default_notice( $saved_provider, $saved_model, '', '' );
+		return array( '', '' );
+	}
+
+	/**
+	 * Choose a provider hint for the empty-saved-model code path.
+	 *
+	 * Keeps the saved provider when it is still authenticated so a user who
+	 * picked Anthropic at install time doesn't get switched to OpenAI just
+	 * because they later cleared the model dropdown. Otherwise returns the
+	 * first authenticated provider, or `''` if none.
+	 *
+	 * @param string                            $saved_provider Saved provider ID (may be '').
+	 * @param array<string, array<int, string>> $registered     Map from {@see collect_registered_provider_models()}.
+	 */
+	private static function resolve_provider_hint( string $saved_provider, array $registered ): string {
+		if ( '' !== $saved_provider && isset( $registered[ $saved_provider ] ) ) {
+			return $saved_provider;
+		}
+		if ( ! empty( $registered ) ) {
+			return (string) array_key_first( $registered );
+		}
+		return '';
+	}
+
+	/**
+	 * Whether the WP AI Client SDK registry is available for validation.
+	 *
+	 * Returns false on installs that lack the SDK (WP < 7.0 without the
+	 * bundled polyfill or where the polyfill could not bootstrap). Callers
+	 * MUST treat a false result as "validation cannot run" and degrade
+	 * gracefully — never as "no providers are registered".
+	 *
+	 * @return bool
+	 */
+	private static function can_validate_against_registry(): bool {
+		return class_exists( '\\WordPress\\AiClient\\AiClient' );
+	}
+
+	/**
+	 * Collect the (provider, model) pairs currently registered with the
+	 * WP AI Client SDK registry.
+	 *
+	 * Per `AGENTS.md → Provider Credentials and Model Discovery`, this method
+	 * does NOT add a plugin-level cache: the SDK already caches
+	 * `listModelMetadata()` for 24 hours and an extra layer broke whenever
+	 * a new third-party provider plugin stored credentials under an option
+	 * we did not know about. Each call walks the registry fresh.
+	 *
+	 * Only providers that have authentication configured are included — an
+	 * unauthenticated provider cannot serve a chat anyway.
+	 *
+	 * Tests can short-circuit the registry walk via the
+	 * `sd_ai_agent_registered_models_for_validation` filter (this is a
+	 * test affordance, not a cache — the filter receives a fresh list on
+	 * every call and may return any list it wants).
+	 *
+	 * @return array<string, array<int, string>> Map of provider ID to the
+	 *         model IDs that provider advertises. Returns an empty array
+	 *         when the SDK is unavailable or no providers are authenticated.
+	 */
+	private static function collect_registered_provider_models(): array {
+		$registered = array();
+
+		/**
+		 * Filter the registered (provider, model) pairs used for default-model
+		 * validation. Return a non-null array to short-circuit the registry
+		 * walk — primarily an affordance for unit tests that do not boot
+		 * the full SDK.
+		 *
+		 * The filter MUST return a `array<string, array<int, string>>` map of
+		 * provider IDs to advertised model IDs, or `null` to fall through to
+		 * the live SDK walk.
+		 *
+		 * @param array<string, array<int, string>>|null $registered Filter override (null = fall through).
+		 */
+		$filtered = apply_filters( 'sd_ai_agent_registered_models_for_validation', null );
+		if ( is_array( $filtered ) ) {
+			/** @var array<string, array<int, string>> $filtered */
+			return $filtered;
+		}
+
+		if ( ! self::can_validate_against_registry() ) {
+			return $registered;
+		}
+
+		try {
+			ProviderCredentialLoader::load();
+			$registry = \WordPress\AiClient\AiClient::defaultRegistry();
+			$ids      = $registry->getRegisteredProviderIds();
+		} catch ( \Throwable $e ) {
+			return $registered;
+		}
+
+		foreach ( $ids as $provider_id ) {
+			try {
+				// Only include providers that have authentication configured.
+				$auth = $registry->getProviderRequestAuthentication( $provider_id );
+				if ( null === $auth ) {
+					continue;
+				}
+
+				$class  = $registry->getProviderClassName( $provider_id );
+				$models = array();
+
+				// For the OpenAI-compatible connector, fetch models directly
+				// from the endpoint rather than going through the SDK model
+				// directory (which can fail due to SDK transporter issues).
+				// Mirrors the carve-out in SettingsController::handle_providers().
+				if ( str_starts_with( $provider_id, 'ai-provider-for-any-openai-compatible' )
+					&& function_exists( 'OpenAiCompatibleConnector\\rest_list_models' )
+				) {
+					$fake_request = new \WP_REST_Request( 'GET' );
+					$fake_request->set_param( 'provider_id', $provider_id );
+					$result = \OpenAiCompatibleConnector\rest_list_models( $fake_request );
+					if ( ! is_wp_error( $result ) ) {
+						$data = $result->get_data();
+						if ( is_array( $data ) ) {
+							foreach ( $data as $model_entry ) {
+								if ( is_array( $model_entry ) && isset( $model_entry['id'] ) ) {
+									$models[] = (string) $model_entry['id'];
+								}
+							}
+						}
+					}
+				} else {
+					$directory      = $class::modelMetadataDirectory();
+					$model_metadata = $directory->listModelMetadata();
+					foreach ( $model_metadata as $model_meta ) {
+						$models[] = (string) $model_meta->getId();
+					}
+				}
+
+				$registered[ (string) $provider_id ] = $models;
+			} catch ( \Throwable $e ) {
+				continue;
+			}
+		}
+
+		return $registered;
+	}
+
+	/**
+	 * Whether `$registered` advertises `$model_id` under `$provider_id`.
+	 *
+	 * When `$provider_id` is empty the check passes if ANY authenticated
+	 * provider advertises the model — the saved-provider hint is allowed
+	 * to be missing without forcing the user back to picking from scratch.
+	 *
+	 * @param string                            $provider_id Saved provider ID hint (may be '').
+	 * @param string                            $model_id    Saved model ID to verify.
+	 * @param array<string, array<int, string>> $registered  Map from {@see collect_registered_provider_models()}.
+	 * @return bool
+	 */
+	private static function pair_is_registered( string $provider_id, string $model_id, array $registered ): bool {
+		if ( '' === $model_id ) {
+			return false;
+		}
+
+		if ( '' !== $provider_id ) {
+			$models = $registered[ $provider_id ] ?? null;
+			return is_array( $models ) && in_array( $model_id, $models, true );
+		}
+
+		foreach ( $registered as $models ) {
+			if ( in_array( $model_id, $models, true ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Whether the WP AI Client SDK registry has an authenticated provider
+	 * that advertises `$model_id`.
+	 *
+	 * Defense-in-depth check intended for callers that take a model ID from
+	 * a source other than {@see get_default_model()} — most notably the
+	 * OpenAI-compatible connector's `\OpenAiCompatibleConnector\get_default_model()`
+	 * legacy fallback in {@see \SdAiAgent\Core\AgentLoop::configure_model()}.
+	 *
+	 * When `$provider_id` is non-empty the check is constrained to that
+	 * provider's advertised models. When empty, ANY authenticated provider's
+	 * model list satisfies the check.
+	 *
+	 * Returns `true` when the registry is not consultable (WP < 7.0 without
+	 * polyfill) so callers degrade gracefully back to historical behaviour
+	 * rather than incorrectly rejecting a value that the SDK would have
+	 * accepted on a supported runtime.
+	 *
+	 * @param string $provider_id Provider ID hint (may be '').
+	 * @param string $model_id    Model ID to validate.
+	 */
+	public static function is_model_advertised( string $provider_id, string $model_id ): bool {
+		if ( '' === $model_id ) {
+			return false;
+		}
+		if ( ! self::can_validate_against_registry() ) {
+			return true;
+		}
+		$registered = self::collect_registered_provider_models();
+		return self::pair_is_registered( $provider_id, $model_id, $registered );
+	}
+
+	/**
+	 * Return the first provider in `$registered` that advertises `$model_id`,
+	 * or `null` when no authenticated provider advertises it.
+	 *
+	 * @param string                            $model_id   Model ID to search for.
+	 * @param array<string, array<int, string>> $registered Map from {@see collect_registered_provider_models()}.
+	 */
+	private static function find_provider_for_model( string $model_id, array $registered ): ?string {
+		if ( '' === $model_id ) {
+			return null;
+		}
+		foreach ( $registered as $provider_id => $models ) {
+			if ( in_array( $model_id, $models, true ) ) {
+				return (string) $provider_id;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Record a one-time admin notice for a rejected default-model value.
+	 *
+	 * Stored in {@see INVALID_DEFAULT_NOTICE_OPTION}. The
+	 * {@see \SdAiAgent\Admin\DefaultModelNoticeHandler} renders it on the
+	 * next admin page load and clears it when the user dismisses the notice.
+	 *
+	 * Repeated calls for the same rejected value are coalesced — the option
+	 * holds the latest replacement so the notice always reflects what the
+	 * resolver is currently doing rather than a stale earlier substitution.
+	 *
+	 * @param string $rejected_provider    Saved provider ID that no longer validates.
+	 * @param string $rejected_model       Saved model ID that no longer validates.
+	 * @param string $replacement_provider Provider chosen by the resolver (may be '').
+	 * @param string $replacement_model    Model chosen by the resolver (may be '').
+	 */
+	private static function record_invalid_default_notice(
+		string $rejected_provider,
+		string $rejected_model,
+		string $replacement_provider,
+		string $replacement_model
+	): void {
+		update_option(
+			self::INVALID_DEFAULT_NOTICE_OPTION,
+			array(
+				'provider'             => $rejected_provider,
+				'model'                => $rejected_model,
+				'replacement_provider' => $replacement_provider,
+				'replacement_model'    => $replacement_model,
+				'recorded_at'          => time(),
+			),
+			false
+		);
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/SettingsTest.php
+++ b/tests/SdAiAgent/Core/SettingsTest.php
@@ -30,6 +30,11 @@ class SettingsTest extends WP_UnitTestCase {
 		parent::tear_down();
 		delete_option( Settings::OPTION_NAME );
 		delete_option( Settings::WOO_AUTO_ENABLED_OPTION );
+		delete_option( Settings::INVALID_DEFAULT_NOTICE_OPTION );
+
+		// Filter registered by the default-model validation tests.
+		remove_all_filters( 'sd_ai_agent_registered_models_for_validation' );
+		remove_all_filters( 'sd_ai_agent_default_model' );
 
 		// ModelCapabilityRegistry writes transients keyed by md5(model_id);
 		// clear the handful this suite touches so cases stay independent.
@@ -435,5 +440,235 @@ class SettingsTest extends WP_UnitTestCase {
 		$this->assertSame( 0, Settings::resolve_max_output_tokens_from_catalog( 'wholly-made-up-model-9000' ) );
 		$this->assertSame( 16384, Settings::resolve_max_output_tokens_from_catalog( 'gpt-4o' ) );
 		$this->assertSame( 128000, Settings::resolve_max_output_tokens_from_catalog( 'claude-opus-4-7-20260513' ) );
+	}
+
+	// ─────────────────────────────────────────────────────────────────────
+	// get_default_model() / get_default_provider() validation — GH#1494
+	// ─────────────────────────────────────────────────────────────────────
+
+	/**
+	 * Short-circuit the registry walk with a fixed (provider → models) map.
+	 *
+	 * @param array<string, array<int, string>> $map Provider ID → list of advertised model IDs.
+	 */
+	private function fake_registry( array $map ): void {
+		add_filter(
+			'sd_ai_agent_registered_models_for_validation',
+			static function () use ( $map ) {
+				return $map;
+			}
+		);
+	}
+
+	/**
+	 * When the saved (provider, model) pair is advertised by an authenticated
+	 * provider, the resolver returns it verbatim and does NOT record a notice.
+	 */
+	public function test_get_default_model_returns_saved_value_when_advertised(): void {
+		$this->fake_registry( array(
+			'anthropic' => array( 'claude-sonnet-4-6', 'claude-opus-4-7' ),
+			'openai'    => array( 'gpt-4o', 'gpt-5' ),
+		) );
+
+		Settings::instance()->update(
+			array(
+				'default_provider' => 'openai',
+				'default_model'    => 'gpt-4o',
+			)
+		);
+
+		$this->assertSame( 'gpt-4o', Settings::instance()->get_default_model() );
+		$this->assertSame( 'openai', Settings::instance()->get_default_provider() );
+		$this->assertFalse( (bool) get_option( Settings::INVALID_DEFAULT_NOTICE_OPTION ) );
+	}
+
+	/**
+	 * Production regression test — GH#1494.
+	 *
+	 * When the saved value is a bogus `(provider, model)` pair (the demo
+	 * site's `gemma4:e4b` situation), the resolver MUST fall back to a
+	 * registered model rather than letting the SDK reject the request with
+	 * "model not available". A notice is recorded for the admin to see.
+	 */
+	public function test_get_default_model_falls_back_when_saved_value_unregistered(): void {
+		$this->fake_registry( array(
+			'anthropic' => array( 'claude-sonnet-4', 'claude-sonnet-4-6' ),
+		) );
+
+		Settings::instance()->update(
+			array(
+				'default_provider' => 'some-bogus-provider',
+				'default_model'    => 'gemma4:e4b',
+			)
+		);
+
+		// SD_AI_AGENT_DEFAULT_MODEL is `claude-sonnet-4`, which the fake
+		// registry advertises under anthropic — the resolver picks it.
+		$this->assertSame( 'claude-sonnet-4', Settings::instance()->get_default_model() );
+		$this->assertSame( 'anthropic', Settings::instance()->get_default_provider() );
+
+		$notice = get_option( Settings::INVALID_DEFAULT_NOTICE_OPTION );
+		$this->assertIsArray( $notice );
+		$this->assertSame( 'gemma4:e4b', $notice['model'] );
+		$this->assertSame( 'some-bogus-provider', $notice['provider'] );
+		$this->assertSame( 'claude-sonnet-4', $notice['replacement_model'] );
+		$this->assertSame( 'anthropic', $notice['replacement_provider'] );
+	}
+
+	/**
+	 * When the constant default is not advertised either, the resolver falls
+	 * through to the first model of the first authenticated provider.
+	 */
+	public function test_get_default_model_falls_through_to_first_registered_model(): void {
+		$this->fake_registry( array(
+			'ai-provider-for-any-openai-compatible' => array(
+				'hf:moonshotai/Kimi-K2.6',
+				'hf:zai-org/GLM-5.1',
+			),
+		) );
+
+		Settings::instance()->update(
+			array(
+				'default_provider' => 'gone-provider',
+				'default_model'    => 'gone:model',
+			)
+		);
+
+		$this->assertSame(
+			'hf:moonshotai/Kimi-K2.6',
+			Settings::instance()->get_default_model()
+		);
+		$this->assertSame(
+			'ai-provider-for-any-openai-compatible',
+			Settings::instance()->get_default_provider()
+		);
+	}
+
+	/**
+	 * When the saved provider is still authenticated but its specific saved
+	 * model has been retired, the resolver keeps the provider stable and
+	 * picks the constant default model when that provider advertises it.
+	 */
+	public function test_get_default_model_keeps_saved_provider_when_only_model_is_invalid(): void {
+		$this->fake_registry( array(
+			'anthropic' => array( 'claude-sonnet-4', 'claude-opus-4-7' ),
+			'openai'    => array( 'gpt-5' ),
+		) );
+
+		Settings::instance()->update(
+			array(
+				'default_provider' => 'anthropic',
+				'default_model'    => 'claude-was-retired-9000',
+			)
+		);
+
+		$this->assertSame( 'claude-sonnet-4', Settings::instance()->get_default_model() );
+		$this->assertSame( 'anthropic', Settings::instance()->get_default_provider() );
+	}
+
+	/**
+	 * The `sd_ai_agent_default_model` filter override is itself validated
+	 * before being returned. A filter that pins an unregistered model falls
+	 * through to the next candidate rather than re-introducing the bug the
+	 * filter is meant to fix.
+	 */
+	public function test_get_default_model_validates_filter_override(): void {
+		$this->fake_registry( array(
+			'anthropic' => array( 'claude-sonnet-4' ),
+		) );
+
+		add_filter(
+			'sd_ai_agent_default_model',
+			static fn() => 'gpt-5-not-installed-yet',
+		);
+
+		// Empty saved value — filter would normally be returned verbatim.
+		$this->assertSame( 'claude-sonnet-4', Settings::instance()->get_default_model() );
+	}
+
+	/**
+	 * Empty saved value (clean install) returns `''` for the model — the
+	 * chat path then falls through to the SDK's per-provider default. The
+	 * provider hint is co-resolved so the chat-path still gets a usable
+	 * `default_provider`. No notice is recorded because an empty saved
+	 * value is not a rejection.
+	 *
+	 * Regression test for the design choice in GH#1494: substituting the
+	 * `SD_AI_AGENT_DEFAULT_MODEL` constant when no user preference was ever
+	 * expressed would pin every install to a fixed model ID even when the
+	 * provider supports something newer in the same family.
+	 */
+	public function test_get_default_model_empty_saved_returns_empty_with_provider_hint(): void {
+		$this->fake_registry( array(
+			'anthropic' => array( 'claude-sonnet-4-6', 'claude-opus-4-7' ),
+		) );
+
+		// No update() call — saved value is the empty default.
+		$this->assertSame( '', Settings::instance()->get_default_model() );
+		$this->assertSame( 'anthropic', Settings::instance()->get_default_provider() );
+		$this->assertFalse( (bool) get_option( Settings::INVALID_DEFAULT_NOTICE_OPTION ) );
+	}
+
+	/**
+	 * Saved provider but empty model — keep the saved provider and let the
+	 * SDK pick a model for that provider. Notice is NOT recorded (empty
+	 * saved model is not a rejection).
+	 */
+	public function test_get_default_provider_keeps_saved_provider_when_model_is_empty(): void {
+		$this->fake_registry( array(
+			'anthropic' => array( 'claude-sonnet-4-6' ),
+			'openai'    => array( 'gpt-5' ),
+		) );
+
+		Settings::instance()->update( array( 'default_provider' => 'openai' ) );
+
+		$this->assertSame( '', Settings::instance()->get_default_model() );
+		$this->assertSame( 'openai', Settings::instance()->get_default_provider() );
+		$this->assertFalse( (bool) get_option( Settings::INVALID_DEFAULT_NOTICE_OPTION ) );
+	}
+
+	/**
+	 * When the registry reports no authenticated providers at all, both
+	 * resolvers return '' so the AgentLoop short-circuits to the "no provider
+	 * configured" error rather than sending an unusable request to the SDK.
+	 *
+	 * A notice IS recorded when a saved value was rejected so the admin
+	 * sees why the dropdown selection no longer applies.
+	 */
+	public function test_get_default_model_empty_registry_returns_empty(): void {
+		$this->fake_registry( array() );
+
+		Settings::instance()->update(
+			array(
+				'default_provider' => 'gone-provider',
+				'default_model'    => 'gone:model',
+			)
+		);
+
+		$this->assertSame( '', Settings::instance()->get_default_model() );
+		$this->assertSame( '', Settings::instance()->get_default_provider() );
+
+		$notice = get_option( Settings::INVALID_DEFAULT_NOTICE_OPTION );
+		$this->assertIsArray( $notice );
+		$this->assertSame( '', $notice['replacement_model'] );
+	}
+
+	/**
+	 * `is_model_advertised()` is the public defense-in-depth helper used by
+	 * {@see \SdAiAgent\Core\AgentLoop::configure_model()} to validate the
+	 * legacy OpenAI-compatible connector default before adopting it. The
+	 * GH#1494 demo regression came in via that path even though the saved
+	 * `sd_ai_agent_settings.default_model` was empty.
+	 */
+	public function test_is_model_advertised_validates_pair(): void {
+		$this->fake_registry( array(
+			'openai' => array( 'gpt-4o' ),
+		) );
+
+		$this->assertTrue( Settings::is_model_advertised( 'openai', 'gpt-4o' ) );
+		$this->assertTrue( Settings::is_model_advertised( '', 'gpt-4o' ) );
+		$this->assertFalse( Settings::is_model_advertised( 'openai', 'gemma4:e4b' ) );
+		$this->assertFalse( Settings::is_model_advertised( 'anthropic', 'gpt-4o' ) );
+		$this->assertFalse( Settings::is_model_advertised( 'openai', '' ) );
 	}
 }


### PR DESCRIPTION
Resolves #1494.

## Problem

The production `gemma4:e4b` regression that crashed every new chat across multiple sites (davidclaude.ultimateagentwp.ai etc., resolved at the data layer at 2026-05-18T13:36Z) was a symptom of a broader class of bug: the plugin trusted whatever `sd_ai_agent_settings.default_model` / `default_provider` was saved and shipped it to `\WordPress\AiClient\AiClient` unchecked. When the saved model was no longer advertised by any authenticated provider, the SDK rejected every request with a top-level "model not available on your plan" error banner — the chat panel was effectively dead.

The same failure mode applies any time a model is retired (e.g. an old Claude point release), a connector plugin is uninstalled, or a demo template propagates a value that doesn't exist on a tenant's API tier.

## Fix

`Settings::resolve_default_provider_and_model()` is now the canonical default resolver. It consults the WP AI Client SDK registry — no extra plugin-level cache, per the `AGENTS.md → Provider Credentials and Model Discovery` rule, since the SDK already caches `listModelMetadata()` for 24h and the previous attempt at adding a second cache layer broke whenever a new connector option appeared. Resolution order:

1. **Registry not consultable** (WP < 7.0 without polyfill, SDK boot failure) → return saved verbatim. Graceful degrade — never reject a value the SDK would have accepted.
2. **Saved model empty AND no `sd_ai_agent_default_model` filter override** → return `('', provider_hint)`. The chat path's `$builder->using_provider()` (no explicit model) lets each provider's adapter pick its newest stable model. Returning the constant unconditionally would pin every install to a fixed ID.
3. **Candidate (filter > saved) registered under the saved provider** → use it.
4. **Candidate registered under some other authenticated provider** → swap to that provider, record a notice only when the saved provider had to change.
5. **`SD_AI_AGENT_DEFAULT_MODEL` registered somewhere** → use it, record notice.
6. **First model of the first authenticated provider** → use it (preferring the saved provider when still registered), record notice.
7. **No authenticated providers at all** → return `('', '')` + notice so the AgentLoop short-circuits to the "no provider configured" error path with a useful message.

A new `Settings::is_model_advertised(provider, model)` public helper is the defense-in-depth check used by `AgentLoop::configure_model()` to validate the legacy `\OpenAiCompatibleConnector\get_default_model()` fallback before adopting it — the production demo regression actually came in via that path even when `sd_ai_agent_settings.default_model` was empty.

`AgentLoop::__construct()` no longer reads `$settings['default_model']` / `$settings['default_provider']` directly. It consumes `$settings_service->get_default_model()` / `get_default_provider()` so there's a single source of truth.

When the resolver substitutes a value, `Settings::INVALID_DEFAULT_NOTICE_OPTION` records the rejected pair + replacement. `Admin\DefaultModelNoticeHandler` renders a dismissible warning notice on `admin_notices`. Dismissal is nonce-checked and deletes the option; the notice only re-appears if the resolver records a fresh rejection.

## Files

- `includes/Core/Settings.php` — resolver + helpers + `is_model_advertised()` + `INVALID_DEFAULT_NOTICE_OPTION`.
- `includes/Core/AgentLoop.php` — constructor + `configure_model()` consume validated defaults.
- `includes/Admin/DefaultModelNoticeHandler.php` — new (notice render + dismiss handshake).
- `includes/Bootstrap/AdminHandler.php` — wires `display_default_model_notice` on `admin_notices` and `handle_dismiss` on `admin_init`.
- `tests/SdAiAgent/Core/SettingsTest.php` — 8 new PHPUnit cases.

## Tests added

| Case | What it locks in |
| --- | --- |
| `test_get_default_model_returns_saved_value_when_advertised` | Saved valid pair passes through unchanged, no notice. |
| `test_get_default_model_falls_back_when_saved_value_unregistered` | The `gemma4:e4b` production regression — substitutes the constant and records a notice. |
| `test_get_default_model_falls_through_to_first_registered_model` | When the constant is also unregistered, fall through to the first available model from the first authenticated provider. |
| `test_get_default_model_keeps_saved_provider_when_only_model_is_invalid` | Saved provider stable when only the specific model has been retired. |
| `test_get_default_model_validates_filter_override` | `sd_ai_agent_default_model` filter result is itself validated; a broken filter doesn't re-introduce the bug. |
| `test_get_default_model_empty_saved_returns_empty_with_provider_hint` | Empty saved value + no filter → `''` + provider hint (preserves "SDK picks newest in family"). |
| `test_get_default_provider_keeps_saved_provider_when_model_is_empty` | Saved provider + empty model — keep the saved provider, no notice. |
| `test_get_default_model_empty_registry_returns_empty` | Empty registry returns `('', '')` with notice; AgentLoop short-circuits cleanly. |
| `test_is_model_advertised_validates_pair` | Public defense-in-depth helper matrix. |

## Verification

- `composer phpcs` — 0 errors on changed files.
- `composer phpstan` — 0 errors.
- `php -l` — clean on all modified files.
- **PHPUnit was not run locally**: the shared `wp-env` mounted by the canonical repo bind-mounts a deleted preamble worktree, and starting a fresh `wp-env` for this worktree fails on `tests-mysql` networking. CI is the authoritative test run for this branch.

## Notes for review

- The empty-saved → `''` return path is deliberate. Returning the constant `claude-sonnet-4` would pin every install to a fixed ID even when Anthropic supports something newer in the same family. The chat path's `using_provider()` call (no explicit model) lets the SDK pick.
- The `sd_ai_agent_registered_models_for_validation` filter is **only** a test affordance, not a cache. Every call walks the registry fresh.
- The OpenAI-compatible carve-out in `collect_registered_provider_models()` mirrors `SettingsController::handle_providers()` (avoids the SDK transporter bug for endpoint-served models).

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.63 plugin for [OpenCode](https://opencode.ai) v1.15.5 with claude-sonnet-4-6 spent 4d 3h and 383 tokens on this as a headless worker.
