### PR TITLE
fix(onboarding): temporarily hide photo-upload tile in Theme Builder

### DIFF
--- a/src/components/onboarding-theme-builder.js
+++ b/src/components/onboarding-theme-builder.js
@@ -11,7 +11,9 @@ import apiFetch from '@wordpress/api-fetch';
  */
 import STORE_NAME from '../store';
 import ChatRedesign from './chat-redesign';
-import OnboardingPhotoUpload from './onboarding-photo-upload';
+// TODO(#hide-photo-upload): Temporarily hidden — the dropzone was breaking the
+// Theme Builder chat UI in some sessions. Re-enable after investigation.
+// import OnboardingPhotoUpload from './onboarding-photo-upload';
 
 /**
  * Onboarding theme-builder component — shown when the user chose
@@ -39,7 +41,10 @@ export default function OnboardingThemeBuilder() {
 	const { openSession, sendMessage, setSelectedAgentId } =
 		useDispatch( STORE_NAME );
 	const bootstrappedRef = useRef( false );
-	const [ sessionId, setSessionId ] = useState( null );
+	// `sessionId` read is currently unused because the photo-upload tile is
+	// temporarily hidden; keep the setter so the value still flows when the
+	// tile is re-enabled (see #hide-photo-upload TODO above).
+	const [ , setSessionId ] = useState( null );
 
 	useEffect( () => {
 		// Guard against double-invocation in React 18 strict-mode or re-renders.
@@ -98,7 +103,8 @@ export default function OnboardingThemeBuilder() {
 
 	return (
 		<div className="sdaa-onboarding-theme-builder">
-			<OnboardingPhotoUpload sessionId={ sessionId } />
+			{ /* TODO(#hide-photo-upload): Temporarily hidden — see import note above. */ }
+			{ /* <OnboardingPhotoUpload sessionId={ sessionId } /> */ }
 			<ChatRedesign />
 		</div>
 	);


### PR DESCRIPTION
## Summary

The drag-and-drop photo upload tile rendered above the Theme Builder chat
(shown as "Drop photos of your space, products, team or events") was
observed breaking the chat UI in a recent admin session. This PR is a
quick, surgical hide so the chat experience is usable again while we
investigate the underlying issue.

The `OnboardingPhotoUpload` component, its tests, its CSS, and the
`/sd-ai-agent/v1/onboarding/interview-uploads` REST endpoint are all
left fully intact — only the call site in `onboarding-theme-builder.js`
is commented out, so re-enabling the tile is a single revert once the
root cause is identified.

## Changes

`src/components/onboarding-theme-builder.js` only:

- Comment out `import OnboardingPhotoUpload from './onboarding-photo-upload';`
- Comment out `<OnboardingPhotoUpload sessionId={ sessionId } />`
- Drop the unused `sessionId` state read (keep `setSessionId`) to satisfy
  ESLint `no-unused-vars` — pattern: `const [ , setSessionId ] = useState( null );`

No PHP, REST, schema, CSS, or test files were touched.

## Follow-up

A separate investigation issue should be filed to determine why the
dropzone was disrupting the chat panel layout (rendering, drag-event
propagation, or wp-data store interaction). The TODO markers in the file
point at that work.

## Worker self-verification

- PHPUnit: not run — change is JS-only and touches no PHP. The
  worktree does not have composer dev deps installed; running the suite
  here would only re-check unmodified PHP. Reviewer / CI will run the
  full suite as the second gate.
- Lint:    JS clean (full `npm run lint:js`), CSS clean (full
  `npm run lint:css`). PHP/PHPStan not run (no PHP touched; dev tools
  not installed in this worktree — CI covers).
- Jest:    full suite green — `Test Suites: 14 passed, 14 total`,
  `Tests: 267 passed, 267 total`. The 13 `OnboardingThemeBuilder`
  tests all pass with the commented-out import (the test file already
  mocked `OnboardingPhotoUpload` and never asserted it rendered).
- Build:   `npm run build` succeeded — `superdav-ai-agent.zip` produced.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled the photo upload tile in the onboarding theme builder interface

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1577?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->