### PR TITLE
GH#1527: feat(abilities): generate sanitised SVG logo candidates

### DIFF
--- a/includes/Abilities/GenerateLogoSvgAbility.php
+++ b/includes/Abilities/GenerateLogoSvgAbility.php
@@ -142,19 +142,19 @@ class GenerateLogoSvgAbility extends AbstractAbility {
 		return [
 			'type'       => 'object',
 			'properties' => [
-				'candidates'               => [
+				'candidates'              => [
 					'type'        => 'array',
 					'description' => 'Generated SVG candidates with attachment_id, url, data_uri, and fallback flag.',
 				],
-				'selected_attachment_id'   => [ 'type' => 'integer' ],
-				'logo_set'                 => [ 'type' => 'boolean' ],
-				'fallback'                 => [
+				'selected_attachment_id'  => [ 'type' => 'integer' ],
+				'logo_set'                => [ 'type' => 'boolean' ],
+				'fallback'                => [
 					'type'        => 'boolean',
 					'description' => 'True when AI generation failed validation and a type-only wordmark was substituted.',
 				],
-				'existing_logo_preserved'  => [ 'type' => 'boolean' ],
-				'message'                  => [ 'type' => 'string' ],
-				'error'                    => [ 'type' => 'string' ],
+				'existing_logo_preserved' => [ 'type' => 'boolean' ],
+				'message'                 => [ 'type' => 'string' ],
+				'error'                   => [ 'type' => 'string' ],
 			],
 		];
 	}

--- a/includes/Abilities/GenerateLogoSvgAbility.php
+++ b/includes/Abilities/GenerateLogoSvgAbility.php
@@ -1,0 +1,786 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Generate Logo SVG ability — AI-powered SVG logo candidate generation.
+ *
+ * Produces sanitised SVG logo candidates (wordmark, monogram, symbol+wordmark,
+ * symbol) via the WordPress AI Client SDK, saves them to the media library, and
+ * optionally wires the chosen candidate as the active site logo.
+ *
+ * @package SdAiAgent\Abilities
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Abilities;
+
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Generates sanitised SVG logo candidates using AI and saves them to the
+ * media library. Falls back to a type-only wordmark when all AI attempts
+ * fail SVG validation.
+ *
+ * @since 1.7.0
+ */
+class GenerateLogoSvgAbility extends AbstractAbility {
+
+	/**
+	 * Maximum number of AI generation attempts per candidate before falling back.
+	 */
+	private const MAX_RETRIES = 3;
+
+	/**
+	 * Maximum allowed SVG byte size (500 KB).
+	 */
+	private const MAX_SVG_BYTES = 512000;
+
+	/**
+	 * Elements that must never appear in a sanitised SVG.
+	 *
+	 * @var list<string>
+	 */
+	private const FORBIDDEN_ELEMENTS = [ 'script', 'foreignObject' ];
+
+	/**
+	 * Register this ability with the WordPress Abilities API.
+	 *
+	 * Safe to call before the API has loaded — returns silently if
+	 * `wp_register_ability` is not yet available.
+	 */
+	public static function register(): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			'sd-ai-agent/generate-logo-svg',
+			[
+				'label'         => __( 'Generate Logo SVG', 'superdav-ai-agent' ),
+				'description'   => __(
+					'Generate sanitised SVG logo candidates using AI, save them to the media library, and optionally set one as the active site logo. Falls back to a type-only wordmark when all AI attempts fail validation.',
+					'superdav-ai-agent'
+				),
+				'ability_class' => self::class,
+			]
+		);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function label(): string {
+		return __( 'Generate Logo SVG', 'superdav-ai-agent' );
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function description(): string {
+		return __(
+			'Generate sanitised SVG logo candidates using AI, save them to the media library, and optionally set one as the active site logo. Falls back to a type-only wordmark when all AI attempts fail validation.',
+			'superdav-ai-agent'
+		);
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function input_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'action'            => [
+					'type'        => 'string',
+					'enum'        => [ 'generate', 'select_candidate' ],
+					'description' => 'generate: produce N SVG logo candidates (default). select_candidate: wire an already-generated candidate as the active site logo.',
+				],
+				'brand_name'        => [
+					'type'        => 'string',
+					'description' => 'Brand or business name to use in the logo. Required for the generate action.',
+				],
+				'description'       => [
+					'type'        => 'string',
+					'description' => 'Brand description or vertical (e.g. "artisan coffee roaster", "SaaS analytics platform"). Required for the generate action.',
+				],
+				'direction'         => [
+					'type'        => 'string',
+					'enum'        => [ 'wordmark', 'monogram', 'symbol+wordmark', 'symbol' ],
+					'description' => 'Logo style direction. Default: symbol+wordmark.',
+				],
+				'style_cues'        => [
+					'type'        => 'string',
+					'description' => 'Optional palette and voice cues (e.g. "warm earth tones, hand-crafted feel").',
+				],
+				'existing_logo_url' => [
+					'type'        => 'string',
+					'description' => 'URL of the user\'s existing logo. When provided the ability returns immediately with the existing logo preserved and skips generation.',
+				],
+				'count'             => [
+					'type'        => 'integer',
+					'minimum'     => 1,
+					'maximum'     => 5,
+					'description' => 'Number of SVG candidates to generate. Default: 3.',
+				],
+				'attachment_id'     => [
+					'type'        => 'integer',
+					'description' => 'Media attachment ID to activate as the site logo. Required for the select_candidate action.',
+				],
+			],
+			'required'   => [],
+		];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function output_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'candidates'               => [
+					'type'        => 'array',
+					'description' => 'Generated SVG candidates with attachment_id, url, data_uri, and fallback flag.',
+				],
+				'selected_attachment_id'   => [ 'type' => 'integer' ],
+				'logo_set'                 => [ 'type' => 'boolean' ],
+				'fallback'                 => [
+					'type'        => 'boolean',
+					'description' => 'True when AI generation failed validation and a type-only wordmark was substituted.',
+				],
+				'existing_logo_preserved'  => [ 'type' => 'boolean' ],
+				'message'                  => [ 'type' => 'string' ],
+				'error'                    => [ 'type' => 'string' ],
+			],
+		];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function execute_callback( mixed $input ): array|\WP_Error {
+		$action = (string) ( $input['action'] ?? 'generate' );
+
+		if ( 'select_candidate' === $action ) {
+			return $this->handle_select_candidate( $input );
+		}
+
+		return $this->handle_generate( $input );
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function permission_callback( mixed $input = null ): bool {
+		return current_user_can( 'upload_files' );
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function meta(): array {
+		return [
+			'mcp'          => [ 'public' => true ],
+			'annotations'  => [
+				'readonly'    => false,
+				'destructive' => false,
+				'idempotent'  => false,
+			],
+			'show_in_rest' => true,
+		];
+	}
+
+	// ─── Action handlers ──────────────────────────────────────────────────────
+
+	/**
+	 * Handle the generate action: produce N SVG logo candidates.
+	 *
+	 * @param mixed $input Input array.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function handle_generate( mixed $input ): array|\WP_Error {
+		$brand_name        = sanitize_text_field( (string) ( $input['brand_name'] ?? '' ) );
+		$brand_description = sanitize_textarea_field( (string) ( $input['description'] ?? '' ) );
+		$direction         = sanitize_text_field( (string) ( $input['direction'] ?? 'symbol+wordmark' ) );
+		$style_cues        = sanitize_textarea_field( (string) ( $input['style_cues'] ?? '' ) );
+		$existing_logo_url = esc_url_raw( (string) ( $input['existing_logo_url'] ?? '' ) );
+		$count             = max( 1, min( 5, (int) ( $input['count'] ?? 3 ) ) );
+
+		if ( empty( $brand_name ) ) {
+			return new WP_Error(
+				'missing_brand_name',
+				__( 'brand_name is required.', 'superdav-ai-agent' )
+			);
+		}
+
+		if ( empty( $brand_description ) ) {
+			return new WP_Error(
+				'missing_description',
+				__( 'description is required.', 'superdav-ai-agent' )
+			);
+		}
+
+		// User already has a logo — preserve it and skip generation.
+		if ( ! empty( $existing_logo_url ) ) {
+			return [
+				'candidates'              => [],
+				'existing_logo_preserved' => true,
+				'logo_set'                => false,
+				'fallback'                => false,
+				'message'                 => __( 'User already has a logo. Existing logo preserved; generation skipped.', 'superdav-ai-agent' ),
+			];
+		}
+
+		$candidates = [];
+		$fallback   = false;
+
+		for ( $i = 1; $i <= $count; $i++ ) {
+			$svg = $this->generate_one_candidate( $brand_name, $brand_description, $direction, $style_cues, $i, $count );
+
+			if ( is_wp_error( $svg ) ) {
+				// All retries exhausted — substitute a type-only wordmark fallback.
+				$svg      = $this->generate_fallback_wordmark( $brand_name );
+				$fallback = true;
+			}
+
+			$attachment_id = $this->save_svg_to_media_library(
+				$svg,
+				sprintf( '%s-logo-candidate-%d', sanitize_file_name( $brand_name ), $i )
+			);
+
+			if ( is_wp_error( $attachment_id ) ) {
+				continue;
+			}
+
+			$candidates[] = [
+				'attachment_id' => $attachment_id,
+				'url'           => (string) wp_get_attachment_url( $attachment_id ),
+				'data_uri'      => 'data:image/svg+xml;base64,' . base64_encode( $svg ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+				'fallback'      => $fallback,
+			];
+
+			// One fallback is sufficient — stop generating more AI candidates.
+			if ( $fallback ) {
+				break;
+			}
+		}
+
+		if ( empty( $candidates ) ) {
+			return new WP_Error(
+				'generation_failed',
+				__( 'Failed to generate or save SVG logo candidates.', 'superdav-ai-agent' )
+			);
+		}
+
+		$message = $fallback
+			? __(
+				'AI generation failed SVG validation; a type-only wordmark fallback was generated. Use select_candidate with attachment_id to activate a logo.',
+				'superdav-ai-agent'
+			)
+			: sprintf(
+				/* translators: %d: number of SVG candidates generated */
+				__( '%d SVG logo candidate(s) generated. Use select_candidate with attachment_id to activate one as the site logo.', 'superdav-ai-agent' ),
+				count( $candidates )
+			);
+
+		return [
+			'candidates' => $candidates,
+			'fallback'   => $fallback,
+			'logo_set'   => false,
+			'message'    => $message,
+		];
+	}
+
+	/**
+	 * Handle the select_candidate action: wire an attachment as the site logo.
+	 *
+	 * @param mixed $input Input array.
+	 * @return array<string,mixed>|\WP_Error
+	 */
+	private function handle_select_candidate( mixed $input ): array|\WP_Error {
+		$attachment_id = (int) ( $input['attachment_id'] ?? 0 );
+
+		if ( $attachment_id <= 0 ) {
+			return new WP_Error(
+				'missing_attachment_id',
+				__( 'attachment_id is required for the select_candidate action.', 'superdav-ai-agent' )
+			);
+		}
+
+		if ( ! get_post( $attachment_id ) ) {
+			return new WP_Error(
+				'invalid_attachment_id',
+				__( 'Attachment not found.', 'superdav-ai-agent' )
+			);
+		}
+
+		// Set the custom_logo theme mod — the standard WordPress site-logo mechanism.
+		set_theme_mod( 'custom_logo', $attachment_id );
+
+		// Also wire as site icon when the attachment is an SVG (modern browsers support SVG favicons).
+		$mime = (string) get_post_mime_type( $attachment_id );
+		if ( 'image/svg+xml' === $mime ) {
+			update_option( 'site_icon', $attachment_id );
+		}
+
+		return [
+			'selected_attachment_id' => $attachment_id,
+			'logo_set'               => true,
+			'message'                => __( 'Site logo updated successfully.', 'superdav-ai-agent' ),
+		];
+	}
+
+	// ─── SVG generation ───────────────────────────────────────────────────────
+
+	/**
+	 * Generate one SVG logo candidate via the AI Client SDK.
+	 *
+	 * Retries up to MAX_RETRIES times; each attempt extracts, sanitises, and
+	 * validates the AI response before accepting it. Returns WP_Error when all
+	 * retries are exhausted.
+	 *
+	 * @param string $brand_name   Brand name.
+	 * @param string $description  Brand description / vertical.
+	 * @param string $direction    Logo style direction.
+	 * @param string $style_cues   Optional style cues.
+	 * @param int    $index        1-based candidate index.
+	 * @param int    $total        Total candidates requested.
+	 * @return string|\WP_Error Sanitised SVG markup or WP_Error on failure.
+	 */
+	protected function generate_one_candidate(
+		string $brand_name,
+		string $description,
+		string $direction,
+		string $style_cues,
+		int $index,
+		int $total
+	): string|\WP_Error {
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			return new WP_Error(
+				'ai_client_unavailable',
+				__( 'wp_ai_client_prompt() is not available.', 'superdav-ai-agent' )
+			);
+		}
+
+		$direction_map = [
+			'wordmark'        => 'A wordmark (type-only logo) using only custom typography to spell out the brand name.',
+			'monogram'        => 'A monogram logo with the brand initials inside a geometric shape.',
+			'symbol+wordmark' => 'A symbol/icon mark alongside the brand name wordmark.',
+			'symbol'          => 'An abstract or literal symbol/icon mark without text.',
+		];
+
+		$direction_desc = $direction_map[ $direction ] ?? $direction_map['symbol+wordmark'];
+
+		$variety_hint = $total > 1
+			? sprintf(
+				' This is candidate %d of %d — make it visually distinct from the other candidates.',
+				$index,
+				$total
+			)
+			: '';
+
+		$style_context = ! empty( $style_cues ) ? "\nStyle cues: {$style_cues}" : '';
+
+		$system_instruction = <<<'INSTRUCTION'
+You are an expert SVG logo designer. Generate clean, professional SVG logo markup.
+
+CRITICAL RULES:
+1. Return ONLY valid, complete SVG markup — nothing else. No XML declaration, no markdown, no explanations.
+2. The SVG root must have: xmlns="http://www.w3.org/2000/svg", a viewBox attribute (e.g. viewBox="0 0 200 80"), and width/height attributes.
+3. NO <script> elements, NO <foreignObject> elements, NO JavaScript event attributes (onclick, onload, etc.).
+4. NO external URLs in href, xlink:href, src, or any other attribute. All resources must be inline.
+5. NO <image> elements pointing to external URLs.
+6. Use only inline SVG elements: <rect>, <circle>, <ellipse>, <path>, <text>, <g>, <defs>, <clipPath>, <linearGradient>, <radialGradient>, <polygon>, <polyline>, <line>.
+7. Text must use generic font-family stacks only (sans-serif, serif, monospace) — no web font @import.
+8. Keep the file under 20 KB of markup. Prefer geometric shapes over complex paths.
+9. Make it professional, scalable, and brand-appropriate.
+10. Start your response with "<svg" and end with "</svg>".
+INSTRUCTION;
+
+		$prompt = "Create a professional SVG logo for: {$brand_name}\n\nBrand: {$description}\nStyle: {$direction_desc}{$style_context}{$variety_hint}";
+
+		$last_error = null;
+
+		for ( $attempt = 1; $attempt <= self::MAX_RETRIES; $attempt++ ) {
+			$raw = wp_ai_client_prompt( $prompt )
+				->using_system_instruction( $system_instruction )
+				->generate_text();
+
+			if ( is_wp_error( $raw ) ) {
+				$last_error = $raw;
+				continue;
+			}
+
+			$svg = $this->extract_svg( (string) $raw );
+			if ( null === $svg ) {
+				$last_error = new WP_Error( 'no_svg_found', 'AI response contained no SVG markup.' );
+				continue;
+			}
+
+			$sanitized = $this->sanitize_svg( $svg );
+			if ( is_wp_error( $sanitized ) ) {
+				$last_error = $sanitized;
+				continue;
+			}
+
+			$valid = $this->validate_svg( $sanitized );
+			if ( is_wp_error( $valid ) ) {
+				$last_error = $valid;
+				continue;
+			}
+
+			return $sanitized;
+		}
+
+		return $last_error instanceof \WP_Error
+			? $last_error
+			: new WP_Error( 'svg_generation_failed', __( 'Failed to generate a valid SVG after multiple attempts.', 'superdav-ai-agent' ) );
+	}
+
+	// ─── SVG helpers ──────────────────────────────────────────────────────────
+
+	/**
+	 * Extract SVG markup from a raw AI response string.
+	 *
+	 * Handles three common formats:
+	 *   1. Direct `<svg ...>...</svg>` output.
+	 *   2. Markdown code block wrapping (```svg or ```xml).
+	 *   3. Mixed prose with embedded SVG.
+	 *
+	 * @param string $raw Raw AI response.
+	 * @return string|null Extracted SVG markup, or null if not found.
+	 */
+	protected function extract_svg( string $raw ): ?string {
+		$raw = trim( $raw );
+
+		// Fast path: response already starts with <svg.
+		if ( str_starts_with( $raw, '<svg' ) ) {
+			return $raw;
+		}
+
+		// Extract from markdown code block.
+		if ( preg_match( '/```(?:svg|xml)?\s*(<svg[\s\S]*?<\/svg>)\s*```/i', $raw, $matches ) ) {
+			return trim( $matches[1] );
+		}
+
+		// Extract embedded SVG from mixed content.
+		if ( preg_match( '/(<svg[\s\S]*?<\/svg>)/i', $raw, $matches ) ) {
+			return trim( $matches[1] );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Sanitise SVG markup by removing dangerous elements and attributes.
+	 *
+	 * Validates as XML, strips forbidden elements (script, foreignObject),
+	 * removes external image references, and strips all event attributes and
+	 * javascript: URIs from every element.
+	 *
+	 * @param string $svg Raw SVG markup.
+	 * @return string|\WP_Error Sanitised SVG string or WP_Error on failure.
+	 */
+	protected function sanitize_svg( string $svg ): string|\WP_Error {
+		if ( strlen( $svg ) > self::MAX_SVG_BYTES ) {
+			return new WP_Error(
+				'svg_too_large',
+				__( 'Generated SVG exceeds the maximum allowed size (500 KB).', 'superdav-ai-agent' )
+			);
+		}
+
+		$dom = new \DOMDocument();
+		libxml_use_internal_errors( true );
+		$loaded = $dom->loadXML( $svg, LIBXML_NONET );
+		libxml_clear_errors();
+		libxml_use_internal_errors( false );
+
+		if ( ! $loaded ) {
+			return new WP_Error(
+				'svg_parse_failed',
+				__( 'Generated SVG is not valid XML.', 'superdav-ai-agent' )
+			);
+		}
+
+		$this->remove_forbidden_nodes( $dom );
+		$this->strip_dangerous_attributes( $dom );
+
+		$clean = $dom->saveXML( $dom->documentElement );
+		if ( false === $clean || '' === $clean ) {
+			return new WP_Error(
+				'svg_save_failed',
+				__( 'Failed to serialise the sanitised SVG.', 'superdav-ai-agent' )
+			);
+		}
+
+		return $clean;
+	}
+
+	/**
+	 * Validate SVG structure after sanitisation.
+	 *
+	 * Checks that the document is parseable XML, has an <svg> root element with
+	 * a viewBox attribute, and contains at least one child node.
+	 *
+	 * @param string $svg Sanitised SVG markup.
+	 * @return true|\WP_Error True on success, WP_Error describing the violation.
+	 */
+	protected function validate_svg( string $svg ): true|\WP_Error {
+		$dom = new \DOMDocument();
+		libxml_use_internal_errors( true );
+		$loaded = $dom->loadXML( $svg, LIBXML_NONET );
+		libxml_clear_errors();
+		libxml_use_internal_errors( false );
+
+		if ( ! $loaded ) {
+			return new WP_Error(
+				'svg_invalid',
+				__( 'SVG failed final validation parse.', 'superdav-ai-agent' )
+			);
+		}
+
+		$root = $dom->documentElement;
+		if ( ! $root || 'svg' !== strtolower( (string) $root->localName ) ) {
+			return new WP_Error(
+				'svg_no_root',
+				__( 'SVG does not have an <svg> root element.', 'superdav-ai-agent' )
+			);
+		}
+
+		// Accept either capitalisation variant of viewBox.
+		if ( ! $root->hasAttribute( 'viewBox' ) && ! $root->hasAttribute( 'viewbox' ) ) {
+			return new WP_Error(
+				'svg_no_viewbox',
+				__( 'SVG is missing a viewBox attribute.', 'superdav-ai-agent' )
+			);
+		}
+
+		if ( 0 === $root->childNodes->length ) {
+			return new WP_Error(
+				'svg_empty',
+				__( 'SVG has no content.', 'superdav-ai-agent' )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Generate a simple type-only wordmark SVG as a safe fallback.
+	 *
+	 * Produces minimal, valid SVG markup that renders the brand name in a
+	 * system sans-serif font. Used when AI generation fails validation after
+	 * MAX_RETRIES attempts.
+	 *
+	 * @param string $brand_name Brand name to display.
+	 * @return string Valid SVG markup.
+	 */
+	protected function generate_fallback_wordmark( string $brand_name ): string {
+		$safe_name   = htmlspecialchars( $brand_name, ENT_XML1 | ENT_QUOTES, 'UTF-8' );
+		$char_count  = mb_strlen( $brand_name );
+		$width       = max( 120, min( 400, $char_count * 14 + 40 ) );
+		$height      = 60;
+		$text_anchor = intdiv( $width, 2 );
+
+		return sprintf(
+			'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 %1$d %2$d" width="%1$d" height="%2$d">'
+			. '<text x="%3$d" y="40" font-family="sans-serif" font-size="28" font-weight="600" fill="#1a1a1a" text-anchor="middle">%4$s</text>'
+			. '</svg>',
+			$width,
+			$height,
+			$text_anchor,
+			$safe_name
+		);
+	}
+
+	// ─── DOM mutation helpers ─────────────────────────────────────────────────
+
+	/**
+	 * Remove forbidden elements (script, foreignObject) and external <image> refs.
+	 *
+	 * @param \DOMDocument $dom The document to mutate.
+	 */
+	private function remove_forbidden_nodes( \DOMDocument $dom ): void {
+		foreach ( self::FORBIDDEN_ELEMENTS as $tag_name ) {
+			$nodes = $dom->getElementsByTagName( $tag_name );
+			// Iterate in reverse to avoid live NodeList index shifting.
+			for ( $i = $nodes->length - 1; $i >= 0; $i-- ) {
+				$node = $nodes->item( $i );
+				if ( $node instanceof \DOMNode && $node->parentNode instanceof \DOMNode ) {
+					$node->parentNode->removeChild( $node );
+				}
+			}
+		}
+
+		// Strip <image> elements that reference external (non-data) URIs.
+		$images = $dom->getElementsByTagName( 'image' );
+		for ( $i = $images->length - 1; $i >= 0; $i-- ) {
+			$node = $images->item( $i );
+			if ( ! ( $node instanceof \DOMElement ) ) {
+				continue;
+			}
+			$href = $node->getAttribute( 'href' )
+				?: $node->getAttributeNS( 'http://www.w3.org/1999/xlink', 'href' );
+			if ( ! str_starts_with( $href, 'data:' ) ) {
+				if ( $node->parentNode instanceof \DOMNode ) {
+					$node->parentNode->removeChild( $node );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Strip dangerous attributes from every element in the document.
+	 *
+	 * Removes:
+	 *  - Event handlers (any attribute starting with "on").
+	 *  - href / xlink:href pointing to non-fragment, non-data URIs.
+	 *  - Any attribute whose value contains a javascript: URI.
+	 *
+	 * @param \DOMDocument $dom The document to mutate.
+	 */
+	private function strip_dangerous_attributes( \DOMDocument $dom ): void {
+		$xpath        = new \DOMXPath( $dom );
+		$all_elements = $xpath->query( '//*' );
+
+		if ( ! $all_elements instanceof \DOMNodeList ) {
+			return;
+		}
+
+		foreach ( $all_elements as $element ) {
+			if ( ! ( $element instanceof \DOMElement ) ) {
+				continue;
+			}
+
+			$attrs_to_remove = [];
+
+			foreach ( $element->attributes as $attr ) {
+				$name  = strtolower( $attr->name );
+				$value = $attr->value;
+
+				// Remove all event handler attributes.
+				if ( str_starts_with( $name, 'on' ) ) {
+					$attrs_to_remove[] = $attr->name;
+					continue;
+				}
+
+				// Remove external href / xlink:href (keep fragment refs and data URIs).
+				if ( 'xlink:href' === $name || 'href' === $name ) {
+					if (
+						! str_starts_with( $value, '#' )
+						&& ! str_starts_with( $value, 'data:' )
+						&& '' !== $value
+					) {
+						$attrs_to_remove[] = $attr->name;
+					}
+					continue;
+				}
+
+				// Remove any attribute that embeds a javascript: URI.
+				if ( str_contains( strtolower( $value ), 'javascript:' ) ) {
+					$attrs_to_remove[] = $attr->name;
+				}
+			}
+
+			foreach ( $attrs_to_remove as $attr_name ) {
+				$element->removeAttribute( $attr_name );
+			}
+		}
+	}
+
+	// ─── Media library ────────────────────────────────────────────────────────
+
+	/**
+	 * Save SVG content directly to the WordPress media library.
+	 *
+	 * Writes the SVG to the current upload directory and creates an attachment
+	 * post with MIME type `image/svg+xml`. Bypasses `media_handle_sideload()`
+	 * because WordPress's MIME check blocks SVG uploads by default.
+	 *
+	 * @param string $svg  Sanitised SVG markup.
+	 * @param string $slug Filename slug (will be sanitised and made unique).
+	 * @return int|\WP_Error Attachment ID or WP_Error on failure.
+	 */
+	protected function save_svg_to_media_library( string $svg, string $slug ): int|\WP_Error {
+		if ( ! function_exists( 'wp_upload_dir' ) ) {
+			return new WP_Error(
+				'no_upload_dir',
+				__( 'WordPress upload functions are not available.', 'superdav-ai-agent' )
+			);
+		}
+
+		$upload_dir = wp_upload_dir();
+		if ( ! empty( $upload_dir['error'] ) ) {
+			return new WP_Error( 'upload_dir_error', (string) $upload_dir['error'] );
+		}
+
+		$filename = sanitize_file_name( $slug ) . '-' . substr( uniqid( '', false ), -6 ) . '.svg';
+		$filepath = trailingslashit( (string) $upload_dir['path'] ) . $filename;
+		$url      = trailingslashit( (string) $upload_dir['url'] ) . $filename;
+
+		// Write SVG to disk.
+		$written = file_put_contents( $filepath, $svg ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+		if ( false === $written ) {
+			return new WP_Error(
+				'svg_write_failed',
+				__( 'Failed to write SVG file to the uploads directory.', 'superdav-ai-agent' )
+			);
+		}
+
+		if ( ! function_exists( 'wp_insert_attachment' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/image.php';
+			require_once ABSPATH . 'wp-admin/includes/media.php';
+		}
+
+		$attachment = [
+			'post_mime_type' => 'image/svg+xml',
+			'post_title'     => sanitize_text_field( $slug ),
+			'post_content'   => '',
+			'post_status'    => 'inherit',
+			'guid'           => $url,
+		];
+
+		$attachment_id = wp_insert_attachment( $attachment, $filepath, 0 );
+
+		if ( is_wp_error( $attachment_id ) ) {
+			wp_delete_file( $filepath );
+			return $attachment_id;
+		}
+
+		if ( ! is_int( $attachment_id ) || $attachment_id <= 0 ) {
+			wp_delete_file( $filepath );
+			return new WP_Error(
+				'attachment_insert_failed',
+				__( 'Failed to insert SVG attachment into the media library.', 'superdav-ai-agent' )
+			);
+		}
+
+		// Store minimal metadata (SVG has no raster dimensions to introspect).
+		if ( function_exists( '_wp_relative_upload_path' ) ) {
+			update_post_meta(
+				$attachment_id,
+				'_wp_attachment_metadata',
+				[
+					'width'  => 0,
+					'height' => 0,
+					'file'   => _wp_relative_upload_path( $filepath ),
+					'sizes'  => [],
+				]
+			);
+		}
+
+		// Cache the data URI so the UI can render an inline preview without
+		// fetching the file from disk.
+		update_post_meta(
+			$attachment_id,
+			'_sd_ai_agent_svg_data_uri',
+			'data:image/svg+xml;base64,' . base64_encode( $svg ) // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+		);
+
+		return $attachment_id;
+	}
+}

--- a/includes/Abilities/ThemeBuilderAbilities.php
+++ b/includes/Abilities/ThemeBuilderAbilities.php
@@ -65,5 +65,7 @@ class ThemeBuilderAbilities {
 				'ability_class' => ActivateThemeAbility::class,
 			]
 		);
+
+		GenerateLogoSvgAbility::register();
 	}
 }

--- a/includes/Models/Agent.php
+++ b/includes/Models/Agent.php
@@ -626,7 +626,15 @@ class Agent {
 				. "2. Call `sd-ai-agent/skill-load` with `skill_name: block-themes` to load block theme guidance.\n"
 				. "3. In your first question, identify the site vertical (café/restaurant, retail shop, service business, portfolio, blog, event venue, etc.).\n"
 				. "4. Ask **one question at a time** to collect the full information surface for every page you plan to create.\n"
-				. "5. Save gathered site information with `sd-ai-agent/memory-save` (category: site_brief).\n\n"
+				. "5. During the interview, ask whether the user already has a logo (URL or upload). Save the answer with `sd-ai-agent/memory-save` (category: site_brief, key: existing_logo_url).\n"
+				. "6. Save gathered site information with `sd-ai-agent/memory-save` (category: site_brief).\n\n"
+				. "### Logo generation (when no existing logo is available)\n\n"
+				. "If the user does not already have a logo, call `sd-ai-agent/generate-logo-svg` during Phase 1 or at the start of Phase 4 (before building the theme):\n"
+				. "1. Call `sd-ai-agent/generate-logo-svg` with `action: generate`, `brand_name`, `description`, and optionally `direction` and `style_cues` from the site brief.\n"
+				. "2. Present the returned candidates to the user by showing their `data_uri` inline previews or `url` links. Ask the user to pick one.\n"
+				. "3. Once the user has chosen, call `sd-ai-agent/generate-logo-svg` with `action: select_candidate` and the chosen `attachment_id` to activate it as the site logo.\n"
+				. "4. If `fallback: true` is returned, explain to the user that a type-only wordmark was generated instead of an AI-designed mark, and offer to retry with different style cues.\n"
+				. "5. If the user already has a logo (`existing_logo_url` is set), pass `existing_logo_url` to skip generation.\n\n"
 				. "### Vertical-aware interview question packs\n\n"
 				. "After detecting the vertical, collect the following before creating any pages. Ask one question at a time.\n\n"
 				. "**Café / Coffee shop / Restaurant:**\n"
@@ -746,6 +754,7 @@ class Agent {
 							'sd-ai-agent/file-write',
 							'sd-ai-agent/validate-block-content',
 							'sd-ai-agent/get-theme-json',
+							'sd-ai-agent/generate-logo-svg',
 						]
 					)
 				)

--- a/tests/SdAiAgent/Abilities/GenerateLogoSvgAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/GenerateLogoSvgAbilityTest.php
@@ -1,0 +1,558 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Unit tests for GenerateLogoSvgAbility (GH#1527).
+ *
+ * Covers parse-and-validate, sanitisation, fallback wordmark, SVG extraction,
+ * and site-logo selection wiring as required by the acceptance criteria.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Abilities;
+
+use SdAiAgent\Abilities\GenerateLogoSvgAbility;
+use WP_UnitTestCase;
+
+/**
+ * Test GenerateLogoSvgAbility.
+ *
+ * Protected helpers (sanitize_svg, validate_svg, extract_svg,
+ * generate_fallback_wordmark, save_svg_to_media_library) are exercised via PHP
+ * Reflection so their logic can be tested independently of the AI provider.
+ */
+class GenerateLogoSvgAbilityTest extends WP_UnitTestCase {
+
+	/**
+	 * The ability under test.
+	 *
+	 * @var GenerateLogoSvgAbility
+	 */
+	private GenerateLogoSvgAbility $ability;
+
+	/**
+	 * Attachment IDs created during tests — removed in tearDown.
+	 *
+	 * @var array<int,int>
+	 */
+	private array $created_attachments = [];
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->ability = new GenerateLogoSvgAbility( 'sd-ai-agent/generate-logo-svg' );
+	}
+
+	public function tearDown(): void {
+		foreach ( $this->created_attachments as $id ) {
+			wp_delete_attachment( $id, true );
+		}
+		remove_theme_mod( 'custom_logo' );
+		delete_option( 'site_icon' );
+		parent::tearDown();
+	}
+
+	// ─── Input validation ─────────────────────────────────────────────────────
+
+	/**
+	 * generate action with empty brand_name returns WP_Error.
+	 */
+	public function test_generate_missing_brand_name_returns_wp_error(): void {
+		$result = $this->ability->run( [
+			'action'      => 'generate',
+			'brand_name'  => '',
+			'description' => 'A coffee shop.',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'missing_brand_name', $result->get_error_code() );
+	}
+
+	/**
+	 * generate action with missing brand_name returns WP_Error.
+	 */
+	public function test_generate_absent_brand_name_returns_wp_error(): void {
+		$result = $this->ability->run( [
+			'description' => 'A coffee shop.',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'missing_brand_name', $result->get_error_code() );
+	}
+
+	/**
+	 * generate action with empty description returns WP_Error.
+	 */
+	public function test_generate_missing_description_returns_wp_error(): void {
+		$result = $this->ability->run( [
+			'action'      => 'generate',
+			'brand_name'  => 'BeanBrew',
+			'description' => '',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'missing_description', $result->get_error_code() );
+	}
+
+	/**
+	 * When existing_logo_url is non-empty the ability returns immediately
+	 * without generating any candidates.
+	 */
+	public function test_generate_preserves_existing_logo(): void {
+		$result = $this->ability->run( [
+			'brand_name'        => 'BeanBrew',
+			'description'       => 'Specialty coffee.',
+			'existing_logo_url' => 'https://example.com/logo.png',
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['existing_logo_preserved'] );
+		$this->assertEmpty( $result['candidates'] );
+		$this->assertFalse( $result['logo_set'] );
+	}
+
+	// ─── select_candidate ────────────────────────────────────────────────────
+
+	/**
+	 * select_candidate with zero attachment_id returns WP_Error.
+	 */
+	public function test_select_candidate_missing_id_returns_wp_error(): void {
+		$result = $this->ability->run( [
+			'action'        => 'select_candidate',
+			'attachment_id' => 0,
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'missing_attachment_id', $result->get_error_code() );
+	}
+
+	/**
+	 * select_candidate with absent attachment_id returns WP_Error.
+	 */
+	public function test_select_candidate_absent_id_returns_wp_error(): void {
+		$result = $this->ability->run( [ 'action' => 'select_candidate' ] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'missing_attachment_id', $result->get_error_code() );
+	}
+
+	/**
+	 * select_candidate with a non-existent attachment ID returns WP_Error.
+	 */
+	public function test_select_candidate_invalid_attachment_id_returns_wp_error(): void {
+		$result = $this->ability->run( [
+			'action'        => 'select_candidate',
+			'attachment_id' => PHP_INT_MAX,
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'invalid_attachment_id', $result->get_error_code() );
+	}
+
+	/**
+	 * select_candidate with a valid attachment ID sets the custom_logo theme mod
+	 * and returns logo_set = true.
+	 */
+	public function test_select_candidate_sets_site_logo(): void {
+		// Create a real attachment for the test.
+		$attachment_id = $this->create_test_svg_attachment();
+		$this->assertGreaterThan( 0, $attachment_id, 'Fixture attachment must be created successfully.' );
+
+		$result = $this->ability->run( [
+			'action'        => 'select_candidate',
+			'attachment_id' => $attachment_id,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['logo_set'] );
+		$this->assertSame( $attachment_id, $result['selected_attachment_id'] );
+
+		// Verify the theme mod was actually set.
+		$this->assertSame( $attachment_id, (int) get_theme_mod( 'custom_logo' ) );
+	}
+
+	/**
+	 * select_candidate wires site_icon option for SVG attachments.
+	 */
+	public function test_select_candidate_sets_site_icon_for_svg(): void {
+		$attachment_id = $this->create_test_svg_attachment();
+		$this->assertGreaterThan( 0, $attachment_id );
+
+		$this->ability->run( [
+			'action'        => 'select_candidate',
+			'attachment_id' => $attachment_id,
+		] );
+
+		$this->assertSame( $attachment_id, (int) get_option( 'site_icon' ) );
+	}
+
+	// ─── sanitize_svg ────────────────────────────────────────────────────────
+
+	/**
+	 * A clean, minimal SVG passes sanitisation unchanged (no dangerous nodes).
+	 */
+	public function test_sanitize_svg_passes_clean_svg(): void {
+		$svg    = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50" width="100" height="50"><rect x="0" y="0" width="100" height="50" fill="#abc"/></svg>';
+		$result = $this->call_protected( 'sanitize_svg', $svg );
+
+		$this->assertIsString( $result );
+		$this->assertStringContainsString( '<rect', $result );
+	}
+
+	/**
+	 * sanitize_svg strips <script> elements.
+	 */
+	public function test_sanitize_svg_removes_script_element(): void {
+		$svg    = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50" width="100" height="50"><script>alert(1)</script><rect x="0" y="0" width="100" height="50" fill="#f00"/></svg>';
+		$result = $this->call_protected( 'sanitize_svg', $svg );
+
+		$this->assertIsString( $result );
+		$this->assertStringNotContainsString( '<script', $result );
+		$this->assertStringNotContainsString( 'alert(1)', $result );
+	}
+
+	/**
+	 * sanitize_svg strips <foreignObject> elements.
+	 */
+	public function test_sanitize_svg_removes_foreignobject_element(): void {
+		$svg    = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50" width="100" height="50"><foreignObject width="100" height="50"><div xmlns="http://www.w3.org/1999/xhtml">evil</div></foreignObject></svg>';
+		$result = $this->call_protected( 'sanitize_svg', $svg );
+
+		$this->assertIsString( $result );
+		$this->assertStringNotContainsString( 'foreignObject', $result );
+		$this->assertStringNotContainsString( 'evil', $result );
+	}
+
+	/**
+	 * sanitize_svg strips event handler attributes (onclick, onload, etc.).
+	 */
+	public function test_sanitize_svg_removes_event_attributes(): void {
+		$svg    = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50" width="100" height="50"><rect onclick="alert(1)" onload="steal()" x="0" y="0" width="100" height="50" fill="#0f0"/></svg>';
+		$result = $this->call_protected( 'sanitize_svg', $svg );
+
+		$this->assertIsString( $result );
+		$this->assertStringNotContainsString( 'onclick', $result );
+		$this->assertStringNotContainsString( 'onload', $result );
+		$this->assertStringNotContainsString( 'alert(1)', $result );
+	}
+
+	/**
+	 * sanitize_svg strips external xlink:href references.
+	 */
+	public function test_sanitize_svg_removes_external_xlink_href(): void {
+		$svg    = '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 100 50" width="100" height="50"><use xlink:href="https://evil.example/sprite.svg#icon"/></svg>';
+		$result = $this->call_protected( 'sanitize_svg', $svg );
+
+		$this->assertIsString( $result );
+		$this->assertStringNotContainsString( 'https://evil.example', $result );
+	}
+
+	/**
+	 * sanitize_svg strips attributes containing javascript: URIs.
+	 */
+	public function test_sanitize_svg_removes_javascript_uri_attributes(): void {
+		$svg    = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50" width="100" height="50"><a href="javascript:alert(1)"><rect x="0" y="0" width="100" height="50" fill="#00f"/></a></svg>';
+		$result = $this->call_protected( 'sanitize_svg', $svg );
+
+		$this->assertIsString( $result );
+		$this->assertStringNotContainsString( 'javascript:', $result );
+	}
+
+	/**
+	 * sanitize_svg strips <image> elements with external (non-data) src.
+	 */
+	public function test_sanitize_svg_removes_external_image_element(): void {
+		$svg    = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50" width="100" height="50"><image href="https://tracker.example/pixel.png" width="1" height="1"/></svg>';
+		$result = $this->call_protected( 'sanitize_svg', $svg );
+
+		$this->assertIsString( $result );
+		$this->assertStringNotContainsString( 'https://tracker.example', $result );
+	}
+
+	/**
+	 * sanitize_svg returns WP_Error for invalid XML.
+	 */
+	public function test_sanitize_svg_rejects_invalid_xml(): void {
+		$result = $this->call_protected( 'sanitize_svg', '<svg><unclosed>' );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'svg_parse_failed', $result->get_error_code() );
+	}
+
+	/**
+	 * sanitize_svg returns WP_Error when SVG exceeds 500 KB.
+	 */
+	public function test_sanitize_svg_rejects_oversized_content(): void {
+		// Create an SVG with enough padding to exceed MAX_SVG_BYTES (512 000).
+		$padding = str_repeat( 'x', 520000 );
+		$svg     = "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 50\">{$padding}</svg>";
+
+		$result = $this->call_protected( 'sanitize_svg', $svg );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'svg_too_large', $result->get_error_code() );
+	}
+
+	// ─── validate_svg ────────────────────────────────────────────────────────
+
+	/**
+	 * validate_svg returns true for a well-formed SVG with viewBox.
+	 */
+	public function test_validate_svg_accepts_valid_svg(): void {
+		$svg    = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50" width="100" height="50"><rect x="0" y="0" width="100" height="50" fill="#abc"/></svg>';
+		$result = $this->call_protected( 'validate_svg', $svg );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * validate_svg returns WP_Error when viewBox is absent.
+	 */
+	public function test_validate_svg_rejects_missing_viewbox(): void {
+		$svg    = '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50"><rect x="0" y="0" width="100" height="50" fill="#abc"/></svg>';
+		$result = $this->call_protected( 'validate_svg', $svg );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'svg_no_viewbox', $result->get_error_code() );
+	}
+
+	/**
+	 * validate_svg returns WP_Error when the root element is not <svg>.
+	 */
+	public function test_validate_svg_rejects_non_svg_root(): void {
+		$svg    = '<div xmlns="http://www.w3.org/1999/xhtml" viewBox="0 0 100 50"><p>not an svg</p></div>';
+		$result = $this->call_protected( 'validate_svg', $svg );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'svg_no_root', $result->get_error_code() );
+	}
+
+	/**
+	 * validate_svg returns WP_Error for non-parseable markup.
+	 */
+	public function test_validate_svg_rejects_invalid_xml(): void {
+		$result = $this->call_protected( 'validate_svg', 'not xml at all' );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'svg_invalid', $result->get_error_code() );
+	}
+
+	// ─── extract_svg ─────────────────────────────────────────────────────────
+
+	/**
+	 * extract_svg returns direct SVG markup unchanged.
+	 */
+	public function test_extract_svg_returns_direct_svg(): void {
+		$svg    = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50"><rect/></svg>';
+		$result = $this->call_protected( 'extract_svg', $svg );
+
+		$this->assertSame( $svg, $result );
+	}
+
+	/**
+	 * extract_svg extracts SVG from a markdown ```svg code block.
+	 */
+	public function test_extract_svg_from_svg_code_block(): void {
+		$svg  = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50"><circle cx="50" cy="25" r="25"/></svg>';
+		$raw  = "Here is your logo:\n\n```svg\n{$svg}\n```\n";
+		$result = $this->call_protected( 'extract_svg', $raw );
+
+		$this->assertSame( $svg, $result );
+	}
+
+	/**
+	 * extract_svg extracts SVG from a markdown ```xml code block.
+	 */
+	public function test_extract_svg_from_xml_code_block(): void {
+		$svg    = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50"><rect x="0" y="0" width="100" height="50"/></svg>';
+		$raw    = "```xml\n{$svg}\n```";
+		$result = $this->call_protected( 'extract_svg', $raw );
+
+		$this->assertSame( $svg, $result );
+	}
+
+	/**
+	 * extract_svg extracts SVG embedded in prose.
+	 */
+	public function test_extract_svg_from_prose(): void {
+		$svg    = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50"><text x="10" y="30">Brand</text></svg>';
+		$raw    = "Sure, here is the logo: {$svg} Hope you like it!";
+		$result = $this->call_protected( 'extract_svg', $raw );
+
+		$this->assertSame( $svg, $result );
+	}
+
+	/**
+	 * extract_svg returns null when no SVG markup is present.
+	 */
+	public function test_extract_svg_returns_null_when_not_found(): void {
+		$result = $this->call_protected( 'extract_svg', 'Sorry, I cannot generate an SVG right now.' );
+
+		$this->assertNull( $result );
+	}
+
+	// ─── generate_fallback_wordmark ───────────────────────────────────────────
+
+	/**
+	 * generate_fallback_wordmark produces valid SVG that passes validation.
+	 */
+	public function test_fallback_wordmark_produces_valid_svg(): void {
+		$svg   = $this->call_protected( 'generate_fallback_wordmark', 'BeanBrew' );
+		$valid = $this->call_protected( 'validate_svg', $svg );
+
+		$this->assertIsString( $svg );
+		$this->assertTrue( $valid, 'Fallback wordmark must pass validate_svg.' );
+	}
+
+	/**
+	 * generate_fallback_wordmark escapes HTML special characters in brand name.
+	 */
+	public function test_fallback_wordmark_escapes_special_chars(): void {
+		$svg = $this->call_protected( 'generate_fallback_wordmark', 'B&B <Bistro>' );
+
+		$this->assertIsString( $svg );
+		$this->assertStringContainsString( '&amp;', $svg );
+		$this->assertStringContainsString( '&lt;', $svg );
+		$this->assertStringNotContainsString( '<Bistro>', $svg );
+	}
+
+	/**
+	 * generate_fallback_wordmark includes the brand name in the output.
+	 */
+	public function test_fallback_wordmark_includes_brand_name(): void {
+		$svg = $this->call_protected( 'generate_fallback_wordmark', 'PixelCraft' );
+
+		$this->assertStringContainsString( 'PixelCraft', $svg );
+	}
+
+	// ─── save_svg_to_media_library ────────────────────────────────────────────
+
+	/**
+	 * save_svg_to_media_library creates an attachment with image/svg+xml MIME type.
+	 */
+	public function test_save_svg_creates_attachment_with_svg_mime(): void {
+		$svg           = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50" width="100" height="50"><rect x="0" y="0" width="100" height="50" fill="#abc"/></svg>';
+		$attachment_id = $this->call_protected( 'save_svg_to_media_library', $svg, 'test-logo' );
+
+		if ( is_wp_error( $attachment_id ) ) {
+			$this->fail( 'save_svg_to_media_library returned WP_Error: ' . $attachment_id->get_error_message() );
+		}
+
+		$this->created_attachments[] = $attachment_id;
+		$this->assertIsInt( $attachment_id );
+		$this->assertGreaterThan( 0, $attachment_id );
+
+		$mime = get_post_mime_type( $attachment_id );
+		$this->assertSame( 'image/svg+xml', $mime );
+	}
+
+	/**
+	 * save_svg_to_media_library stores a data URI in post meta for inline preview.
+	 */
+	public function test_save_svg_stores_data_uri_meta(): void {
+		$svg           = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50" width="100" height="50"><rect x="0" y="0" width="100" height="50" fill="#abc"/></svg>';
+		$attachment_id = $this->call_protected( 'save_svg_to_media_library', $svg, 'test-logo-meta' );
+
+		if ( is_wp_error( $attachment_id ) ) {
+			$this->markTestSkipped( 'Attachment creation failed: ' . $attachment_id->get_error_message() );
+		}
+
+		$this->created_attachments[] = $attachment_id;
+		$data_uri = get_post_meta( $attachment_id, '_sd_ai_agent_svg_data_uri', true );
+
+		$this->assertNotEmpty( $data_uri );
+		$this->assertStringStartsWith( 'data:image/svg+xml;base64,', $data_uri );
+	}
+
+	// ─── end-to-end via run() when AI is unavailable ──────────────────────────
+
+	/**
+	 * When wp_ai_client_prompt is not available, generate falls back to the
+	 * type-only wordmark and still returns valid candidates.
+	 *
+	 * In the PHPUnit environment the WP AI Client SDK is not loaded, so
+	 * generate_one_candidate() always returns a WP_Error which triggers the
+	 * fallback path.
+	 */
+	public function test_generate_falls_back_to_wordmark_without_ai_provider(): void {
+		$result = $this->ability->run( [
+			'brand_name'  => 'TestBrand',
+			'description' => 'A test service business.',
+			'count'       => 1,
+		] );
+
+		// In the test environment the AI client SDK is not available, so we
+		// expect either a fallback wordmark result or a generation_failed error.
+		// Both are valid outcomes — the key assertion is no exception is thrown.
+		$this->assertTrue(
+			is_array( $result ) || is_wp_error( $result ),
+			'run() must return an array or WP_Error, not throw.'
+		);
+
+		if ( is_array( $result ) && ! empty( $result['candidates'] ) ) {
+			// If candidates were generated, fallback flag must be true since AI is unavailable.
+			$this->assertTrue( $result['fallback'], 'fallback must be true when AI provider is unavailable.' );
+			foreach ( $result['candidates'] as $candidate ) {
+				$this->assertArrayHasKey( 'attachment_id', $candidate );
+				$this->assertArrayHasKey( 'data_uri', $candidate );
+				$this->created_attachments[] = (int) $candidate['attachment_id'];
+			}
+		}
+	}
+
+	// ─── Helpers ─────────────────────────────────────────────────────────────
+
+	/**
+	 * Call a protected method on the ability instance via reflection.
+	 *
+	 * @param string $method_name  The protected method name.
+	 * @param mixed  ...$args      Arguments to pass to the method.
+	 * @return mixed               The return value.
+	 */
+	private function call_protected( string $method_name, mixed ...$args ): mixed {
+		$method = new \ReflectionMethod( GenerateLogoSvgAbility::class, $method_name );
+		$method->setAccessible( true );
+		return $method->invokeArgs( $this->ability, $args );
+	}
+
+	/**
+	 * Create a minimal SVG attachment for testing select_candidate.
+	 *
+	 * @return int Attachment ID.
+	 */
+	private function create_test_svg_attachment(): int {
+		$upload_dir = wp_upload_dir();
+		if ( ! empty( $upload_dir['error'] ) ) {
+			$this->markTestSkipped( 'Upload directory not available: ' . $upload_dir['error'] );
+		}
+
+		$svg      = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50" width="100" height="50"><rect x="0" y="0" width="100" height="50" fill="#abc"/></svg>';
+		$filename = 'test-logo-fixture-' . substr( uniqid( '', false ), -6 ) . '.svg';
+		$filepath = trailingslashit( (string) $upload_dir['path'] ) . $filename;
+		$url      = trailingslashit( (string) $upload_dir['url'] ) . $filename;
+
+		file_put_contents( $filepath, $svg ); // phpcs:ignore WordPress.WP.AlternativeFunctions
+
+		$attachment_id = wp_insert_attachment(
+			[
+				'post_mime_type' => 'image/svg+xml',
+				'post_title'     => 'Test Logo Fixture',
+				'post_content'   => '',
+				'post_status'    => 'inherit',
+				'guid'           => $url,
+			],
+			$filepath,
+			0
+		);
+
+		if ( is_wp_error( $attachment_id ) || ! is_int( $attachment_id ) || $attachment_id <= 0 ) {
+			$this->markTestSkipped( 'Could not create fixture attachment.' );
+		}
+
+		$this->created_attachments[] = $attachment_id;
+
+		return $attachment_id;
+	}
+}


### PR DESCRIPTION
## Summary

Implements issue #1527 — generates sanitised SVG logo candidates for the Theme Builder. Adds the `GenerateLogoSvgAbility`, 558 lines of new test coverage, and updates the Theme Builder agent prompt.

## Files Changed

- `includes/Abilities/GenerateLogoSvgAbility.php` (new)
- `tests/SdAiAgent/Abilities/GenerateLogoSvgAbilityTest.php` (new, 558 lines)
- `includes/Models/Agent.php`
- Additional supporting files

See `git log origin/main..HEAD` and `git diff --stat origin/main..HEAD` for the full file list.

## Worker self-verification

**INCOMPLETE — worker exited during verify phase.** The headless worker hit `service_interruption_exhausted` (exit code 81, `local_error`) at 2026-05-20T00:19:09Z after the implementation and `style:` cleanup commits but before pushing the branch or completing the full `npm run verify` summary. The commits were preserved on the local worktree and pushed manually by the maintainer.

**Verification status: defer to CI.** The required PHPUnit / PHPCS / PHPStan / lint / build workflows in `.github/workflows/` will run the full suite on this PR. If any check fails, this PR will be closed and the issue re-dispatched per the Worker Self-Verification Protocol (`AGENTS.md`).

Resolves #1527


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI-powered SVG logo generation with automatic safety validation
  * Users can generate multiple logo candidates and select their preferred option
  * Generated logos automatically integrate with WordPress site and branding settings
  * Includes fallback wordmark generation for reliability

* **Tests**
  * Added comprehensive test suite for logo generation validation and safety features

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1543?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->