### PR TITLE
GH#1550: fix(tests): use reset_defaults() to avoid stale activation seed

### DIFF
--- a/tests/SdAiAgent/Abilities/StockImageAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/StockImageAbilityTest.php
@@ -419,7 +419,7 @@ class StockImageAbilityTest extends WP_UnitTestCase {
 	 * in its tier_1_tools so the imagery guidance in Phase 4 can be executed.
 	 */
 	public function test_theme_builder_tier_1_tools_include_imagery_abilities(): void {
-		\SdAiAgent\Models\Agent::seed_defaults();
+		\SdAiAgent\Models\Agent::reset_defaults();
 
 		$agent = \SdAiAgent\Models\Agent::get_by_slug( 'theme-builder' );
 		$this->assertNotNull( $agent, 'theme-builder agent must exist after seed_defaults()' );
@@ -450,7 +450,7 @@ class StockImageAbilityTest extends WP_UnitTestCase {
 	 * The theme-builder system prompt references the stock-image imagery workflow.
 	 */
 	public function test_theme_builder_system_prompt_references_imagery_workflow(): void {
-		\SdAiAgent\Models\Agent::seed_defaults();
+		\SdAiAgent\Models\Agent::reset_defaults();
 
 		$agent = \SdAiAgent\Models\Agent::get_by_slug( 'theme-builder' );
 		$this->assertNotNull( $agent );


### PR DESCRIPTION
## Summary

Two tests in `StockImageAbilityTest` fail against `main` because they call
`Agent::seed_defaults()` which is a no-op when the agent already exists,
and the plugin's activation hook seeds defaults at wp-env install time —
so any later additions to the `theme-builder` system_prompt or
tier_1_tools (e.g. the Phase 4 imagery workflow added in #1542, #1528,
#1529) never reach the DB at test time and the assertions fail against
the stale activation seed.

Resolves #1550.

## Diagnosis

- `Agent::seed_defaults()` (`includes/Models/Agent.php:414`) skips when
  `get_by_slug()` returns an existing row — by design, to preserve user
  customisations. But this means tests that rely on `seed_defaults()` to
  install the *current* built-in definition see whatever was seeded the
  first time the plugin activated in this WP install.
- `Agent::reset_defaults()` (`includes/Models/Agent.php:435`) exists for
  exactly this case: it updates `name`, `description`, `system_prompt`,
  `greeting`, `tier_1_tools`, `suggestions`, `avatar_icon`, and `enabled`
  back to canonical values, without touching `provider_id`, `model_id`,
  `temperature`, or `max_iterations`.
- The other test file that exercises theme-builder seeding,
  `tests/SdAiAgent/Models/AgentThemeBuilderTest.php`, sidesteps the
  problem with explicit `set_up()`/`tear_down()` hooks that delete the
  row directly. That's also valid but more verbose; using
  `reset_defaults()` is the canonical fix.

## Fix

Two-line change in `tests/SdAiAgent/Abilities/StockImageAbilityTest.php`:

```diff
- \SdAiAgent\Models\Agent::seed_defaults();
+ \SdAiAgent\Models\Agent::reset_defaults();
```

Applied to both
`test_theme_builder_tier_1_tools_include_imagery_abilities` and
`test_theme_builder_system_prompt_references_imagery_workflow`.

## Worker self-verification

- PHPUnit (filtered): `OK (1 test, 4 assertions)` for both fixed tests
- Lint: PHP/JS/CSS unchanged (only test file modified, only string literal
  method-name change — no syntactic delta)
- PHPStan: 0 errors (no code surface change)
- Build: unchanged (no source changes)

Filtered run confirmation, both tests passing against the same wp-env
where the full suite previously surfaced the failure:

```text
test_theme_builder_system_prompt_references_imagery_workflow
.                                                                   1 / 1 (100%)
OK (1 test, 4 assertions)

test_theme_builder_tier_1_tools_include_imagery_abilities
.                                                                   1 / 1 (100%)
OK (1 test, 4 assertions)
```

(Full-suite run intentionally skipped for this targeted 2-line test
fix; the change is mechanically obvious from the diff and the relevant
unit tests are demonstrated green above. CI will run the full suite.)

## Note

This PR addresses *test correctness*. It does **not** address the
production-side stale-seed concern that would surface if a real
WordPress site's plugin update added new built-in agents or extended
existing system prompts — that is a separate, larger concern about the
`seed_defaults` vs `reset_defaults` policy and is out of scope here.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.0 plugin for [OpenCode](https://opencode.ai) v1.15.5 with claude-sonnet-4-6 spent 2h 10m and 108 tokens on this as a headless worker.
