### PR TITLE
GH#1536: bug(create-menu): support navigation labels distinct from page titles

### DIFF
--- a/includes/Abilities/MenuAbilities.php
+++ b/includes/Abilities/MenuAbilities.php
@@ -110,7 +110,7 @@ class MenuAbilities {
 			'sd-ai-agent/create-menu',
 			[
 				'label'               => __( 'Create Menu', 'superdav-ai-agent' ),
-				'description'         => __( 'Create a new WordPress navigation menu with the given name. Optionally assign it to a theme location.', 'superdav-ai-agent' ),
+				'description'         => __( 'Create a new WordPress navigation menu with the given name. Optionally assign it to a theme location and populate it with items in one call. Each item may supply a navigation_label to override the linked page\'s title in the rendered nav.', 'superdav-ai-agent' ),
 				'category'            => 'sd-ai-agent',
 				'input_schema'        => [
 					'type'       => 'object',
@@ -123,15 +123,41 @@ class MenuAbilities {
 							'type'        => 'string',
 							'description' => 'Optional theme location slug to assign this menu to (e.g. "primary", "footer").',
 						],
+						'items'    => [
+							'type'        => 'array',
+							'description' => 'Optional list of items to add to the menu immediately after creation. Items are added in the order provided.',
+							'items'       => [
+								'type'       => 'object',
+								'properties' => [
+									'page_id'          => [
+										'type'        => 'integer',
+										'description' => 'ID of a page/post to link. When supplied the item type is set to post_type/page.',
+									],
+									'url'              => [
+										'type'        => 'string',
+										'description' => 'URL for a custom-link item (used when page_id is not provided).',
+									],
+									'navigation_label' => [
+										'type'        => 'string',
+										'description' => 'The label rendered in the navigation. When omitted the linked page title (or url) is used as the label.',
+									],
+									'title'            => [
+										'type'        => 'string',
+										'description' => 'Alias for navigation_label (navigation_label takes precedence when both are supplied).',
+									],
+								],
+							],
+						],
 					],
 					'required'   => [ 'name' ],
 				],
 				'output_schema'       => [
 					'type'       => 'object',
 					'properties' => [
-						'menu_id' => [ 'type' => 'integer' ],
-						'name'    => [ 'type' => 'string' ],
-						'slug'    => [ 'type' => 'string' ],
+						'menu_id'     => [ 'type' => 'integer' ],
+						'name'        => [ 'type' => 'string' ],
+						'slug'        => [ 'type' => 'string' ],
+						'items_added' => [ 'type' => 'integer' ],
 					],
 				],
 				'meta'                => [
@@ -452,7 +478,7 @@ class MenuAbilities {
 	/**
 	 * Handle the create-menu ability.
 	 *
-	 * @param array<string, mixed> $input Input with name and optional location.
+	 * @param array<string, mixed> $input Input with name, optional location, and optional items.
 	 * @return array<string, mixed>|WP_Error
 	 */
 	public static function handle_create_menu( array $input ) {
@@ -460,6 +486,8 @@ class MenuAbilities {
 		$name = sanitize_text_field( $input['name'] ?? '' );
 		// @phpstan-ignore-next-line
 		$location = sanitize_text_field( $input['location'] ?? '' );
+		// @phpstan-ignore-next-line
+		$items = isset( $input['items'] ) && is_array( $input['items'] ) ? $input['items'] : [];
 
 		if ( empty( $name ) ) {
 			return new WP_Error( 'ai_agent_empty_menu_name', __( 'Menu name is required.', 'superdav-ai-agent' ) );
@@ -478,12 +506,68 @@ class MenuAbilities {
 			set_theme_mod( 'nav_menu_locations', $locations );
 		}
 
+		// Add items if provided.
+		$items_added = 0;
+		foreach ( $items as $position => $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+
+			// @phpstan-ignore-next-line
+			$page_id = (int) ( $item['page_id'] ?? 0 );
+			// @phpstan-ignore-next-line
+			$url = esc_url_raw( $item['url'] ?? '' );
+
+			// Resolve label: navigation_label > title > page post_title > url.
+			// @phpstan-ignore-next-line
+			$navigation_label = sanitize_text_field( $item['navigation_label'] ?? '' );
+			if ( '' === $navigation_label ) {
+				// @phpstan-ignore-next-line
+				$navigation_label = sanitize_text_field( $item['title'] ?? '' );
+			}
+			if ( '' === $navigation_label && $page_id > 0 ) {
+				$page = get_post( $page_id );
+				if ( $page instanceof \WP_Post ) {
+					$navigation_label = $page->post_title;
+				}
+			}
+			if ( '' === $navigation_label ) {
+				$navigation_label = $url;
+			}
+
+			if ( '' === $navigation_label ) {
+				// Cannot determine a label; skip this item.
+				continue;
+			}
+
+			$item_data = [
+				'menu-item-title'    => $navigation_label,
+				'menu-item-position' => $position + 1,
+				'menu-item-status'   => 'publish',
+			];
+
+			if ( $page_id > 0 ) {
+				$item_data['menu-item-object-id'] = $page_id;
+				$item_data['menu-item-object']    = 'page';
+				$item_data['menu-item-type']      = 'post_type';
+			} else {
+				$item_data['menu-item-url']  = $url;
+				$item_data['menu-item-type'] = 'custom';
+			}
+
+			$result = wp_update_nav_menu_item( $menu_id, 0, $item_data );
+			if ( ! is_wp_error( $result ) ) {
+				++$items_added;
+			}
+		}
+
 		$menu = wp_get_nav_menu_object( $menu_id );
 
 		return [
-			'menu_id' => $menu_id,
-			'name'    => $menu ? $menu->name : $name,
-			'slug'    => $menu ? $menu->slug : sanitize_title( $name ),
+			'menu_id'     => $menu_id,
+			'name'        => $menu ? $menu->name : $name,
+			'slug'        => $menu ? $menu->slug : sanitize_title( $name ),
+			'items_added' => $items_added,
 		];
 	}
 

--- a/tests/SdAiAgent/Abilities/MenuAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/MenuAbilitiesTest.php
@@ -381,6 +381,227 @@ class MenuAbilitiesTest extends WP_UnitTestCase {
 		$this->assertTrue( $result['deleted'] );
 	}
 
+	// ─── handle_create_menu with items ───────────────────────────
+
+	/**
+	 * Test handle_create_menu without items returns items_added = 0 (no regression).
+	 */
+	public function test_handle_create_menu_items_added_zero_when_no_items() {
+		$result = MenuAbilities::handle_create_menu( [ 'name' => 'No Items Menu' ] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'items_added', $result );
+		$this->assertSame( 0, $result['items_added'] );
+	}
+
+	/**
+	 * Test handle_create_menu with empty items array returns items_added = 0.
+	 */
+	public function test_handle_create_menu_empty_items_array() {
+		$result = MenuAbilities::handle_create_menu( [ 'name' => 'Empty Items Menu', 'items' => [] ] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 0, $result['items_added'] );
+	}
+
+	/**
+	 * Test handle_create_menu navigation_label overrides page post_title.
+	 *
+	 * Regression test for GH#1536: page titled "Shop Our Beans" should render
+	 * as "Shop" when navigation_label = "Shop" is supplied.
+	 */
+	public function test_handle_create_menu_navigation_label_overrides_page_title() {
+		$page_id = $this->factory->post->create(
+			[
+				'post_type'   => 'page',
+				'post_title'  => 'Shop Our Beans',
+				'post_status' => 'publish',
+			]
+		);
+
+		$result = MenuAbilities::handle_create_menu(
+			[
+				'name'  => 'Navigation Label Menu',
+				'items' => [
+					[
+						'page_id'          => $page_id,
+						'navigation_label' => 'Shop',
+					],
+				],
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 1, $result['items_added'] );
+
+		$items = wp_get_nav_menu_items( $result['menu_id'] );
+		$this->assertIsArray( $items );
+		$this->assertCount( 1, $items );
+		$this->assertSame( 'Shop', $items[0]->title, 'navigation_label should override page post_title' );
+	}
+
+	/**
+	 * Test handle_create_menu falls back to page post_title when navigation_label is omitted.
+	 */
+	public function test_handle_create_menu_fallback_to_page_title() {
+		$page_id = $this->factory->post->create(
+			[
+				'post_type'   => 'page',
+				'post_title'  => 'Shop Our Beans',
+				'post_status' => 'publish',
+			]
+		);
+
+		$result = MenuAbilities::handle_create_menu(
+			[
+				'name'  => 'Fallback Title Menu',
+				'items' => [
+					[
+						'page_id' => $page_id,
+					],
+				],
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 1, $result['items_added'] );
+
+		$items = wp_get_nav_menu_items( $result['menu_id'] );
+		$this->assertIsArray( $items );
+		$this->assertCount( 1, $items );
+		$this->assertSame( 'Shop Our Beans', $items[0]->title, 'Should fall back to page post_title when navigation_label is omitted' );
+	}
+
+	/**
+	 * Test handle_create_menu title field is an alias for navigation_label.
+	 */
+	public function test_handle_create_menu_title_alias_for_navigation_label() {
+		$page_id = $this->factory->post->create(
+			[
+				'post_type'   => 'page',
+				'post_title'  => 'About Our Company',
+				'post_status' => 'publish',
+			]
+		);
+
+		$result = MenuAbilities::handle_create_menu(
+			[
+				'name'  => 'Title Alias Menu',
+				'items' => [
+					[
+						'page_id' => $page_id,
+						'title'   => 'About',
+					],
+				],
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 1, $result['items_added'] );
+
+		$items = wp_get_nav_menu_items( $result['menu_id'] );
+		$this->assertIsArray( $items );
+		$this->assertCount( 1, $items );
+		$this->assertSame( 'About', $items[0]->title, 'title field should act as alias for navigation_label' );
+	}
+
+	/**
+	 * Test handle_create_menu navigation_label takes precedence over title when both supplied.
+	 */
+	public function test_handle_create_menu_navigation_label_takes_precedence_over_title() {
+		$page_id = $this->factory->post->create(
+			[
+				'post_type'   => 'page',
+				'post_title'  => 'Contact Us Today',
+				'post_status' => 'publish',
+			]
+		);
+
+		$result = MenuAbilities::handle_create_menu(
+			[
+				'name'  => 'Precedence Menu',
+				'items' => [
+					[
+						'page_id'          => $page_id,
+						'navigation_label' => 'Contact',
+						'title'            => 'Contact Us',
+					],
+				],
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 1, $result['items_added'] );
+
+		$items = wp_get_nav_menu_items( $result['menu_id'] );
+		$this->assertIsArray( $items );
+		$this->assertCount( 1, $items );
+		$this->assertSame( 'Contact', $items[0]->title, 'navigation_label should take precedence over title' );
+	}
+
+	/**
+	 * Test handle_create_menu adds custom-link items with navigation_label.
+	 */
+	public function test_handle_create_menu_custom_url_item() {
+		$result = MenuAbilities::handle_create_menu(
+			[
+				'name'  => 'Custom URL Menu',
+				'items' => [
+					[
+						'url'              => 'https://example.com/shop',
+						'navigation_label' => 'Shop',
+					],
+				],
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 1, $result['items_added'] );
+
+		$items = wp_get_nav_menu_items( $result['menu_id'] );
+		$this->assertIsArray( $items );
+		$this->assertCount( 1, $items );
+		$this->assertSame( 'Shop', $items[0]->title );
+	}
+
+	/**
+	 * Test handle_create_menu adds multiple items in order.
+	 */
+	public function test_handle_create_menu_multiple_items_in_order() {
+		$page_ids = [];
+		$titles   = [ 'Home Page Title', 'About Page Title', 'Shop Page Title' ];
+		foreach ( $titles as $title ) {
+			$page_ids[] = $this->factory->post->create(
+				[
+					'post_type'   => 'page',
+					'post_title'  => $title,
+					'post_status' => 'publish',
+				]
+			);
+		}
+
+		$result = MenuAbilities::handle_create_menu(
+			[
+				'name'  => 'Multi Item Menu',
+				'items' => [
+					[ 'page_id' => $page_ids[0], 'navigation_label' => 'Home' ],
+					[ 'page_id' => $page_ids[1], 'navigation_label' => 'About' ],
+					[ 'page_id' => $page_ids[2], 'navigation_label' => 'Shop' ],
+				],
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 3, $result['items_added'] );
+
+		$items = wp_get_nav_menu_items( $result['menu_id'] );
+		$this->assertIsArray( $items );
+		$this->assertCount( 3, $items );
+		$this->assertSame( 'Home', $items[0]->title );
+		$this->assertSame( 'About', $items[1]->title );
+		$this->assertSame( 'Shop', $items[2]->title );
+	}
+
 	// ─── handle_assign_menu_location ─────────────────────────────
 
 	/**


### PR DESCRIPTION
GH#1536: bug(create-menu): support navigation labels distinct from page titles

Resolves #1536

## What changed

- `MenuAbilities::handle_create_menu()` now accepts an optional `items` array, allowing callers to create a menu and populate it in a single ability call.
- Each item may supply `navigation_label` to override the linked page's `post_title` as the rendered nav label.  
  Fallback chain: `navigation_label` → `title` (alias) → page `post_title` → `url`.
- When `page_id` is present, the item is wired as a `post_type/page` link; otherwise a custom-link item is created with the supplied `url`.
- Item positions are auto-assigned (1-based) to preserve insertion order, consistent with the ordering fix from GH#1524.
- Output schema gains `items_added` count.

## Files changed

- `includes/Abilities/MenuAbilities.php` — schema extension + loop in `handle_create_menu()`
- `tests/SdAiAgent/Abilities/MenuAbilitiesTest.php` — 7 new tests

## Tests added

| Test | Covers |
|---|---|
| `test_handle_create_menu_items_added_zero_when_no_items` | No regression when `items` omitted |
| `test_handle_create_menu_empty_items_array` | No regression when `items` is `[]` |
| `test_handle_create_menu_navigation_label_overrides_page_title` | Core fix: "Shop Our Beans" → "Shop" |
| `test_handle_create_menu_fallback_to_page_title` | Fallback when `navigation_label` omitted |
| `test_handle_create_menu_title_alias_for_navigation_label` | `title` field as alias |
| `test_handle_create_menu_navigation_label_takes_precedence_over_title` | Precedence when both supplied |
| `test_handle_create_menu_custom_url_item` | Custom-link items |
| `test_handle_create_menu_multiple_items_in_order` | Multiple items, correct order |

## Worker self-verification

- PHPUnit: Tests: 2401, Assertions: 6520, Errors: 0, Failures: 0, Skipped: 104
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.1 plugin for [OpenCode](https://opencode.ai) v1.15.5 with claude-sonnet-4-6 spent 7m and 5,756 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Menu creation ability now supports populating items in a single request
  * Specify custom labels and link items to pages or custom URLs
  * Flexible label resolution with fallback options for item titles
  * Response includes count of successfully added items

* **Tests**
  * Added comprehensive test coverage for menu item creation with various label and linking scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->