### PR TITLE
feat(theme-builder): add sd-ai-agent/site-scrape to tier_1_tools (GH#1548)

### DIFF
--- a/includes/Models/Agent.php
+++ b/includes/Models/Agent.php
@@ -784,7 +784,8 @@ class Agent {
 							'sd-ai-agent/render-design-previews',
 							// Hospitality menu page generation (issue #1531).
 							'sd-ai-agent/generate-menu-page',
-							// Image tools required for brand-specific and stock imagery (issue #1528, #1529).
+							// Site pre-fill (issue #1530) and imagery tools (issues #1528, #1529).
+							'sd-ai-agent/site-scrape',
 							'sd-ai-agent/stock-image',
 							'sd-ai-agent/generate-image',
 						]

--- a/tests/SdAiAgent/Models/AgentThemeBuilderTest.php
+++ b/tests/SdAiAgent/Models/AgentThemeBuilderTest.php
@@ -557,6 +557,26 @@ class AgentThemeBuilderTest extends WP_UnitTestCase {
 		);
 	}
 
+	// ─── Site scrape tool (issue #1548) ─────────────────────────────────────
+
+	/**
+	 * The seeded theme-builder agent includes sd-ai-agent/site-scrape in
+	 * tier_1_tools so the model can pre-fill interview answers without
+	 * extra ability-search + ability-call round-trips (issue #1548).
+	 */
+	public function test_tier_1_tools_contains_site_scrape(): void {
+		Agent::seed_defaults();
+
+		$agent = Agent::get_by_slug( self::SLUG );
+		$this->assertNotNull( $agent );
+
+		$this->assertContains(
+			'sd-ai-agent/site-scrape',
+			$agent->tier_1_tools,
+			'tier_1_tools must contain sd-ai-agent/site-scrape for site pre-fill (issue #1548)'
+		);
+	}
+
 	// ─── Image generation tools (issue #1529) ────────────────────────────────
 
 	/**


### PR DESCRIPTION
## Summary

Adds `'sd-ai-agent/site-scrape'` to the Theme Builder agent's curated `tier_1_tools` list in `Agent::get_theme_builder_definition()`.

The ability was introduced in PR #1546 (issue #1530) but was omitted from `tier_1_tools`, so the model could only reach it via the two-hop `ability-search` + `ability-call` fallback. This costs 2 extra round-trips on every Theme Builder interview start.

## Changes

- `includes/Models/Agent.php`: adds `'sd-ai-agent/site-scrape'` above the existing imagery tools, updates the comment
- `tests/SdAiAgent/Models/AgentThemeBuilderTest.php`: adds `test_tier_1_tools_contains_site_scrape()` verifying the entry appears in the seeded agent definition

## Worker self-verification

- PHPUnit: Tests: 2394, Assertions: 6485, Errors: 0, Failures: 0, Skipped: 104
- Lint:    PHP clean (PHPCS 0 violations); JS/CSS tooling not runnable in worktree (node_modules env-only, no source changes)
- PHPStan: 0 errors
- Build:   JS build not runnable in worktree (env-only); build passes on main with same source

Resolves #1548

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.1 plugin for [OpenCode](https://opencode.ai) v1.15.5 with claude-sonnet-4-6 spent 10m and 11,173 tokens on this as a headless worker.
