### PR TITLE
feat(block-validator): wire save-time gate into create_post + update_post (GH#1584 follow-up)

### DIFF
--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -346,7 +346,7 @@ class BlockAbilities {
 			'sd-ai-agent/validate-block-content',
 			[
 				'label'               => __( 'Validate Block Content', 'superdav-ai-agent' ),
-				'description'         => __( 'Validate block content before insertion. Checks for mixed markdown/block markup, malformed block comments, empty blocks, and freeform content that should be wrapped in blocks. Use this after building complex block content to catch errors before creating a post or page.', 'superdav-ai-agent' ),
+				'description'         => __( 'Validate Gutenberg block content before insertion. Mirrors wp.blocks.validateBlock() server-side: detects heading-level/wrapper-tag/required-class mismatches, mixed markdown/block markup, malformed block comments, empty blocks, and core/html policy violations. When a block is invalid, the response includes results[].expectedContent — the corrected innerHTML to substitute in a follow-up create_post / update_post call. Always call this BEFORE saving complex block markup; create_post and update_post also auto-run this validator and attach the report under block_validation so you can self-repair on a retry.', 'superdav-ai-agent' ),
 				'category'            => 'sd-ai-agent',
 				'input_schema'        => [
 					'type'       => 'object',
@@ -361,7 +361,49 @@ class BlockAbilities {
 				'output_schema'       => [
 					'type'       => 'object',
 					'properties' => [
-						'valid'          => [ 'type' => 'boolean' ],
+						'valid'          => [
+							'type'        => 'boolean',
+							'description' => 'Convenience flag: true when invalidBlocks === 0 and warnings is empty.',
+						],
+						'totalBlocks'    => [
+							'type'        => 'integer',
+							'description' => 'Total number of blocks parsed from the input (flat count, includes inner blocks).',
+						],
+						'validBlocks'    => [
+							'type'        => 'integer',
+							'description' => 'Number of blocks that passed validation.',
+						],
+						'invalidBlocks'  => [
+							'type'        => 'integer',
+							'description' => 'Number of blocks that failed validation. When > 0, inspect results[] for per-block diffs.',
+						],
+						'results'        => [
+							'type'        => 'array',
+							'description' => 'Per-block validation results. When isValid=false, replace originalContent with expectedContent in your follow-up create_post / update_post call.',
+							'items'       => [
+								'type'       => 'object',
+								'properties' => [
+									'blockName'       => [ 'type' => 'string' ],
+									'isValid'         => [ 'type' => 'boolean' ],
+									'issues'          => [
+										'type'  => 'array',
+										'items' => [ 'type' => 'string' ],
+									],
+									'originalContent' => [
+										'type'        => 'string',
+										'description' => 'The innerHTML as it appeared in the input.',
+									],
+									'expectedContent' => [
+										'type'        => 'string',
+										'description' => 'The corrected innerHTML the model should substitute on retry. Replaces originalContent only — do NOT copy this into the block-comment attributes.',
+									],
+								],
+							],
+						],
+						'source'         => [
+							'type'        => 'string',
+							'description' => 'Validation engine that produced the report: "php" (server-side rules) or "js-cached" (browser-primed wp.blocks.validateBlock result).',
+						],
 						'warnings'       => [
 							'type'  => 'array',
 							'items' => [ 'type' => 'string' ],

--- a/includes/Abilities/PostAbilities.php
+++ b/includes/Abilities/PostAbilities.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Abilities;
 
+use SdAiAgent\Core\BlockValidator;
 use SdAiAgent\Models\MarkdownToBlocks;
 use WP_Error;
 use WP_Post;
@@ -884,12 +885,22 @@ class PostAbilities {
 			restore_current_blog();
 		}
 
-		return [
+		$response = [
 			'post_id'   => $post_id,
 			'permalink' => $permalink ?: '',
 			'status'    => $status,
 			'post_type' => $post_type,
 		];
+
+		// GH#1584 follow-up: run BlockValidator on serialized block content so
+		// the model gets save-time feedback even when it forgets to call
+		// validate_block_content first. The save itself is never rejected.
+		$validation = self::maybe_validate_block_content( $content );
+		if ( null !== $validation ) {
+			$response['block_validation'] = $validation;
+		}
+
+		return $response;
 	}
 
 	/**
@@ -1080,12 +1091,23 @@ class PostAbilities {
 			restore_current_blog();
 		}
 
-		return [
+		$response = [
 			'post_id'   => $post_id,
 			'permalink' => $permalink ?: '',
 			'status'    => $updated_post instanceof WP_Post ? $updated_post->post_status : '',
 			'post_type' => $updated_post instanceof WP_Post ? $updated_post->post_type : '',
 		];
+
+		// GH#1584 follow-up: re-validate after update so the model knows
+		// whether its repair attempt actually fixed the block markup.
+		if ( isset( $post_data['post_content'] ) ) {
+			$validation = self::maybe_validate_block_content( (string) $post_data['post_content'] );
+			if ( null !== $validation ) {
+				$response['block_validation'] = $validation;
+			}
+		}
+
+		return $response;
 	}
 
 	/**
@@ -1494,5 +1516,66 @@ class PostAbilities {
 			}
 		}
 		return $ids;
+	}
+
+	/**
+	 * Run BlockValidator on content that contains Gutenberg block markup, then
+	 * shape the report so the model can apply `expectedContent` on a follow-up
+	 * update_post call without parsing the full structure.
+	 *
+	 * Returns null when the content has no block delimiters (`<!-- wp:`) — for
+	 * pure markdown or empty content the validator has nothing to say. When
+	 * the content does contain blocks, the returned array is attached to the
+	 * create_post / update_post success response under the `block_validation`
+	 * key. Saves still go through unchanged — this is feedback only, never a
+	 * hard rejection, so partial work is never lost. Models that see
+	 * `invalidBlocks > 0` are expected to re-emit an update_post call with
+	 * `originalContent` replaced by `expectedContent`.
+	 *
+	 * @since 1.16.2
+	 *
+	 * @param string $content Block content that was just saved (post_kses'd).
+	 * @return array<string, mixed>|null
+	 */
+	private static function maybe_validate_block_content( string $content ): ?array {
+		if ( '' === $content || false === strpos( $content, '<!-- wp:' ) ) {
+			return null;
+		}
+
+		$validator = new BlockValidator();
+		$report    = $validator->validate( $content );
+
+		$invalid = (int) ( $report['invalidBlocks'] ?? 0 );
+
+		// Only surface the report when there is something the model should act on.
+		if ( $invalid <= 0 ) {
+			return array(
+				'isValid'       => true,
+				'totalBlocks'   => (int) ( $report['totalBlocks'] ?? 0 ),
+				'invalidBlocks' => 0,
+				'source'        => (string) ( $report['source'] ?? 'php' ),
+			);
+		}
+
+		// Pick the first invalid result so the response stays small. The
+		// validator can report many issues; the model only needs one diff
+		// at a time to make a follow-up update_post call.
+		$first_invalid = null;
+		foreach ( (array) ( $report['results'] ?? array() ) as $result ) {
+			if ( empty( $result['isValid'] ) ) {
+				$first_invalid = $result;
+				break;
+			}
+		}
+
+		return array(
+			'isValid'        => false,
+			'totalBlocks'    => (int) ( $report['totalBlocks'] ?? 0 ),
+			'invalidBlocks'  => $invalid,
+			'source'         => (string) ( $report['source'] ?? 'php' ),
+			'firstInvalid'   => $first_invalid,
+			'results'        => (array) ( $report['results'] ?? array() ),
+			'recommendation' => __( 'One or more blocks failed validation. To self-repair, call update_post on this post_id with content rebuilt from results[].expectedContent (substitute each invalid block\'s originalContent with its expectedContent). Do NOT copy expectedContent verbatim into the block-comment attributes — it replaces the innerHTML only.', 'superdav-ai-agent' ),
+		);
 	}
 }

--- a/includes/Core/SystemInstructionBuilder.php
+++ b/includes/Core/SystemInstructionBuilder.php
@@ -285,6 +285,7 @@ class SystemInstructionBuilder {
 			. "- For blog posts: set `post_type` to `post`.\n"
 			. "- **Blog posts and articles**: write content in markdown (`## headings`, `**bold**`, `- lists`). Markdown is auto-converted to Gutenberg blocks.\n"
 			. "- **Pages with visual layouts** (landing pages, about pages, services pages): write content as serialized Gutenberg block markup (`<!-- wp:blockname -->` HTML `<!-- /wp:blockname -->`). Use columns, groups, covers, and buttons for professional layouts. A skill guide with complete block markup examples will be auto-loaded when relevant.\n"
+			. "- **Block-markup self-repair loop.** Whenever `post_content` contains `<!-- wp:` markup, `sd-ai-agent/create-post` and `sd-ai-agent/update-post` automatically run the block validator and attach a `block_validation` object to the response. If `block_validation.invalidBlocks > 0`, immediately call `sd-ai-agent/update-post` on the same `post_id` with the content rebuilt by substituting each invalid block's `originalContent` with its `expectedContent` (from `block_validation.results[]`). Do NOT copy `expectedContent` into block-comment attributes — it replaces innerHTML only. You may also call `sd-ai-agent/validate-block-content` pre-save to catch issues before the first write.\n"
 			. "- **NEVER mix markdown with block markup** in the same content — use one or the other.\n"
 			. "- Set `status` to `publish` to make it live, or `draft` to save without publishing.\n"
 			. "- Include `categories` and `tags` arrays for blog posts.\n"

--- a/tests/SdAiAgent/Abilities/PostAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/PostAbilitiesTest.php
@@ -362,6 +362,109 @@ class PostAbilitiesTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'status', $result );
 	}
 
+	// ─── block_validation save-time gate (GH#1584 follow-up) ────────
+
+	/**
+	 * Content without block markup should omit the block_validation key — the
+	 * helper short-circuits when `<!-- wp:` is not present.
+	 */
+	public function test_handle_create_post_omits_block_validation_for_markdown() {
+		$result = PostAbilities::handle_create_post( [
+			'title'   => 'Markdown post',
+			'content' => "## Heading\n\nParagraph.",
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayNotHasKey( 'block_validation', $result );
+	}
+
+	/**
+	 * Content with valid block markup should attach block_validation with
+	 * isValid=true and invalidBlocks=0.
+	 */
+	public function test_handle_create_post_attaches_valid_block_validation() {
+		$valid_blocks = "<!-- wp:heading {\"level\":2} -->\n<h2 class=\"wp-block-heading\">Hello</h2>\n<!-- /wp:heading -->";
+
+		$result = PostAbilities::handle_create_post( [
+			'title'   => 'Valid blocks page',
+			'content' => $valid_blocks,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'block_validation', $result );
+		$this->assertTrue( $result['block_validation']['isValid'] );
+		$this->assertSame( 0, $result['block_validation']['invalidBlocks'] );
+		$this->assertGreaterThanOrEqual( 1, $result['block_validation']['totalBlocks'] );
+	}
+
+	/**
+	 * Heading level mismatch in created post should:
+	 *  - still save (post_id is returned)
+	 *  - attach block_validation with invalidBlocks > 0
+	 *  - expose firstInvalid.expectedContent so the model can self-repair.
+	 */
+	public function test_handle_create_post_flags_heading_level_mismatch_without_blocking_save() {
+		$bad_blocks = "<!-- wp:heading {\"level\":3} -->\n<h2 class=\"wp-block-heading\">Wrong level</h2>\n<!-- /wp:heading -->";
+
+		$result = PostAbilities::handle_create_post( [
+			'title'   => 'Bad heading page',
+			'content' => $bad_blocks,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertGreaterThan( 0, $result['post_id'], 'Save must succeed even when blocks are invalid.' );
+
+		$this->assertArrayHasKey( 'block_validation', $result );
+		$this->assertFalse( $result['block_validation']['isValid'] );
+		$this->assertSame( 1, $result['block_validation']['invalidBlocks'] );
+		$this->assertArrayHasKey( 'firstInvalid', $result['block_validation'] );
+		$this->assertSame( 'core/heading', $result['block_validation']['firstInvalid']['blockName'] );
+
+		$expected = $result['block_validation']['firstInvalid']['expectedContent'];
+		$this->assertStringContainsString( '<h3', $expected );
+		$this->assertStringContainsString( '</h3>', $expected );
+
+		$this->assertArrayHasKey( 'recommendation', $result['block_validation'] );
+		$this->assertNotEmpty( $result['block_validation']['recommendation'] );
+	}
+
+	/**
+	 * Updating a post with invalid block markup attaches block_validation to
+	 * the update_post response so the model can detect and self-repair.
+	 */
+	public function test_handle_update_post_flags_invalid_blocks_in_response() {
+		$post_id = $this->factory->post->create( [ 'post_status' => 'draft' ] );
+
+		$result = PostAbilities::handle_update_post( [
+			'post_id' => $post_id,
+			'content' => "<!-- wp:quote -->\n<div class=\"wp-block-quote\"><p>Wisdom.</p></div>\n<!-- /wp:quote -->",
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'block_validation', $result );
+		$this->assertFalse( $result['block_validation']['isValid'] );
+		$this->assertGreaterThanOrEqual( 1, $result['block_validation']['invalidBlocks'] );
+		$this->assertArrayHasKey( 'firstInvalid', $result['block_validation'] );
+		$this->assertSame( 'core/quote', $result['block_validation']['firstInvalid']['blockName'] );
+		$this->assertStringContainsString( '<blockquote', $result['block_validation']['firstInvalid']['expectedContent'] );
+	}
+
+	/**
+	 * update_post without a content field should not attach block_validation
+	 * (we only validate content we just wrote).
+	 */
+	public function test_handle_update_post_no_content_no_block_validation() {
+		$post_id = $this->factory->post->create( [ 'post_status' => 'draft' ] );
+
+		$result = PostAbilities::handle_update_post( [
+			'post_id' => $post_id,
+			'title'   => 'Title only update',
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayNotHasKey( 'block_validation', $result );
+	}
+
 	// ─── handle_append_post_content ──────────────────────────────────
 
 	/**


### PR DESCRIPTION
## Summary

Closes the agent-loop integration gap left by GH#1584. The merged PR shipped a deep PHP `BlockValidator` + JS `wp.blocks.validateBlock()` bridge but nothing in the actual write path used it: `PostAbilities::handle_create_post` / `handle_update_post` never invoked the validator, the `validate-block-content` ability's `output_schema` omitted `results[].expectedContent`, and `SystemInstructionBuilder` never described the self-repair workflow. The model could therefore save invalid block markup with zero feedback.

This PR makes the validator usable end-to-end:

### (A) Save-time gate in `PostAbilities`

`handle_create_post` and `handle_update_post` now run `BlockValidator::validate()` whenever `post_content` contains `<!-- wp:` markup, and attach a `block_validation` object to the success response. Saves are never rejected — partial work is preserved, the model receives the diff, and `update_post` re-validates so the model can confirm a repair attempt actually landed. Markdown / pure-HTML content short-circuits the helper (no overhead).

Response shape (only when block markup is present):

```json
{
  "post_id": 123, "permalink": "...", "status": "draft", "post_type": "page",
  "block_validation": {
    "isValid": false,
    "totalBlocks": 1,
    "invalidBlocks": 1,
    "source": "php",
    "firstInvalid": {
      "blockName": "core/heading",
      "isValid": false,
      "issues": ["core/heading: attribute \"level\" is 3 but markup uses <h2> (expected <h3>)."],
      "originalContent": "<h2 class=\"wp-block-heading\">Wrong level</h2>",
      "expectedContent": "<h3 class=\"wp-block-heading\">Wrong level</h3>"
    },
    "results": [...],
    "recommendation": "One or more blocks failed validation. To self-repair, call update_post …"
  }
}
```

`firstInvalid` is exposed alongside the full `results[]` so single-block fixes stay token-cheap while multi-block repairs still have everything they need.

### (B) `validate-block-content` output_schema completed

The ability now declares `totalBlocks`, `validBlocks`, `invalidBlocks`, `results[]` (with `blockName`, `isValid`, `issues`, `originalContent`, `expectedContent`), and `source`. The tool description also tells the model about the save-time gate and the `originalContent` → `expectedContent` substitution rule, with an explicit warning not to copy `expectedContent` into block-comment attributes.

### (C) Self-repair workflow paragraph in `SystemInstructionBuilder`

One concise paragraph added to the Content Creation section, after the existing block-markup guidance:

> **Block-markup self-repair loop.** Whenever `post_content` contains `<!-- wp:` markup, `sd-ai-agent/create-post` and `sd-ai-agent/update-post` automatically run the block validator and attach a `block_validation` object to the response. If `block_validation.invalidBlocks > 0`, immediately call `sd-ai-agent/update-post` on the same `post_id` with the content rebuilt by substituting each invalid block's `originalContent` with its `expectedContent` (from `block_validation.results[]`). Do NOT copy `expectedContent` into block-comment attributes — it replaces innerHTML only. You may also call `sd-ai-agent/validate-block-content` pre-save to catch issues before the first write.

### Test coverage

Five new `PostAbilitiesTest` cases:

- `test_handle_create_post_omits_block_validation_for_markdown` — markdown content short-circuits, no `block_validation` key.
- `test_handle_create_post_attaches_valid_block_validation` — valid block content returns `isValid: true, invalidBlocks: 0`.
- `test_handle_create_post_flags_heading_level_mismatch_without_blocking_save` — `level:3` + `<h2>` markup saves successfully AND surfaces `firstInvalid.expectedContent` containing `<h3>` / `</h3>`.
- `test_handle_update_post_flags_invalid_blocks_in_response` — `core/quote` as `<div>` triggers `firstInvalid.expectedContent` with `<blockquote>`.
- `test_handle_update_post_no_content_no_block_validation` — title-only update has no `block_validation` key (we only validate what we just wrote).

### Verified end-to-end

Drove the change through the live WordPress dev install (`wp eval-file`):

```text
Calling handle_create_post() with <h2> markup tagged level:3…
Result keys: post_id, permalink, status, post_type, block_validation
block_validation.firstInvalid.expectedContent: <h3 class="wp-block-heading">Wrong level</h3>
```

The model now receives the corrected markup immediately after a bad save.

## Worker self-verification

- PHPUnit: Tests: 2563, Assertions: 6916, Errors: 0, Failures: 0, Skipped: 102
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Refs #1584

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.24 plugin for [OpenCode](https://opencode.ai) v1.15.7 with claude-opus-4-7 spent 5h 10m and 159,640 tokens on this with the user in an interactive session.