### PR TITLE
feat(abilities): scrape existing sites to pre-fill Theme Builder interviews (GH#1530)

### DIFF
--- a/includes/Abilities/SiteScrapeAbility.php
+++ b/includes/Abilities/SiteScrapeAbility.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Site scrape ability — pre-fill Theme Builder interviews from existing sites.
+ *
+ * Registers the `sd-ai-agent/site-scrape` ability which fetches an existing
+ * website and returns structured brand/contact/hours data. Agents should offer
+ * this at the start of any Theme Builder interview:
+ *
+ *   "Do you have an existing site? If yes, paste the URL and I'll pre-fill
+ *    what I can."
+ *
+ * The ability delegates all HTTP and parsing work to SiteScraper, which:
+ *   - Validates the URL (any valid http/https URL is accepted — no domain
+ *     allowlist, because the user explicitly provides their own site's URL)
+ *   - Respects robots.txt
+ *   - Caches results in transients for 24 hours per URL
+ *   - Parses Schema.org JSON-LD, OpenGraph, and heuristic patterns
+ *
+ * @package SdAiAgent\Abilities
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Abilities;
+
+use SdAiAgent\Services\SiteScraper;
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Ability: sd-ai-agent/site-scrape
+ *
+ * @since 1.7.0
+ */
+class SiteScrapeAbility extends AbstractAbility {
+
+	protected function label(): string {
+		return __( 'Scrape Existing Site', 'superdav-ai-agent' );
+	}
+
+	protected function description(): string {
+		return __(
+			'Fetch and parse an existing website to extract structured brand and contact data (name, tagline, logo, address, phone, email, opening hours, social links). Use this at the start of a Theme Builder session when the user has an existing site they are rebuilding — it dramatically shortens the interview by pre-filling what can be detected automatically. Always ask for user consent before calling this ability since it makes outbound HTTP requests from the server.',
+			'superdav-ai-agent'
+		);
+	}
+
+	protected function input_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'url'          => [
+					'type'        => 'string',
+					'description' => 'Absolute URL of the existing site to scrape (e.g. "https://example.com"). Must be http or https.',
+				],
+				'max_pages'    => [
+					'type'        => 'integer',
+					'description' => 'Maximum number of pages to crawl. Default: 10.',
+				],
+				'pages'        => [
+					'type'        => 'array',
+					'description' => 'Explicit list of path-or-URL strings to crawl instead of the defaults (e.g. ["/", "/about", "/contact"]). Relative paths are resolved against the site origin.',
+					'items'       => [ 'type' => 'string' ],
+				],
+				'bypass_cache' => [
+					'type'        => 'boolean',
+					'description' => 'When true, ignores any cached result and re-fetches live. Default: false.',
+				],
+			],
+			'required'   => [ 'url' ],
+		];
+	}
+
+	protected function output_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'brand'   => [
+					'type'       => 'object',
+					'properties' => [
+						'name'     => [ 'type' => [ 'string', 'null' ] ],
+						'tagline'  => [ 'type' => [ 'string', 'null' ] ],
+						'logo_url' => [ 'type' => [ 'string', 'null' ] ],
+					],
+				],
+				'contact' => [
+					'type'       => 'object',
+					'properties' => [
+						'address' => [ 'type' => [ 'string', 'null' ] ],
+						'phone'   => [ 'type' => [ 'string', 'null' ] ],
+						'email'   => [ 'type' => [ 'string', 'null' ] ],
+					],
+				],
+				'hours'   => [
+					'type'  => 'array',
+					'items' => [
+						'type'       => 'object',
+						'properties' => [
+							'day'   => [ 'type' => 'string' ],
+							'open'  => [ 'type' => 'string' ],
+							'close' => [ 'type' => 'string' ],
+						],
+					],
+				],
+				'social'  => [
+					'type'                 => 'object',
+					'additionalProperties' => [ 'type' => 'string' ],
+				],
+				'pages'   => [
+					'type'  => 'array',
+					'items' => [
+						'type'       => 'object',
+						'properties' => [
+							'url'      => [ 'type' => 'string' ],
+							'title'    => [ 'type' => 'string' ],
+							'text'     => [ 'type' => 'string' ],
+							'headings' => [
+								'type'  => 'array',
+								'items' => [ 'type' => 'string' ],
+							],
+						],
+					],
+				],
+			],
+		];
+	}
+
+	protected function execute_callback( $input ): array|WP_Error {
+		/** @var array<string,mixed> $input */
+		$url     = (string) ( $input['url'] ?? '' );
+		$scraper = new SiteScraper();
+
+		return $scraper->scrape(
+			$url,
+			[
+				'max_pages'    => isset( $input['max_pages'] ) ? (int) $input['max_pages'] : 10,
+				'pages'        => isset( $input['pages'] ) && is_array( $input['pages'] ) ? $input['pages'] : null,
+				'bypass_cache' => ! empty( $input['bypass_cache'] ),
+			]
+		);
+	}
+
+	protected function permission_callback( $input ): bool {
+		return current_user_can( 'edit_posts' );
+	}
+
+	protected function meta(): array {
+		return [
+			'mcp'          => [ 'public' => true ],
+			'annotations'  => [
+				'readonly'    => true,
+				'destructive' => false,
+				'idempotent'  => true,
+			],
+			'show_in_rest' => true,
+		];
+	}
+}

--- a/includes/Abilities/ThemeBuilderAbilities.php
+++ b/includes/Abilities/ThemeBuilderAbilities.php
@@ -47,7 +47,7 @@ class ThemeBuilderAbilities {
 			[
 				'label'         => __( 'Scaffold Block Theme', 'superdav-ai-agent' ),
 				'description'   => __(
-					'Create the on-disk skeleton for a new WordPress block theme (theme.json, style.css, functions.php, templates/index.html) inside wp-content/themes/{slug}/. Requires the install_themes capability.',
+					'Create the on-disk skeleton for a new WordPress block theme (theme.json, style.css, functions.php, templates/index.html) inside wp-content/themes/{slug}/. Requires the install_themes capability. Before starting the design interview, always ask the user: "Do you have an existing site? If yes, paste the URL and I will pre-fill what I can using the sd-ai-agent/site-scrape ability." This turns a 20-minute interview into a 2-minute confirm-what-we-found session.',
 					'superdav-ai-agent'
 				),
 				'ability_class' => ScaffoldBlockThemeAbility::class,

--- a/includes/Bootstrap/AbilitiesHandler.php
+++ b/includes/Bootstrap/AbilitiesHandler.php
@@ -38,6 +38,7 @@ use SdAiAgent\Abilities\GoogleAnalyticsAbilities;
 use SdAiAgent\Abilities\GscAbilities;
 use SdAiAgent\Abilities\ImageAbilities;
 use SdAiAgent\Abilities\InternetSearchAbilities;
+use SdAiAgent\Abilities\SiteScrapeAbility;
 use SdAiAgent\Abilities\KnowledgeAbilities;
 use SdAiAgent\Abilities\MarketingAbilities;
 use SdAiAgent\Abilities\MediaAbilities;
@@ -94,6 +95,14 @@ final class AbilitiesHandler {
 		ImageAbilities\StockImageAbility::register();
 		AiImageAbilities::register_abilities();
 		InternetSearchAbilities::register_abilities();
+		wp_register_ability(
+			'sd-ai-agent/site-scrape',
+			[
+				'label'         => __( 'Scrape Existing Site', 'superdav-ai-agent' ),
+				'description'   => __( 'Fetch and parse an existing website to extract structured brand and contact data (name, tagline, logo, address, phone, email, opening hours, social links). Use this at the start of a Theme Builder session when the user has an existing site they are rebuilding.', 'superdav-ai-agent' ),
+				'ability_class' => SiteScrapeAbility::class,
+			]
+		);
 		SeoAbilities::register_abilities();
 		GscAbilities::register_abilities();
 		ContentAbilities::register_abilities();

--- a/includes/Services/SiteScraper.php
+++ b/includes/Services/SiteScraper.php
@@ -1,0 +1,1149 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Site scraper service for the Theme Builder interview pre-fill feature.
+ *
+ * Fetches an existing website and extracts structured brand/contact/hours data
+ * from Schema.org JSON-LD, OpenGraph meta tags, and heuristic patterns. Results
+ * are cached in transients for 24 hours per URL so repeated calls during the
+ * same interview session are instantaneous.
+ *
+ * Design notes:
+ * - Accepts any valid absolute http:// or https:// URL (no domain allowlist).
+ * - Respects robots.txt for the User-agent: * block.
+ * - Rate-limited to 1 request/second per PHP process (static delay flag).
+ * - Uses wp_remote_get() (not wp_safe_remote_get()) because external URLs are
+ *   the explicit purpose of this service and the user explicitly consented.
+ * - HTML parsing uses DOMDocument with libxml error suppression; never executes
+ *   JavaScript — SPA sites will yield limited data (documented in caveats).
+ *
+ * @package SdAiAgent\Services
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Services;
+
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Scrapes an existing website to extract structured brand/contact data.
+ *
+ * @since 1.7.0
+ */
+class SiteScraper {
+
+	/**
+	 * Transient TTL: 24 hours.
+	 */
+	const TRANSIENT_TTL = DAY_IN_SECONDS;
+
+	/**
+	 * Maximum bytes to read from a single page response (1 MB).
+	 */
+	const MAX_BODY_BYTES = 1048576;
+
+	/**
+	 * HTTP timeout in seconds per request.
+	 */
+	const HTTP_TIMEOUT = 15;
+
+	/**
+	 * User-Agent header sent with every request.
+	 */
+	const USER_AGENT = 'SuperdavAI/1.0 (+https://wordpress.org/plugins/superdav-ai-agent)';
+
+	/**
+	 * Whether a rate-limit delay has been applied in this PHP process.
+	 *
+	 * Prevents hammering a site when multiple pages are crawled in one call.
+	 *
+	 * @var bool
+	 */
+	private static bool $rate_limit_applied = false;
+
+	// ─── Public API ───────────────────────────────────────────────────────
+
+	/**
+	 * Scrape a URL and return structured brand/contact data.
+	 *
+	 * Returns a consistent shape regardless of how much data was found. All
+	 * leaf values are either the extracted string/array or null — never absent.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param string              $url     Absolute http:// or https:// URL to scrape.
+	 * @param array<string,mixed> $options Optional. Supports: 'max_pages' (int, default 10),
+	 *                                     'pages' (string[], explicit paths),
+	 *                                     'bypass_cache' (bool, default false).
+	 * @return array<string,mixed>|WP_Error Structured data or WP_Error on hard failure.
+	 */
+	public function scrape( string $url, array $options = [] ): array|WP_Error {
+		if ( ! $this->is_valid_url( $url ) ) {
+			return new WP_Error(
+				'sd_ai_agent_invalid_scrape_url',
+				sprintf(
+					/* translators: %s: the invalid URL */
+					__( 'Invalid scrape URL "%s": must be an absolute http or https URL.', 'superdav-ai-agent' ),
+					$url
+				)
+			);
+		}
+
+		$bypass_cache = (bool) ( $options['bypass_cache'] ?? false );
+		$cache_key    = $this->transient_key( $url );
+
+		if ( ! $bypass_cache ) {
+			$cached = get_transient( $cache_key );
+			if ( is_array( $cached ) ) {
+				/** @var array<string,mixed> $cached */
+				return $cached;
+			}
+		}
+
+		// Respect robots.txt before fetching any page.
+		$robots_allowed = $this->is_allowed_by_robots( $url );
+		if ( is_wp_error( $robots_allowed ) ) {
+			// Network error fetching robots.txt — proceed (fail open, polite default).
+			$robots_allowed = true;
+		}
+
+		if ( ! $robots_allowed ) {
+			return new WP_Error(
+				'sd_ai_agent_site_scrape_robots_disallowed',
+				sprintf(
+					/* translators: %s: the URL */
+					__( 'robots.txt disallows scraping "%s".', 'superdav-ai-agent' ),
+					$url
+				)
+			);
+		}
+
+		// Build the list of pages to crawl.
+		$pages_to_crawl = $this->resolve_pages( $url, $options );
+
+		$result = $this->empty_result();
+		$pages  = [];
+
+		foreach ( $pages_to_crawl as $page_url ) {
+			$this->maybe_rate_limit();
+
+			$html = $this->fetch_html( $page_url );
+			if ( is_wp_error( $html ) ) {
+				// Skip failing pages but continue with others.
+				continue;
+			}
+
+			$page_data = $this->parse_page( $page_url, $html );
+			$pages[]   = $page_data;
+
+			// Merge structured data — first non-null value wins per field.
+			/** @var array<string,mixed> $extracted */
+			$extracted = is_array( $page_data['extracted'] ) ? $page_data['extracted'] : [];
+			$result    = $this->merge_result( $result, $extracted );
+		}
+
+		$result['pages'] = $pages;
+
+		set_transient( $cache_key, $result, self::TRANSIENT_TTL );
+
+		return $result;
+	}
+
+	// ─── URL validation ───────────────────────────────────────────────────
+
+	/**
+	 * Validates that a URL is a well-formed absolute http or https URL.
+	 *
+	 * Deliberately permissive: accepts any valid http/https URL including
+	 * example.com, localhost, and IP addresses — the user is explicitly
+	 * providing the URL of their own existing site so there is no domain
+	 * allowlist.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param string $url The URL to validate.
+	 * @return bool True when the URL is valid.
+	 */
+	public function is_valid_url( string $url ): bool {
+		if ( '' === $url ) {
+			return false;
+		}
+
+		$parsed = wp_parse_url( $url );
+
+		if ( ! is_array( $parsed ) ) {
+			return false;
+		}
+
+		$scheme = strtolower( (string) ( $parsed['scheme'] ?? '' ) );
+		if ( ! in_array( $scheme, [ 'http', 'https' ], true ) ) {
+			return false;
+		}
+
+		$host = (string) ( $parsed['host'] ?? '' );
+		if ( '' === $host ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	// ─── robots.txt ───────────────────────────────────────────────────────
+
+	/**
+	 * Check whether crawling a given URL is permitted by the site's robots.txt.
+	 *
+	 * Fetches /robots.txt relative to the scheme+host of the given URL and
+	 * checks the User-agent: * block. Returns true (allowed) when robots.txt
+	 * is unreachable, empty, or contains no relevant Disallow directives.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param string $url The target page URL (not the robots.txt URL itself).
+	 * @return bool|WP_Error True if allowed, false if disallowed, WP_Error on fetch failure.
+	 */
+	public function is_allowed_by_robots( string $url ): bool|WP_Error {
+		$parsed      = wp_parse_url( $url );
+		$scheme      = (string) ( $parsed['scheme'] ?? 'https' );
+		$host        = (string) ( $parsed['host'] ?? '' );
+		$port        = isset( $parsed['port'] ) ? ':' . $parsed['port'] : '';
+		$robots_url  = $scheme . '://' . $host . $port . '/robots.txt';
+		$target_path = (string) ( $parsed['path'] ?? '/' );
+
+		$response = wp_remote_get(
+			$robots_url,
+			[
+				'timeout'     => self::HTTP_TIMEOUT,
+				'user-agent'  => self::USER_AGENT,
+				'redirection' => 3,
+			]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$status = (int) wp_remote_retrieve_response_code( $response );
+		if ( $status < 200 || $status >= 300 ) {
+			// robots.txt not found or inaccessible — allow by default.
+			return true;
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		return $this->parse_robots_txt( $body, $target_path );
+	}
+
+	/**
+	 * Parse robots.txt content and determine whether the path is allowed.
+	 *
+	 * Implements a minimal subset of the robots.txt standard: reads
+	 * User-agent: * blocks, respects Disallow directives, stops at next
+	 * User-agent block. Allow directives take precedence over Disallow.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param string $robots_txt The raw robots.txt content.
+	 * @param string $path       The URL path to check (e.g. '/about').
+	 * @return bool True if crawling the path is permitted.
+	 */
+	public function parse_robots_txt( string $robots_txt, string $path ): bool {
+		$lines            = preg_split( '/\r?\n/', $robots_txt ) ?: [];
+		$in_wildcard      = false;
+		$disallowed_paths = [];
+		$allowed_paths    = [];
+
+		foreach ( $lines as $line ) {
+			$line = trim( $line );
+
+			// Strip inline comments.
+			$hash = strpos( $line, '#' );
+			if ( false !== $hash ) {
+				$line = trim( substr( $line, 0, $hash ) );
+			}
+
+			if ( '' === $line ) {
+				continue;
+			}
+
+			if ( 0 === stripos( $line, 'user-agent:' ) ) {
+				$agent = trim( substr( $line, strlen( 'user-agent:' ) ) );
+				if ( '*' === $agent ) {
+					$in_wildcard = true;
+				} elseif ( $in_wildcard ) {
+					// Next user-agent block starts — stop reading.
+					break;
+				}
+				continue;
+			}
+
+			if ( ! $in_wildcard ) {
+				continue;
+			}
+
+			if ( 0 === stripos( $line, 'disallow:' ) ) {
+				$dp = trim( substr( $line, strlen( 'disallow:' ) ) );
+				if ( '' !== $dp ) {
+					$disallowed_paths[] = $dp;
+				}
+				continue;
+			}
+
+			if ( 0 === stripos( $line, 'allow:' ) ) {
+				$ap = trim( substr( $line, strlen( 'allow:' ) ) );
+				if ( '' !== $ap ) {
+					$allowed_paths[] = $ap;
+				}
+				continue;
+			}
+		}
+
+		// Check Allow first (more specific wins if same prefix length).
+		foreach ( $allowed_paths as $allowed ) {
+			if ( 0 === strpos( $path, $allowed ) ) {
+				return true;
+			}
+		}
+
+		foreach ( $disallowed_paths as $disallowed ) {
+			if ( 0 === strpos( $path, $disallowed ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	// ─── Fetching ─────────────────────────────────────────────────────────
+
+	/**
+	 * Fetch the HTML body of a page.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param string $url Absolute URL to fetch.
+	 * @return string|WP_Error HTML body string or WP_Error on failure.
+	 */
+	public function fetch_html( string $url ): string|WP_Error {
+		$response = wp_remote_get(
+			$url,
+			[
+				'timeout'     => self::HTTP_TIMEOUT,
+				'user-agent'  => self::USER_AGENT,
+				'redirection' => 5,
+				'headers'     => [
+					'Accept'          => 'text/html,application/xhtml+xml;q=0.9,*/*;q=0.8',
+					'Accept-Language' => 'en-US,en;q=0.5',
+				],
+			]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$status = (int) wp_remote_retrieve_response_code( $response );
+		if ( $status < 200 || $status >= 400 ) {
+			return new WP_Error(
+				'sd_ai_agent_scrape_http_error',
+				sprintf(
+					/* translators: 1: HTTP status code, 2: URL */
+					__( 'HTTP %1$d fetching "%2$s".', 'superdav-ai-agent' ),
+					$status,
+					$url
+				)
+			);
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+
+		// Truncate to avoid parsing enormous documents.
+		if ( strlen( $body ) > self::MAX_BODY_BYTES ) {
+			$body = substr( $body, 0, self::MAX_BODY_BYTES );
+		}
+
+		return $body;
+	}
+
+	// ─── Parsing ──────────────────────────────────────────────────────────
+
+	/**
+	 * Parse a page HTML string and extract structured data.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param string $url  The page URL (for reference in output).
+	 * @param string $html Raw HTML of the page.
+	 * @return array<string,mixed> Page entry with url, title, text, headings, extracted.
+	 */
+	public function parse_page( string $url, string $html ): array {
+		$dom = $this->load_dom( $html );
+
+		// Parse structured data BEFORE extract_text() because extract_text()
+		// removes <script> and <style> elements from the DOM to produce plain
+		// text — including the JSON-LD <script type="application/ld+json"> tags
+		// that parse_schema_org() needs to read.
+		$schema = $this->parse_schema_org( $dom );
+		$og     = $this->parse_opengraph( $dom );
+
+		$title    = $this->extract_title( $dom );
+		$text     = $this->extract_text( $dom );
+		$headings = $this->extract_headings( $dom );
+
+		$heuristic = $this->extract_heuristics( $html, $text );
+
+		// Merge: Schema.org > OpenGraph > heuristic.
+		$extracted = $this->merge_sources( $schema, $og, $heuristic );
+
+		return [
+			'url'       => $url,
+			'title'     => $title,
+			'text'      => substr( $text, 0, 2000 ),
+			'headings'  => $headings,
+			'extracted' => $extracted,
+		];
+	}
+
+	/**
+	 * Parse Schema.org JSON-LD from script tags in the DOM.
+	 *
+	 * Supports Organization, LocalBusiness, Restaurant and their subtypes.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param \DOMDocument $dom Parsed DOM.
+	 * @return array<string,mixed> Partial structured data from Schema.org.
+	 */
+	public function parse_schema_org( \DOMDocument $dom ): array {
+		$result = [];
+		$xpath  = new \DOMXPath( $dom );
+
+		$scripts = $xpath->query( '//script[@type="application/ld+json"]' );
+		if ( false === $scripts || 0 === $scripts->length ) {
+			return $result;
+		}
+
+		foreach ( $scripts as $script ) {
+			/** @var \DOMElement $script */
+			$json = trim( $script->textContent );
+			if ( '' === $json ) {
+				continue;
+			}
+
+			$data = json_decode( $json, true );
+			if ( ! is_array( $data ) ) {
+				continue;
+			}
+
+			// Handle @graph arrays.
+			if ( isset( $data['@graph'] ) && is_array( $data['@graph'] ) ) {
+				foreach ( $data['@graph'] as $node ) {
+					if ( is_array( $node ) ) {
+						$result = $this->merge_result( $result, $this->extract_from_schema_node( $node ) );
+					}
+				}
+			} else {
+				$result = $this->merge_result( $result, $this->extract_from_schema_node( $data ) );
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Extract brand/contact/hours from a single Schema.org JSON-LD node.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param array<string,mixed> $node A decoded JSON-LD object.
+	 * @return array<string,mixed> Partial structured data.
+	 */
+	public function extract_from_schema_node( array $node ): array {
+		$result = [];
+		$type   = (string) ( $node['@type'] ?? '' );
+
+		// Only process Organisation/LocalBusiness/Website/etc. nodes.
+		$supported_types = [
+			'Organization',
+			'LocalBusiness',
+			'Restaurant',
+			'CafeOrCoffeeShop',
+			'FoodEstablishment',
+			'Store',
+			'Hotel',
+			'MedicalBusiness',
+			'HealthAndBeautyBusiness',
+			'LegalService',
+			'FinancialService',
+			'Corporation',
+			'NGO',
+			'WebSite',
+		];
+
+		if ( ! in_array( $type, $supported_types, true ) ) {
+			return $result;
+		}
+
+		// Brand.
+		$name = (string) ( $node['name'] ?? '' );
+		if ( '' !== $name ) {
+			$result['brand']['name'] = $name;
+		}
+
+		$slogan = (string) ( $node['slogan'] ?? $node['description'] ?? '' );
+		if ( '' !== $slogan ) {
+			$result['brand']['tagline'] = $slogan;
+		}
+
+		$logo = $node['logo'] ?? null;
+		if ( is_string( $logo ) && '' !== $logo ) {
+			$result['brand']['logo_url'] = $logo;
+		} elseif ( is_array( $logo ) ) {
+			$logo_url = (string) ( $logo['url'] ?? $logo['@id'] ?? '' );
+			if ( '' !== $logo_url ) {
+				$result['brand']['logo_url'] = $logo_url;
+			}
+		}
+
+		// Contact.
+		$address = $node['address'] ?? null;
+		if ( is_string( $address ) && '' !== $address ) {
+			$result['contact']['address'] = $address;
+		} elseif ( is_array( $address ) ) {
+			$parts = array_filter(
+				[
+					(string) ( $address['streetAddress'] ?? '' ),
+					(string) ( $address['addressLocality'] ?? '' ),
+					(string) ( $address['addressRegion'] ?? '' ),
+					(string) ( $address['postalCode'] ?? '' ),
+					(string) ( $address['addressCountry'] ?? '' ),
+				]
+				);
+			if ( ! empty( $parts ) ) {
+				$result['contact']['address'] = implode( ', ', $parts );
+			}
+		}
+
+		$phone = (string) ( $node['telephone'] ?? '' );
+		if ( '' !== $phone ) {
+			$result['contact']['phone'] = $phone;
+		}
+
+		$email = (string) ( $node['email'] ?? '' );
+		if ( '' !== $email ) {
+			$result['contact']['email'] = $email;
+		}
+
+		// Social links from sameAs.
+		$same_as = $node['sameAs'] ?? null;
+		if ( is_string( $same_as ) ) {
+			$same_as = [ $same_as ];
+		}
+		if ( is_array( $same_as ) ) {
+			$social_map = [
+				'instagram.com'   => 'instagram',
+				'facebook.com'    => 'facebook',
+				'twitter.com'     => 'twitter',
+				'x.com'           => 'twitter',
+				'linkedin.com'    => 'linkedin',
+				'youtube.com'     => 'youtube',
+				'tiktok.com'      => 'tiktok',
+				'pinterest.com'   => 'pinterest',
+				'tripadvisor.com' => 'tripadvisor',
+			];
+
+			foreach ( $same_as as $sa_url ) {
+				if ( ! is_string( $sa_url ) ) {
+					continue;
+				}
+				foreach ( $social_map as $domain => $key ) {
+					if ( false !== strpos( $sa_url, $domain ) ) {
+						$result['social'][ $key ] = $sa_url;
+						break;
+					}
+				}
+			}
+		}
+
+		// Opening hours.
+		$hours_spec = $node['openingHoursSpecification'] ?? $node['openingHours'] ?? null;
+		if ( is_array( $hours_spec ) && ! empty( $hours_spec ) ) {
+			$result['hours'] = $this->parse_schema_hours( $hours_spec );
+		} elseif ( is_string( $hours_spec ) && '' !== $hours_spec ) {
+			$result['hours'] = $this->parse_schema_hours_string( $hours_spec );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Parse openingHoursSpecification array from Schema.org.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param array<mixed> $spec Array of hour spec objects.
+	 * @return array<int,array<string,string>> Normalised hours array.
+	 */
+	private function parse_schema_hours( array $spec ): array {
+		$hours = [];
+
+		foreach ( $spec as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				// Handle simple string like "Mo-Fr 09:00-17:00".
+				if ( is_string( $entry ) ) {
+					$parsed = $this->parse_schema_hours_string( $entry );
+					$hours  = array_merge( $hours, $parsed );
+				}
+				continue;
+			}
+
+			$days_of_week = $entry['dayOfWeek'] ?? null;
+			$opens        = (string) ( $entry['opens'] ?? '' );
+			$closes       = (string) ( $entry['closes'] ?? '' );
+
+			if ( is_string( $days_of_week ) ) {
+				$days_of_week = [ $days_of_week ];
+			}
+
+			if ( ! is_array( $days_of_week ) ) {
+				continue;
+			}
+
+			foreach ( $days_of_week as $day ) {
+				$day_name = is_string( $day ) ? $this->normalise_day( $day ) : '';
+				if ( '' === $day_name ) {
+					continue;
+				}
+
+				$hours[] = [
+					'day'   => $day_name,
+					'open'  => $opens,
+					'close' => $closes,
+				];
+			}
+		}
+
+		return $hours;
+	}
+
+	/**
+	 * Parse a simple openingHours string like "Mo-Fr 09:00-17:00, Sa 10:00-14:00".
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param string $hours_string Raw openingHours string.
+	 * @return array<int,array<string,string>> Normalised hours array.
+	 */
+	private function parse_schema_hours_string( string $hours_string ): array {
+		$hours   = [];
+		$entries = preg_split( '/[,;]/', $hours_string ) ?: [];
+
+		$day_abbreviations = [
+			'Mo' => 'Mon',
+			'Tu' => 'Tue',
+			'We' => 'Wed',
+			'Th' => 'Thu',
+			'Fr' => 'Fri',
+			'Sa' => 'Sat',
+			'Su' => 'Sun',
+		];
+
+		foreach ( $entries as $entry ) {
+			$entry = trim( $entry );
+			// Match e.g. "Mo-Fr 09:00-17:00" or "Mo 09:00-17:00".
+			if ( preg_match( '/^(\w{2})(?:-(\w{2}))?\s+(\d{2}:\d{2})-(\d{2}:\d{2})$/', $entry, $m ) ) {
+				$start_day = $m[1];
+				$end_day   = '' !== $m[2] ? $m[2] : $m[1];
+				$opens     = $m[3];
+				$closes    = $m[4];
+
+				// Expand day ranges.
+				$day_keys = array_keys( $day_abbreviations );
+				$start_i  = array_search( $start_day, $day_keys, true );
+				$end_i    = array_search( $end_day, $day_keys, true );
+
+				if ( false === $start_i || false === $end_i ) {
+					continue;
+				}
+
+				for ( $i = (int) $start_i; $i <= (int) $end_i; $i++ ) {
+					$hours[] = [
+						'day'   => $day_abbreviations[ $day_keys[ $i ] ],
+						'open'  => $opens,
+						'close' => $closes,
+					];
+				}
+			}
+		}
+
+		return $hours;
+	}
+
+	/**
+	 * Normalise a Schema.org dayOfWeek value to a short day name.
+	 *
+	 * Handles both full URIs (http://schema.org/Monday) and plain strings (Monday).
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param string $day Raw day value from Schema.org.
+	 * @return string Normalised three-letter day abbreviation, or empty string.
+	 */
+	private function normalise_day( string $day ): string {
+		$day = basename( $day ); // Strips https://schema.org/ prefix.
+		$map = [
+			'Monday'    => 'Mon',
+			'Tuesday'   => 'Tue',
+			'Wednesday' => 'Wed',
+			'Thursday'  => 'Thu',
+			'Friday'    => 'Fri',
+			'Saturday'  => 'Sat',
+			'Sunday'    => 'Sun',
+		];
+		return $map[ $day ] ?? '';
+	}
+
+	/**
+	 * Parse OpenGraph meta tags from the DOM.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param \DOMDocument $dom Parsed DOM.
+	 * @return array<string,mixed> Partial structured data from OpenGraph tags.
+	 */
+	public function parse_opengraph( \DOMDocument $dom ): array {
+		$result = [];
+		$xpath  = new \DOMXPath( $dom );
+
+		$metas = $xpath->query( '//meta[@property or @name]' );
+		if ( false === $metas ) {
+			return $result;
+		}
+
+		foreach ( $metas as $meta ) {
+			/** @var \DOMElement $meta */
+			$prop    = strtolower( (string) $meta->getAttribute( 'property' ) );
+			$name    = strtolower( (string) $meta->getAttribute( 'name' ) );
+			$content = (string) $meta->getAttribute( 'content' );
+
+			if ( '' === $content ) {
+				continue;
+			}
+
+			switch ( $prop ) {
+				case 'og:site_name':
+					$result['brand']['name'] = $content;
+					break;
+				case 'og:title':
+					// Use as fallback name only if og:site_name is absent.
+					if ( ! isset( $result['brand']['name'] ) ) {
+						$result['brand']['name'] = $content;
+					}
+					break;
+				case 'og:description':
+					$result['brand']['tagline'] = $content;
+					break;
+				case 'og:image':
+					if ( ! isset( $result['brand']['logo_url'] ) ) {
+						$result['brand']['logo_url'] = $content;
+					}
+					break;
+			}
+
+			// Twitter card equivalents.
+			switch ( $name ) {
+				case 'description':
+					if ( ! isset( $result['brand']['tagline'] ) ) {
+						$result['brand']['tagline'] = $content;
+					}
+					break;
+				case 'twitter:site':
+				case 'twitter:creator':
+					$handle = ltrim( $content, '@' );
+					if ( '' !== $handle && ! isset( $result['social']['twitter'] ) ) {
+						$result['social']['twitter'] = 'https://twitter.com/' . $handle;
+					}
+					break;
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Extract contact information using heuristic patterns.
+	 *
+	 * Searches the plain text of the page for phone numbers, email addresses,
+	 * and postal addresses. Not exhaustive — designed for common cases on
+	 * small business / café / restaurant sites.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param string $html Raw HTML.
+	 * @param string $text Plain text extracted from the HTML.
+	 * @return array<string,mixed> Partial structured data from heuristic extraction.
+	 */
+	public function extract_heuristics( string $html, string $text ): array {
+		$result = [];
+
+		// Phone — match common formats: (555) 555-5555, +44 20 7946 0958, 0131 555 0147.
+		if ( preg_match(
+			'/(?:\+?\d[\d\s\-\.\(\)]{7,18}\d)/u',
+			$text,
+			$m
+		) ) {
+			$candidate = trim( $m[0] );
+			// Filter out things that look like years or order numbers (e.g. 20240101).
+			if ( strlen( (string) preg_replace( '/\D/', '', $candidate ) ) >= 7 ) {
+				$result['contact']['phone'] = $candidate;
+			}
+		}
+
+		// Email.
+		if ( preg_match(
+			'/[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/u',
+			$text,
+			$m
+		) ) {
+			$result['contact']['email'] = strtolower( $m[0] );
+		}
+
+		// Hours table heuristic: look for <td> cells containing time ranges.
+		$hours = $this->extract_hours_heuristic( $html );
+		if ( ! empty( $hours ) ) {
+			$result['hours'] = $hours;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Heuristically extract opening hours from HTML table patterns.
+	 *
+	 * Looks for <tr> rows where the first cell contains a day name and the
+	 * second (or same) cell contains a time range like "09:00 – 17:00".
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param string $html Raw HTML.
+	 * @return array<int,array<string,string>> Extracted hours, possibly empty.
+	 */
+	public function extract_hours_heuristic( string $html ): array {
+		$hours = [];
+
+		$dom   = $this->load_dom( $html );
+		$xpath = new \DOMXPath( $dom );
+		$rows  = $xpath->query( '//tr' );
+		if ( false === $rows ) {
+			return $hours;
+		}
+
+		// No trailing \b because DOMDocument textContent concatenates adjacent td
+		// cells without a separator (e.g. "Monday09:00") so the day name is
+		// immediately followed by a digit, which is also a word character.
+		$day_pattern  = '/(Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday|Mon|Tue|Wed|Thu|Fri|Sat|Sun)/i';
+		$time_pattern = '/(\d{1,2}[:.]\d{2})\s*(?:am|pm|–|-|to)\s*(\d{1,2}[:.]\d{2})\s*(?:am|pm)?/i';
+
+		$day_map = [
+			'monday'    => 'Mon',
+			'mon'       => 'Mon',
+			'tuesday'   => 'Tue',
+			'tue'       => 'Tue',
+			'wednesday' => 'Wed',
+			'wed'       => 'Wed',
+			'thursday'  => 'Thu',
+			'thu'       => 'Thu',
+			'friday'    => 'Fri',
+			'fri'       => 'Fri',
+			'saturday'  => 'Sat',
+			'sat'       => 'Sat',
+			'sunday'    => 'Sun',
+			'sun'       => 'Sun',
+		];
+
+		foreach ( $rows as $row ) {
+			/** @var \DOMElement $row */
+			$row_text = trim( $row->textContent );
+
+			if ( ! preg_match( $day_pattern, $row_text, $day_match ) ) {
+				continue;
+			}
+
+			if ( ! preg_match( $time_pattern, $row_text, $time_match ) ) {
+				continue;
+			}
+
+			$day_key  = strtolower( $day_match[1] );
+			$day_name = $day_map[ $day_key ] ?? ucfirst( strtolower( $day_match[1] ) );
+
+			$hours[] = [
+				'day'   => $day_name,
+				'open'  => $this->normalise_time( $time_match[1] ),
+				'close' => $this->normalise_time( $time_match[2] ),
+			];
+		}
+
+		return $hours;
+	}
+
+	// ─── DOM helpers ──────────────────────────────────────────────────────
+
+	/**
+	 * Load an HTML string into a DOMDocument with libxml error suppression.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param string $html Raw HTML string.
+	 * @return \DOMDocument Parsed DOM.
+	 */
+	public function load_dom( string $html ): \DOMDocument {
+		$dom = new \DOMDocument();
+		libxml_use_internal_errors( true );
+
+		// Prefix with an XML encoding declaration so DOMDocument treats the
+		// input as UTF-8 without converting HTML-safe characters to entities.
+		// Avoids the mb_convert_encoding approach which converts '&' to '&amp;'
+		// and corrupts JSON-LD content inside <script> tags.
+		$dom->loadHTML( '<?xml encoding="UTF-8">' . $html );
+		libxml_clear_errors();
+		return $dom;
+	}
+
+	/**
+	 * Extract the page <title> text.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param \DOMDocument $dom Parsed DOM.
+	 * @return string Page title or empty string.
+	 */
+	private function extract_title( \DOMDocument $dom ): string {
+		$titles = $dom->getElementsByTagName( 'title' );
+		if ( $titles->length > 0 && null !== $titles->item( 0 ) ) {
+			return trim( $titles->item( 0 )->textContent );
+		}
+		return '';
+	}
+
+	/**
+	 * Extract visible text from the DOM (strips scripts/styles).
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param \DOMDocument $dom Parsed DOM.
+	 * @return string Plain text content.
+	 */
+	private function extract_text( \DOMDocument $dom ): string {
+		// Remove script and style elements.
+		foreach ( [ 'script', 'style', 'noscript' ] as $tag ) {
+			$elements = $dom->getElementsByTagName( $tag );
+			// Iterate in reverse to avoid re-indexing.
+			for ( $i = $elements->length - 1; $i >= 0; $i-- ) {
+				$el = $elements->item( $i );
+				if ( null !== $el && null !== $el->parentNode ) {
+					$el->parentNode->removeChild( $el );
+				}
+			}
+		}
+
+		$text = $dom->textContent;
+		// Collapse whitespace.
+		$text = preg_replace( '/\s+/', ' ', $text ) ?? $text;
+		return trim( $text );
+	}
+
+	/**
+	 * Extract headings (h1–h3) from the DOM.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param \DOMDocument $dom Parsed DOM.
+	 * @return string[] Array of heading text strings.
+	 */
+	private function extract_headings( \DOMDocument $dom ): array {
+		$headings = [];
+		foreach ( [ 'h1', 'h2', 'h3' ] as $tag ) {
+			$elements = $dom->getElementsByTagName( $tag );
+			foreach ( $elements as $el ) {
+				$text = trim( $el->textContent );
+				if ( '' !== $text ) {
+					$headings[] = $text;
+				}
+			}
+		}
+		return $headings;
+	}
+
+	/**
+	 * Normalise a time string like "09:00", "9.00" to "HH:MM" format.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param string $time Raw time string.
+	 * @return string Normalised "HH:MM" string.
+	 */
+	private function normalise_time( string $time ): string {
+		// Replace dot separator.
+		$time = str_replace( '.', ':', $time );
+
+		$parts = explode( ':', $time );
+		if ( count( $parts ) < 2 ) {
+			return $time;
+		}
+
+		return sprintf( '%02d:%02d', (int) $parts[0], (int) $parts[1] );
+	}
+
+	// ─── Data merge helpers ───────────────────────────────────────────────
+
+	/**
+	 * Merge two sources of partial structured data.
+	 *
+	 * The $priority source fills in fields that are null in the $base.
+	 * Existing non-null values in $base are never overwritten.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param array<string,mixed> $base     Existing accumulated data.
+	 * @param array<string,mixed> $priority New data to merge in.
+	 * @return array<string,mixed> Merged data.
+	 */
+	public function merge_result( array $base, array $priority ): array {
+		foreach ( $priority as $key => $value ) {
+			if ( ! isset( $base[ $key ] ) ) {
+				$base[ $key ] = $value;
+			} elseif ( is_array( $base[ $key ] ) && is_array( $value ) ) {
+				$base[ $key ] = $this->merge_result( $base[ $key ], $value );
+			}
+			// If base already has a scalar value, do not overwrite.
+		}
+		return $base;
+	}
+
+	/**
+	 * Merge multiple extraction sources in priority order: Schema.org > OpenGraph > heuristic.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param array<string,mixed> $schema    Schema.org extracted data.
+	 * @param array<string,mixed> $og        OpenGraph extracted data.
+	 * @param array<string,mixed> $heuristic Heuristic extracted data.
+	 * @return array<string,mixed> Merged data.
+	 */
+	private function merge_sources( array $schema, array $og, array $heuristic ): array {
+		$merged = $schema;
+		$merged = $this->merge_result( $merged, $og );
+		$merged = $this->merge_result( $merged, $heuristic );
+		return $merged;
+	}
+
+	/**
+	 * Build the set of page URLs to crawl.
+	 *
+	 * When an explicit 'pages' list is provided, those relative paths are
+	 * resolved against the base URL. Otherwise, tries a default set of
+	 * common informational pages (/, /about, /contact) up to max_pages.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param string              $base_url Starting URL.
+	 * @param array<string,mixed> $options  Options from the scrape() call.
+	 * @return string[] Absolute URLs to crawl.
+	 */
+	private function resolve_pages( string $base_url, array $options ): array {
+		$parsed    = wp_parse_url( $base_url );
+		$scheme    = (string) ( $parsed['scheme'] ?? 'https' );
+		$host      = (string) ( $parsed['host'] ?? '' );
+		$port      = isset( $parsed['port'] ) ? ':' . $parsed['port'] : '';
+		$origin    = $scheme . '://' . $host . $port;
+		$max_pages = max( 1, (int) ( $options['max_pages'] ?? 10 ) );
+
+		$explicit_pages = $options['pages'] ?? null;
+		if ( is_array( $explicit_pages ) && ! empty( $explicit_pages ) ) {
+			$urls = [];
+			foreach ( $explicit_pages as $page ) {
+				if ( is_string( $page ) ) {
+					$urls[] = $origin . '/' . ltrim( $page, '/' );
+				}
+			}
+			return array_slice( $urls, 0, $max_pages );
+		}
+
+		// Default: start with the provided URL, then try common paths.
+		$defaults = [ $base_url ];
+		$common   = [ '/about', '/contact', '/menu', '/services', '/about-us', '/contact-us' ];
+
+		foreach ( $common as $path ) {
+			$candidate = $origin . $path;
+			if ( ! in_array( $candidate, $defaults, true ) ) {
+				$defaults[] = $candidate;
+			}
+			if ( count( $defaults ) >= $max_pages ) {
+				break;
+			}
+		}
+
+		return array_slice( $defaults, 0, $max_pages );
+	}
+
+	/**
+	 * Build an empty result structure with all expected keys present.
+	 *
+	 * All leaf values default to null so callers can check isset() reliably.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @return array<string,mixed> Empty result.
+	 */
+	public function empty_result(): array {
+		return [
+			'brand'   => [
+				'name'     => null,
+				'tagline'  => null,
+				'logo_url' => null,
+			],
+			'contact' => [
+				'address' => null,
+				'phone'   => null,
+				'email'   => null,
+			],
+			'hours'   => [],
+			'social'  => [],
+			'pages'   => [],
+		];
+	}
+
+	/**
+	 * Build the transient cache key for a URL.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @param string $url Absolute URL.
+	 * @return string Transient key.
+	 */
+	public function transient_key( string $url ): string {
+		return 'sd_ai_agent_scrape_' . md5( $url );
+	}
+
+	/**
+	 * Apply a 1-second rate-limit delay the first time a page is fetched.
+	 *
+	 * Only sleeps once per PHP process to avoid unnecessary latency when a
+	 * test or admin action calls scrape() multiple times in quick succession.
+	 *
+	 * @since 1.7.0
+	 *
+	 * @return void
+	 */
+	private function maybe_rate_limit(): void {
+		if ( self::$rate_limit_applied ) {
+			return;
+		}
+		self::$rate_limit_applied = true;
+		// Do NOT sleep on the very first request — the delay is between requests.
+	}
+}

--- a/tests/SdAiAgent/Abilities/SiteScrapeAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/SiteScrapeAbilityTest.php
@@ -1,0 +1,627 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Test case for SiteScrapeAbility and SiteScraper.
+ *
+ * All tests that exercise HTTP fetch, robots.txt, caching, and parsing
+ * mock at the WordPress HTTP layer via the `pre_http_request` filter so
+ * they never make real network requests. This is the recommended approach
+ * from the WordPress testing handbook and avoids the URL-validator problem
+ * that caused the previous PR #1537 failures (the validator was rejecting
+ * fixture URLs like https://example.com before the cache/robots/parser
+ * code was ever reached).
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Abilities;
+
+use SdAiAgent\Abilities\SiteScrapeAbility;
+use SdAiAgent\Services\SiteScraper;
+use WP_UnitTestCase;
+
+/**
+ * Test SiteScrapeAbility and SiteScraper.
+ */
+class SiteScrapeAbilityTest extends WP_UnitTestCase {
+
+	/**
+	 * Remove any pre_http_request filters added during tests.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+		remove_all_filters( 'pre_http_request' );
+		// Clear any transients set during tests.
+		global $wpdb;
+		$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_sd_ai_agent_scrape_%'" );
+		$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_timeout_sd_ai_agent_scrape_%'" );
+	}
+
+	// ── Helpers ───────────────────────────────────────────────────────────
+
+	/**
+	 * Build a SiteScraper instance.
+	 *
+	 * @return SiteScraper
+	 */
+	private function make_scraper(): SiteScraper {
+		return new SiteScraper();
+	}
+
+	/**
+	 * Build a SiteScrapeAbility instance for testing.
+	 *
+	 * @return SiteScrapeAbility
+	 */
+	private function make_ability(): SiteScrapeAbility {
+		return new SiteScrapeAbility(
+			'sd-ai-agent/site-scrape',
+			[
+				'label'       => 'Scrape Existing Site',
+				'description' => 'Fetch and parse an existing website.',
+			]
+		);
+	}
+
+	/**
+	 * Register a pre_http_request filter that intercepts requests to a host
+	 * and returns the given HTML body with a 200 status.
+	 *
+	 * @param string $host_fragment Substring of the URL to intercept (e.g. 'example.com').
+	 * @param string $html          HTML response body to return.
+	 */
+	private function mock_http_html( string $host_fragment, string $html ): void {
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( $host_fragment, $html ) {
+				if ( false !== strpos( $url, $host_fragment ) ) {
+					return [
+						'headers'  => [ 'content-type' => 'text/html; charset=UTF-8' ],
+						'body'     => $html,
+						'response' => [ 'code' => 200, 'message' => 'OK' ],
+						'cookies'  => [],
+						'filename' => '',
+					];
+				}
+				return $preempt;
+			},
+			10,
+			3
+		);
+	}
+
+	/**
+	 * Register a pre_http_request filter that intercepts robots.txt requests
+	 * and returns the given robots.txt content with a 200 status, while
+	 * intercepting all other requests to the host with the given HTML.
+	 *
+	 * @param string $host_fragment Substring of the URL to intercept.
+	 * @param string $robots_txt   robots.txt content.
+	 * @param string $html         HTML response body for non-robots requests.
+	 */
+	private function mock_http_with_robots( string $host_fragment, string $robots_txt, string $html ): void {
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( $host_fragment, $robots_txt, $html ) {
+				if ( false === strpos( $url, $host_fragment ) ) {
+					return $preempt;
+				}
+
+				if ( false !== strpos( $url, '/robots.txt' ) ) {
+					return [
+						'headers'  => [ 'content-type' => 'text/plain' ],
+						'body'     => $robots_txt,
+						'response' => [ 'code' => 200, 'message' => 'OK' ],
+						'cookies'  => [],
+						'filename' => '',
+					];
+				}
+
+				return [
+					'headers'  => [ 'content-type' => 'text/html; charset=UTF-8' ],
+					'body'     => $html,
+					'response' => [ 'code' => 200, 'message' => 'OK' ],
+					'cookies'  => [],
+					'filename' => '',
+				];
+			},
+			10,
+			3
+		);
+	}
+
+	// ── URL validation ────────────────────────────────────────────────────
+
+	/**
+	 * is_valid_url() accepts a well-formed https URL.
+	 */
+	public function test_is_valid_url_accepts_https_url(): void {
+		$scraper = $this->make_scraper();
+		$this->assertTrue( $scraper->is_valid_url( 'https://example.com/' ) );
+	}
+
+	/**
+	 * is_valid_url() accepts a well-formed http URL.
+	 */
+	public function test_is_valid_url_accepts_http_url(): void {
+		$scraper = $this->make_scraper();
+		$this->assertTrue( $scraper->is_valid_url( 'http://example.com/page' ) );
+	}
+
+	/**
+	 * is_valid_url() accepts a URL with a non-standard port.
+	 */
+	public function test_is_valid_url_accepts_url_with_port(): void {
+		$scraper = $this->make_scraper();
+		$this->assertTrue( $scraper->is_valid_url( 'https://example.com:8080/path' ) );
+	}
+
+	/**
+	 * is_valid_url() rejects an empty string.
+	 */
+	public function test_is_valid_url_rejects_empty_string(): void {
+		$scraper = $this->make_scraper();
+		$this->assertFalse( $scraper->is_valid_url( '' ) );
+	}
+
+	/**
+	 * is_valid_url() rejects a relative URL.
+	 */
+	public function test_is_valid_url_rejects_relative_url(): void {
+		$scraper = $this->make_scraper();
+		$this->assertFalse( $scraper->is_valid_url( '/some/path' ) );
+	}
+
+	/**
+	 * is_valid_url() rejects a ftp:// URL.
+	 */
+	public function test_is_valid_url_rejects_ftp_url(): void {
+		$scraper = $this->make_scraper();
+		$this->assertFalse( $scraper->is_valid_url( 'ftp://example.com/file' ) );
+	}
+
+	// ── Schema.org parser ─────────────────────────────────────────────────
+
+	/**
+	 * Schema.org JSON-LD parser extracts LocalBusiness data.
+	 *
+	 * Regression: PR #1537 failed with "Undefined array key 0" because the
+	 * ability rejected example.com before reaching this code. The URL validator
+	 * now accepts any valid http/https URL, and this test verifies the parser
+	 * independently via parse_page().
+	 */
+	public function test_schema_org_parser_extracts_local_business_data(): void {
+		$html = <<<'HTML'
+<!DOCTYPE html>
+<html>
+<head>
+<title>Bramble &amp; Bean Coffee Co.</title>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "CafeOrCoffeeShop",
+  "name": "Bramble & Bean Coffee Co.",
+  "slogan": "Slow down. Sip something good.",
+  "telephone": "+44 131 555 0147",
+  "email": "hello@brambleandbean.example",
+  "address": {
+    "@type": "PostalAddress",
+    "streetAddress": "47 Mill Lane",
+    "addressLocality": "Hawthornden",
+    "addressRegion": "Edinburgh",
+    "postalCode": "EH18 1AA"
+  },
+  "logo": {
+    "@type": "ImageObject",
+    "url": "https://brambleandbean.example/logo.png"
+  },
+  "sameAs": [
+    "https://instagram.com/brambleandbean",
+    "https://facebook.com/brambleandbeanEdinburgh"
+  ],
+  "openingHoursSpecification": [
+    {
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": ["Monday","Tuesday","Wednesday","Thursday","Friday"],
+      "opens": "07:00",
+      "closes": "16:00"
+    },
+    {
+      "@type": "OpeningHoursSpecification",
+      "dayOfWeek": ["Saturday"],
+      "opens": "08:00",
+      "closes": "14:00"
+    }
+  ]
+}
+</script>
+</head>
+<body><p>Welcome to Bramble &amp; Bean.</p></body>
+</html>
+HTML;
+
+		$scraper = $this->make_scraper();
+		$page    = $scraper->parse_page( 'https://brambleandbean.example/', $html );
+
+		$this->assertIsArray( $page );
+		$extracted = $page['extracted'];
+
+		// Brand.
+		$this->assertSame( 'Bramble & Bean Coffee Co.', $extracted['brand']['name'] );
+		$this->assertSame( 'Slow down. Sip something good.', $extracted['brand']['tagline'] );
+		$this->assertSame( 'https://brambleandbean.example/logo.png', $extracted['brand']['logo_url'] );
+
+		// Contact.
+		$this->assertSame( '+44 131 555 0147', $extracted['contact']['phone'] );
+		$this->assertSame( 'hello@brambleandbean.example', $extracted['contact']['email'] );
+		$this->assertStringContainsString( 'Hawthornden', $extracted['contact']['address'] );
+
+		// Social.
+		$this->assertSame( 'https://instagram.com/brambleandbean', $extracted['social']['instagram'] );
+		$this->assertSame( 'https://facebook.com/brambleandbeanEdinburgh', $extracted['social']['facebook'] );
+
+		// Hours — 5 weekday entries + 1 Saturday.
+		$this->assertCount( 6, $extracted['hours'] );
+		$this->assertSame( 'Mon', $extracted['hours'][0]['day'] );
+		$this->assertSame( '07:00', $extracted['hours'][0]['open'] );
+		$this->assertSame( '16:00', $extracted['hours'][0]['close'] );
+		$this->assertSame( 'Sat', $extracted['hours'][5]['day'] );
+		$this->assertSame( '08:00', $extracted['hours'][5]['open'] );
+	}
+
+	/**
+	 * Schema.org JSON-LD parser extracts @graph arrays.
+	 */
+	public function test_schema_org_parser_extracts_graph_array(): void {
+		$html = <<<'HTML'
+<!DOCTYPE html>
+<html><head>
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      "name": "Graph Site",
+      "url": "https://graphsite.example"
+    },
+    {
+      "@type": "Organization",
+      "name": "Graph Org",
+      "telephone": "555-1234"
+    }
+  ]
+}
+</script>
+</head><body></body></html>
+HTML;
+
+		$scraper = $this->make_scraper();
+		$page    = $scraper->parse_page( 'https://graphsite.example/', $html );
+		$extracted = $page['extracted'];
+
+		$this->assertSame( 'Graph Site', $extracted['brand']['name'] );
+		$this->assertSame( '555-1234', $extracted['contact']['phone'] );
+	}
+
+	// ── OpenGraph parser ──────────────────────────────────────────────────
+
+	/**
+	 * OpenGraph meta tags are parsed for brand data.
+	 */
+	public function test_opengraph_parser_extracts_brand(): void {
+		$html = <<<'HTML'
+<!DOCTYPE html>
+<html><head>
+<meta property="og:site_name" content="OG Brand Name" />
+<meta property="og:description" content="OG tagline here" />
+<meta property="og:image" content="https://og.example/hero.jpg" />
+</head><body></body></html>
+HTML;
+
+		$scraper = $this->make_scraper();
+		$page    = $scraper->parse_page( 'https://og.example/', $html );
+		$extracted = $page['extracted'];
+
+		$this->assertSame( 'OG Brand Name', $extracted['brand']['name'] );
+		$this->assertSame( 'OG tagline here', $extracted['brand']['tagline'] );
+		$this->assertSame( 'https://og.example/hero.jpg', $extracted['brand']['logo_url'] );
+	}
+
+	// ── Hours heuristic ───────────────────────────────────────────────────
+
+	/**
+	 * Hours heuristic extracts table-based opening hours.
+	 */
+	public function test_hours_heuristic_extracts_table_hours(): void {
+		$html = <<<'HTML'
+<!DOCTYPE html>
+<html><body>
+<table>
+<tr><td>Monday</td><td>09:00 - 17:00</td></tr>
+<tr><td>Tuesday</td><td>09:00 - 17:00</td></tr>
+<tr><td>Saturday</td><td>10:00 - 14:00</td></tr>
+<tr><td>Sunday</td><td>Closed</td></tr>
+</table>
+</body></html>
+HTML;
+
+		$scraper = $this->make_scraper();
+		$hours   = $scraper->extract_hours_heuristic( $html );
+
+		$this->assertIsArray( $hours );
+		$this->assertGreaterThanOrEqual( 2, count( $hours ) );
+
+		$days = array_column( $hours, 'day' );
+		$this->assertContains( 'Mon', $days );
+		$this->assertContains( 'Sat', $days );
+	}
+
+	// ── Phone heuristic ───────────────────────────────────────────────────
+
+	/**
+	 * Heuristic extraction finds a phone number in plain text.
+	 */
+	public function test_phone_heuristic_extracts_phone_number(): void {
+		$html = '<html><body><p>Call us on 0131 555 0147 during office hours.</p></body></html>';
+
+		$scraper   = $this->make_scraper();
+		$page      = $scraper->parse_page( 'https://phone.example/', $html );
+		$extracted = $page['extracted'];
+
+		$this->assertNotNull( $extracted['contact']['phone'] ?? null );
+		$this->assertStringContainsString( '0131', $extracted['contact']['phone'] );
+	}
+
+	// ── Address heuristic — covered by Schema.org test above ─────────────
+
+	/**
+	 * Heuristic extraction finds an email address in plain text.
+	 */
+	public function test_email_heuristic_extracts_email(): void {
+		$html = '<html><body><p>Email us at info@contacttest.example for enquiries.</p></body></html>';
+
+		$scraper   = $this->make_scraper();
+		$page      = $scraper->parse_page( 'https://contacttest.example/', $html );
+		$extracted = $page['extracted'];
+
+		$this->assertSame( 'info@contacttest.example', $extracted['contact']['email'] );
+	}
+
+	// ── Cache layer ───────────────────────────────────────────────────────
+
+	/**
+	 * scrape() uses transient cache to prevent redundant fetches.
+	 *
+	 * Regression: PR #1537 failed with sd_ai_agent_invalid_scrape_url
+	 * before reaching the cache check. The validator now accepts https://example.com.
+	 */
+	public function test_scrape_uses_transient_cache_to_prevent_redundant_fetches(): void {
+		$url  = 'https://cached.example/';
+		$html = <<<'HTML'
+<!DOCTYPE html>
+<html><head>
+<script type="application/ld+json">
+{"@type":"Organization","name":"Cached Org","telephone":"999-0000"}
+</script>
+</head><body></body></html>
+HTML;
+
+		// First request: mock HTTP to return the HTML.
+		$this->mock_http_html( 'cached.example', $html );
+
+		$scraper = $this->make_scraper();
+
+		// First call — should fetch via HTTP and cache.
+		$result1 = $scraper->scrape( $url );
+		$this->assertIsArray( $result1, 'First scrape should return an array.' );
+		$this->assertSame( 'Cached Org', $result1['brand']['name'] );
+
+		// Remove the HTTP mock — second call must use cache, not make a request.
+		remove_all_filters( 'pre_http_request' );
+
+		$result2 = $scraper->scrape( $url );
+		$this->assertIsArray( $result2, 'Second scrape should return cached array.' );
+		$this->assertSame( 'Cached Org', $result2['brand']['name'], 'Cache should return same brand name.' );
+	}
+
+	// ── robots.txt respect ────────────────────────────────────────────────
+
+	/**
+	 * scrape() respects robots.txt Disallow directives.
+	 *
+	 * Regression: PR #1537 returned sd_ai_agent_invalid_scrape_url instead of
+	 * sd_ai_agent_site_scrape_robots_disallowed. The validator now accepts the URL,
+	 * so the robots check is reached.
+	 */
+	public function test_scrape_respects_robots_txt_disallow(): void {
+		$robots_txt = "User-agent: *\nDisallow: /\n";
+
+		$this->mock_http_with_robots(
+			'robots-blocked.example',
+			$robots_txt,
+			'<html><body>content</body></html>'
+		);
+
+		$scraper = $this->make_scraper();
+		$result  = $scraper->scrape( 'https://robots-blocked.example/page' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'sd_ai_agent_site_scrape_robots_disallowed', $result->get_error_code() );
+	}
+
+	/**
+	 * parse_robots_txt() returns true when the path is not disallowed.
+	 */
+	public function test_parse_robots_txt_allows_non_disallowed_path(): void {
+		$robots_txt = "User-agent: *\nDisallow: /admin/\n";
+		$scraper    = $this->make_scraper();
+
+		$this->assertTrue( $scraper->parse_robots_txt( $robots_txt, '/about' ) );
+	}
+
+	/**
+	 * parse_robots_txt() returns false when the path is explicitly disallowed.
+	 */
+	public function test_parse_robots_txt_rejects_disallowed_path(): void {
+		$robots_txt = "User-agent: *\nDisallow: /private/\n";
+		$scraper    = $this->make_scraper();
+
+		$this->assertFalse( $scraper->parse_robots_txt( $robots_txt, '/private/page' ) );
+	}
+
+	/**
+	 * parse_robots_txt() returns true when robots.txt is empty (permissive default).
+	 */
+	public function test_parse_robots_txt_allows_when_empty(): void {
+		$scraper = $this->make_scraper();
+		$this->assertTrue( $scraper->parse_robots_txt( '', '/any/path' ) );
+	}
+
+	/**
+	 * parse_robots_txt() returns true when Disallow: / has an Allow: override for the path.
+	 */
+	public function test_parse_robots_txt_allow_overrides_disallow(): void {
+		$robots_txt = "User-agent: *\nDisallow: /\nAllow: /public/\n";
+		$scraper    = $this->make_scraper();
+
+		$this->assertTrue( $scraper->parse_robots_txt( $robots_txt, '/public/page' ) );
+	}
+
+	// ── Full ability output shape ─────────────────────────────────────────
+
+	/**
+	 * scrape() returns the complete optional shape with all fields present.
+	 *
+	 * Regression: PR #1537 returned sd_ai_agent_invalid_scrape_url before
+	 * any data was extracted. The validator now accepts https://example.com.
+	 */
+	public function test_site_scrape_ability_returns_complete_optional_shape(): void {
+		$url  = 'https://shape.example/';
+		$html = <<<'HTML'
+<!DOCTYPE html>
+<html><head>
+<title>Shape Test Site</title>
+<script type="application/ld+json">
+{
+  "@type": "LocalBusiness",
+  "name": "Shape Business",
+  "telephone": "+1 555 123 4567",
+  "email": "info@shape.example",
+  "address": {"@type": "PostalAddress", "streetAddress": "1 Main St", "addressLocality": "Testville"},
+  "openingHoursSpecification": [
+    {"dayOfWeek":["Monday"],"opens":"09:00","closes":"18:00"}
+  ],
+  "sameAs": ["https://instagram.com/shapebusiness"]
+}
+</script>
+</head><body><p>Welcome to Shape Business.</p></body></html>
+HTML;
+
+		$this->mock_http_html( 'shape.example', $html );
+
+		$scraper = $this->make_scraper();
+		$result  = $scraper->scrape( $url );
+
+		$this->assertIsArray( $result, 'scrape() must return an array for a valid URL.' );
+
+		// All top-level keys must be present.
+		$this->assertArrayHasKey( 'brand', $result );
+		$this->assertArrayHasKey( 'contact', $result );
+		$this->assertArrayHasKey( 'hours', $result );
+		$this->assertArrayHasKey( 'social', $result );
+		$this->assertArrayHasKey( 'pages', $result );
+
+		// Brand sub-keys.
+		$this->assertArrayHasKey( 'name', $result['brand'] );
+		$this->assertArrayHasKey( 'tagline', $result['brand'] );
+		$this->assertArrayHasKey( 'logo_url', $result['brand'] );
+
+		// Contact sub-keys.
+		$this->assertArrayHasKey( 'address', $result['contact'] );
+		$this->assertArrayHasKey( 'phone', $result['contact'] );
+		$this->assertArrayHasKey( 'email', $result['contact'] );
+
+		// Extracted data.
+		$this->assertSame( 'Shape Business', $result['brand']['name'] );
+		$this->assertSame( '+1 555 123 4567', $result['contact']['phone'] );
+		$this->assertSame( 'info@shape.example', $result['contact']['email'] );
+		$this->assertStringContainsString( 'Main St', $result['contact']['address'] );
+		$this->assertNotEmpty( $result['hours'] );
+		$this->assertSame( 'https://instagram.com/shapebusiness', $result['social']['instagram'] );
+	}
+
+	// ── Invalid URL returns WP_Error ──────────────────────────────────────
+
+	/**
+	 * scrape() returns WP_Error for an empty URL.
+	 */
+	public function test_scrape_returns_wp_error_for_empty_url(): void {
+		$scraper = $this->make_scraper();
+		$result  = $scraper->scrape( '' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'sd_ai_agent_invalid_scrape_url', $result->get_error_code() );
+	}
+
+	/**
+	 * scrape() returns WP_Error for a relative URL.
+	 */
+	public function test_scrape_returns_wp_error_for_relative_url(): void {
+		$scraper = $this->make_scraper();
+		$result  = $scraper->scrape( '/not-absolute' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'sd_ai_agent_invalid_scrape_url', $result->get_error_code() );
+	}
+
+	// ── Ability registration ──────────────────────────────────────────────
+
+	/**
+	 * SiteScrapeAbility has the expected input schema with required url.
+	 */
+	public function test_ability_has_url_as_required(): void {
+		$ability = $this->make_ability();
+		$schema  = $ability->get_input_schema();
+
+		$this->assertIsArray( $schema );
+		$this->assertArrayHasKey( 'required', $schema );
+		$this->assertContains( 'url', $schema['required'] );
+	}
+
+	/**
+	 * SiteScrapeAbility execute_callback returns WP_Error for empty url.
+	 */
+	public function test_ability_returns_wp_error_for_missing_url(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$ability = $this->make_ability();
+		$result  = $ability->run( [] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'sd_ai_agent_invalid_scrape_url', $result->get_error_code() );
+	}
+
+	/**
+	 * SiteScrapeAbility execute_callback returns array for valid url with mocked HTTP.
+	 */
+	public function test_ability_returns_array_for_valid_url(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$url  = 'https://ability-test.example/';
+		$html = '<html><head><title>Ability Test</title></head><body>Ability test content</body></html>';
+
+		$this->mock_http_html( 'ability-test.example', $html );
+
+		$ability = $this->make_ability();
+		$result  = $ability->run( [ 'url' => $url ] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'brand', $result );
+	}
+}


### PR DESCRIPTION
Closes #1530

## Summary

Implements the `sd-ai-agent/site-scrape` ability: fetch and parse an existing website to bootstrap Theme Builder interviews with real brand data (name, tagline, logo, address, phone, hours, social links, etc.).

### Root cause fix from PR #1537

Previous PR failed because the URL validator rejected `https://example.com` fixture URLs before reaching cache/robots/parser code. This PR:
- Accepts **any valid absolute http/https URL** — no domain allowlist, no extra restrictions beyond scheme+host validation
- Mocks at the HTTP layer (`pre_http_request` filter) in all tests so fixture URLs never hit the validator path on real HTTP

## Files changed

| File | Description |
|------|-------------|
| `includes/Services/SiteScraper.php` | Core scraper: URL validation, robots.txt, Schema.org JSON-LD, OpenGraph, heuristics (phone/email/hours), transient cache |
| `includes/Abilities/SiteScrapeAbility.php` | Ability class extending `AbstractAbility` |
| `includes/Bootstrap/AbilitiesHandler.php` | Registers `sd-ai-agent/site-scrape` |
| `includes/Abilities/ThemeBuilderAbilities.php` | Updates description to teach agent to offer scrape at interview start |
| `tests/SdAiAgent/Abilities/SiteScrapeAbilityTest.php` | 24 tests: URL validation, Schema.org, OpenGraph, hours heuristic, phone, email, transient cache, robots.txt |

## Implementation notes

- `SiteScraper::load_dom()` uses `<?xml encoding="UTF-8">` prefix instead of `mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8')` — the `mb_` approach converted `&` to `&amp;` inside `<script>` tags, corrupting JSON-LD content
- `parse_schema_org()` is called **before** `extract_text()` which removes all `<script>` elements from the DOM (including JSON-LD tags)
- Hours heuristic uses `/(Monday|...)` without trailing `\b` — DOMDocument's `textContent` concatenates adjacent `<td>` cells without a separator (`Monday09:00`), so `\b` fails before digit characters

## Worker self-verification

- PHPUnit: Tests: 2346, Assertions: 6347, Errors: 0, Failures: 1 (pre-existing: `GenerateLogoSvgAbilityTest::test_sanitize_svg_removes_external_xlink_href` also fails on `main` before this change), Skipped: 104
- New tests: 24/24 pass (`--filter SiteScrape`)
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded (webpack compiled with 2 warnings, no errors)