### PR TITLE
fix(theme-builder): auto-kickoff regression on fresh start (#1522)

### DIFF
--- a/includes/Core/OnboardingManager.php
+++ b/includes/Core/OnboardingManager.php
@@ -462,8 +462,12 @@ class OnboardingManager {
 	 *     repeat calls return the same session.
 	 *  5. Sets THEME_BUILDER_STARTED_OPTION on first call to prevent the React
 	 *     component from re-firing the kickoff message on reload.
-	 *  6. Returns a `started_at` flag so the React component can skip the
-	 *     kickoff if this is a resume (not a fresh start).
+	 *  6. Returns an explicit `is_fresh_start` boolean so the React component
+	 *     can distinguish a fresh-create request (kickoff SHOULD fire) from a
+	 *     resume request (kickoff MUST NOT fire). The boolean is the
+	 *     authoritative signal — `started_at` is also returned for
+	 *     observability/back-compat but MUST NOT be used to drive kickoff
+	 *     behaviour because both branches return a truthy timestamp.
 	 *  7. Returns the same JSON shape as bootstrap-start so the React entry
 	 *     component can use a single helper.
 	 *
@@ -489,7 +493,8 @@ class OnboardingManager {
 
 		// Early-return if a theme-builder session was already created. Reuse the
 		// persisted session ID so the frontend can resume the same conversation
-		// without re-firing the kickoff message.
+		// without re-firing the kickoff message. `is_fresh_start` is false on
+		// this branch so the React component skips the kickoff send.
 		$existing_session_id = get_option( self::THEME_BUILDER_SESSION_OPTION );
 		if ( ! empty( $existing_session_id ) ) {
 			return new \WP_REST_Response(
@@ -499,6 +504,7 @@ class OnboardingManager {
 					'agent_id'        => $theme_builder_agent_id,
 					'kickoff_message' => $kickoff_message,
 					'started_at'      => get_option( self::THEME_BUILDER_STARTED_OPTION ),
+					'is_fresh_start'  => false,
 				],
 				200
 			);
@@ -542,6 +548,10 @@ class OnboardingManager {
 		update_option( self::THEME_BUILDER_SESSION_OPTION, $session_id, false );
 		update_option( self::THEME_BUILDER_STARTED_OPTION, $started_at, false );
 
+		// `is_fresh_start` is true on this branch — the React component will
+		// auto-send the kickoff message exactly once. Subsequent calls hit the
+		// resume branch above (is_fresh_start=false) so reloads never duplicate
+		// the kickoff. See #1522 for the regression this signal fixes.
 		return new \WP_REST_Response(
 			[
 				'success'         => true,
@@ -549,6 +559,7 @@ class OnboardingManager {
 				'agent_id'        => $theme_builder_agent_id,
 				'kickoff_message' => $kickoff_message,
 				'started_at'      => $started_at,
+				'is_fresh_start'  => true,
 			],
 			200
 		);

--- a/src/components/__tests__/OnboardingThemeBuilder.test.js
+++ b/src/components/__tests__/OnboardingThemeBuilder.test.js
@@ -126,11 +126,12 @@ describe( 'OnboardingThemeBuilder', () => {
 		expect( openSessionMock ).toHaveBeenCalledWith( 99 );
 	} );
 
-	test( 'sends the kickoff message after session opens', async () => {
+	test( 'sends the kickoff message after session opens (fresh start)', async () => {
 		apiFetch.mockResolvedValue( {
 			session_id: 42,
 			agent_id: 7,
 			kickoff_message: 'Hello from theme-builder kickoff',
+			is_fresh_start: true,
 		} );
 		await renderThemeBuilder();
 		expect( sendMessageMock ).toHaveBeenCalledWith(
@@ -153,12 +154,53 @@ describe( 'OnboardingThemeBuilder', () => {
 			session_id: 42,
 			agent_id: 7,
 			kickoff_message: null,
+			is_fresh_start: true,
 		} );
 		await renderThemeBuilder();
 		const [ msg ] = sendMessageMock.mock.calls[ 0 ];
 		// Should contain a non-empty fallback string.
 		expect( msg ).toBeTruthy();
 		expect( typeof msg ).toBe( 'string' );
+	} );
+
+	// ── is_fresh_start regression coverage (#1522) ──────────────────────────
+
+	test( 'sends the kickoff when is_fresh_start is true', async () => {
+		apiFetch.mockResolvedValue( {
+			session_id: 42,
+			agent_id: 7,
+			kickoff_message: 'Hi from kickoff',
+			is_fresh_start: true,
+		} );
+		await renderThemeBuilder();
+		expect( sendMessageMock ).toHaveBeenCalledWith( 'Hi from kickoff' );
+	} );
+
+	test( 'does NOT send the kickoff when is_fresh_start is false (resume)', async () => {
+		apiFetch.mockResolvedValue( {
+			session_id: 42,
+			agent_id: 7,
+			kickoff_message: 'Hi from kickoff',
+			started_at: 1779203410, // truthy: would have fired kickoff under the pre-fix code
+			is_fresh_start: false,
+		} );
+		await renderThemeBuilder();
+		// openSession + setSelectedAgentId still fire on resume — only kickoff is suppressed.
+		expect( openSessionMock ).toHaveBeenCalledWith( 42 );
+		expect( setSelectedAgentIdMock ).toHaveBeenCalledWith( 7 );
+		expect( sendMessageMock ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does NOT send the kickoff when is_fresh_start is missing (defensive default)', async () => {
+		// Defensive: an older server that does not return is_fresh_start
+		// must not auto-fire the kickoff because we cannot prove it is fresh.
+		apiFetch.mockResolvedValue( {
+			session_id: 42,
+			agent_id: 7,
+			kickoff_message: 'Hi from kickoff',
+		} );
+		await renderThemeBuilder();
+		expect( sendMessageMock ).not.toHaveBeenCalled();
 	} );
 
 	test( 'does not throw when theme-builder-start fails', async () => {

--- a/src/components/onboarding-theme-builder.js
+++ b/src/components/onboarding-theme-builder.js
@@ -18,12 +18,16 @@ import ChatRedesign from './chat-redesign';
  *
  * Calls POST /onboarding/theme-builder-start to:
  *  1. Create a new session and resolve the Theme Builder agent_id.
- *  2. Return a `started_at` timestamp to indicate whether this is a fresh
- *     start or a resume of an existing session.
+ *  2. Return an `is_fresh_start` boolean indicating whether the server just
+ *     created the session (true) or returned an existing one for resume
+ *     (false). This is the authoritative signal — the `started_at`
+ *     timestamp is also returned but MUST NOT be used to drive kickoff
+ *     because both branches return a truthy timestamp (see #1522).
  *
- * On first call (fresh start), the component selects the Theme Builder agent
- * and auto-sends a kickoff message. On subsequent calls (resume), the component
- * skips the kickoff to prevent duplicate messages on reload.
+ * On first call (is_fresh_start=true), the component selects the Theme Builder
+ * agent and auto-sends a kickoff message. On subsequent calls (is_fresh_start
+ * =false), the component skips the kickoff to prevent duplicate messages on
+ * reload.
  *
  * The agent's stored system prompt drives the design-theme conversational flow
  * — no parallel onboarding prompt exists.
@@ -63,10 +67,13 @@ export default function OnboardingThemeBuilder() {
 				// Activate the theme-builder session in the store.
 				openSession( data.session_id )
 					.then( () => {
-						// Only send the kickoff message on first call (fresh start).
-						// If started_at is set, this is a resume and we skip the kickoff
-						// to prevent duplicate messages on reload.
-						if ( ! data.started_at ) {
+						// Only send the kickoff message on a genuine fresh start.
+						// `is_fresh_start` is true only when the server just
+						// created the session; on every resume it is false, so
+						// reloads never re-fire the kickoff. See #1522 — the
+						// pre-fix code keyed off `started_at`, which is truthy
+						// on both branches, so kickoff never fired.
+						if ( data.is_fresh_start ) {
 							sendMessage(
 								data.kickoff_message ||
 									__(

--- a/tests/SdAiAgent/Core/OnboardingManagerTest.php
+++ b/tests/SdAiAgent/Core/OnboardingManagerTest.php
@@ -467,6 +467,12 @@ class OnboardingManagerTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'agent_id', $data );
 		$this->assertArrayHasKey( 'kickoff_message', $data );
 		$this->assertArrayHasKey( 'started_at', $data );
+		// is_fresh_start drives the React kickoff guard (see #1522).
+		// `started_at` is retained for observability / back-compat but MUST NOT
+		// be used to distinguish fresh-start from resume because it is truthy
+		// on both branches.
+		$this->assertArrayHasKey( 'is_fresh_start', $data );
+		$this->assertIsBool( $data['is_fresh_start'] );
 	}
 
 	/**
@@ -521,8 +527,15 @@ class OnboardingManagerTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * rest_theme_builder_start() returns started_at on resume so the React
-	 * component can skip the kickoff message.
+	 * rest_theme_builder_start() returns the same started_at timestamp on resume.
+	 *
+	 * Historical note: pre-#1522 the React component used `started_at` as the
+	 * kickoff guard, which was broken because the fresh-create branch also
+	 * stamped a fresh timestamp before returning — so the JS check
+	 * `if ( ! data.started_at )` was false on the very first call and the
+	 * kickoff never fired. `is_fresh_start` is now the authoritative signal
+	 * (see test_rest_theme_builder_start_distinguishes_fresh_start_from_resume
+	 * below). `started_at` is retained for observability and back-compat.
 	 */
 	public function test_rest_theme_builder_start_returns_started_at_on_resume(): void {
 		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
@@ -539,9 +552,39 @@ class OnboardingManagerTest extends WP_UnitTestCase {
 		$response2 = OnboardingManager::rest_theme_builder_start();
 		$data2     = $response2->get_data();
 
-		// started_at should still be set on resume.
+		// started_at should still be set on resume and unchanged.
 		$this->assertNotEmpty( $data2['started_at'] );
 		$this->assertSame( $data1['started_at'], $data2['started_at'] );
+	}
+
+	/**
+	 * rest_theme_builder_start() returns is_fresh_start=true on the very first
+	 * call and is_fresh_start=false on every subsequent (resume) call.
+	 *
+	 * Regression coverage for #1522 — the broken signal `started_at` is
+	 * truthy on both branches; `is_fresh_start` is the only field that can
+	 * be used to drive the React component's kickoff guard.
+	 */
+	public function test_rest_theme_builder_start_distinguishes_fresh_start_from_resume(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		// First call — fresh start.
+		$first  = OnboardingManager::rest_theme_builder_start()->get_data();
+		$this->assertTrue(
+			$first['is_fresh_start'],
+			'First call must report is_fresh_start=true so the React component fires the kickoff.'
+		);
+
+		// Second call — resume.
+		$second = OnboardingManager::rest_theme_builder_start()->get_data();
+		$this->assertFalse(
+			$second['is_fresh_start'],
+			'Subsequent calls must report is_fresh_start=false so the React component skips the kickoff.'
+		);
+
+		// Sanity: both calls share the same session.
+		$this->assertSame( $first['session_id'], $second['session_id'] );
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/OnboardingManagerThemeBuilderTest.php
+++ b/tests/SdAiAgent/Core/OnboardingManagerThemeBuilderTest.php
@@ -176,11 +176,68 @@ class OnboardingManagerThemeBuilderTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'session_id', $data );
 		$this->assertArrayHasKey( 'agent_id', $data );
 		$this->assertArrayHasKey( 'kickoff_message', $data );
+		// is_fresh_start is the authoritative kickoff signal (see #1522).
+		$this->assertArrayHasKey( 'is_fresh_start', $data );
+		$this->assertIsBool( $data['is_fresh_start'] );
 
 		// Should NOT have these bootstrap-specific keys.
 		$this->assertArrayNotHasKey( 'onboarding_complete', $data );
 		$this->assertArrayNotHasKey( 'woo_detected', $data );
 		$this->assertArrayNotHasKey( 'already_complete', $data );
+	}
+
+	// ── is_fresh_start regression coverage (#1522) ────────────────────────
+
+	/**
+	 * rest_theme_builder_start() returns is_fresh_start=true on the very
+	 * first call so the React component auto-sends the kickoff message.
+	 *
+	 * Regression coverage for #1522 — the pre-fix code returned
+	 * `started_at => time()` on this branch which the React component
+	 * interpreted as "resume" (truthy), so kickoff never fired on fresh
+	 * installs.
+	 */
+	public function test_rest_theme_builder_start_returns_is_fresh_start_true_on_first_call(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$response = OnboardingManager::rest_theme_builder_start();
+		$data     = $response->get_data();
+
+		$this->assertTrue(
+			$data['is_fresh_start'],
+			'First call must report is_fresh_start=true so the React component fires the kickoff.'
+		);
+	}
+
+	/**
+	 * rest_theme_builder_start() returns is_fresh_start=false on subsequent
+	 * calls so reloads do NOT re-fire the kickoff message.
+	 *
+	 * This is the original #1509 protection — the regression in #1522 was
+	 * that BOTH calls returned a truthy resume signal. With is_fresh_start
+	 * the first call is distinguishable from later calls.
+	 */
+	public function test_rest_theme_builder_start_returns_is_fresh_start_false_on_resume(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		// First call: fresh start.
+		$first_response = OnboardingManager::rest_theme_builder_start();
+		$first_data     = $first_response->get_data();
+		$this->assertTrue( $first_data['is_fresh_start'] );
+
+		// Second call: resume (same session, kickoff must NOT fire).
+		$second_response = OnboardingManager::rest_theme_builder_start();
+		$second_data     = $second_response->get_data();
+
+		$this->assertFalse(
+			$second_data['is_fresh_start'],
+			'Subsequent calls must report is_fresh_start=false so the React component skips the kickoff.'
+		);
+
+		// Both calls share the same session — sanity check.
+		$this->assertSame( $first_data['session_id'], $second_data['session_id'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fix the auto-kickoff regression introduced by PR #1520 (#1509 fix).

PR #1520 protected against the original "kickoff re-sent on every reload" bug by stamping `THEME_BUILDER_STARTED_OPTION = time()` in `OnboardingManager::rest_theme_builder_start()` and returning it as `started_at` so the React component could skip the kickoff on resume. The over-correction was that **both** branches (fresh-create and resume) return a truthy `started_at`, so the React check `if ( ! data.started_at )` is false on the very first call — kickoff never fires on a fresh install. Users land on an empty chat with no greeting and must type a kickoff phrase manually.

## Fix

Add an explicit `is_fresh_start` boolean to the REST response:

- Fresh-create branch → `is_fresh_start: true` (kickoff SHOULD fire)
- Resume branch → `is_fresh_start: false` (kickoff MUST NOT fire — original #1509 protection preserved)

The React component now keys off `is_fresh_start`. `started_at` is retained for observability / back-compat but MUST NOT be used to drive kickoff behaviour.

A missing field is treated as resume (defensive default — an older server response we can't prove is fresh shouldn't trigger a kickoff).

## Tests

- **3 new Jest tests** in `OnboardingThemeBuilder.test.js`:
  - sends the kickoff when `is_fresh_start: true`
  - does NOT send the kickoff when `is_fresh_start: false` (resume)
  - does NOT send the kickoff when `is_fresh_start` is missing (defensive)
- **2 new PHPUnit tests** in `OnboardingManagerThemeBuilderTest.php` and **1 in `OnboardingManagerTest.php`**:
  - `test_rest_theme_builder_start_returns_is_fresh_start_true_on_first_call`
  - `test_rest_theme_builder_start_returns_is_fresh_start_false_on_resume`
  - `test_rest_theme_builder_start_distinguishes_fresh_start_from_resume`
- Existing shape tests in both PHP test files extended to assert `is_fresh_start` is present and boolean.

## Quality Gates

| Gate | Result |
| --- | --- |
| `composer phpstan` | No errors |
| `composer phpcs` | Clean (test files excluded by ruleset) |
| `npm run lint:js` | Clean |
| `npm run build` | Webpack succeeds; bundle chunk `build/onboarding-theme-builder.js` contains `a.is_fresh_start&&s(...)` |
| `npm run test:js` on `OnboardingThemeBuilder.test.js` | 13/13 pass (incl 3 new regression tests) |
| `npm run test:php` | Deferred to CI — local wp-env ports were held by unrelated worktrees and the `test:php` script's hardcoded plugin basename `sd-ai-agent` does not match the worktree directory name produced by `interactive-start-helper.sh`. Verified the PHP contract directly via `wp eval` against the live install: resume call returned `is_fresh_start=false` as expected. |

## End-to-End Verification

Against a clean install on WP 6.9.4 (`http://wordpress.local:8080`):

1. **Fresh start** — opened `wp-admin/admin.php?page=sd-ai-agent` on a freshly-reset site (no sessions, no theme-builder options, no posts):
   - The kickoff "I'd like to design a custom block theme for my site. Please start the interview." appeared in the chat automatically.
   - The agent responded with "Question 1 of ~8".
   - DOM showed 2 message rows (user + assistant).
   - DB session messages length: 2761 bytes.
2. **Reload** — reloaded the page mid-interview:
   - Conversation persisted exactly.
   - DOM row count unchanged (2 → 2).
   - No duplicate kickoff appended (the original #1509 protection still holds).

## Caveats

- This is a regression introduced by PR #1520; the original `started_at` value is now redundant for kickoff-gating purposes but retained on the response for back-compat and observability.
- The defensive default (missing `is_fresh_start` → no kickoff) means an older client paired with a newer server won't auto-fire the kickoff. That's the safer failure mode — better than spamming a kickoff we can't prove is genuine. The bundle ships server+client together so this only matters in mismatched-version setups (none expected).
- The hardcoded `cd /var/www/html/wp-content/plugins/sd-ai-agent` in `package.json:test:php` should be normalised against the actual `.wp-env.json` plugin mount (which uses `$(basename $PWD)`). Filed as a separate concern — not in scope here.

Resolves #1522.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.67 plugin for [OpenCode](https://opencode.ai) v1.15.5 with claude-sonnet-4-6 spent 4d 20h and 383 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where onboarding kickoff messages were being sent multiple times when users resumed or reloaded their sessions instead of only on initial session creation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1523?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->