### PR TITLE
docs(abilities): wp-rest ability reference (docs/wp-rest-ability.md) + agent skill (wp-rest-fallback.md)

### DIFF
--- a/docs/wp-rest-ability.md
+++ b/docs/wp-rest-ability.md
@@ -1,0 +1,264 @@
+# WP REST Ability
+
+The `wp-rest/*` ability family lets the AI agent read and write any registered
+WordPress REST endpoint through the internal dispatcher (`rest_do_request()`),
+without an HTTP loopback. Use it when a third-party plugin exposes a REST route
+and no dedicated ability exists for the operation you need. Prefer a named
+ability (`posts`, `options`, `media`, etc.) whenever one is available — they
+carry tighter parameter validation, richer error messages, and purpose-built
+audit entries.
+
+## The three abilities
+
+| Ability | Purpose |
+| --- | --- |
+| `wp-rest/discover` | List registered namespaces and route paths (read-only, no side effects). |
+| `wp-rest/inspect` | Return schema, accepted methods, argument definitions, and permission summary for one route. |
+| `wp-rest/execute` | Dispatch a `GET`, `POST`, `PUT`, `PATCH`, or `DELETE` request to a registered route. |
+
+## Self-documenting flow
+
+The recommended pattern — discover, inspect, then execute — lets the agent
+confirm a route exists and understand its contract before making a write or
+destructive call.
+
+**Scenario:** Clear the Elementor CSS cache via the Elementor REST API.
+
+### Step 1 — Discover routes in the Elementor namespace
+
+```json
+// Ability: wp-rest/discover
+{ "namespace": "elementor/v1" }
+```
+
+Response (excerpt):
+
+```json
+[
+  { "route": "/elementor/v1/kit-data", "methods": ["GET", "POST"] },
+  { "route": "/elementor/v1/reset-api-data", "methods": ["POST"] }
+]
+```
+
+The agent identifies `/elementor/v1/reset-api-data` as a likely cache-clear
+target and proceeds to inspect it.
+
+### Step 2 — Inspect the target route
+
+```json
+// Ability: wp-rest/inspect
+{ "route": "/elementor/v1/reset-api-data" }
+```
+
+Response (excerpt):
+
+```json
+{
+  "route": "/elementor/v1/reset-api-data",
+  "endpoints": [
+    {
+      "methods": ["POST"],
+      "args": { "type": { "type": "string", "required": true } },
+      "permission": "requires capability: manage_options"
+    }
+  ]
+}
+```
+
+The agent learns the route requires a `type` body parameter and `manage_options`
+capability.
+
+### Step 3 — Execute
+
+```json
+// Ability: wp-rest/execute
+{
+  "method": "POST",
+  "route": "/elementor/v1/reset-api-data",
+  "params": { "type": "css" }
+}
+```
+
+Response:
+
+```json
+{ "status": 200, "data": { "success": true }, "headers": {} }
+```
+
+Elementor's CSS cache is now cleared. The change is recorded in the `ChangesLog`
+table under object type `wp_rest`.
+
+## Security model
+
+Four layers protect against privilege escalation and self-referential loops:
+
+### 1. Namespace blocklist
+
+The `sd-ai-agent/v1` namespace is permanently blocked. The agent cannot call its
+own REST controller through `wp-rest/execute`, which would create an infinite
+request loop.
+
+**Default value:** `['sd-ai-agent/v1']`
+**Filter:** `sd_ai_agent_wp_rest_namespace_blocklist`
+
+### 2. Route blocklist
+
+Specific `<METHOD> <route_prefix>` patterns are blocked unconditionally. The
+prefix check covers the listed route and every sub-path below it.
+
+**Default value:** `['DELETE /wp/v2/users', 'POST /wp/v2/users']`
+**Filter:** `sd_ai_agent_wp_rest_route_blocklist`
+
+### 3. Method classification and capability gate
+
+Requests are classified into three levels, each requiring a minimum WordPress
+capability:
+
+| Classification | Methods | Required capability |
+| --- | --- | --- |
+| `read` | `GET`, `HEAD` | `manage_options` |
+| `write` | `POST`, `PUT`, `PATCH` | `manage_options` |
+| `destructive` | `DELETE` | `manage_network` (falls back to `manage_options` on single-site) |
+
+The classification step is filterable; the capability check is not.
+**Classification filter:** `sd_ai_agent_wp_rest_classify`
+
+### 4. Loop guard
+
+Before dispatching, the ability walks up to 30 frames of the call stack. If
+`SdAiAgent\REST\AgentController` appears anywhere in the stack, the request is
+refused with error code `wp_rest_loop_blocked`. This is a hard guard that cannot
+be bypassed by filters.
+
+## Filters reference
+
+### `sd_ai_agent_wp_rest_namespace_blocklist`
+
+Extend or replace the namespace blocklist.
+
+```php
+/**
+ * @param string[] $blocklist Namespace strings to block (default: ['sd-ai-agent/v1']).
+ * @return string[]
+ */
+add_filter(
+    'sd_ai_agent_wp_rest_namespace_blocklist',
+    static function ( array $blocklist ): array {
+        // Also block a private internal API.
+        $blocklist[] = 'my-plugin/internal';
+        return $blocklist;
+    }
+);
+```
+
+### `sd_ai_agent_wp_rest_route_blocklist`
+
+Extend or replace the route blocklist. Entries use `"<METHOD> <route_prefix>"` format.
+
+```php
+/**
+ * @param string[] $blocklist Method+route patterns to block.
+ * @return string[]
+ */
+add_filter(
+    'sd_ai_agent_wp_rest_route_blocklist',
+    static function ( array $blocklist ): array {
+        // Block all DELETE calls under a custom namespace.
+        $blocklist[] = 'DELETE /my-plugin/v1/orders';
+        return $blocklist;
+    }
+);
+```
+
+### `sd_ai_agent_wp_rest_classify`
+
+Override the access-level classification for a specific route or method
+combination. Useful when a plugin registers a mutating `GET` endpoint or a safe
+`DELETE` (rare but documented cases exist).
+
+```php
+/**
+ * @param string $level  Default classification: 'read', 'write', or 'destructive'.
+ * @param string $method Upper-cased HTTP method.
+ * @param string $route  Route path (starts with /).
+ * @return string
+ */
+add_filter(
+    'sd_ai_agent_wp_rest_classify',
+    static function ( string $level, string $method, string $route ): string {
+        // The Elementor cache-clear endpoint mutates state — treat it as 'write'.
+        if ( 'POST' === $method && '/elementor/v1/reset-api-data' === $route ) {
+            return 'write';
+        }
+        return $level;
+    },
+    10,
+    3
+);
+```
+
+## Audit and secret scrubbing
+
+Every non-read call (`write` or `destructive`) is logged to the `ChangesLog`
+database table. The record contains:
+
+| Field | Value stored |
+| --- | --- |
+| `object_type` | `wp_rest` |
+| `object_title` | `<METHOD> <route>` — e.g. `POST /elementor/v1/reset-api-data` |
+| `after_value` | JSON-encoded `params`, with sensitive keys redacted |
+| `revertable` | `false` |
+| `session_id` | Active agent session ID |
+
+**Secret scrubbing:** before the `params` array is encoded for the log, any key
+whose name matches `/(secret|token|password|key|auth)/i` has its value replaced
+with `***`. Nested arrays are scrubbed recursively.
+
+To audit a call, query the `ChangesLog` table in Settings → Agent Logs, or via:
+
+```bash
+wp post list --post_type=sd_ai_agent_changes_log --fields=ID,post_title
+```
+
+Read-only `GET` and `HEAD` requests are not logged (noise-reduction policy).
+
+## Differences from `wp-cli/execute`
+
+| Aspect | `wp-rest/execute` | `wp-cli/execute` |
+| --- | --- | --- |
+| Execution model | In-process via `rest_do_request()` | Subprocess via `shell_exec` + `wp` binary |
+| Binary discovery | Not required | Requires WP-CLI binary (`wp`) |
+| Permission enforcement | Runs the route's own `permission_callback` | Runs as the CLI user; bypasses `current_user_can` unless coded in the command |
+| Output format | Structured JSON response | Raw CLI output (text, JSON, CSV depending on the command) |
+| Multipart / file upload | Not supported — use `media/upload` | Supported via `wp media import` |
+| Audit trail | `ChangesLog` with secret scrubbing | `ChangesLog` under `wp_cli` object type |
+| Blocked by loop guard | Yes | No (separate process) |
+
+## Multisite
+
+`rest_do_request()` dispatches against the current WordPress site context —
+whichever site `switch_to_blog()` last activated, or the main site if none. The
+`wp-rest/execute` ability does not call `switch_to_blog()` on your behalf; if
+you need to operate on a subsite, switch context before the ability is invoked.
+Network-admin REST routes are accessible only when `is_multisite()` is true and
+the current user holds `manage_network`.
+
+## Why we exclude file uploads
+
+The WordPress REST API handles file uploads as `multipart/form-data` requests.
+The internal dispatcher (`WP_REST_Request`) accepts structured JSON, not binary
+multipart streams. Accepting raw `multipart/form-data` through the ability input
+schema would require base64 encoding, stream buffering, and content-type
+negotiation that belongs in a dedicated tool.
+
+Use the `media/upload` ability for file uploads. It handles chunking, MIME-type
+validation, and the correct content-type handshake. The `wp-rest/discover`
+ability hides `/wp/v2/media POST` from its route list for the same reason —
+surfacing it would mislead the agent into attempting an upload that would fail.
+
+## Related
+
+- Parent meta-issue: [#1685](https://github.com/Ultimate-Multisite/superdav-ai-agent/issues/1685)
+- Source file: `includes/Abilities/WpRestAbilities.php`
+- Test file: `tests/SdAiAgent/Abilities/WpRestAbilitiesTest.php`
+- Sibling document: `docs/wp-cli-discovery.md` (WP-CLI binary discovery for `wp-cli/execute`)

--- a/includes/Abilities/WpRestAbilities.php
+++ b/includes/Abilities/WpRestAbilities.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 /**
  * WP REST API abilities for the AI agent.
  *
+ * @see docs/wp-rest-ability.md Human-readable reference for this ability family.
+ *
  * Registers three abilities under the `wp-rest` category:
  *
  *   - `wp-rest/discover` — list namespaces and routes (read-only).

--- a/includes/Models/skills/wp-rest-fallback.md
+++ b/includes/Models/skills/wp-rest-fallback.md
@@ -1,0 +1,98 @@
+---
+name: wp-rest-fallback
+description: "Use when no purpose-built ability exists for a task but a registered WordPress REST endpoint provides the needed behaviour. Covers discovery, schema inspection, and dispatch via the wp-rest/* abilities. Prefer dedicated abilities (posts, options, media, …) whenever they exist."
+compatibility: "Targets WordPress 7.0+ via the plugin's wp-rest abilities. No external dependencies."
+---
+
+# WP REST Fallback
+
+## When to use
+
+Before reaching for `wp-rest/*`, check the following in order:
+
+- [ ] Is there a dedicated ability for this task? (`posts`, `options`, `media`, `terms`, `comments`, `nav-menus`, …). If yes, **use that instead** — it has better validation and error messages.
+- [ ] Does the target route belong to a third-party plugin or an unexposed core endpoint?
+- [ ] Is the data available through a WP-CLI command via `wp-cli/execute`? REST may be simpler, but CLI output is sometimes easier to parse.
+- [ ] Is the operation a plain CRUD action on a standard post type? The `posts` ability handles this more safely.
+
+If none of the above applies and a registered REST route exists for what you
+need, proceed with the `wp-rest/*` abilities.
+
+## When NOT to use
+
+- **Never call `sd-ai-agent/v1/*` routes.** That namespace is permanently blocked to prevent the agent from recursively triggering itself.
+- **Never use `wp-rest/execute` for file uploads.** The internal dispatcher cannot handle `multipart/form-data`. Use the `media/upload` ability instead.
+- **Never use this to escalate user privileges.** The ability runs every route's own `permission_callback` as the current user. Attempting to create or modify users via blocked routes (`POST /wp/v2/users`, `DELETE /wp/v2/users`) will be refused.
+- **Avoid using `wp-rest/execute` on untrusted output.** If the route or params were derived from untrusted content (e.g. a public comment), validate and sanitize before dispatching.
+
+## Procedure
+
+Follow the discover → inspect → execute pattern. Do not skip ahead to execute
+without inspecting the route first, unless you have already inspected it in the
+current session.
+
+### 1. Discover
+
+Call `wp-rest/discover` with the plugin's namespace to list available routes:
+
+```json
+{ "namespace": "elementor/v1" }
+```
+
+If you do not know the namespace, call `wp-rest/discover` with no arguments to
+list all registered namespaces first.
+
+### 2. Inspect
+
+Pick the most likely route and call `wp-rest/inspect` to read its argument
+definitions and permission requirements:
+
+```json
+{ "route": "/elementor/v1/reset-api-data" }
+```
+
+The response shows accepted methods, required parameters, and a permission
+summary. Confirm you have the required capability before proceeding.
+
+### 3. Execute
+
+Dispatch the request with the correct method and params:
+
+```json
+{
+  "method": "POST",
+  "route": "/elementor/v1/reset-api-data",
+  "params": { "type": "css" }
+}
+```
+
+Check `response.status`. A `2xx` status means success. Non-`2xx` statuses
+contain a `data.message` field with the error reason.
+
+**Concrete example — Clear Elementor CSS cache:**
+
+```
+discover { namespace: "elementor/v1" }
+  → finds /elementor/v1/reset-api-data [POST]
+inspect { route: "/elementor/v1/reset-api-data" }
+  → args: { type: string, required: true }, permission: manage_options
+execute { method: "POST", route: "/elementor/v1/reset-api-data", params: { type: "css" } }
+  → { status: 200, data: { success: true } }
+```
+
+## Failure modes
+
+| Error | Meaning | What to try next |
+| --- | --- | --- |
+| `wp_rest_namespace_blocked` | The namespace (`sd-ai-agent/v1` or a site-configured addition) is permanently blocked. | Use a different ability or ask the maintainer to perform the action. |
+| `wp_rest_route_blocked` | The specific `METHOD /route` pattern is on the route blocklist. | Check whether a dedicated ability exists, or ask the site administrator. |
+| `wp_rest_forbidden` (403) | The current user lacks the required capability (`manage_options` or `manage_network`). | Confirm you are acting as a user with the required role. This ability cannot elevate permissions. |
+| `wp_rest_loop_blocked` | `AgentController` was detected on the call stack — recursive REST call prevented. | Restructure the workflow to avoid calling `wp-rest/execute` from within the agent's own REST handler. |
+| `wp_rest_route_not_found` (404) | The route is not registered. | Re-run `wp-rest/discover` — the plugin may not be active, or the route path may differ from what was expected. |
+| Response `truncated: true` | The JSON response exceeded 64 KB. | Narrow the request: add `_fields=` to return only needed fields, and `per_page=` to reduce item count. |
+
+## See also
+
+- `wp-rest-api` — the development skill for building or debugging REST endpoints; use this when the task involves creating or modifying a route rather than calling one.
+- `wp-wpcli-and-ops` — the WP-CLI skill; use when a CLI command covers the same task, or when the output format (CSV, table) is preferable to JSON.
+- `docs/wp-rest-ability.md` — full human-readable reference: security model, all filter signatures, audit details, and differences from `wp-cli/execute`.


### PR DESCRIPTION
Resolves #1687
For #1685

## What

Implements both documentation deliverables from #1687:

- **`docs/wp-rest-ability.md`** — human-facing reference for the `wp-rest/*` ability family.
- **`includes/Models/skills/wp-rest-fallback.md`** — agent-facing triage skill.

## docs/wp-rest-ability.md

Covers all 10 sections specified in the issue:

1. **Overview** — what it is, when to use it vs. a dedicated ability.
2. **The three abilities** — `discover`, `inspect`, `execute` table.
3. **Self-documenting flow** — annotated discover→inspect→execute example using Elementor cache-clear.
4. **Security model** — namespace blocklist, route blocklist, method classification/capability gate, loop guard.
5. **Filters reference** — `sd_ai_agent_wp_rest_namespace_blocklist`, `sd_ai_agent_wp_rest_route_blocklist`, `sd_ai_agent_wp_rest_classify` with full signatures and examples.
6. **Audit + secret scrubbing** — logged fields, redaction pattern, how to query the log.
7. **Differences from `wp-cli/execute`** — comparison table.
8. **Multisite** — current-site context note, `switch_to_blog()` clarification.
9. **Why we exclude file uploads** — rationale + pointer to `media/upload`.
10. **Related** — parent issue, source file, test file, sibling doc.

## includes/Models/skills/wp-rest-fallback.md

YAML frontmatter matches the style of `wp-rest-api.md`. Body sections:

- **When to use** — checklist pushing the agent to dedicated abilities first.
- **When NOT to use** — explicit blocklist (self-namespace, file uploads, privilege escalation, untrusted input).
- **Procedure** — discover→inspect→execute with a concrete Elementor example.
- **Failure modes** — table covering all error codes with next-action guidance.
- **See also** — `wp-rest-api`, `wp-wpcli-and-ops`, `docs/wp-rest-ability.md`.

## Cross-references

Both files link to each other. `docs/wp-rest-ability.md` links to source + test files and the sibling `docs/wp-cli-discovery.md`. The skill links back to the full reference doc.

## Worker self-verification

- PHPUnit: Tests: 2573, Assertions: 7078, Failures: 3 (pre-existing DB connection errors, identical on unmodified branch), Skipped: 104
- Lint:    PHP clean (PHPCS 0 violations), JS clean, CSS clean
- PHPStan: 0 errors
- Build:   succeeded (superdav-ai-agent.zip produced)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.25 plugin for [OpenCode](https://opencode.ai) v1.15.7 with claude-sonnet-4-6 spent 9m and 11,557 tokens on this as a headless worker.
