### PR TITLE
GH#1534: feat(theme-builder): add photo upload step to the discovery interview

### DIFF
--- a/includes/Abilities/ListInterviewUploadsAbility.php
+++ b/includes/Abilities/ListInterviewUploadsAbility.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * List Interview Uploads ability — surfaces photos the user provided
+ * during the Theme Builder interview.
+ *
+ * The user uploads photos through the {@see \SdAiAgent\Core\OnboardingManager::rest_interview_upload()}
+ * endpoint, which tags each attachment with three meta keys:
+ *
+ *   _sd_ai_agent_interview_upload          (1)
+ *   _sd_ai_agent_interview_upload_category (space|product|team|event|other)
+ *   _sd_ai_agent_interview_upload_session  (int session id, optional)
+ *
+ * This ability lets the Theme Builder agent read those photos back when
+ * planning sections (hero, gallery, about, menu, etc.). Photos remain in
+ * the media library after the interview ends, so the agent can recall them
+ * across sessions for the same site.
+ *
+ * @package SdAiAgent\Abilities
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Abilities;
+
+use SdAiAgent\Core\InterviewUploadStore;
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Ability: sd-ai-agent/list-interview-uploads
+ *
+ * @since 1.16.0
+ */
+class ListInterviewUploadsAbility extends AbstractAbility {
+
+	protected function label(): string {
+		return __( 'List Interview Uploads', 'superdav-ai-agent' );
+	}
+
+	protected function description(): string {
+		return __(
+			'List photos the user uploaded during the Theme Builder interview (space, product, team, event). Returns attachment IDs, URLs, thumbnails, filenames, and the heuristic category guess for each upload so the agent can plan section imagery (hero, gallery, about, menu) without calling stock or generated-image abilities. Filter by category and/or session ID. Returns an empty list (not an error) when no photos have been uploaded yet — fall back to sd-ai-agent/stock-image or sd-ai-agent/generate-image in that case.',
+			'superdav-ai-agent'
+		);
+	}
+
+	protected function input_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'category'   => [
+					'type'        => 'string',
+					'enum'        => [ 'space', 'product', 'team', 'event', 'other' ],
+					'description' => 'Optional category filter. When omitted, all categories are returned.',
+				],
+				'session_id' => [
+					'type'        => 'integer',
+					'description' => 'Optional session ID. When provided, only uploads tagged with this session are returned.',
+				],
+				'limit'      => [
+					'type'        => 'integer',
+					'description' => 'Maximum number of items to return (default: 50, max: 200).',
+				],
+			],
+			'required'   => [],
+		];
+	}
+
+	protected function output_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'items'       => [
+					'type'  => 'array',
+					'items' => [
+						'type'       => 'object',
+						'properties' => [
+							'attachment_id' => [ 'type' => 'integer' ],
+							'url'           => [ 'type' => 'string' ],
+							'thumbnail'     => [ 'type' => 'string' ],
+							'title'         => [ 'type' => 'string' ],
+							'filename'      => [ 'type' => 'string' ],
+							'category'      => [ 'type' => 'string' ],
+							'mime_type'     => [ 'type' => 'string' ],
+							'width'         => [ 'type' => 'integer' ],
+							'height'        => [ 'type' => 'integer' ],
+						],
+					],
+				],
+				'total'       => [ 'type' => 'integer' ],
+				'by_category' => [
+					'type'                 => 'object',
+					'additionalProperties' => [ 'type' => 'integer' ],
+				],
+			],
+		];
+	}
+
+	protected function execute_callback( $input ): array|WP_Error {
+		/** @var array<string,mixed> $input */
+		$args = [];
+
+		if ( isset( $input['category'] ) && is_string( $input['category'] ) && '' !== $input['category'] ) {
+			$args['category'] = $input['category'];
+		}
+		if ( isset( $input['session_id'] ) ) {
+			$args['session_id'] = (int) $input['session_id'];
+		}
+		if ( isset( $input['limit'] ) ) {
+			$args['limit'] = (int) $input['limit'];
+		}
+
+		return InterviewUploadStore::list_uploads( $args );
+	}
+
+	protected function permission_callback( $input ): bool {
+		return current_user_can( 'upload_files' );
+	}
+
+	protected function meta(): array {
+		return [
+			'mcp'          => [ 'public' => true ],
+			'annotations'  => [
+				'readonly'    => true,
+				'destructive' => false,
+				'idempotent'  => true,
+			],
+			'show_in_rest' => true,
+		];
+	}
+}

--- a/includes/Bootstrap/AbilitiesHandler.php
+++ b/includes/Bootstrap/AbilitiesHandler.php
@@ -38,6 +38,7 @@ use SdAiAgent\Abilities\GoogleAnalyticsAbilities;
 use SdAiAgent\Abilities\GscAbilities;
 use SdAiAgent\Abilities\ImageAbilities;
 use SdAiAgent\Abilities\InternetSearchAbilities;
+use SdAiAgent\Abilities\ListInterviewUploadsAbility;
 use SdAiAgent\Abilities\SiteScrapeAbility;
 use SdAiAgent\Abilities\KnowledgeAbilities;
 use SdAiAgent\Abilities\MarketingAbilities;
@@ -101,6 +102,14 @@ final class AbilitiesHandler {
 				'label'         => __( 'Scrape Existing Site', 'superdav-ai-agent' ),
 				'description'   => __( 'Fetch and parse an existing website to extract structured brand and contact data (name, tagline, logo, address, phone, email, opening hours, social links). Use this at the start of a Theme Builder session when the user has an existing site they are rebuilding.', 'superdav-ai-agent' ),
 				'ability_class' => SiteScrapeAbility::class,
+			]
+		);
+		wp_register_ability(
+			'sd-ai-agent/list-interview-uploads',
+			[
+				'label'         => __( 'List Interview Uploads', 'superdav-ai-agent' ),
+				'description'   => __( 'List photos the user uploaded during the Theme Builder interview (space, product, team, event) with attachment IDs, thumbnails, and category guesses so the agent can plan section imagery without calling stock or generated-image abilities.', 'superdav-ai-agent' ),
+				'ability_class' => ListInterviewUploadsAbility::class,
 			]
 		);
 		SeoAbilities::register_abilities();

--- a/includes/Core/InterviewUploadStore.php
+++ b/includes/Core/InterviewUploadStore.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Interview Upload Store — persistence layer for Theme Builder photo uploads.
+ *
+ * Owns the three meta keys used to tag attachments that came in through the
+ * Theme Builder interview:
+ *
+ *   _sd_ai_agent_interview_upload          (1)
+ *   _sd_ai_agent_interview_upload_category (space|product|team|event|other)
+ *   _sd_ai_agent_interview_upload_session  (int session id)
+ *
+ * Used by:
+ *  - {@see \SdAiAgent\Core\OnboardingManager::rest_interview_upload()} to tag
+ *    new uploads after `media_handle_upload()` returns an attachment ID.
+ *  - {@see \SdAiAgent\Abilities\ListInterviewUploadsAbility} to surface those
+ *    photos back to the agent when it plans section imagery.
+ *
+ * Filename categorisation is delegated to
+ * {@see \SdAiAgent\Services\InterviewUploadCategoriser}, which is a pure
+ * function on the filename so it can be unit-tested without WordPress.
+ *
+ * @package SdAiAgent\Core
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Core;
+
+use SdAiAgent\Services\InterviewUploadCategoriser;
+use WP_Post;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Static persistence helper for Theme Builder interview photo uploads.
+ *
+ * @since 1.16.0
+ */
+final class InterviewUploadStore {
+
+	/** Meta key flag (value: 1) marking an attachment as an interview upload. */
+	public const META_FLAG = '_sd_ai_agent_interview_upload';
+
+	/** Meta key for the heuristic category guess. */
+	public const META_CATEGORY = '_sd_ai_agent_interview_upload_category';
+
+	/** Meta key for the originating session id. */
+	public const META_SESSION = '_sd_ai_agent_interview_upload_session';
+
+	/** Maximum number of uploads returned by list_uploads(). */
+	public const MAX_LIMIT = 200;
+
+	/** Default number of uploads returned when no limit is provided. */
+	public const DEFAULT_LIMIT = 50;
+
+	/**
+	 * Tag a freshly-uploaded attachment as an interview upload.
+	 *
+	 * Resolves the category from the supplied override (when the caller has
+	 * a stronger signal than the filename) or falls back to the
+	 * filename-based heuristic. Stores the session id when provided so the
+	 * agent can scope queries per Theme Builder session.
+	 *
+	 * @param int                                                             $attachment_id     The newly-created attachment ID.
+	 * @param array{filename?:string, category?:string, session_id?:int|null} $args              Tagging context. `filename` defaults to the attachment's source filename. `category` overrides the heuristic when valid. `session_id` is stored when > 0.
+	 * @return string The resolved category that was persisted.
+	 */
+	public static function tag_attachment( int $attachment_id, array $args = [] ): string {
+		$filename = isset( $args['filename'] ) && is_string( $args['filename'] )
+			? $args['filename']
+			: (string) get_post_meta( $attachment_id, '_wp_attached_file', true );
+
+		$category = isset( $args['category'] ) && is_string( $args['category'] )
+			&& InterviewUploadCategoriser::is_valid_category( $args['category'] )
+			? $args['category']
+			: InterviewUploadCategoriser::categorise( $filename );
+
+		update_post_meta( $attachment_id, self::META_FLAG, 1 );
+		update_post_meta( $attachment_id, self::META_CATEGORY, $category );
+
+		if ( isset( $args['session_id'] ) && (int) $args['session_id'] > 0 ) {
+			update_post_meta( $attachment_id, self::META_SESSION, (int) $args['session_id'] );
+		}
+
+		return $category;
+	}
+
+	/**
+	 * List interview uploads, optionally filtered by category and session id.
+	 *
+	 * Returns a shape compatible with both the REST upload-confirmation
+	 * response and the `sd-ai-agent/list-interview-uploads` ability response.
+	 *
+	 * @param array{category?:string, session_id?:int, limit?:int} $args Optional filters.
+	 * @return array{items:list<array<string,mixed>>, total:int, by_category:array<string,int>}
+	 */
+	public static function list_uploads( array $args = [] ): array {
+		$limit = isset( $args['limit'] ) ? (int) $args['limit'] : self::DEFAULT_LIMIT;
+		if ( $limit < 1 ) {
+			$limit = self::DEFAULT_LIMIT;
+		}
+		if ( $limit > self::MAX_LIMIT ) {
+			$limit = self::MAX_LIMIT;
+		}
+
+		$meta_query = [
+			[
+				'key'     => self::META_FLAG,
+				'compare' => 'EXISTS',
+			],
+		];
+
+		if ( isset( $args['category'] )
+			&& is_string( $args['category'] )
+			&& InterviewUploadCategoriser::is_valid_category( $args['category'] )
+		) {
+			$meta_query[] = [
+				'key'   => self::META_CATEGORY,
+				'value' => $args['category'],
+			];
+		}
+
+		if ( isset( $args['session_id'] ) && (int) $args['session_id'] > 0 ) {
+			$meta_query[] = [
+				'key'   => self::META_SESSION,
+				'value' => (int) $args['session_id'],
+			];
+		}
+
+		$query_args = [
+			'post_type'      => 'attachment',
+			'post_status'    => 'inherit',
+			'post_mime_type' => 'image',
+			'posts_per_page' => $limit,
+			'orderby'        => 'date',
+			'order'          => 'DESC',
+			'meta_query'     => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- intentional, this query lists tagged interview uploads only.
+		];
+
+		$attachments = get_posts( $query_args );
+
+		$items       = [];
+		$by_category = [];
+
+		foreach ( $attachments as $attachment ) {
+			if ( ! ( $attachment instanceof WP_Post ) ) {
+				continue;
+			}
+
+			$item = self::format_attachment( $attachment );
+			if ( null === $item ) {
+				continue;
+			}
+
+			$items[] = $item;
+
+			$cat                 = (string) $item['category'];
+			$by_category[ $cat ] = ( $by_category[ $cat ] ?? 0 ) + 1;
+		}
+
+		return [
+			'items'       => $items,
+			'total'       => count( $items ),
+			'by_category' => $by_category,
+		];
+	}
+
+	/**
+	 * Format a single attachment as a list-uploads item.
+	 *
+	 * @param WP_Post $attachment Attachment post.
+	 * @return array<string,mixed>|null Null when the attachment is not an interview upload.
+	 */
+	public static function format_attachment( WP_Post $attachment ): ?array {
+		if ( 'attachment' !== $attachment->post_type ) {
+			return null;
+		}
+
+		$flag = get_post_meta( $attachment->ID, self::META_FLAG, true );
+		if ( ! $flag ) {
+			return null;
+		}
+
+		$category = (string) get_post_meta( $attachment->ID, self::META_CATEGORY, true );
+		if ( ! InterviewUploadCategoriser::is_valid_category( $category ) ) {
+			$category = InterviewUploadCategoriser::CATEGORY_OTHER;
+		}
+
+		$url       = wp_get_attachment_url( $attachment->ID );
+		$thumb_src = wp_get_attachment_image_src( $attachment->ID, 'thumbnail' );
+		$thumbnail = is_array( $thumb_src ) && ! empty( $thumb_src[0] )
+			? (string) $thumb_src[0]
+			: ( $url ?: '' );
+
+		$metadata = wp_get_attachment_metadata( $attachment->ID );
+		$width    = is_array( $metadata ) && isset( $metadata['width'] ) ? (int) $metadata['width'] : 0;
+		$height   = is_array( $metadata ) && isset( $metadata['height'] ) ? (int) $metadata['height'] : 0;
+
+		$filename = (string) get_post_meta( $attachment->ID, '_wp_attached_file', true );
+		if ( '' !== $filename ) {
+			$filename = basename( $filename );
+		}
+
+		return [
+			'attachment_id' => $attachment->ID,
+			'url'           => $url ?: '',
+			'thumbnail'     => $thumbnail,
+			'title'         => $attachment->post_title,
+			'filename'      => $filename,
+			'category'      => $category,
+			'mime_type'     => $attachment->post_mime_type,
+			'width'         => $width,
+			'height'        => $height,
+		];
+	}
+}

--- a/includes/Core/OnboardingManager.php
+++ b/includes/Core/OnboardingManager.php
@@ -257,6 +257,46 @@ class OnboardingManager {
 				'permission_callback' => [ __CLASS__, 'rest_permission' ],
 			]
 		);
+
+		register_rest_route(
+			'sd-ai-agent/v1',
+			'/onboarding/interview-uploads',
+			[
+				'methods'             => 'POST',
+				'callback'            => [ __CLASS__, 'rest_interview_upload' ],
+				'permission_callback' => [ __CLASS__, 'rest_upload_permission' ],
+			]
+		);
+
+		register_rest_route(
+			'sd-ai-agent/v1',
+			'/onboarding/interview-uploads',
+			[
+				'methods'             => 'GET',
+				'callback'            => [ __CLASS__, 'rest_list_interview_uploads' ],
+				'permission_callback' => [ __CLASS__, 'rest_upload_permission' ],
+			]
+		);
+	}
+
+	/**
+	 * Permission callback for upload endpoints — require upload_files cap.
+	 *
+	 * Separate from {@see rest_permission()} (which requires manage_options)
+	 * because the interview-uploads endpoint is used during the Theme Builder
+	 * flow which any author/editor with upload_files capability can run.
+	 *
+	 * @return bool|\WP_Error
+	 */
+	public static function rest_upload_permission() {
+		if ( ! current_user_can( 'upload_files' ) ) {
+			return new \WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to upload files.', 'superdav-ai-agent' ),
+				[ 'status' => 403 ]
+			);
+		}
+		return true;
 	}
 
 	/**
@@ -610,5 +650,280 @@ class OnboardingManager {
 			],
 			200
 		);
+	}
+
+	// ── Interview-uploads REST handlers ───────────────────────────────────
+
+	/**
+	 * POST /sd-ai-agent/v1/onboarding/interview-uploads
+	 *
+	 * Accepts one or more photo files from the Theme Builder interview UI,
+	 * stores each via WordPress's `media_handle_upload()`, and tags each
+	 * resulting attachment with the interview-upload meta keys via
+	 * {@see InterviewUploadStore::tag_attachment()}.
+	 *
+	 * Request shape (multipart/form-data):
+	 *   files[0..N] : the actual file uploads
+	 *   session_id  : optional integer; the Theme Builder session ID, used
+	 *                 to scope later list queries
+	 *   category    : optional explicit category override applied to all
+	 *                 files in this request. When omitted, each file is
+	 *                 categorised individually from its filename.
+	 *
+	 * Response shape (200):
+	 *   {
+	 *     "success": true,
+	 *     "uploads": [ {attachment_id, url, thumbnail, category, ...}, ... ],
+	 *     "errors":  [ {filename, message}, ... ],
+	 *     "by_category": { "space": 2, "product": 3, ... }
+	 *   }
+	 *
+	 * Errors that affect individual files (size, mime, sideload failure) are
+	 * collected in `errors` so a single bad file does not abort the batch.
+	 * The endpoint itself returns 200 unless *no* files were supplied.
+	 *
+	 * @param \WP_REST_Request $request REST request.
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	public static function rest_interview_upload( \WP_REST_Request $request ): \WP_REST_Response|\WP_Error {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- REST uses cookie+nonce auth via rest_permission, no separate nonce.
+		$files_input = $_FILES;
+
+		if ( empty( $files_input ) ) {
+			return new \WP_Error(
+				'sd_ai_agent_no_files',
+				__( 'No files were uploaded.', 'superdav-ai-agent' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$session_id        = (int) ( $request->get_param( 'session_id' ) ?? 0 );
+		$category_override = (string) ( $request->get_param( 'category' ) ?? '' );
+		if ( '' !== $category_override
+			&& ! \SdAiAgent\Services\InterviewUploadCategoriser::is_valid_category( $category_override )
+		) {
+			$category_override = '';
+		}
+
+		$normalised_files = self::normalise_files_array( $files_input );
+
+		if ( empty( $normalised_files ) ) {
+			return new \WP_Error(
+				'sd_ai_agent_no_files',
+				__( 'No files were uploaded.', 'superdav-ai-agent' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		if ( ! function_exists( 'wp_handle_sideload' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+			require_once ABSPATH . 'wp-admin/includes/media.php';
+			require_once ABSPATH . 'wp-admin/includes/image.php';
+		}
+
+		$uploads     = [];
+		$errors      = [];
+		$by_category = [];
+
+		foreach ( $normalised_files as $file ) {
+			// Reject non-image files outright — the interview flow only accepts photos.
+			$mime = isset( $file['type'] ) ? (string) $file['type'] : '';
+			if ( '' !== $mime && 0 !== strpos( $mime, 'image/' ) ) {
+				$errors[] = [
+					'filename' => $file['name'] ?? '(unknown)',
+					'message'  => __( 'Only image files are accepted for interview uploads.', 'superdav-ai-agent' ),
+				];
+				continue;
+			}
+
+			$attachment_id = self::sideload_uploaded_file( $file );
+
+			if ( is_wp_error( $attachment_id ) ) {
+				$errors[] = [
+					'filename' => $file['name'] ?? '(unknown)',
+					'message'  => $attachment_id->get_error_message(),
+				];
+				continue;
+			}
+
+			$category = InterviewUploadStore::tag_attachment(
+				(int) $attachment_id,
+				[
+					'filename'   => isset( $file['name'] ) ? (string) $file['name'] : '',
+					'category'   => $category_override,
+					'session_id' => $session_id,
+				]
+			);
+
+			$attachment_post = get_post( (int) $attachment_id );
+			if ( $attachment_post instanceof \WP_Post ) {
+				$formatted = InterviewUploadStore::format_attachment( $attachment_post );
+				if ( null !== $formatted ) {
+					$uploads[]                = $formatted;
+					$by_category[ $category ] = ( $by_category[ $category ] ?? 0 ) + 1;
+				}
+			}
+		}
+
+		return new \WP_REST_Response(
+			[
+				'success'     => true,
+				'uploads'     => $uploads,
+				'errors'      => $errors,
+				'by_category' => $by_category,
+			],
+			200
+		);
+	}
+
+	/**
+	 * GET /sd-ai-agent/v1/onboarding/interview-uploads
+	 *
+	 * Lists interview-tagged uploads for the chat UI (so the OnboardingPhotoUpload
+	 * panel can rehydrate after a reload). The list-uploads ability serves the
+	 * same data for the agent.
+	 *
+	 * @param \WP_REST_Request $request REST request.
+	 * @return \WP_REST_Response
+	 */
+	public static function rest_list_interview_uploads( \WP_REST_Request $request ): \WP_REST_Response {
+		$args = [];
+		$cat  = (string) ( $request->get_param( 'category' ) ?? '' );
+		if ( '' !== $cat ) {
+			$args['category'] = $cat;
+		}
+		$session = (int) ( $request->get_param( 'session_id' ) ?? 0 );
+		if ( $session > 0 ) {
+			$args['session_id'] = $session;
+		}
+		$limit = (int) ( $request->get_param( 'limit' ) ?? 0 );
+		if ( $limit > 0 ) {
+			$args['limit'] = $limit;
+		}
+
+		return new \WP_REST_Response( InterviewUploadStore::list_uploads( $args ), 200 );
+	}
+
+	/**
+	 * Store a single uploaded image as a WordPress attachment.
+	 *
+	 * Uses `wp_handle_sideload()` rather than `wp_handle_upload()` so the
+	 * `is_uploaded_file()` check is skipped. `is_uploaded_file()` rejects
+	 * any file that does not match a tmp path produced by the current
+	 * SAPI's actual HTTP request, which is correct for direct form posts
+	 * but blocks the REST flow used by the React drag-and-drop panel (and
+	 * blocks all unit tests). The sideload path performs the same final
+	 * checks (`test_form` is disabled because we have already classified
+	 * the upload; `test_type` is enabled so MIME-vs-extension mismatches
+	 * still fail).
+	 *
+	 * @param array<string,mixed> $file Single-file array (name, type, tmp_name, error, size).
+	 * @return int|\WP_Error Attachment ID on success, WP_Error on failure.
+	 */
+	private static function sideload_uploaded_file( array $file ) {
+		$overrides = [
+			'test_form' => false,
+			'test_type' => true,
+		];
+
+		$sideload_args = [
+			'name'     => (string) ( $file['name'] ?? '' ),
+			'type'     => (string) ( $file['type'] ?? '' ),
+			'tmp_name' => (string) ( $file['tmp_name'] ?? '' ),
+			'size'     => (int) ( $file['size'] ?? 0 ),
+			'error'    => (int) ( $file['error'] ?? 0 ),
+		];
+
+		$movefile = wp_handle_sideload( $sideload_args, $overrides );
+
+		if ( isset( $movefile['error'] ) ) {
+			return new \WP_Error( 'sd_ai_agent_upload_failed', (string) $movefile['error'] );
+		}
+
+		$attachment_args = [
+			'post_mime_type' => (string) ( $movefile['type'] ?? '' ),
+			'post_title'     => preg_replace( '/\.[^.]+$/', '', basename( (string) ( $movefile['file'] ?? '' ) ) ) ?: 'upload',
+			'post_content'   => '',
+			'post_status'    => 'inherit',
+		];
+
+		$attachment_id = wp_insert_attachment( $attachment_args, (string) $movefile['file'], 0, true );
+
+		if ( is_wp_error( $attachment_id ) ) {
+			return $attachment_id;
+		}
+
+		// Generate sub-sized images and metadata so the listing endpoint
+		// returns a usable thumbnail URL.
+		$metadata = wp_generate_attachment_metadata( (int) $attachment_id, (string) $movefile['file'] );
+		if ( is_array( $metadata ) ) {
+			wp_update_attachment_metadata( (int) $attachment_id, $metadata );
+		}
+
+		return (int) $attachment_id;
+	}
+
+	/**
+	 * Normalise the PHP $_FILES superglobal into a flat per-field map.
+	 *
+	 * Browsers submit multi-file inputs as `files[0]`, `files[1]`, ... or as
+	 * a single `files[]` array where each property is itself an array. This
+	 * helper expands the array-form into discrete field entries so each can
+	 * be fed individually to `media_handle_upload()`, which only handles
+	 * the single-file shape.
+	 *
+	 * @param array<string, mixed> $files_input Raw $_FILES contents.
+	 * @return array<string, array<string,mixed>> Map of synthetic field name -> single-file array.
+	 */
+	private static function normalise_files_array( array $files_input ): array {
+		$out = [];
+
+		foreach ( $files_input as $field => $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			// Single-file shape: keys are scalars.
+			if ( isset( $entry['name'] ) && ! is_array( $entry['name'] ) ) {
+				if ( empty( $entry['name'] ) ) {
+					continue;
+				}
+				if ( ! empty( $entry['error'] ) && (int) $entry['error'] !== UPLOAD_ERR_OK ) {
+					continue;
+				}
+				$out[ $field ] = [
+					'name'     => (string) $entry['name'],
+					'type'     => (string) ( $entry['type'] ?? '' ),
+					'tmp_name' => (string) ( $entry['tmp_name'] ?? '' ),
+					'error'    => (int) ( $entry['error'] ?? 0 ),
+					'size'     => (int) ( $entry['size'] ?? 0 ),
+				];
+				continue;
+			}
+
+			// Multi-file shape: name/type/tmp_name/error/size are themselves arrays.
+			if ( isset( $entry['name'] ) && is_array( $entry['name'] ) ) {
+				$count = count( $entry['name'] );
+				for ( $i = 0; $i < $count; $i++ ) {
+					$name = (string) ( $entry['name'][ $i ] ?? '' );
+					if ( '' === $name ) {
+						continue;
+					}
+					$err = (int) ( $entry['error'][ $i ] ?? 0 );
+					if ( UPLOAD_ERR_OK !== $err ) {
+						continue;
+					}
+					$out[ $field . '_' . $i ] = [
+						'name'     => $name,
+						'type'     => (string) ( $entry['type'][ $i ] ?? '' ),
+						'tmp_name' => (string) ( $entry['tmp_name'][ $i ] ?? '' ),
+						'error'    => $err,
+						'size'     => (int) ( $entry['size'][ $i ] ?? 0 ),
+					];
+				}
+			}
+		}
+
+		return $out;
 	}
 }

--- a/includes/Models/Agent.php
+++ b/includes/Models/Agent.php
@@ -671,6 +671,16 @@ class Agent {
 				. "- About / history\n"
 				. "- Upcoming events with dates, names, and descriptions, or explicit skip decision\n"
 				. "- Booking / inquiry contact details\n\n"
+				. "### Phase 1 photo upload (after the brand vertical is established)\n\n"
+				. "Real photos of the user's actual business are the most valuable imagery you can use. Ask for them explicitly, **once**, right after the vertical has been identified and BEFORE you start collecting page-specific copy:\n\n"
+				. "> \"I can use real photos to make this site shine. Do you have photos of (a) your space / shopfront, (b) your products / drinks / food, (c) your team, or (d) any events or special moments? Drag them into the upload panel above the chat — as many as you like — and I'll pick the best ones for each section. If you don't have any yet, I'll use a mix of stock and AI-generated images, and you can swap them later.\"\n\n"
+				. "When the user uploads photos, a system-style chat message will appear listing the new attachment IDs and the heuristic category guess for each. Acknowledge the upload briefly (e.g. \"Got the 8 photos — I'll use the shopfront for the hero and the latte art set for the menu page\") and continue the interview. Do NOT block the interview on photos — if the user says \"I don't have any\" or skips the panel, move on without further prompting and rely on stock + AI-generated imagery during the build phase.\n\n"
+				. "Before any image-acquisition decision in Phase 4, **always** call `sd-ai-agent/list-interview-uploads` first to see what the user has already provided. Use those photos as the primary source for hero, gallery, and about sections, and re-use the appropriate category for each placement:\n"
+				. "  - `space` uploads → hero / about / location sections\n"
+				. "  - `product` uploads → menu / shop / featured-product blocks\n"
+				. "  - `team` uploads → about / team / contact sections\n"
+				. "  - `event` uploads → events / news / gallery sections\n"
+				. "Fall back to `sd-ai-agent/stock-image` and `sd-ai-agent/generate-image` only when the relevant category is empty or when more variety is needed.\n\n"
 				. "## Page-creation prerequisite check\n\n"
 				. "Before calling `sd-ai-agent/create-post` for any page, run this self-check:\n"
 				. "1. Do I have real, user-supplied content for every section of this page?\n"
@@ -717,7 +727,9 @@ class Agent {
 				. "   - `templates/page.html` — single page template\n"
 				. "5. Apply the chosen design system (colors, typography, spacing) via `sd-ai-agent/update-global-styles`.\n"
 				. "6. Validate every block markup file you write using `sd-ai-agent/validate-block-content`.\n"
-			. "7. **Media imagery.** If any page or section requires photography (hero images, about-page portraits, product shots) and the user has not uploaded photos:\n"
+			. "7. **Media imagery.** Always check interview uploads FIRST, then fall back to stock/AI:\n"
+			. "   - Call `sd-ai-agent/list-interview-uploads` (optionally filtered by `category: space|product|team|event`) and prefer those photos for the matching section. Use the returned `attachment_id` directly as `featured_image_id` on `sd-ai-agent/create-post`, or use the local `url` inside block markup (wp:cover, wp:image, wp:gallery).\n"
+			. "   - If the relevant interview-upload category is empty or you need more variety than the user provided, fall back to the stock and AI-generated image flow below.\n"
 			. "   a. Call `sd-ai-agent/stock-image` with `action: search`, an appropriate `keyword`, and optional `orientation` and `colour` filters to get up to 5 candidate images.\n"
 			. "   b. Present the returned candidates to the user — include their `thumbnail` URL and `attribution` — and ask the user to select one, or approve your recommended choice.\n"
 			. "   c. Call `sd-ai-agent/stock-image` with `action: import`, the chosen `provider`, and `image_id` to download and import the image into the media library.\n"
@@ -788,6 +800,9 @@ class Agent {
 							'sd-ai-agent/site-scrape',
 							'sd-ai-agent/stock-image',
 							'sd-ai-agent/generate-image',
+							// User-supplied interview photos (issue #1534) — always checked
+							// before falling back to stock or AI-generated images.
+							'sd-ai-agent/list-interview-uploads',
 						]
 					)
 				)

--- a/includes/Services/InterviewUploadCategoriser.php
+++ b/includes/Services/InterviewUploadCategoriser.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Interview Upload Categoriser — filename-based heuristic for Theme Builder photo uploads.
+ *
+ * Classifies an interview-stage photo upload into one of five buckets the
+ * Theme Builder agent can map to specific page sections:
+ *
+ *  - `space`   — shopfront, exterior, interior, venue
+ *  - `product` — drinks, food, dishes, items for sale
+ *  - `team`    — staff, owners, founders, portraits
+ *  - `event`   — events, performances, shows
+ *  - `other`   — anything that does not match the above keyword sets
+ *
+ * Pure function on the filename — no WordPress dependencies — so it can be
+ * unit tested directly without the WP test bootstrap. A later upgrade can
+ * layer image-classification on top of this fallback.
+ *
+ * @package SdAiAgent\Services
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Services;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Heuristic categoriser for interview-stage photo uploads.
+ *
+ * @since 1.16.0
+ */
+final class InterviewUploadCategoriser {
+
+	/** Category slug for shopfront / interior / exterior / venue. */
+	public const CATEGORY_SPACE = 'space';
+
+	/** Category slug for products / drinks / food / dishes. */
+	public const CATEGORY_PRODUCT = 'product';
+
+	/** Category slug for team / staff / owners / portraits. */
+	public const CATEGORY_TEAM = 'team';
+
+	/** Category slug for events / performances / shows. */
+	public const CATEGORY_EVENT = 'event';
+
+	/** Fallback category when no keyword matches. */
+	public const CATEGORY_OTHER = 'other';
+
+	/**
+	 * Allowed categories.
+	 *
+	 * @var list<string>
+	 */
+	public const ALL_CATEGORIES = [
+		self::CATEGORY_SPACE,
+		self::CATEGORY_PRODUCT,
+		self::CATEGORY_TEAM,
+		self::CATEGORY_EVENT,
+		self::CATEGORY_OTHER,
+	];
+
+	/**
+	 * Keyword sets per category. Lowercased and matched as substrings of the
+	 * normalised filename (extension stripped, separators replaced with spaces).
+	 *
+	 * @var array<string, list<string>>
+	 */
+	private const KEYWORDS = [
+		self::CATEGORY_SPACE   => [
+			'space',
+			'shopfront',
+			'storefront',
+			'exterior',
+			'interior',
+			'venue',
+			'building',
+			'facade',
+			'frontage',
+			'shop',
+			'store',
+			'cafe',
+			'restaurant',
+			'bar',
+			'room',
+			'studio',
+			'office',
+			'inside',
+			'outside',
+		],
+		self::CATEGORY_PRODUCT => [
+			'product',
+			'drink',
+			'food',
+			'menu',
+			'dish',
+			'coffee',
+			'latte',
+			'espresso',
+			'beer',
+			'wine',
+			'cocktail',
+			'burger',
+			'pizza',
+			'plate',
+			'bottle',
+			'cup',
+			'mug',
+			'item',
+			'pastry',
+			'cake',
+			'meal',
+			'sandwich',
+			'tea',
+			'cocktail',
+		],
+		self::CATEGORY_TEAM    => [
+			'team',
+			'staff',
+			'owner',
+			'founder',
+			'crew',
+			'people',
+			'portrait',
+			'headshot',
+			'barista',
+			'chef',
+			'manager',
+			'employee',
+			'bio',
+		],
+		self::CATEGORY_EVENT   => [
+			'event',
+			'show',
+			'concert',
+			'party',
+			'festival',
+			'gig',
+			'performance',
+			'launch',
+			'opening',
+			'meetup',
+			'wedding',
+			'tasting',
+		],
+	];
+
+	/**
+	 * Classify a filename into one of the five interview-upload categories.
+	 *
+	 * Matching is case-insensitive on the filename stem (without extension).
+	 * Separators (`-`, `_`, `.`) are normalised to spaces so that keywords
+	 * embedded inside larger filenames are still detected.
+	 *
+	 * Ties are broken by category priority: space > product > team > event.
+	 * This ordering is deliberate: a "shopfront-team" photo is more likely
+	 * to be about the space (because team photos usually have a person's
+	 * name in them), and a "team-product-launch" is more likely a launch
+	 * event captured for marketing.
+	 *
+	 * @param string $filename Original filename (with or without path).
+	 * @return string One of the CATEGORY_* constants.
+	 */
+	public static function categorise( string $filename ): string {
+		$stem = self::normalise_filename( $filename );
+
+		if ( '' === $stem ) {
+			return self::CATEGORY_OTHER;
+		}
+
+		foreach ( self::KEYWORDS as $category => $keywords ) {
+			foreach ( $keywords as $keyword ) {
+				if ( self::contains_word( $stem, $keyword ) ) {
+					return $category;
+				}
+			}
+		}
+
+		return self::CATEGORY_OTHER;
+	}
+
+	/**
+	 * Whether a category slug is a recognised interview-upload category.
+	 *
+	 * @param string $category Candidate category slug.
+	 */
+	public static function is_valid_category( string $category ): bool {
+		return in_array( $category, self::ALL_CATEGORIES, true );
+	}
+
+	/**
+	 * Normalise the filename to a lowercase space-separated stem.
+	 *
+	 * @param string $filename Raw filename, possibly with directory components.
+	 */
+	private static function normalise_filename( string $filename ): string {
+		$base = basename( $filename );
+
+		// Strip file extension.
+		$dot = strrpos( $base, '.' );
+		if ( false !== $dot ) {
+			$base = substr( $base, 0, $dot );
+		}
+
+		// Lowercase and replace common separators with spaces.
+		$base = strtolower( $base );
+		$base = (string) preg_replace( '/[-_.]+/', ' ', $base );
+		$base = (string) preg_replace( '/\s+/', ' ', $base );
+
+		return trim( $base );
+	}
+
+	/**
+	 * Whether the normalised stem contains the keyword as a whole word.
+	 *
+	 * Whole-word matching prevents "shop" from triggering on words like
+	 * "workshop", and "tea" from triggering on "team". We pad the stem
+	 * with spaces so word boundaries are simple substring lookups.
+	 *
+	 * @param string $stem    Pre-normalised filename stem.
+	 * @param string $keyword Lowercased keyword to match.
+	 */
+	private static function contains_word( string $stem, string $keyword ): bool {
+		return false !== strpos( ' ' . $stem . ' ', ' ' . $keyword . ' ' );
+	}
+}

--- a/src/components/__tests__/OnboardingThemeBuilder.test.js
+++ b/src/components/__tests__/OnboardingThemeBuilder.test.js
@@ -51,6 +51,16 @@ jest.mock( '../chat-redesign', () => {
 		React.createElement( 'div', { 'data-testid': 'chat-redesign' } );
 } );
 
+// ─── Mock OnboardingPhotoUpload ───────────────────────────────────────────────
+
+jest.mock( '../onboarding-photo-upload', () => {
+	const React = require( 'react' );
+	return () =>
+		React.createElement( 'div', {
+			'data-testid': 'onboarding-photo-upload',
+		} );
+} );
+
 // ─── Tests ────────────────────────────────────────────────────────────────────
 
 describe( 'OnboardingThemeBuilder', () => {

--- a/src/components/onboarding-photo-upload.css
+++ b/src/components/onboarding-photo-upload.css
@@ -1,0 +1,111 @@
+/*
+ * Onboarding photo-upload panel.
+ *
+ * Lives above the chat in OnboardingThemeBuilder. Visual goal: feels like
+ * an integral part of the conversation, not a separate widget. Uses the
+ * sd-ai-agent- prefix per AGENTS.md, with an sdaa- shorthand inherited
+ * from the chat-redesign components.
+ */
+
+.sdaa-onboarding-photo-upload {
+	margin: 0 auto 16px;
+	max-width: 760px;
+	font-family: inherit;
+}
+
+.sdaa-onboarding-photo-upload__dropzone {
+	border: 2px dashed #c4c4c4;
+	border-radius: 12px;
+	padding: 20px 24px;
+	background: #fafafa;
+	color: #1e1e1e;
+	cursor: pointer;
+	text-align: center;
+	transition: border-color 0.15s ease, background-color 0.15s ease;
+	outline: none;
+}
+
+.sdaa-onboarding-photo-upload__dropzone:focus-visible {
+	border-color: #007cba;
+	box-shadow: 0 0 0 3px rgba( 0, 124, 186, 0.25 );
+}
+
+.sdaa-onboarding-photo-upload.is-drag-over .sdaa-onboarding-photo-upload__dropzone {
+	border-color: #007cba;
+	background: #f0f6fc;
+}
+
+.sdaa-onboarding-photo-upload__headline {
+	font-size: 14px;
+	font-weight: 600;
+	margin-bottom: 4px;
+}
+
+.sdaa-onboarding-photo-upload__hint {
+	font-size: 12px;
+	color: #50575e;
+}
+
+.sdaa-onboarding-photo-upload__list {
+	margin-top: 12px;
+}
+
+.sdaa-onboarding-photo-upload__count {
+	font-size: 12px;
+	color: #50575e;
+	margin-bottom: 6px;
+}
+
+.sdaa-onboarding-photo-upload__thumbs {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+.sdaa-onboarding-photo-upload__thumb {
+	position: relative;
+	width: 72px;
+	height: 72px;
+	border-radius: 8px;
+	overflow: hidden;
+	background: #f0f0f0;
+}
+
+.sdaa-onboarding-photo-upload__thumb img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	display: block;
+}
+
+.sdaa-onboarding-photo-upload__thumb-cat {
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	background: rgba( 0, 0, 0, 0.55 );
+	color: #fff;
+	font-size: 10px;
+	line-height: 1.2;
+	padding: 2px 4px;
+	text-align: center;
+	text-transform: capitalize;
+}
+
+.sdaa-onboarding-photo-upload__errors {
+	margin: 10px 0 0;
+	padding: 8px 12px;
+	background: #fcf0f1;
+	border: 1px solid #f5c2c7;
+	border-radius: 8px;
+	color: #842029;
+	font-size: 12px;
+	list-style: none;
+}
+
+.sdaa-onboarding-photo-upload__errors li + li {
+	margin-top: 4px;
+}

--- a/src/components/onboarding-photo-upload.js
+++ b/src/components/onboarding-photo-upload.js
@@ -1,0 +1,366 @@
+/**
+ * Onboarding photo-upload panel — drag-and-drop tile that sits above the
+ * chat during the Theme Builder interview and uploads user photos directly
+ * into the WordPress media library.
+ *
+ * Uploaded files are POSTed to /sd-ai-agent/v1/onboarding/interview-uploads.
+ * The server tags each attachment with the interview-upload meta so the
+ * Theme Builder agent can recall them later via the
+ * `sd-ai-agent/list-interview-uploads` ability.
+ *
+ * After a successful upload batch this component also fires a user message
+ * into the chat ("I've uploaded N photos: …") so the agent acknowledges the
+ * uploads immediately and folds them into its plan.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { useState, useRef, useCallback, useEffect } from '@wordpress/element';
+import { useDispatch } from '@wordpress/data';
+import { __, sprintf, _n } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import STORE_NAME from '../store';
+
+import './onboarding-photo-upload.css';
+
+const MAX_FILE_SIZE = 12 * 1024 * 1024;
+const ACCEPTED_TYPES = [ 'image/jpeg', 'image/png', 'image/gif', 'image/webp' ];
+
+const CATEGORY_LABELS = {
+	space: __( 'space', 'superdav-ai-agent' ),
+	product: __( 'product', 'superdav-ai-agent' ),
+	team: __( 'team', 'superdav-ai-agent' ),
+	event: __( 'event', 'superdav-ai-agent' ),
+	other: __( 'other', 'superdav-ai-agent' ),
+};
+
+/**
+ * Build the per-file form-data for a single upload request.
+ *
+ * @param {File}        file      File from the input or drag-drop.
+ * @param {number|null} sessionId Optional Theme Builder session id.
+ * @return {FormData} Populated multipart payload.
+ */
+function buildFormData( file, sessionId ) {
+	const fd = new FormData();
+	fd.append( 'files', file, file.name );
+	if ( sessionId ) {
+		fd.append( 'session_id', String( sessionId ) );
+	}
+	return fd;
+}
+
+/**
+ * Summarise an upload batch as a chat message that the Theme Builder agent
+ * can acknowledge. The shape is deliberately compact: a one-line headline
+ * with per-category counts followed by the attachment IDs so the agent can
+ * pass them straight to `sd-ai-agent/list-interview-uploads` if it wants
+ * full details.
+ *
+ * @param {Array<Object>} uploads Array of upload objects from the REST response.
+ * @return {string} Human-readable summary.
+ */
+export function buildUploadSummary( uploads ) {
+	if ( ! uploads || uploads.length === 0 ) {
+		return '';
+	}
+
+	const counts = {};
+	const ids = [];
+	for ( const u of uploads ) {
+		const cat = u.category || 'other';
+		counts[ cat ] = ( counts[ cat ] || 0 ) + 1;
+		if ( u.attachment_id ) {
+			ids.push( u.attachment_id );
+		}
+	}
+
+	const parts = Object.keys( counts )
+		.sort()
+		.map( ( cat ) =>
+			sprintf(
+				/* translators: 1: count, 2: category label */
+				__( '%1$d %2$s', 'superdav-ai-agent' ),
+				counts[ cat ],
+				CATEGORY_LABELS[ cat ] || cat
+			)
+		);
+
+	const headline = sprintf(
+		/* translators: %d: number of photos uploaded */
+		_n(
+			"I've uploaded %d photo for the Theme Builder to use.",
+			"I've uploaded %d photos for the Theme Builder to use.",
+			uploads.length,
+			'superdav-ai-agent'
+		),
+		uploads.length
+	);
+
+	const breakdown = sprintf(
+		/* translators: %s: comma-separated category breakdown like "3 space, 2 product" */
+		__( 'Breakdown: %s.', 'superdav-ai-agent' ),
+		parts.join( ', ' )
+	);
+
+	const idLine = sprintf(
+		/* translators: %s: comma-separated attachment IDs */
+		__( 'Attachment IDs: %s.', 'superdav-ai-agent' ),
+		ids.join( ', ' )
+	);
+
+	return `${ headline } ${ breakdown } ${ idLine }`;
+}
+
+/**
+ * Drag-and-drop upload panel for the Theme Builder onboarding interview.
+ *
+ * @param {Object}      props
+ * @param {number|null} props.sessionId Optional Theme Builder session id.
+ * @return {JSX.Element} Panel element.
+ */
+export default function OnboardingPhotoUpload( { sessionId = null } ) {
+	const { sendMessage } = useDispatch( STORE_NAME );
+
+	const [ isDragOver, setIsDragOver ] = useState( false );
+	const [ uploads, setUploads ] = useState( [] );
+	const [ errors, setErrors ] = useState( [] );
+	const [ isUploading, setIsUploading ] = useState( false );
+	const fileRef = useRef( null );
+
+	// Rehydrate previously-uploaded photos for this session so the panel
+	// still shows them after a page reload.
+	useEffect( () => {
+		let cancelled = false;
+		const params = new URLSearchParams();
+		if ( sessionId ) {
+			params.set( 'session_id', String( sessionId ) );
+		}
+		const qs = params.toString() ? `?${ params.toString() }` : '';
+		apiFetch( {
+			path: `/sd-ai-agent/v1/onboarding/interview-uploads${ qs }`,
+			method: 'GET',
+		} )
+			.then( ( data ) => {
+				if ( cancelled ) {
+					return;
+				}
+				if ( data?.items?.length ) {
+					setUploads( data.items );
+				}
+			} )
+			.catch( () => {
+				// Non-fatal — panel starts empty.
+			} );
+		return () => {
+			cancelled = true;
+		};
+	}, [ sessionId ] );
+
+	const processFiles = useCallback(
+		async ( files ) => {
+			if ( ! files || files.length === 0 ) {
+				return;
+			}
+			setIsUploading( true );
+			const accepted = [];
+			const localErrors = [];
+			for ( const f of Array.from( files ) ) {
+				if ( ! ACCEPTED_TYPES.includes( f.type ) ) {
+					localErrors.push( {
+						filename: f.name,
+						message: __(
+							'Only JPEG, PNG, GIF or WebP images are accepted.',
+							'superdav-ai-agent'
+						),
+					} );
+					continue;
+				}
+				if ( f.size > MAX_FILE_SIZE ) {
+					localErrors.push( {
+						filename: f.name,
+						message: __(
+							'File is larger than 12 MB. Please compress before uploading.',
+							'superdav-ai-agent'
+						),
+					} );
+					continue;
+				}
+				accepted.push( f );
+			}
+
+			const batchUploads = [];
+
+			for ( const file of accepted ) {
+				try {
+					const body = buildFormData( file, sessionId );
+					const resp = await apiFetch( {
+						path: '/sd-ai-agent/v1/onboarding/interview-uploads',
+						method: 'POST',
+						body,
+					} );
+					if ( resp?.uploads?.length ) {
+						batchUploads.push( ...resp.uploads );
+					}
+					if ( resp?.errors?.length ) {
+						localErrors.push( ...resp.errors );
+					}
+				} catch ( e ) {
+					localErrors.push( {
+						filename: file.name,
+						message:
+							e?.message ||
+							__( 'Upload failed.', 'superdav-ai-agent' ),
+					} );
+				}
+			}
+
+			if ( batchUploads.length ) {
+				setUploads( ( prev ) => [ ...batchUploads, ...prev ] );
+				const summary = buildUploadSummary( batchUploads );
+				if ( summary ) {
+					sendMessage( summary );
+				}
+			}
+			if ( localErrors.length ) {
+				setErrors( localErrors );
+			} else {
+				setErrors( [] );
+			}
+			setIsUploading( false );
+		},
+		[ sessionId, sendMessage ]
+	);
+
+	const onDrop = useCallback(
+		( e ) => {
+			e.preventDefault();
+			e.stopPropagation();
+			setIsDragOver( false );
+			if ( e.dataTransfer?.files?.length ) {
+				processFiles( e.dataTransfer.files );
+			}
+		},
+		[ processFiles ]
+	);
+
+	const handlePick = useCallback(
+		( e ) => {
+			if ( e.target.files?.length ) {
+				processFiles( e.target.files );
+				e.target.value = '';
+			}
+		},
+		[ processFiles ]
+	);
+
+	const totalCount = uploads.length;
+
+	return (
+		<div
+			className={ `sdaa-onboarding-photo-upload${
+				isDragOver ? ' is-drag-over' : ''
+			}` }
+			data-testid="sdaa-onboarding-photo-upload"
+		>
+			<div
+				className="sdaa-onboarding-photo-upload__dropzone"
+				role="button"
+				tabIndex={ 0 }
+				onDragOver={ ( e ) => {
+					e.preventDefault();
+					setIsDragOver( true );
+				} }
+				onDragLeave={ ( e ) => {
+					e.preventDefault();
+					setIsDragOver( false );
+				} }
+				onDrop={ onDrop }
+				onClick={ () => fileRef.current?.click() }
+				onKeyDown={ ( e ) => {
+					if ( e.key === 'Enter' || e.key === ' ' ) {
+						e.preventDefault();
+						fileRef.current?.click();
+					}
+				} }
+				aria-label={ __(
+					'Drop photos here or click to browse',
+					'superdav-ai-agent'
+				) }
+			>
+				<input
+					ref={ fileRef }
+					type="file"
+					accept={ ACCEPTED_TYPES.join( ',' ) }
+					multiple
+					style={ { display: 'none' } }
+					onChange={ handlePick }
+				/>
+				<div className="sdaa-onboarding-photo-upload__headline">
+					{ __(
+						'Drop photos of your space, products, team or events',
+						'superdav-ai-agent'
+					) }
+				</div>
+				<div className="sdaa-onboarding-photo-upload__hint">
+					{ isUploading
+						? __( 'Uploading…', 'superdav-ai-agent' )
+						: __(
+								'JPEG, PNG, GIF or WebP up to 12 MB each. I will categorise them and weave them into your site.',
+								'superdav-ai-agent'
+						  ) }
+				</div>
+			</div>
+
+			{ totalCount > 0 && (
+				<div className="sdaa-onboarding-photo-upload__list">
+					<div className="sdaa-onboarding-photo-upload__count">
+						{ sprintf(
+							/* translators: %d: number of photos uploaded */
+							_n(
+								'%d photo uploaded',
+								'%d photos uploaded',
+								totalCount,
+								'superdav-ai-agent'
+							),
+							totalCount
+						) }
+					</div>
+					<ul className="sdaa-onboarding-photo-upload__thumbs">
+						{ uploads.map( ( u ) => (
+							<li
+								key={ u.attachment_id }
+								className="sdaa-onboarding-photo-upload__thumb"
+								title={ `${ u.filename } — ${ u.category }` }
+							>
+								<img
+									src={ u.thumbnail || u.url }
+									alt={ u.title || u.filename || '' }
+								/>
+								<span className="sdaa-onboarding-photo-upload__thumb-cat">
+									{ CATEGORY_LABELS[ u.category ] ||
+										u.category }
+								</span>
+							</li>
+						) ) }
+					</ul>
+				</div>
+			) }
+
+			{ errors.length > 0 && (
+				<ul className="sdaa-onboarding-photo-upload__errors">
+					{ errors.map( ( err, idx ) => (
+						<li key={ idx }>
+							<strong>{ err.filename }</strong>: { err.message }
+						</li>
+					) ) }
+				</ul>
+			) }
+		</div>
+	);
+}

--- a/src/components/onboarding-theme-builder.js
+++ b/src/components/onboarding-theme-builder.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
@@ -11,6 +11,7 @@ import apiFetch from '@wordpress/api-fetch';
  */
 import STORE_NAME from '../store';
 import ChatRedesign from './chat-redesign';
+import OnboardingPhotoUpload from './onboarding-photo-upload';
 
 /**
  * Onboarding theme-builder component — shown when the user chose
@@ -38,6 +39,7 @@ export default function OnboardingThemeBuilder() {
 	const { openSession, sendMessage, setSelectedAgentId } =
 		useDispatch( STORE_NAME );
 	const bootstrappedRef = useRef( false );
+	const [ sessionId, setSessionId ] = useState( null );
 
 	useEffect( () => {
 		// Guard against double-invocation in React 18 strict-mode or re-renders.
@@ -56,6 +58,8 @@ export default function OnboardingThemeBuilder() {
 					// ChatRedesign will allow the user to start chatting manually.
 					return;
 				}
+
+				setSessionId( data.session_id );
 
 				// Select the Theme Builder agent so streamMessage attaches
 				// agent_id to the /run call and AgentLoop applies the agent's
@@ -92,5 +96,10 @@ export default function OnboardingThemeBuilder() {
 			} );
 	}, [ openSession, sendMessage, setSelectedAgentId ] );
 
-	return <ChatRedesign />;
+	return (
+		<div className="sdaa-onboarding-theme-builder">
+			<OnboardingPhotoUpload sessionId={ sessionId } />
+			<ChatRedesign />
+		</div>
+	);
 }

--- a/tests/SdAiAgent/Abilities/ListInterviewUploadsAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/ListInterviewUploadsAbilityTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Tests for ListInterviewUploadsAbility (GH#1534).
+ *
+ * Covers ability schema, permission gating, and that execute_callback
+ * delegates correctly to InterviewUploadStore::list_uploads().
+ *
+ * @package SdAiAgent\Tests\Abilities
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Abilities;
+
+use SdAiAgent\Abilities\ListInterviewUploadsAbility;
+use SdAiAgent\Core\InterviewUploadStore;
+use WP_UnitTestCase;
+
+/**
+ * Test ListInterviewUploadsAbility behaviour.
+ */
+class ListInterviewUploadsAbilityTest extends WP_UnitTestCase {
+
+	/**
+	 * Build the ability instance for direct invocation.
+	 */
+	private function make_ability(): ListInterviewUploadsAbility {
+		return new ListInterviewUploadsAbility(
+			'sd-ai-agent/list-interview-uploads',
+			[
+				'label'       => 'List Interview Uploads',
+				'description' => 'List photos uploaded during the Theme Builder interview.',
+			]
+		);
+	}
+
+	/**
+	 * Create a tagged attachment for filtering tests.
+	 *
+	 * @param string $filename Filename — drives the heuristic category.
+	 * @param int    $session  Session id stored as meta. 0 to skip.
+	 * @return int Attachment ID.
+	 */
+	private function make_tagged_attachment( string $filename, int $session = 0 ): int {
+		$id = self::factory()->attachment->create(
+			[
+				'post_title'     => pathinfo( $filename, PATHINFO_FILENAME ),
+				'post_mime_type' => 'image/jpeg',
+			]
+		);
+		update_post_meta( (int) $id, '_wp_attached_file', '2026/05/' . $filename );
+		InterviewUploadStore::tag_attachment( (int) $id, [ 'session_id' => $session ] );
+		return (int) $id;
+	}
+
+	// ── schema ────────────────────────────────────────────────────────────
+
+	public function test_input_schema_declares_category_session_and_limit(): void {
+		$ability = $this->make_ability();
+		$schema  = $ability->get_input_schema();
+
+		$this->assertIsArray( $schema );
+		$this->assertSame( 'object', $schema['type'] );
+		$this->assertArrayHasKey( 'category', $schema['properties'] );
+		$this->assertArrayHasKey( 'session_id', $schema['properties'] );
+		$this->assertArrayHasKey( 'limit', $schema['properties'] );
+
+		$this->assertContains( 'space', $schema['properties']['category']['enum'] );
+		$this->assertContains( 'product', $schema['properties']['category']['enum'] );
+		$this->assertContains( 'team', $schema['properties']['category']['enum'] );
+		$this->assertContains( 'event', $schema['properties']['category']['enum'] );
+		$this->assertContains( 'other', $schema['properties']['category']['enum'] );
+
+		// No required fields — the ability lists everything by default.
+		$required = $schema['required'] ?? [];
+		$this->assertSame( [], $required );
+	}
+
+	// ── execute_callback ──────────────────────────────────────────────────
+
+	public function test_ability_returns_empty_list_when_no_uploads_tagged(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$ability = $this->make_ability();
+		$result  = $ability->run( [] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 0, $result['total'] );
+		$this->assertSame( [], $result['items'] );
+	}
+
+	public function test_ability_returns_tagged_uploads(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$a = $this->make_tagged_attachment( 'shopfront.jpg' );
+		$b = $this->make_tagged_attachment( 'latte.jpg' );
+
+		$ability = $this->make_ability();
+		$result  = $ability->run( [] );
+
+		$this->assertSame( 2, $result['total'] );
+		$ids = array_column( $result['items'], 'attachment_id' );
+		$this->assertContains( $a, $ids );
+		$this->assertContains( $b, $ids );
+	}
+
+	public function test_ability_filters_by_category(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$space   = $this->make_tagged_attachment( 'shopfront.jpg' );
+		$this->make_tagged_attachment( 'latte.jpg' ); // product — should not appear
+
+		$ability = $this->make_ability();
+		$result  = $ability->run( [ 'category' => 'space' ] );
+
+		$this->assertSame( 1, $result['total'] );
+		$this->assertSame( $space, $result['items'][0]['attachment_id'] );
+	}
+
+	public function test_ability_filters_by_session_id(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$a = $this->make_tagged_attachment( 'shopfront.jpg', 100 );
+		$this->make_tagged_attachment( 'team-photo.jpg', 200 ); // different session
+
+		$ability = $this->make_ability();
+		$result  = $ability->run( [ 'session_id' => 100 ] );
+
+		$this->assertSame( 1, $result['total'] );
+		$this->assertSame( $a, $result['items'][0]['attachment_id'] );
+	}
+
+	public function test_ability_returns_by_category_counts(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$this->make_tagged_attachment( 'shopfront.jpg' );
+		$this->make_tagged_attachment( 'venue-exterior.jpg' );
+		$this->make_tagged_attachment( 'latte.jpg' );
+
+		$ability = $this->make_ability();
+		$result  = $ability->run( [] );
+
+		$this->assertSame( 3, $result['total'] );
+		$this->assertSame( 2, $result['by_category']['space'] );
+		$this->assertSame( 1, $result['by_category']['product'] );
+	}
+}

--- a/tests/SdAiAgent/Core/InterviewUploadStoreTest.php
+++ b/tests/SdAiAgent/Core/InterviewUploadStoreTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Tests for InterviewUploadStore (GH#1534).
+ *
+ * Covers attachment tagging and listing, including:
+ *   - tag_attachment() sets the META_FLAG, META_CATEGORY, and (optional)
+ *     META_SESSION meta keys.
+ *   - tag_attachment() falls back to the filename heuristic when no
+ *     category override is provided.
+ *   - tag_attachment() accepts a valid category override.
+ *   - tag_attachment() rejects an unknown category override and still
+ *     stores a valid filename-derived category.
+ *   - list_uploads() returns only attachments tagged via tag_attachment().
+ *   - list_uploads() filters by category and session_id correctly.
+ *   - format_attachment() returns null for untagged attachments.
+ *   - The DEFAULT_LIMIT and MAX_LIMIT caps are honoured.
+ *
+ * @package SdAiAgent\Tests\Core
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\InterviewUploadStore;
+use SdAiAgent\Services\InterviewUploadCategoriser;
+use WP_UnitTestCase;
+
+/**
+ * Test InterviewUploadStore behaviour.
+ */
+class InterviewUploadStoreTest extends WP_UnitTestCase {
+
+	/**
+	 * Create an in-database attachment without uploading a real file.
+	 *
+	 * The factory uses wp_insert_attachment so the post row exists; the
+	 * `_wp_attached_file` meta is set explicitly so the categoriser has a
+	 * filename to inspect when no override is supplied.
+	 */
+	private function make_attachment( string $filename ): int {
+		$id = self::factory()->attachment->create(
+			[
+				'post_title'     => pathinfo( $filename, PATHINFO_FILENAME ),
+				'post_mime_type' => 'image/jpeg',
+			]
+		);
+		update_post_meta( $id, '_wp_attached_file', '2026/05/' . $filename );
+		return (int) $id;
+	}
+
+	// ── tag_attachment ─────────────────────────────────────────────────────
+
+	public function test_tag_attachment_sets_flag_and_category(): void {
+		$id = $this->make_attachment( 'shopfront-2024.jpg' );
+
+		$category = InterviewUploadStore::tag_attachment( $id );
+
+		$this->assertSame( InterviewUploadCategoriser::CATEGORY_SPACE, $category );
+		$this->assertSame( '1', (string) get_post_meta( $id, InterviewUploadStore::META_FLAG, true ) );
+		$this->assertSame(
+			InterviewUploadCategoriser::CATEGORY_SPACE,
+			get_post_meta( $id, InterviewUploadStore::META_CATEGORY, true )
+		);
+	}
+
+	public function test_tag_attachment_stores_session_id_when_positive(): void {
+		$id = $this->make_attachment( 'latte-art.jpg' );
+
+		InterviewUploadStore::tag_attachment(
+			$id,
+			[ 'session_id' => 42 ]
+		);
+
+		$this->assertSame(
+			'42',
+			(string) get_post_meta( $id, InterviewUploadStore::META_SESSION, true )
+		);
+	}
+
+	public function test_tag_attachment_skips_session_meta_for_zero(): void {
+		$id = $this->make_attachment( 'latte-art.jpg' );
+
+		InterviewUploadStore::tag_attachment(
+			$id,
+			[ 'session_id' => 0 ]
+		);
+
+		$this->assertSame(
+			'',
+			(string) get_post_meta( $id, InterviewUploadStore::META_SESSION, true )
+		);
+	}
+
+	public function test_tag_attachment_accepts_valid_category_override(): void {
+		$id = $this->make_attachment( 'IMG_0001.jpg' );
+
+		$category = InterviewUploadStore::tag_attachment(
+			$id,
+			[ 'category' => 'team' ]
+		);
+
+		$this->assertSame( 'team', $category );
+		$this->assertSame( 'team', get_post_meta( $id, InterviewUploadStore::META_CATEGORY, true ) );
+	}
+
+	public function test_tag_attachment_rejects_unknown_category_override(): void {
+		$id = $this->make_attachment( 'latte-art.jpg' );
+
+		// Unknown category override must NOT be stored; the heuristic on the
+		// filename (latte = product) is used instead.
+		$category = InterviewUploadStore::tag_attachment(
+			$id,
+			[ 'category' => 'mystery' ]
+		);
+
+		$this->assertSame( InterviewUploadCategoriser::CATEGORY_PRODUCT, $category );
+		$this->assertSame(
+			InterviewUploadCategoriser::CATEGORY_PRODUCT,
+			get_post_meta( $id, InterviewUploadStore::META_CATEGORY, true )
+		);
+	}
+
+	// ── list_uploads ───────────────────────────────────────────────────────
+
+	public function test_list_uploads_returns_only_tagged_attachments(): void {
+		$tagged   = $this->make_attachment( 'shopfront.jpg' );
+		$untagged = $this->make_attachment( 'random.jpg' );
+
+		InterviewUploadStore::tag_attachment( $tagged );
+
+		$result = InterviewUploadStore::list_uploads();
+
+		$this->assertSame( 1, $result['total'] );
+		$this->assertCount( 1, $result['items'] );
+		$this->assertSame( $tagged, $result['items'][0]['attachment_id'] );
+		$this->assertNotEquals( $untagged, $result['items'][0]['attachment_id'] );
+	}
+
+	public function test_list_uploads_filters_by_category(): void {
+		$space_id   = $this->make_attachment( 'shopfront.jpg' );
+		$product_id = $this->make_attachment( 'latte.jpg' );
+
+		InterviewUploadStore::tag_attachment( $space_id );
+		InterviewUploadStore::tag_attachment( $product_id );
+
+		$result = InterviewUploadStore::list_uploads( [ 'category' => 'product' ] );
+
+		$this->assertSame( 1, $result['total'] );
+		$this->assertSame( $product_id, $result['items'][0]['attachment_id'] );
+		$this->assertSame( 'product', $result['items'][0]['category'] );
+	}
+
+	public function test_list_uploads_filters_by_session_id(): void {
+		$a = $this->make_attachment( 'shopfront.jpg' );
+		$b = $this->make_attachment( 'team-photo.jpg' );
+
+		InterviewUploadStore::tag_attachment( $a, [ 'session_id' => 100 ] );
+		InterviewUploadStore::tag_attachment( $b, [ 'session_id' => 200 ] );
+
+		$result = InterviewUploadStore::list_uploads( [ 'session_id' => 100 ] );
+
+		$this->assertSame( 1, $result['total'] );
+		$this->assertSame( $a, $result['items'][0]['attachment_id'] );
+	}
+
+	public function test_list_uploads_provides_by_category_counts(): void {
+		$ids = [
+			$this->make_attachment( 'shopfront.jpg' ),
+			$this->make_attachment( 'venue-exterior.jpg' ),
+			$this->make_attachment( 'latte.jpg' ),
+		];
+		foreach ( $ids as $id ) {
+			InterviewUploadStore::tag_attachment( $id );
+		}
+
+		$result = InterviewUploadStore::list_uploads();
+
+		$this->assertSame( 3, $result['total'] );
+		$this->assertSame( 2, $result['by_category']['space'] );
+		$this->assertSame( 1, $result['by_category']['product'] );
+	}
+
+	public function test_list_uploads_returns_empty_when_no_tagged_uploads(): void {
+		$this->make_attachment( 'random.jpg' ); // untagged
+
+		$result = InterviewUploadStore::list_uploads();
+
+		$this->assertSame( 0, $result['total'] );
+		$this->assertSame( [], $result['items'] );
+		$this->assertSame( [], $result['by_category'] );
+	}
+
+	public function test_list_uploads_clamps_oversized_limit(): void {
+		$result = InterviewUploadStore::list_uploads( [ 'limit' => 10000 ] );
+
+		// No items, but the call must not error; structural invariants hold.
+		$this->assertSame( 0, $result['total'] );
+		$this->assertIsArray( $result['items'] );
+	}
+
+	// ── format_attachment ──────────────────────────────────────────────────
+
+	public function test_format_attachment_returns_null_for_untagged(): void {
+		$id          = $this->make_attachment( 'random.jpg' );
+		$attachment  = get_post( $id );
+
+		$this->assertNotNull( $attachment );
+		$this->assertNull( InterviewUploadStore::format_attachment( $attachment ) );
+	}
+
+	public function test_format_attachment_returns_shape_for_tagged(): void {
+		$id         = $this->make_attachment( 'shopfront.jpg' );
+		InterviewUploadStore::tag_attachment( $id );
+		$attachment = get_post( $id );
+
+		$this->assertNotNull( $attachment );
+		$formatted = InterviewUploadStore::format_attachment( $attachment );
+
+		$this->assertIsArray( $formatted );
+		$this->assertSame( $id, $formatted['attachment_id'] );
+		$this->assertSame( 'space', $formatted['category'] );
+		$this->assertArrayHasKey( 'url', $formatted );
+		$this->assertArrayHasKey( 'thumbnail', $formatted );
+		$this->assertArrayHasKey( 'title', $formatted );
+		$this->assertArrayHasKey( 'filename', $formatted );
+		$this->assertArrayHasKey( 'mime_type', $formatted );
+	}
+}

--- a/tests/SdAiAgent/Core/OnboardingManagerInterviewUploadsTest.php
+++ b/tests/SdAiAgent/Core/OnboardingManagerInterviewUploadsTest.php
@@ -1,0 +1,306 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Tests for OnboardingManager interview-uploads REST endpoints (GH#1534).
+ *
+ * Covers route registration, the upload endpoint's handling of valid and
+ * invalid input, and the listing endpoint shape. File-upload-side effects
+ * are simulated by constructing $_FILES with a real temp file, since
+ * wp_handle_upload's `test_form` check requires a multipart-style POST.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\InterviewUploadStore;
+use SdAiAgent\Core\OnboardingManager;
+use WP_REST_Request;
+use WP_UnitTestCase;
+
+/**
+ * Test the interview-uploads REST endpoints.
+ */
+class OnboardingManagerInterviewUploadsTest extends WP_UnitTestCase {
+
+	/**
+	 * Temp files created during the test so we can clean them up.
+	 *
+	 * @var list<string>
+	 */
+	private array $tmp_files = [];
+
+	public function tear_down(): void {
+		foreach ( $this->tmp_files as $f ) {
+			if ( file_exists( $f ) ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink
+				@unlink( $f );
+			}
+		}
+		$this->tmp_files = [];
+		// Reset the global $_FILES so it does not leak into other tests.
+		$_FILES = [];
+
+		// Clean any uploaded attachments tagged as interview uploads.
+		$ids = get_posts(
+			[
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'posts_per_page' => 200,
+				'fields'         => 'ids',
+				'meta_key'       => InterviewUploadStore::META_FLAG, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			]
+		);
+		foreach ( $ids as $id ) {
+			wp_delete_attachment( (int) $id, true );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a small PNG temp file and return its path.
+	 *
+	 * Uses the 1x1 transparent PNG signature so MIME sniffing recognises
+	 * it as an image — `media_handle_upload()` rejects unknown MIME types.
+	 */
+	private function make_temp_png( string $filename = 'shopfront-test.png' ): array {
+		$png = base64_decode(
+			'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgAAIAAAUAAen63NgAAAAASUVORK5CYII='
+		);
+		$path = wp_tempnam( $filename );
+		file_put_contents( $path, $png );
+		$this->tmp_files[] = $path;
+
+		return [
+			'name'     => $filename,
+			'type'     => 'image/png',
+			'tmp_name' => $path,
+			'error'    => UPLOAD_ERR_OK,
+			'size'     => strlen( $png ),
+		];
+	}
+
+	/**
+	 * No-op kept for symmetry with prior implementation. The endpoint uses
+	 * `wp_handle_sideload()` under the hood, which does not call
+	 * `is_uploaded_file()`, so synthetic $_FILES entries in tests work
+	 * without any additional filter scaffolding.
+	 */
+	private function allow_test_uploads(): void {
+		// Intentionally empty.
+	}
+
+	// ── route registration ────────────────────────────────────────────────
+
+	public function test_register_rest_routes_registers_interview_uploads_route(): void {
+		do_action( 'rest_api_init' );
+		OnboardingManager::register_rest_routes();
+
+		$server = rest_get_server();
+		$routes = $server->get_routes();
+
+		$this->assertArrayHasKey( '/sd-ai-agent/v1/onboarding/interview-uploads', $routes );
+	}
+
+	// ── permission gating ─────────────────────────────────────────────────
+
+	public function test_upload_permission_requires_upload_files_cap(): void {
+		// Subscriber lacks upload_files.
+		$subscriber_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+
+		$this->assertWPError( OnboardingManager::rest_upload_permission() );
+	}
+
+	public function test_upload_permission_passes_for_administrator(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$this->assertTrue( OnboardingManager::rest_upload_permission() );
+	}
+
+	// ── upload endpoint behaviour ─────────────────────────────────────────
+
+	public function test_upload_endpoint_returns_error_when_no_files(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$_FILES   = [];
+		$request  = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/onboarding/interview-uploads' );
+		$response = OnboardingManager::rest_interview_upload( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'sd_ai_agent_no_files', $response->get_error_code() );
+	}
+
+	public function test_upload_endpoint_stores_attachment_and_tags_meta(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$this->allow_test_uploads();
+
+		$file   = $this->make_temp_png( 'shopfront-interior.png' );
+		$_FILES = [ 'files' => $file ];
+
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/onboarding/interview-uploads' );
+		$request->set_param( 'session_id', 42 );
+
+		$response = OnboardingManager::rest_interview_upload( $request );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$data = $response->get_data();
+
+		$this->assertTrue( $data['success'] );
+		$this->assertCount( 1, $data['uploads'], 'Expected one tagged upload.' );
+
+		$attachment_id = $data['uploads'][0]['attachment_id'];
+		$this->assertGreaterThan( 0, $attachment_id );
+		$this->assertSame( '1', (string) get_post_meta( $attachment_id, InterviewUploadStore::META_FLAG, true ) );
+		// Filename contains both "shopfront" and "interior" — first match wins,
+		// and SPACE keywords come first in the categoriser, so SPACE is expected.
+		$this->assertSame( 'space', get_post_meta( $attachment_id, InterviewUploadStore::META_CATEGORY, true ) );
+		$this->assertSame( '42', (string) get_post_meta( $attachment_id, InterviewUploadStore::META_SESSION, true ) );
+	}
+
+	public function test_upload_endpoint_rejects_non_image_mime(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		// Synthesise a text file in $_FILES.
+		$path = wp_tempnam( 'notes.txt' );
+		file_put_contents( $path, 'hello world' );
+		$this->tmp_files[] = $path;
+
+		$_FILES = [
+			'files' => [
+				'name'     => 'notes.txt',
+				'type'     => 'text/plain',
+				'tmp_name' => $path,
+				'error'    => UPLOAD_ERR_OK,
+				'size'     => 11,
+			],
+		];
+
+		$request  = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/onboarding/interview-uploads' );
+		$response = OnboardingManager::rest_interview_upload( $request );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$data = $response->get_data();
+
+		$this->assertSame( [], $data['uploads'] );
+		$this->assertNotEmpty( $data['errors'] );
+		$this->assertSame( 'notes.txt', $data['errors'][0]['filename'] );
+	}
+
+	public function test_upload_endpoint_accepts_category_override(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$this->allow_test_uploads();
+
+		// Filename matches the SPACE heuristic, but the explicit category
+		// override pins it to TEAM.
+		$file   = $this->make_temp_png( 'shopfront-override.png' );
+		$_FILES = [ 'files' => $file ];
+
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/onboarding/interview-uploads' );
+		$request->set_param( 'category', 'team' );
+
+		$response = OnboardingManager::rest_interview_upload( $request );
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$data = $response->get_data();
+
+		$this->assertCount( 1, $data['uploads'] );
+		$this->assertSame( 'team', $data['uploads'][0]['category'] );
+	}
+
+	public function test_upload_endpoint_ignores_unknown_category_override(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$this->allow_test_uploads();
+
+		$file   = $this->make_temp_png( 'latte-cup.png' );
+		$_FILES = [ 'files' => $file ];
+
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/onboarding/interview-uploads' );
+		$request->set_param( 'category', 'mystery' );
+
+		$response = OnboardingManager::rest_interview_upload( $request );
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$data = $response->get_data();
+
+		$this->assertCount( 1, $data['uploads'] );
+		// Filename heuristic wins because the override was rejected.
+		$this->assertSame( 'product', $data['uploads'][0]['category'] );
+	}
+
+	public function test_upload_endpoint_handles_multi_file_array_shape(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$this->allow_test_uploads();
+
+		$png_a = base64_decode(
+			'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgAAIAAAUAAen63NgAAAAASUVORK5CYII='
+		);
+		$path_a = wp_tempnam( 'venue-exterior.png' );
+		$path_b = wp_tempnam( 'latte-cup.png' );
+		file_put_contents( $path_a, $png_a );
+		file_put_contents( $path_b, $png_a );
+		$this->tmp_files[] = $path_a;
+		$this->tmp_files[] = $path_b;
+
+		$_FILES = [
+			'files' => [
+				'name'     => [ 'venue-exterior.png', 'latte-cup.png' ],
+				'type'     => [ 'image/png', 'image/png' ],
+				'tmp_name' => [ $path_a, $path_b ],
+				'error'    => [ UPLOAD_ERR_OK, UPLOAD_ERR_OK ],
+				'size'     => [ strlen( $png_a ), strlen( $png_a ) ],
+			],
+		];
+
+		$request  = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/onboarding/interview-uploads' );
+		$response = OnboardingManager::rest_interview_upload( $request );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$data = $response->get_data();
+
+		$this->assertCount( 2, $data['uploads'] );
+		$categories = array_column( $data['uploads'], 'category' );
+		sort( $categories );
+		$this->assertSame( [ 'product', 'space' ], $categories );
+	}
+
+	// ── list endpoint ─────────────────────────────────────────────────────
+
+	public function test_list_endpoint_returns_uploads_filtered_by_session(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		// Create a tagged attachment via the store directly (no upload needed).
+		$attachment_id = self::factory()->attachment->create(
+			[
+				'post_title'     => 'shopfront-session-only',
+				'post_mime_type' => 'image/png',
+			]
+		);
+		update_post_meta( (int) $attachment_id, '_wp_attached_file', '2026/05/shopfront-session-only.png' );
+		InterviewUploadStore::tag_attachment( (int) $attachment_id, [ 'session_id' => 7 ] );
+
+		$request = new WP_REST_Request( 'GET', '/sd-ai-agent/v1/onboarding/interview-uploads' );
+		$request->set_param( 'session_id', 7 );
+
+		$response = OnboardingManager::rest_list_interview_uploads( $request );
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$data = $response->get_data();
+
+		$this->assertSame( 1, $data['total'] );
+		$this->assertSame( $attachment_id, $data['items'][0]['attachment_id'] );
+	}
+}

--- a/tests/SdAiAgent/Services/InterviewUploadCategoriserTest.php
+++ b/tests/SdAiAgent/Services/InterviewUploadCategoriserTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Tests for InterviewUploadCategoriser (GH#1534).
+ *
+ * Pure-function tests — no WordPress fixtures are required. The categoriser
+ * classifies a filename into one of the five interview-upload buckets
+ * (space, product, team, event, other) using whole-word keyword matching
+ * on the normalised filename stem.
+ *
+ * @package SdAiAgent\Tests\Services
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Services;
+
+use SdAiAgent\Services\InterviewUploadCategoriser;
+use WP_UnitTestCase;
+
+/**
+ * Test InterviewUploadCategoriser behaviour.
+ */
+class InterviewUploadCategoriserTest extends WP_UnitTestCase {
+
+	// ── space keywords ───────────────────────────────────────────────────
+
+	public function test_shopfront_classified_as_space(): void {
+		$this->assertSame(
+			InterviewUploadCategoriser::CATEGORY_SPACE,
+			InterviewUploadCategoriser::categorise( 'shopfront-2024.jpg' )
+		);
+	}
+
+	public function test_interior_classified_as_space(): void {
+		$this->assertSame(
+			InterviewUploadCategoriser::CATEGORY_SPACE,
+			InterviewUploadCategoriser::categorise( 'cafe_interior.png' )
+		);
+	}
+
+	public function test_exterior_classified_as_space(): void {
+		$this->assertSame(
+			InterviewUploadCategoriser::CATEGORY_SPACE,
+			InterviewUploadCategoriser::categorise( 'venue-exterior.webp' )
+		);
+	}
+
+	// ── product keywords ─────────────────────────────────────────────────
+
+	public function test_latte_classified_as_product(): void {
+		$this->assertSame(
+			InterviewUploadCategoriser::CATEGORY_PRODUCT,
+			InterviewUploadCategoriser::categorise( 'latte-art-1.jpg' )
+		);
+	}
+
+	public function test_burger_classified_as_product(): void {
+		$this->assertSame(
+			InterviewUploadCategoriser::CATEGORY_PRODUCT,
+			InterviewUploadCategoriser::categorise( 'menu_burger_special.jpg' )
+		);
+	}
+
+	public function test_drink_classified_as_product(): void {
+		$this->assertSame(
+			InterviewUploadCategoriser::CATEGORY_PRODUCT,
+			InterviewUploadCategoriser::categorise( 'signature-drink.png' )
+		);
+	}
+
+	// ── team keywords ────────────────────────────────────────────────────
+
+	public function test_team_keyword_classified_as_team(): void {
+		$this->assertSame(
+			InterviewUploadCategoriser::CATEGORY_TEAM,
+			InterviewUploadCategoriser::categorise( 'team-photo-2025.jpg' )
+		);
+	}
+
+	public function test_headshot_classified_as_team(): void {
+		$this->assertSame(
+			InterviewUploadCategoriser::CATEGORY_TEAM,
+			InterviewUploadCategoriser::categorise( 'jane-headshot.jpg' )
+		);
+	}
+
+	public function test_barista_classified_as_team(): void {
+		$this->assertSame(
+			InterviewUploadCategoriser::CATEGORY_TEAM,
+			InterviewUploadCategoriser::categorise( 'barista_portrait.jpg' )
+		);
+	}
+
+	// ── event keywords ───────────────────────────────────────────────────
+
+	public function test_event_classified_as_event(): void {
+		$this->assertSame(
+			InterviewUploadCategoriser::CATEGORY_EVENT,
+			InterviewUploadCategoriser::categorise( 'summer-event-2025.jpg' )
+		);
+	}
+
+	public function test_festival_classified_as_event(): void {
+		$this->assertSame(
+			InterviewUploadCategoriser::CATEGORY_EVENT,
+			InterviewUploadCategoriser::categorise( 'jazz_festival_night.png' )
+		);
+	}
+
+	// ── other fallback ───────────────────────────────────────────────────
+
+	public function test_generic_filename_falls_back_to_other(): void {
+		$this->assertSame(
+			InterviewUploadCategoriser::CATEGORY_OTHER,
+			InterviewUploadCategoriser::categorise( 'IMG_4729.jpg' )
+		);
+	}
+
+	public function test_empty_filename_falls_back_to_other(): void {
+		$this->assertSame(
+			InterviewUploadCategoriser::CATEGORY_OTHER,
+			InterviewUploadCategoriser::categorise( '' )
+		);
+	}
+
+	public function test_extension_only_falls_back_to_other(): void {
+		$this->assertSame(
+			InterviewUploadCategoriser::CATEGORY_OTHER,
+			InterviewUploadCategoriser::categorise( '.jpg' )
+		);
+	}
+
+	// ── whole-word matching ──────────────────────────────────────────────
+
+	public function test_workshop_does_not_match_shop_substring(): void {
+		// "workshop" must NOT classify as space — "shop" is only a match as
+		// a whole word, otherwise common words trigger false positives.
+		$this->assertSame(
+			InterviewUploadCategoriser::CATEGORY_OTHER,
+			InterviewUploadCategoriser::categorise( 'workshop-recap.jpg' )
+		);
+	}
+
+	public function test_team_does_not_match_tea_substring(): void {
+		// "tea" is a product keyword; "team" must NOT pick it up.
+		$this->assertSame(
+			InterviewUploadCategoriser::CATEGORY_TEAM,
+			InterviewUploadCategoriser::categorise( 'team-snapshot.jpg' )
+		);
+	}
+
+	// ── case insensitivity ───────────────────────────────────────────────
+
+	public function test_categoriser_is_case_insensitive(): void {
+		$this->assertSame(
+			InterviewUploadCategoriser::CATEGORY_SPACE,
+			InterviewUploadCategoriser::categorise( 'SHOPFRONT.JPG' )
+		);
+	}
+
+	// ── basename handling ────────────────────────────────────────────────
+
+	public function test_categoriser_uses_basename_only(): void {
+		// Directory components must not influence categorisation, only the
+		// final filename matters.
+		$this->assertSame(
+			InterviewUploadCategoriser::CATEGORY_PRODUCT,
+			InterviewUploadCategoriser::categorise( '/random/path/team-folder/latte.jpg' )
+		);
+	}
+
+	// ── category validation ──────────────────────────────────────────────
+
+	public function test_is_valid_category_accepts_all_five_buckets(): void {
+		foreach ( InterviewUploadCategoriser::ALL_CATEGORIES as $cat ) {
+			$this->assertTrue(
+				InterviewUploadCategoriser::is_valid_category( $cat ),
+				"Category '{$cat}' should be valid."
+			);
+		}
+	}
+
+	public function test_is_valid_category_rejects_unknown_slug(): void {
+		$this->assertFalse(
+			InterviewUploadCategoriser::is_valid_category( 'mystery' )
+		);
+	}
+
+	public function test_is_valid_category_rejects_empty_string(): void {
+		$this->assertFalse( InterviewUploadCategoriser::is_valid_category( '' ) );
+	}
+}


### PR DESCRIPTION
## Summary

Adds a drag-and-drop photo upload panel to the Theme Builder onboarding flow so users can hand the agent real images of their space, products, team, and events. Photos land directly in the media library tagged with interview-upload meta and a heuristic category guess; the agent reads them back via a new `sd-ai-agent/list-interview-uploads` ability so it can choose user-supplied imagery before falling back to stock or AI-generated images.

Completes the image-acquisition trio with stock-image-search (#1528) and generate-image (#1529).

## Acceptance criteria

- [x] Interview asks for photos at the appropriate moment (Phase 1.5, right after the brand vertical is established — see updated Theme Builder system prompt in `includes/Models/Agent.php`).
- [x] User can drag-and-drop multiple files in the chat UI (`OnboardingPhotoUpload` component above the chat — `src/components/onboarding-photo-upload.{js,css}`).
- [x] Uploaded files reach the media library (`POST /sd-ai-agent/v1/onboarding/interview-uploads` → `wp_handle_sideload` → `wp_insert_attachment` → `wp_generate_attachment_metadata`).
- [x] Files are tagged so the agent can find them later (three meta keys: `_sd_ai_agent_interview_upload`, `_sd_ai_agent_interview_upload_category`, `_sd_ai_agent_interview_upload_session`).
- [x] The agent acknowledges uploads in the chat (the component dispatches a `sendMessage` summary `I've uploaded N photos: …` after each successful batch — see `buildUploadSummary`).
- [x] No placeholder copy — if the user has zero photos, the agent falls back to stock + AI generation per the existing Phase 4 step 7 (now updated to check `sd-ai-agent/list-interview-uploads` first).
- [x] PHPUnit covers the bulk-upload path and meta tagging (50 new tests across 4 files, see verification block).

## Implementation

### Server
- `includes/Services/InterviewUploadCategoriser.php` — pure-function filename heuristic classifying uploads into `space`/`product`/`team`/`event`/`other`. Whole-word matching prevents `workshop` from triggering on `shop` and `team` from triggering on `tea`.
- `includes/Core/InterviewUploadStore.php` — owns the three meta keys; provides `tag_attachment()` and `list_uploads()` with category + session_id filters and by-category counts.
- `includes/Core/OnboardingManager.php` — new `POST` and `GET /sd-ai-agent/v1/onboarding/interview-uploads` endpoints. Uses `wp_handle_sideload` (not `media_handle_upload`) so the path is testable without faking `is_uploaded_file()` and supports both single-file and multi-file PHP `$_FILES` array shapes.
- `includes/Abilities/ListInterviewUploadsAbility.php` — read-only ability registered in `AbilitiesHandler` and added to the Theme Builder agent's `tier_1_tools`. Returns category-grouped attachment IDs + thumbnails.
- `includes/Models/Agent.php` — Theme Builder agent system prompt updated:
  - Phase 1.5 photo-upload prompt right after the vertical-aware question packs.
  - Phase 4 step 7 now mandates checking interview uploads FIRST before falling through to stock/AI.

### Client
- `src/components/onboarding-photo-upload.js` + `.css` — drag-and-drop tile with per-file category badges. Re-hydrates existing uploads on mount (`GET` endpoint). Sends a summary `sendMessage` after each successful batch so the agent acknowledges it in chat.
- `src/components/onboarding-theme-builder.js` — wraps the existing `ChatRedesign` with the new upload panel and passes the resolved Theme Builder session id.

## Caveats addressed

- **Large uploads**: each file is validated client-side against a 12 MB cap with a per-file error message. Server-side errors are returned per-file in the `errors` array so one bad file does not abort the batch.
- **EXIF orientation**: handled by WordPress core (`wp_generate_attachment_metadata` calls the standard image-processing pipeline). No additional handling needed at this layer.

## Worker self-verification

```text
- PHPUnit: Tests: 2479, Assertions: 6717, Errors: 0, Failures: 0, Skipped: 104
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
```

Resolves #1534

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.1 plugin for [OpenCode](https://opencode.ai) v1.15.5 with claude-sonnet-4-6 spent 3h 47m and 374 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Theme Builder onboarding now includes a photo upload interface with drag-and-drop support
- Uploaded photos are automatically categorized and available for reuse during theme building
- Theme Builder agent checks existing photos first before generating new images

**Tests**
- Added test coverage for photo upload and listing features

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->