### PR TITLE
feat(scaffold-block-theme): slim default theme.json to minimal baseline (GH#1593)

### DIFF
--- a/includes/Abilities/ScaffoldBlockThemeAbility.php
+++ b/includes/Abilities/ScaffoldBlockThemeAbility.php
@@ -460,6 +460,13 @@ class ScaffoldBlockThemeAbility extends AbstractAbility {
 	/**
 	 * Build the minimal default theme.json document.
 	 *
+	 * Intentionally slim — mirrors the Studio renderThemeJson() baseline.
+	 * Only `$schema`, `version`, `settings.appearanceTools`, and the two
+	 * mandatory `templateParts` (header/footer) are written. All palette,
+	 * layout, typography, and style decisions are deferred to the subsequent
+	 * theme-customisation turn where the agent fills them via anchor-comment
+	 * Edits (GH#1593, following GH#1587 Phase 4 audit).
+	 *
 	 * @return array<string,mixed> theme.json structure.
 	 */
 	private static function default_theme_json(): array {
@@ -468,38 +475,6 @@ class ScaffoldBlockThemeAbility extends AbstractAbility {
 			'version'       => 3,
 			'settings'      => [
 				'appearanceTools' => true,
-				'layout'          => [
-					'contentSize' => '720px',
-					'wideSize'    => '1200px',
-				],
-				'color'           => [
-					'palette' => [
-						[
-							'slug'  => 'foreground',
-							'name'  => 'Foreground',
-							'color' => '#1a1a1a',
-						],
-						[
-							'slug'  => 'background',
-							'name'  => 'Background',
-							'color' => '#ffffff',
-						],
-						[
-							'slug'  => 'accent',
-							'name'  => 'Accent',
-							'color' => '#3858e9',
-						],
-					],
-				],
-				'typography'      => [
-					'fluid' => true,
-				],
-			],
-			'styles'        => [
-				'color' => [
-					'background' => 'var(--wp--preset--color--background)',
-					'text'       => 'var(--wp--preset--color--foreground)',
-				],
 			],
 			'templateParts' => [
 				[

--- a/tests/SdAiAgent/Abilities/ScaffoldBlockThemeAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/ScaffoldBlockThemeAbilityTest.php
@@ -390,6 +390,89 @@ class ScaffoldBlockThemeAbilityTest extends WP_UnitTestCase {
 		);
 	}
 
+	// ── Default theme.json minimal baseline (GH#1593) ────────────────────
+
+	/**
+	 * The default theme.json must be minimal: only $schema, version 3,
+	 * settings.appearanceTools, and templateParts (header/footer).
+	 *
+	 * Regression test for GH#1593: the previous default included opinionated
+	 * colour palettes, layout sizes, and typography settings that leaked design
+	 * decisions into the scaffold. The slim baseline defers all palette/layout/
+	 * typography choices to the subsequent theme-customisation turn.
+	 *
+	 * Fails loudly if any of the following are re-introduced:
+	 *   - settings.color.palette (custom palettes)
+	 *   - settings.layout (contentSize / wideSize)
+	 *   - settings.typography.fluid or other typography keys
+	 *   - top-level styles block
+	 */
+	public function test_scaffold_default_theme_json_is_minimal(): void {
+		$slug    = $this->unique_slug( 'slim-default' );
+		$ability = new ScaffoldBlockThemeAbility( 'sd-ai-agent/scaffold-block-theme' );
+
+		$result = $ability->run(
+			[
+				'slug' => $slug,
+				'name' => 'Slim Default Theme',
+			]
+		);
+
+		$this->assertIsArray( $result, is_wp_error( $result ) ? $result->get_error_message() : '' );
+
+		$theme_dir  = trailingslashit( get_theme_root() ) . $slug;
+		$theme_json = json_decode( (string) file_get_contents( $theme_dir . '/theme.json' ), true );
+
+		$this->assertIsArray( $theme_json );
+
+		// Must have the required top-level keys.
+		$this->assertArrayHasKey( '$schema', $theme_json, 'Default theme.json must include $schema.' );
+		$this->assertSame( 3, $theme_json['version'], 'Default theme.json must be version 3.' );
+		$this->assertArrayHasKey( 'settings', $theme_json, 'Default theme.json must include settings.' );
+		$this->assertArrayHasKey( 'templateParts', $theme_json, 'Default theme.json must include templateParts.' );
+
+		// settings must contain appearanceTools and nothing else.
+		$settings = $theme_json['settings'];
+		$this->assertSame( true, $settings['appearanceTools'], 'settings.appearanceTools must be true.' );
+
+		$this->assertArrayNotHasKey(
+			'color',
+			$settings,
+			'Default theme.json must not contain settings.color (no custom palettes). '
+			. 'If this fails a future change re-introduced palettes — revert and file a follow-up.'
+		);
+
+		$this->assertArrayNotHasKey(
+			'layout',
+			$settings,
+			'Default theme.json must not contain settings.layout (no contentSize/wideSize). '
+			. 'If this fails a future change re-introduced layout sizes — revert and file a follow-up.'
+		);
+
+		$this->assertArrayNotHasKey(
+			'typography',
+			$settings,
+			'Default theme.json must not contain settings.typography (no fluid typography). '
+			. 'If this fails a future change re-introduced typography settings — revert and file a follow-up.'
+		);
+
+		// No top-level styles block (palette preset references depend on removed palettes).
+		$this->assertArrayNotHasKey(
+			'styles',
+			$theme_json,
+			'Default theme.json must not contain a top-level styles block. '
+			. 'If this fails a future change re-introduced preset-colour references — revert and file a follow-up.'
+		);
+
+		// templateParts must have exactly header and footer entries.
+		$parts = $theme_json['templateParts'];
+		$this->assertCount( 2, $parts, 'Default theme.json must have exactly 2 templateParts (header and footer).' );
+
+		$part_names = array_column( $parts, 'name' );
+		$this->assertContains( 'header', $part_names, 'templateParts must include a header entry.' );
+		$this->assertContains( 'footer', $part_names, 'templateParts must include a footer entry.' );
+	}
+
 	// ── Helpers ───────────────────────────────────────────────────────────
 
 	/**


### PR DESCRIPTION
## Summary

Slim `ScaffoldBlockThemeAbility::default_theme_json()` to the minimal Studio `renderThemeJson()` baseline.

### Changes

**`includes/Abilities/ScaffoldBlockThemeAbility.php`**
- Removed `settings.layout` (`contentSize: 720px`, `wideSize: 1200px`)
- Removed `settings.color.palette` (foreground/background/accent palettes)
- Removed `settings.typography.fluid: true`
- Removed top-level `styles.color` preset references
- Retained: `$schema`, `version: 3`, `settings.appearanceTools: true`, `templateParts` (header/footer)
- Updated docblock to explain the minimal-baseline rationale (GH#1593, GH#1587)

**`tests/SdAiAgent/Abilities/ScaffoldBlockThemeAbilityTest.php`**
- Added `test_scaffold_default_theme_json_is_minimal()`: fails loudly if any of the following are re-introduced into the default: `settings.color`, `settings.layout`, `settings.typography`, or top-level `styles` block
- Also asserts `templateParts` has exactly header and footer entries

### Why

The cadence-injection rules from GH#1587 rely on a clean scaffold baseline. An opinionated `theme.json` with custom palettes, layout sizes, and typography settings leaks design decisions into the scaffold that the model must then work around or override. A minimal scaffold defers all such choices to the subsequent theme-customisation turn.

## Worker self-verification

- PHPUnit: Tests: 2522, Assertions: 6819, Errors: 0, Failures: 0, Skipped: 102
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded (webpack 5.105.3 compiled with 2 warnings)

Resolves #1593

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.18 plugin for [OpenCode](https://opencode.ai) v1.15.6 with claude-sonnet-4-6 spent 6m and 9,161 tokens on this as a headless worker.
