### PR TITLE
fix: split multi-part assistant messages with function_calls (sd-ai-j72)

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -730,7 +730,12 @@ class AgentLoop {
 			// so an unrelated later truncation doesn't inherit prior state.
 			$this->preamble_truncation_retries = 0;
 
-			$this->history[] = $assistant_message;
+			// Split multi-part assistant messages so each function_call lives
+			// in its own ModelMessage. The OpenAI Responses API rejects
+			// "function_call + other part" shapes (see
+			// ConversationSerializer::append_assistant_message for the full
+			// rationale and provider-side validator reference).
+			ConversationSerializer::append_assistant_message( $this->history, $assistant_message );
 
 			// Check if the model wants to call tools.
 			if ( ! $this->get_ability_resolver()->has_ability_calls( $assistant_message ) ) {
@@ -767,7 +772,7 @@ class AgentLoop {
 
 					if ( ! is_wp_error( $followup_result ) ) {
 						$followup_message = $followup_result->toMessage();
-						$this->history[]  = $followup_message;
+						ConversationSerializer::append_assistant_message( $this->history, $followup_message );
 						$this->accumulate_tokens( $followup_result );
 
 						try {
@@ -937,7 +942,7 @@ class AgentLoop {
 
 			if ( ! is_wp_error( $fallback_result ) ) {
 				$fallback_message = $fallback_result->toMessage();
-				$this->history[]  = $fallback_message;
+				ConversationSerializer::append_assistant_message( $this->history, $fallback_message );
 				$this->accumulate_tokens( $fallback_result );
 
 				$reply = '';

--- a/includes/Core/ConversationSerializer.php
+++ b/includes/Core/ConversationSerializer.php
@@ -15,6 +15,7 @@ namespace SdAiAgent\Core;
 
 use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\DTO\ModelMessage;
 use WordPress\AiClient\Messages\DTO\UserMessage;
 use WordPress\AiClient\Tools\DTO\FunctionResponse;
 
@@ -93,6 +94,93 @@ class ConversationSerializer {
 
 		foreach ( $parts as $part ) {
 			$history[] = new UserMessage( array( $part ) );
+		}
+	}
+
+	/**
+	 * Append an assistant (model-role) message to history, splitting multi-part
+	 * messages that contain function_call parts into one ModelMessage per
+	 * function_call (plus, if any non-function_call parts are present, a
+	 * leading ModelMessage that carries those text/reasoning parts).
+	 *
+	 * The OpenAI Responses API contract — enforced client-side by
+	 * `OpenAiTextGenerationModel::validateMessages()` in the
+	 * `ai-provider-for-openai` plugin — requires each `function_call` to be its
+	 * own top-level input item. A single Message containing two function_calls,
+	 * or text+function_call, cannot be serialised into one item and the
+	 * validator throws `"Function call parts must be the only part in a
+	 * message for the OpenAI Responses API."` before any HTTP request is sent.
+	 *
+	 * Multi-part assistant messages legitimately arise when:
+	 *   - Anthropic Claude emits parallel `tool_use` blocks in one assistant
+	 *     message (the SDK's `Message` preserves that shape).
+	 *   - An OpenAI Responses model returns text plus one or more function_calls
+	 *     in the same `message` output item (or PR #26's reasoning support
+	 *     prepends a thought-channel part to a function_call candidate).
+	 *
+	 * Anthropic accepts the split form too (each `Message` becomes one
+	 * Anthropic `message` with N content blocks → splitting only changes how
+	 * many messages get sent, not the semantics), so this transformation is
+	 * provider-agnostic.
+	 *
+	 * Mirrors {@see self::append_tool_response()}, which already solves the
+	 * equivalent problem on the tool-response side.
+	 *
+	 * @param Message[] $history The conversation history (passed by reference).
+	 * @param Message   $message Assistant message returned by the model.
+	 */
+	public static function append_assistant_message( array &$history, Message $message ): void {
+		$parts = $message->getParts();
+
+		// Defensive: never append a zero-parts message. The SDK's
+		// PromptBuilder::validateMessages() throws when it sees one, so
+		// silently dropping it here is preferable to a downstream exception
+		// that bubbles up as a bare error to the user.
+		if ( empty( $parts ) ) {
+			return;
+		}
+
+		// `MessagePartTypeEnum::isFunctionCall()` is a magic method dispatched
+		// via AbstractEnum's `__call`, so `method_exists()` would return false.
+		// Fall back to the legacy `getFunctionCall()` accessor when the
+		// MessagePart implementation is older or mocked without the enum API.
+		$function_call_parts = array();
+		$other_parts         = array();
+		foreach ( $parts as $part ) {
+			$is_function_call = false;
+			if ( method_exists( $part, 'getType' ) ) {
+				$type = $part->getType();
+				if ( is_object( $type ) && is_callable( array( $type, 'isFunctionCall' ) ) ) {
+					$is_function_call = (bool) $type->isFunctionCall();
+				}
+			}
+			if ( ! $is_function_call && method_exists( $part, 'getFunctionCall' ) ) {
+				$is_function_call = null !== $part->getFunctionCall();
+			}
+			if ( $is_function_call ) {
+				$function_call_parts[] = $part;
+			} else {
+				$other_parts[] = $part;
+			}
+		}
+
+		// Fast path: ≤1 part total, or zero function_call parts, or exactly
+		// one function_call and no other parts — already compliant.
+		if ( count( $parts ) <= 1 || empty( $function_call_parts )
+			|| ( 1 === count( $function_call_parts ) && empty( $other_parts ) ) ) {
+			$history[] = $message;
+			return;
+		}
+
+		// Preserve "text/reasoning first, then function_calls" ordering — this
+		// is how the official OpenAI plugin's `convertMessageToInputItems`
+		// would have emitted them across separate messages.
+		if ( ! empty( $other_parts ) ) {
+			$history[] = new ModelMessage( $other_parts );
+		}
+
+		foreach ( $function_call_parts as $fc_part ) {
+			$history[] = new ModelMessage( array( $fc_part ) );
 		}
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "superdav-ai-agent",
-	"version": "1.15.0",
+	"version": "1.16.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "superdav-ai-agent",
-			"version": "1.15.0",
+			"version": "1.16.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@codemirror/commands": "^6.10.3",

--- a/tests/SdAiAgent/Core/ConversationSerializerTest.php
+++ b/tests/SdAiAgent/Core/ConversationSerializerTest.php
@@ -1,0 +1,323 @@
+<?php
+/**
+ * Test case for ConversationSerializer class.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\ConversationSerializer;
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\DTO\ModelMessage;
+use WordPress\AiClient\Messages\DTO\UserMessage;
+use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
+use WordPress\AiClient\Tools\DTO\FunctionCall;
+use WordPress\AiClient\Tools\DTO\FunctionResponse;
+use WP_UnitTestCase;
+
+/**
+ * Test ConversationSerializer functionality.
+ *
+ * Focuses on append_assistant_message — the splitter that protects the
+ * OpenAI Responses API contract (each `function_call` must be its own
+ * top-level input item; assistant messages containing function_call plus
+ * any other part are rejected by the official `ai-provider-for-openai`
+ * plugin's `validateMessages()` before any HTTP request is sent).
+ *
+ * @group ai-client
+ */
+class ConversationSerializerTest extends WP_UnitTestCase {
+
+	/**
+	 * Skip the test if the AI Client SDK isn't autoloaded in this environment.
+	 */
+	private function skip_if_sdk_unavailable(): void {
+		if ( ! class_exists( ModelMessage::class ) ) {
+			$this->markTestSkipped( 'AI Client SDK not available.' );
+		}
+	}
+
+	/**
+	 * Build a real MessagePart wrapping a FunctionCall (no mocks — the
+	 * splitter dispatches on `getType()->isFunctionCall()` which only works
+	 * on real MessagePart instances).
+	 */
+	private function function_call_part( string $id, string $name, array $args = [] ): MessagePart {
+		return new MessagePart( new FunctionCall( $id, $name, $args ) );
+	}
+
+	/**
+	 * Build a real MessagePart wrapping plain text.
+	 */
+	private function text_part( string $text ): MessagePart {
+		return new MessagePart( $text );
+	}
+
+	/**
+	 * Assert that every assistant Message in $history is compliant with the
+	 * OpenAI Responses API `validateMessages` rule: no Message may contain
+	 * more than one part if any of those parts is a function_call (the rule
+	 * applies symmetrically to function_response, but the splitter only
+	 * concerns the assistant side).
+	 *
+	 * @param Message[] $history
+	 */
+	private function assertHistoryPassesOpenAiValidator( array $history ): void {
+		foreach ( $history as $i => $message ) {
+			$parts        = $message->getParts();
+			$has_func_call = false;
+			foreach ( $parts as $part ) {
+				if ( $part->getType()->isFunctionCall() ) {
+					$has_func_call = true;
+					break;
+				}
+			}
+			if ( $has_func_call && count( $parts ) > 1 ) {
+				$this->fail(
+					sprintf(
+						'history[%d] would trigger OpenAI Responses API validator: %d parts, contains function_call',
+						$i,
+						count( $parts )
+					)
+				);
+			}
+		}
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Single-part assistant message must be appended verbatim.
+	 */
+	public function test_append_assistant_message_single_text_part(): void {
+		$this->skip_if_sdk_unavailable();
+
+		$message = new ModelMessage( [ $this->text_part( 'Hello' ) ] );
+		$history = [];
+
+		ConversationSerializer::append_assistant_message( $history, $message );
+
+		$this->assertCount( 1, $history );
+		$this->assertSame( $message, $history[0] );
+		$this->assertHistoryPassesOpenAiValidator( $history );
+	}
+
+	/**
+	 * Single-part function_call message must be appended verbatim
+	 * (it's already compliant — one part, one function_call).
+	 */
+	public function test_append_assistant_message_single_function_call(): void {
+		$this->skip_if_sdk_unavailable();
+
+		$message = new ModelMessage(
+			[ $this->function_call_part( 'call_1', 'wpab__sd-ai-agent__skill-load', [ 'slug' => 'foo' ] ) ]
+		);
+		$history = [];
+
+		ConversationSerializer::append_assistant_message( $history, $message );
+
+		$this->assertCount( 1, $history );
+		$this->assertSame( $message, $history[0] );
+		$this->assertHistoryPassesOpenAiValidator( $history );
+	}
+
+	/**
+	 * Multi-part text-only assistant message must be appended verbatim
+	 * (no function_call → no violation possible).
+	 */
+	public function test_append_assistant_message_multi_text_no_function_call(): void {
+		$this->skip_if_sdk_unavailable();
+
+		$message = new ModelMessage(
+			[ $this->text_part( 'part one' ), $this->text_part( 'part two' ) ]
+		);
+		$history = [];
+
+		ConversationSerializer::append_assistant_message( $history, $message );
+
+		$this->assertCount( 1, $history );
+		$this->assertSame( $message, $history[0] );
+		$this->assertHistoryPassesOpenAiValidator( $history );
+	}
+
+	/**
+	 * Regression: trace 3571 msg[1] — Anthropic parallel tool_use → two
+	 * function_calls in one assistant message. Must split into two
+	 * ModelMessages, one per function_call.
+	 */
+	public function test_append_assistant_message_parallel_function_calls_no_text(): void {
+		$this->skip_if_sdk_unavailable();
+
+		$message = new ModelMessage(
+			[
+				$this->function_call_part( 'toolu_a', 'wpab__sd-ai-agent__skill-load', [ 'slug' => 'site-specification' ] ),
+				$this->function_call_part( 'toolu_b', 'wpab__sd-ai-agent__skill-load', [ 'slug' => 'block-themes' ] ),
+			]
+		);
+		$history = [];
+
+		ConversationSerializer::append_assistant_message( $history, $message );
+
+		$this->assertCount( 2, $history );
+		foreach ( $history as $i => $msg ) {
+			$this->assertInstanceOf( Message::class, $msg );
+			$this->assertTrue( $msg->getRole()->isModel(), "history[$i] role must be model" );
+			$this->assertCount( 1, $msg->getParts(), "history[$i] must have exactly one part" );
+		}
+		$this->assertSame( 'toolu_a', $history[0]->getParts()[0]->getFunctionCall()->getId() );
+		$this->assertSame( 'toolu_b', $history[1]->getParts()[0]->getFunctionCall()->getId() );
+		$this->assertHistoryPassesOpenAiValidator( $history );
+	}
+
+	/**
+	 * Regression: trace 3571 msg[44] — assistant text plus a single
+	 * function_call. Must split into one text-only ModelMessage followed
+	 * by one function_call-only ModelMessage.
+	 */
+	public function test_append_assistant_message_text_then_function_call(): void {
+		$this->skip_if_sdk_unavailable();
+
+		$message = new ModelMessage(
+			[
+				$this->text_part( 'Excellent choice! Loading the next skill.' ),
+				$this->function_call_part( 'call_14', 'wpab__sd-ai-agent__skill-load', [ 'slug' => 'design-system' ] ),
+			]
+		);
+		$history = [];
+
+		ConversationSerializer::append_assistant_message( $history, $message );
+
+		$this->assertCount( 2, $history );
+		// First message: text only.
+		$this->assertCount( 1, $history[0]->getParts() );
+		$this->assertTrue( $history[0]->getParts()[0]->getType()->isText() );
+		$this->assertSame(
+			'Excellent choice! Loading the next skill.',
+			$history[0]->getParts()[0]->getText()
+		);
+		// Second message: function_call only.
+		$this->assertCount( 1, $history[1]->getParts() );
+		$this->assertTrue( $history[1]->getParts()[0]->getType()->isFunctionCall() );
+		$this->assertSame( 'call_14', $history[1]->getParts()[0]->getFunctionCall()->getId() );
+		$this->assertHistoryPassesOpenAiValidator( $history );
+	}
+
+	/**
+	 * Regression: trace 3571 msg[46] — text + 3 parallel function_calls.
+	 * Must split into one text message + 3 function_call messages, in order.
+	 */
+	public function test_append_assistant_message_text_plus_three_parallel_calls(): void {
+		$this->skip_if_sdk_unavailable();
+
+		$message = new ModelMessage(
+			[
+				$this->text_part( "I'll write three design previews now." ),
+				$this->function_call_part( 'call_15', 'wpab__sd-ai-agent__file-write', [ 'path' => 'design-1.html' ] ),
+				$this->function_call_part( 'call_16', 'wpab__sd-ai-agent__file-write', [ 'path' => 'design-2.html' ] ),
+				$this->function_call_part( 'call_17', 'wpab__sd-ai-agent__file-write', [ 'path' => 'design-3.html' ] ),
+			]
+		);
+		$history = [];
+
+		ConversationSerializer::append_assistant_message( $history, $message );
+
+		$this->assertCount( 4, $history );
+		$this->assertTrue( $history[0]->getParts()[0]->getType()->isText() );
+		$this->assertSame( 'call_15', $history[1]->getParts()[0]->getFunctionCall()->getId() );
+		$this->assertSame( 'call_16', $history[2]->getParts()[0]->getFunctionCall()->getId() );
+		$this->assertSame( 'call_17', $history[3]->getParts()[0]->getFunctionCall()->getId() );
+		$this->assertHistoryPassesOpenAiValidator( $history );
+	}
+
+	/**
+	 * Regression: trace 3571 msg[54] — text + 2 parallel ability-calls.
+	 */
+	public function test_append_assistant_message_text_plus_two_parallel_calls(): void {
+		$this->skip_if_sdk_unavailable();
+
+		$message = new ModelMessage(
+			[
+				$this->text_part( 'Building the theme now.' ),
+				$this->function_call_part( 'call_19', 'wpab__sd-ai-agent__ability-call', [ 'ability' => 'sd-ai-agent/scaffold-block-theme' ] ),
+				$this->function_call_part( 'call_20', 'wpab__sd-ai-agent__ability-call', [ 'ability' => 'sd-ai-agent/get-theme-json' ] ),
+			]
+		);
+		$history = [];
+
+		ConversationSerializer::append_assistant_message( $history, $message );
+
+		$this->assertCount( 3, $history );
+		$this->assertTrue( $history[0]->getParts()[0]->getType()->isText() );
+		$this->assertTrue( $history[1]->getParts()[0]->getType()->isFunctionCall() );
+		$this->assertTrue( $history[2]->getParts()[0]->getType()->isFunctionCall() );
+		$this->assertHistoryPassesOpenAiValidator( $history );
+	}
+
+	/**
+	 * Empty parts must be silently dropped (matches existing
+	 * append_tool_response contract — never append zero-parts messages).
+	 */
+	public function test_append_assistant_message_drops_empty(): void {
+		$this->skip_if_sdk_unavailable();
+
+		$message = new ModelMessage( [] );
+		$history = [];
+
+		ConversationSerializer::append_assistant_message( $history, $message );
+
+		$this->assertSame( [], $history );
+	}
+
+	/**
+	 * Existing history must be preserved — splitter appends, never replaces.
+	 */
+	public function test_append_assistant_message_preserves_existing_history(): void {
+		$this->skip_if_sdk_unavailable();
+
+		$existing_user = new UserMessage( [ $this->text_part( 'prior user' ) ] );
+		$history       = [ $existing_user ];
+
+		$message = new ModelMessage(
+			[
+				$this->text_part( 'reply' ),
+				$this->function_call_part( 'c1', 'tool', [] ),
+			]
+		);
+
+		ConversationSerializer::append_assistant_message( $history, $message );
+
+		$this->assertCount( 3, $history );
+		$this->assertSame( $existing_user, $history[0] );
+		$this->assertHistoryPassesOpenAiValidator( $history );
+	}
+
+	/**
+	 * Sanity: the existing append_tool_response splitter still works for
+	 * the mirror case (multi-part function_response in a UserMessage). This
+	 * guards against accidental coupling between the two helpers.
+	 */
+	public function test_append_tool_response_still_splits_multi_part(): void {
+		$this->skip_if_sdk_unavailable();
+
+		$message = new UserMessage(
+			[
+				new MessagePart( new FunctionResponse( 'c1', 'tool', '{"ok":true}' ) ),
+				new MessagePart( new FunctionResponse( 'c2', 'tool', '{"ok":true}' ) ),
+			]
+		);
+		$history = [];
+
+		ConversationSerializer::append_tool_response( $history, $message );
+
+		$this->assertCount( 2, $history );
+		foreach ( $history as $msg ) {
+			$this->assertCount( 1, $msg->getParts() );
+			$this->assertNotNull( $msg->getParts()[0]->getFunctionResponse() );
+		}
+	}
+}


### PR DESCRIPTION
## Bug

Conversations that include parallel tool calls (Anthropic Claude) or assistant text+tool_call turns (OpenAI gpt-5.x via the Responses API) fail with:

> Error: Function call parts must be the only part in a message for the OpenAI Responses API.

The exception is thrown client-side by `OpenAiTextGenerationModel::validateMessages()` in the `ai-provider-for-openai` plugin **before** any HTTP request is sent.

Trace evidence — `wp_sd_ai_agent_provider_trace` rows 3569–3571:
- `status_code = 0`
- `error = 'no_result_event'`
- `duration_ms ~20`
- empty `response_body`

## Root cause

`AgentLoop::run()` appended the assistant `Message` returned by `$result->toMessage()` verbatim at three sites:

- `includes/Core/AgentLoop.php:733` — normal turn
- `includes/Core/AgentLoop.php:775` — follow-up summarisation
- `includes/Core/AgentLoop.php:945` — final fallback summarisation

`GenerativeAiResult::toMessage()` can legitimately return a `Message` with multiple parts:

- `[function_call, function_call]` — Anthropic parallel `tool_use` blocks
- `[text, function_call]` — OpenAI text + call
- `[text, function_call, function_call, function_call]` — mixed shape

The OpenAI Responses API contract requires each `function_call` to be its own top-level input item; a single `Message` cannot serialise into one item.

`ConversationSerializer::append_tool_response()` already solved the mirror problem for `function_response` (split into one `UserMessage` per tool result). The equivalent splitter on the **assistant** side was missing.

### Offending message shapes observed in trace 3571

| msg | parts | shape | ID format |
| --- | --- | --- | --- |
| `[01]` | 2 | `function_call + function_call` | `toolu_…` (Anthropic) |
| `[44]` | 2 | `text + function_call` | `functions.xxx:14` (OpenAI) |
| `[46]` | 4 | `text + 3× function_call` (parallel `file-write`) | OpenAI |
| `[54]` | 3 | `text + 2× function_call` (parallel `ability-call`) | OpenAI |

## Fix

Add `ConversationSerializer::append_assistant_message( array &$history, Message $message )` mirroring `append_tool_response()`:

- ≤1 part, or no `function_call` part, or single `function_call` with no other parts → append as-is
- otherwise → one `ModelMessage` for non-function_call parts (text / reasoning), if any, followed by one `ModelMessage` per `function_call`, preserving order

Detection is dual-pathed: prefer `MessagePart->getType()->isFunctionCall()` when the enum-magic-method is callable, fall back to `MessagePart->getFunctionCall() !== null`. This keeps the splitter robust against mocked parts that don't expose the enum API.

Route the three `AgentLoop::run()` sites that previously appended assistant messages verbatim through the new helper.

This transformation is provider-agnostic — Anthropic accepts each `Message` becoming one Anthropic `message` with N content blocks, so splitting only changes how many `messages` get sent, not the semantics.

## Files

- `includes/Core/ConversationSerializer.php` — new `append_assistant_message()` helper
- `includes/Core/AgentLoop.php` — route 3 assistant-append sites through the helper
- `tests/SdAiAgent/Core/ConversationSerializerTest.php` — new, 10 cases covering compliant shapes + the 3 offending shapes from trace 3571 + empty-drop + existing-history preservation + sibling `append_tool_response` sanity

## Worker self-verification

```text
- PHPUnit: Tests: 2472, Assertions: 6727, Errors: 0, Failures: 0, Skipped: 102
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
```

Resolves sd-ai-j72.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.14 plugin for [OpenCode](https://opencode.ai) v1.15.6 with claude-sonnet-4-6 spent 14m and 40 tokens on this as a headless worker.
