### PR TITLE
feat(skills): vendor WordPress/agent-skills bundle — 5 curated skills (GH#1588)

### DIFF
--- a/includes/Bootstrap/CliHandler.php
+++ b/includes/Bootstrap/CliHandler.php
@@ -13,6 +13,7 @@ namespace SdAiAgent\Bootstrap;
 use SdAiAgent\CLI\BenchmarkCommand;
 use SdAiAgent\CLI\CliCommand;
 use SdAiAgent\CLI\ModelsCommand;
+use SdAiAgent\CLI\SkillsCommand;
 use SdAiAgent\CLI\TraceCommand;
 use SdAiAgent\Models\ProviderTrace;
 use WP_CLI;
@@ -54,6 +55,7 @@ final class CliHandler {
 		'prompt'    => CliCommand::class,
 		'benchmark' => BenchmarkCommand::class,
 		'models'    => ModelsCommand::class,
+		'skills'    => SkillsCommand::class,
 	);
 
 	/**

--- a/includes/CLI/SkillsCommand.php
+++ b/includes/CLI/SkillsCommand.php
@@ -1,0 +1,295 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * WP-CLI command: wp sd-ai-agent skills
+ *
+ * Maintenance commands for the vendored WordPress/agent-skills bundle.
+ *
+ * @package SdAiAgent\CLI
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\CLI;
+
+use WP_CLI;
+use WP_CLI_Command;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manage vendored WordPress agent skills.
+ *
+ * ## EXAMPLES
+ *
+ *   # Dry-run: preview what would change
+ *   wp sd-ai-agent skills sync-wp-agent-skills --dry-run
+ *
+ *   # Perform a live sync
+ *   wp sd-ai-agent skills sync-wp-agent-skills
+ */
+class SkillsCommand extends WP_CLI_Command {
+
+	/**
+	 * Upstream repo API base URL.
+	 */
+	private const UPSTREAM_API_BASE = 'https://api.github.com/repos/WordPress/agent-skills/contents/skills';
+
+	/**
+	 * Raw content base for direct file downloads.
+	 */
+	private const UPSTREAM_RAW_BASE = 'https://raw.githubusercontent.com/WordPress/agent-skills/trunk/skills';
+
+	/**
+	 * Skills to sync (slugs from WordPress/agent-skills).
+	 *
+	 * @var list<string>
+	 */
+	private const SYNC_SLUGS = [
+		'wp-plugin-development',
+		'wp-block-development',
+		'wp-block-themes',
+		'wp-rest-api',
+		'wp-wpcli-and-ops',
+	];
+
+	/**
+	 * Attribution header prepended to every vendored skill file.
+	 */
+	private const ATTRIBUTION_HEADER = "<!-- Adapted from github.com/WordPress/agent-skills (GPL-2.0-or-later) -->\n<!-- studio wp  →  wp  (Studio WP-CLI prefix removed for non-Studio environments) -->\n";
+
+	/**
+	 * Sync the five curated WordPress/agent-skills into includes/Models/skills/.
+	 *
+	 * Fetches each SKILL.md from WordPress/agent-skills, applies sanitisation
+	 * (removes Studio-specific `studio wp ` CLI prefix, replaces wp-project-triage
+	 * Node script references), prepends an attribution header, and writes the
+	 * result to `includes/Models/skills/<slug>.md`.
+	 *
+	 * Uses `wp_remote_get()` so it works in any WP environment (honours
+	 * `WP_HTTP_BLOCK_EXTERNAL` and proxy settings).
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--dry-run]
+	 * : Show what would change without writing any files.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *   wp sd-ai-agent skills sync-wp-agent-skills --dry-run
+	 *   wp sd-ai-agent skills sync-wp-agent-skills
+	 *
+	 * @subcommand sync-wp-agent-skills
+	 * @param array<int, string>   $args       Positional arguments (unused).
+	 * @param array<string, mixed> $assoc_args Named arguments.
+	 */
+	public function sync_wp_agent_skills( array $args, array $assoc_args ): void {
+		$dry_run    = (bool) ( $assoc_args['dry-run'] ?? false );
+		$skills_dir = SD_AI_AGENT_DIR . 'includes/Models/skills/';
+
+		if ( $dry_run ) {
+			WP_CLI::log( '[dry-run] No files will be written.' );
+		}
+
+		$results = [];
+
+		foreach ( self::SYNC_SLUGS as $slug ) {
+			$result    = $this->sync_skill( $slug, $skills_dir, $dry_run );
+			$results[] = $result;
+			$status    = $result['status'];
+			$msg       = "[{$slug}] {$status}";
+			if ( 'error' === $result['outcome'] ) {
+				WP_CLI::warning( $msg );
+			} else {
+				WP_CLI::log( $msg );
+			}
+		}
+
+		$this->print_summary( $results, $dry_run );
+	}
+
+	/**
+	 * Sync a single skill file.
+	 *
+	 * @param string $slug       Skill slug.
+	 * @param string $skills_dir Absolute path to skills directory (trailing slash).
+	 * @param bool   $dry_run    When true, skip writing.
+	 * @return array{slug:string, status:string, outcome:string}
+	 */
+	private function sync_skill( string $slug, string $skills_dir, bool $dry_run ): array {
+		$url     = self::UPSTREAM_RAW_BASE . "/{$slug}/SKILL.md";
+		$content = $this->fetch_remote( $url );
+
+		if ( null === $content ) {
+			return [
+				'slug'    => $slug,
+				'status'  => "FETCH FAILED ({$url})",
+				'outcome' => 'error',
+			];
+		}
+
+		$sanitised = $this->sanitise( $content );
+		$dest_path = $skills_dir . $slug . '.md';
+
+		// Check if the current file (without attribution header) matches.
+		$existing_body = '';
+		if ( file_exists( $dest_path ) ) {
+			// Reading a local plugin file path, not a remote URL — wp_remote_get() does not apply.
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			$raw_existing  = (string) file_get_contents( $dest_path );
+			$existing_body = $this->strip_attribution_header( $raw_existing );
+		}
+
+		if ( $sanitised === $existing_body ) {
+			return [
+				'slug'    => $slug,
+				'status'  => 'up to date',
+				'outcome' => 'ok',
+			];
+		}
+
+		$final = self::ATTRIBUTION_HEADER . $sanitised;
+
+		if ( ! $dry_run ) {
+			// Writing a local plugin file — WP_Filesystem initialization is not appropriate
+			// in a CLI command context where the filesystem transport is always direct.
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			file_put_contents( $dest_path, $final );
+			$action = file_exists( $dest_path ) ? 'updated' : 'created';
+		} else {
+			$action = file_exists( $dest_path ) ? 'would update' : 'would create';
+		}
+
+		return [
+			'slug'    => $slug,
+			'status'  => $action,
+			'outcome' => 'ok',
+		];
+	}
+
+	/**
+	 * Apply sanitisation rules to upstream skill content.
+	 *
+	 * Rules:
+	 * 1. Replace `studio wp ` with `wp ` (Studio's WP-CLI prefix is not used outside Studio).
+	 * 2. Replace `node skills/wp-project-triage/scripts/detect_wp_project.mjs` (and variations)
+	 *    with a manual verification note, since the Node triage script is not available here.
+	 * 3. Replace other `node skills/{slug}/scripts/{name}.mjs` invocations with a manual note.
+	 *
+	 * @param string $content Raw upstream content.
+	 * @return string Sanitised content (no attribution header).
+	 */
+	private function sanitise( string $content ): string {
+		// Rule 1: strip Studio WP-CLI prefix.
+		$content = str_replace( 'studio wp ', 'wp ', $content );
+
+		// Rule 2: replace wp-project-triage Node script reference.
+		$content = preg_replace(
+			'/`node\s+skills\/wp-project-triage\/scripts\/detect_wp_project\.mjs`/',
+			'Verify WordPress project structure manually before proceeding.',
+			(string) $content
+		);
+		$content = preg_replace(
+			'/node\s+skills\/wp-project-triage\/scripts\/detect_wp_project\.mjs/',
+			'Verify WordPress project structure manually before proceeding.',
+			(string) $content
+		);
+
+		// Rule 3: replace remaining skill-specific Node script references.
+		$content = preg_replace(
+			'/`node\s+skills\/[^`]+\.mjs(?:[^`]*)`/',
+			'Run the appropriate manual inspection for this skill (Node triage scripts are not available in this environment).',
+			(string) $content
+		);
+		$content = preg_replace(
+			'/- `node\s+skills\/[^\n]+\.mjs[^\n]*`\n/',
+			'- Inspect manually (Node triage scripts are not available in this environment).' . "\n",
+			(string) $content
+		);
+
+		return (string) $content;
+	}
+
+	/**
+	 * Strip the attribution header block from existing file content for comparison.
+	 *
+	 * @param string $content Existing file content (may or may not have the header).
+	 * @return string Content without the header lines.
+	 */
+	private function strip_attribution_header( string $content ): string {
+		$lines     = explode( "\n", $content );
+		$result    = [];
+		$in_header = true;
+
+		foreach ( $lines as $line ) {
+			if ( $in_header && str_starts_with( $line, '<!--' ) ) {
+				continue;
+			}
+			$in_header = false;
+			$result[]  = $line;
+		}
+
+		return ltrim( implode( "\n", $result ) );
+	}
+
+	/**
+	 * Fetch a remote URL using wp_remote_get().
+	 *
+	 * @param string $url URL to fetch.
+	 * @return string|null Response body, or null on failure.
+	 */
+	private function fetch_remote( string $url ): ?string {
+		$response = wp_remote_get(
+			$url,
+			[
+				'timeout'    => 30,
+				'user-agent' => 'SdAiAgent/skills-sync (+https://github.com/Ultimate-Multisite/superdav-ai-agent)',
+			]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			WP_CLI::warning( 'HTTP error for ' . $url . ': ' . $response->get_error_message() );
+			return null;
+		}
+
+		$code = wp_remote_retrieve_response_code( $response );
+		if ( 200 !== (int) $code ) {
+			WP_CLI::warning( "HTTP {$code} for {$url}" );
+			return null;
+		}
+
+		return wp_remote_retrieve_body( $response );
+	}
+
+	/**
+	 * Print a summary table of sync results.
+	 *
+	 * @param list<array{slug:string, status:string, outcome:string}> $results Sync results.
+	 * @param bool                                                    $dry_run Whether this was a dry run.
+	 */
+	private function print_summary( array $results, bool $dry_run ): void {
+		$errors = array_filter( $results, fn( $r ) => 'error' === $r['outcome'] );
+
+		WP_CLI\Utils\format_items(
+			'table',
+			array_map(
+				fn( $r ) => [
+					'skill'  => $r['slug'],
+					'result' => $r['status'],
+				],
+				$results
+				),
+			[ 'skill', 'result' ]
+		);
+
+		if ( ! empty( $errors ) ) {
+			WP_CLI::error( count( $errors ) . ' skill(s) failed to sync. Check warnings above.' );
+			return;
+		}
+
+		$label = $dry_run ? 'Dry run complete.' : 'Sync complete.';
+		WP_CLI::success( $label . ' ' . count( $results ) . ' skill(s) processed.' );
+	}
+}

--- a/includes/Core/SkillAutoInjector.php
+++ b/includes/Core/SkillAutoInjector.php
@@ -43,6 +43,10 @@ class SkillAutoInjector {
 	 * Keys are regex patterns matched against the user message (case-insensitive).
 	 * Values are skill slugs from the skills table.
 	 *
+	 * Order matters: more-specific patterns must appear before catch-all patterns
+	 * that share keyword overlap (e.g. kadence before gutenberg, wp-block-development
+	 * before gutenberg-blocks, wp-block-themes before block-themes).
+	 *
 	 * @var array<string, string>
 	 */
 	private const TRIGGER_MAP = [
@@ -50,11 +54,27 @@ class SkillAutoInjector {
 		// so that messages mentioning kadence/* blocks route to the kadence skill first.
 		'/\bkadence\b|kadence\/(?:rowlayout|column|advancedheading|advancedbtn|singlebtn)|\bkbVersion\b|\bcolLayout\b|kt-adv-heading|kt-inside-inner-col|kb-section-dir-horizontal|kt-highlight/i' => 'kadence-blocks',
 		'/\b(?:header\s*builder|footer\s*builder|kadence\s*theme)\b|kadence_(?:before|after)_/i'                                       => 'kadence-theme',
+
+		// WP REST API — precedes wp-plugin-development to avoid ambiguity on 'endpoint'/'register'.
+		'/\brest\b.*\bendpoint\b|\bendpoint\b.*\brest\b|wp\/v2|REST_Controller|\/wp-json\/|register_rest_route|rest_api_init\b/i'     => 'wp-rest-api',
+
+		// WP Block development — precedes gutenberg-blocks (content) patterns.
+		'/block\.json|register_block_type|apiVersion|edit\.js|save\.js|\bviewScriptModule\b|\bwp-block-development\b/i'               => 'wp-block-development',
+
+		// WP Block themes (structural) — precedes generic block-themes (content/FSE) pattern.
+		'/\btheme\.json\b|\bblock\s+theme\b|\btemplates\/|\bparts\/|\bstyle\s+variation/i'                                            => 'wp-block-themes',
+
+		// WP Plugin development — plugin architecture, hooks, settings, security.
+		'/plugin\s+header|Plugin\s+Name\s*:|register_activation_hook|add_action\s*\(|add_filter\s*\(/i'                               => 'wp-plugin-development',
+
+		// WP-CLI and ops — wp search-replace, wp cron, wp db, wp-cli.yml.
+		'/\bwp-cli\b|\bwp\s+search-replace\b|\bwp\s+db\b|\bwp\s+cron\b|\bwp\s+cache\s+flush\b|\bwp-cli\.yml\b|\bwp_cron\b/i'        => 'wp-wpcli-and-ops',
+
 		'/\b(?:create|build|make|write|generate|add)\b.*\b(?:page|pages|post|posts|blog|article|content|landing|homepage|layout)\b/i' => 'gutenberg-blocks',
 		'/\b(?:page|pages|landing|homepage|layout|column|columns|hero|section|block|blocks|gutenberg)\b|\bfull[-\s]?width\b|\bfull[-\s]?bleed\b/i' => 'gutenberg-blocks',
 		'/\b(?:woocommerce|product|products|store|shop|order|orders|cart|checkout|coupon)\b/i'                                         => 'woocommerce',
 		'/\b(?:seo|ranking|rankings|meta\s*tags?|meta\s*description|sitemap|search\s*engine|keyword|keywords)\b/i'                     => 'seo-optimization',
-		'/\b(?:full\s*site\s*edit|fse|block\s*theme|template\s*part|site\s*editor|theme\.json)\b/i'                                    => 'block-themes',
+		'/\b(?:full\s*site\s*edit|fse|block\s*theme|template\s*part|site\s*editor)\b/i'                                               => 'block-themes',
 		'/\b(?:classic\s*theme|customizer|functions\.php|widget\s*area|sidebar\s*widget|child\s*theme)\b/i'                          => 'classic-themes',
 		'/\b(?:multisite|network|subsite|subsites|sub-site)\b/i'                                                                       => 'multisite-management',
 		'/\b(?:content\s*market|editorial|content\s*strateg|publish\s*schedule|content\s*audit)\b/i'                                    => 'content-marketing',

--- a/includes/Models/skills/block-themes.md
+++ b/includes/Models/skills/block-themes.md
@@ -476,3 +476,5 @@ After editing templates or `theme.json`:
 ## See also
 
 - `gutenberg-blocks` → **Block-theme layout cascade** — the three structural patterns (full-bleed/constrained, full-bleed/full-bleed, plain constrained) that cause ~80% of "looks broken" outputs. Required reading before generating any landing-page section.
+- `wp-block-themes` → **Canonical WP block-theme skill** — templates, template parts, patterns, style variations, and `theme.json` procedure from the official WordPress/agent-skills library.
+- `wp-block-development` → Block.json, `apiVersion`, dynamic rendering, and deprecations when the theme ships custom blocks.

--- a/includes/Models/skills/gutenberg-blocks.md
+++ b/includes/Models/skills/gutenberg-blocks.md
@@ -513,6 +513,11 @@ Never use `update-post` to "append" by re-sending the full accumulated content â
 3. Build improved content using block markup
 4. Use `sd-ai-agent/update-post` to replace the content (only if the new content fits in one call â€” otherwise rebuild incrementally as above)
 
+## See also
+
+- `wp-block-development` for `block.json` / `apiVersion` / deprecations / `register_block_type` when developing the block PHP/JS source.
+- `wp-block-themes` for `theme.json` global settings, style variations, templates, and template parts in a block theme.
+
 ## Verifying generated markup
 
 After generating block markup, verify before committing it to a published post:

--- a/includes/Models/skills/wp-block-development.md
+++ b/includes/Models/skills/wp-block-development.md
@@ -1,0 +1,180 @@
+<!-- Adapted from github.com/WordPress/agent-skills (GPL-2.0-or-later) -->
+<!-- studio wp  →  wp  (Studio WP-CLI prefix removed for non-Studio environments) -->
+---
+name: wp-block-development
+description: "Use when developing WordPress (Gutenberg) blocks: block.json metadata, register_block_type(_from_metadata), attributes/serialization, supports, dynamic rendering (render.php/render_callback), deprecations/migrations, viewScript vs viewScriptModule, and @wordpress/scripts/@wordpress/create-block build and test workflows."
+compatibility: "Targets WordPress 6.9+ (PHP 7.2.24+). Some workflows require WP-CLI."
+---
+
+# WP Block Development
+
+## When to use
+
+Use this skill for block work such as:
+
+- creating a new block, or updating an existing one
+- changing `block.json` (scripts/styles/supports/attributes/render/viewScriptModule)
+- fixing "block invalid / not saving / attributes not persisting"
+- adding dynamic rendering (`render.php` / `render_callback`)
+- block deprecations and migrations (`deprecated` versions)
+- build tooling for blocks (`@wordpress/scripts`, `@wordpress/create-block`, `wp-env`)
+
+## Inputs required
+
+- Repo root and target (plugin vs theme vs full site).
+- The block name/namespace and where it lives (path to `block.json` if known).
+- Target WordPress version range (especially if using modules / `viewScriptModule`).
+
+## Procedure
+
+### 0) Triage and locate blocks
+
+1. Verify WordPress project structure manually before proceeding.
+2. List blocks (deterministic scan): search for `block.json` files in the plugin/theme directory.
+3. Identify the block root (directory containing `block.json`) you're changing.
+
+If this repo is a full site (`wp-content/` present), be explicit about *which* plugin/theme contains the block.
+
+### 1) Create a new block (if needed)
+
+If you are creating a new block, prefer scaffolding rather than hand-rolling structure:
+
+- Use `@wordpress/create-block` to scaffold a modern block/plugin setup.
+- If you need Interactivity API from day 1, use the interactive template.
+
+Read:
+- `references/creating-new-blocks.md`
+
+After scaffolding:
+
+1. Re-run the block list and confirm the new block root.
+2. Continue with the remaining steps (model choice, metadata, registration, serialization).
+
+### 2) Ensure apiVersion 3 (WordPress 6.9+)
+
+WordPress 6.9 enforces `apiVersion: 3` in the block.json schema. Blocks with apiVersion 2 or lower trigger console warnings when `SCRIPT_DEBUG` is enabled.
+
+**Why this matters:**
+- WordPress 7.0 will run the post editor in an iframe regardless of block apiVersion.
+- apiVersion 3 ensures your block works correctly inside the iframed editor (style isolation, viewport units, media queries).
+
+**Migration:** Changing from version 2 to 3 is usually as simple as updating the `apiVersion` field in `block.json`. However:
+- Test in a local environment with the iframe editor enabled.
+- Ensure any style handles are included in `block.json` (styles missing from the iframe won't apply).
+- Third-party scripts attached to a specific `window` may have scoping issues.
+
+Read:
+- `references/block-json.md` (apiVersion and schema details)
+
+### 3) Pick the right block model
+
+- **Static block** (markup saved into post content): implement `save()`; keep attributes serialization stable.
+- **Dynamic block** (server-rendered): use `render` in `block.json` (or `render_callback` in PHP) and keep `save()` minimal or `null`.
+- **Interactive frontend behavior**:
+  - Prefer `viewScriptModule` for modern module-based view scripts where supported.
+  - If you're working primarily on `data-wp-*` directives or stores, also use `wp-interactivity-api`.
+
+### 4) Update `block.json` safely
+
+Make changes in the block's `block.json`, then confirm registration matches metadata.
+
+For field-by-field guidance, read:
+- `references/block-json.md`
+
+Common pitfalls:
+
+- changing `name` breaks compatibility (treat it as stable API)
+- changing saved markup without adding `deprecated` causes "Invalid block"
+- adding attributes without defining source/serialization correctly causes "attribute not saving"
+
+### 5) Register the block (server-side preferred)
+
+Prefer PHP registration using metadata, especially when:
+
+- you need dynamic rendering
+- you need translations (`wp_set_script_translations`)
+- you need conditional asset loading
+
+Read and apply:
+- `references/registration.md`
+
+### 6) Implement edit/save/render patterns
+
+Follow wrapper attribute best practices:
+
+- Editor: `useBlockProps()`
+- Static save: `useBlockProps.save()`
+- Dynamic render (PHP): `get_block_wrapper_attributes()`
+
+Read:
+- `references/supports-and-wrappers.md`
+- `references/dynamic-rendering.md` (if dynamic)
+
+### 7) Inner blocks (block composition)
+
+If your block is a "container" that nests other blocks, treat Inner Blocks as a first-class feature:
+
+- Use `useInnerBlocksProps()` to integrate inner blocks with wrapper props.
+- Keep migrations in mind if you change inner markup.
+
+Read:
+- `references/inner-blocks.md`
+
+### 8) Attributes and serialization
+
+Before changing attributes:
+
+- confirm where the attribute value lives (comment delimiter vs HTML vs context)
+- avoid the deprecated `meta` attribute source
+
+Read:
+- `references/attributes-and-serialization.md`
+
+### 9) Migrations and deprecations (avoid "Invalid block")
+
+If you change saved markup or attributes:
+
+1. Add a `deprecated` entry (newest → oldest).
+2. Provide `save` for old versions and an optional `migrate` to normalize attributes.
+
+Read:
+- `references/deprecations.md`
+
+### 10) Tooling and verification commands
+
+Prefer whatever the repo already uses:
+
+- `@wordpress/scripts` (common) → run existing npm scripts
+- `wp-env` (common) → use for local WP + E2E
+
+Read:
+- `references/tooling-and-testing.md`
+
+## Verification
+
+- Block appears in inserter and inserts successfully.
+- Saving + reloading does not create "Invalid block".
+- Frontend output matches expectations (static: saved markup; dynamic: server output).
+- Assets load where expected (editor vs frontend).
+- Run the repo's lint/build/tests that triage recommends.
+
+## Failure modes / debugging
+
+If something fails, start here:
+
+- `references/debugging.md` (common failures + fastest checks)
+- `references/attributes-and-serialization.md` (attributes not saving)
+- `references/deprecations.md` (invalid block after change)
+
+## Escalation
+
+If you're uncertain about upstream behavior/version support, consult canonical docs first:
+
+- WordPress Developer Resources (Block Editor Handbook, Theme Handbook, Plugin Handbook)
+- Gutenberg repo docs for bleeding-edge behaviors
+
+## See also
+
+- `gutenberg-blocks` for block markup patterns and layout cascade rules in content/pages.
+- `wp-block-themes` for theme.json, templates, and style variations in a block theme.
+- `wp-plugin-development` for plugin architecture, settings API, and security when shipping a block plugin.

--- a/includes/Models/skills/wp-block-themes.md
+++ b/includes/Models/skills/wp-block-themes.md
@@ -1,0 +1,122 @@
+<!-- Adapted from github.com/WordPress/agent-skills (GPL-2.0-or-later) -->
+<!-- studio wp  →  wp  (Studio WP-CLI prefix removed for non-Studio environments) -->
+---
+name: wp-block-themes
+description: "Use when developing WordPress block themes: theme.json (global settings/styles), templates and template parts, patterns, style variations, and Site Editor troubleshooting (style hierarchy, overrides, caching)."
+compatibility: "Targets WordPress 6.9+ (PHP 7.2.24+). Some workflows require WP-CLI."
+---
+
+# WP Block Themes
+
+## When to use
+
+Use this skill for block theme work such as:
+
+- editing `theme.json` (presets, settings, styles, per-block styles)
+- adding or changing templates (`templates/*.html`) and template parts (`parts/*.html`)
+- adding patterns (`patterns/*.php`) and controlling what appears in the inserter
+- adding style variations (`styles/*.json`)
+- debugging "styles not applying" / "editor doesn't reflect theme.json"
+
+## Inputs required
+
+- Repo root and which theme is targeted (theme directory if multiple exist).
+- Target WordPress version range (theme.json version and features vary by core version).
+- Where the issue manifests: Site Editor, post editor, frontend, or all.
+
+## Procedure
+
+### 0) Triage and locate block theme roots
+
+1. Verify WordPress project structure manually before proceeding.
+2. Detect theme roots and key folders: look for `theme.json` and `templates/` or `parts/` directories in the theme root.
+
+If multiple themes exist, pick one and scope all changes to that theme root.
+
+### 1) Create a new block theme (if needed)
+
+If you are creating a new block theme from scratch (or converting a classic theme):
+
+- Prefer starting from a known-good scaffold (or exporting from a WP environment) rather than guessing file layout.
+- Be explicit about the minimum supported WordPress version because `theme.json` schema versions differ.
+
+Read:
+- `references/creating-new-block-theme.md`
+
+After creating the theme root, re-check for the theme's `theme.json` and continue below.
+
+### 2) Confirm theme type and override expectations
+
+- Block theme indicators:
+  - `theme.json` present
+  - `templates/` and/or `parts/` present
+- Remember the style hierarchy:
+  - core defaults → theme.json → child theme → user customizations
+  - user customizations can make theme.json edits appear "ignored"
+
+Read:
+- `references/debugging.md` (style hierarchy + fastest checks)
+
+### 3) Make `theme.json` changes safely
+
+Decide whether you are changing:
+
+- **settings** (what the UI allows): presets, typography scale, colors, layout, spacing
+- **styles** (how it looks by default): CSS-like rules for elements/blocks
+
+Read:
+- `references/theme-json.md`
+
+### 4) Templates and template parts
+
+- Templates live under `templates/` and are HTML.
+- Template parts live under `parts/` and must not be nested in subdirectories.
+
+Read:
+- `references/templates-and-parts.md`
+
+### 5) Patterns
+
+Prefer filesystem patterns under `patterns/` when you want theme-owned patterns.
+
+Read:
+- `references/patterns.md`
+
+### 6) Style variations
+
+Style variations are JSON files under `styles/`. Note: once a user picks a style variation, that selection is stored in the DB, so changing the file may not "update what the user sees" automatically.
+
+Read:
+- `references/style-variations.md`
+
+## Verification
+
+- Site Editor reflects changes where expected (Styles UI, templates, patterns).
+- Frontend renders with expected styles.
+- If styles aren't changing, confirm whether user customizations override theme defaults.
+- Run the repo's build/lint scripts if assets are involved (fonts, custom JS/CSS build).
+
+## Failure modes / debugging
+
+Start with:
+
+- `references/debugging.md`
+
+Common issues:
+
+- wrong theme root (editing an inactive theme)
+- user customizations override your defaults
+- invalid `theme.json` shape/typos prevent application
+- templates/parts in wrong folders (or nested parts)
+
+## Escalation
+
+If upstream behavior is unclear, consult canonical docs:
+
+- Theme Handbook and Block Editor Handbook for `theme.json`, templates, patterns, and style variations.
+
+## See also
+
+- `block-themes` for in-plugin block markup patterns, absolute rules, and Site Editor tooling within this plugin.
+- `wp-block-development` for block.json, apiVersion, deprecations, and dynamic rendering when the theme ships custom blocks.
+- `gutenberg-blocks` for block markup patterns and layout cascade rules when composing page content.

--- a/includes/Models/skills/wp-plugin-development.md
+++ b/includes/Models/skills/wp-plugin-development.md
@@ -1,0 +1,118 @@
+<!-- Adapted from github.com/WordPress/agent-skills (GPL-2.0-or-later) -->
+<!-- studio wp  →  wp  (Studio WP-CLI prefix removed for non-Studio environments) -->
+---
+name: wp-plugin-development
+description: "Use when developing WordPress plugins: architecture and hooks, activation/deactivation/uninstall, admin UI and Settings API, data storage, cron/tasks, security (nonces/capabilities/sanitization/escaping), and release packaging."
+compatibility: "Targets WordPress 6.9+ (PHP 7.2.24+). Some workflows require WP-CLI."
+---
+
+# WP Plugin Development
+
+## When to use
+
+Use this skill for plugin work such as:
+
+- creating or refactoring plugin structure (bootstrap, includes, namespaces/classes)
+- adding hooks/actions/filters
+- activation/deactivation/uninstall behavior and migrations
+- adding settings pages / options / admin UI (Settings API)
+- security fixes (nonces, capabilities, sanitization/escaping, SQL safety)
+- packaging a release (build artifacts, readme, assets)
+
+## Inputs required
+
+- Repo root + target plugin(s) (path to plugin main file if known).
+- Where this plugin runs: single site vs multisite; WP.com conventions if applicable.
+- Target WordPress + PHP versions (affects available APIs and placeholder support in `$wpdb->prepare()`).
+
+## Procedure
+
+### 0) Triage and locate plugin entrypoints
+
+1. Verify WordPress project structure manually before proceeding.
+2. Detect plugin headers (deterministic scan): look for PHP files with the `Plugin Name:` header comment in the plugin root or target directory.
+
+If this is a full site repo, pick the specific plugin under `wp-content/plugins/` or `mu-plugins/` before changing code.
+
+### 1) Follow a predictable architecture
+
+Guidelines:
+
+- Keep a single bootstrap (main plugin file with header).
+- Avoid heavy side effects at file load time; load on hooks.
+- Prefer a dedicated loader/class to register hooks.
+- Keep admin-only code behind `is_admin()` (or admin hooks) to reduce frontend overhead.
+
+See:
+- `references/structure.md`
+
+### 2) Hooks and lifecycle (activation/deactivation/uninstall)
+
+Activation hooks are fragile; follow guardrails:
+
+- register activation/deactivation hooks at top-level, not inside other hooks
+- flush rewrite rules only when needed and only after registering CPTs/rules
+- uninstall should be explicit and safe (`uninstall.php` or `register_uninstall_hook`)
+
+See:
+- `references/lifecycle.md`
+
+### 3) Settings and admin UI (Settings API)
+
+Prefer Settings API for options:
+
+- `register_setting()`, `add_settings_section()`, `add_settings_field()`
+- sanitize via `sanitize_callback`
+
+See:
+- `references/settings-api.md`
+
+### 4) Security baseline (always)
+
+Before shipping:
+
+- Validate/sanitize input early; escape output late.
+- Use nonces to prevent CSRF *and* capability checks for authorization.
+- Avoid directly trusting `$_POST` / `$_GET`; use `wp_unslash()` and specific keys.
+- Use `$wpdb->prepare()` for SQL; avoid building SQL with string concatenation.
+
+See:
+- `references/security.md`
+
+### 5) Data storage, cron, migrations (if needed)
+
+- Prefer options for small config; custom tables only if necessary.
+- For cron tasks, ensure idempotency and provide manual run paths (WP-CLI or admin).
+- For schema changes, write upgrade routines and store schema version.
+
+See:
+- `references/data-and-cron.md`
+
+## Verification
+
+- Plugin activates with no fatals/notices.
+- Settings save and read correctly (capability + nonce enforced).
+- Uninstall removes intended data (and nothing else).
+- Run repo lint/tests (PHPUnit/PHPCS if present) and any JS build steps if the plugin ships assets.
+
+## Failure modes / debugging
+
+- Activation hook not firing:
+  - hook registered incorrectly (not in main file scope), wrong main file path, or plugin is network-activated
+- Settings not saving:
+  - settings not registered, wrong option group, missing capability, nonce failure
+- Security regressions:
+  - nonce present but missing capability checks; or sanitized input not escaped on output
+
+See:
+- `references/debugging.md`
+
+## Escalation
+
+For canonical detail, consult the Plugin Handbook and security guidelines before inventing patterns.
+
+## See also
+
+- `wp-block-development` for block.json / deprecations / apiVersion when the plugin ships Gutenberg blocks.
+- `wp-rest-api` for REST endpoint registration, permission callbacks, and schema validation.
+- `wp-wpcli-and-ops` for WP-CLI commands, search-replace, and operational scripting.

--- a/includes/Models/skills/wp-rest-api.md
+++ b/includes/Models/skills/wp-rest-api.md
@@ -1,0 +1,120 @@
+<!-- Adapted from github.com/WordPress/agent-skills (GPL-2.0-or-later) -->
+<!-- studio wp  →  wp  (Studio WP-CLI prefix removed for non-Studio environments) -->
+---
+name: wp-rest-api
+description: "Use when building, extending, or debugging WordPress REST API endpoints/routes: register_rest_route, WP_REST_Controller/controller classes, schema/argument validation, permission_callback/authentication, response shaping, register_rest_field/register_meta, or exposing CPTs/taxonomies via show_in_rest."
+compatibility: "Targets WordPress 6.9+ (PHP 7.2.24+). Some workflows require WP-CLI."
+---
+
+# WP REST API
+
+## When to use
+
+Use this skill when you need to:
+
+- create or update REST routes/endpoints
+- debug 401/403/404 errors or permission/nonce issues
+- add custom fields/meta to REST responses
+- expose custom post types or taxonomies via REST
+- implement schema + argument validation
+- adjust response links/embedding/pagination
+
+## Inputs required
+
+- Repo root + target plugin/theme/mu-plugin (path to entrypoint).
+- Desired namespace + version (e.g. `my-plugin/v1`) and routes.
+- Authentication mode (cookie + nonce vs application passwords vs auth plugin).
+- Target WordPress version constraints (if below 6.9, call out).
+
+## Procedure
+
+### 0) Triage and locate REST usage
+
+1. Verify WordPress project structure manually before proceeding.
+2. Search for existing REST usage:
+   - `register_rest_route`
+   - `WP_REST_Controller`
+   - `rest_api_init`
+   - `show_in_rest`, `rest_base`, `rest_controller_class`
+
+If this is a full site repo, pick the specific plugin/theme before changing code.
+
+### 1) Choose the right approach
+
+- **Expose CPT/taxonomy in `wp/v2`:**
+  - Use `show_in_rest => true` + `rest_base` if needed.
+  - Optionally provide `rest_controller_class`.
+  - Read `references/custom-content-types.md`.
+- **Custom endpoints:**
+  - Use `register_rest_route()` on `rest_api_init`.
+  - Prefer a controller class (`WP_REST_Controller` subclass) for anything non-trivial.
+  - Read `references/routes-and-endpoints.md` and `references/schema.md`.
+
+### 2) Register routes safely (namespaces, methods, permissions)
+
+- Use a unique namespace `vendor/v1`; avoid `wp/*` unless core.
+- Always provide `permission_callback` (use `__return_true` for public endpoints).
+- Use `WP_REST_Server::READABLE/CREATABLE/EDITABLE/DELETABLE` constants.
+- Return data via `rest_ensure_response()` or `WP_REST_Response`.
+- Return errors via `WP_Error` with an explicit `status`.
+
+Read `references/routes-and-endpoints.md`.
+
+### 3) Validate/sanitize request args
+
+- Define `args` with `type`, `default`, `required`, `validate_callback`, `sanitize_callback`.
+- Prefer JSON Schema validation with `rest_validate_value_from_schema` then `rest_sanitize_value_from_schema`.
+- Never read `$_GET`/`$_POST` directly inside endpoints; use `WP_REST_Request`.
+
+Read `references/schema.md`.
+
+### 4) Responses, fields, and links
+
+- Do **not** remove core fields from default endpoints; add fields instead.
+- Use `register_rest_field` for computed fields; `register_meta` with `show_in_rest` for meta.
+- For `object`/`array` meta, define schema in `show_in_rest.schema`.
+- If you need unfiltered post content (e.g., ToC plugins injecting HTML), request `?context=edit` to access `content.raw` (auth required). Pair with `_fields=content.raw` to keep responses small.
+- Add related resource links via `WP_REST_Response::add_link()`.
+
+Read `references/responses-and-fields.md`.
+
+### 5) Authentication and authorization
+
+- For wp-admin/JS: cookie auth + `X-WP-Nonce` (action `wp_rest`).
+- For external clients: application passwords (basic auth) or an auth plugin.
+- Use capability checks in `permission_callback` (authorization), not just "logged in".
+
+Read `references/authentication.md`.
+
+### 6) Client-facing behavior (discovery, pagination, embeds)
+
+- Ensure discovery works (`Link` header or `<link rel="https://api.w.org/">`).
+- Support `_fields`, `_embed`, `_method`, `_envelope`, pagination headers.
+- Remember `per_page` is capped at 100.
+
+Read `references/discovery-and-params.md`.
+
+## Verification
+
+- `/wp-json/` index includes your namespace.
+- `OPTIONS` on your route returns schema (when provided).
+- Endpoint returns expected data; permission failures return 401/403 as appropriate.
+- CPT/taxonomy routes appear under `wp/v2` when `show_in_rest` is true.
+- Run repo lint/tests and any PHP/JS build steps.
+
+## Failure modes / debugging
+
+- 404: `rest_api_init` not firing, route typo, or permalinks off (use `?rest_route=`).
+- 401/403: missing nonce/auth, or `permission_callback` too strict.
+- `_doing_it_wrong` for missing `permission_callback`: add it (use `__return_true` if public).
+- Invalid params: missing/incorrect `args` schema or validation callbacks.
+- Fields missing: `show_in_rest` false, meta not registered, or CPT lacks `custom-fields` support.
+
+## Escalation
+
+If version support or behavior is unclear, consult the REST API Handbook and core docs before inventing patterns.
+
+## See also
+
+- `wp-plugin-development` for plugin architecture, hooks, and security when the endpoint lives in a plugin.
+- `wp-wpcli-and-ops` for inspecting REST routes via WP-CLI (`wp rest-api`).

--- a/includes/Models/skills/wp-wpcli-and-ops.md
+++ b/includes/Models/skills/wp-wpcli-and-ops.md
@@ -1,0 +1,133 @@
+<!-- Adapted from github.com/WordPress/agent-skills (GPL-2.0-or-later) -->
+<!-- studio wp  →  wp  (Studio WP-CLI prefix removed for non-Studio environments) -->
+---
+name: wp-wpcli-and-ops
+description: "Use when working with WP-CLI (wp) for WordPress operations: safe search-replace, db export/import, plugin/theme/user/content management, cron, cache flushing, multisite, and scripting/automation with wp-cli.yml."
+compatibility: "Targets WordPress 6.9+ (PHP 7.2.24+). Requires WP-CLI in the execution environment."
+---
+
+# WP-CLI and Ops
+
+## When to use
+
+Use this skill when the task involves WordPress operational work via WP-CLI, including:
+
+- `wp search-replace` (URL changes, domain migrations, protocol switch)
+- DB export/import, resets, and inspections (`wp db *`)
+- plugin/theme install/activate/update, language packs
+- cron event listing/running
+- cache/rewrite flushing
+- multisite operations (`wp site *`, `--url`, `--network`)
+- building repeatable scripts (`wp-cli.yml`, shell scripts, CI jobs)
+
+## Inputs required
+
+- Where WP-CLI will run (local dev, staging, production) and whether it's safe to run.
+- How to target the correct site root:
+  - `--path=<wordpress-root>` and (multisite) `--url=<site-url>`
+- Whether this is multisite and whether commands should run network-wide.
+- Any constraints (no downtime, no DB writes, maintenance window).
+
+## Procedure
+
+### 0) Guardrails: confirm environment and blast radius
+
+WP-CLI commands can be destructive. Before running anything that writes:
+
+1. Confirm environment (dev/staging/prod).
+2. Confirm targeting (path/url) so you don't hit the wrong site.
+3. Make a backup when performing risky operations.
+
+Read:
+- `references/safety.md`
+
+### 1) Inspect WP-CLI and site targeting (deterministic)
+
+Run the inspector to confirm WP-CLI is available and targeting is correct:
+
+```bash
+wp cli info
+wp core version --path=<path>
+```
+
+If WP-CLI isn't available, fall back to installing it via the project's documented tooling (Composer, container, or system package), or ask for the expected execution environment.
+
+### 2) Choose the right workflow
+
+#### A) Safe URL/domain migration (`search-replace`)
+
+Follow a safe sequence:
+
+1. `wp db export` (backup)
+2. `wp search-replace --dry-run` (review impact)
+3. Run the real replace with appropriate flags
+4. Flush caches/rewrite if needed
+
+Read:
+- `references/search-replace.md`
+
+#### B) Plugin/theme operations
+
+Use `wp plugin *` / `wp theme *` and confirm you're acting on the intended site (and network) first.
+
+Read:
+- `references/packages-and-updates.md`
+
+#### C) Cron and queues
+
+Inspect cron state and run individual events for debugging rather than "run everything blindly".
+
+Read:
+- `references/cron-and-cache.md`
+
+#### D) Multisite operations
+
+Multisite changes can affect many sites. Always decide whether you're operating:
+
+- on a single site (`--url=`), or
+- network-wide (`--network` / iterating sites)
+
+Read:
+- `references/multisite.md`
+
+### 3) Automation patterns (scripts + wp-cli.yml)
+
+For repeatable ops, prefer:
+
+- `wp-cli.yml` for defaults (path/url, PHP memory limits)
+- shell scripts that log commands and stop on error
+- CI jobs that run read-only checks by default
+
+Read:
+- `references/automation.md`
+
+## Verification
+
+- Re-run `wp cli info && wp core version` after changes that could affect targeting or config.
+- Confirm intended side effects:
+  - correct URLs updated
+  - plugins/themes in expected state
+  - cron/caches flushed where needed
+- If there's a health check endpoint or smoke test suite, run it after ops changes.
+
+## Failure modes / debugging
+
+- "Error: This does not seem to be a WordPress installation."
+  - wrong `--path`, wrong container, or missing `wp-config.php`
+- Multisite commands affecting the wrong site
+  - missing `--url` or wrong URL
+- Search-replace causes unexpected serialization issues
+  - wrong flags or changing serialized data unsafely
+
+See:
+- `references/debugging.md`
+
+## Escalation
+
+- If you cannot confirm environment safety, do not run write operations.
+- If the repo uses containerized tooling (Docker/wp-env) but you can't access it, ask for the intended command runner or CI job.
+
+## See also
+
+- `wp-plugin-development` for WP-CLI command registration (`WP_CLI_Command`) inside plugins.
+- `wp-rest-api` for inspecting REST routes via `wp rest-api`.

--- a/tests/SdAiAgent/Core/SkillAutoInjectorTest.php
+++ b/tests/SdAiAgent/Core/SkillAutoInjectorTest.php
@@ -238,4 +238,147 @@ class SkillAutoInjectorTest extends WP_UnitTestCase {
 		$this->assertGreaterThan( strlen( $hint ), strlen( $full_injection ), 'Full injection must be longer than the index hint.' );
 		$this->assertLessThan( 200, strlen( $hint ), 'Index hint should be under 200 characters (got ' . strlen( $hint ) . ').' );
 	}
+
+	// ─── WP agent skills trigger tests (Phase 5 / GH#1588) ───────────────
+
+	/**
+	 * Messages containing REST API keywords route to wp-rest-api.
+	 *
+	 * @dataProvider provide_wp_rest_api_phrases
+	 */
+	public function test_get_index_description_routes_rest_api_phrases( string $phrase ): void {
+		$result = SkillAutoInjector::get_index_description( $phrase );
+
+		$this->assertStringContainsString(
+			'wp-rest-api',
+			$result,
+			"Phrase '{$phrase}' must route to wp-rest-api."
+		);
+	}
+
+	/**
+	 * @return array<string, array{0:string}>
+	 */
+	public function provide_wp_rest_api_phrases(): array {
+		return [
+			'register_rest_route'   => [ 'How do I use register_rest_route to add a custom endpoint?' ],
+			'REST_Controller'       => [ 'Extend WP_REST_Controller for my custom API.' ],
+			'wp-json path'          => [ 'My /wp-json/ route is returning 404.' ],
+			'rest api_init'         => [ 'I hook into rest_api_init to register routes.' ],
+			'rest + endpoint combo' => [ 'Create a REST endpoint that returns user data.' ],
+		];
+	}
+
+	/**
+	 * Messages containing block.json / apiVersion keywords route to wp-block-development.
+	 *
+	 * @dataProvider provide_wp_block_development_phrases
+	 */
+	public function test_get_index_description_routes_block_development_phrases( string $phrase ): void {
+		$result = SkillAutoInjector::get_index_description( $phrase );
+
+		$this->assertStringContainsString(
+			'wp-block-development',
+			$result,
+			"Phrase '{$phrase}' must route to wp-block-development."
+		);
+	}
+
+	/**
+	 * @return array<string, array{0:string}>
+	 */
+	public function provide_wp_block_development_phrases(): array {
+		return [
+			'block.json'           => [ 'How do I update block.json to add a new attribute?' ],
+			'register_block_type'  => [ 'Call register_block_type from my plugin.' ],
+			'apiVersion'           => [ 'Should I use apiVersion 3 for my block?' ],
+			'edit.js / save.js'    => [ 'My edit.js and save.js are out of sync.' ],
+			'viewScriptModule'     => [ 'I need to use viewScriptModule for the Interactivity API.' ],
+		];
+	}
+
+	/**
+	 * Messages containing theme.json / templates / parts route to wp-block-themes.
+	 *
+	 * @dataProvider provide_wp_block_themes_phrases
+	 */
+	public function test_get_index_description_routes_block_themes_phrases( string $phrase ): void {
+		$result = SkillAutoInjector::get_index_description( $phrase );
+
+		$this->assertStringContainsString(
+			'wp-block-themes',
+			$result,
+			"Phrase '{$phrase}' must route to wp-block-themes."
+		);
+	}
+
+	/**
+	 * @return array<string, array{0:string}>
+	 */
+	public function provide_wp_block_themes_phrases(): array {
+		return [
+			'theme.json'          => [ 'How do I add a color palette in theme.json?' ],
+			'block theme phrase'  => [ 'I am building a block theme from scratch.' ],
+			'templates/'          => [ 'Where should I put my templates/ directory?' ],
+			'parts/'              => [ 'I added a header template part in parts/ but it does not appear.' ],
+			'style variation'     => [ 'How do I add a dark style variation to my theme?' ],
+		];
+	}
+
+	/**
+	 * Messages containing plugin header / add_action keywords route to wp-plugin-development.
+	 *
+	 * @dataProvider provide_wp_plugin_development_phrases
+	 */
+	public function test_get_index_description_routes_plugin_development_phrases( string $phrase ): void {
+		$result = SkillAutoInjector::get_index_description( $phrase );
+
+		$this->assertStringContainsString(
+			'wp-plugin-development',
+			$result,
+			"Phrase '{$phrase}' must route to wp-plugin-development."
+		);
+	}
+
+	/**
+	 * @return array<string, array{0:string}>
+	 */
+	public function provide_wp_plugin_development_phrases(): array {
+		return [
+			'Plugin Name header'           => [ 'I need to write the Plugin Name: header for my plugin file.' ],
+			'register_activation_hook'     => [ 'How do I use register_activation_hook correctly?' ],
+			'add_action call'              => [ 'Use add_action( \'init\', \'my_callback\' ) to register CPTs.' ],
+			'add_filter call'              => [ 'I need to use add_filter( \'the_content\', \'my_filter\' ).' ],
+		];
+	}
+
+	/**
+	 * Messages containing WP-CLI / wp search-replace keywords route to wp-wpcli-and-ops.
+	 *
+	 * @dataProvider provide_wp_wpcli_phrases
+	 */
+	public function test_get_index_description_routes_wpcli_phrases( string $phrase ): void {
+		$result = SkillAutoInjector::get_index_description( $phrase );
+
+		$this->assertStringContainsString(
+			'wp-wpcli-and-ops',
+			$result,
+			"Phrase '{$phrase}' must route to wp-wpcli-and-ops."
+		);
+	}
+
+	/**
+	 * @return array<string, array{0:string}>
+	 */
+	public function provide_wp_wpcli_phrases(): array {
+		return [
+			'wp-cli explicit'          => [ 'How do I install wp-cli on my server?' ],
+			'wp search-replace'        => [ 'Run wp search-replace to update the domain after migration.' ],
+			'wp db export'             => [ 'Use wp db export to take a backup before the deployment.' ],
+			'wp cron event'            => [ 'List all scheduled tasks with wp cron event list.' ],
+			'wp cache flush'           => [ 'Run wp cache flush to clear the object cache.' ],
+			'wp-cli.yml config'        => [ 'Set path defaults in wp-cli.yml for this project.' ],
+			'wp_cron constant'         => [ 'I disabled wp_cron in wp-config.php to use real cron.' ],
+		];
+	}
 }


### PR DESCRIPTION
Resolves #1588

## Summary

Phase 5: vendor the five WordPress.org-curated AI skills from [WordPress/agent-skills](https://github.com/WordPress/agent-skills) as built-in default skills, wire them into the auto-injector, add a WP-CLI sync command, and cross-reference existing skills.

## Changes

### New skill files (`includes/Models/skills/`)
| File | Source slug |
|---|---|
| `wp-plugin-development.md` | `wp-plugin-development` |
| `wp-block-development.md` | `wp-block-development` |
| `wp-block-themes.md` | `wp-block-themes` |
| `wp-rest-api.md` | `wp-rest-api` |
| `wp-wpcli-and-ops.md` | `wp-wpcli-and-ops` |

Each file includes:
- Attribution header: `<!-- Adapted from github.com/WordPress/agent-skills (GPL-2.0-or-later) -->`
- Sanitisation: `studio wp ` → `wp ` (Studio CLI prefix removed)
- Node triage script references replaced with manual verification notes
- See-also cross-references to related skills

### Auto-injector wiring (`includes/Core/SkillAutoInjector.php`)
Five new `TRIGGER_MAP` patterns added before the existing `gutenberg-blocks` catch-alls:
- **`wp-rest-api`** → `register_rest_route | REST_Controller | /wp-json/ | rest_api_init`
- **`wp-block-development`** → `block.json | register_block_type | apiVersion | edit.js | viewScriptModule`
- **`wp-block-themes`** → `theme.json | block theme | templates/ | parts/ | style variation`
- **`wp-plugin-development`** → `Plugin Name: | register_activation_hook | add_action( | add_filter(`
- **`wp-wpcli-and-ops`** → `wp-cli | wp search-replace | wp db | wp cron | wp cache flush | wp_cron`

### WP-CLI sync command (`includes/CLI/SkillsCommand.php`)
```
wp sd-ai-agent skills sync-wp-agent-skills [--dry-run]
```
Fetches `SKILL.md` for each of the 5 upstream slugs via `wp_remote_get()`, applies sanitisation, writes to `includes/Models/skills/`. Registered as `skills` subcommand in `CliHandler.php`.

### Cross-references
- `gutenberg-blocks.md` → See also: `wp-block-development`, `wp-block-themes`
- `block-themes.md` → See also: `wp-block-themes`, `wp-block-development`

### Tests (`tests/SdAiAgent/Core/SkillAutoInjectorTest.php`)
25 new test cases across 5 `@dataProvider` methods confirming each new skill slug appears in `get_index_description()` for representative trigger phrases.

## Licence verification

`github.com/WordPress/agent-skills` root `LICENSE` file is GPL-2.0-or-later — GPL-compatible. Attribution header added to each vendored file.

## Worker self-verification

- PHPUnit: Tests: 2526, Assertions: 6802, Errors: 0, Failures: 0, Skipped: 102
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.18 plugin for [OpenCode](https://opencode.ai) v1.15.6 with claude-sonnet-4-6 spent 14m and 35,220 tokens on this as a headless worker.
