### PR TITLE
refactor(deps): upgrade x-wp/di v1.x → v2.0.0-beta.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"pondermatic/composer-archive-project": "^1.1",
 		"psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
 		"smalot/pdfparser": "^2.0",
-		"x-wp/di": "dev-fix/rest-context-plain-permalink-support as 1.9.99"
+		"x-wp/di": "dev-fix/v2-rest-context-plain-permalink-support as 2.0.99"
 	},
 	"repositories": [
 		{

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "119297fe735db1d2cce9165f148b2487",
+    "content-hash": "242b978223e4f00cd5c7b2111944e857",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -600,16 +600,16 @@
         },
         {
             "name": "x-wp/di",
-            "version": "dev-fix/rest-context-plain-permalink-support",
+            "version": "dev-fix/v2-rest-context-plain-permalink-support",
             "source": {
                 "type": "git",
                 "url": "https://github.com/superdav42/di.git",
-                "reference": "64b5fcf01ca96ecc7e3362a0c21e4ba031115c86"
+                "reference": "b07dab9320ffc0d94d1a93a8d008347d69e16cdb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/superdav42/di/zipball/64b5fcf01ca96ecc7e3362a0c21e4ba031115c86",
-                "reference": "64b5fcf01ca96ecc7e3362a0c21e4ba031115c86",
+                "url": "https://api.github.com/repos/superdav42/di/zipball/b07dab9320ffc0d94d1a93a8d008347d69e16cdb",
+                "reference": "b07dab9320ffc0d94d1a93a8d008347d69e16cdb",
                 "shasum": ""
             },
             "require": {
@@ -627,7 +627,6 @@
                 "x-wp/di-implementation": "self.version"
             },
             "require-dev": {
-                "automattic/jetpack-autoloader": "*",
                 "oblak/wordpress-coding-standard": "^1.1",
                 "php-stubs/woocommerce-stubs": "^9.5",
                 "php-stubs/wordpress-stubs": "^6.6",
@@ -638,8 +637,7 @@
                 "symfony/polyfill-php82": "^1.31",
                 "symfony/var-dumper": "^5.4",
                 "szepeviktor/phpstan-wordpress": "^1.3",
-                "wp-cli/wp-cli": "^2.11",
-                "x-wp/whoops": "^1.1"
+                "wp-cli/wp-cli": "^2.11"
             },
             "suggest": {
                 "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
@@ -650,7 +648,7 @@
                     "XWP\\DI\\": "src/"
                 },
                 "classmap": [
-                    "src/Core/"
+                    "src/Global/"
                 ],
                 "files": [
                     "src/Functions/xwp-di-container-fns.php",
@@ -658,7 +656,12 @@
                 ]
             },
             "autoload-dev": {
-                "XWP\\DI\\T\\": "tests/fixtures/shared/"
+                "psr-4": {
+                    "XWP\\DIT\\": "test/fixtures/shared"
+                },
+                "classmap": [
+                    "test/fixtures/shared/App_Module.php"
+                ]
             },
             "license": [
                 "GPL-2.0-only"
@@ -679,10 +682,10 @@
                 "wordpress"
             ],
             "support": {
-                "issues": "https://github.com/x-wp/di/issues",
-                "source": "https://github.com/superdav42/di/tree/fix/rest-context-plain-permalink-support"
+                "issues": "https://github.com/x-wp/hook-manager/issues",
+                "source": "https://github.com/superdav42/di/tree/fix/v2-rest-context-plain-permalink-support"
             },
-            "time": "2026-04-21T01:40:03+00:00"
+            "time": "2026-05-19T04:57:34+00:00"
         },
         {
             "name": "x-wp/helper-classes",
@@ -3586,9 +3589,9 @@
     "aliases": [
         {
             "package": "x-wp/di",
-            "version": "dev-fix/rest-context-plain-permalink-support",
-            "alias": "1.9.99",
-            "alias_normalized": "1.9.99.0"
+            "version": "dev-fix/v2-rest-context-plain-permalink-support",
+            "alias": "2.0.99",
+            "alias_normalized": "2.0.99.0"
         }
     ],
     "minimum-stability": "stable",


### PR DESCRIPTION
## Summary

Upgrades the `x-wp/di` DI container from the v1.x fork branch to v2.0.0-beta.1 (+ a 5-line ported plain-permalink REST fix).

| Was | Now |
|---|---|
| `"x-wp/di": "dev-fix/rest-context-plain-permalink-support as 1.9.99"` | `"x-wp/di": "dev-fix/v2-rest-context-plain-permalink-support as 2.0.99"` |

The new constraint resolves to [`superdav42/di@fix/v2-rest-context-plain-permalink-support`](https://github.com/superdav42/di/tree/fix/v2-rest-context-plain-permalink-support), which is `v2.0.0-beta.1` + the existing plain-permalink fix ported onto v2's `src/Global/Context.php` (file moved from `src/Core/Context.php` during the v2 architecture rework).

## Why

In a Bedrock install that has both this plugin and another plugin which bundles `x-wp/di` v2.x (e.g. `polylang-ai-automatic-translation` which bundles `v2.0.0-alpha.8` via Jetpack autoloader), the Jetpack autoloader resolves `XWP\DI\App_Factory` to the v2 alpha-8 copy while the outer Bedrock vendor's `xwp_create_app()` calls `App_Factory::create()` statically — a v1.x-only invocation path. This produces:

```
PHP Fatal error: Non-static method XWP\DI\App_Factory::create() cannot be called statically
```

Aligning ai-agent (and the outer Bedrock install) on v2 lets the v2 `App_Factory` instance-method API resolve consistently regardless of which copy wins the autoload race.

## v2 API compatibility

All ai-agent decorator usages remain functional under v2 — **no code changes required**:

- `Handler` / `REST_Handler` / `Module` all have `mixed ...$args` variadic absorbers in their v2 constructors (see `vendor/x-wp/di/src/Decorators/Handler.php`).
- The 35 `container: 'sd-ai-agent'` named args land in `compat_args` and are silently ignored at runtime (v2 binds container per app, not per decorator).
- v2 `REST_Handler` still forwards `container:` explicitly to its parent for ABI compat.
- ai-agent does not access the dropped `Handler->classname` / `Handler->target` properties (verified via grep).

## Verification

```
$ ./vendor/bin/phpcs --standard=phpcs.xml includes/
.........................................................   0 violations (230 files)

$ ./vendor/bin/phpstan analyse --memory-limit=2G
 [OK] No errors

$ composer update x-wp/di --with-all-dependencies
... No security vulnerability advisories found.
```

## Pending upstream

[`superdav42/di#6`](https://github.com/x-wp/di/pull/6) (v1 fix) is open against `x-wp/di:master`. A v2 port should follow once `v2.0.0` stabilises; until then the fork branch is the pinning target.

## Test plan for a Bedrock install

```bash
cd site/web/app/plugins/superdav-ai-agent
composer install --prefer-source
# Verify vendor/x-wp/di/src/Global/Context.php exists (v2 marker)
# Verify rest() method contains: || ! empty( $_GET['rest_route'] )

# In a second plugin that requires x-wp/di v2.x (e.g. polylang-ai-automatic-translation):
wp --url=<network-site> plugin activate polylang-ai-automatic-translation
# Should activate without "cannot be called statically" fatal.
```

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.64 plugin for [OpenCode](https://opencode.ai) v1.15.5 with claude-sonnet-4-6 spent 4d 9h and 383 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to a newer version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1513?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->