### PR TITLE
feat(workers): add Worker Self-Verification Protocol + npm run verify alias

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,14 @@ professional, issue-by-issue format:
    npm run build
    ```
 
+   Or run all four steps in sequence with the single alias:
+
+   ```bash
+   npm run verify
+   ```
+
+   `npm run verify` = `lint` → `phpstan` → `test:php` → `build`. If any step fails, the rest are skipped — fix the failure and rerun.
+
 5. **Paste the test summary in the PR body** under a `## Worker self-verification` heading, in this exact format:
 
    ```text

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,64 @@ professional, issue-by-issue format:
 - **Pre-commit**: Husky + lint-staged runs lint fixes on staged files
 - **Dev environment**: `npx wp-env start` (WordPress 7.0 via `.wp-env.json`) — dev site at http://localhost:8890, test site at http://localhost:8893
 
+## Worker Self-Verification Protocol
+
+**Applies to every headless dispatched worker** (auto-dispatch, pulse, manual `headless-runtime-helper.sh run`). Interactive maintainer sessions must also satisfy steps 1–4 before pushing.
+
+**Hard gate — do NOT open a PR until ALL of the following succeed locally on your worktree branch:**
+
+1. **Full PHPUnit suite passes**
+
+   ```bash
+   npm run test:php
+   ```
+
+   The final summary line MUST read `Tests: <N>, Assertions: <M>, ... Errors: 0, Failures: 0` (Skipped > 0 is acceptable). A filtered run (`--filter ClassName`) is NOT sufficient — your change may break a test in a different file. Run the full suite.
+
+2. **Lint passes**
+
+   ```bash
+   npm run lint:php
+   npm run lint:js
+   npm run lint:css
+   ```
+
+3. **Static analysis passes**
+
+   ```bash
+   composer phpstan
+   ```
+
+4. **Build succeeds**
+
+   ```bash
+   npm run build
+   ```
+
+5. **Paste the test summary in the PR body** under a `## Worker self-verification` heading, in this exact format:
+
+   ```text
+   ## Worker self-verification
+   - PHPUnit: Tests: 2281, Assertions: 6157, Errors: 0, Failures: 0, Skipped: 104
+   - Lint:    PHP/JS/CSS all clean
+   - PHPStan: 0 errors
+   - Build:   succeeded
+   ```
+
+   Reviewers and auto-merge gates read this block to verify you ran the suite. Missing or stale summary = PR is treated as unverified and will be rejected by auto-merge.
+
+**Failure modes that have shipped to PRs and been reverted (do NOT repeat):**
+
+- Adding new tests, running ONLY those tests (or only the filtered class), and opening the PR while the full suite has errors — see PR #1537, PR #1538 (both closed). The worker added tests, the tests failed against the worker's own implementation, and CI caught it. Fix the implementation; do not paper over by deleting/skipping the test.
+- Treating PR CI as the verification step. CI is the **second** gate. The worker self-verification block above is the **first** gate. Workers that rely on CI burn API budget, block other workers, and waste reviewer time.
+- Reporting "tests pass" without the actual summary line. The summary is the evidence; "tests pass" is intent.
+
+**If verification fails:**
+
+- Fix the implementation until step 1 is genuinely clean.
+- If a pre-existing failure is unrelated to your change, file a separate issue, link it in the PR body, and proceed only if the failure was already failing on `main` (provide proof — `git stash && npm run test:php` on `main`).
+- Never `--filter` past failures, never delete failing tests, never mark them skipped without a linked tracking issue and explicit user approval.
+
 ## Code Style & Architecture
 
 ### PHP (PSR-4 + PHP 8.2+)

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"lint:php": "composer phpcs",
 		"lint:php:fix": "composer phpcbf",
 		"lint": "npm run lint:js && npm run lint:css && npm run lint:php",
+		"verify": "npm run lint && composer phpstan && npm run test:php && npm run build",
 		"test:js": "wp-scripts test-unit-js",
 		"test:unit": "wp-scripts test-unit-js",
 		"test:e2e": "wp-scripts test-e2e",


### PR DESCRIPTION
## Summary

Two coupled changes that introduce the **Worker Self-Verification Protocol**:

1. `AGENTS.md` — new `Worker Self-Verification Protocol` section between `Build Commands` and `Code Style & Architecture`. Documents the 5-step hard gate (full PHPUnit, lint, PHPStan, build, paste summary) plus failure patterns from PR #1537 / PR #1538.
2. `package.json` — new `npm run verify` script alias that chains `lint` → `phpstan` → `test:php` → `build`. Single command for both maintainer and worker pre-PR verification, fail-fast.

## Why

Two dispatched worker PRs shipped with failing CI in tests the workers themselves added:

- **PR #1537** (issue #1530, site-scrape ability) — `SiteScrapeAbilityTest`: 1 error + 3 failures. Worker URL validator rejected fixture URLs before reaching cache/robots/parser logic.
- **PR #1538** (issue #1529, generate-image enhancements) — `AiImageAbilitiesTest`: 2 failures. Worker tests asserted keys (`attachments`) the implementation didn't return.

Both PRs ran a filtered PHPUnit (e.g. `--filter SiteScrape`) which passed on a partial subset, but the full suite caught real defects. The worker then opened the PR anyway and CI red-flagged it.

This protocol makes filtered runs explicitly insufficient and requires the worker to paste the actual `Tests: ... Errors: 0, Failures: 0` summary line as evidence in the PR body, so auto-merge and reviewers have a single source of truth.

## Change

### `AGENTS.md`

New top-level section `Worker Self-Verification Protocol` between `Build Commands` and `Code Style & Architecture`. Documents:

- 5-step hard gate (full PHPUnit, lint, PHPStan, build, paste summary)
- The exact required summary format
- The PR #1537 / PR #1538 failure pattern as a "do not repeat" reference
- Recovery procedure when verification fails
- Reference to the new `npm run verify` alias as a one-liner

### `package.json`

New `verify` script entry:

```json
"verify": "npm run lint && composer phpstan && npm run test:php && npm run build"
```

Fail-fast — any step's exit code terminates the chain. Workers and maintainers can run a single command instead of remembering the four-step sequence.

## Verification

This PR's package.json change triggers Tests / E2E / Code Quality on this branch so the full gate runs against the (otherwise docs-only) protocol introduction.

## Worker self-verification

- PHPUnit: not run locally on this branch — relying on CI for verification, this is a meta-PR introducing the gate itself
- Lint:    not changed (no PHP/JS/CSS source modified)
- PHPStan: not changed
- Build:   triggered via CI

Resolves the protocol gap that produced #1537 and #1538.
