### PR TITLE
GH#1530: feat: add site scrape ability

### DIFF
--- a/includes/Abilities/SiteScrapeAbility.php
+++ b/includes/Abilities/SiteScrapeAbility.php
@@ -89,7 +89,7 @@ class SiteScrapeAbility extends AbstractAbility {
 	}
 
 	protected function meta(): array {
-		$meta = parent::meta();
+		$meta                = parent::meta();
 		$meta['annotations'] = [
 			'readonly'    => true,
 			'destructive' => false,

--- a/includes/Abilities/SiteScrapeAbility.php
+++ b/includes/Abilities/SiteScrapeAbility.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Site scrape ability for Theme Builder onboarding.
+ *
+ * @package SdAiAgent\Abilities
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Abilities;
+
+use SdAiAgent\Services\SiteScraper;
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Scrapes an existing public website into structured Theme Builder pre-fill data.
+ */
+class SiteScrapeAbility extends AbstractAbility {
+
+	protected function label(): string {
+		return __( 'Scrape Existing Site', 'superdav-ai-agent' );
+	}
+
+	protected function description(): string {
+		return __( 'Fetch and parse an existing website to pre-fill Theme Builder interviews with brand, contact, hours, logo, social links, and page text.', 'superdav-ai-agent' );
+	}
+
+	protected function input_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'url'                 => [
+					'type'        => 'string',
+					'format'      => 'uri',
+					'description' => 'Existing public website URL to scrape after the user consents.',
+				],
+				'max_pages'           => [
+					'type'        => 'integer',
+					'minimum'     => 1,
+					'maximum'     => 25,
+					'description' => 'Maximum pages to crawl. Defaults to 10.',
+				],
+				'target_pages'        => [
+					'type'        => 'array',
+					'items'       => [ 'type' => 'string' ],
+					'description' => 'Optional explicit paths or URLs to fetch, such as /about or /contact.',
+				],
+				'extract_preferences' => [
+					'type'        => 'string',
+					'enum'        => [ 'auto', 'structured_only', 'full_text' ],
+					'description' => 'Extraction mode. auto uses structured parsers and AI gap-fill when available.',
+				],
+			],
+			'required'   => [ 'url' ],
+		];
+	}
+
+	protected function output_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'brand'   => [ 'type' => 'object' ],
+				'contact' => [ 'type' => 'object' ],
+				'hours'   => [ 'type' => 'array' ],
+				'social'  => [ 'type' => 'object' ],
+				'pages'   => [ 'type' => 'array' ],
+				'errors'  => [ 'type' => 'array' ],
+				'cached'  => [ 'type' => 'boolean' ],
+			],
+		];
+	}
+
+	protected function execute_callback( $input ): array|WP_Error {
+		$url         = isset( $input['url'] ) ? (string) $input['url'] : '';
+		$max_pages   = isset( $input['max_pages'] ) ? (int) $input['max_pages'] : 10;
+		$target      = isset( $input['target_pages'] ) && is_array( $input['target_pages'] ) ? array_values( array_map( 'strval', $input['target_pages'] ) ) : [];
+		$preferences = isset( $input['extract_preferences'] ) ? (string) $input['extract_preferences'] : 'auto';
+
+		return ( new SiteScraper() )->scrape( $url, $max_pages, $target, $preferences );
+	}
+
+	protected function permission_callback( $input ): bool {
+		return current_user_can( 'edit_theme_options' );
+	}
+
+	protected function meta(): array {
+		$meta = parent::meta();
+		$meta['annotations'] = [
+			'readonly'    => true,
+			'destructive' => false,
+			'idempotent'  => true,
+		];
+
+		return $meta;
+	}
+}

--- a/includes/Abilities/SiteScrapeAbility.php
+++ b/includes/Abilities/SiteScrapeAbility.php
@@ -78,10 +78,25 @@ class SiteScrapeAbility extends AbstractAbility {
 	protected function execute_callback( $input ): array|WP_Error {
 		$url         = isset( $input['url'] ) ? (string) $input['url'] : '';
 		$max_pages   = isset( $input['max_pages'] ) ? (int) $input['max_pages'] : 10;
-		$target      = isset( $input['target_pages'] ) && is_array( $input['target_pages'] ) ? array_values( array_map( 'strval', $input['target_pages'] ) ) : [];
+		$target      = isset( $input['target_pages'] ) && is_array( $input['target_pages'] ) ? $this->string_list( $input['target_pages'] ) : [];
 		$preferences = isset( $input['extract_preferences'] ) ? (string) $input['extract_preferences'] : 'auto';
 
 		return ( new SiteScraper() )->scrape( $url, $max_pages, $target, $preferences );
+	}
+
+	/**
+	 * @param array<mixed> $values Raw values.
+	 * @return array<string>
+	 */
+	private function string_list( array $values ): array {
+		$list = [];
+		foreach ( $values as $value ) {
+			if ( is_scalar( $value ) ) {
+				$list[] = (string) $value;
+			}
+		}
+
+		return $list;
 	}
 
 	protected function permission_callback( $input ): bool {

--- a/includes/Abilities/ThemeBuilderAbilities.php
+++ b/includes/Abilities/ThemeBuilderAbilities.php
@@ -7,8 +7,9 @@ declare(strict_types=1);
  * Registers two abilities via the WordPress 7.0+ Abilities API that the
  * theme-builder onboarding branch (Phase 3 of t226) relies on:
  *
- *   - sd-ai-agent/scaffold-block-theme
- *   - sd-ai-agent/activate-theme
+	 *   - sd-ai-agent/scaffold-block-theme
+	 *   - sd-ai-agent/activate-theme
+	 *   - sd-ai-agent/site-scrape
  *
  * Both abilities also stand alone outside onboarding — any agent flow that
  * needs to generate or switch a theme can call them.
@@ -63,6 +64,18 @@ class ThemeBuilderAbilities {
 					'superdav-ai-agent'
 				),
 				'ability_class' => ActivateThemeAbility::class,
+			]
+		);
+
+		wp_register_ability(
+			'sd-ai-agent/site-scrape',
+			[
+				'label'         => __( 'Scrape Existing Site', 'superdav-ai-agent' ),
+				'description'   => __(
+					'Fetch and parse an existing website to pre-fill Theme Builder interviews with brand, contact, hours, logo, social links, and page text. Requires edit_theme_options.',
+					'superdav-ai-agent'
+				),
+				'ability_class' => SiteScrapeAbility::class,
 			]
 		);
 	}

--- a/includes/Models/Agent.php
+++ b/includes/Models/Agent.php
@@ -613,8 +613,9 @@ class Agent {
 				. "Start every conversation by loading the site-specification skill:\n"
 				. "1. Call `sd-ai-agent/skill-load` with `skill_name: site-specification` to get the full specification template.\n"
 				. "2. Call `sd-ai-agent/skill-load` with `skill_name: block-themes` to load block theme guidance.\n"
-				. "3. Interview the user using the site-specification framework. Ask **one question at a time**.\n"
-				. "4. Save gathered site information with `sd-ai-agent/memory-save` (category: site_brief).\n\n"
+				. "3. Ask: \"Do you have an existing site? If yes, paste the URL and I'll pre-fill what I can.\" If the user provides a URL and consents to an outbound fetch, call `sd-ai-agent/site-scrape` and use the returned brand, contact, hours, social, and page data as draft answers for confirmation.\n"
+				. "4. Interview the user using the site-specification framework. Ask **one question at a time**, confirming any scraped fields instead of asking the user to retype them.\n"
+				. "5. Save gathered site information with `sd-ai-agent/memory-save` (category: site_brief).\n\n"
 				. "## Phase 2: Design Directions\n\n"
 				. "At the start of Phase 2, call `sd-ai-agent/skill-load` with `skill_name: design-system-aesthetics` to load topic-grounded visual direction guidance before generating previews.\n"
 				. "After loading the aesthetics skill, propose 3 distinct topic-grounded design directions:\n"
@@ -669,6 +670,7 @@ class Agent {
 					array_merge(
 						$base_tools,
 						[
+							'sd-ai-agent/site-scrape',
 							'sd-ai-agent/scaffold-block-theme',
 							'sd-ai-agent/activate-theme',
 							'sd-ai-agent/file-write',

--- a/includes/Services/SiteScraper.php
+++ b/includes/Services/SiteScraper.php
@@ -26,10 +26,10 @@ class SiteScraper {
 	/**
 	 * Scrape a site into the Theme Builder pre-fill shape.
 	 *
-	 * @param string       $url          Absolute site URL.
-	 * @param int          $max_pages    Maximum pages to crawl.
-	 * @param list<string> $target_pages Optional explicit paths/URLs.
-	 * @param string       $extract_mode structured_only, full_text, or auto.
+	 * @param string        $url          Absolute site URL.
+	 * @param int           $max_pages    Maximum pages to crawl.
+	 * @param array<string> $target_pages Optional explicit paths/URLs.
+	 * @param string        $extract_mode structured_only, full_text, or auto.
 	 * @return array<string,mixed>|WP_Error
 	 */
 	public function scrape( string $url, int $max_pages = 10, array $target_pages = [], string $extract_mode = 'auto' ): array|WP_Error {
@@ -61,7 +61,8 @@ class SiteScraper {
 		$queue  = $this->initial_queue( $url, $target_pages );
 		$seen   = [];
 
-		while ( ! empty( $queue ) && count( $result['pages'] ) < $max_pages ) {
+		$pages_count = count( $result['pages'] );
+		while ( ! empty( $queue ) && $pages_count < $max_pages ) {
 			$current = array_shift( $queue );
 			if ( ! is_string( $current ) ) {
 				continue;
@@ -87,13 +88,14 @@ class SiteScraper {
 				continue;
 			}
 
-			$page = $this->parse_page( $current, $response );
+			$page              = $this->parse_page( $current, $response );
 			$result['pages'][] = $page;
 			$result            = $this->merge_extracted( $result, $this->extract_from_html( $current, $response, $page['text'] ) );
+			$pages_count       = count( $result['pages'] );
 
 			if ( empty( $target_pages ) ) {
 				foreach ( $this->discover_links( $url, $response ) as $link ) {
-					if ( count( $queue ) + count( $result['pages'] ) >= $max_pages ) {
+					if ( count( $queue ) + $pages_count >= $max_pages ) {
 						break;
 					}
 					$queue[] = $link;
@@ -228,8 +230,8 @@ class SiteScraper {
 				continue;
 			}
 			[ $field, $value ] = array_map( 'trim', explode( ':', $line, 2 ) );
-			$field            = strtolower( $field );
-			$value            = strtolower( $value );
+			$field             = strtolower( $field );
+			$value             = strtolower( $value );
 			if ( 'user-agent' === $field ) {
 				$applies = '*' === $value || str_contains( 'superdavai', $value );
 				continue;
@@ -253,7 +255,7 @@ class SiteScraper {
 	 */
 	private function empty_result(): array {
 		return [
-			'brand'  => [
+			'brand'   => [
 				'name'     => null,
 				'tagline'  => null,
 				'logo_url' => null,
@@ -421,7 +423,7 @@ class SiteScraper {
 	}
 
 	/**
-	 * @param list<mixed> $urls Social URL candidates.
+	 * @param array<mixed> $urls Social URL candidates.
 	 * @return array<string,mixed>
 	 */
 	private function classify_social_urls( array $urls ): array {
@@ -564,7 +566,8 @@ class SiteScraper {
 	}
 
 	/**
-	 * @param list<string> $target_pages Target pages.
+	 * @param string        $url          Base URL.
+	 * @param array<string> $target_pages Target pages.
 	 * @return list<string>
 	 */
 	private function initial_queue( string $url, array $target_pages ): array {
@@ -643,7 +646,10 @@ class SiteScraper {
 	}
 
 	/**
-	 * @param list<string> $target_pages Target pages.
+	 * @param string        $url          URL being scraped.
+	 * @param int           $max_pages    Maximum pages.
+	 * @param array<string> $target_pages Target pages.
+	 * @param string        $extract_mode Extraction mode.
 	 */
 	private function cache_key( string $url, int $max_pages, array $target_pages, string $extract_mode ): string {
 		return self::CACHE_GROUP . md5( wp_json_encode( [ $url, $max_pages, $target_pages, $extract_mode ] ) ?: $url );

--- a/includes/Services/SiteScraper.php
+++ b/includes/Services/SiteScraper.php
@@ -46,8 +46,7 @@ class SiteScraper {
 		$cache_key = $this->cache_key( $url, $max_pages, $target_pages, $extract_mode );
 		$cached    = get_transient( $cache_key );
 		if ( is_array( $cached ) ) {
-			$cached['cached'] = true;
-			return $cached;
+			return $this->normalize_cached_result( $cached );
 		}
 
 		if ( ! $this->is_allowed_by_robots( $url ) ) {
@@ -80,18 +79,23 @@ class SiteScraper {
 
 			$response = $this->fetch( $current );
 			if ( is_wp_error( $response ) ) {
-				$result['errors'][] = [
+				$errors           = is_array( $result['errors'] ) ? $result['errors'] : [];
+				$errors[]         = [
 					'url'     => $current,
 					'code'    => $response->get_error_code(),
 					'message' => $response->get_error_message(),
 				];
+				$result['errors'] = $errors;
 				continue;
 			}
 
-			$page              = $this->parse_page( $current, $response );
-			$result['pages'][] = $page;
-			$result            = $this->merge_extracted( $result, $this->extract_from_html( $current, $response, $page['text'] ) );
-			$pages_count       = count( $result['pages'] );
+			$page            = $this->parse_page( $current, $response );
+			$page_text       = is_string( $page['text'] ?? null ) ? $page['text'] : '';
+			$pages           = is_array( $result['pages'] ) ? $result['pages'] : [];
+			$pages[]         = $page;
+			$result['pages'] = $pages;
+			$result          = $this->merge_extracted( $result, $this->extract_from_html( $current, $response, $page_text ) );
+			$pages_count     = count( $pages );
 
 			if ( empty( $target_pages ) ) {
 				foreach ( $this->discover_links( $url, $response ) as $link ) {
@@ -144,7 +148,10 @@ class SiteScraper {
 			);
 		}
 
-		$content_type = (string) wp_remote_retrieve_header( $response, 'content-type' );
+		$content_type = wp_remote_retrieve_header( $response, 'content-type' );
+		if ( is_array( $content_type ) ) {
+			$content_type = implode( ',', array_filter( $content_type, 'is_string' ) );
+		}
 		if ( '' !== $content_type && ! str_contains( strtolower( $content_type ), 'html' ) ) {
 			return new WP_Error(
 				'sd_ai_agent_site_scrape_not_html',
@@ -225,7 +232,7 @@ class SiteScraper {
 		$applies  = false;
 		$disallow = [];
 		foreach ( preg_split( '/\R/', (string) wp_remote_retrieve_body( $response ) ) ?: [] as $line ) {
-			$line = trim( preg_replace( '/#.*/', '', $line ) );
+			$line = trim( (string) preg_replace( '/#.*/', '', $line ) );
 			if ( '' === $line || ! str_contains( $line, ':' ) ) {
 				continue;
 			}
@@ -291,7 +298,8 @@ class SiteScraper {
 				continue;
 			}
 			foreach ( $next[ $section ] as $key => $value ) {
-				if ( ( ! isset( $base[ $section ][ $key ] ) || null === $base[ $section ][ $key ] || '' === $base[ $section ][ $key ] ) && ! empty( $value ) ) {
+				$existing = $base[ $section ][ $key ] ?? null;
+				if ( ( null === $existing || '' === $existing ) && ! empty( $value ) ) {
 					$base[ $section ][ $key ] = $value;
 				}
 			}
@@ -356,20 +364,46 @@ class SiteScraper {
 		if ( isset( $decoded['@graph'] ) && is_array( $decoded['@graph'] ) ) {
 			foreach ( $decoded['@graph'] as $node ) {
 				if ( is_array( $node ) ) {
-					$nodes[] = $node;
+					$nodes[] = $this->string_keyed_array( $node );
 				}
 			}
 		} elseif ( array_is_list( $decoded ) ) {
 			foreach ( $decoded as $node ) {
 				if ( is_array( $node ) ) {
-					$nodes[] = $node;
+					$nodes[] = $this->string_keyed_array( $node );
 				}
 			}
 		} else {
-			$nodes[] = $decoded;
+			$nodes[] = $this->string_keyed_array( $decoded );
 		}
 
 		return $nodes;
+	}
+
+	/**
+	 * @param array<mixed> $node Raw associative array.
+	 * @return array<string,mixed>
+	 */
+	private function string_keyed_array( array $node ): array {
+		$result = [];
+		foreach ( $node as $key => $value ) {
+			$result[ (string) $key ] = $value;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @param array<mixed> $cached Cached transient payload.
+	 * @return array<string,mixed>
+	 */
+	private function normalize_cached_result( array $cached ): array {
+		$result           = $this->merge_extracted( $this->empty_result(), $cached );
+		$result['pages']  = isset( $cached['pages'] ) && is_array( $cached['pages'] ) ? $cached['pages'] : [];
+		$result['errors'] = isset( $cached['errors'] ) && is_array( $cached['errors'] ) ? $cached['errors'] : [];
+		$result['cached'] = true;
+
+		return $result;
 	}
 
 	/**

--- a/includes/Services/SiteScraper.php
+++ b/includes/Services/SiteScraper.php
@@ -1,0 +1,693 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Existing-site scraper for Theme Builder pre-fill data.
+ *
+ * @package SdAiAgent\Services
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Services;
+
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Fetches a small, polite crawl of an existing site and extracts brand data.
+ */
+class SiteScraper {
+
+	private const CACHE_GROUP = 'sd_ai_agent_site_scrape_';
+
+	/**
+	 * Scrape a site into the Theme Builder pre-fill shape.
+	 *
+	 * @param string       $url          Absolute site URL.
+	 * @param int          $max_pages    Maximum pages to crawl.
+	 * @param list<string> $target_pages Optional explicit paths/URLs.
+	 * @param string       $extract_mode structured_only, full_text, or auto.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public function scrape( string $url, int $max_pages = 10, array $target_pages = [], string $extract_mode = 'auto' ): array|WP_Error {
+		$url       = $this->normalize_url( $url );
+		$max_pages = max( 1, min( 25, $max_pages ) );
+
+		if ( '' === $url || ! wp_http_validate_url( $url ) ) {
+			return new WP_Error(
+				'sd_ai_agent_invalid_scrape_url',
+				__( 'Site scrape requires a valid absolute HTTP or HTTPS URL.', 'superdav-ai-agent' )
+			);
+		}
+
+		$cache_key = $this->cache_key( $url, $max_pages, $target_pages, $extract_mode );
+		$cached    = get_transient( $cache_key );
+		if ( is_array( $cached ) ) {
+			$cached['cached'] = true;
+			return $cached;
+		}
+
+		if ( ! $this->is_allowed_by_robots( $url ) ) {
+			return new WP_Error(
+				'sd_ai_agent_site_scrape_robots_disallowed',
+				__( 'robots.txt disallows fetching this URL for the site-scrape ability.', 'superdav-ai-agent' )
+			);
+		}
+
+		$result = $this->empty_result();
+		$queue  = $this->initial_queue( $url, $target_pages );
+		$seen   = [];
+
+		while ( ! empty( $queue ) && count( $result['pages'] ) < $max_pages ) {
+			$current = array_shift( $queue );
+			if ( ! is_string( $current ) ) {
+				continue;
+			}
+
+			$current = $this->normalize_url( $current );
+			if ( '' === $current || isset( $seen[ $current ] ) || ! $this->same_origin( $url, $current ) ) {
+				continue;
+			}
+
+			$seen[ $current ] = true;
+			if ( ! $this->is_allowed_by_robots( $current ) ) {
+				continue;
+			}
+
+			$response = $this->fetch( $current );
+			if ( is_wp_error( $response ) ) {
+				$result['errors'][] = [
+					'url'     => $current,
+					'code'    => $response->get_error_code(),
+					'message' => $response->get_error_message(),
+				];
+				continue;
+			}
+
+			$page = $this->parse_page( $current, $response );
+			$result['pages'][] = $page;
+			$result            = $this->merge_extracted( $result, $this->extract_from_html( $current, $response, $page['text'] ) );
+
+			if ( empty( $target_pages ) ) {
+				foreach ( $this->discover_links( $url, $response ) as $link ) {
+					if ( count( $queue ) + count( $result['pages'] ) >= $max_pages ) {
+						break;
+					}
+					$queue[] = $link;
+				}
+			}
+
+			$this->rate_limit();
+		}
+
+		if ( 'structured_only' !== $extract_mode ) {
+			$result = $this->maybe_ai_complete( $result );
+		}
+
+		$result['cached'] = false;
+		set_transient( $cache_key, $result, DAY_IN_SECONDS );
+
+		return $result;
+	}
+
+	/**
+	 * Fetch one URL using WordPress' safe HTTP API.
+	 */
+	public function fetch( string $url ): string|WP_Error {
+		$response = wp_safe_remote_get(
+			$url,
+			[
+				'timeout'     => 12,
+				'redirection' => 3,
+				'user-agent'  => $this->user_agent(),
+				'headers'     => [
+					'Accept' => 'text/html,application/xhtml+xml',
+				],
+			]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$status = (int) wp_remote_retrieve_response_code( $response );
+		if ( $status < 200 || $status >= 300 ) {
+			return new WP_Error(
+				'sd_ai_agent_site_scrape_http_error',
+				/* translators: %d: HTTP response status code */
+				sprintf( __( 'The site returned HTTP %d while scraping.', 'superdav-ai-agent' ), $status )
+			);
+		}
+
+		$content_type = (string) wp_remote_retrieve_header( $response, 'content-type' );
+		if ( '' !== $content_type && ! str_contains( strtolower( $content_type ), 'html' ) ) {
+			return new WP_Error(
+				'sd_ai_agent_site_scrape_not_html',
+				__( 'The fetched URL did not return HTML.', 'superdav-ai-agent' )
+			);
+		}
+
+		return (string) wp_remote_retrieve_body( $response );
+	}
+
+	/**
+	 * Parse title, visible text, and headings from a page.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function parse_page( string $url, string $html ): array {
+		$title    = $this->first_match( '/<title[^>]*>(.*?)<\/title>/is', $html );
+		$headings = [];
+		if ( preg_match_all( '/<h[1-6][^>]*>(.*?)<\/h[1-6]>/is', $html, $matches ) ) {
+			foreach ( $matches[1] as $heading ) {
+				$clean = $this->clean_text( $heading );
+				if ( '' !== $clean ) {
+					$headings[] = $clean;
+				}
+			}
+		}
+
+		$text = preg_replace( '/<(script|style|noscript|svg)[\s\S]*?<\/\1>/i', ' ', $html );
+		$text = $this->clean_text( (string) $text );
+
+		return [
+			'url'      => $url,
+			'title'    => '' !== $title ? $this->clean_text( $title ) : null,
+			'text'     => mb_substr( $text, 0, 12000 ),
+			'headings' => $headings,
+		];
+	}
+
+	/**
+	 * Extract structured, OpenGraph, and heuristic data from HTML.
+	 *
+	 * @return array<string,mixed>
+	 */
+	public function extract_from_html( string $url, string $html, string $text = '' ): array {
+		$result = $this->empty_result();
+		$result = $this->merge_extracted( $result, $this->extract_json_ld( $html ) );
+		$result = $this->merge_extracted( $result, $this->extract_meta( $html ) );
+		$result = $this->merge_extracted( $result, $this->extract_logo( $url, $html ) );
+		$result = $this->merge_extracted( $result, $this->extract_social_links( $html ) );
+		$result = $this->merge_extracted( $result, $this->extract_heuristics( $text ) );
+
+		return $result;
+	}
+
+	/**
+	 * Return whether robots.txt permits this URL.
+	 */
+	public function is_allowed_by_robots( string $url ): bool {
+		$parts = wp_parse_url( $url );
+		if ( empty( $parts['scheme'] ) || empty( $parts['host'] ) ) {
+			return false;
+		}
+
+		$robots_url = $parts['scheme'] . '://' . $parts['host'] . '/robots.txt';
+		$response   = wp_safe_remote_get(
+			$robots_url,
+			[
+				'timeout'    => 5,
+				'user-agent' => $this->user_agent(),
+			]
+		);
+
+		if ( is_wp_error( $response ) || 200 !== (int) wp_remote_retrieve_response_code( $response ) ) {
+			return true;
+		}
+
+		$path     = $parts['path'] ?? '/';
+		$applies  = false;
+		$disallow = [];
+		foreach ( preg_split( '/\R/', (string) wp_remote_retrieve_body( $response ) ) ?: [] as $line ) {
+			$line = trim( preg_replace( '/#.*/', '', $line ) );
+			if ( '' === $line || ! str_contains( $line, ':' ) ) {
+				continue;
+			}
+			[ $field, $value ] = array_map( 'trim', explode( ':', $line, 2 ) );
+			$field            = strtolower( $field );
+			$value            = strtolower( $value );
+			if ( 'user-agent' === $field ) {
+				$applies = '*' === $value || str_contains( 'superdavai', $value );
+				continue;
+			}
+			if ( $applies && 'disallow' === $field && '' !== $value ) {
+				$disallow[] = $value;
+			}
+		}
+
+		foreach ( $disallow as $rule ) {
+			if ( '/' === $rule || str_starts_with( $path, $rule ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private function empty_result(): array {
+		return [
+			'brand'  => [
+				'name'     => null,
+				'tagline'  => null,
+				'logo_url' => null,
+			],
+			'contact' => [
+				'address' => null,
+				'phone'   => null,
+				'email'   => null,
+			],
+			'hours'   => [],
+			'social'  => [
+				'instagram' => null,
+				'facebook'  => null,
+				'linkedin'  => null,
+				'x'         => null,
+				'youtube'   => null,
+				'tiktok'    => null,
+			],
+			'pages'   => [],
+			'errors'  => [],
+			'cached'  => false,
+		];
+	}
+
+	/**
+	 * @param array<string,mixed> $base Base result.
+	 * @param array<string,mixed> $next New result.
+	 * @return array<string,mixed>
+	 */
+	private function merge_extracted( array $base, array $next ): array {
+		foreach ( [ 'brand', 'contact', 'social' ] as $section ) {
+			if ( empty( $next[ $section ] ) || ! is_array( $next[ $section ] ) ) {
+				continue;
+			}
+			foreach ( $next[ $section ] as $key => $value ) {
+				if ( ( ! isset( $base[ $section ][ $key ] ) || null === $base[ $section ][ $key ] || '' === $base[ $section ][ $key ] ) && ! empty( $value ) ) {
+					$base[ $section ][ $key ] = $value;
+				}
+			}
+		}
+
+		if ( ! empty( $next['hours'] ) && is_array( $next['hours'] ) && empty( $base['hours'] ) ) {
+			$base['hours'] = $next['hours'];
+		}
+
+		return $base;
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private function extract_json_ld( string $html ): array {
+		$result = $this->empty_result();
+		if ( ! preg_match_all( '/<script[^>]+type=["\']application\/ld\+json["\'][^>]*>(.*?)<\/script>/is', $html, $matches ) ) {
+			return $result;
+		}
+
+		foreach ( $matches[1] as $json ) {
+			$decoded = json_decode( html_entity_decode( trim( $json ) ), true );
+			foreach ( $this->json_ld_nodes( $decoded ) as $node ) {
+				$type = $node['@type'] ?? '';
+				$type = is_array( $type ) ? implode( ' ', $type ) : (string) $type;
+				if ( ! preg_match( '/Organization|LocalBusiness|Restaurant|Store|CafeOrCoffeeShop|FoodEstablishment/i', $type ) ) {
+					continue;
+				}
+
+				$result['brand']['name']     = $this->string_value( $node['name'] ?? null ) ?: $result['brand']['name'];
+				$result['brand']['tagline']  = $this->string_value( $node['slogan'] ?? ( $node['description'] ?? null ) ) ?: $result['brand']['tagline'];
+				$result['brand']['logo_url'] = $this->string_value( $node['logo'] ?? ( $node['image'] ?? null ) ) ?: $result['brand']['logo_url'];
+				$result['contact']['phone']  = $this->string_value( $node['telephone'] ?? null ) ?: $result['contact']['phone'];
+				$result['contact']['email']  = $this->string_value( $node['email'] ?? null ) ?: $result['contact']['email'];
+
+				if ( ! empty( $node['address'] ) ) {
+					$result['contact']['address'] = $this->format_address( $node['address'] );
+				}
+
+				if ( ! empty( $node['sameAs'] ) && is_array( $node['sameAs'] ) ) {
+					$result = $this->merge_extracted( $result, $this->classify_social_urls( $node['sameAs'] ) );
+				}
+
+				$result['hours'] = $this->parse_opening_hours( $node['openingHours'] ?? ( $node['openingHoursSpecification'] ?? null ) );
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @param mixed $decoded JSON-LD decoded value.
+	 * @return list<array<string,mixed>>
+	 */
+	private function json_ld_nodes( mixed $decoded ): array {
+		if ( ! is_array( $decoded ) ) {
+			return [];
+		}
+
+		$nodes = [];
+		if ( isset( $decoded['@graph'] ) && is_array( $decoded['@graph'] ) ) {
+			foreach ( $decoded['@graph'] as $node ) {
+				if ( is_array( $node ) ) {
+					$nodes[] = $node;
+				}
+			}
+		} elseif ( array_is_list( $decoded ) ) {
+			foreach ( $decoded as $node ) {
+				if ( is_array( $node ) ) {
+					$nodes[] = $node;
+				}
+			}
+		} else {
+			$nodes[] = $decoded;
+		}
+
+		return $nodes;
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private function extract_meta( string $html ): array {
+		$result = $this->empty_result();
+		$meta   = [];
+		if ( preg_match_all( '/<meta\s+([^>]+)>/i', $html, $matches ) ) {
+			foreach ( $matches[1] as $attrs ) {
+				$name    = strtolower( $this->attr_value( $attrs, 'property' ) ?: $this->attr_value( $attrs, 'name' ) );
+				$content = $this->attr_value( $attrs, 'content' );
+				if ( '' !== $name && '' !== $content ) {
+					$meta[ $name ] = html_entity_decode( $content );
+				}
+			}
+		}
+
+		$result['brand']['name']     = $meta['og:site_name'] ?? null;
+		$result['brand']['tagline']  = $meta['og:description'] ?? ( $meta['description'] ?? null );
+		$result['brand']['logo_url'] = $meta['og:image'] ?? null;
+
+		return $result;
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private function extract_logo( string $url, string $html ): array {
+		$result = $this->empty_result();
+		if ( preg_match( '/<img\s+[^>]*(?:class|alt|src)=["\'][^"\']*logo[^"\']*["\'][^>]*>/i', $html, $match ) ) {
+			$src = $this->attr_value( $match[0], 'src' );
+			if ( '' !== $src ) {
+				$result['brand']['logo_url'] = $this->resolve_url( $url, $src );
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private function extract_social_links( string $html ): array {
+		$urls = [];
+		if ( preg_match_all( '/<a\s+[^>]*href=["\']([^"\']+)["\'][^>]*>/i', $html, $matches ) ) {
+			$urls = $matches[1];
+		}
+
+		return $this->classify_social_urls( $urls );
+	}
+
+	/**
+	 * @param list<mixed> $urls Social URL candidates.
+	 * @return array<string,mixed>
+	 */
+	private function classify_social_urls( array $urls ): array {
+		$result = $this->empty_result();
+		foreach ( $urls as $url ) {
+			$url = (string) $url;
+			$map = [
+				'instagram.com' => 'instagram',
+				'facebook.com'  => 'facebook',
+				'linkedin.com'  => 'linkedin',
+				'twitter.com'   => 'x',
+				'x.com'         => 'x',
+				'youtube.com'   => 'youtube',
+				'tiktok.com'    => 'tiktok',
+			];
+			foreach ( $map as $host => $key ) {
+				if ( str_contains( strtolower( $url ), $host ) && empty( $result['social'][ $key ] ) ) {
+					$result['social'][ $key ] = esc_url_raw( $url );
+				}
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * @return array<string,mixed>
+	 */
+	private function extract_heuristics( string $text ): array {
+		$result = $this->empty_result();
+		if ( preg_match( '/[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}/i', $text, $match ) ) {
+			$result['contact']['email'] = sanitize_email( $match[0] );
+		}
+
+		if ( preg_match( '/(?:\+?\d[\d\s().\-]{7,}\d)/', $text, $match ) ) {
+			$result['contact']['phone'] = trim( $match[0] );
+		}
+
+		if ( preg_match( '/\b\d{1,5}\s+[A-Z][A-Za-z0-9 .\'-]+\s(?:Street|St|Road|Rd|Lane|Ln|Avenue|Ave|Drive|Dr|Way|High Street|Mill Lane)[^\n,]*(?:,\s*[^\n]+)?/i', $text, $match ) ) {
+			$result['contact']['address'] = trim( $match[0], " \t\n\r\0\x0B,." );
+		}
+
+		$hours = [];
+		if ( preg_match_all( '/\b(Mon|Tue|Wed|Thu|Fri|Sat|Sun)(?:day)?(?:\s*-\s*(Mon|Tue|Wed|Thu|Fri|Sat|Sun)(?:day)?)?\s*:?\s*(\d{1,2}(?::\d{2})?\s*(?:am|pm)?)\s*[-–]\s*(\d{1,2}(?::\d{2})?\s*(?:am|pm)?)/i', $text, $matches, PREG_SET_ORDER ) ) {
+			foreach ( $matches as $match ) {
+				$hours[] = [
+					'day'   => ucfirst( strtolower( substr( $match[1], 0, 3 ) ) ),
+					'open'  => $this->normalize_time( $match[3] ),
+					'close' => $this->normalize_time( $match[4] ),
+				];
+			}
+		}
+		$result['hours'] = $hours;
+
+		return $result;
+	}
+
+	/**
+	 * @param mixed $hours Hours value from JSON-LD.
+	 * @return list<array<string,string|null>>
+	 */
+	private function parse_opening_hours( mixed $hours ): array {
+		$parsed = [];
+		if ( is_string( $hours ) ) {
+			$hours = [ $hours ];
+		}
+		if ( ! is_array( $hours ) ) {
+			return [];
+		}
+
+		foreach ( $hours as $entry ) {
+			if ( is_string( $entry ) && preg_match( '/^([A-Za-z]{2})\s+(\d{1,2}:\d{2})-(\d{1,2}:\d{2})/', $entry, $match ) ) {
+				$parsed[] = [
+					'day'   => ucfirst( strtolower( $match[1] ) ),
+					'open'  => $match[2],
+					'close' => $match[3],
+				];
+			} elseif ( is_array( $entry ) ) {
+				$days = $entry['dayOfWeek'] ?? [];
+				$days = is_array( $days ) ? $days : [ $days ];
+				foreach ( $days as $day ) {
+					$parsed[] = [
+						'day'   => substr( basename( (string) $day ), 0, 3 ),
+						'open'  => $this->string_value( $entry['opens'] ?? null ),
+						'close' => $this->string_value( $entry['closes'] ?? null ),
+					];
+				}
+			}
+		}
+
+		return $parsed;
+	}
+
+	/**
+	 * @param mixed $address JSON-LD address value.
+	 */
+	private function format_address( mixed $address ): ?string {
+		if ( is_string( $address ) ) {
+			return $address;
+		}
+		if ( ! is_array( $address ) ) {
+			return null;
+		}
+
+		$parts = array_filter(
+			[
+				$this->string_value( $address['streetAddress'] ?? null ),
+				$this->string_value( $address['addressLocality'] ?? null ),
+				$this->string_value( $address['addressRegion'] ?? null ),
+				$this->string_value( $address['postalCode'] ?? null ),
+				$this->string_value( $address['addressCountry'] ?? null ),
+			]
+		);
+
+		return ! empty( $parts ) ? implode( ', ', $parts ) : null;
+	}
+
+	/**
+	 * @param mixed $value Input value.
+	 */
+	private function string_value( mixed $value ): ?string {
+		if ( is_array( $value ) ) {
+			if ( isset( $value['url'] ) ) {
+				return $this->string_value( $value['url'] );
+			}
+			$value = reset( $value );
+		}
+
+		$value = is_scalar( $value ) ? trim( (string) $value ) : '';
+		return '' !== $value ? $value : null;
+	}
+
+	private function normalize_url( string $url ): string {
+		$url = trim( $url );
+		if ( '' !== $url && ! preg_match( '#^https?://#i', $url ) ) {
+			$url = 'https://' . ltrim( $url, '/' );
+		}
+
+		return esc_url_raw( $url );
+	}
+
+	/**
+	 * @param list<string> $target_pages Target pages.
+	 * @return list<string>
+	 */
+	private function initial_queue( string $url, array $target_pages ): array {
+		if ( empty( $target_pages ) ) {
+			return [ $url ];
+		}
+
+		$queue = [];
+		foreach ( $target_pages as $page ) {
+			$queue[] = $this->resolve_url( $url, $page );
+		}
+
+		return array_values( array_unique( $queue ) );
+	}
+
+	/**
+	 * @return list<string>
+	 */
+	private function discover_links( string $base_url, string $html ): array {
+		$links = [];
+		if ( preg_match_all( '/<a\s+[^>]*href=["\']([^"\']+)["\'][^>]*>/i', $html, $matches ) ) {
+			foreach ( $matches[1] as $href ) {
+				$absolute = $this->resolve_url( $base_url, html_entity_decode( $href ) );
+				if ( $this->same_origin( $base_url, $absolute ) && preg_match( '#/(about|contact|hours|menu|team|visit)#i', $absolute ) ) {
+					$links[] = $absolute;
+				}
+			}
+		}
+
+		return array_values( array_unique( $links ) );
+	}
+
+	private function resolve_url( string $base_url, string $href ): string {
+		if ( preg_match( '#^https?://#i', $href ) ) {
+			return esc_url_raw( $href );
+		}
+
+		$parts = wp_parse_url( $base_url );
+		if ( empty( $parts['scheme'] ) || empty( $parts['host'] ) ) {
+			return '';
+		}
+
+		$root = $parts['scheme'] . '://' . $parts['host'];
+		return esc_url_raw( $root . '/' . ltrim( $href, '/' ) );
+	}
+
+	private function same_origin( string $a, string $b ): bool {
+		$a_parts = wp_parse_url( $a );
+		$b_parts = wp_parse_url( $b );
+
+		return strtolower( (string) ( $a_parts['host'] ?? '' ) ) === strtolower( (string) ( $b_parts['host'] ?? '' ) );
+	}
+
+	private function attr_value( string $attrs, string $name ): string {
+		if ( preg_match( '/\b' . preg_quote( $name, '/' ) . '\s*=\s*(["\'])(.*?)\1/i', $attrs, $match ) ) {
+			return trim( html_entity_decode( $match[2] ) );
+		}
+
+		return '';
+	}
+
+	private function first_match( string $pattern, string $subject ): string {
+		return preg_match( $pattern, $subject, $match ) ? (string) $match[1] : '';
+	}
+
+	private function clean_text( string $text ): string {
+		$text = wp_strip_all_tags( html_entity_decode( $text ), true );
+		$text = preg_replace( '/\s+/', ' ', $text );
+
+		return trim( (string) $text );
+	}
+
+	private function normalize_time( string $time ): string {
+		$timestamp = strtotime( $time );
+		return false !== $timestamp ? gmdate( 'H:i', $timestamp ) : trim( $time );
+	}
+
+	/**
+	 * @param list<string> $target_pages Target pages.
+	 */
+	private function cache_key( string $url, int $max_pages, array $target_pages, string $extract_mode ): string {
+		return self::CACHE_GROUP . md5( wp_json_encode( [ $url, $max_pages, $target_pages, $extract_mode ] ) ?: $url );
+	}
+
+	private function rate_limit(): void {
+		$seconds = (int) apply_filters( 'sd_ai_agent_site_scraper_rate_limit_seconds', 1 );
+		if ( $seconds > 0 ) {
+			sleep( min( 3, $seconds ) );
+		}
+	}
+
+	private function user_agent(): string {
+		$version = defined( 'SD_AI_AGENT_VERSION' ) ? (string) SD_AI_AGENT_VERSION : '1.0.0';
+		return sprintf( 'SuperdavAI/%s (+%s)', $version, home_url( '/' ) );
+	}
+
+	/**
+	 * @param array<string,mixed> $result Existing result.
+	 * @return array<string,mixed>
+	 */
+	private function maybe_ai_complete( array $result ): array {
+		if ( ! function_exists( 'wp_ai_client_prompt' ) || empty( $result['pages'] ) ) {
+			return $result;
+		}
+
+		$has_gaps = empty( $result['brand']['name'] ) || empty( $result['contact']['address'] );
+		if ( ! $has_gaps ) {
+			return $result;
+		}
+
+		$pages_json = wp_json_encode( $result['pages'] );
+		$prompt     = "Extract brand, contact, hours, and social profile data from this website text. Return only JSON matching {brand:{name,tagline,logo_url},contact:{address,phone,email},hours:[{day,open,close}],social:{instagram,facebook,linkedin,x,youtube,tiktok}}.\n\n" . (string) $pages_json;
+		$raw        = wp_ai_client_prompt( $prompt )->generate_text();
+		if ( is_wp_error( $raw ) || ! is_string( $raw ) ) {
+			return $result;
+		}
+
+		$json = $this->first_match( '/\{[\s\S]*\}/', $raw );
+		$data = json_decode( '' !== $json ? $json : $raw, true );
+		if ( ! is_array( $data ) ) {
+			return $result;
+		}
+
+		return $this->merge_extracted( $result, $data );
+	}
+}

--- a/tests/SdAiAgent/Abilities/SiteScrapeAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/SiteScrapeAbilityTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Tests for the site-scrape Theme Builder ability.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Abilities;
+
+use SdAiAgent\Abilities\SiteScrapeAbility;
+use SdAiAgent\Services\SiteScraper;
+use WP_UnitTestCase;
+
+/**
+ * Covers parsers, heuristics, caching, and robots behaviour.
+ */
+class SiteScrapeAbilityTest extends WP_UnitTestCase {
+
+	private array $responses = [];
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->responses = [];
+		add_filter( 'pre_http_request', [ $this, 'mock_http' ], 10, 3 );
+		add_filter( 'sd_ai_agent_site_scraper_rate_limit_seconds', [ $this, 'disable_rate_limit' ] );
+	}
+
+	public function tearDown(): void {
+		remove_filter( 'pre_http_request', [ $this, 'mock_http' ], 10 );
+		remove_filter( 'sd_ai_agent_site_scraper_rate_limit_seconds', [ $this, 'disable_rate_limit' ] );
+		parent::tearDown();
+	}
+
+	public function disable_rate_limit(): int {
+		return 0;
+	}
+
+	/**
+	 * @param false|array<string,mixed>|\WP_Error $preempt Preempted value.
+	 * @param array<string,mixed>                 $args    Request args.
+	 * @param string                              $url     Request URL.
+	 * @return array<string,mixed>|false
+	 */
+	public function mock_http( $preempt, array $args, string $url ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		if ( ! array_key_exists( $url, $this->responses ) ) {
+			return false;
+		}
+
+		$body = $this->responses[ $url ];
+		return [
+			'headers'  => [ 'content-type' => str_ends_with( $url, 'robots.txt' ) ? 'text/plain' : 'text/html' ],
+			'body'     => $body,
+			'response' => [
+				'code'    => 200,
+				'message' => 'OK',
+			],
+			'cookies'  => [],
+			'filename' => null,
+		];
+	}
+
+	public function test_schema_org_parser_extracts_local_business_data(): void {
+		$scraper = new SiteScraper();
+		$html    = (string) file_get_contents( __DIR__ . '/../fixtures/site-scrape/local-business.html' );
+
+		$result = $scraper->extract_from_html( 'https://bramble.example/', $html, wp_strip_all_tags( $html ) );
+
+		$this->assertSame( 'Bramble & Bean Coffee Co.', $result['brand']['name'] );
+		$this->assertSame( 'Slow down. Sip something good.', $result['brand']['tagline'] );
+		$this->assertSame( '0131 555 0147', $result['contact']['phone'] );
+		$this->assertSame( 'hello@bramble.example', $result['contact']['email'] );
+		$this->assertStringContainsString( '47 Mill Lane', $result['contact']['address'] );
+		$this->assertSame( 'https://instagram.com/bramblebean', $result['social']['instagram'] );
+		$this->assertSame( 'Tue', $result['hours'][0]['day'] );
+	}
+
+	public function test_opengraph_parser_extracts_common_brand_metadata(): void {
+		$scraper = new SiteScraper();
+		$html    = (string) file_get_contents( __DIR__ . '/../fixtures/site-scrape/opengraph.html' );
+
+		$result = $scraper->extract_from_html( 'https://studio.example/', $html, '' );
+
+		$this->assertSame( 'North Pier Studio', $result['brand']['name'] );
+		$this->assertSame( 'Thoughtful interiors by the coast.', $result['brand']['tagline'] );
+		$this->assertSame( 'https://studio.example/og-logo.png', $result['brand']['logo_url'] );
+	}
+
+	public function test_heuristics_extract_phone_email_address_and_hours(): void {
+		$scraper = new SiteScraper();
+		$html    = (string) file_get_contents( __DIR__ . '/../fixtures/site-scrape/heuristics-cafe.html' );
+
+		$result = $scraper->extract_from_html( 'https://heuristic.example/', $html, wp_strip_all_tags( $html ) );
+
+		$this->assertSame( 'hello@heuristic.example', $result['contact']['email'] );
+		$this->assertSame( '+44 131 555 0188', $result['contact']['phone'] );
+		$this->assertStringContainsString( '12 Market Street', $result['contact']['address'] );
+		$this->assertSame( 'Mon', $result['hours'][0]['day'] );
+		$this->assertSame( '08:00', $result['hours'][0]['open'] );
+		$this->assertSame( '17:30', $result['hours'][0]['close'] );
+	}
+
+	public function test_scrape_uses_transient_cache_to_prevent_redundant_fetches(): void {
+		$this->responses = [
+			'https://cached.example/robots.txt' => '',
+			'https://cached.example/'           => (string) file_get_contents( __DIR__ . '/../fixtures/site-scrape/opengraph.html' ),
+		];
+		$scraper         = new SiteScraper();
+
+		$first = $scraper->scrape( 'https://cached.example/', 1, [], 'structured_only' );
+		$this->assertIsArray( $first );
+		$this->assertFalse( $first['cached'] );
+
+		$this->responses = [ 'https://cached.example/robots.txt' => '' ];
+		$second          = $scraper->scrape( 'https://cached.example/', 1, [], 'structured_only' );
+		$this->assertIsArray( $second );
+		$this->assertTrue( $second['cached'] );
+		$this->assertSame( 'North Pier Studio', $second['brand']['name'] );
+	}
+
+	public function test_scrape_respects_robots_txt_disallow(): void {
+		$this->responses = [
+			'https://blocked.example/robots.txt' => "User-agent: *\nDisallow: /",
+		];
+
+		$result = ( new SiteScraper() )->scrape( 'https://blocked.example/', 1, [], 'structured_only' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'sd_ai_agent_site_scrape_robots_disallowed', $result->get_error_code() );
+	}
+
+	public function test_site_scrape_ability_returns_complete_optional_shape(): void {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$this->responses = [
+			'https://ability.example/robots.txt' => '',
+			'https://ability.example/'           => (string) file_get_contents( __DIR__ . '/../fixtures/site-scrape/local-business.html' ),
+		];
+		$ability         = new SiteScrapeAbility( 'sd-ai-agent/site-scrape' );
+
+		$result = $ability->run(
+			[
+				'url'                 => 'https://ability.example/',
+				'max_pages'           => 1,
+				'extract_preferences' => 'structured_only',
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'brand', $result );
+		$this->assertArrayHasKey( 'name', $result['brand'] );
+		$this->assertArrayHasKey( 'contact', $result );
+		$this->assertArrayHasKey( 'address', $result['contact'] );
+		$this->assertArrayHasKey( 'social', $result );
+		$this->assertArrayHasKey( 'facebook', $result['social'] );
+		$this->assertSame( 'Bramble & Bean Coffee Co.', $result['brand']['name'] );
+	}
+}

--- a/tests/SdAiAgent/fixtures/site-scrape/heuristics-cafe.html
+++ b/tests/SdAiAgent/fixtures/site-scrape/heuristics-cafe.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+<head><title>Market Table</title></head>
+<body>
+	<h1>Market Table</h1>
+	<p>Visit us at 12 Market Street, Stirling FK8 1AA.</p>
+	<p>Call +44 131 555 0188 or email hello@heuristic.example.</p>
+	<p>Mon: 8:00am - 5:30pm<br>Tue: 8:00am - 5:30pm</p>
+</body>
+</html>

--- a/tests/SdAiAgent/fixtures/site-scrape/local-business.html
+++ b/tests/SdAiAgent/fixtures/site-scrape/local-business.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+<head>
+	<title>Bramble &amp; Bean Coffee Co.</title>
+	<script type="application/ld+json">
+	{
+		"@context": "https://schema.org",
+		"@type": "CafeOrCoffeeShop",
+		"name": "Bramble & Bean Coffee Co.",
+		"slogan": "Slow down. Sip something good.",
+		"logo": "https://bramble.example/logo.png",
+		"telephone": "0131 555 0147",
+		"email": "hello@bramble.example",
+		"address": {
+			"@type": "PostalAddress",
+			"streetAddress": "47 Mill Lane",
+			"addressLocality": "Hawthornden",
+			"addressRegion": "Edinburgh",
+			"postalCode": "EH18"
+		},
+		"sameAs": ["https://instagram.com/bramblebean"],
+		"openingHours": ["Tue 07:00-16:00", "Wed 07:00-16:00"]
+	}
+	</script>
+</head>
+<body><h1>Bramble &amp; Bean Coffee Co.</h1><p>Independent coffee in Hawthornden.</p></body>
+</html>

--- a/tests/SdAiAgent/fixtures/site-scrape/opengraph.html
+++ b/tests/SdAiAgent/fixtures/site-scrape/opengraph.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+<head>
+	<title>North Pier Studio</title>
+	<meta property="og:site_name" content="North Pier Studio">
+	<meta property="og:description" content="Thoughtful interiors by the coast.">
+	<meta property="og:image" content="https://studio.example/og-logo.png">
+</head>
+<body><h1>North Pier Studio</h1><p>Interior design studio.</p></body>
+</html>

--- a/tests/SdAiAgent/fixtures/site-scrape/restaurant-hours.html
+++ b/tests/SdAiAgent/fixtures/site-scrape/restaurant-hours.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+<head>
+	<script type="application/ld+json">
+	{
+		"@context":"https://schema.org",
+		"@type":"Restaurant",
+		"name":"Fennel House",
+		"openingHoursSpecification":[
+			{"@type":"OpeningHoursSpecification","dayOfWeek":["Monday","Tuesday"],"opens":"12:00","closes":"22:00"}
+		]
+	}
+	</script>
+</head>
+<body><h1>Fennel House</h1></body>
+</html>

--- a/tests/SdAiAgent/fixtures/site-scrape/social-and-logo.html
+++ b/tests/SdAiAgent/fixtures/site-scrape/social-and-logo.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html>
+<body>
+	<img class="site-logo" src="/assets/logo.svg" alt="Logo">
+	<a href="https://facebook.com/examplebiz">Facebook</a>
+	<a href="https://www.linkedin.com/company/examplebiz">LinkedIn</a>
+	<a href="https://www.youtube.com/@examplebiz">YouTube</a>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Added sd-ai-agent/site-scrape, a SiteScraper service for robots-aware cached crawling, Schema.org/OpenGraph/heuristic extraction, Theme Builder prompt/tool wiring, and PHPUnit fixtures for parser/cache/robots coverage.

## Files Changed

includes/Abilities/SiteScrapeAbility.php,includes/Abilities/ThemeBuilderAbilities.php,includes/Models/Agent.php,includes/Services/SiteScraper.php,tests/SdAiAgent/Abilities/SiteScrapeAbilityTest.php,tests/SdAiAgent/fixtures/site-scrape/heuristics-cafe.html,tests/SdAiAgent/fixtures/site-scrape/local-business.html,tests/SdAiAgent/fixtures/site-scrape/opengraph.html,tests/SdAiAgent/fixtures/site-scrape/restaurant-hours.html,tests/SdAiAgent/fixtures/site-scrape/social-and-logo.html

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** composer phpcs; composer phpstan; targeted npm run test:php -- --filter SiteScrape blocked because wp-env could not start tests-wordpress: port 8890 is already allocated; local phpunit blocked by missing wordpress-tests-lib.

Resolves #1530


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.67 plugin for [OpenCode](https://opencode.ai) v1.15.5 with gpt-5.5 spent 13m and 129,438 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added site scraping functionality that automatically extracts brand information, contact details, opening hours, and social media profiles from existing websites to pre-fill Theme Builder data
  * Theme Builder onboarding now prompts users for existing site URLs and uses extracted information as draft answers during the setup interview
  * Respects robots.txt rules and caches results to prevent redundant data fetches

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1537?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->