### PR TITLE
GH#1561: fix(e2e): register deterministic SDK provider for Playwright tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -186,17 +186,11 @@ jobs:
           npx wp-env run cli wp option update sd_ai_agent_settings \
             '{"onboarding_complete":true}' --format=json
 
-          # Configure a fake OpenAI key via the WP 7.0 Connectors API option
-          # so the /providers endpoint returns at least one provider. Without
-          # a provider the AdminPageApp renders the ConnectorGate instead of
-          # the chat layout, breaking all tests that look for
-          # .sd-ai-agent-layout or .sd-ai-agent-chat-panel.
-          # The key is never used for real API calls — E2E specs mock the
-          # /stream endpoint — but its non-empty value is enough for
-          # SettingsController::handle_providers() to include OpenAI in the
-          # list returned to the React app.
-          npx wp-env run cli wp option update connectors_ai_openai_api_key \
-            '[redacted-credential]'
+          # Register the deterministic SDK provider from tests/mu-plugins so
+          # /providers returns one authenticated provider without installing a
+          # real ai-provider-for-* plugin. E2E specs mock /stream, so no real
+          # provider API calls are made.
+          npx wp-env run cli wp option update sd_ai_agent_e2e_register_provider 1
 
           # Create a real post so the site is no longer detected as a fresh install
           # even after the transient expires (belt-and-suspenders).

--- a/tests/mu-plugins/ai-agent-test-helpers.php
+++ b/tests/mu-plugins/ai-agent-test-helpers.php
@@ -47,3 +47,139 @@ add_action(
 	},
 	999
 );
+
+/**
+ * Register a deterministic AI Client SDK provider for Playwright E2E tests.
+ *
+ * The admin chat UI intentionally renders the ConnectorGate when the
+ * /sd-ai-agent/v1/providers endpoint returns no authenticated SDK providers.
+ * CI does not install third-party ai-provider-for-* plugins, so the workflow
+ * opts into this provider with the sd_ai_agent_e2e_register_provider option.
+ */
+add_action(
+	'plugins_loaded',
+	static function (): void {
+		if ( ! (bool) get_option( 'sd_ai_agent_e2e_register_provider', false ) ) {
+			return;
+		}
+
+		if ( ! class_exists( '\WordPress\AiClient\AiClient' ) ) {
+			return;
+		}
+
+		$required_classes = array(
+			'\WordPress\AiClient\Providers\Contracts\ProviderInterface',
+			'\WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface',
+			'\WordPress\AiClient\Providers\Contracts\ModelMetadataDirectoryInterface',
+			'\WordPress\AiClient\Providers\DTO\ProviderMetadata',
+			'\WordPress\AiClient\Providers\Enums\ProviderTypeEnum',
+			'\WordPress\AiClient\Providers\Models\Contracts\ModelInterface',
+			'\WordPress\AiClient\Providers\Models\DTO\ModelConfig',
+			'\WordPress\AiClient\Providers\Models\DTO\ModelMetadata',
+			'\WordPress\AiClient\Providers\Models\Enums\CapabilityEnum',
+			'\WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication',
+		);
+
+		foreach ( $required_classes as $required_class ) {
+			if ( ! class_exists( $required_class ) && ! interface_exists( $required_class ) ) {
+				return;
+			}
+		}
+
+		if ( ! class_exists( 'SdAiAgentE2EProvider', false ) ) {
+			class SdAiAgentE2EModelMetadataDirectory implements \WordPress\AiClient\Providers\Contracts\ModelMetadataDirectoryInterface {
+				/**
+				 * @return list<\WordPress\AiClient\Providers\Models\DTO\ModelMetadata>
+				 */
+				public function listModelMetadata(): array {
+					return array( $this->getModelMetadata( 'e2e-model' ) );
+				}
+
+				public function hasModelMetadata( string $modelId ): bool {
+					return 'e2e-model' === $modelId;
+				}
+
+				public function getModelMetadata( string $modelId ): \WordPress\AiClient\Providers\Models\DTO\ModelMetadata {
+					if ( 'e2e-model' !== $modelId ) {
+						throw new \WordPress\AiClient\Common\Exception\InvalidArgumentException( 'Unknown E2E model.' );
+					}
+
+					return new \WordPress\AiClient\Providers\Models\DTO\ModelMetadata(
+						'e2e-model',
+						'E2E Model',
+						array( \WordPress\AiClient\Providers\Models\Enums\CapabilityEnum::textGeneration() ),
+						array()
+					);
+				}
+			}
+
+			class SdAiAgentE2EProvider implements \WordPress\AiClient\Providers\Contracts\ProviderInterface {
+				public static function metadata(): \WordPress\AiClient\Providers\DTO\ProviderMetadata {
+					return new \WordPress\AiClient\Providers\DTO\ProviderMetadata(
+						'e2e-provider',
+						'E2E Provider',
+						\WordPress\AiClient\Providers\Enums\ProviderTypeEnum::cloud()
+					);
+				}
+
+				public static function model( string $modelId, ?\WordPress\AiClient\Providers\Models\DTO\ModelConfig $modelConfig = null ): \WordPress\AiClient\Providers\Models\Contracts\ModelInterface {
+					$metadata = self::modelMetadataDirectory()->getModelMetadata( $modelId );
+					$config   = $modelConfig ?? new \WordPress\AiClient\Providers\Models\DTO\ModelConfig();
+
+					return new class( $metadata, $config ) implements \WordPress\AiClient\Providers\Models\Contracts\ModelInterface {
+						private \WordPress\AiClient\Providers\Models\DTO\ModelMetadata $metadata;
+						private \WordPress\AiClient\Providers\Models\DTO\ModelConfig $config;
+
+						public function __construct( \WordPress\AiClient\Providers\Models\DTO\ModelMetadata $metadata, \WordPress\AiClient\Providers\Models\DTO\ModelConfig $config ) {
+							$this->metadata = $metadata;
+							$this->config   = $config;
+						}
+
+						public function metadata(): \WordPress\AiClient\Providers\Models\DTO\ModelMetadata {
+							return $this->metadata;
+						}
+
+						public function providerMetadata(): \WordPress\AiClient\Providers\DTO\ProviderMetadata {
+							return SdAiAgentE2EProvider::metadata();
+						}
+
+						public function setConfig( \WordPress\AiClient\Providers\Models\DTO\ModelConfig $config ): void {
+							$this->config = $config;
+						}
+
+						public function getConfig(): \WordPress\AiClient\Providers\Models\DTO\ModelConfig {
+							return $this->config;
+						}
+					};
+				}
+
+				public static function availability(): \WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface {
+					return new class() implements \WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface {
+						public function isConfigured(): bool {
+							return true;
+						}
+					};
+				}
+
+				public static function modelMetadataDirectory(): \WordPress\AiClient\Providers\Contracts\ModelMetadataDirectoryInterface {
+					return new SdAiAgentE2EModelMetadataDirectory();
+				}
+			}
+		}
+
+		try {
+			$registry = \WordPress\AiClient\AiClient::defaultRegistry();
+			if ( ! $registry->hasProvider( 'e2e-provider' ) ) {
+				$registry->registerProvider( 'SdAiAgentE2EProvider' );
+			}
+			$registry->setProviderRequestAuthentication(
+				'e2e-provider',
+				new \WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication( 'e2e-test-key' )
+			);
+		} catch ( \Throwable $e ) {
+			// If the SDK changes shape on trunk, fail closed and let E2E surface it.
+			return;
+		}
+	},
+	1
+);


### PR DESCRIPTION
Fixes systemic CI failure: Playwright E2E (WP trunk shard 3) (22 events)

## Summary
The E2E tests were failing because the ConnectorGate was rendering instead of the chat UI, preventing tests from finding UI elements like .sdaa-cr-session-row.

## Root Cause
The workflow was setting a fake OpenAI connector option, but after the recent refactor (a36c9f9) that made the SDK registry the single source of truth for providers, this approach no longer works reliably.

## Solution
- Register a deterministic E2E provider (SdAiAgentE2EProvider) in tests/mu-plugins/ai-agent-test-helpers.php
- Update e2e.yml workflow to set sd_ai_agent_e2e_register_provider option instead of the OpenAI connector option
- The E2E provider is authenticated and available without real API keys
- Tests mock the /stream endpoint, so no real provider API calls are made

## Changes
- tests/mu-plugins/ai-agent-test-helpers.php: Add E2E provider registration
- .github/workflows/e2e.yml: Update provider setup step

## Testing
- PHP linting: ✓ PASS
- JavaScript linting: ✓ PASS
- CSS linting: ✓ PASS
- Build: ✓ PASS

Resolves #1561
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.6 plugin for [OpenCode](https://opencode.ai) v1.15.5 with claude-haiku-4-5 spent 3m and 1,419 tokens on this as a headless worker.
