### PR TITLE
GH#1551: fix(tests): redirect upload_dir to /tmp in PluginUpdater/Integration tests

### DIFF
--- a/tests/SdAiAgent/PluginBuilder/PluginBuilderIntegrationTest.php
+++ b/tests/SdAiAgent/PluginBuilder/PluginBuilderIntegrationTest.php
@@ -53,10 +53,25 @@ class PluginBuilderIntegrationTest extends WP_UnitTestCase {
 	 */
 	private array $created_ids = [];
 
+	/**
+	 * Temporary upload basedir used during this test class.
+	 *
+	 * Redirects wp_upload_dir() basedir to a writable location so that
+	 * PluginUpdater::copy_directory() can call wp_mkdir_p() for the staging
+	 * and backup paths without hitting permission failures in the
+	 * tests-wordpress container (where wp-content/uploads is typically owned
+	 * by www-data while PHPUnit runs as the host user, e.g. 1000:1000).
+	 *
+	 * @var string
+	 */
+	private string $tmp_upload_basedir;
+
 	// ── Lifecycle ──────────────────────────────────────────────────────────
 
 	public function setUp(): void {
 		parent::setUp();
+		$this->tmp_upload_basedir = sys_get_temp_dir() . '/sd-ai-agent-phpunit';
+		add_filter( 'upload_dir', [ $this, 'filter_upload_dir_to_tmp' ] );
 		$this->fixtures_dir = dirname( __DIR__, 2 ) . '/fixtures/plugins/';
 		$this->created_dirs = [];
 		$this->created_ids  = [];
@@ -71,7 +86,28 @@ class PluginBuilderIntegrationTest extends WP_UnitTestCase {
 		foreach ( $this->created_ids as $id ) {
 			PluginInstaller::delete( $id, false );
 		}
+		remove_filter( 'upload_dir', [ $this, 'filter_upload_dir_to_tmp' ] );
 		parent::tearDown();
+	}
+
+	/**
+	 * Redirect wp_upload_dir() basedir to a writable tmp directory.
+	 *
+	 * PluginUpdater::staging_root() and ::backups_root() derive their paths
+	 * from wp_upload_dir()['basedir']. By filtering upload_dir to point at
+	 * a tmp location, we ensure wp_mkdir_p() calls inside PluginUpdater can
+	 * always create the staging and backup directories regardless of which
+	 * user owns wp-content/uploads in the test container.
+	 *
+	 * @param array<string,string> $uploads Upload directory info passed by WP.
+	 * @return array<string,string>
+	 */
+	public function filter_upload_dir_to_tmp( array $uploads ): array {
+		$uploads['basedir'] = $this->tmp_upload_basedir;
+		$uploads['path']    = $this->tmp_upload_basedir;
+		$uploads['baseurl'] = 'http://example.org/tmp-uploads';
+		$uploads['url']     = 'http://example.org/tmp-uploads';
+		return $uploads;
 	}
 
 	// ── Private helpers ────────────────────────────────────────────────────

--- a/tests/SdAiAgent/PluginBuilder/PluginUpdaterTest.php
+++ b/tests/SdAiAgent/PluginBuilder/PluginUpdaterTest.php
@@ -42,10 +42,25 @@ class PluginUpdaterTest extends WP_UnitTestCase {
 	private PluginUpdater $updater;
 
 	/**
+	 * Temporary upload basedir used during this test class.
+	 *
+	 * Redirects wp_upload_dir() basedir to a writable location so that
+	 * PluginUpdater::copy_directory() can call wp_mkdir_p() for the staging
+	 * and backup paths without hitting permission failures in the
+	 * tests-wordpress container (where wp-content/uploads is typically owned
+	 * by www-data while PHPUnit runs as the host user, e.g. 1000:1000).
+	 *
+	 * @var string
+	 */
+	private string $tmp_upload_basedir;
+
+	/**
 	 * Set up test directories and a minimal plugin before each test.
 	 */
 	public function setUp(): void {
 		parent::setUp();
+		$this->tmp_upload_basedir = sys_get_temp_dir() . '/sd-ai-agent-phpunit';
+		add_filter( 'upload_dir', [ $this, 'filter_upload_dir_to_tmp' ] );
 		$this->plugin_dir = trailingslashit( WP_PLUGIN_DIR ) . $this->slug . '/';
 		$this->updater    = new PluginUpdater();
 		$this->cleanup_all();
@@ -57,7 +72,27 @@ class PluginUpdaterTest extends WP_UnitTestCase {
 	 */
 	public function tearDown(): void {
 		$this->cleanup_all();
+		remove_filter( 'upload_dir', [ $this, 'filter_upload_dir_to_tmp' ] );
 		parent::tearDown();
+	}
+
+	/**
+	 * Redirect wp_upload_dir() basedir to a writable tmp directory.
+	 *
+	 * PluginUpdater::staging_root() and ::backups_root() derive their paths
+	 * from wp_upload_dir()['basedir']. The helper methods backups_root() and
+	 * staging_root() in this class do the same, so both production and test
+	 * paths stay consistent and point to a location writable by any user.
+	 *
+	 * @param array<string,string> $uploads Upload directory info passed by WP.
+	 * @return array<string,string>
+	 */
+	public function filter_upload_dir_to_tmp( array $uploads ): array {
+		$uploads['basedir'] = $this->tmp_upload_basedir;
+		$uploads['path']    = $this->tmp_upload_basedir;
+		$uploads['baseurl'] = 'http://example.org/tmp-uploads';
+		$uploads['url']     = 'http://example.org/tmp-uploads';
+		return $uploads;
 	}
 
 	// ─── backup() ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

`PluginUpdater::copy_directory()` calls `wp_mkdir_p()` for staging and backup paths that are derived from `wp_upload_dir()['basedir']`. In the `tests-wordpress` Docker container, `wp-content/uploads` is owned by `www-data`, but PHPUnit runs as the host user (1000:1000), causing `wp_mkdir_p()` permission failures.

## Fix

Added an `upload_dir` filter (`filter_upload_dir_to_tmp`) to both affected test classes:

- `tests/SdAiAgent/PluginBuilder/PluginUpdaterTest.php`
- `tests/SdAiAgent/PluginBuilder/PluginBuilderIntegrationTest.php`

The filter redirects `basedir` to `sys_get_temp_dir() . '/sd-ai-agent-phpunit'`, a location writable by any user. The filter is added in `setUp()` and removed in `tearDown()`, so it has no cross-test side effects.

Both `PluginUpdater::staging_root()` and `::backups_root()` — and the test helpers that mirror them — call `wp_upload_dir()` directly, so the single filter patch is sufficient to make all paths consistent.

## Worker self-verification

- PHPUnit: Tests: 2393, Assertions: 6483, Errors: 0, Failures: 0, Skipped: 104
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Resolves #1551

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.1 plugin for [OpenCode](https://opencode.ai) v1.15.5 with claude-sonnet-4-6 spent 28m and 31,974 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of plugin update and builder tests by implementing isolated upload directory handling, preventing filesystem permission-related test failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1554?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->