### PR TITLE
fix(active-jobs): prevent zombie rows when AgentLoop terminates abnormally (GH#1510)

### DIFF
--- a/includes/Bootstrap/LifecycleHandler.php
+++ b/includes/Bootstrap/LifecycleHandler.php
@@ -23,6 +23,7 @@ namespace SdAiAgent\Bootstrap;
 
 use SdAiAgent\Abilities\ToolCapabilities;
 use SdAiAgent\Automations\AutomationRunner;
+use SdAiAgent\Core\ActiveJobsCleanupService;
 use SdAiAgent\Core\Database;
 use SdAiAgent\Core\OnboardingManager;
 use SdAiAgent\Core\SkillUpdateChecker;
@@ -54,6 +55,7 @@ final class LifecycleHandler {
 		AutomationRunner::reschedule_all();
 		OnboardingManager::on_activation();
 		SkillUpdateChecker::schedule();
+		ActiveJobsCleanupService::schedule();
 		ToolCapabilities::register_capabilities( ToolCapabilities::all_ability_ids() );
 	}
 
@@ -69,5 +71,6 @@ final class LifecycleHandler {
 		AutomationRunner::unschedule_all();
 		SiteScanner::unschedule();
 		SkillUpdateChecker::unschedule();
+		ActiveJobsCleanupService::unschedule();
 	}
 }

--- a/includes/Bootstrap/OnboardingHandler.php
+++ b/includes/Bootstrap/OnboardingHandler.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Bootstrap;
 
+use SdAiAgent\Core\ActiveJobsCleanupService;
 use SdAiAgent\Core\OnboardingManager;
 use SdAiAgent\Core\Settings;
 use SdAiAgent\Core\SkillUpdateChecker;
@@ -57,6 +58,18 @@ final class OnboardingHandler {
 	#[Action( tag: SkillUpdateChecker::CRON_HOOK, priority: 10 )]
 	public function run_skill_update_check(): void {
 		SkillUpdateChecker::run();
+	}
+
+	/**
+	 * Run the hourly stale active-jobs reaper cron job.
+	 *
+	 * Scheduled as a recurring hourly event via {@see ActiveJobsCleanupService::schedule()}.
+	 * Marks rows as 'abandoned' when status='processing' and updated_at has
+	 * not advanced within the configured threshold (default 15 minutes).
+	 */
+	#[Action( tag: ActiveJobsCleanupService::CRON_HOOK, priority: 10 )]
+	public function run_active_jobs_cleanup(): void {
+		ActiveJobsCleanupService::run();
 	}
 
 	/**

--- a/includes/Core/ActiveJobsCleanupService.php
+++ b/includes/Core/ActiveJobsCleanupService.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Active Jobs Cleanup Service — hourly reaper for zombie processing rows.
+ *
+ * Rows in wp_sd_ai_agent_active_jobs become permanently stuck in
+ * status='processing' when the PHP request running an AgentLoop terminates
+ * abnormally (PHP fatal, FastCGI/nginx timeout, SIGKILL, OOM, FPM child exit).
+ *
+ * Two-tier cleanup strategy:
+ *
+ * 1. Shutdown handler (best-effort, fires on normal-or-abnormal request exit):
+ *    Registered in SessionController::handle_process(). If the row is still
+ *    'processing' at shutdown, it is marked 'interrupted' with a reason note.
+ *
+ * 2. Periodic reaper (this class, hourly cron):
+ *    For cases where the shutdown handler itself could not run. Marks rows as
+ *    'abandoned' when status='processing' and updated_at has not advanced
+ *    within the configured threshold (default 15 minutes, filterable via
+ *    `sd_ai_agent_stale_job_threshold_minutes`).
+ *
+ * The AgentLoop heartbeat (updated_at advance on each loop iteration) ensures
+ * the 15-minute threshold is honest: a genuinely-running loop keeps its row
+ * fresh and the reaper leaves it alone.
+ *
+ * Reference: issue #1510.
+ *
+ * @package SdAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Core;
+
+use SdAiAgent\Models\ActiveJobRepository;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class ActiveJobsCleanupService {
+
+	/**
+	 * WP-Cron hook name for the hourly stale-job cleanup.
+	 */
+	const CRON_HOOK = 'sd_ai_agent_cleanup_stale_active_jobs';
+
+	/**
+	 * Default stale-job threshold in minutes.
+	 *
+	 * A row is considered stale when status='processing' and updated_at has
+	 * not advanced within this window. Must be longer than the longest
+	 * expected legitimate single loop iteration (image generation, large RAG
+	 * queries, etc. can legitimately take several minutes).
+	 */
+	const DEFAULT_THRESHOLD_MINUTES = 15;
+
+	// ── Registration ─────────────────────────────────────────────────────
+
+	/**
+	 * Register the cron hook handler (add_action for the cron callback).
+	 */
+	public static function register(): void {
+		add_action( self::CRON_HOOK, [ __CLASS__, 'run' ] );
+	}
+
+	/**
+	 * Schedule an hourly cleanup check (idempotent — safe to call multiple times).
+	 */
+	public static function schedule(): void {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			wp_schedule_event( time(), 'hourly', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Cancel the scheduled cleanup (e.g. on plugin deactivation).
+	 */
+	public static function unschedule(): void {
+		$timestamp = wp_next_scheduled( self::CRON_HOOK );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, self::CRON_HOOK );
+		}
+	}
+
+	// ── Cron callback ────────────────────────────────────────────────────
+
+	/**
+	 * Execute the stale-job reaper (called by WP-Cron).
+	 *
+	 * Marks rows as 'abandoned' when:
+	 *   - status = 'processing', AND
+	 *   - updated_at < NOW() - INTERVAL {threshold} MINUTE
+	 *
+	 * The threshold is filterable via `sd_ai_agent_stale_job_threshold_minutes`.
+	 * Clamped to a minimum of 1 minute.
+	 *
+	 * Fires the `sd_ai_agent_stale_jobs_reaped` action with the count of
+	 * reaped rows so logging/monitoring integrations can observe cleanup.
+	 */
+	public static function run(): void {
+		/**
+		 * Filter the number of minutes of inactivity before a processing row
+		 * is considered stale and reaped by the hourly cron job.
+		 *
+		 * Must be longer than the longest expected legitimate single loop
+		 * iteration. Default is 15 minutes.
+		 *
+		 * @param int $minutes Threshold in minutes.
+		 */
+		$threshold = (int) apply_filters( 'sd_ai_agent_stale_job_threshold_minutes', self::DEFAULT_THRESHOLD_MINUTES );
+		$threshold = max( 1, $threshold );
+
+		$count = ActiveJobRepository::cleanup_stale( $threshold );
+
+		if ( $count > 0 ) {
+			/**
+			 * Fired after the hourly reaper marks stale processing rows as abandoned.
+			 *
+			 * @param int $count Number of rows reaped.
+			 */
+			do_action( 'sd_ai_agent_stale_jobs_reaped', $count );
+		}
+	}
+}

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -27,6 +27,7 @@ use SdAiAgent\Abilities\FeedbackAbilities;
 use SdAiAgent\Core\AbilityVisibility;
 use SdAiAgent\Core\BudgetManager;
 use SdAiAgent\Core\ChangeLogger;
+use SdAiAgent\Models\ActiveJobRepository;
 use SdAiAgent\Repositories\SkillUsageRepository;
 use SdAiAgent\Tools\ModelHealthTracker;
 use SdAiAgent\Tools\ToolDiscovery;
@@ -152,6 +153,20 @@ class AgentLoop {
 
 	/** @var int Session ID for change attribution (0 = no session). */
 	private int $session_id = 0;
+
+	/**
+	 * Active job UUID for heartbeat and shutdown-handler updates.
+	 *
+	 * Empty string when the loop is not running under a background job
+	 * (e.g. automations, CLI, or direct invocations). When set, each
+	 * loop iteration calls ActiveJobRepository::heartbeat() so the
+	 * hourly stale-job reaper can distinguish an actively-running job
+	 * from a zombie, and register_shutdown_function() marks the row as
+	 * 'interrupted' if the PHP process terminates before the loop completes.
+	 *
+	 * @var string
+	 */
+	private string $active_job_id = '';
 
 	/** @var int Maximum attempts for retryable provider failures. */
 	private int $provider_retry_max_attempts = self::PROVIDER_RETRY_MAX_ATTEMPTS;
@@ -312,6 +327,10 @@ class AgentLoop {
 		$this->tool_call_log = $options['tool_call_log'] ?? array();
 		// @phpstan-ignore-next-line
 		$this->session_id = (int) ( $options['session_id'] ?? 0 );
+		// Active job UUID for heartbeat and shutdown-handler updates.
+		// Empty string when the loop is not running under a background job.
+		// @phpstan-ignore-next-line
+		$this->active_job_id = (string) ( $options['active_job_id'] ?? '' );
 		// @phpstan-ignore-next-line -- Test/job callers may lower attempts or delays; production defaults remain 10 attempts.
 		$this->provider_retry_max_attempts = max( 1, (int) ( $options['provider_retry_max_attempts'] ?? self::PROVIDER_RETRY_MAX_ATTEMPTS ) );
 		// @phpstan-ignore-next-line -- Values are normalised below to non-negative integer seconds.
@@ -419,6 +438,29 @@ class AgentLoop {
 
 		// Ensure provider auth is available (critical for loopback requests).
 		ProviderCredentialLoader::load();
+
+		// Register a shutdown handler to mark the active-jobs row as
+		// 'interrupted' if the PHP request terminates before the loop
+		// completes (PHP fatal, FastCGI/nginx timeout, SIGKILL, OOM).
+		// Only registered when an active_job_id is set (background jobs).
+		// The handler is a no-op when the row is no longer 'processing'
+		// (i.e. the loop finished normally and updated the status first).
+		if ( '' !== $this->active_job_id ) {
+			$active_job_id_for_shutdown = $this->active_job_id;
+			register_shutdown_function(
+				static function () use ( $active_job_id_for_shutdown ): void {
+					$connection_status = connection_status();
+					if ( CONNECTION_ABORTED === $connection_status ) {
+						$reason = 'shutdown handler — client disconnected before loop completion';
+					} elseif ( CONNECTION_TIMEOUT === $connection_status ) {
+						$reason = 'shutdown handler — PHP request timed out before loop completion';
+					} else {
+						$reason = 'shutdown handler — request terminated without loop completion';
+					}
+					ActiveJobRepository::mark_interrupted( $active_job_id_for_shutdown, $reason );
+				}
+			);
+		}
 
 		// Append the new user message to history.
 		$this->history[] = new UserMessage( array( new MessagePart( $this->user_message ) ) );
@@ -578,6 +620,14 @@ class AgentLoop {
 		while ( $iterations > 0 ) {
 			--$iterations;
 			++$this->iterations_used;
+
+			// Heartbeat: advance updated_at so the hourly stale-job reaper
+			// can distinguish an actively-running loop from a zombie row.
+			// Skipped when not running under a background job (active_job_id
+			// empty) to avoid unnecessary DB writes from automations/CLI.
+			if ( '' !== $this->active_job_id ) {
+				ActiveJobRepository::heartbeat( $this->active_job_id );
+			}
 
 			// Wall-clock timeout check.
 			if ( microtime( true ) >= $deadline ) {

--- a/includes/Core/Database.php
+++ b/includes/Core/Database.php
@@ -36,7 +36,7 @@ use SdAiAgent\Tools\CustomTools;
 class Database {
 
 	const DB_VERSION_OPTION = 'sd_ai_agent_db_version';
-	const DB_VERSION        = '19.3.0';
+	const DB_VERSION        = '19.4.0';
 
 	// ─── Table Name Registry ──────────────────────────────────────────────────
 
@@ -619,12 +619,15 @@ class Database {
 			status varchar(30) NOT NULL DEFAULT 'processing',
 			pending_tools longtext NOT NULL,
 			tool_calls longtext NOT NULL,
+			error text NULL,
+			interrupted_at datetime NULL,
 			created_at datetime NOT NULL,
 			updated_at datetime NOT NULL,
 			PRIMARY KEY  (id),
 			UNIQUE KEY job_id (job_id),
 			KEY session_id (session_id),
-			KEY user_id_status (user_id, status)
+			KEY user_id_status (user_id, status),
+			KEY status_updated_at (status, updated_at)
 		) {$charset};
 
 		CREATE TABLE {$skill_usage_table} (

--- a/includes/Models/ActiveJobRepository.php
+++ b/includes/Models/ActiveJobRepository.php
@@ -19,8 +19,16 @@ class ActiveJobRepository {
 
 	/**
 	 * Valid job status values.
+	 *
+	 * - processing            — loop is actively running.
+	 * - awaiting_confirmation — paused waiting for user confirmation.
+	 * - awaiting_client_tools — paused waiting for browser to execute JS tools.
+	 * - complete              — loop finished normally.
+	 * - error                 — loop finished with an error.
+	 * - interrupted           — PHP request terminated before loop completion (shutdown handler fired).
+	 * - abandoned             — row reaped by the hourly cron because updated_at is stale.
 	 */
-	const STATUSES = [ 'processing', 'awaiting_confirmation', 'awaiting_client_tools', 'complete', 'error' ];
+	const STATUSES = [ 'processing', 'awaiting_confirmation', 'awaiting_client_tools', 'complete', 'error', 'interrupted', 'abandoned' ];
 
 	/**
 	 * Get the active jobs table name.
@@ -182,6 +190,88 @@ class ActiveJobRepository {
 		);
 
 		return $result !== false;
+	}
+
+	/**
+	 * Update only the updated_at timestamp for a job (heartbeat).
+	 *
+	 * Called at the start of each AgentLoop iteration so the periodic reaper
+	 * can distinguish an actively-running job from a zombie.
+	 *
+	 * @param string $job_id The job UUID.
+	 * @return bool True on success, false on failure.
+	 */
+	public static function heartbeat( string $job_id ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
+		$result = $wpdb->update(
+			self::table_name(),
+			[ 'updated_at' => current_time( 'mysql', true ) ],
+			[ 'job_id' => $job_id ],
+			[ '%s' ],
+			[ '%s' ]
+		);
+
+		return $result !== false && (int) $result > 0;
+	}
+
+	/**
+	 * Mark a job as interrupted (PHP request terminated before loop completion).
+	 *
+	 * Called by the shutdown handler registered in handle_process(). Only
+	 * updates the row when the status is still 'processing' so a normally-
+	 * completed job that finished just before shutdown is not overwritten.
+	 *
+	 * @param string $job_id The job UUID.
+	 * @param string $reason Human-readable reason for the interruption.
+	 * @return bool True on success, false on failure.
+	 */
+	public static function mark_interrupted( string $job_id, string $reason ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$now = current_time( 'mysql', true );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE %i SET status = 'interrupted', error = %s, interrupted_at = %s, updated_at = %s WHERE job_id = %s AND status = 'processing'",
+				self::table_name(),
+				$reason,
+				$now,
+				$now,
+				$job_id
+			)
+		);
+
+		return $result !== false && $result > 0;
+	}
+
+	/**
+	 * Reap stale processing rows by marking them as 'abandoned'.
+	 *
+	 * Rows are considered stale when status='processing' and updated_at has
+	 * not advanced within the given threshold. Called by the hourly cron job.
+	 *
+	 * @param int $threshold_minutes Number of minutes of inactivity before a row is considered stale.
+	 * @return int Number of rows updated.
+	 */
+	public static function cleanup_stale( int $threshold_minutes ): int {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE %i SET status = 'abandoned', updated_at = UTC_TIMESTAMP() WHERE status = 'processing' AND updated_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL %d MINUTE)",
+				self::table_name(),
+				$threshold_minutes
+			)
+		);
+
+		return (int) $result;
 	}
 
 	/**

--- a/includes/Models/DTO/ActiveJobRow.php
+++ b/includes/Models/DTO/ActiveJobRow.php
@@ -20,15 +20,17 @@ namespace SdAiAgent\Models\DTO;
 readonly class ActiveJobRow {
 
 	/**
-	 * @param int    $id            Row ID (auto-increment PK).
-	 * @param int    $session_id    WordPress session ID (FK to sessions table).
-	 * @param string $job_id        UUID identifying the background job.
-	 * @param int    $user_id       WordPress user ID.
-	 * @param string $status        Job status: processing|awaiting_confirmation|complete|error.
-	 * @param string $pending_tools JSON-encoded pending tool-call confirmations (default '[]').
-	 * @param string $tool_calls    JSON-encoded tool-call log (default '[]').
-	 * @param string $created_at    MySQL datetime string (UTC).
-	 * @param string $updated_at    MySQL datetime string (UTC).
+	 * @param int         $id             Row ID (auto-increment PK).
+	 * @param int         $session_id     WordPress session ID (FK to sessions table).
+	 * @param string      $job_id         UUID identifying the background job.
+	 * @param int         $user_id        WordPress user ID.
+	 * @param string      $status         Job status: processing|awaiting_confirmation|awaiting_client_tools|complete|error|interrupted|abandoned.
+	 * @param string      $pending_tools  JSON-encoded pending tool-call confirmations (default '[]').
+	 * @param string      $tool_calls     JSON-encoded tool-call log (default '[]').
+	 * @param string|null $error          Error or interruption message, null when not set.
+	 * @param string|null $interrupted_at MySQL datetime string (UTC) when the shutdown handler fired, null if not interrupted.
+	 * @param string      $created_at     MySQL datetime string (UTC).
+	 * @param string      $updated_at     MySQL datetime string (UTC).
 	 */
 	public function __construct(
 		public int $id,
@@ -38,6 +40,8 @@ readonly class ActiveJobRow {
 		public string $status,
 		public string $pending_tools,
 		public string $tool_calls,
+		public ?string $error,
+		public ?string $interrupted_at,
 		public string $created_at,
 		public string $updated_at,
 	) {}
@@ -50,15 +54,17 @@ readonly class ActiveJobRow {
 	 */
 	public static function from_row( object $row ): self {
 		return new self(
-			id:            (int) $row->id,
-			session_id:    (int) $row->session_id,
-			job_id:        (string) ( $row->job_id ?? '' ),
-			user_id:       (int) $row->user_id,
-			status:        (string) ( $row->status ?? 'processing' ),
-			pending_tools: (string) ( $row->pending_tools ?? '[]' ),
-			tool_calls:    (string) ( $row->tool_calls ?? '[]' ),
-			created_at:    (string) ( $row->created_at ?? '' ),
-			updated_at:    (string) ( $row->updated_at ?? '' ),
+			id:             (int) $row->id,
+			session_id:     (int) $row->session_id,
+			job_id:         (string) ( $row->job_id ?? '' ),
+			user_id:        (int) $row->user_id,
+			status:         (string) ( $row->status ?? 'processing' ),
+			pending_tools:  (string) ( $row->pending_tools ?? '[]' ),
+			tool_calls:     (string) ( $row->tool_calls ?? '[]' ),
+			error:          isset( $row->error ) ? (string) $row->error : null,
+			interrupted_at: isset( $row->interrupted_at ) ? (string) $row->interrupted_at : null,
+			created_at:     (string) ( $row->created_at ?? '' ),
+			updated_at:     (string) ( $row->updated_at ?? '' ),
 		);
 	}
 }

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -1484,6 +1484,15 @@ final class SessionController {
 			$options       = array_merge( $options, $agent_options );
 		}
 
+		/*
+		 * Pass the job UUID to AgentLoop so it can:
+		 * (a) issue heartbeats on each iteration, keeping updated_at fresh so
+		 *     the hourly stale-job reaper treats this as an active loop; and
+		 * (b) register a shutdown handler that marks the row as 'interrupted'
+		 *     when the PHP process terminates before loop completion.
+		 */
+		$options['active_job_id'] = $job_id;
+
 		// Progress callback: write live tool-call activity to the job
 		// transient so the polling frontend can display it incrementally.
 		$progress_job_id              = $job_id;

--- a/tests/SdAiAgent/Core/ActiveJobsCleanupTest.php
+++ b/tests/SdAiAgent/Core/ActiveJobsCleanupTest.php
@@ -1,0 +1,346 @@
+<?php
+/**
+ * Test case for active-jobs zombie cleanup (GH#1510).
+ *
+ * Covers:
+ * - ActiveJobRepository::heartbeat() advances updated_at.
+ * - ActiveJobRepository::mark_interrupted() sets status='interrupted' with error and timestamp.
+ * - ActiveJobRepository::cleanup_stale() marks stale processing rows as 'abandoned'.
+ * - ActiveJobRepository::cleanup_stale() leaves recently-updated rows untouched.
+ * - ActiveJobsCleanupService::schedule() / unschedule() lifecycle.
+ * - ActiveJobsCleanupService::run() triggers cleanup and fires action.
+ * - New status values 'interrupted' and 'abandoned' are accepted by update_status().
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\ActiveJobsCleanupService;
+use SdAiAgent\Models\ActiveJobRepository;
+use WP_UnitTestCase;
+
+/**
+ * Integration tests for active-jobs zombie cleanup.
+ *
+ * Runs inside wp-env (real MySQL) so direct SQL manipulation of timestamps
+ * works as expected.
+ */
+class ActiveJobsCleanupTest extends WP_UnitTestCase {
+
+	/**
+	 * Remove all test rows and unschedule cron events after each test.
+	 */
+	public function tear_down(): void {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test cleanup.
+		$wpdb->query( 'DELETE FROM ' . ActiveJobRepository::table_name() . " WHERE job_id LIKE 'test-%'" );
+		ActiveJobsCleanupService::unschedule();
+		remove_all_actions( 'sd_ai_agent_stale_jobs_reaped' );
+		remove_all_filters( 'sd_ai_agent_stale_job_threshold_minutes' );
+
+		parent::tear_down();
+	}
+
+	// ── Helpers ──────────────────────────────────────────────────────────
+
+	/**
+	 * Insert a synthetic active-jobs row with a controlled updated_at timestamp.
+	 *
+	 * @param string $job_id     UUID for the test row (prefix with 'test-' for teardown cleanup).
+	 * @param string $status     Row status (default 'processing').
+	 * @param string $updated_at MySQL datetime string for updated_at (default NOW()).
+	 * @return int Row ID.
+	 */
+	private function insert_job( string $job_id, string $status = 'processing', string $updated_at = '' ): int {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$now        = current_time( 'mysql', true );
+		$updated_at = '' === $updated_at ? $now : $updated_at;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Test helper.
+		$wpdb->insert(
+			ActiveJobRepository::table_name(),
+			[
+				'session_id'    => 1,
+				'job_id'        => $job_id,
+				'user_id'       => 1,
+				'status'        => $status,
+				'pending_tools' => '[]',
+				'tool_calls'    => '[]',
+				'created_at'    => $now,
+				'updated_at'    => $updated_at,
+			],
+			[ '%d', '%s', '%d', '%s', '%s', '%s', '%s', '%s' ]
+		);
+
+		return (int) $wpdb->insert_id;
+	}
+
+	/**
+	 * Fetch the raw row for a job_id.
+	 *
+	 * @param string $job_id Job UUID.
+	 * @return object|null Raw row or null.
+	 */
+	private function fetch_row( string $job_id ): ?object {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test helper.
+		return $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE job_id = %s',
+				ActiveJobRepository::table_name(),
+				$job_id
+			)
+		);
+	}
+
+	// ── heartbeat() ──────────────────────────────────────────────────────
+
+	/**
+	 * heartbeat() advances updated_at for an existing processing row.
+	 */
+	public function test_heartbeat_advances_updated_at(): void {
+		// Insert a row with a timestamp two minutes in the past.
+		$stale_time = gmdate( 'Y-m-d H:i:s', time() - 120 );
+		$this->insert_job( 'test-heartbeat-1', 'processing', $stale_time );
+
+		$before = $this->fetch_row( 'test-heartbeat-1' );
+		$this->assertNotNull( $before );
+		$this->assertSame( $stale_time, $before->updated_at );
+
+		$result = ActiveJobRepository::heartbeat( 'test-heartbeat-1' );
+
+		$after = $this->fetch_row( 'test-heartbeat-1' );
+		$this->assertNotNull( $after );
+		$this->assertTrue( $result );
+		$this->assertGreaterThan( $before->updated_at, $after->updated_at, 'updated_at should advance after heartbeat' );
+	}
+
+	/**
+	 * heartbeat() returns false for a non-existent job_id without erroring.
+	 */
+	public function test_heartbeat_returns_false_for_unknown_job(): void {
+		$result = ActiveJobRepository::heartbeat( 'test-heartbeat-nonexistent' );
+		$this->assertFalse( $result );
+	}
+
+	// ── mark_interrupted() ───────────────────────────────────────────────
+
+	/**
+	 * mark_interrupted() sets status='interrupted', error, and interrupted_at
+	 * for a row that is still 'processing'.
+	 */
+	public function test_mark_interrupted_updates_processing_row(): void {
+		$this->insert_job( 'test-interrupted-1', 'processing' );
+
+		$reason = 'shutdown handler — request terminated without loop completion';
+		$result = ActiveJobRepository::mark_interrupted( 'test-interrupted-1', $reason );
+
+		$row = $this->fetch_row( 'test-interrupted-1' );
+
+		$this->assertTrue( $result, 'mark_interrupted() should return true when it updated a row' );
+		$this->assertNotNull( $row );
+		$this->assertSame( 'interrupted', $row->status );
+		$this->assertSame( $reason, $row->error );
+		$this->assertNotEmpty( $row->interrupted_at );
+	}
+
+	/**
+	 * mark_interrupted() is a no-op when the row status is not 'processing'
+	 * (e.g. the loop already completed normally and set status='complete').
+	 */
+	public function test_mark_interrupted_does_not_overwrite_complete_row(): void {
+		$this->insert_job( 'test-interrupted-2', 'complete' );
+
+		$result = ActiveJobRepository::mark_interrupted( 'test-interrupted-2', 'shutdown' );
+		$row    = $this->fetch_row( 'test-interrupted-2' );
+
+		$this->assertFalse( $result, 'mark_interrupted() should return false when no rows were updated' );
+		$this->assertNotNull( $row );
+		$this->assertSame( 'complete', $row->status, 'Complete row status must not be overwritten' );
+	}
+
+	// ── cleanup_stale() ──────────────────────────────────────────────────
+
+	/**
+	 * cleanup_stale() marks rows as 'abandoned' when status='processing' and
+	 * updated_at is older than the threshold.
+	 */
+	public function test_cleanup_stale_marks_old_processing_rows_as_abandoned(): void {
+		// Set updated_at to 30 minutes ago — well beyond the 15-minute default.
+		$stale_time = gmdate( 'Y-m-d H:i:s', time() - 1800 );
+		$this->insert_job( 'test-stale-1', 'processing', $stale_time );
+
+		$count = ActiveJobRepository::cleanup_stale( 15 );
+		$row   = $this->fetch_row( 'test-stale-1' );
+
+		$this->assertGreaterThanOrEqual( 1, $count, 'cleanup_stale() should report at least one reaped row' );
+		$this->assertNotNull( $row );
+		$this->assertSame( 'abandoned', $row->status );
+	}
+
+	/**
+	 * cleanup_stale() does NOT touch rows whose updated_at is within the threshold.
+	 */
+	public function test_cleanup_stale_leaves_fresh_rows_untouched(): void {
+		// updated_at is only 2 minutes ago — well within the 15-minute window.
+		$fresh_time = gmdate( 'Y-m-d H:i:s', time() - 120 );
+		$this->insert_job( 'test-fresh-1', 'processing', $fresh_time );
+
+		ActiveJobRepository::cleanup_stale( 15 );
+		$row = $this->fetch_row( 'test-fresh-1' );
+
+		$this->assertNotNull( $row );
+		$this->assertSame( 'processing', $row->status, 'Fresh row must not be marked abandoned' );
+	}
+
+	/**
+	 * cleanup_stale() does NOT touch rows with terminal statuses (complete, error, etc.).
+	 */
+	public function test_cleanup_stale_ignores_terminal_status_rows(): void {
+		$stale_time = gmdate( 'Y-m-d H:i:s', time() - 3600 );
+		$this->insert_job( 'test-complete-1', 'complete', $stale_time );
+		$this->insert_job( 'test-error-1', 'error', $stale_time );
+		$this->insert_job( 'test-abandoned-1', 'abandoned', $stale_time );
+
+		$count = ActiveJobRepository::cleanup_stale( 15 );
+		$this->assertSame( 0, $count, 'cleanup_stale() should not touch terminal-status rows' );
+	}
+
+	/**
+	 * cleanup_stale() returns 0 when there are no stale rows.
+	 */
+	public function test_cleanup_stale_returns_zero_when_no_stale_rows(): void {
+		$count = ActiveJobRepository::cleanup_stale( 15 );
+		$this->assertSame( 0, $count );
+	}
+
+	// ── ActiveJobsCleanupService scheduling ──────────────────────────────
+
+	/**
+	 * schedule() registers the hourly cron event exactly once (idempotent).
+	 */
+	public function test_schedule_registers_hourly_cron_event(): void {
+		ActiveJobsCleanupService::unschedule();
+
+		ActiveJobsCleanupService::schedule();
+		$first = wp_next_scheduled( ActiveJobsCleanupService::CRON_HOOK );
+
+		ActiveJobsCleanupService::schedule();
+		$second = wp_next_scheduled( ActiveJobsCleanupService::CRON_HOOK );
+
+		$this->assertNotFalse( $first );
+		$this->assertSame( $first, $second, 'Calling schedule() twice should not move the timestamp' );
+	}
+
+	/**
+	 * unschedule() removes the hourly cron event.
+	 */
+	public function test_unschedule_removes_cron_event(): void {
+		ActiveJobsCleanupService::schedule();
+		$this->assertNotFalse( wp_next_scheduled( ActiveJobsCleanupService::CRON_HOOK ) );
+
+		ActiveJobsCleanupService::unschedule();
+		$this->assertFalse( wp_next_scheduled( ActiveJobsCleanupService::CRON_HOOK ) );
+	}
+
+	// ── ActiveJobsCleanupService::run() ──────────────────────────────────
+
+	/**
+	 * run() calls cleanup_stale() with the filtered threshold and fires
+	 * sd_ai_agent_stale_jobs_reaped when rows are reaped.
+	 */
+	public function test_run_reaps_stale_rows_and_fires_action(): void {
+		$stale_time = gmdate( 'Y-m-d H:i:s', time() - 1800 );
+		$this->insert_job( 'test-run-stale-1', 'processing', $stale_time );
+
+		$reaped_count = 0;
+		add_action(
+			'sd_ai_agent_stale_jobs_reaped',
+			static function ( int $count ) use ( &$reaped_count ): void {
+				$reaped_count = $count;
+			}
+		);
+
+		ActiveJobsCleanupService::run();
+
+		$row = $this->fetch_row( 'test-run-stale-1' );
+
+		$this->assertNotNull( $row );
+		$this->assertSame( 'abandoned', $row->status );
+		$this->assertGreaterThanOrEqual( 1, $reaped_count, 'sd_ai_agent_stale_jobs_reaped action should receive the count' );
+	}
+
+	/**
+	 * run() respects the sd_ai_agent_stale_job_threshold_minutes filter.
+	 */
+	public function test_run_uses_filterable_threshold(): void {
+		// Row updated 5 minutes ago — stale only with a 3-minute threshold.
+		$five_min_ago = gmdate( 'Y-m-d H:i:s', time() - 300 );
+		$this->insert_job( 'test-threshold-1', 'processing', $five_min_ago );
+
+		// With the default 15-minute threshold the row should not be reaped.
+		ActiveJobsCleanupService::run();
+		$row = $this->fetch_row( 'test-threshold-1' );
+		$this->assertSame( 'processing', $row->status ?? '', 'Row should not be reaped by default 15-min threshold' );
+
+		// Now lower the threshold to 3 minutes — the row should be reaped.
+		add_filter( 'sd_ai_agent_stale_job_threshold_minutes', static fn() => 3 );
+		ActiveJobsCleanupService::run();
+		$row = $this->fetch_row( 'test-threshold-1' );
+
+		$this->assertSame( 'abandoned', $row->status ?? '', 'Row should be reaped with 3-minute threshold' );
+	}
+
+	/**
+	 * run() does not fire sd_ai_agent_stale_jobs_reaped when no rows were reaped.
+	 */
+	public function test_run_does_not_fire_action_when_no_rows_reaped(): void {
+		$action_fired = false;
+		add_action(
+			'sd_ai_agent_stale_jobs_reaped',
+			static function () use ( &$action_fired ): void {
+				$action_fired = true;
+			}
+		);
+
+		ActiveJobsCleanupService::run();
+
+		$this->assertFalse( $action_fired, 'sd_ai_agent_stale_jobs_reaped must not fire when no rows were reaped' );
+	}
+
+	// ── STATUSES constant ─────────────────────────────────────────────────
+
+	/**
+	 * 'interrupted' and 'abandoned' are valid status values accepted by update_status().
+	 */
+	public function test_interrupted_and_abandoned_are_valid_statuses(): void {
+		$this->insert_job( 'test-status-interrupted', 'processing' );
+		$this->insert_job( 'test-status-abandoned', 'processing' );
+
+		$this->assertTrue(
+			ActiveJobRepository::update_status( 'test-status-interrupted', 'interrupted' ),
+			"'interrupted' should be a valid status"
+		);
+		$this->assertTrue(
+			ActiveJobRepository::update_status( 'test-status-abandoned', 'abandoned' ),
+			"'abandoned' should be a valid status"
+		);
+
+		$row1 = $this->fetch_row( 'test-status-interrupted' );
+		$row2 = $this->fetch_row( 'test-status-abandoned' );
+
+		$this->assertSame( 'interrupted', $row1->status ?? '' );
+		$this->assertSame( 'abandoned', $row2->status ?? '' );
+	}
+}

--- a/tests/SdAiAgent/Core/DatabaseSchemaTest.php
+++ b/tests/SdAiAgent/Core/DatabaseSchemaTest.php
@@ -337,6 +337,27 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Active jobs table has the zombie-cleanup columns introduced in DB 19.4.0.
+	 *
+	 * Regression guard for GH#1510: the error and interrupted_at columns are
+	 * used by the shutdown handler (mark_interrupted) and the hourly cron reaper.
+	 * The status_updated_at composite index supports the reaper query.
+	 */
+	public function test_active_jobs_table_has_cleanup_columns(): void {
+		Database::install();
+
+		$columns = $this->get_column_names( Database::active_jobs_table_name() );
+
+		foreach ( [ 'error', 'interrupted_at' ] as $col ) {
+			$this->assertContains(
+				$col,
+				$columns,
+				"active_jobs table missing column '{$col}' — see GH#1510."
+			);
+		}
+	}
+
+	/**
 	 * Knowledge tables are created with correct structure.
 	 */
 	public function test_knowledge_tables_have_required_columns(): void {


### PR DESCRIPTION
## Summary

Rows in `wp_sd_ai_agent_active_jobs` become permanently stuck in `status='processing'` when the PHP request running an AgentLoop terminates abnormally. This PR implements the two-tier cleanup strategy from GH#1510.

## Changes

### Schema (DB_VERSION 19.4.0)
- Added `error TEXT NULL` and `interrupted_at DATETIME NULL` to `sd_ai_agent_active_jobs`.
- Added `KEY status_updated_at (status, updated_at)` composite index for the reaper query.

### Shutdown handler (primary defence)
- `AgentLoop::run()` registers `register_shutdown_function()` when `active_job_id` is set, marking the row as `'interrupted'` with a contextual reason (client-disconnect / PHP-timeout / generic).
- Only fires when the row is still `'processing'`; a normally-completed loop is untouched.
- `SessionController::handle_process()` passes `job_id` as `active_job_id` option to AgentLoop.

### Heartbeat + hourly cron reaper (safety net)
- `AgentLoop::run_loop()` calls `ActiveJobRepository::heartbeat()` at the top of each iteration, advancing `updated_at` so a running loop stays fresh.
- New `ActiveJobsCleanupService` (mirrors `SkillUpdateChecker` pattern):
  - `CRON_HOOK = sd_ai_agent_cleanup_stale_active_jobs` (hourly)
  - Marks rows as `'abandoned'` when stale (default 15-min threshold, filterable via `sd_ai_agent_stale_job_threshold_minutes`)
  - Fires `sd_ai_agent_stale_jobs_reaped` action with row count
  - Scheduled/unscheduled in `LifecycleHandler` activate/deactivate
  - Wired as `#[Action]` in `OnboardingHandler`

### New repository methods
- `ActiveJobRepository::heartbeat($job_id): bool`
- `ActiveJobRepository::mark_interrupted($job_id, $reason): bool`
- `ActiveJobRepository::cleanup_stale($threshold_minutes): int`

### New status values
- `'interrupted'` — shutdown handler fired
- `'abandoned'` — hourly cron reaped the row

Both added to `STATUSES` const; `update_status()` accepts them.

## Tests
- 14 new tests in `ActiveJobsCleanupTest` covering heartbeat, mark_interrupted, cleanup_stale, schedule/unschedule, threshold filter, and action hook.
- `DatabaseSchemaTest::test_active_jobs_table_has_cleanup_columns()` — regression guard for new columns.
- All existing AgentLoop and DatabaseSchema tests pass unaffected.

## Verification

```bash
composer phpstan   # OK No errors
composer phpcs     # OK No violations
WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter ActiveJobsCleanupTest
# OK (14 tests, 37 assertions)
WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter DatabaseSchemaTest
# OK (25 tests, 176 assertions)
WP_TESTS_DIR=/tmp/wordpress-tests-lib vendor/bin/phpunit --filter "AgentLoopTest|AgentLoopClientToolsTest"
# OK, Tests: 116, Skipped: 55 (pre-existing)
```

Resolves #1510

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.64 plugin for [OpenCode](https://opencode.ai) v1.15.5 with claude-sonnet-4-6 spent 15m and 45,218 tokens on this as a headless worker.
