### PR TITLE
fix(activate-theme): validate WP and PHP requirements before switch_theme (GH#1508)

### DIFF
--- a/includes/Abilities/ActivateThemeAbility.php
+++ b/includes/Abilities/ActivateThemeAbility.php
@@ -110,6 +110,23 @@ class ActivateThemeAbility extends AbstractAbility {
 			);
 		}
 
+		// Validate WordPress and PHP version requirements declared in the
+		// theme's style.css before calling switch_theme(). Without this gate,
+		// switch_theme() silently updates the option but WordPress's
+		// validate_current_theme() reverts it on the next page load, leaving
+		// the AgentLoop hanging on the activate-theme tool call with no error
+		// surfaced to the user (GH#1508).
+		//
+		// validate_theme_requirements() has been in core since WP 5.5 and is
+		// always present on the plugin's supported range (WP 7.0+).
+		$requirements_check = validate_theme_requirements( $stylesheet );
+		if ( is_wp_error( $requirements_check ) ) {
+			return new WP_Error(
+				'sd_ai_agent_theme_requirements_unmet',
+				$requirements_check->get_error_message()
+			);
+		}
+
 		$previous_stylesheet = (string) get_stylesheet();
 		$previous_template   = (string) get_template();
 

--- a/tests/SdAiAgent/Abilities/ThemeBuilderAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/ThemeBuilderAbilitiesTest.php
@@ -338,6 +338,54 @@ class ThemeBuilderAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * ActivateThemeAbility returns WP_Error when the theme declares a
+	 * WordPress version requirement that exceeds the running core version
+	 * (GH#1508). The stylesheet option must remain unchanged.
+	 */
+	public function test_activate_returns_wp_error_when_wp_version_requirement_unmet(): void {
+		$slug = $this->unique_slug( 'req-wp' );
+		$this->stage_minimal_theme( $slug, '99.9.9', '' );
+		wp_clean_themes_cache();
+
+		$ability  = new ActivateThemeAbility( 'sd-ai-agent/activate-theme' );
+		$previous = (string) get_stylesheet();
+
+		$result = $ability->run( [ 'stylesheet' => $slug ] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'sd_ai_agent_theme_requirements_unmet', $result->get_error_code() );
+		$this->assertSame(
+			$previous,
+			(string) get_stylesheet(),
+			'stylesheet option must not change when WP version requirement is unmet'
+		);
+	}
+
+	/**
+	 * ActivateThemeAbility returns WP_Error when the theme declares a PHP
+	 * version requirement that exceeds the running PHP version (GH#1508).
+	 * The stylesheet option must remain unchanged.
+	 */
+	public function test_activate_returns_wp_error_when_php_version_requirement_unmet(): void {
+		$slug = $this->unique_slug( 'req-php' );
+		$this->stage_minimal_theme( $slug, '', '99.9.9' );
+		wp_clean_themes_cache();
+
+		$ability  = new ActivateThemeAbility( 'sd-ai-agent/activate-theme' );
+		$previous = (string) get_stylesheet();
+
+		$result = $ability->run( [ 'stylesheet' => $slug ] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'sd_ai_agent_theme_requirements_unmet', $result->get_error_code() );
+		$this->assertSame(
+			$previous,
+			(string) get_stylesheet(),
+			'stylesheet option must not change when PHP version requirement is unmet'
+		);
+	}
+
+	/**
 	 * ActivateThemeAbility activates a previously-scaffolded theme and
 	 * reports both the previous and the new stylesheet.
 	 */
@@ -380,6 +428,42 @@ class ThemeBuilderAbilitiesTest extends WP_UnitTestCase {
 		$slug                  = 'sd-ai-test-' . $prefix . '-' . strtolower( wp_generate_password( 8, false ) );
 		$this->created_slugs[] = $slug;
 		return $slug;
+	}
+
+	/**
+	 * Stage a minimal theme on disk with the given version requirements so
+	 * ActivateThemeAbility tests can exercise the requirements-validation path
+	 * without going through ScaffoldBlockThemeAbility (GH#1508).
+	 *
+	 * The slug must already be registered with unique_slug() so tearDown()
+	 * removes the directory.
+	 *
+	 * @param string $slug         Theme directory name / stylesheet slug.
+	 * @param string $requires_wp  Value for "Requires at least:" header; '' to omit.
+	 * @param string $requires_php Value for "Requires PHP:" header; '' to omit.
+	 */
+	private function stage_minimal_theme( string $slug, string $requires_wp, string $requires_php ): void {
+		$theme_dir = trailingslashit( get_theme_root() ) . $slug;
+		wp_mkdir_p( $theme_dir . '/templates' );
+
+		$requires_wp_line  = '' !== $requires_wp  ? "Requires at least: {$requires_wp}\n" : '';
+		$requires_php_line = '' !== $requires_php ? "Requires PHP: {$requires_php}\n" : '';
+
+		file_put_contents(
+			$theme_dir . '/style.css',
+			"/*\n" .
+			"Theme Name: Test Requirements {$slug}\n" .
+			"Description: Staged by requirements validation test.\n" .
+			"Version: 1.0.0\n" .
+			$requires_wp_line .
+			$requires_php_line .
+			'*/'
+		);
+
+		// Block themes require templates/index.html to be considered structurally
+		// valid by WP_Theme::errors(). Without it the ability returns
+		// sd_ai_agent_theme_invalid before reaching validate_theme_requirements().
+		file_put_contents( $theme_dir . '/templates/index.html', '<!-- wp:paragraph --><p></p><!-- /wp:paragraph -->' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Adds `validate_theme_requirements()` in `ActivateThemeAbility::execute_callback()` before `switch_theme()` to surface WP/PHP version failures as structured tool errors instead of silent reverts.

## Problem

Without this gate, a theme whose `style.css` declares `Requires at least: 7.0` on a WP 6.9.x install causes:
1. `switch_theme()` to silently update the option (returns void, no error)
2. WP's own `validate_current_theme()` to revert it on the next page load
3. The AgentLoop to hang on the `activate-theme` tool call indefinitely — the spinner shows, no provider trace is emitted, and the `wp_sd_ai_agent_active_jobs` row stays `processing` forever

This was the root cause of the broken Theme Builder onboarding walkthrough on WP 6.9.4 described in #1508.

## Changes

### `includes/Abilities/ActivateThemeAbility.php`

Adds the gate immediately after the existing `$theme->errors()` check (which catches a different class of failure — malformed style.css, scandir errors) and before `switch_theme()`:

```php
$requirements_check = validate_theme_requirements( $stylesheet );
if ( is_wp_error( $requirements_check ) ) {
    return new WP_Error(
        'sd_ai_agent_theme_requirements_unmet',
        $requirements_check->get_error_message()
    );
}
```

`validate_theme_requirements()` checks both `Requires at least:` (WP version) and `Requires PHP:` headers and has been in core since WP 5.5 — always available on this plugin's WP 7.0+ supported range.

### `tests/SdAiAgent/Abilities/ThemeBuilderAbilitiesTest.php`

- `test_activate_returns_wp_error_when_wp_version_requirement_unmet`: stages a theme with `Requires at least: 99.9.9` and asserts `sd_ai_agent_theme_requirements_unmet` is returned and the stylesheet option is unchanged.
- `test_activate_returns_wp_error_when_php_version_requirement_unmet`: same for `Requires PHP: 99.9.9`.
- `stage_minimal_theme()` helper: writes a minimal valid `style.css` with configurable version headers to the theme root for the duration of the test.

## Verification

```bash
composer phpstan   # OK — no errors
composer phpcs     # OK — no violations
composer test -- --filter ThemeBuilderAbilitiesTest  # run in wp-env
```

## Acceptance criteria checklist

- [x] `validate_theme_requirements()` invoked before `switch_theme()` in `execute_callback()`
- [x] Returns `WP_Error('sd_ai_agent_theme_requirements_unmet', <core message>)` on requirement failure
- [x] Unit test covers WP-version-too-low case
- [x] Unit test covers PHP-version-too-low case
- [x] PHPCS passes
- [x] PHPStan passes
- [ ] PHPUnit — CI gate (wp-env not running in this worktree)

Resolves #1508

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.64 plugin for [OpenCode](https://opencode.ai) v1.15.5 with claude-sonnet-4-6 spent 6m and 18,098 tokens on this as a headless worker.
