### PR TITLE
GH#1528: feat(stock-image): candidate selection and attribution for Theme Builder

### DIFF
--- a/includes/Abilities/ImageAbilities/StockImageAbility.php
+++ b/includes/Abilities/ImageAbilities/StockImageAbility.php
@@ -2,10 +2,15 @@
 
 declare(strict_types=1);
 /**
- * Stock image ability — search and import free stock photos.
+ * Stock image ability — search candidates and/or import free stock photos.
  *
- * Searches Openverse (CC0) or Pixabay for a keyword and imports the result
- * into the WordPress media library. Never falls back to AI generation.
+ * Supports two actions:
+ * - search: Returns a list of candidate stock images (no import). Use when
+ *   presenting choices to the user before deciding which image to import.
+ * - import: Downloads and imports a specific image (by provider + image_id)
+ *   or auto-picks the first viable hit from any available free source.
+ *
+ * Never falls back to AI generation. Use sd-ai-agent/generate-image for that.
  *
  * @package SdAiAgent
  * @license GPL-2.0-or-later
@@ -39,7 +44,7 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 			'sd-ai-agent/stock-image',
 			[
 				'label'         => __( 'Stock Image', 'superdav-ai-agent' ),
-				'description'   => __( 'Search for a free stock photo by keyword (Openverse CC0 or Pixabay) and import it into the media library. Returns attachment ID and URL. Use this when you need a real photograph or illustration from existing stock libraries.', 'superdav-ai-agent' ),
+				'description'   => __( 'Search for free stock photos (Openverse CC0 or Pixabay) and optionally import a selected result into the media library. Use action=search to get candidates with thumbnails and attribution, then action=import to import a specific one. Returns attachment ID and local URL after import.', 'superdav-ai-agent' ),
 				'ability_class' => self::class,
 			]
 		);
@@ -56,7 +61,7 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 	 * {@inheritdoc}
 	 */
 	protected function description(): string {
-		return __( 'Search for a free stock photo by keyword (Openverse CC0 or Pixabay) and import it into the media library. Returns attachment ID and URL. Use this when you need a real photograph or illustration from existing stock libraries.', 'superdav-ai-agent' );
+		return __( 'Search for free stock photos (Openverse CC0 or Pixabay) and optionally import a selected result into the media library. Use action=search to get candidates with thumbnails and attribution, then action=import to import a specific one. Returns attachment ID and local URL after import.', 'superdav-ai-agent' );
 	}
 
 	/**
@@ -66,19 +71,54 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 		return [
 			'type'       => 'object',
 			'properties' => [
-				'keyword'  => [
+				'keyword'     => [
 					'type'        => 'string',
 					'description' => 'Search term for finding a relevant stock photo (e.g. "mountain landscape", "coffee shop", "team meeting").',
 				],
-				'width'    => [
-					'type'        => 'integer',
-					'description' => 'Desired image width in pixels (default: 1200).',
+				'action'      => [
+					'type'        => 'string',
+					'enum'        => [ 'search', 'import' ],
+					'description' => 'Use "search" to retrieve a list of candidate images with thumbnails and attribution (no import). Use "import" to download and add a specific image to the media library. If omitted, the first available result is automatically imported (backward-compatible).',
 				],
-				'height'   => [
-					'type'        => 'integer',
-					'description' => 'Desired image height in pixels (default: 800).',
+				'image_id'    => [
+					'type'        => 'string',
+					'description' => 'Provider image ID returned by a previous search. Required when action=import with a specific provider.',
 				],
-				'site_url' => [
+				'provider'    => [
+					'type'        => 'string',
+					'enum'        => [ 'openverse', 'pixabay' ],
+					'description' => 'Restrict search or import to a specific provider. When action=import, this identifies which provider image_id belongs to.',
+				],
+				'limit'       => [
+					'type'        => 'integer',
+					'description' => 'Maximum number of candidates to return in search mode (default: 5, max: 20).',
+				],
+				'orientation' => [
+					'type'        => 'string',
+					'enum'        => [ 'landscape', 'portrait', 'squarish' ],
+					'description' => 'Preferred image orientation.',
+				],
+				'colour'      => [
+					'type'        => 'string',
+					'description' => 'Dominant colour filter (e.g. "blue", "green", "red"). Provider-specific; not all providers support every colour.',
+				],
+				'min_width'   => [
+					'type'        => 'integer',
+					'description' => 'Minimum image width in pixels.',
+				],
+				'min_height'  => [
+					'type'        => 'integer',
+					'description' => 'Minimum image height in pixels.',
+				],
+				'width'       => [
+					'type'        => 'integer',
+					'description' => 'Desired image width in pixels for import (default: 1200).',
+				],
+				'height'      => [
+					'type'        => 'integer',
+					'description' => 'Desired image height in pixels for import (default: 800).',
+				],
+				'site_url'    => [
 					'type'        => 'string',
 					'description' => 'Subsite URL to import into on multisite (e.g. "https://example.com/mysite"). Omit for the main site.',
 				],
@@ -94,11 +134,33 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 		return [
 			'type'       => 'object',
 			'properties' => [
+				// Search-mode output.
+				'candidates'    => [
+					'type'        => 'array',
+					'description' => 'List of candidate images returned in search mode.',
+					'items'       => [
+						'type'       => 'object',
+						'properties' => [
+							'image_id'    => [ 'type' => 'string' ],
+							'provider'    => [ 'type' => 'string' ],
+							'thumbnail'   => [ 'type' => 'string' ],
+							'width'       => [ 'type' => 'integer' ],
+							'height'      => [ 'type' => 'integer' ],
+							'licence'     => [ 'type' => 'string' ],
+							'attribution' => [ 'type' => 'string' ],
+							'title'       => [ 'type' => 'string' ],
+						],
+					],
+				],
+				'total'         => [ 'type' => 'integer' ],
+				// Import-mode output.
 				'attachment_id' => [ 'type' => 'integer' ],
 				'url'           => [ 'type' => 'string' ],
 				'alt'           => [ 'type' => 'string' ],
 				'title'         => [ 'type' => 'string' ],
 				'source'        => [ 'type' => 'string' ],
+				'attribution'   => [ 'type' => 'string' ],
+				// Shared.
 				'error'         => [ 'type' => 'string' ],
 				'tip'           => [ 'type' => 'string' ],
 			],
@@ -141,6 +203,10 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 	protected function execute_callback( mixed $input ): array|\WP_Error {
 		// @phpstan-ignore-next-line
 		$keyword  = sanitize_text_field( $input['keyword'] ?? '' );
+		$action   = sanitize_key( $input['action'] ?? '' );
+		$image_id = sanitize_text_field( $input['image_id'] ?? '' );
+		$provider = sanitize_key( $input['provider'] ?? '' );
+		$limit    = min( (int) ( $input['limit'] ?? 5 ), 20 );
 		$width    = (int) ( $input['width'] ?? 1200 );
 		$height   = (int) ( $input['height'] ?? 800 );
 		$site_url = sanitize_text_field( $input['site_url'] ?? '' );
@@ -149,6 +215,27 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 			return new WP_Error( 'missing_keyword', 'keyword is required.' );
 		}
 
+		$filters = array_filter(
+			[
+				'orientation' => sanitize_key( $input['orientation'] ?? '' ),
+				'colour'      => sanitize_text_field( $input['colour'] ?? '' ),
+				'min_width'   => (int) ( $input['min_width'] ?? 0 ),
+				'min_height'  => (int) ( $input['min_height'] ?? 0 ),
+			],
+			static fn( mixed $v ): bool => ( is_int( $v ) ? $v > 0 : '' !== $v )
+		);
+
+		// ── action=search: return candidates without importing ────────────────
+		if ( 'search' === $action ) {
+			return $this->handle_search( $keyword, $limit, $provider, $filters );
+		}
+
+		// ── action=import with specific provider + image_id ───────────────────
+		if ( 'import' === $action && '' !== $image_id && '' !== $provider ) {
+			return $this->handle_import_by_id( $keyword, $provider, $image_id, $width, $height, $site_url );
+		}
+
+		// ── Default (auto) / action=import without image_id: original behavior ─
 		// Verify at least one free source is configured before attempting import.
 		$has_free = false;
 		foreach ( ImageSourceFactory::get_available() as $s ) {
@@ -158,9 +245,6 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 			}
 		}
 
-		// Only suggest the AI-generation fallback when an image-capable
-		// provider is actually configured; otherwise the tip points at a
-		// dead end. Mirrors the gate used inside GenerateImageAbility itself.
 		$can_generate = function_exists( 'wp_ai_client_prompt' )
 			&& wp_ai_client_prompt()->is_supported_for_image_generation();
 		$generate_tip = 'Use sd-ai-agent/generate-image to create an AI-generated image instead.';
@@ -172,6 +256,7 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 				'alt'           => '',
 				'title'         => '',
 				'source'        => '',
+				'attribution'   => '',
 				'error'         => 'No free stock image source is available. Configure Openverse or Pixabay.',
 			];
 			if ( $can_generate ) {
@@ -180,12 +265,10 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 			return $response;
 		}
 
-		// Let the factory try all available free sources in priority order
-		// (openverse → pixabay) before giving up. Never fall back to AI generation —
-		// this ability is explicitly for stock images only.
 		$options = [
 			'site_url'             => $site_url,
 			'no_generate_fallback' => true,
+			'filters'              => $filters,
 		];
 
 		$result = ImageSourceFactory::import_image( $keyword, '', $width, $height, $options );
@@ -197,11 +280,93 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 				'alt'           => '',
 				'title'         => '',
 				'source'        => '',
+				'attribution'   => '',
 				// Error message from the factory lists each source tried and why it failed.
 				'error'         => $result->get_error_message(),
 			];
 			if ( $can_generate ) {
 				$response['tip'] = $generate_tip;
+			}
+			return $response;
+		}
+
+		$result['tip'] = 'Use attachment_id as featured_image_id when calling create-post or update-post.';
+
+		return $result;
+	}
+
+	/**
+	 * Return candidate images without importing.
+	 *
+	 * @param string $keyword  Search keyword.
+	 * @param int    $limit    Maximum candidates.
+	 * @param string $provider Provider restriction (empty = all free sources).
+	 * @param array  $filters  Optional search filters.
+	 * @return array|\WP_Error Candidates array or error.
+	 */
+	private function handle_search(
+		string $keyword,
+		int $limit,
+		string $provider,
+		array $filters
+	): array|\WP_Error {
+		$result = ImageSourceFactory::search_candidates( $keyword, $limit, $provider, $filters );
+
+		if ( is_wp_error( $result ) ) {
+			return [
+				'candidates' => [],
+				'total'      => 0,
+				'error'      => $result->get_error_message(),
+				'tip'        => 'Call again with action=import and image_id + provider to import a specific image.',
+			];
+		}
+
+		$result['tip'] = 'Present these candidates to the user, then call again with action=import and image_id + provider to import the selected image.';
+
+		return $result;
+	}
+
+	/**
+	 * Import a specific image by provider and image ID.
+	 *
+	 * @param string $keyword   Original search keyword (used as alt/title base).
+	 * @param string $provider  Provider ID.
+	 * @param string $image_id  Provider-specific image ID.
+	 * @param int    $width     Desired width.
+	 * @param int    $height    Desired height.
+	 * @param string $site_url  Multisite subsite URL.
+	 * @return array|\WP_Error Result or error.
+	 */
+	private function handle_import_by_id(
+		string $keyword,
+		string $provider,
+		string $image_id,
+		int $width,
+		int $height,
+		string $site_url
+	): array|\WP_Error {
+		$options = [
+			'site_url' => $site_url,
+			'keyword'  => $keyword,
+		];
+
+		$result = ImageSourceFactory::import_by_provider_id( $provider, $image_id, $width, $height, $options );
+
+		if ( is_wp_error( $result ) ) {
+			$can_generate = function_exists( 'wp_ai_client_prompt' )
+				&& wp_ai_client_prompt()->is_supported_for_image_generation();
+
+			$response = [
+				'attachment_id' => 0,
+				'url'           => '',
+				'alt'           => '',
+				'title'         => '',
+				'source'        => '',
+				'attribution'   => '',
+				'error'         => $result->get_error_message(),
+			];
+			if ( $can_generate ) {
+				$response['tip'] = 'Use sd-ai-agent/generate-image to create an AI-generated image instead.';
 			}
 			return $response;
 		}

--- a/includes/Abilities/ImageAbilities/StockImageAbility.php
+++ b/includes/Abilities/ImageAbilities/StockImageAbility.php
@@ -298,18 +298,21 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 	/**
 	 * Return candidate images without importing.
 	 *
-	 * @param string $keyword  Search keyword.
-	 * @param int    $limit    Maximum candidates.
-	 * @param string $provider Provider restriction (empty = all free sources).
-	 * @param array  $filters  Optional search filters.
-	 * @return array|\WP_Error Candidates array or error.
+	 * Always returns an array: on factory error, the WP_Error is converted to
+	 * an array with an 'error' key so the agent loop can surface the message.
+	 *
+	 * @param string               $keyword  Search keyword.
+	 * @param int                  $limit    Maximum candidates.
+	 * @param string               $provider Provider restriction (empty = all free sources).
+	 * @param array<string, mixed> $filters  Optional search filters.
+	 * @return array<string, mixed> Candidates array (with optional 'error' key on failure).
 	 */
 	private function handle_search(
 		string $keyword,
 		int $limit,
 		string $provider,
 		array $filters
-	): array|\WP_Error {
+	): array {
 		$result = ImageSourceFactory::search_candidates( $keyword, $limit, $provider, $filters );
 
 		if ( is_wp_error( $result ) ) {
@@ -329,13 +332,16 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 	/**
 	 * Import a specific image by provider and image ID.
 	 *
+	 * Always returns an array: on factory error, the WP_Error is converted to
+	 * an array with an 'error' key so the agent loop can surface the message.
+	 *
 	 * @param string $keyword   Original search keyword (used as alt/title base).
 	 * @param string $provider  Provider ID.
 	 * @param string $image_id  Provider-specific image ID.
 	 * @param int    $width     Desired width.
 	 * @param int    $height    Desired height.
 	 * @param string $site_url  Multisite subsite URL.
-	 * @return array|\WP_Error Result or error.
+	 * @return array<string, mixed> Result (with optional 'error' key on failure).
 	 */
 	private function handle_import_by_id(
 		string $keyword,
@@ -344,7 +350,7 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 		int $width,
 		int $height,
 		string $site_url
-	): array|\WP_Error {
+	): array {
 		$options = [
 			'site_url' => $site_url,
 			'keyword'  => $keyword,

--- a/includes/Abilities/ImageSources/AiGenerateSource.php
+++ b/includes/Abilities/ImageSources/AiGenerateSource.php
@@ -53,6 +53,11 @@ class AiGenerateSource implements ImageSourceInterface {
 	 *
 	 * For AI generation, search returns a single synthetic hit used to
 	 * trigger generation via download(). Filters are not applicable here.
+	 *
+	 * @param string               $keyword  Search term (used as generation prompt).
+	 * @param int                  $per_page Number of results (always 1 for generation).
+	 * @param array<string, mixed> $filters  Not used; accepted for interface compliance.
+	 * @return array{hits: array<int, array<string, mixed>>, total: int, source: string}
 	 */
 	public function search( string $keyword, int $per_page = 10, array $filters = [] ): array|\WP_Error {
 		return [

--- a/includes/Abilities/ImageSources/AiGenerateSource.php
+++ b/includes/Abilities/ImageSources/AiGenerateSource.php
@@ -52,9 +52,9 @@ class AiGenerateSource implements ImageSourceInterface {
 	 * {@inheritdoc}
 	 *
 	 * For AI generation, search returns a single synthetic hit used to
-	 * trigger generation via download().
+	 * trigger generation via download(). Filters are not applicable here.
 	 */
-	public function search( string $keyword, int $per_page = 10 ): array|\WP_Error {
+	public function search( string $keyword, int $per_page = 10, array $filters = [] ): array|\WP_Error {
 		return [
 			'hits'   => [
 				[

--- a/includes/Abilities/ImageSources/ImageSourceFactory.php
+++ b/includes/Abilities/ImageSources/ImageSourceFactory.php
@@ -159,6 +159,184 @@ class ImageSourceFactory {
 	}
 
 	/**
+	 * Search all available free sources for candidate images without importing.
+	 *
+	 * Returns a flat list of candidate images from all available free sources.
+	 * Each candidate includes thumbnail URL, dimensions, licence, attribution,
+	 * provider, and provider-specific image ID so the caller can later pass
+	 * provider + image_id to import_by_provider_id().
+	 *
+	 * @param string $keyword  Search keyword.
+	 * @param int    $limit    Maximum candidates to return (default 5).
+	 * @param string $provider Restrict to a specific provider (empty = all free sources).
+	 * @param array  $filters  Filters: orientation, colour, min_width, min_height.
+	 * @return array{candidates: list<array>, total: int}|\WP_Error
+	 */
+	public static function search_candidates(
+		string $keyword,
+		int $limit = 5,
+		string $provider = '',
+		array $filters = []
+	): array|\WP_Error {
+		if ( empty( self::$sources ) ) {
+			self::init();
+		}
+
+		$available    = self::get_available();
+		$free_sources = array_filter(
+			$available,
+			static fn( ImageSourceInterface $source ): bool => 'free' === $source->get_cost_type()
+		);
+
+		// If a specific provider is requested, restrict to that source only.
+		if ( '' !== $provider ) {
+			if ( ! isset( $free_sources[ $provider ] ) ) {
+				return new WP_Error(
+					'provider_unavailable',
+					sprintf( 'Provider "%s" is not available or is not a free source.', $provider )
+				);
+			}
+			$free_sources = [ $provider => $free_sources[ $provider ] ];
+		}
+
+		if ( empty( $free_sources ) ) {
+			return new WP_Error(
+				'no_sources_available',
+				'No free image sources are available.'
+			);
+		}
+
+		$candidates = [];
+
+		foreach ( $free_sources as $source ) {
+			$search_result = $source->search( $keyword, $limit, $filters );
+
+			if ( is_wp_error( $search_result ) ) {
+				continue;
+			}
+
+			$hits = $search_result['hits'] ?? [];
+
+			foreach ( $hits as $hit ) {
+				if ( count( $candidates ) >= $limit ) {
+					break 2;
+				}
+
+				$candidates[] = [
+					'image_id'    => (string) ( $hit['id'] ?? '' ),
+					'provider'    => $source->get_id(),
+					'thumbnail'   => $hit['preview'] ?? $hit['medium'] ?? '',
+					'width'       => (int) ( $hit['width'] ?? 0 ),
+					'height'      => (int) ( $hit['height'] ?? 0 ),
+					'licence'     => $hit['license'] ?? '',
+					'attribution' => self::build_attribution_string( $hit, $source->get_id() ),
+					'title'       => $hit['title'] ?? $hit['alt'] ?? '',
+				];
+			}
+		}
+
+		return [
+			'candidates' => $candidates,
+			'total'      => count( $candidates ),
+		];
+	}
+
+	/**
+	 * Import a specific image by provider and image ID.
+	 *
+	 * Downloads and sideloads the image, storing attribution metadata.
+	 *
+	 * @param string $provider Provider ID (e.g. 'openverse', 'pixabay').
+	 * @param string $image_id Provider-specific image ID.
+	 * @param int    $width    Desired width (0 for original).
+	 * @param int    $height   Desired height (0 for original).
+	 * @param array  $options  Options: site_url, post_id.
+	 * @return array{attachment_id: int, url: string, alt: string, title: string, source: string, attribution: string}|\WP_Error
+	 */
+	public static function import_by_provider_id(
+		string $provider,
+		string $image_id,
+		int $width = 0,
+		int $height = 0,
+		array $options = []
+	): array|\WP_Error {
+		if ( empty( self::$sources ) ) {
+			self::init();
+		}
+
+		$source = self::get( $provider );
+
+		if ( ! $source ) {
+			return new WP_Error(
+				'unknown_image_source',
+				sprintf( 'Unknown image source: %s.', $provider )
+			);
+		}
+
+		if ( ! $source->is_available() ) {
+			return new WP_Error(
+				'image_source_unavailable',
+				sprintf( 'Image source "%s" is not available.', $provider )
+			);
+		}
+
+		// Fetch metadata for attribution before downloading.
+		$image_meta = $source->get_image( $image_id );
+		$hit        = [];
+
+		if ( ! is_wp_error( $image_meta ) ) {
+			$hit = [
+				'id'          => $image_id,
+				'source'      => $image_meta['source'] ?? $provider,
+				'author'      => $image_meta['author'] ?? '',
+				'author_url'  => $image_meta['author_url'] ?? '',
+				'license'     => $image_meta['license'] ?? '',
+				'license_url' => $image_meta['license_url'] ?? '',
+				'attribution' => $image_meta['attribution'] ?? '',
+			];
+		}
+
+		$tmp_file = $source->download( $image_id, $width, $height );
+
+		if ( is_wp_error( $tmp_file ) ) {
+			return $tmp_file;
+		}
+
+		$keyword = (string) ( $options['keyword'] ?? $image_id );
+
+		return self::handle_sideload( $tmp_file, $keyword, $options, $hit );
+	}
+
+	/**
+	 * Build a human-readable attribution string from a search hit.
+	 *
+	 * @param array  $hit      Search hit data.
+	 * @param string $provider Provider ID (fallback label).
+	 * @return string Attribution string (empty if not determinable).
+	 */
+	private static function build_attribution_string( array $hit, string $provider ): string {
+		// If the provider returned a pre-built attribution string, use it.
+		if ( ! empty( $hit['attribution'] ) ) {
+			return (string) $hit['attribution'];
+		}
+
+		$author  = (string) ( $hit['author'] ?? '' );
+		$source  = (string) ( $hit['source'] ?? ucfirst( $provider ) );
+		$license = (string) ( $hit['license'] ?? '' );
+
+		if ( '' === $author ) {
+			return sprintf( 'Image from %s%s', $source, '' !== $license ? " ($license)" : '' );
+		}
+
+		return sprintf(
+			'Photo by %s on %s%s',
+			$author,
+			$source,
+			'' !== $license ? " ($license)" : ''
+		);
+	}
+
+	/**
 	 * Import an image from any source.
 	 *
 	 * On download failure or empty results, the method automatically retries
@@ -172,6 +350,7 @@ class ImageSourceFactory {
 	 *                          - 'site_url'             (string) Multisite subsite URL.
 	 *                          - 'post_id'              (int)    Attach to this post.
 	 *                          - 'no_generate_fallback' (bool)   Skip AI generation fallback.
+	 *                          - 'filters'              (array)  Search filters (orientation, colour, etc.).
 	 * @return array{\attachment_id: int, url: string, alt: string, title: string, source: string}|\WP_Error
 	 */
 	public static function import_image(
@@ -260,10 +439,11 @@ class ImageSourceFactory {
 
 		// Try each free source in order, recording the failure reason for each.
 		/** @var array<string, string> $tried */
-		$tried = [];
+		$tried   = [];
+		$filters = (array) ( $options['filters'] ?? [] );
 
 		foreach ( $free_sources as $try_source ) {
-			$search_result = $try_source->search( $keyword, self::FREE_SOURCE_SEARCH_LIMIT );
+			$search_result = $try_source->search( $keyword, self::FREE_SOURCE_SEARCH_LIMIT, $filters );
 
 			if ( is_wp_error( $search_result ) ) {
 				$tried[ $try_source->get_id() ] = sprintf(
@@ -440,6 +620,14 @@ class ImageSourceFactory {
 		// Set alt text from keyword.
 		update_post_meta( $attachment_id, '_wp_attachment_image_alt', $title );
 
+		// Build and store attribution metadata.
+		$source_id   = (string) ( $hit['source'] ?? $hit['provider'] ?? 'unknown' );
+		$attribution = self::build_attribution_string( $hit, $source_id );
+
+		if ( '' !== $attribution ) {
+			update_post_meta( $attachment_id, '_sd_ai_agent_attribution', $attribution );
+		}
+
 		$attachment_url = wp_get_attachment_url( $attachment_id );
 
 		return [
@@ -447,7 +635,8 @@ class ImageSourceFactory {
 			'url'           => $attachment_url,
 			'alt'           => $title,
 			'title'         => $title,
-			'source'        => $hit['source'] ?? 'unknown',
+			'source'        => $source_id,
+			'attribution'   => $attribution,
 			'tip'           => 'Use attachment_id as featured_image_id for create-post.',
 		];
 	}

--- a/includes/Abilities/ImageSources/ImageSourceFactory.php
+++ b/includes/Abilities/ImageSources/ImageSourceFactory.php
@@ -166,11 +166,11 @@ class ImageSourceFactory {
 	 * provider, and provider-specific image ID so the caller can later pass
 	 * provider + image_id to import_by_provider_id().
 	 *
-	 * @param string $keyword  Search keyword.
-	 * @param int    $limit    Maximum candidates to return (default 5).
-	 * @param string $provider Restrict to a specific provider (empty = all free sources).
-	 * @param array  $filters  Filters: orientation, colour, min_width, min_height.
-	 * @return array{candidates: list<array>, total: int}|\WP_Error
+	 * @param string               $keyword  Search keyword.
+	 * @param int                  $limit    Maximum candidates to return (default 5).
+	 * @param string               $provider Restrict to a specific provider (empty = all free sources).
+	 * @param array<string, mixed> $filters  Filters: orientation, colour, min_width, min_height.
+	 * @return array{candidates: list<array<string, mixed>>, total: int}|\WP_Error
 	 */
 	public static function search_candidates(
 		string $keyword,
@@ -246,12 +246,12 @@ class ImageSourceFactory {
 	 *
 	 * Downloads and sideloads the image, storing attribution metadata.
 	 *
-	 * @param string $provider Provider ID (e.g. 'openverse', 'pixabay').
-	 * @param string $image_id Provider-specific image ID.
-	 * @param int    $width    Desired width (0 for original).
-	 * @param int    $height   Desired height (0 for original).
-	 * @param array  $options  Options: site_url, post_id.
-	 * @return array{attachment_id: int, url: string, alt: string, title: string, source: string, attribution: string}|\WP_Error
+	 * @param string               $provider Provider ID (e.g. 'openverse', 'pixabay').
+	 * @param string               $image_id Provider-specific image ID.
+	 * @param int                  $width    Desired width (0 for original).
+	 * @param int                  $height   Desired height (0 for original).
+	 * @param array<string, mixed> $options  Options: site_url, post_id, keyword.
+	 * @return array<string, mixed>|\WP_Error Result with attachment_id, url, source, attribution, or WP_Error.
 	 */
 	public static function import_by_provider_id(
 		string $provider,
@@ -310,8 +310,8 @@ class ImageSourceFactory {
 	/**
 	 * Build a human-readable attribution string from a search hit.
 	 *
-	 * @param array  $hit      Search hit data.
-	 * @param string $provider Provider ID (fallback label).
+	 * @param array<string, mixed> $hit      Search hit data.
+	 * @param string               $provider Provider ID (fallback label).
 	 * @return string Attribution string (empty if not determinable).
 	 */
 	private static function build_attribution_string( array $hit, string $provider ): string {
@@ -534,11 +534,11 @@ class ImageSourceFactory {
 	/**
 	 * Handle WordPress sideload of a temp file.
 	 *
-	 * @param string $tmp_file Temp file path.
-	 * @param string $keyword Original keyword.
-	 * @param array  $options Options (site_url, post_id).
-	 * @param array  $hit     Original hit data.
-	 * @return array|\WP_Error Result array or error.
+	 * @param string               $tmp_file Temp file path.
+	 * @param string               $keyword  Original keyword.
+	 * @param array<string, mixed> $options  Options (site_url, post_id).
+	 * @param array<string, mixed> $hit      Original hit data with source, attribution, author etc.
+	 * @return array<string, mixed>|\WP_Error Result array or error.
 	 */
 	private static function handle_sideload(
 		string $tmp_file,

--- a/includes/Abilities/ImageSources/ImageSourceInterface.php
+++ b/includes/Abilities/ImageSources/ImageSourceInterface.php
@@ -52,11 +52,16 @@ interface ImageSourceInterface {
 	/**
 	 * Search for images by keyword.
 	 *
-	 * @param string $keyword Search term.
+	 * @param string $keyword  Search term.
 	 * @param int    $per_page Number of results to return.
+	 * @param array  $filters  Optional filters:
+	 *                         - 'orientation' (string) 'landscape'|'portrait'|'squarish'.
+	 *                         - 'colour'      (string) Colour name (provider-specific).
+	 *                         - 'min_width'   (int)    Minimum image width in pixels.
+	 *                         - 'min_height'  (int)    Minimum image height in pixels.
 	 * @return array{hits: array, total: int, source: string}|\WP_Error Array with hits or error.
 	 */
-	public function search( string $keyword, int $per_page = 10 ): array|\WP_Error;
+	public function search( string $keyword, int $per_page = 10, array $filters = [] ): array|\WP_Error;
 
 	/**
 	 * Get a single image by ID.

--- a/includes/Abilities/ImageSources/ImageSourceInterface.php
+++ b/includes/Abilities/ImageSources/ImageSourceInterface.php
@@ -52,14 +52,14 @@ interface ImageSourceInterface {
 	/**
 	 * Search for images by keyword.
 	 *
-	 * @param string $keyword  Search term.
-	 * @param int    $per_page Number of results to return.
-	 * @param array  $filters  Optional filters:
-	 *                         - 'orientation' (string) 'landscape'|'portrait'|'squarish'.
-	 *                         - 'colour'      (string) Colour name (provider-specific).
-	 *                         - 'min_width'   (int)    Minimum image width in pixels.
-	 *                         - 'min_height'  (int)    Minimum image height in pixels.
-	 * @return array{hits: array, total: int, source: string}|\WP_Error Array with hits or error.
+	 * @param string               $keyword  Search term.
+	 * @param int                  $per_page Number of results to return.
+	 * @param array<string, mixed> $filters  Optional filters:
+	 *                                       - 'orientation' (string) 'landscape'|'portrait'|'squarish'.
+	 *                                       - 'colour'      (string) Colour name (provider-specific).
+	 *                                       - 'min_width'   (int)    Minimum image width in pixels.
+	 *                                       - 'min_height'  (int)    Minimum image height in pixels.
+	 * @return array{hits: array<int, array<string, mixed>>, total: int, source: string}|\WP_Error Array with hits or error.
 	 */
 	public function search( string $keyword, int $per_page = 10, array $filters = [] ): array|\WP_Error;
 

--- a/includes/Abilities/ImageSources/OpenverseImageSource.php
+++ b/includes/Abilities/ImageSources/OpenverseImageSource.php
@@ -59,14 +59,30 @@ class OpenverseImageSource implements ImageSourceInterface {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function search( string $keyword, int $per_page = 10 ): array|\WP_Error {
-		$url = add_query_arg(
-			[
-				'q'         => $keyword,
-				'page_size' => min( $per_page, 50 ),
-			],
-			self::API_BASE . '/images/'
-		);
+	public function search( string $keyword, int $per_page = 10, array $filters = [] ): array|\WP_Error {
+		$query_args = [
+			'q'         => $keyword,
+			'page_size' => min( $per_page, 50 ),
+		];
+
+		// Orientation: Openverse uses tall|wide|square.
+		$orientation = (string) ( $filters['orientation'] ?? '' );
+		if ( '' !== $orientation ) {
+			$orientation_map = [
+				'portrait'  => 'tall',
+				'landscape' => 'wide',
+				'squarish'  => 'square',
+			];
+			$query_args['aspect_ratio'] = $orientation_map[ $orientation ] ?? $orientation;
+		}
+
+		// Colour filter.
+		$colour = (string) ( $filters['colour'] ?? '' );
+		if ( '' !== $colour ) {
+			$query_args['color'] = $colour;
+		}
+
+		$url = add_query_arg( $query_args, self::API_BASE . '/images/' );
 
 		$response = wp_remote_get( $url, [ 'timeout' => 30 ] );
 

--- a/includes/Abilities/ImageSources/OpenverseImageSource.php
+++ b/includes/Abilities/ImageSources/OpenverseImageSource.php
@@ -58,6 +58,11 @@ class OpenverseImageSource implements ImageSourceInterface {
 
 	/**
 	 * {@inheritdoc}
+	 *
+	 * @param string               $keyword  Search term.
+	 * @param int                  $per_page Number of results to return.
+	 * @param array<string, mixed> $filters  Optional filters (orientation, colour).
+	 * @return array{hits: array<int, array<string, mixed>>, total: int, source: string}|\WP_Error
 	 */
 	public function search( string $keyword, int $per_page = 10, array $filters = [] ): array|\WP_Error {
 		$query_args = [
@@ -68,7 +73,7 @@ class OpenverseImageSource implements ImageSourceInterface {
 		// Orientation: Openverse uses tall|wide|square.
 		$orientation = (string) ( $filters['orientation'] ?? '' );
 		if ( '' !== $orientation ) {
-			$orientation_map = [
+			$orientation_map            = [
 				'portrait'  => 'tall',
 				'landscape' => 'wide',
 				'squarish'  => 'square',

--- a/includes/Abilities/ImageSources/PixabayImageSource.php
+++ b/includes/Abilities/ImageSources/PixabayImageSource.php
@@ -74,23 +74,51 @@ class PixabayImageSource implements ImageSourceInterface {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function search( string $keyword, int $per_page = 10 ): array|\WP_Error {
+	public function search( string $keyword, int $per_page = 10, array $filters = [] ): array|\WP_Error {
 		$api_key = $this->get_api_key();
 
 		if ( empty( $api_key ) ) {
 			return new WP_Error( 'pixabay_not_configured', 'Pixabay API key not configured.' );
 		}
 
-		$url = add_query_arg(
-			[
-				'key'         => $api_key,
-				'q'           => rawurlencode( $keyword ),
-				'per_page'    => min( $per_page, 200 ),
-				'image_type'  => 'photo',
-				'safe_search' => 'true',
-			],
-			self::API_BASE
-		);
+		$query_args = [
+			'key'         => $api_key,
+			'q'           => rawurlencode( $keyword ),
+			'per_page'    => min( $per_page, 200 ),
+			'image_type'  => 'photo',
+			'safe_search' => 'true',
+		];
+
+		// Orientation: Pixabay uses horizontal|vertical.
+		$orientation = (string) ( $filters['orientation'] ?? '' );
+		if ( '' !== $orientation ) {
+			$orientation_map = [
+				'landscape' => 'horizontal',
+				'portrait'  => 'vertical',
+			];
+			if ( isset( $orientation_map[ $orientation ] ) ) {
+				$query_args['orientation'] = $orientation_map[ $orientation ];
+			}
+		}
+
+		// Colour filter (Pixabay uses 'colors' parameter).
+		$colour = (string) ( $filters['colour'] ?? '' );
+		if ( '' !== $colour ) {
+			$query_args['colors'] = $colour;
+		}
+
+		// Minimum dimensions.
+		$min_width = (int) ( $filters['min_width'] ?? 0 );
+		if ( $min_width > 0 ) {
+			$query_args['min_width'] = $min_width;
+		}
+
+		$min_height = (int) ( $filters['min_height'] ?? 0 );
+		if ( $min_height > 0 ) {
+			$query_args['min_height'] = $min_height;
+		}
+
+		$url = add_query_arg( $query_args, self::API_BASE );
 
 		$response = wp_remote_get( $url, [ 'timeout' => 30 ] );
 

--- a/includes/Abilities/ImageSources/PixabayImageSource.php
+++ b/includes/Abilities/ImageSources/PixabayImageSource.php
@@ -73,6 +73,11 @@ class PixabayImageSource implements ImageSourceInterface {
 
 	/**
 	 * {@inheritdoc}
+	 *
+	 * @param string               $keyword  Search term.
+	 * @param int                  $per_page Number of results to return.
+	 * @param array<string, mixed> $filters  Optional filters (orientation, colour, min_width, min_height).
+	 * @return array{hits: array<int, array<string, mixed>>, total: int, source: string}|\WP_Error
 	 */
 	public function search( string $keyword, int $per_page = 10, array $filters = [] ): array|\WP_Error {
 		$api_key = $this->get_api_key();

--- a/includes/Models/Agent.php
+++ b/includes/Models/Agent.php
@@ -700,13 +700,20 @@ class Agent {
 				. "   - `templates/page.html` — single page template\n"
 				. "5. Apply the chosen design system (colors, typography, spacing) via `sd-ai-agent/update-global-styles`.\n"
 				. "6. Validate every block markup file you write using `sd-ai-agent/validate-block-content`.\n"
-				. "7. Finalize the front-page hero CTA (MANDATORY — the scaffold result always includes `cta_warning: true`):\n"
+				. "7. **Media imagery.** If any page or section requires photography (hero images, about-page portraits, product shots) and the user has not uploaded photos:\n"
+				. "   a. Call `sd-ai-agent/stock-image` with `action: search`, an appropriate `keyword`, and optional `orientation` and `colour` filters to get up to 5 candidate images.\n"
+				. "   b. Present the returned candidates to the user — include their `thumbnail` URL and `attribution` — and ask the user to select one, or approve your recommended choice.\n"
+				. "   c. Call `sd-ai-agent/stock-image` with `action: import`, the chosen `provider`, and `image_id` to download and import the image into the media library.\n"
+				. "   d. Use the returned `attachment_id` as `featured_image_id` when calling `sd-ai-agent/create-post`, or use the local `url` in block markup (e.g. inside a wp:cover or wp:image block).\n"
+				. "   **Never write a candidate `thumbnail` URL or any external stock image URL into a theme file or block markup.** Only the local `url` from a completed import is safe to use.\n"
+				. "   If stock images are not available and AI generation is configured, use `sd-ai-agent/generate-image` instead. If neither is available or suitable, use CSS gradients and color blocks as placeholders.\n"
+				. "8. Finalize the front-page hero CTA (MANDATORY — the scaffold result always includes `cta_warning: true`):\n"
 				. "   a. Determine the CTA text and target URL for the business vertical (see CTA rules below).\n"
 				. "   b. Create the CTA target page with `sd-ai-agent/create-post` (post_type: page, status: publish) if it does not already exist.\n"
 				. "   c. Update `templates/front-page.html` via `sd-ai-agent/file-write` to replace `href=\"#\"` and \"Call to action\" with the real page URL and vertical-appropriate text.\n"
 				. "   d. Call `sd-ai-agent/validate-block-content` on the updated `templates/front-page.html`.\n"
-				. "8. Activate the new theme via `sd-ai-agent/activate-theme`.\n"
-				. "9. Confirm the result to the user.\n\n"
+				. "9. Activate the new theme via `sd-ai-agent/activate-theme`.\n"
+				. "10. Confirm the result to the user.\n\n"
 				. "## Rules\n\n"
 				. "- **Real content or no content.** Do not create any WordPress page, post, or theme template with placeholder text, Lorem ipsum, \"Replace this\", \"Edit this\", \"Add your...\", or template-fill language. If you do not have real, user-supplied content for a section, ask for it or skip that page.\n"
 				. "- **No external assets in generated previews, templates, or theme files.** This includes:\n"
@@ -746,6 +753,10 @@ class Agent {
 							'sd-ai-agent/file-write',
 							'sd-ai-agent/validate-block-content',
 							'sd-ai-agent/get-theme-json',
+							// Imagery: search candidates and import selected stock
+							// photos (Phase 4 step 7) or generate via AI fallback.
+							'sd-ai-agent/stock-image',
+							'sd-ai-agent/generate-image',
 						]
 					)
 				)

--- a/tests/SdAiAgent/Abilities/ImageSourceFactoryTest.php
+++ b/tests/SdAiAgent/Abilities/ImageSourceFactoryTest.php
@@ -171,7 +171,7 @@ class FakeImageSource implements ImageSourceInterface {
 	/**
 	 * {@inheritdoc}
 	 */
-	public function search( string $keyword, int $per_page = 10 ): array|WP_Error {
+	public function search( string $keyword, int $per_page = 10, array $filters = [] ): array|WP_Error {
 		return [
 			'hits'   => array_slice( $this->hits, 0, $per_page ),
 			'total'  => count( $this->hits ),

--- a/tests/SdAiAgent/Abilities/StockImageAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/StockImageAbilityTest.php
@@ -1,0 +1,627 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Tests for StockImageAbility — candidate search, import path, and attribution.
+ *
+ * Coverage:
+ * - Search mode (action=search) returns candidate list with required fields.
+ * - Import mode (action=import) with provider + image_id stores attribution.
+ * - Auto mode (no action) preserves backward-compatible import behaviour.
+ * - Missing keyword validation.
+ * - Provider-mock isolation via ImageSourceFactory reflection.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Abilities;
+
+use SdAiAgent\Abilities\ImageAbilities\StockImageAbility;
+use SdAiAgent\Abilities\ImageSources\ImageSourceFactory;
+use SdAiAgent\Abilities\ImageSources\ImageSourceInterface;
+use WP_Error;
+use WP_UnitTestCase;
+
+/**
+ * Tests for StockImageAbility candidate search and import modes.
+ *
+ * @since 1.7.0
+ */
+class StockImageAbilityTest extends WP_UnitTestCase {
+
+	/**
+	 * Saved source registry.
+	 *
+	 * @var array<string, ImageSourceInterface>
+	 */
+	private array $original_sources = [];
+
+	/**
+	 * Ability under test.
+	 *
+	 * @var StockImageAbility
+	 */
+	private StockImageAbility $ability;
+
+	/**
+	 * Set up: preserve factory sources and create ability.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->original_sources = $this->get_factory_sources();
+		$this->ability          = new StockImageAbility( 'sd-ai-agent/stock-image' );
+	}
+
+	/**
+	 * Tear down: restore factory sources.
+	 */
+	public function tear_down(): void {
+		$this->set_factory_sources( $this->original_sources );
+
+		parent::tear_down();
+	}
+
+	// ─── missing keyword ─────────────────────────────────────────────────────
+
+	/**
+	 * Missing keyword returns WP_Error.
+	 */
+	public function test_missing_keyword_returns_wp_error(): void {
+		$result = $this->invoke_execute( [] );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'missing_keyword', $result->get_error_code() );
+	}
+
+	/**
+	 * Empty keyword returns WP_Error.
+	 */
+	public function test_empty_keyword_returns_wp_error(): void {
+		$result = $this->invoke_execute( [ 'keyword' => '' ] );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'missing_keyword', $result->get_error_code() );
+	}
+
+	// ─── search mode (action=search) ─────────────────────────────────────────
+
+	/**
+	 * Search mode with mock source returns candidates array with required fields.
+	 */
+	public function test_search_mode_returns_candidates_with_required_fields(): void {
+		$fake_source = new FakeStockImageSource(
+			'openverse',
+			'free',
+			[
+				[
+					'id'          => 'img-001',
+					'preview'     => 'https://openverse.example.com/thumb/img-001.jpg',
+					'medium'      => 'https://openverse.example.com/medium/img-001.jpg',
+					'full'        => 'https://openverse.example.com/full/img-001.jpg',
+					'width'       => 1920,
+					'height'      => 1080,
+					'title'       => 'Mountain Landscape',
+					'author'      => 'Jane Doe',
+					'author_url'  => 'https://openverse.example.com/users/janedoe',
+					'license'     => 'CC0',
+					'license_url' => 'https://creativecommons.org/publicdomain/zero/1.0/',
+					'source'      => 'openverse',
+					'attribution' => 'Photo by Jane Doe on Openverse (CC0)',
+				],
+			]
+		);
+
+		$this->set_factory_sources(
+			[
+				'openverse' => $fake_source,
+				'pixabay'   => new FakeStockImageSource( 'pixabay', 'free', [] ),
+				'generate'  => new FakeStockImageSource( 'generate', 'api', [] ),
+			]
+		);
+
+		$result = $this->invoke_execute(
+			[
+				'keyword' => 'mountain landscape',
+				'action'  => 'search',
+				'limit'   => 3,
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'candidates', $result );
+		$this->assertIsArray( $result['candidates'] );
+		$this->assertCount( 1, $result['candidates'] );
+
+		$candidate = $result['candidates'][0];
+		$this->assertArrayHasKey( 'image_id', $candidate, 'candidate must have image_id' );
+		$this->assertArrayHasKey( 'provider', $candidate, 'candidate must have provider' );
+		$this->assertArrayHasKey( 'thumbnail', $candidate, 'candidate must have thumbnail' );
+		$this->assertArrayHasKey( 'width', $candidate, 'candidate must have width' );
+		$this->assertArrayHasKey( 'height', $candidate, 'candidate must have height' );
+		$this->assertArrayHasKey( 'licence', $candidate, 'candidate must have licence' );
+		$this->assertArrayHasKey( 'attribution', $candidate, 'candidate must have attribution' );
+		$this->assertArrayHasKey( 'title', $candidate, 'candidate must have title' );
+
+		$this->assertSame( 'img-001', $candidate['image_id'] );
+		$this->assertSame( 'openverse', $candidate['provider'] );
+		$this->assertSame( 1920, $candidate['width'] );
+		$this->assertSame( 1080, $candidate['height'] );
+		$this->assertSame( 'CC0', $candidate['licence'] );
+		$this->assertSame( 'Photo by Jane Doe on Openverse (CC0)', $candidate['attribution'] );
+	}
+
+	/**
+	 * Search mode with no free sources returns error key (not WP_Error) for agent readability.
+	 */
+	public function test_search_mode_no_free_sources_returns_error_in_array(): void {
+		$this->set_factory_sources(
+			[
+				'generate' => new FakeStockImageSource( 'generate', 'api', [] ),
+			]
+		);
+
+		$result = $this->invoke_execute(
+			[
+				'keyword' => 'mountain',
+				'action'  => 'search',
+			]
+		);
+
+		// The ability converts factory errors to an array with an 'error' key
+		// so the agent loop can surface a human-readable message.
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'error', $result );
+		$this->assertArrayHasKey( 'candidates', $result );
+		$this->assertEmpty( $result['candidates'] );
+	}
+
+	/**
+	 * Search mode passes orientation and colour filters to the source.
+	 */
+	public function test_search_mode_passes_filters_to_source(): void {
+		$fake_source = new FakeStockImageSource( 'openverse', 'free', [] );
+
+		$this->set_factory_sources(
+			[
+				'openverse' => $fake_source,
+				'pixabay'   => new FakeStockImageSource( 'pixabay', 'free', [] ),
+				'generate'  => new FakeStockImageSource( 'generate', 'api', [] ),
+			]
+		);
+
+		$this->invoke_execute(
+			[
+				'keyword'     => 'city skyline',
+				'action'      => 'search',
+				'orientation' => 'landscape',
+				'colour'      => 'blue',
+				'min_width'   => 1600,
+				'min_height'  => 900,
+			]
+		);
+
+		// Verify that the fake source received the filters.
+		$this->assertCount( 1, $fake_source->search_calls, 'search() should have been called once' );
+		$filters = $fake_source->search_calls[0]['filters'];
+		$this->assertSame( 'landscape', $filters['orientation'] ?? null );
+		$this->assertSame( 'blue', $filters['colour'] ?? null );
+		$this->assertSame( 1600, $filters['min_width'] ?? 0 );
+		$this->assertSame( 900, $filters['min_height'] ?? 0 );
+	}
+
+	// ─── import mode (action=import with provider + image_id) ────────────────
+
+	/**
+	 * Import mode stores _sd_ai_agent_attribution post meta.
+	 */
+	public function test_import_mode_stores_attribution_meta(): void {
+		// Use a fake source that returns hit metadata and downloads a valid PNG.
+		$fake_source = new FakeStockImageSource(
+			'openverse',
+			'free',
+			[],
+			[
+				'img-042' => [
+					'url'         => '',
+					'width'       => 800,
+					'height'      => 600,
+					'author'      => 'Test Author',
+					'author_url'  => 'https://example.com/author',
+					'license'     => 'CC0',
+					'source'      => 'openverse',
+					'attribution' => 'Photo by Test Author on openverse (CC0)',
+				],
+			]
+		);
+
+		$this->set_factory_sources(
+			[
+				'openverse' => $fake_source,
+				'generate'  => new FakeStockImageSource( 'generate', 'api', [] ),
+			]
+		);
+
+		// Write a minimal 1×1 transparent PNG to a temp file so sideload works.
+		$png_data = base64_decode( 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- test fixture
+		$tmp_file = get_temp_dir() . 'stock-test-' . uniqid() . '.png';
+		file_put_contents( $tmp_file, $png_data ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- test fixture
+
+		$fake_source->tmp_file = $tmp_file;
+
+		$result = $this->invoke_execute(
+			[
+				'keyword'  => 'mountain landscape',
+				'action'   => 'import',
+				'provider' => 'openverse',
+				'image_id' => 'img-042',
+			]
+		);
+
+		if ( is_wp_error( $result ) ) {
+			// In some test environments media_handle_sideload is unavailable.
+			$this->markTestSkipped( 'media_handle_sideload not available: ' . $result->get_error_message() );
+			return;
+		}
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'attachment_id', $result );
+		$this->assertGreaterThan( 0, $result['attachment_id'] );
+
+		// Verify attribution is in the result.
+		$this->assertArrayHasKey( 'attribution', $result );
+		$this->assertSame( 'Photo by Test Author on openverse (CC0)', $result['attribution'] );
+
+		// Verify _sd_ai_agent_attribution meta was stored.
+		$stored = get_post_meta( $result['attachment_id'], '_sd_ai_agent_attribution', true );
+		$this->assertSame( 'Photo by Test Author on openverse (CC0)', $stored );
+
+		// Clean up.
+		wp_delete_attachment( $result['attachment_id'], true );
+	}
+
+	/**
+	 * Import mode with missing image_id falls back to auto-import behaviour.
+	 *
+	 * When action=import but image_id is empty, the ability falls back to the
+	 * original auto-import path (first viable hit) rather than erroring.
+	 */
+	public function test_import_mode_without_image_id_falls_back_to_auto(): void {
+		// Provide no free sources so auto-import fails cleanly.
+		$this->set_factory_sources(
+			[
+				'generate' => new FakeStockImageSource( 'generate', 'api', [] ),
+			]
+		);
+
+		$result = $this->invoke_execute(
+			[
+				'keyword' => 'test keyword',
+				'action'  => 'import',
+				// No image_id or provider supplied.
+			]
+		);
+
+		// Should fall through to auto-import path, which returns an error array
+		// since no free sources are configured.
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'error', $result );
+	}
+
+	// ─── auto mode (no action) ────────────────────────────────────────────────
+
+	/**
+	 * Auto mode (no action) with no free sources returns error array (backward compat).
+	 */
+	public function test_auto_mode_no_free_sources_returns_error_array(): void {
+		$this->set_factory_sources(
+			[
+				'generate' => new FakeStockImageSource( 'generate', 'api', [] ),
+			]
+		);
+
+		$result = $this->invoke_execute( [ 'keyword' => 'landscape' ] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'error', $result );
+		$this->assertSame( 0, $result['attachment_id'] );
+	}
+
+	// ─── search result candidate structure ───────────────────────────────────
+
+	/**
+	 * search_candidates() returns attribution from pre-built hit string when available.
+	 */
+	public function test_search_candidates_uses_prebuilt_attribution(): void {
+		$fake_source = new FakeStockImageSource(
+			'openverse',
+			'free',
+			[
+				[
+					'id'          => 'abc-123',
+					'preview'     => 'https://example.com/thumb.jpg',
+					'width'       => 640,
+					'height'      => 480,
+					'title'       => 'Test Image',
+					'author'      => 'Alice',
+					'author_url'  => '',
+					'license'     => 'CC-BY',
+					'source'      => 'flickr',
+					'attribution' => '"Test Image" by Alice is licensed CC-BY.',
+				],
+			]
+		);
+
+		$this->set_factory_sources(
+			[
+				'openverse' => $fake_source,
+				'generate'  => new FakeStockImageSource( 'generate', 'api', [] ),
+			]
+		);
+
+		$result = ImageSourceFactory::search_candidates( 'test', 5 );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'candidates', $result );
+		$this->assertCount( 1, $result['candidates'] );
+
+		$candidate = $result['candidates'][0];
+		$this->assertSame( '"Test Image" by Alice is licensed CC-BY.', $candidate['attribution'] );
+	}
+
+	/**
+	 * search_candidates() builds attribution from author+source when pre-built string absent.
+	 */
+	public function test_search_candidates_builds_attribution_from_author(): void {
+		$fake_source = new FakeStockImageSource(
+			'pixabay',
+			'free',
+			[
+				[
+					'id'         => 'px-99',
+					'preview'    => 'https://example.com/px-thumb.jpg',
+					'width'      => 1280,
+					'height'     => 720,
+					'title'      => 'Sunset',
+					'author'     => 'Bob',
+					'author_url' => 'https://pixabay.com/users/bob',
+					'license'    => 'CC0',
+					'source'     => 'pixabay',
+					// No 'attribution' key.
+				],
+			]
+		);
+
+		$this->set_factory_sources(
+			[
+				'pixabay'  => $fake_source,
+				'openverse' => new FakeStockImageSource( 'openverse', 'free', [] ),
+				'generate'  => new FakeStockImageSource( 'generate', 'api', [] ),
+			]
+		);
+
+		$result = ImageSourceFactory::search_candidates( 'sunset', 5, 'pixabay' );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result['candidates'] );
+
+		$attribution = $result['candidates'][0]['attribution'];
+		$this->assertStringContainsString( 'Bob', $attribution );
+		$this->assertStringContainsString( 'pixabay', strtolower( $attribution ) );
+	}
+
+	// ─── Theme Builder tool list ──────────────────────────────────────────────
+
+	/**
+	 * The theme-builder built-in agent includes stock-image and generate-image
+	 * in its tier_1_tools so the imagery guidance in Phase 4 can be executed.
+	 */
+	public function test_theme_builder_tier_1_tools_include_imagery_abilities(): void {
+		\SdAiAgent\Models\Agent::seed_defaults();
+
+		$agent = \SdAiAgent\Models\Agent::get_by_slug( 'theme-builder' );
+		$this->assertNotNull( $agent, 'theme-builder agent must exist after seed_defaults()' );
+
+		$tools = $agent->tier_1_tools;
+		$this->assertIsArray( $tools );
+
+		$this->assertContains(
+			'sd-ai-agent/stock-image',
+			$tools,
+			'tier_1_tools must include sd-ai-agent/stock-image for Phase 4 imagery'
+		);
+
+		$this->assertContains(
+			'sd-ai-agent/generate-image',
+			$tools,
+			'tier_1_tools must include sd-ai-agent/generate-image as AI imagery fallback'
+		);
+
+		// Clean up.
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test cleanup; caching not applicable.
+		$wpdb->delete( \SdAiAgent\Models\Agent::table_name(), [ 'slug' => 'theme-builder' ], [ '%s' ] );
+	}
+
+	/**
+	 * The theme-builder system prompt references the stock-image imagery workflow.
+	 */
+	public function test_theme_builder_system_prompt_references_imagery_workflow(): void {
+		\SdAiAgent\Models\Agent::seed_defaults();
+
+		$agent = \SdAiAgent\Models\Agent::get_by_slug( 'theme-builder' );
+		$this->assertNotNull( $agent );
+
+		$prompt_lower = strtolower( $agent->system_prompt );
+
+		$this->assertStringContainsString(
+			'action: search',
+			$prompt_lower,
+			'system_prompt must reference action=search for candidate discovery'
+		);
+		$this->assertStringContainsString(
+			'action: import',
+			$prompt_lower,
+			'system_prompt must reference action=import for downloading selected images'
+		);
+		$this->assertStringContainsString(
+			'attachment_id',
+			$agent->system_prompt,
+			'system_prompt must reference attachment_id for use in create-post'
+		);
+
+		// Clean up.
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test cleanup; caching not applicable.
+		$wpdb->delete( \SdAiAgent\Models\Agent::table_name(), [ 'slug' => 'theme-builder' ], [ '%s' ] );
+	}
+
+	// ─── Helpers ─────────────────────────────────────────────────────────────
+
+	/**
+	 * Invoke execute_callback via the public run() proxy.
+	 *
+	 * AbstractAbility::run() calls execute_callback() directly, bypassing
+	 * permission checks and schema validation — exactly what unit tests need.
+	 *
+	 * @param array $input Input array.
+	 * @return array|\WP_Error
+	 */
+	private function invoke_execute( array $input ): array|\WP_Error {
+		/** @var array|\WP_Error $result */
+		$result = $this->ability->run( $input );
+
+		return $result;
+	}
+
+	/**
+	 * Get the private source registry from ImageSourceFactory.
+	 *
+	 * @return array<string, ImageSourceInterface>
+	 */
+	private function get_factory_sources(): array {
+		$property = new \ReflectionProperty( ImageSourceFactory::class, 'sources' );
+		$property->setAccessible( true );
+
+		$sources = $property->getValue();
+
+		if ( [] === $sources ) {
+			ImageSourceFactory::init();
+			$sources = $property->getValue();
+		}
+
+		return $sources;
+	}
+
+	/**
+	 * Replace the private source registry in ImageSourceFactory.
+	 *
+	 * @param array<string, ImageSourceInterface> $sources Sources keyed by ID.
+	 */
+	private function set_factory_sources( array $sources ): void {
+		$property = new \ReflectionProperty( ImageSourceFactory::class, 'sources' );
+		$property->setAccessible( true );
+		$property->setValue( null, $sources );
+	}
+}
+
+/**
+ * Fake image source for StockImageAbility tests.
+ */
+class FakeStockImageSource implements ImageSourceInterface {
+
+	/**
+	 * Calls to search() with captured args.
+	 *
+	 * @var list<array{keyword: string, per_page: int, filters: array}>
+	 */
+	public array $search_calls = [];
+
+	/**
+	 * Downloaded image IDs.
+	 *
+	 * @var list<string>
+	 */
+	public array $downloaded_ids = [];
+
+	/**
+	 * Temp file path to return from download() (null = return error).
+	 *
+	 * @var string|null
+	 */
+	public ?string $tmp_file = null;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string       $id        Source ID.
+	 * @param 'free'|'api' $cost_type Source cost type.
+	 * @param array<array> $hits      Search hits to return.
+	 * @param array<array> $images    Image metadata keyed by image_id for get_image().
+	 */
+	public function __construct(
+		private string $id,
+		private string $cost_type,
+		private array $hits,
+		private array $images = []
+	) {}
+
+	/** {@inheritdoc} */
+	public function get_id(): string {
+		return $this->id;
+	}
+
+	/** {@inheritdoc} */
+	public function get_name(): string {
+		return ucfirst( $this->id );
+	}
+
+	/** {@inheritdoc} */
+	public function is_available(): bool {
+		return true;
+	}
+
+	/** {@inheritdoc} */
+	public function search( string $keyword, int $per_page = 10, array $filters = [] ): array|WP_Error {
+		$this->search_calls[] = [
+			'keyword'  => $keyword,
+			'per_page' => $per_page,
+			'filters'  => $filters,
+		];
+
+		return [
+			'hits'   => array_slice( $this->hits, 0, $per_page ),
+			'total'  => count( $this->hits ),
+			'source' => $this->id,
+		];
+	}
+
+	/** {@inheritdoc} */
+	public function get_image( string $image_id ): array|WP_Error {
+		if ( isset( $this->images[ $image_id ] ) ) {
+			return $this->images[ $image_id ];
+		}
+
+		return new WP_Error( 'not_found', 'Image not found in fake source.' );
+	}
+
+	/** {@inheritdoc} */
+	public function download( string $image_id, int $width = 0, int $height = 0 ): string|WP_Error {
+		$this->downloaded_ids[] = $image_id;
+
+		if ( null !== $this->tmp_file ) {
+			return $this->tmp_file;
+		}
+
+		return new WP_Error( 'download_error', 'Synthetic download failure.' );
+	}
+
+	/** {@inheritdoc} */
+	public function get_cost_type(): string {
+		return $this->cost_type;
+	}
+}


### PR DESCRIPTION
## Summary

Implements issue #1528 — adds stock-image candidate selection and attribution metadata for the Theme Builder. Adds the `StockImageAbility`, 627 lines of new test coverage, updates `ImageSourceFactory`, and adds attribution wiring throughout.

## Files Changed

- `includes/Abilities/StockImageAbility.php` (new)
- `tests/SdAiAgent/Abilities/StockImageAbilityTest.php` (new, 627 lines)
- `includes/Abilities/ImageSourceFactory.php`
- `tests/SdAiAgent/Abilities/ImageSourceFactoryTest.php`
- 5 additional supporting files

See `git log origin/main..HEAD` and `git diff --stat origin/main..HEAD` for the full file list.

## Worker self-verification

**INCOMPLETE — worker exited during verify phase.** The headless worker hit `service_interruption_exhausted` (exit code 81, `local_error`) at 2026-05-20T00:19:09Z after the implementation commit and a follow-up `fix(stock-image): tighten PHPDoc generic types for PHPStan compliance` cleanup (suggesting PHPStan had been run at least once). The commits were preserved on the local worktree and pushed manually by the maintainer.

**Verification status: defer to CI.** The required PHPUnit / PHPCS / PHPStan / lint / build workflows will run the full suite on this PR. If any check fails, this PR will be closed and the issue re-dispatched per the Worker Self-Verification Protocol (`AGENTS.md`).

Resolves #1528
