### PR TITLE
GH#1511: fix(scaffold-block-theme): coerce theme.json version to 3 and update system prompt

### DIFF
--- a/includes/Abilities/ScaffoldBlockThemeAbility.php
+++ b/includes/Abilities/ScaffoldBlockThemeAbility.php
@@ -100,14 +100,18 @@ class ScaffoldBlockThemeAbility extends AbstractAbility {
 		return [
 			'type'       => 'object',
 			'properties' => [
-				'slug'        => [ 'type' => 'string' ],
-				'theme_dir'   => [ 'type' => 'string' ],
-				'stylesheet'  => [ 'type' => 'string' ],
-				'files'       => [
+				'slug'            => [ 'type' => 'string' ],
+				'theme_dir'       => [ 'type' => 'string' ],
+				'stylesheet'      => [ 'type' => 'string' ],
+				'files'           => [
 					'type'  => 'array',
 					'items' => [ 'type' => 'string' ],
 				],
-				'overwritten' => [ 'type' => 'boolean' ],
+				'overwritten'     => [ 'type' => 'boolean' ],
+				'version_coerced' => [
+					'type'        => 'boolean',
+					'description' => 'True when the supplied theme_json used a schema version older than 3 and was silently upgraded to version 3.',
+				],
 			],
 		];
 	}
@@ -184,6 +188,24 @@ class ScaffoldBlockThemeAbility extends AbstractAbility {
 			? $input['theme_json']
 			: self::default_theme_json();
 
+		// Server-side guardrail: coerce stale schema versions to v3.
+		// The plugin requires WordPress 7.0+ where theme.json version 3 is
+		// the standard format; normalise silently and log for transparency.
+		$version_coerced = false;
+		if ( isset( $theme_json['version'] ) && is_int( $theme_json['version'] ) && $theme_json['version'] < 3 ) {
+			$old_version           = $theme_json['version'];
+			$theme_json['version'] = 3;
+			$version_coerced       = true;
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Intentional diagnostic log for schema-version coercion transparency (GH#1511).
+			error_log(
+				sprintf(
+					'ScaffoldBlockThemeAbility: theme.json version coerced from %d to 3 for theme "%s" — WordPress 7.0+ requires version 3.',
+					$old_version,
+					$slug
+				)
+			);
+		}
+
 		$encoded_theme_json = wp_json_encode( $theme_json, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
 		if ( false === $encoded_theme_json ) {
 			return new WP_Error(
@@ -231,11 +253,12 @@ class ScaffoldBlockThemeAbility extends AbstractAbility {
 		}
 
 		return [
-			'slug'        => $slug,
-			'theme_dir'   => $theme_dir,
-			'stylesheet'  => $slug,
-			'files'       => $written,
-			'overwritten' => $overwritten,
+			'slug'            => $slug,
+			'theme_dir'       => $theme_dir,
+			'stylesheet'      => $slug,
+			'files'           => $written,
+			'overwritten'     => $overwritten,
+			'version_coerced' => $version_coerced,
 		];
 	}
 

--- a/includes/Models/Agent.php
+++ b/includes/Models/Agent.php
@@ -649,6 +649,14 @@ class Agent {
 				. "- Ask one question at a time during the interview phase.\n"
 				. "- Save the final site brief and chosen design direction with `sd-ai-agent/memory-save` (category: site_brief) before building.\n"
 				. "- If a tool call fails, try a different approach or skip and continue; never stop entirely after a single error.\n"
+				. "- When supplying a `theme_json` argument to `sd-ai-agent/scaffold-block-theme`, **always** use schema version 3 with `\"\$schema\": \"https://schemas.wp.org/trunk/theme.json\"` and `\"version\": 3`. **Never** use version 2 — this plugin requires WordPress 7.0+, where version 3 is the standard format and unlocks section-style variations and root-level background controls. Minimal example:\n"
+				. "  ```json\n"
+				. "  {\n"
+				. "    \"\$schema\": \"https://schemas.wp.org/trunk/theme.json\",\n"
+				. "    \"version\": 3,\n"
+				. "    \"settings\": { \"appearanceTools\": true }\n"
+				. "  }\n"
+				. "  ```\n"
 				. '- After completing all build steps, summarize what was created and confirm the active theme.',
 			'greeting'      => __( "I'm your Theme Builder. I'll guide you through designing and building a custom WordPress block theme — from a quick interview about your site, through design concepts, to a fully activated theme. Ready to start?", 'superdav-ai-agent' ),
 			'avatar_icon'   => 'dashicons-art',

--- a/tests/SdAiAgent/Abilities/ScaffoldBlockThemeAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/ScaffoldBlockThemeAbilityTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Unit tests for ScaffoldBlockThemeAbility — theme.json schema version
+ * coercion (GH#1511).
+ *
+ * Covers the server-side guardrail that normalises any caller-supplied
+ * theme_json with version < 3 to version 3, which is the only correct
+ * value for this plugin's minimum requirement of WordPress 7.0+.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Abilities;
+
+use SdAiAgent\Abilities\ScaffoldBlockThemeAbility;
+use WP_UnitTestCase;
+
+/**
+ * Test ScaffoldBlockThemeAbility version-coercion behaviour.
+ */
+class ScaffoldBlockThemeAbilityTest extends WP_UnitTestCase {
+
+	/**
+	 * Slugs created during tests, removed in tearDown.
+	 *
+	 * @var array<int,string>
+	 */
+	private array $created_slugs = [];
+
+	public function tearDown(): void {
+		foreach ( $this->created_slugs as $slug ) {
+			$dir = trailingslashit( get_theme_root() ) . $slug;
+			if ( is_dir( $dir ) ) {
+				self::rrmdir( $dir );
+			}
+		}
+
+		parent::tearDown();
+	}
+
+	// ── version coercion ──────────────────────────────────────────────────
+
+	/**
+	 * When the caller supplies a theme_json with version 2, the on-disk
+	 * theme.json must have version 3.
+	 *
+	 * This is the primary regression test for GH#1511: the agent was
+	 * emitting version 2 in its tool_use input; the server-side guardrail
+	 * must silently normalise this before writing the file.
+	 */
+	public function test_scaffold_coerces_version_2_to_3_on_disk(): void {
+		$slug    = $this->unique_slug( 'coerce-v2' );
+		$ability = new ScaffoldBlockThemeAbility( 'sd-ai-agent/scaffold-block-theme' );
+
+		$result = $ability->run(
+			[
+				'slug'       => $slug,
+				'name'       => 'Coerce V2 Theme',
+				'theme_json' => [
+					'$schema'  => 'https://schemas.wp.org/trunk/theme.json',
+					'version'  => 2,
+					'settings' => [
+						'appearanceTools' => true,
+					],
+				],
+			]
+		);
+
+		$this->assertIsArray( $result, is_wp_error( $result ) ? $result->get_error_message() : '' );
+
+		$theme_dir  = trailingslashit( get_theme_root() ) . $slug;
+		$theme_json = json_decode( (string) file_get_contents( $theme_dir . '/theme.json' ), true );
+
+		$this->assertIsArray( $theme_json );
+		$this->assertSame( 3, $theme_json['version'], 'On-disk theme.json must have version 3 when caller supplied version 2.' );
+	}
+
+	/**
+	 * When the caller supplies version 2, the result array must report
+	 * version_coerced = true for change-log transparency.
+	 */
+	public function test_scaffold_v2_sets_version_coerced_flag(): void {
+		$slug    = $this->unique_slug( 'coerce-flag' );
+		$ability = new ScaffoldBlockThemeAbility( 'sd-ai-agent/scaffold-block-theme' );
+
+		$result = $ability->run(
+			[
+				'slug'       => $slug,
+				'name'       => 'Coerce Flag Theme',
+				'theme_json' => [
+					'$schema' => 'https://schemas.wp.org/trunk/theme.json',
+					'version' => 2,
+				],
+			]
+		);
+
+		$this->assertIsArray( $result, is_wp_error( $result ) ? $result->get_error_message() : '' );
+		$this->assertTrue( $result['version_coerced'], 'version_coerced must be true when the input version was 2.' );
+	}
+
+	/**
+	 * When the caller supplies a theme_json with version 3, the on-disk
+	 * theme.json must also have version 3 and must not be altered.
+	 */
+	public function test_scaffold_preserves_version_3_unchanged(): void {
+		$slug    = $this->unique_slug( 'keep-v3' );
+		$ability = new ScaffoldBlockThemeAbility( 'sd-ai-agent/scaffold-block-theme' );
+
+		$result = $ability->run(
+			[
+				'slug'       => $slug,
+				'name'       => 'Keep V3 Theme',
+				'theme_json' => [
+					'$schema'  => 'https://schemas.wp.org/trunk/theme.json',
+					'version'  => 3,
+					'settings' => [
+						'color' => [
+							'palette' => [
+								[
+									'slug'  => 'brand',
+									'name'  => 'Brand',
+									'color' => '#123456',
+								],
+							],
+						],
+					],
+				],
+			]
+		);
+
+		$this->assertIsArray( $result, is_wp_error( $result ) ? $result->get_error_message() : '' );
+
+		$theme_dir  = trailingslashit( get_theme_root() ) . $slug;
+		$theme_json = json_decode( (string) file_get_contents( $theme_dir . '/theme.json' ), true );
+
+		$this->assertIsArray( $theme_json );
+		$this->assertSame( 3, $theme_json['version'], 'Version 3 input must remain version 3 on disk.' );
+		// Custom content must survive unchanged.
+		$this->assertSame( '#123456', $theme_json['settings']['color']['palette'][0]['color'] );
+	}
+
+	/**
+	 * When the caller supplies version 3, version_coerced must be false.
+	 */
+	public function test_scaffold_v3_does_not_set_version_coerced_flag(): void {
+		$slug    = $this->unique_slug( 'no-coerce' );
+		$ability = new ScaffoldBlockThemeAbility( 'sd-ai-agent/scaffold-block-theme' );
+
+		$result = $ability->run(
+			[
+				'slug'       => $slug,
+				'name'       => 'No Coerce Theme',
+				'theme_json' => [
+					'$schema' => 'https://schemas.wp.org/trunk/theme.json',
+					'version' => 3,
+				],
+			]
+		);
+
+		$this->assertIsArray( $result, is_wp_error( $result ) ? $result->get_error_message() : '' );
+		$this->assertFalse( $result['version_coerced'], 'version_coerced must be false when the input version was already 3.' );
+	}
+
+	/**
+	 * When theme_json is omitted the default scaffold writes version 3.
+	 *
+	 * Verifies that ScaffoldBlockThemeAbility::default_theme_json() has not
+	 * regressed to an older version.
+	 */
+	public function test_scaffold_default_theme_json_is_version_3(): void {
+		$slug    = $this->unique_slug( 'default-v3' );
+		$ability = new ScaffoldBlockThemeAbility( 'sd-ai-agent/scaffold-block-theme' );
+
+		$result = $ability->run(
+			[
+				'slug' => $slug,
+				'name' => 'Default V3 Theme',
+			]
+		);
+
+		$this->assertIsArray( $result, is_wp_error( $result ) ? $result->get_error_message() : '' );
+
+		$theme_dir  = trailingslashit( get_theme_root() ) . $slug;
+		$theme_json = json_decode( (string) file_get_contents( $theme_dir . '/theme.json' ), true );
+
+		$this->assertIsArray( $theme_json );
+		$this->assertSame( 3, $theme_json['version'], 'Default scaffold must write version 3.' );
+		$this->assertFalse( $result['version_coerced'], 'version_coerced must be false when theme_json was omitted (default path).' );
+	}
+
+	// ── Helpers ───────────────────────────────────────────────────────────
+
+	/**
+	 * Generate a unique theme slug and register it for tearDown cleanup.
+	 *
+	 * @param string $prefix Short label embedded in the slug for log clarity.
+	 * @return string
+	 */
+	private function unique_slug( string $prefix ): string {
+		$slug                  = 'sd-ai-test-' . $prefix . '-' . strtolower( wp_generate_password( 8, false ) );
+		$this->created_slugs[] = $slug;
+		return $slug;
+	}
+
+	/**
+	 * Recursively delete a directory.
+	 *
+	 * @param string $dir Absolute directory path.
+	 */
+	private static function rrmdir( string $dir ): void {
+		if ( ! is_dir( $dir ) ) {
+			return;
+		}
+		foreach ( scandir( $dir ) ?: [] as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+			$path = $dir . DIRECTORY_SEPARATOR . $entry;
+			if ( is_dir( $path ) ) {
+				self::rrmdir( $path );
+			} else {
+				@unlink( $path );
+			}
+		}
+		@rmdir( $dir );
+	}
+}


### PR DESCRIPTION
## Summary

Adds a server-side guardrail in ScaffoldBlockThemeAbility that normalises any caller-supplied theme_json with version < 3 to version 3, logging the coercion for transparency. Updates the Theme Builder agent system prompt to explicitly instruct the model to emit version 3 with the trunk schema URL. Adds ScaffoldBlockThemeAbilityTest.php covering: v2 coercion to v3 on disk, version_coerced flag, v3 preserved unchanged, default scaffold is v3.

## Files Changed

includes/Abilities/ScaffoldBlockThemeAbility.php,includes/Models/Agent.php,tests/SdAiAgent/Abilities/ScaffoldBlockThemeAbilityTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** composer phpcs (passes), vendor/bin/phpstan analyse (0 errors). Unit tests: ScaffoldBlockThemeAbilityTest — 5 test cases covering v2 coercion, v3 passthrough, version_coerced flag, and default scaffold. Run: composer test -- --filter ScaffoldBlockThemeAbilityTest

Resolves #1511


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.64 plugin for [OpenCode](https://opencode.ai) v1.15.5 with claude-sonnet-4-6 spent 4m and 13,749 tokens on this as a headless worker.