### PR TITLE
fix(onboarding): require >1 published post for siteHasContent probe (default WP installs)

### DIFF
--- a/src/admin-page/index.js
+++ b/src/admin-page/index.js
@@ -84,13 +84,16 @@ const ShortcutsHelp = lazy( () =>
  */
 function AdminPageApp() {
 	/**
-	 * Tracks whether the site has any published content yet. Used to pick the
-	 * default first-run agent: empty install → Theme Builder; otherwise →
-	 * Setup Assistant. `null` means the heuristic probe is still in flight.
+	 * Tracks whether the site has any "real" published content yet. Used to
+	 * pick the default first-run agent: empty install → Theme Builder;
+	 * otherwise → Setup Assistant. `null` means the heuristic probe is still
+	 * in flight.
 	 *
-	 * Probe target: GET /wp/v2/posts?per_page=1&status=publish.
-	 * The probe is fired lazily — only when we actually need to show one of
-	 * the bootstrappers — so existing installs pay no probe cost.
+	 * Probe target: GET /wp/v2/posts?per_page=2&status=publish. The probe
+	 * returns true when at least TWO published posts exist, so the WordPress
+	 * default "Hello world!" seed post is treated as "no real content yet".
+	 * Fired lazily — only when we actually need to show one of the
+	 * bootstrappers — so existing installs pay no probe cost.
 	 */
 	const [ siteHasContent, setSiteHasContent ] = useState( null );
 
@@ -165,6 +168,18 @@ function AdminPageApp() {
 	// When we are about to mount one of the onboarding bootstrappers, probe
 	// /wp/v2/posts once to decide which agent to drop the user into. Fired
 	// lazily — existing installs (onboarding already complete) never call it.
+	//
+	// Threshold is `> 1`, not `> 0`, because every fresh WordPress install
+	// ships with one seeded "Hello world!" post. A `> 0` check would always
+	// be true on a default install and the Theme Builder branch would be
+	// unreachable. `> 1` treats the seed post as "no real content yet" and
+	// only flips to Setup Assistant once the user has at least two
+	// published posts. Edge case: a user who deletes the seed post and
+	// writes exactly one real post will still be routed to Theme Builder
+	// (they can switch agents from the chat picker if they prefer the
+	// Setup Assistant). Tracked in the v1.16.1 follow-up issue alongside
+	// the broader probe (it currently only counts `post`-type entries and
+	// misses page-only / CPT-only / WooCommerce-only installs).
 	const onboardingComplete = settings?.onboarding_complete !== false;
 	useEffect( () => {
 		if ( ! settingsLoaded || onboardingComplete ) {
@@ -173,9 +188,9 @@ function AdminPageApp() {
 		if ( siteHasContent !== null ) {
 			return;
 		}
-		apiFetch( { path: '/wp/v2/posts?per_page=1&status=publish' } )
+		apiFetch( { path: '/wp/v2/posts?per_page=2&status=publish' } )
 			.then( ( posts ) => {
-				setSiteHasContent( Array.isArray( posts ) && posts.length > 0 );
+				setSiteHasContent( Array.isArray( posts ) && posts.length > 1 );
 			} )
 			.catch( () => {
 				// Probe failed (e.g., REST blocked, network error): treat


### PR DESCRIPTION
## Summary

Fixes a bug in the first-run `siteHasContent` probe that made the Theme Builder onboarding branch effectively unreachable on default WordPress installs.

The probe at `src/admin-page/index.js:176-185` used `posts.length > 0` against `/wp/v2/posts?per_page=1&status=publish`. Every fresh WordPress install ships with the seeded `Hello world!` post, so the check was always true on a default install — first-run users were always routed to the Setup Assistant regardless of whether the install was actually empty.

This is a follow-up to PR #1580 (already merged); it ships in v1.16.1.

## Change

```diff
-apiFetch( { path: '/wp/v2/posts?per_page=1&status=publish' } )
+apiFetch( { path: '/wp/v2/posts?per_page=2&status=publish' } )
   .then( ( posts ) => {
-    setSiteHasContent( Array.isArray( posts ) && posts.length > 0 );
+    setSiteHasContent( Array.isArray( posts ) && posts.length > 1 );
   } )
```

- `per_page=2` so the response actually contains the second post when present.
- `posts.length > 1` so the WordPress seed post no longer counts as "real content".
- Failure mode unchanged: REST error / blocked endpoint → `setSiteHasContent(true)` so we land on the Setup Assistant (safer default for an unknown state).
- Docblock and inline comment updated to explain the threshold, the rationale, and the edge case.

## Behaviour

| Site state                                       | Old probe | New probe |
| ------------------------------------------------ | --------- | --------- |
| Default install (just "Hello world!")            | `true`    | `false`   |
| Hello world! + 1 user post                       | `true`    | `true`    |
| Hello world! deleted, 0 user posts               | `false`   | `false`   |
| Hello world! deleted, 1 user post (edge case)    | `true`    | `false`   |
| Pages or CPTs only, no `post`-type posts         | `false`   | `false`   |

So:

- Default fresh install → Theme Builder branch (correct — empty install).
- Real blog with 2+ posts → Setup Assistant branch (correct — populated site).
- Edge case: a user who deletes `Hello world!` and writes exactly one real post → Theme Builder. They can switch agents from the chat picker if they prefer. Documented inline.

## Out of scope (tracked separately)

A broader probe (count pages, CPTs, WooCommerce products, attachments, etc.) is a meaningfully larger heuristic change. The current probe still only inspects `post`-type entries, so pages-only / CPT-only / WooCommerce-only installs are still misclassified as "empty". That's an existing design limitation that pre-dates this PR and will be addressed in a follow-up issue alongside the `onboarding_complete` lifecycle work (separate bug — `onboarding_complete` can be NULL on installs that have already been through onboarding, causing the probe to re-fire).

## Canonical naming check (AGENTS.md)

No `sd-ai-agent` ↔ `superdav-ai-agent` renames in either direction. JS-only change in `src/admin-page/index.js`.

## Worker self-verification

- PHPUnit: Tests: 2472, Assertions: 6727, Errors: 0, Failures: 0, Skipped: 102
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.14 plugin for [OpenCode](https://opencode.ai) v1.15.6 with claude-opus-4-7 spent 3h 5m and 122,329 tokens on this with the user in an interactive session.
