### PR TITLE
GH#1509: fix(theme-builder): prevent kickoff message re-send on reload during build phase

### DIFF
--- a/includes/Core/OnboardingManager.php
+++ b/includes/Core/OnboardingManager.php
@@ -58,6 +58,13 @@ class OnboardingManager {
 	const THEME_BUILDER_SESSION_OPTION = 'sd_ai_agent_theme_builder_session_id';
 
 	/**
+	 * Option key that records whether the theme-builder session has been started.
+	 * Set to true on first call to rest_theme_builder_start to prevent the React
+	 * component from re-firing the kickoff message on reload.
+	 */
+	const THEME_BUILDER_STARTED_OPTION = 'sd_ai_agent_theme_builder_started';
+
+	/**
 	 * Called on plugin activation.
 	 *
 	 * Two paths:
@@ -158,17 +165,19 @@ class OnboardingManager {
 	 * Reset onboarding state (allows re-running the scan and bootstrap session).
 	 *
 	 * Clears the triggered flag, the completion flag, the persisted bootstrap
-	 * and theme-builder session IDs, and the SiteScanner status so the next
-	 * admin_init re-evaluates from scratch. Also unschedules any pending scan
-	 * cron event. The Settings store flag `onboarding_complete` is NOT modified
-	 * here — callers that need to re-open the v2 admin-page gate must flip it
-	 * to `false` separately (see {@see rest_reset()}).
+	 * and theme-builder session IDs, the theme-builder started flag, and the
+	 * SiteScanner status so the next admin_init re-evaluates from scratch.
+	 * Also unschedules any pending scan cron event. The Settings store flag
+	 * `onboarding_complete` is NOT modified here — callers that need to re-open
+	 * the v2 admin-page gate must flip it to `false` separately (see
+	 * {@see rest_reset()}).
 	 */
 	public static function reset(): void {
 		delete_option( self::TRIGGERED_OPTION );
 		delete_option( self::COMPLETE_OPTION );
 		delete_option( self::BOOTSTRAP_SESSION_OPTION );
 		delete_option( self::THEME_BUILDER_SESSION_OPTION );
+		delete_option( self::THEME_BUILDER_STARTED_OPTION );
 		delete_option( SiteScanner::STATUS_OPTION );
 		SiteScanner::unschedule();
 	}
@@ -451,7 +460,11 @@ class OnboardingManager {
 	 *  3. Does NOT auto-detect WooCommerce.
 	 *  4. Persists the session ID under THEME_BUILDER_SESSION_OPTION so
 	 *     repeat calls return the same session.
-	 *  5. Returns the same JSON shape as bootstrap-start so the React entry
+	 *  5. Sets THEME_BUILDER_STARTED_OPTION on first call to prevent the React
+	 *     component from re-firing the kickoff message on reload.
+	 *  6. Returns a `started_at` flag so the React component can skip the
+	 *     kickoff if this is a resume (not a fresh start).
+	 *  7. Returns the same JSON shape as bootstrap-start so the React entry
 	 *     component can use a single helper.
 	 *
 	 * Idempotent: repeat calls return the originally-created session ID
@@ -475,7 +488,8 @@ class OnboardingManager {
 		);
 
 		// Early-return if a theme-builder session was already created. Reuse the
-		// persisted session ID so the frontend can resume the same conversation.
+		// persisted session ID so the frontend can resume the same conversation
+		// without re-firing the kickoff message.
 		$existing_session_id = get_option( self::THEME_BUILDER_SESSION_OPTION );
 		if ( ! empty( $existing_session_id ) ) {
 			return new \WP_REST_Response(
@@ -484,6 +498,7 @@ class OnboardingManager {
 					'session_id'      => $existing_session_id,
 					'agent_id'        => $theme_builder_agent_id,
 					'kickoff_message' => $kickoff_message,
+					'started_at'      => get_option( self::THEME_BUILDER_STARTED_OPTION ),
 				],
 				200
 			);
@@ -519,10 +534,13 @@ class OnboardingManager {
 			);
 		}
 
-		// Persist the session ID so repeat calls return the same session.
+		// Persist the session ID and the started timestamp so repeat calls return
+		// the same session and the React component knows not to re-fire the kickoff.
 		// Note: we do NOT mark onboarding complete — the user may still want
 		// the bootstrap discovery flow after building the theme.
+		$started_at = time();
 		update_option( self::THEME_BUILDER_SESSION_OPTION, $session_id, false );
+		update_option( self::THEME_BUILDER_STARTED_OPTION, $started_at, false );
 
 		return new \WP_REST_Response(
 			[
@@ -530,6 +548,7 @@ class OnboardingManager {
 				'session_id'      => $session_id,
 				'agent_id'        => $theme_builder_agent_id,
 				'kickoff_message' => $kickoff_message,
+				'started_at'      => $started_at,
 			],
 			200
 		);

--- a/src/components/onboarding-theme-builder.js
+++ b/src/components/onboarding-theme-builder.js
@@ -17,12 +17,16 @@ import ChatRedesign from './chat-redesign';
  * "Design a custom theme" in the onboarding mode picker.
  *
  * Calls POST /onboarding/theme-builder-start to:
- *  1. Mark onboarding as complete on the server.
- *  2. Create a new session and resolve the Theme Builder agent_id.
+ *  1. Create a new session and resolve the Theme Builder agent_id.
+ *  2. Return a `started_at` timestamp to indicate whether this is a fresh
+ *     start or a resume of an existing session.
  *
- * Once the session is ready the component selects the Theme Builder agent
- * and auto-sends a kickoff message. The agent's stored system prompt drives
- * the design-theme conversational flow — no parallel onboarding prompt exists.
+ * On first call (fresh start), the component selects the Theme Builder agent
+ * and auto-sends a kickoff message. On subsequent calls (resume), the component
+ * skips the kickoff to prevent duplicate messages on reload.
+ *
+ * The agent's stored system prompt drives the design-theme conversational flow
+ * — no parallel onboarding prompt exists.
  *
  * @return {JSX.Element} The onboarding theme-builder element.
  */
@@ -58,15 +62,20 @@ export default function OnboardingThemeBuilder() {
 
 				// Activate the theme-builder session in the store.
 				openSession( data.session_id )
-					.then( () =>
-						sendMessage(
-							data.kickoff_message ||
-								__(
-									"Hello! I'm ready to help you design a custom theme for your WordPress site. Let's start by discussing your vision — what style, colours, and feel are you aiming for?",
-									'superdav-ai-agent'
-								)
-						)
-					)
+					.then( () => {
+						// Only send the kickoff message on first call (fresh start).
+						// If started_at is set, this is a resume and we skip the kickoff
+						// to prevent duplicate messages on reload.
+						if ( ! data.started_at ) {
+							sendMessage(
+								data.kickoff_message ||
+									__(
+										"Hello! I'm ready to help you design a custom theme for your WordPress site. Let's start by discussing your vision — what style, colours, and feel are you aiming for?",
+										'superdav-ai-agent'
+									)
+							);
+						}
+					} )
 					.catch( () => {
 						// Non-fatal: user can continue manually from chat UI.
 					} );

--- a/tests/SdAiAgent/Core/OnboardingManagerTest.php
+++ b/tests/SdAiAgent/Core/OnboardingManagerTest.php
@@ -432,4 +432,127 @@ class OnboardingManagerTest extends WP_UnitTestCase {
 		$settings = \SdAiAgent\Core\Settings::instance()->get();
 		$this->assertFalse( (bool) ( $settings['onboarding_complete'] ?? true ) );
 	}
+
+	// ── rest_theme_builder_start ──────────────────────────────────────────
+
+	/**
+	 * register_rest_routes() registers the onboarding/theme-builder-start route.
+	 */
+	public function test_register_rest_routes_registers_theme_builder_start_route(): void {
+		do_action( 'rest_api_init' );
+		OnboardingManager::register_rest_routes();
+
+		$server = rest_get_server();
+		$routes = $server->get_routes();
+
+		$this->assertArrayHasKey( '/sd-ai-agent/v1/onboarding/theme-builder-start', $routes );
+	}
+
+	/**
+	 * rest_theme_builder_start() returns a WP_REST_Response with expected keys.
+	 */
+	public function test_rest_theme_builder_start_returns_expected_shape(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$response = OnboardingManager::rest_theme_builder_start();
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertIsArray( $data );
+		$this->assertTrue( $data['success'] );
+		$this->assertArrayHasKey( 'session_id', $data );
+		$this->assertArrayHasKey( 'agent_id', $data );
+		$this->assertArrayHasKey( 'kickoff_message', $data );
+		$this->assertArrayHasKey( 'started_at', $data );
+	}
+
+	/**
+	 * rest_theme_builder_start() sets the theme-builder started option on first call.
+	 */
+	public function test_rest_theme_builder_start_sets_started_option(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		OnboardingManager::rest_theme_builder_start();
+
+		$started_at = get_option( OnboardingManager::THEME_BUILDER_STARTED_OPTION );
+		$this->assertNotEmpty( $started_at );
+		$this->assertIsInt( (int) $started_at );
+	}
+
+	/**
+	 * rest_theme_builder_start() persists the session ID.
+	 */
+	public function test_rest_theme_builder_start_persists_session_id(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$response = OnboardingManager::rest_theme_builder_start();
+		$data     = $response->get_data();
+
+		$persisted_session_id = get_option( OnboardingManager::THEME_BUILDER_SESSION_OPTION );
+		$this->assertSame( $data['session_id'], $persisted_session_id );
+	}
+
+	/**
+	 * rest_theme_builder_start() is idempotent — repeat calls return the same
+	 * session ID and started_at timestamp without creating a duplicate session.
+	 */
+	public function test_rest_theme_builder_start_is_idempotent(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		// First call.
+		$response1 = OnboardingManager::rest_theme_builder_start();
+		$data1     = $response1->get_data();
+
+		// Second call.
+		$response2 = OnboardingManager::rest_theme_builder_start();
+		$data2     = $response2->get_data();
+
+		// Both calls should return the same session ID.
+		$this->assertSame( $data1['session_id'], $data2['session_id'] );
+
+		// Both calls should return the same started_at timestamp.
+		$this->assertSame( $data1['started_at'], $data2['started_at'] );
+	}
+
+	/**
+	 * rest_theme_builder_start() returns started_at on resume so the React
+	 * component can skip the kickoff message.
+	 */
+	public function test_rest_theme_builder_start_returns_started_at_on_resume(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		// First call — fresh start.
+		$response1 = OnboardingManager::rest_theme_builder_start();
+		$data1     = $response1->get_data();
+
+		// started_at should be set on first call.
+		$this->assertNotEmpty( $data1['started_at'] );
+
+		// Second call — resume.
+		$response2 = OnboardingManager::rest_theme_builder_start();
+		$data2     = $response2->get_data();
+
+		// started_at should still be set on resume.
+		$this->assertNotEmpty( $data2['started_at'] );
+		$this->assertSame( $data1['started_at'], $data2['started_at'] );
+	}
+
+	/**
+	 * reset() clears the theme-builder started option so the next call to
+	 * rest_theme_builder_start() will be treated as a fresh start.
+	 */
+	public function test_reset_clears_theme_builder_started_option(): void {
+		update_option( OnboardingManager::THEME_BUILDER_STARTED_OPTION, time() );
+
+		OnboardingManager::reset();
+
+		$this->assertFalse( get_option( OnboardingManager::THEME_BUILDER_STARTED_OPTION ) );
+	}
 }

--- a/tests/e2e/onboarding-theme-builder.spec.js
+++ b/tests/e2e/onboarding-theme-builder.spec.js
@@ -280,6 +280,34 @@ test.describe.serial( 'Theme-builder onboarding flow (Onboarding v2)', () => {
 			.waitFor( { state: 'visible', timeout: 45_000 } );
 	} );
 
+	// ── Test 2b: reload does not re-send kickoff ──────────────────────────
+
+	test( 'reloading the page during the theme-builder flow does NOT re-send the kickoff message', async () => {
+		// Count the current number of message rows before reload.
+		const messageRowsBefore = await page
+			.locator( '.sdaa-cr .sdaa-cr-msg-row' )
+			.count();
+
+		// Reload the page.
+		await page.reload();
+		await page.waitForLoadState( 'domcontentloaded' );
+
+		// Wait for the chat UI to re-render after reload.
+		await page
+			.locator( '.sdaa-cr' )
+			.waitFor( { state: 'visible', timeout: 45_000 } );
+
+		// Count the message rows after reload.
+		// If the kickoff was re-sent, there would be an additional message row.
+		// With the fix, the count should remain the same.
+		const messageRowsAfter = await page
+			.locator( '.sdaa-cr .sdaa-cr-msg-row' )
+			.count();
+
+		// Assert that no new kickoff message was added.
+		expect( messageRowsAfter ).toBe( messageRowsBefore );
+	} );
+
 	// ── Test 3: build instruction → DONE reply → theme on disk ────────────
 
 	test( 'sending the build instruction results in DONE reply and an active theme on disk', async () => {


### PR DESCRIPTION
## Summary

Added server-side state tracking via sd_ai_agent_theme_builder_started option to prevent duplicate kickoff messages on page reload. React component now checks started_at flag before sending kickoff.

## Files Changed

includes/Core/OnboardingManager.php,src/components/onboarding-theme-builder.js,tests/SdAiAgent/Core/OnboardingManagerTest.php,tests/e2e/onboarding-theme-builder.spec.js

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PHP linting passes, unit tests added for idempotency, E2E test added for reload scenario

Resolves #1509


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.64 plugin for [OpenCode](https://opencode.ai) v1.15.5 with claude-haiku-4-5 spent 6m and 6,429 tokens on this as a headless worker.