### PR TITLE
Fix and rename plugin row action links (Open AI Agent, Settings)

### DIFF
--- a/includes/Bootstrap/AdminHandler.php
+++ b/includes/Bootstrap/AdminHandler.php
@@ -118,37 +118,39 @@ final class AdminHandler {
 	}
 
 	/**
-	 * Add action links to the plugin listing on plugins.php.
+	 * Add action links to the plugin row on plugins.php.
 	 *
-	 * @param array<string, string> $actions     Plugin action links.
-	 * @param string                $plugin_file Path to plugin file relative to plugins directory.
+	 * Uses the plugin-specific filter
+	 * `plugin_action_links_superdav-ai-agent/superdav-ai-agent.php` so the
+	 * callback only runs for this plugin's row — no per-row basename guard
+	 * needed, and no risk of accidentally mutating other plugins' links.
+	 *
+	 * The hash route uses the canonical `#/<route>` form recognised by the
+	 * unified-admin React app's hash router (see `src/unified-admin/index.js`).
+	 * The previous `#chat` (no slash) silently fell through to the default
+	 * route, which is why "Start Chat" appeared to land on the wrong screen.
+	 *
+	 * @param array<string, string> $actions Plugin action links.
 	 * @return array<string, string> Modified action links.
 	 */
-	#[Filter( tag: 'plugin_action_links', priority: 10 )]
-	public function add_plugin_action_links( array $actions, string $plugin_file ): array {
-		// Only modify our plugin.
-		if ( $plugin_file !== 'superdav-ai-agent/superdav-ai-agent.php' ) {
-			return $actions;
-		}
+	#[Filter( tag: 'plugin_action_links_superdav-ai-agent/superdav-ai-agent.php', priority: 10 )]
+	#[Filter( tag: 'network_admin_plugin_action_links_superdav-ai-agent/superdav-ai-agent.php', priority: 10 )]
+	public function add_plugin_action_links( array $actions ): array {
+		$chat_url     = admin_url( 'admin.php?page=sd-ai-agent#/chat' );
+		$settings_url = admin_url( 'admin.php?page=sd-ai-agent#/settings' );
 
-		$connectors_url = UnifiedAdminMenu::hasNativeConnectorsPage()
-			? admin_url( 'options-connectors.php' )
-			: admin_url( 'options-general.php?page=options-connectors-wp-admin' );
-
-		$chat_url = admin_url( 'admin.php?page=sd-ai-agent#chat' );
-
-		$actions['sd_chat'] = sprintf(
-			'<a href="%s">%s</a>',
-			esc_url( $chat_url ),
-			esc_html__( 'Start Chat', 'superdav-ai-agent' )
-		);
-
-		$actions['sd_connections'] = sprintf(
-			'<a href="%s">%s</a>',
-			esc_url( $connectors_url ),
-			esc_html__( 'Configure Connections', 'superdav-ai-agent' )
-		);
-
-		return $actions;
+		// Prepend so they appear before the WP core "Deactivate" link.
+		return array(
+			'sd_settings' => sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( $settings_url ),
+				esc_html__( 'Settings', 'superdav-ai-agent' )
+			),
+			'sd_chat'     => sprintf(
+				'<a href="%s">%s</a>',
+				esc_url( $chat_url ),
+				esc_html__( 'Open AI Agent', 'superdav-ai-agent' )
+			),
+		) + $actions;
 	}
 }


### PR DESCRIPTION
## Summary

The plugin row on **network admin** `plugins.php` was missing the custom
action links entirely. Two compounding bugs:

1. **Wrong filter for network admin.** This repo's dev install is a
   multisite where the plugin is **network-activated**. WP fires
   `network_admin_plugin_action_links_<basename>` on the network admin
   plugins screen — not the generic `plugin_action_links` filter the old
   code subscribed to. On site-level `plugins.php` the row also has no
   action slot because the plugin is network-active. Net result: nothing
   was ever rendered.
2. **Wrong hash route.** The chat URL was `#chat`, but the unified-admin
   React router only matches `#/<route>` (see
   `src/unified-admin/index.js` lines 25–27). The link silently fell
   back to the default route.

## Changes

- Switch to `plugin_action_links_superdav-ai-agent/superdav-ai-agent.php`
  **and** `network_admin_plugin_action_links_superdav-ai-agent/superdav-ai-agent.php`
  (using `#[Filter]`'s `IS_REPEATABLE` semantics) so the links render in
  both contexts. The per-row basename guard is no longer needed.
- Rename **Start Chat → Open AI Agent**.
- Replace **Configure Connections → Settings** (now points at the
  unified admin Settings panel, per request).
- Use canonical `#/chat` and `#/settings` so the React hash router
  resolves the route correctly.
- Prepend so the custom links appear before WP's `Network Deactivate`.

## Browser verification

Loaded `/wp-admin/network/plugins.php` against the local multisite. The
Superdav AI Agent row now shows:

> **Settings | Open AI Agent | Network Deactivate | Rebrand Item**

Both `href`s confirmed via DOM inspection:

- `admin.php?page=sd-ai-agent#/settings`
- `admin.php?page=sd-ai-agent#/chat`

## Worker self-verification

- PHPCS:   clean on `includes/Bootstrap/AdminHandler.php`
- PHPStan: 0 errors on `includes/Bootstrap/AdminHandler.php`
- Build:   `npm run build` succeeded
- PHPUnit: not run locally — wp-env in this worktree would collide with
  the running instance on the main worktree (same ports). CI will run
  the full suite. The change is a single hook-tag/signature edit in one
  method with no existing tests covering `add_plugin_action_links`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced plugin action link handling for improved reliability across single-site and multisite environments. Plugin action links now consistently display **Settings** and **Open AI Agent** navigation options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1571?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->