### PR TITLE
feat(system-prompt): inject working-cadence section for content-generation turns (#1587)

### DIFF
--- a/includes/Compat/ai-client/class-wp-ai-client-prompt-builder.php
+++ b/includes/Compat/ai-client/class-wp-ai-client-prompt-builder.php
@@ -493,6 +493,38 @@ class WP_AI_Client_Prompt_Builder {
 	}
 
 	/**
+	 * Return the "Working cadence" section for content-generation turns.
+	 *
+	 * This text is injected into the system prompt when the active tool list
+	 * includes content-generation or theme-modification abilities (e.g.
+	 * create-post, update-post, scaffold-block-theme, file-write, file-edit).
+	 * It prevents gateway timeouts and preserves the validate → screenshot →
+	 * fix feedback loop by enforcing one Edit/Write per turn for large files.
+	 *
+	 * Mirrors the Studio `## Working cadence` rule from
+	 * `apps/cli/ai/system-prompt.ts` (Studio-specific tool refs removed).
+	 *
+	 * @since 1.10.0
+	 * @return string The cadence rules string.
+	 */
+	public static function build_working_cadence_section(): string {
+		return "## Working cadence\n\n"
+			. "One Write or Edit per turn for content >50 lines. "
+			. "Read-only inspection tools (`get-post`, `list-posts`, `get-block-type`) may be combined within a turn. "
+			. "Short prose between tools — no long design-plan essays.\n\n"
+			. "**Long files (style.css >200 lines, page content >300 lines): skeleton first, then fill across Edits.**\n\n"
+			. "- **style.css:** skeleton = `:root { ... }` custom properties + 6–10 anchor comments "
+			. "`/* === <concern> === */` (e.g. `reset`, `typography`, `hero`, `features`, `cta`, `footer`, `responsive`), "
+			. "<2KB total. Fill one anchor per Edit (300–2000B each) — `oldString` is the anchor line, "
+			. "`newString` is `<anchor>\\n\\n<styles>`.\n"
+			. "- **Page content:** create the post empty (`wp_insert_post` with empty content), write block markup "
+			. "to a draft using anchor comments `<!-- section:hero -->`, fill one anchor per Edit, then "
+			. "`wp_update_post()` with the assembled content.\n\n"
+			. "**Never overwrite a freshly scaffolded `style.css`** — it contains the required theme header. "
+			. 'Always Edit to append, never Write to replace.';
+	}
+
+	/**
 	 * Extract per-ability usage instructions from meta.ai.usage_instructions.
 	 *
 	 * First checks the ability's meta.ai.usage_instructions field. If not

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -1045,11 +1045,22 @@ class AgentLoop {
 		$builder = wp_ai_client_prompt();
 		/** @var \WP_AI_Client_Prompt_Builder $builder */
 
+		// Resolve abilities once here so they are available for both the
+		// system-instruction rebuild (cadence injection) and the prompt
+		// builder's using_abilities() call below.
+		$abilities = $this->resolve_abilities();
+
 		// Rebuild the system instruction unless the caller pinned a static
 		// override. This lets the manifest's "recently fetched ability
 		// schemas" block reach the model on subsequent turns.
+		// Pass active ability names so the cadence section is injected
+		// when content-generation or theme-modification tools are in scope.
 		if ( ! $this->system_instruction_locked ) {
-			$this->system_instruction = $this->instruction_builder->build( $this->settings_for_prompt );
+			$ability_names            = array_map(
+				static fn( \WP_Ability $a ): string => $a->get_name(),
+				$abilities
+			);
+			$this->system_instruction = $this->instruction_builder->build( $this->settings_for_prompt, $ability_names );
 		}
 		$builder->using_system_instruction( $this->system_instruction );
 		$this->configure_model( $builder );
@@ -1094,7 +1105,8 @@ class AgentLoop {
 		}
 		$builder->using_max_tokens( $this->get_effective_max_output_tokens() );
 
-		$abilities = $this->resolve_abilities();
+		// $abilities was already resolved before the system-instruction rebuild
+		// above; reuse it here instead of calling resolve_abilities() twice.
 		if ( ! empty( $abilities ) ) {
 			$builder->using_abilities( ...$abilities );
 		}

--- a/includes/Core/SystemInstructionBuilder.php
+++ b/includes/Core/SystemInstructionBuilder.php
@@ -23,6 +23,27 @@ use SdAiAgent\Tools\ToolDiscovery;
 class SystemInstructionBuilder {
 
 	/**
+	 * Ability names that trigger cadence-section injection.
+	 *
+	 * When any of these are present in the active tool list the "Working
+	 * cadence" block is appended to the system prompt so the model writes
+	 * one Edit/Write per turn for large files and never overwrites a
+	 * freshly scaffolded style.css.
+	 *
+	 * @since 1.10.0
+	 * @var string[]
+	 */
+	public const CONTENT_GENERATION_ABILITY_NAMES = array(
+		'sd-ai-agent/create-post',
+		'sd-ai-agent/update-post',
+		'sd-ai-agent/append-post-content',
+		'sd-ai-agent/batch-create-posts',
+		'sd-ai-agent/scaffold-block-theme',
+		'sd-ai-agent/file-write',
+		'sd-ai-agent/file-edit',
+	);
+
+	/**
 	 * @param string                   $model_id     Current AI model ID (for weak-model nudges).
 	 * @param string                   $user_message User's message (for knowledge context RAG).
 	 * @param array<int|string, mixed> $page_context Page context from the widget.
@@ -36,12 +57,41 @@ class SystemInstructionBuilder {
 	) {}
 
 	/**
+	 * Return the "Working cadence" section string for content-generation turns.
+	 *
+	 * Injected into the system prompt when any content-generation or
+	 * theme-modification ability is active. Keeps turns atomic and prevents
+	 * gateway timeouts on long-file writes.
+	 *
+	 * @since 1.10.0
+	 * @return string The cadence rules string.
+	 */
+	public static function build_working_cadence_section(): string {
+		return "## Working cadence\n\n"
+			. 'One Write or Edit per turn for content >50 lines. '
+			. 'Read-only inspection tools (`get-post`, `list-posts`, `get-block-type`) may be combined within a turn. '
+			. "Short prose between tools — no long design-plan essays.\n\n"
+			. "**Long files (style.css >200 lines, page content >300 lines): skeleton first, then fill across Edits.**\n\n"
+			. '- **style.css:** skeleton = `:root { ... }` custom properties + 6–10 anchor comments '
+			. '`/* === <concern> === */` (e.g. `reset`, `typography`, `hero`, `features`, `cta`, `footer`, `responsive`), '
+			. '<2KB total. Fill one anchor per Edit (300–2000B each) — `oldString` is the anchor line, '
+			. "`newString` is `<anchor>\\n\\n<styles>`.\n"
+			. '- **Page content:** create the post empty (`wp_insert_post` with empty content), write block markup '
+			. 'to a draft using anchor comments `<!-- section:hero -->`, fill one anchor per Edit, then '
+			. "`wp_update_post()` with the assembled content.\n\n"
+			. '**Never overwrite a freshly scaffolded `style.css`** — it contains the required theme header. '
+			. 'Always Edit to append, never Write to replace.';
+	}
+
+	/**
 	 * Build the system instruction, incorporating custom prompt and memories.
 	 *
-	 * @param array<string, mixed> $settings Plugin settings.
+	 * @param array<string, mixed> $settings      Plugin settings.
+	 * @param string[]             $ability_names Names of active Tier-1 abilities for this turn.
+	 *                                             Used to conditionally inject the Working-cadence section.
 	 * @return string
 	 */
-	public function build( array $settings ): string {
+	public function build( array $settings, array $ability_names = array() ): string {
 		// Use custom system prompt if set, otherwise the built-in default.
 		$custom = $settings['system_prompt'] ?? '';
 		$base   = ! empty( $custom ) ? $custom : self::default_system_instruction();
@@ -159,6 +209,15 @@ class SystemInstructionBuilder {
 			}
 		}
 
+		// Working cadence: inject one-file-per-turn rules when the active
+		// tool list includes content-generation or theme-modification abilities.
+		// Prevents gateway timeouts on large file writes and keeps the
+		// validate → screenshot → fix feedback loop intact.
+		if ( self::has_content_generation_ability( $ability_names ) ) {
+			// @phpstan-ignore-next-line
+			$base .= "\n\n" . self::build_working_cadence_section();
+		}
+
 		// Suggestion chips: instruct the AI to append follow-up suggestions.
 		// @phpstan-ignore-next-line
 		$suggestion_count = (int) ( $settings['suggestion_count'] ?? 3 );
@@ -179,6 +238,23 @@ class SystemInstructionBuilder {
 
 		// @phpstan-ignore-next-line
 		return $base;
+	}
+
+	/**
+	 * Return true when at least one active ability triggers cadence injection.
+	 *
+	 * @since 1.10.0
+	 *
+	 * @param string[] $ability_names Names of active Tier-1 abilities for this turn.
+	 * @return bool
+	 */
+	public static function has_content_generation_ability( array $ability_names ): bool {
+		foreach ( $ability_names as $name ) {
+			if ( in_array( $name, self::CONTENT_GENERATION_ABILITY_NAMES, true ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/includes/Models/skills/working-cadence.md
+++ b/includes/Models/skills/working-cadence.md
@@ -1,0 +1,112 @@
+# Working Cadence for Content and Theme Generation
+
+## When to Load
+
+This skill is automatically injected into the system prompt whenever content-generation
+or theme-modification abilities are active (e.g. `sd-ai-agent/create-post`,
+`sd-ai-agent/scaffold-block-theme`, `sd-ai-agent/file-write`). Load it manually
+when you need to reference the skeleton-first pattern or anchor-comment convention.
+
+## Working Cadence Rules
+
+**One Write or Edit per turn for content >50 lines.** Read-only inspection tools
+(`get-post`, `list-posts`, `get-block-type`) may be combined within a turn.
+Short prose between tools — no long design-plan essays.
+
+### Long Files: Skeleton First, Then Fill Across Edits
+
+**style.css (>200 lines):**
+
+1. Emit a skeleton: `:root { ... }` custom properties + 6–10 anchor comments
+   `/* === <concern> === */` (e.g. `reset`, `typography`, `hero`, `features`, `cta`,
+   `footer`, `responsive`), <2KB total.
+2. Fill one anchor per Edit (300–2000B each).
+   - `oldString`: the anchor line (`/* === typography === */`)
+   - `newString`: `/* === typography === */\n\n<styles>`
+3. **Never overwrite a freshly scaffolded `style.css`** — it contains the required
+   theme header. Always Edit to append; never Write to replace.
+
+**Page content (>300 lines):**
+
+1. Create the post empty: `wp_insert_post` with empty content (or `sd-ai-agent/create-post`
+   with `status: "draft"` and no content).
+2. Write block markup with anchor comments `<!-- section:hero -->`, one anchor per section.
+3. Fill one anchor per Edit — `oldString` is the anchor comment, `newString` is the
+   anchor followed by the full block markup for that section.
+4. When all anchors are filled, publish via `sd-ai-agent/update-post` with `status: "publish"`.
+
+## Why This Matters
+
+1. **Gateway timeouts.** Asking a model to produce a complete 600-line `style.css` in
+   one turn frequently times out, returns partial output, or burns the entire turn budget
+   on a single file. The skeleton/anchor cadence produces deliverable increments.
+2. **Lost screenshot-fix loop.** The validate → screenshot → fix loop only works if
+   visual increments are small enough to inspect. A monolithic write blocks feedback
+   until the whole file is done.
+
+## Reference Pattern: style.css Skeleton
+
+```css
+/*
+Theme Name: My Theme
+Theme URI:
+Author: My Name
+Author URI:
+Description: A custom block theme.
+Version: 1.0.0
+Requires at least: 7.0
+Requires PHP: 8.2
+License: GPL-2.0-or-later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: my-theme
+Tags: block-theme, full-site-editing
+*/
+
+/* === reset === */
+
+/* === custom-properties === */
+
+/* === typography === */
+
+/* === layout === */
+
+/* === header === */
+
+/* === hero === */
+
+/* === features === */
+
+/* === footer === */
+
+/* === responsive === */
+```
+
+Then fill each anchor in subsequent Edits:
+
+```
+oldString: "/* === typography === */"
+newString: "/* === typography === */\n\nbody {\n  font-family: var(--wp--preset--font-family--body);\n  font-size: var(--wp--preset--font-size--medium);\n  line-height: 1.6;\n}"
+```
+
+## Reference Pattern: Page Content Anchors
+
+```html
+<!-- section:hero -->
+
+<!-- section:features -->
+
+<!-- section:cta -->
+
+<!-- section:testimonials -->
+
+<!-- section:footer-cta -->
+```
+
+Fill one anchor per Edit, then publish the assembled content.
+
+## Verification
+
+After a `sd-ai-agent/scaffold-block-theme` call, the scaffolded `style.css` must
+contain only the theme header comment (<500 bytes). If it is larger, the scaffold
+has regressed — file an issue immediately and do not proceed with the skeleton step
+(there is no clean anchor baseline).

--- a/tests/SdAiAgent/Abilities/ScaffoldBlockThemeAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/ScaffoldBlockThemeAbilityTest.php
@@ -337,6 +337,59 @@ class ScaffoldBlockThemeAbilityTest extends WP_UnitTestCase {
 		);
 	}
 
+	// ── Minimal baseline audit (GH#1587 Phase 4) ─────────────────────────
+
+	/**
+	 * Scaffolded style.css must contain only the theme header (<500 bytes).
+	 *
+	 * The Working-cadence rules depend on a clean baseline: the model fills
+	 * style.css via incremental Edits, anchored to the header comment block.
+	 * If the scaffold ever writes CSS rules into style.css this test will fail
+	 * loudly so the regression is caught before reaching production.
+	 *
+	 * Acceptance criterion: GH#1587 — "ScaffoldBlockThemeAbility produces
+	 * style.css with theme header only (<500 bytes) — fail loudly if regressed."
+	 */
+	public function test_scaffold_style_css_is_minimal_header_only(): void {
+		$slug    = $this->unique_slug( 'minimal-css' );
+		$ability = new ScaffoldBlockThemeAbility( 'sd-ai-agent/scaffold-block-theme' );
+
+		$result = $ability->run(
+			[
+				'slug' => $slug,
+				'name' => 'Minimal CSS Theme',
+			]
+		);
+
+		$this->assertIsArray( $result, is_wp_error( $result ) ? $result->get_error_message() : '' );
+
+		$theme_dir  = trailingslashit( get_theme_root() ) . $slug;
+		$style_css  = (string) file_get_contents( $theme_dir . '/style.css' );
+
+		// Must be < 500 bytes — theme header only, no CSS rules.
+		$this->assertLessThan(
+			500,
+			strlen( $style_css ),
+			'Scaffolded style.css must be < 500 bytes (theme header only). '
+			. 'If this fails the scaffold has added CSS rules — revert and file a follow-up.'
+		);
+
+		// Must contain the theme name in the header comment.
+		$this->assertStringContainsString(
+			'Theme Name: Minimal CSS Theme',
+			$style_css,
+			'style.css must include the Theme Name header'
+		);
+
+		// Must NOT contain any CSS ruleset — no opening brace outside the comment.
+		$without_comment = preg_replace( '/\/\*.*?\*\//s', '', $style_css ) ?? '';
+		$this->assertStringNotContainsString(
+			'{',
+			trim( $without_comment ),
+			'Scaffolded style.css must not contain CSS rules outside the header comment'
+		);
+	}
+
 	// ── Helpers ───────────────────────────────────────────────────────────
 
 	/**

--- a/tests/SdAiAgent/Core/PromptBuilderCadenceTest.php
+++ b/tests/SdAiAgent/Core/PromptBuilderCadenceTest.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Tests for the Working Cadence section in SystemInstructionBuilder.
+ *
+ * Verifies that the "Working cadence" section is injected into the system
+ * prompt when content-generation or theme-modification abilities are active,
+ * and omitted for pure Q&A turns.
+ *
+ * Acceptance criteria (GH#1587 Phase 4):
+ * - System prompt contains "Working cadence" when a content-generation tool is in scope.
+ * - System prompt does NOT contain it for pure-Q&A turns.
+ * - build_working_cadence_section() returns the expected key phrases.
+ * - has_content_generation_ability() correctly identifies trigger abilities.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\SystemInstructionBuilder;
+use WP_UnitTestCase;
+
+/**
+ * Test Working-cadence injection in SystemInstructionBuilder.
+ *
+ * @covers \SdAiAgent\Core\SystemInstructionBuilder::build
+ * @covers \SdAiAgent\Core\SystemInstructionBuilder::build_working_cadence_section
+ * @covers \SdAiAgent\Core\SystemInstructionBuilder::has_content_generation_ability
+ */
+class PromptBuilderCadenceTest extends WP_UnitTestCase {
+
+	// ── build_working_cadence_section ─────────────────────────────────────
+
+	/**
+	 * The cadence section must start with the canonical heading.
+	 */
+	public function test_cadence_section_has_heading(): void {
+		$section = SystemInstructionBuilder::build_working_cadence_section();
+
+		$this->assertStringContainsString(
+			'## Working cadence',
+			$section,
+			'Cadence section must contain the "## Working cadence" heading'
+		);
+	}
+
+	/**
+	 * The cadence section must explain the one-edit-per-turn rule.
+	 */
+	public function test_cadence_section_has_one_per_turn_rule(): void {
+		$section = SystemInstructionBuilder::build_working_cadence_section();
+
+		$this->assertStringContainsString(
+			'One Write or Edit per turn',
+			$section,
+			'Cadence section must describe the one-write-per-turn rule'
+		);
+	}
+
+	/**
+	 * The cadence section must describe the style.css skeleton approach.
+	 */
+	public function test_cadence_section_has_skeleton_rule(): void {
+		$section = SystemInstructionBuilder::build_working_cadence_section();
+
+		$this->assertStringContainsString(
+			'style.css',
+			$section,
+			'Cadence section must reference style.css'
+		);
+		$this->assertStringContainsString(
+			'skeleton',
+			$section,
+			'Cadence section must describe the skeleton-first approach'
+		);
+	}
+
+	/**
+	 * The cadence section must warn against overwriting a freshly scaffolded style.css.
+	 */
+	public function test_cadence_section_has_never_overwrite_rule(): void {
+		$section = SystemInstructionBuilder::build_working_cadence_section();
+
+		$this->assertStringContainsString(
+			'Never overwrite a freshly scaffolded',
+			$section,
+			'Cadence section must warn against overwriting style.css'
+		);
+	}
+
+	/**
+	 * The cadence section must describe the page-content anchor approach.
+	 */
+	public function test_cadence_section_has_anchor_rule(): void {
+		$section = SystemInstructionBuilder::build_working_cadence_section();
+
+		$this->assertStringContainsString(
+			'section:hero',
+			$section,
+			'Cadence section must reference the anchor comment pattern'
+		);
+	}
+
+	// ── has_content_generation_ability ───────────────────────────────────
+
+	/**
+	 * create-post triggers cadence injection.
+	 */
+	public function test_create_post_triggers_cadence(): void {
+		$this->assertTrue(
+			SystemInstructionBuilder::has_content_generation_ability( array( 'sd-ai-agent/create-post' ) ),
+			'create-post should trigger cadence injection'
+		);
+	}
+
+	/**
+	 * update-post triggers cadence injection.
+	 */
+	public function test_update_post_triggers_cadence(): void {
+		$this->assertTrue(
+			SystemInstructionBuilder::has_content_generation_ability( array( 'sd-ai-agent/update-post' ) ),
+			'update-post should trigger cadence injection'
+		);
+	}
+
+	/**
+	 * scaffold-block-theme triggers cadence injection.
+	 */
+	public function test_scaffold_block_theme_triggers_cadence(): void {
+		$this->assertTrue(
+			SystemInstructionBuilder::has_content_generation_ability( array( 'sd-ai-agent/scaffold-block-theme' ) ),
+			'scaffold-block-theme should trigger cadence injection'
+		);
+	}
+
+	/**
+	 * file-write triggers cadence injection (used for theme file output).
+	 */
+	public function test_file_write_triggers_cadence(): void {
+		$this->assertTrue(
+			SystemInstructionBuilder::has_content_generation_ability( array( 'sd-ai-agent/file-write' ) ),
+			'file-write should trigger cadence injection'
+		);
+	}
+
+	/**
+	 * file-edit triggers cadence injection (used for incremental CSS fills).
+	 */
+	public function test_file_edit_triggers_cadence(): void {
+		$this->assertTrue(
+			SystemInstructionBuilder::has_content_generation_ability( array( 'sd-ai-agent/file-edit' ) ),
+			'file-edit should trigger cadence injection'
+		);
+	}
+
+	/**
+	 * A pure-read ability should NOT trigger cadence injection.
+	 */
+	public function test_readonly_ability_does_not_trigger_cadence(): void {
+		$this->assertFalse(
+			SystemInstructionBuilder::has_content_generation_ability( array( 'sd-ai-agent/get-post', 'sd-ai-agent/list-posts' ) ),
+			'Read-only abilities should not trigger cadence injection'
+		);
+	}
+
+	/**
+	 * An empty ability list should not trigger cadence injection.
+	 */
+	public function test_empty_ability_list_does_not_trigger_cadence(): void {
+		$this->assertFalse(
+			SystemInstructionBuilder::has_content_generation_ability( array() ),
+			'Empty ability list should not trigger cadence injection'
+		);
+	}
+
+	/**
+	 * Mixed read+write abilities trigger cadence injection via the write ability.
+	 */
+	public function test_mixed_abilities_triggers_cadence_if_any_write(): void {
+		$this->assertTrue(
+			SystemInstructionBuilder::has_content_generation_ability(
+				array(
+					'sd-ai-agent/get-post',
+					'sd-ai-agent/list-posts',
+					'sd-ai-agent/create-post',
+				)
+			),
+			'Mixed read+write set should trigger cadence injection'
+		);
+	}
+
+	// ── build() integration ───────────────────────────────────────────────
+
+	/**
+	 * Cadence section IS injected when create-post is among the active abilities.
+	 */
+	public function test_build_injects_cadence_for_create_post(): void {
+		$builder  = new SystemInstructionBuilder();
+		$settings = array();
+
+		$instruction = $builder->build( $settings, array( 'sd-ai-agent/create-post' ) );
+
+		$this->assertStringContainsString(
+			'## Working cadence',
+			$instruction,
+			'build() must inject the cadence section when create-post is active'
+		);
+	}
+
+	/**
+	 * Cadence section IS injected when scaffold-block-theme is active.
+	 */
+	public function test_build_injects_cadence_for_scaffold_block_theme(): void {
+		$builder  = new SystemInstructionBuilder();
+		$settings = array();
+
+		$instruction = $builder->build( $settings, array( 'sd-ai-agent/scaffold-block-theme' ) );
+
+		$this->assertStringContainsString(
+			'## Working cadence',
+			$instruction,
+			'build() must inject the cadence section when scaffold-block-theme is active'
+		);
+	}
+
+	/**
+	 * Cadence section is NOT injected for a pure Q&A turn (no abilities).
+	 *
+	 * This is the regression test that prevents the cadence block from bloating
+	 * system prompts on read-only or conversational turns.
+	 */
+	public function test_build_omits_cadence_for_empty_ability_list(): void {
+		$builder  = new SystemInstructionBuilder();
+		$settings = array();
+
+		$instruction = $builder->build( $settings, array() );
+
+		$this->assertStringNotContainsString(
+			'## Working cadence',
+			$instruction,
+			'build() must NOT inject the cadence section when no abilities are active'
+		);
+	}
+
+	/**
+	 * Cadence section is NOT injected when only read-only abilities are active.
+	 *
+	 * Regression: ensures get-post / list-posts turns stay lean.
+	 */
+	public function test_build_omits_cadence_for_readonly_abilities(): void {
+		$builder  = new SystemInstructionBuilder();
+		$settings = array();
+
+		$instruction = $builder->build(
+			$settings,
+			array(
+				'sd-ai-agent/get-post',
+				'sd-ai-agent/list-posts',
+				'sd-ai-agent/memory-list',
+			)
+		);
+
+		$this->assertStringNotContainsString(
+			'## Working cadence',
+			$instruction,
+			'build() must NOT inject the cadence section for read-only ability lists'
+		);
+	}
+
+	/**
+	 * build() still works with the default empty $ability_names (backward compat).
+	 */
+	public function test_build_backward_compat_no_ability_names(): void {
+		$builder  = new SystemInstructionBuilder();
+		$settings = array();
+
+		// Calling build() without the second argument must not raise an error.
+		$instruction = $builder->build( $settings );
+
+		$this->assertStringContainsString(
+			'## Core Principles',
+			$instruction,
+			'build() must return a valid instruction even without ability_names argument'
+		);
+		$this->assertStringNotContainsString(
+			'## Working cadence',
+			$instruction,
+			'build() must NOT inject cadence when ability_names is omitted (backward compat)'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Add a "Working cadence" section to the agent system prompt that is injected whenever content-generation or theme-modification abilities are active. This eliminates two production failure modes:

1. **Gateway timeouts** — asking a model to produce a complete 600-line `style.css` in one turn frequently times out or returns partial output. The skeleton/anchor cadence produces deliverable increments.
2. **Lost screenshot-fix loop** — the validate → screenshot → fix loop needs small visual increments; a monolithic write blocks feedback until the whole file is done.

## Changes

### `includes/Compat/ai-client/class-wp-ai-client-prompt-builder.php`
- Added `build_working_cadence_section()` static method (per issue spec).

### `includes/Core/SystemInstructionBuilder.php`
- Added `build_working_cadence_section()` static method (canonical implementation).
- Added `CONTENT_GENERATION_ABILITY_NAMES` constant listing trigger abilities.
- Added `has_content_generation_ability(array $ability_names): bool` helper.
- `build()` gains an optional `$ability_names` parameter (default `[]`); cadence section appended when any trigger ability is present. Backward-compatible — no cadence section when called without `$ability_names`.

### `includes/Core/AgentLoop.php`
- `send_prompt()`: `resolve_abilities()` moved before the system-instruction rebuild so ability names are available for cadence detection on every turn. Eliminates the duplicate `resolve_abilities()` call.

### `includes/Models/skills/working-cadence.md`
- New skill documenting the skeleton/anchor pattern with reference CSS and HTML examples.

### `tests/SdAiAgent/Core/PromptBuilderCadenceTest.php`
- 18 new tests covering cadence injection (content-gen abilities) and omission (pure Q&A / read-only abilities), plus `has_content_generation_ability()` and `build_working_cadence_section()` unit coverage.

### `tests/SdAiAgent/Abilities/ScaffoldBlockThemeAbilityTest.php`
- New `test_scaffold_style_css_is_minimal_header_only()` regression test: asserts `style.css` is < 500 bytes (header only) and contains no CSS rules outside the comment block.

## Audit: ScaffoldBlockThemeAbility

- **`style.css`**: ✅ Confirmed minimal — theme header comment only (< 500 bytes). Regression test added.
- **`theme.json`**: ⚠️ Default contains opinionated palettes, layout sizes, and `typography.fluid` — deviates from Studio's minimal baseline. Filed **GH#1593** as follow-up.

## Worker self-verification

- PHPUnit: Tests: 2497, Assertions: 6757, Errors: 0, Failures: 0, Skipped: 102
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.18 plugin for [OpenCode](https://opencode.ai) v1.15.6 with claude-sonnet-4-6 spent 17m and 39,482 tokens on this as a headless worker.