### PR TITLE
fix(playground): use renamed superdav-ai-agent.zip in blueprint download URLs

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -23,7 +23,7 @@
       "step": "installPlugin",
       "pluginData": {
         "resource": "url",
-        "url": "https://github.com/Ultimate-Multisite/sd-ai-agent/releases/latest/download/sd-ai-agent.zip",
+        "url": "https://github.com/Ultimate-Multisite/superdav-ai-agent/releases/latest/download/superdav-ai-agent.zip",
         "caption": "Downloading AI Agent..."
       },
       "options": {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SD AI Agent for WordPress
 
-[![Download Plugin Now](https://img.shields.io/github/v/release/Ultimate-Multisite/sd-ai-agent?style=for-the-badge&label=Download+Plugin+Now&color=0073aa)](https://github.com/Ultimate-Multisite/sd-ai-agent/releases/latest/download/sd-ai-agent.zip) &nbsp; Upload the zip to WordPress like any other plugin
+[![Download Plugin Now](https://img.shields.io/github/v/release/Ultimate-Multisite/superdav-ai-agent?style=for-the-badge&label=Download+Plugin+Now&color=0073aa)](https://github.com/Ultimate-Multisite/superdav-ai-agent/releases/latest/download/superdav-ai-agent.zip) &nbsp; Upload the zip to WordPress like any other plugin
 
 [![Tests](https://github.com/Ultimate-Multisite/sd-ai-agent/actions/workflows/tests.yml/badge.svg)](https://github.com/Ultimate-Multisite/sd-ai-agent/actions/workflows/tests.yml)
 [![Code Quality](https://github.com/Ultimate-Multisite/sd-ai-agent/actions/workflows/code-quality.yml/badge.svg)](https://github.com/Ultimate-Multisite/sd-ai-agent/actions/workflows/code-quality.yml)

--- a/playground/blueprint-dev.json
+++ b/playground/blueprint-dev.json
@@ -32,7 +32,7 @@
       "step": "installPlugin",
       "pluginData": {
         "resource": "url",
-        "url": "https://github.com/Ultimate-Multisite/sd-ai-agent/releases/latest/download/sd-ai-agent.zip",
+        "url": "https://github.com/Ultimate-Multisite/superdav-ai-agent/releases/latest/download/superdav-ai-agent.zip",
         "caption": "Downloading AI Agent..."
       },
       "options": {

--- a/playground/blueprint.json
+++ b/playground/blueprint.json
@@ -32,7 +32,7 @@
       "step": "installPlugin",
       "pluginData": {
         "resource": "url",
-        "url": "https://github.com/Ultimate-Multisite/sd-ai-agent/releases/latest/download/sd-ai-agent.zip",
+        "url": "https://github.com/Ultimate-Multisite/superdav-ai-agent/releases/latest/download/superdav-ai-agent.zip",
         "caption": "Downloading AI Agent..."
       },
       "options": {


### PR DESCRIPTION
## Problem

The WordPress Playground demo is broken since the repo rename `sd-ai-agent` → `superdav-ai-agent`. Three blueprint files and the README download badge still point at the old zip filename:

```
https://github.com/Ultimate-Multisite/sd-ai-agent/releases/latest/download/sd-ai-agent.zip
```

The release asset has been `superdav-ai-agent.zip` since the rename (verified on v1.16.0), so every Playground launch 404s on the plugin install step.

## Fix

Update the URL to the actual release asset name:

```
https://github.com/Ultimate-Multisite/superdav-ai-agent/releases/latest/download/superdav-ai-agent.zip
```

## Verification

```
$ gh release view v1.16.0 -R Ultimate-Multisite/superdav-ai-agent --json assets --jq '.assets[].name'
superdav-ai-agent-1.16.0-wporg.zip
superdav-ai-agent-1.16.0.zip
superdav-ai-agent.zip
```

All three blueprint JSON files validated with `python3 -m json.tool`.

## Files

- `playground/blueprint.json`
- `playground/blueprint-dev.json`
- `.wordpress-org/blueprints/blueprint.json`
- `README.md` (download badge — same bug)

## Scope discipline

Per `AGENTS.md` "CANONICAL NAMING - DO NOT CHANGE", internal `sd-ai-agent` identifiers (DI container ID, namespaces, REST routes, CSS prefix, DB tables, `page=sd-ai-agent` admin slug, `sd_ai_agent_settings` option, etc.) are deliberately preserved. This PR only updates the **external GitHub repo URL** and the **release zip filename** — both legitimately follow the WP.org plugin slug `superdav-ai-agent` and the actual renamed repo.

Other stale `Ultimate-Multisite/sd-ai-agent` references (workflow badges, wiki link, `composer.json` metadata, scripts) still work via GitHub's rename redirect and are intentionally left for a separate cleanup PR to keep this fix tight.

## Worker self-verification

No PHP/JS/CSS touched — only JSON config + Markdown badge. Standard `npm run verify` gates do not apply. Verified:

- JSON syntax: all three blueprints parse cleanly with `python3 -c 'import json; json.load(open(...))'`
- Release asset name confirmed via `gh release view` (above)
- Diff is 4 lines across 4 files, no other content changed

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.18 plugin for [OpenCode](https://opencode.ai) v1.15.6 with claude-sonnet-4-6 spent 5h 24m and 40 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin installation and download source URLs across configuration and documentation files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->