### PR TITLE
feat(validate-block): append diff-interpretation hint when invalidBlocks > 0 (#1589)

### DIFF
--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -368,6 +368,10 @@ class BlockAbilities {
 						],
 						'block_count'    => [ 'type' => 'integer' ],
 						'freeform_count' => [ 'type' => 'integer' ],
+						'hint'           => [
+							'type'        => 'string',
+							'description' => 'Diff-interpretation guidance emitted only when invalidBlocks > 0.',
+						],
 					],
 				],
 				'meta'                => [
@@ -1157,7 +1161,7 @@ class BlockAbilities {
 			);
 		}
 
-		return array_merge(
+		$result = array_merge(
 			$report,
 			[
 				'valid'          => empty( $warnings ) && 0 === $report['invalidBlocks'],
@@ -1166,5 +1170,14 @@ class BlockAbilities {
 				'freeform_count' => $freeform_count,
 			]
 		);
+
+		// GH#1589: append diff-interpretation hint only when blocks are invalid.
+		// Without this, models "fix" by copy-pasting the Expected string literally
+		// and omit the matching block-comment attribute, causing a fix loop.
+		if ( $report['invalidBlocks'] > 0 ) {
+			$result['hint'] = 'Before fixing: each Expected/Actual diff is a structural change, not a literal text swap. Classes the validator adds or removes (`has-X-color`, `alignwide`, `is-style-Y`, `wp-block-*-is-layout-flex`) pull in or strip core CSS that drives layout, spacing, and color. Diff the markup explicitly, update any style.css selectors that target the old class or nesting in the same edit batch, preserve your intentional className hooks, then take a screenshot of desktop and mobile to verify the design did not drift.';
+		}
+
+		return $result;
 	}
 }

--- a/tests/SdAiAgent/Abilities/BlockAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/BlockAbilitiesTest.php
@@ -394,4 +394,40 @@ class BlockAbilitiesTest extends WP_UnitTestCase {
 			$this->assertArrayHasKey( 'innerHTML', $block );
 		}
 	}
+
+	// ─── validate-block-content ───────────────────────────────────
+
+	/**
+	 * Test handle_validate_block_content emits the diff-interpretation hint
+	 * when at least one block is invalid (GH#1589).
+	 *
+	 * Uses a heading block whose comment declares level:3 but whose HTML uses
+	 * <h2>, which BlockValidator flags as structurally invalid.
+	 */
+	public function test_validate_block_content_hint_present_when_invalid() {
+		$invalid_content = "<!-- wp:heading {\"level\":3} -->\n<h2 class=\"wp-block-heading\">x</h2>\n<!-- /wp:heading -->";
+
+		$result = BlockAbilities::handle_validate_block_content( [
+			'content' => $invalid_content,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'hint', $result );
+		$this->assertStringContainsString( 'Expected/Actual diff is a structural change', $result['hint'] );
+	}
+
+	/**
+	 * Test handle_validate_block_content does NOT emit the hint when all
+	 * blocks are valid — no false positives (GH#1589).
+	 */
+	public function test_validate_block_content_hint_absent_when_valid() {
+		$valid_content = "<!-- wp:paragraph -->\n<p>Hello world</p>\n<!-- /wp:paragraph -->";
+
+		$result = BlockAbilities::handle_validate_block_content( [
+			'content' => $valid_content,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayNotHasKey( 'hint', $result );
+	}
 }


### PR DESCRIPTION
Resolves #1589

## What

When `sd-ai-agent/validate-block-content` returns `invalidBlocks > 0`, append a `hint` key to the result. The hint paragraph warns the model that each Expected/Actual diff is a **structural change** — not a literal text swap — and names specific class drivers to watch for.

## Why

Without the hint, the most common failure loop is:
1. Validator says Expected `<h3 class="wp-block-heading has-large-font-size">`, Actual `<h3 class="wp-block-heading">`.
2. Model copy-pastes the Expected string literally.
3. `has-large-font-size` implies `{"fontSize":"large"}` in the block comment — model omits it, validator fails again with inverse error.
4. Loop until the turn budget runs out (median 4 turns).

Studio tested the verbatim paragraph in production and shortened the median fix loop from 4 turns to 1 (source: `apps/cli/ai/tools/validate-blocks.ts` lines 76-84).

## Changes

- `includes/Abilities/BlockAbilities.php`: add `hint` to `output_schema`; emit hint string in `handle_validate_block_content` when `invalidBlocks > 0`
- `tests/SdAiAgent/Abilities/BlockAbilitiesTest.php`: two new tests — hint present when block is invalid (GH#1589 acceptance criterion), hint absent when all blocks are valid (no false positive)

## Worker self-verification

- PHPUnit: Tests: 2502, Assertions: 6781, Errors: 0, Failures: 0, Skipped: 102
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.18 plugin for [OpenCode](https://opencode.ai) v1.15.6 with claude-sonnet-4-6 spent 8m and 13,588 tokens on this as a headless worker.
