### PR TITLE
feat(onboarding): add Restart Setup Assistant control to Settings → Advanced (GH#1505)

### DIFF
--- a/includes/Core/OnboardingManager.php
+++ b/includes/Core/OnboardingManager.php
@@ -157,13 +157,18 @@ class OnboardingManager {
 	/**
 	 * Reset onboarding state (allows re-running the scan and bootstrap session).
 	 *
-	 * Clears both the triggered flag and the completion flag so the next
-	 * admin_init will re-evaluate and a fresh bootstrap session can be created.
+	 * Clears the triggered flag, the completion flag, the persisted bootstrap
+	 * and theme-builder session IDs, and the SiteScanner status so the next
+	 * admin_init re-evaluates from scratch. Also unschedules any pending scan
+	 * cron event. The Settings store flag `onboarding_complete` is NOT modified
+	 * here — callers that need to re-open the v2 admin-page gate must flip it
+	 * to `false` separately (see {@see rest_reset()}).
 	 */
 	public static function reset(): void {
 		delete_option( self::TRIGGERED_OPTION );
 		delete_option( self::COMPLETE_OPTION );
 		delete_option( self::BOOTSTRAP_SESSION_OPTION );
+		delete_option( self::THEME_BUILDER_SESSION_OPTION );
 		delete_option( SiteScanner::STATUS_OPTION );
 		SiteScanner::unschedule();
 	}
@@ -230,6 +235,16 @@ class OnboardingManager {
 			[
 				'methods'             => 'POST',
 				'callback'            => [ __CLASS__, 'rest_theme_builder_start' ],
+				'permission_callback' => [ __CLASS__, 'rest_permission' ],
+			]
+		);
+
+		register_rest_route(
+			'sd-ai-agent/v1',
+			'/onboarding/reset',
+			[
+				'methods'             => 'POST',
+				'callback'            => [ __CLASS__, 'rest_reset' ],
 				'permission_callback' => [ __CLASS__, 'rest_permission' ],
 			]
 		);
@@ -515,6 +530,53 @@ class OnboardingManager {
 				'session_id'      => $session_id,
 				'agent_id'        => $theme_builder_agent_id,
 				'kickoff_message' => $kickoff_message,
+			],
+			200
+		);
+	}
+
+	// ── Reset REST handler ────────────────────────────────────────────────
+
+	/**
+	 * POST /sd-ai-agent/v1/onboarding/reset
+	 *
+	 * Clears onboarding state so the v2 direct-routing gate in
+	 * src/admin-page/index.js fires on the next chat-page mount. Used by the
+	 * "Restart Setup Assistant" control on the Settings → Advanced tab.
+	 *
+	 * Unlike the legacy v1 flow, this endpoint does NOT re-launch a wizard.
+	 * The v2 gate probes `/wp/v2/posts` once per mount and drops the user
+	 * into either:
+	 *  - OnboardingBootstrap (Setup Assistant agent) — sites with content
+	 *  - OnboardingThemeBuilder (Theme Builder agent) — empty installs
+	 *
+	 * Resets, in order:
+	 *  1. {@see OnboardingManager::reset()} — clears TRIGGERED_OPTION,
+	 *     COMPLETE_OPTION, BOOTSTRAP_SESSION_OPTION,
+	 *     THEME_BUILDER_SESSION_OPTION, and the SiteScanner status; unschedules
+	 *     any pending scan cron event.
+	 *  2. `settings.onboarding_complete` — the React admin-page treats
+	 *     `settings.onboarding_complete !== false` as "done", so an explicit
+	 *     `false` is required to re-open the gate.
+	 *
+	 * Returns the chat-page URL so the frontend can offer a one-click link
+	 * into the freshly-mounted gate.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public static function rest_reset(): \WP_REST_Response {
+		self::reset();
+
+		// Mirror the reset in the Settings store. The JS admin-page gates the
+		// onboarding flow on `settings.onboarding_complete !== false`, so an
+		// explicit `false` (not just option deletion) is required.
+		Settings::instance()->update( [ 'onboarding_complete' => false ] );
+
+		return new \WP_REST_Response(
+			[
+				'success'  => true,
+				'message'  => __( 'Onboarding state cleared. The Setup Assistant will reintroduce itself the next time you open the AI Agent chat page.', 'superdav-ai-agent' ),
+				'chat_url' => admin_url( 'admin.php?page=sd-ai-agent#/chat' ),
 			],
 			200
 		);

--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -130,6 +130,12 @@ export default function SettingsApp() {
 	const [ tavilySaving, setTavilySaving ] = useState( false );
 	const [ tavilyNotice, setTavilyNotice ] = useState( null );
 
+	// Onboarding reset state (Advanced tab → Onboarding section).
+	// Mirrors PR #1502 in shape but resets the v2 direct-routing gate rather
+	// than re-launching a wizard — the wizard was removed in PR #1503.
+	const [ onboardingResetting, setOnboardingResetting ] = useState( false );
+	const [ onboardingNotice, setOnboardingNotice ] = useState( null );
+
 	useEffect( () => {
 		fetchSettings();
 		fetchProviders();
@@ -330,6 +336,54 @@ export default function SettingsApp() {
 			} );
 		}
 		setTavilySaving( false );
+	}, [] );
+
+	const handleOnboardingReset = useCallback( async () => {
+		// Confirm before discarding onboarding state. The v2 gate will re-fire
+		// on the next chat-page mount and drop the user into either the Setup
+		// Assistant (site with content) or Theme Builder (empty install)
+		// agent — saved settings, memories, and chat history are kept.
+		const confirmMessage = __(
+			'Restart the Setup Assistant? Your existing settings, memories, and chat sessions are kept — the agent will simply reintroduce itself the next time you open the AI Agent chat page.',
+			'superdav-ai-agent'
+		);
+		// eslint-disable-next-line no-alert
+		const confirmed = window.confirm( confirmMessage );
+		if ( ! confirmed ) {
+			return;
+		}
+
+		setOnboardingResetting( true );
+		setOnboardingNotice( null );
+		try {
+			const result = await apiFetch( {
+				path: '/sd-ai-agent/v1/onboarding/reset',
+				method: 'POST',
+			} );
+			setOnboardingNotice( {
+				status: 'success',
+				message:
+					result?.message ||
+					__( 'Onboarding state cleared.', 'superdav-ai-agent' ),
+				chatUrl: result?.chat_url || '',
+			} );
+			// Mirror the server-side reset locally so the global Save Settings
+			// button does not immediately re-save onboarding_complete=true.
+			setLocal( ( prev ) =>
+				prev ? { ...prev, onboarding_complete: false } : prev
+			);
+		} catch ( err ) {
+			setOnboardingNotice( {
+				status: 'error',
+				message:
+					err?.message ||
+					__(
+						'Failed to reset onboarding state.',
+						'superdav-ai-agent'
+					),
+			} );
+		}
+		setOnboardingResetting( false );
 	}, [] );
 
 	useEffect( () => {
@@ -2231,6 +2285,64 @@ export default function SettingsApp() {
 													) }
 												</Button>
 											) }
+										</div>
+
+										<h3 className="sdaa-settings-section-title">
+											{ __(
+												'Onboarding',
+												'superdav-ai-agent'
+											) }
+										</h3>
+										<p className="description">
+											{ __(
+												'Clears onboarding state. The next time you open the AI Agent chat page, the Setup Assistant will reintroduce itself (or the Theme Builder agent will run on an empty install). Your existing memories, chat sessions, and saved settings are kept.',
+												'superdav-ai-agent'
+											) }
+										</p>
+										{ onboardingNotice && (
+											<Notice
+												status={
+													onboardingNotice.status
+												}
+												isDismissible
+												onDismiss={ () =>
+													setOnboardingNotice( null )
+												}
+											>
+												{ onboardingNotice.message }
+												{ onboardingNotice.status ===
+													'success' &&
+													onboardingNotice.chatUrl && (
+														<>
+															{ ' ' }
+															<a
+																href={
+																	onboardingNotice.chatUrl
+																}
+															>
+																{ __(
+																	'Open AI Agent chat →',
+																	'superdav-ai-agent'
+																) }
+															</a>
+														</>
+													) }
+											</Notice>
+										) }
+										<div className="sdaa-settings-row-actions">
+											<Button
+												variant="secondary"
+												onClick={
+													handleOnboardingReset
+												}
+												isBusy={ onboardingResetting }
+												disabled={ onboardingResetting }
+											>
+												{ __(
+													'Restart Setup Assistant',
+													'superdav-ai-agent'
+												) }
+											</Button>
 										</div>
 									</div>
 								);

--- a/tests/SdAiAgent/Core/OnboardingManagerTest.php
+++ b/tests/SdAiAgent/Core/OnboardingManagerTest.php
@@ -365,4 +365,71 @@ class OnboardingManagerTest extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( '/sd-ai-agent/v1/onboarding/bootstrap', $routes );
 		$this->assertArrayNotHasKey( '/sd-ai-agent/v1/onboarding/interview', $routes );
 	}
+
+	/**
+	 * register_rest_routes() registers the onboarding/reset route used by the
+	 * Settings → Advanced "Restart Setup Assistant" button.
+	 */
+	public function test_register_rest_routes_registers_reset_route(): void {
+		do_action( 'rest_api_init' );
+		OnboardingManager::register_rest_routes();
+
+		$server = rest_get_server();
+		$routes = $server->get_routes();
+
+		$this->assertArrayHasKey( '/sd-ai-agent/v1/onboarding/reset', $routes );
+	}
+
+	// ── reset() — v2 cleanup ──────────────────────────────────────────────
+
+	/**
+	 * reset() clears the persisted bootstrap and theme-builder session IDs so
+	 * the v2 direct-routing gate creates fresh sessions on the next mount.
+	 */
+	public function test_reset_clears_persisted_session_options(): void {
+		update_option( OnboardingManager::COMPLETE_OPTION, true );
+		update_option( OnboardingManager::BOOTSTRAP_SESSION_OPTION, 42 );
+		update_option( OnboardingManager::THEME_BUILDER_SESSION_OPTION, 99 );
+
+		OnboardingManager::reset();
+
+		$this->assertFalse( get_option( OnboardingManager::COMPLETE_OPTION ) );
+		$this->assertFalse( get_option( OnboardingManager::BOOTSTRAP_SESSION_OPTION ) );
+		$this->assertFalse( get_option( OnboardingManager::THEME_BUILDER_SESSION_OPTION ) );
+	}
+
+	// ── rest_reset ────────────────────────────────────────────────────────
+
+	/**
+	 * rest_reset() returns a success response with a chat URL the frontend
+	 * can use to drop the user back into the v2 direct-routing gate.
+	 */
+	public function test_rest_reset_returns_success_with_chat_url(): void {
+		$response = OnboardingManager::rest_reset();
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertIsArray( $data );
+		$this->assertTrue( $data['success'] );
+		$this->assertArrayHasKey( 'chat_url', $data );
+		$this->assertStringContainsString( 'page=sd-ai-agent', (string) $data['chat_url'] );
+		$this->assertStringContainsString( '#/chat', (string) $data['chat_url'] );
+	}
+
+	/**
+	 * rest_reset() flips settings.onboarding_complete back to false. The
+	 * React admin-page gates the bootstrap flow on
+	 * `settings.onboarding_complete !== false`, so the option-only reset is
+	 * not enough on its own — the Settings store must also be updated.
+	 */
+	public function test_rest_reset_sets_settings_onboarding_complete_false(): void {
+		\SdAiAgent\Core\Settings::instance()->update( [ 'onboarding_complete' => true ] );
+
+		OnboardingManager::rest_reset();
+
+		$settings = \SdAiAgent\Core\Settings::instance()->get();
+		$this->assertFalse( (bool) ( $settings['onboarding_complete'] ?? true ) );
+	}
 }


### PR DESCRIPTION
## Summary

Re-implements the Settings → Advanced restart affordance reverted in PR #1503, with **v2-correct semantics**: the new control resets onboarding state and lets the existing direct-routing gate in `src/admin-page/index.js` fire on the next chat-page mount. No wizard is re-launched (the wizard was removed in PR #1503). On next mount, the user lands in the Setup Assistant agent (sites with content) or the Theme Builder agent (empty installs), per the v2 gate.

Resolves #1505.

## Changes

### `includes/Core/OnboardingManager.php`

- `reset()` now also clears `THEME_BUILDER_SESSION_OPTION` so a fresh theme-builder session can be created on next mount.
- New REST route `POST /sd-ai-agent/v1/onboarding/reset` gated on `manage_options`.
- New `rest_reset()` handler:
  - Calls `reset()`.
  - Flips `Settings.onboarding_complete` to `false` (the React gate keys off `settings?.onboarding_complete !== false`, so option-only deletion is not enough).
  - Returns `{ success: true, message, chat_url }` where `chat_url = admin_url('admin.php?page=sd-ai-agent#/chat')`.

### `src/settings-page/settings-app.js`

- New "Onboarding" section at the bottom of the Advanced tab.
- Button label **"Restart Setup Assistant"** (deliberately not "Wizard" — the wizard is gone).
- Inline help text explaining the v2 behaviour (no wizard language).
- `window.confirm()` prompt before POSTing.
- Busy state while the request is in flight.
- Success `Notice` with an "Open AI Agent chat →" link to the returned `chat_url`.
- Local mirror of `onboarding_complete: false` so the global Save Settings button does not immediately re-save `true`.
- Uses the canonical `superdav-ai-agent` text domain per AGENTS.md.

### `tests/SdAiAgent/Core/OnboardingManagerTest.php`

Four new PHPUnit tests:

1. `test_register_rest_routes_registers_reset_route` — `/sd-ai-agent/v1/onboarding/reset` is registered.
2. `test_reset_clears_persisted_session_options` — `reset()` clears `COMPLETE_OPTION`, `BOOTSTRAP_SESSION_OPTION`, and `THEME_BUILDER_SESSION_OPTION`.
3. `test_rest_reset_returns_success_with_chat_url` — response is `WP_REST_Response` with status 200, `success: true`, and `chat_url` containing both `page=sd-ai-agent` and `#/chat`.
4. `test_rest_reset_sets_settings_onboarding_complete_false` — `Settings.onboarding_complete` is `false` after `rest_reset()`, regardless of prior state.

## Verification

Local checks (run from this worktree):

```
$ vendor/bin/phpcs includes/Core/OnboardingManager.php tests/SdAiAgent/Core/OnboardingManagerTest.php
. 1 / 1 (100%)
Time: 404ms; Memory: 14MB

$ vendor/bin/phpstan analyse includes/Core/OnboardingManager.php --memory-limit=512M
[OK] No errors

$ npx eslint src/settings-page/settings-app.js
# (no output — clean)

$ npm run lint:css
# (clean)

$ npm run build
# admin-page.js + route-settings.js rebuilt — new "Restart Setup Assistant" string verified in route-settings.js

$ npm run test:js
Test Suites: 14 passed, 14 total
Tests:       264 passed, 264 total
```

PHPUnit (`npm run test:php`) will run in CI; the new tests follow the same pattern as the existing tests in the same file.

PHPStan reports the usual baseline `Call to an undefined method assertX()` false positives in the test file (PHPStan can't resolve `WP_UnitTestCase`). Production code (`OnboardingManager.php`) is clean.

## Manual QA plan

1. With `onboarding_complete=true`, open Settings → Advanced → scroll to "Onboarding" section.
2. Click **Restart Setup Assistant** → confirm prompt.
3. Expect a success `Notice` with the "Open AI Agent chat →" link.
4. Click the link → `admin.php?page=sd-ai-agent#/chat` opens.
5. `AdminPageApp` re-runs the `/wp/v2/posts` probe and mounts:
   - `OnboardingBootstrap` (site with content) — Setup Assistant agent runs.
   - `OnboardingThemeBuilder` (empty install) — Theme Builder agent runs.
6. The agent auto-sends its kickoff message and is ready for input.

## Acceptance criteria

- [x] Button labelled "Restart Setup Assistant" (not "Wizard") with confirmation prompt.
- [x] REST endpoint `POST /sd-ai-agent/v1/onboarding/reset` exists, requires `manage_options`, returns `{ success, message, chat_url }`.
- [x] PHPUnit tests cover route registration, option clearing, settings flip, and response shape.
- [x] PHPCS, PHPStan (production), ESLint, build, Jest all clean.
- [x] No re-introduction of `onboarding-wizard.js`, `onboarding-interview.js`, or `.sdaa-wizard*` CSS.

## Out of scope

Per issue #1505:

- No changes to the v2 gate logic in `src/admin-page/index.js`.
- No reset of provider configuration (lives in WordPress Connectors).
- No reset of memories, RAG indexes, conversation history, or any agent artefacts.
- No re-introduction of any wizard, mode picker, or interview UI.

## Caveats

- Resetting onboarding does **not** close the user's existing chat session — it just makes the gate re-fire on the next admin-page mount. Users with the chat tab already open should reload to see the bootstrapper.
- If neither content nor a provider is configured, the connector gate takes precedence over the bootstrapper. The reset endpoint still succeeds and the connector gate renders normally — no special-casing needed.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.64 plugin for [OpenCode](https://opencode.ai) v1.15.5 with claude-sonnet-4-6 spent 4d 8h and 383 tokens on this as a headless worker.
