### PR TITLE
GH#1524: fix(create-menu): auto-assign menu item positions to preserve insertion order

### DIFF
--- a/includes/Abilities/MenuAbilities.php
+++ b/includes/Abilities/MenuAbilities.php
@@ -559,6 +559,14 @@ class MenuAbilities {
 			$object_type = 'custom';
 		}
 
+		// Auto-assign the next sequential position when the caller does not specify one.
+		// Without this, wp_update_nav_menu_item sets menu_order = 0 for every item,
+		// causing WordPress to fall back to alphabetical sorting by post title (GH#1524).
+		if ( $position <= 0 ) {
+			$existing_items = wp_get_nav_menu_items( $menu->term_id );
+			$position       = is_array( $existing_items ) ? count( $existing_items ) + 1 : 1;
+		}
+
 		$item_data = [
 			'menu-item-title'      => $title,
 			'menu-item-url'        => $url,

--- a/tests/SdAiAgent/Abilities/MenuAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/MenuAbilitiesTest.php
@@ -251,6 +251,88 @@ class MenuAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 'About', $items[0]->title );
 	}
 
+	/**
+	 * Test handle_add_menu_item preserves insertion order when no position is specified.
+	 *
+	 * Regression test for GH#1524: items were sorted alphabetically because
+	 * wp_update_nav_menu_item received menu-item-position = 0 for every item.
+	 */
+	public function test_handle_add_menu_item_preserves_insertion_order() {
+		$menu_id = wp_create_nav_menu( 'Order Test Menu' );
+		$this->assertIsInt( $menu_id );
+
+		$titles = [ 'Home', 'Menu', 'Our Story', 'Events', 'Find Us', 'Shop' ];
+
+		foreach ( $titles as $title ) {
+			$result = MenuAbilities::handle_add_menu_item(
+				[
+					'menu_id' => $menu_id,
+					'title'   => $title,
+					'url'     => 'https://example.com/' . sanitize_title( $title ),
+				]
+			);
+			$this->assertIsArray( $result, "Expected array result for item '$title'" );
+		}
+
+		// wp_get_nav_menu_items returns items sorted by menu_order.
+		$items = wp_get_nav_menu_items( $menu_id );
+		$this->assertIsArray( $items );
+		$this->assertCount( count( $titles ), $items );
+
+		foreach ( $titles as $index => $expected_title ) {
+			$this->assertSame(
+				$expected_title,
+				$items[ $index ]->title,
+				"Item at position " . ( $index + 1 ) . " should be '$expected_title'"
+			);
+			$this->assertSame(
+				$index + 1,
+				(int) $items[ $index ]->menu_order,
+				"menu_order for '$expected_title' should be " . ( $index + 1 )
+			);
+		}
+	}
+
+	/**
+	 * Test handle_add_menu_item respects explicitly provided positions for ordering.
+	 *
+	 * Adds two items in reverse position order (Second first, First second) and
+	 * verifies they are returned in position order (First, Second).
+	 */
+	public function test_handle_add_menu_item_respects_explicit_position() {
+		$menu_id = wp_create_nav_menu( 'Explicit Position Menu' );
+		$this->assertIsInt( $menu_id );
+
+		// Add "Second" at position 2 first.
+		$result_second = MenuAbilities::handle_add_menu_item(
+			[
+				'menu_id'  => $menu_id,
+				'title'    => 'Second',
+				'url'      => 'https://example.com/second',
+				'position' => 2,
+			]
+		);
+		$this->assertIsArray( $result_second );
+
+		// Add "First" at position 1 second (inserted after "Second").
+		$result_first = MenuAbilities::handle_add_menu_item(
+			[
+				'menu_id'  => $menu_id,
+				'title'    => 'First',
+				'url'      => 'https://example.com/first',
+				'position' => 1,
+			]
+		);
+		$this->assertIsArray( $result_first );
+
+		// wp_get_nav_menu_items sorts by menu_order; "First" (pos 1) should come before "Second" (pos 2).
+		$items = wp_get_nav_menu_items( $menu_id );
+		$this->assertIsArray( $items );
+		$this->assertCount( 2, $items );
+		$this->assertSame( 'First', $items[0]->title, 'Item with position 1 should come first' );
+		$this->assertSame( 'Second', $items[1]->title, 'Item with position 2 should come second' );
+	}
+
 	// ─── handle_remove_menu_item ──────────────────────────────────
 
 	/**


### PR DESCRIPTION
## Summary

Added auto-increment position logic in handle_add_menu_item(): when no explicit position is given, the item gets (existing_count + 1), preserving caller order. Explicit positions (> 0) pass through unchanged. Regression test added with the exact HOME/MENU/OUR STORY/EVENTS/FIND US/SHOP sequence from the issue report.

## Files Changed

includes/Abilities/MenuAbilities.php,tests/SdAiAgent/Abilities/MenuAbilitiesTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PHPUnit: Tests: 2277, Assertions: 6165, Errors: 0, Failures: 0, Skipped: 104 | Lint: PHP/JS/CSS all clean | PHPStan: 0 errors | Build: succeeded

Resolves #1524


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.68 plugin for [OpenCode](https://opencode.ai) v1.15.5 with claude-sonnet-4-6 spent 25m and 33,530 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Menu items now maintain insertion order by default instead of falling back to alphabetical ordering when position is not explicitly specified. Explicitly provided positions continue to be respected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1540?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->