### PR TITLE
chore: remove beads/bd integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,49 +238,27 @@ wp plugin deactivate $(basename $PWD) # deactivate
 wp db reset --yes && cd ../wordpress && ./reset.sh  # full reset
 ```
 
-<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
-## Beads Issue Tracker
-
-This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
-
-### Quick Reference
-
-```bash
-bd ready              # Find available work
-bd show <id>          # View issue details
-bd update <id> --claim  # Claim work
-bd close <id>         # Complete work
-```
-
-### Rules
-
-- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
-- Run `bd prime` for detailed command reference and session close protocol
-- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
-
 ## Session Completion
 
 **When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
 
 **MANDATORY WORKFLOW:**
 
-1. **File issues for remaining work** - Create issues for anything that needs follow-up
+1. **File issues for remaining work** - Create GitHub issues for anything that needs follow-up
 2. **Run quality gates** (if code changed) - Tests, linters, builds
-3. **Update issue status** - Close finished work, update in-progress items
-4. **PUSH TO REMOTE** - This is MANDATORY:
+3. **PUSH TO REMOTE** - This is MANDATORY:
    ```bash
    git pull --rebase
-   bd dolt push
    git push
    git status  # MUST show "up to date with origin"
    ```
-5. **Clean up** - Clear stashes, prune remote branches
-6. **Verify** - All changes committed AND pushed
-7. **Hand off** - Provide context for next session
+4. **Clean up** - Clear stashes, prune remote branches
+5. **Verify** - All changes committed AND pushed
+6. **Hand off** - Provide context for next session
 
 **CRITICAL RULES:**
 - Work is NOT complete until `git push` succeeds
 - NEVER stop before pushing - that leaves work stranded locally
 - NEVER say "ready to push when you are" - YOU must push
 - If push fails, resolve and retry until it succeeds
-<!-- END BEADS INTEGRATION -->
+- Do NOT use `bd`, `beads`, or any local issue tracker — use GitHub issues directly

--- a/todo/PLANS.md
+++ b/todo/PLANS.md
@@ -5,7 +5,7 @@
 
 Complex, multi-session work requiring research, design decisions, and detailed tracking.
 
-Based on [OpenAI's PLANS.md](https://cookbook.openai.com/articles/codex_exec_plans) with TOON-enhanced parsing and [Beads](https://github.com/steveyegge/beads) integration for dependency visualization.
+Based on [OpenAI's PLANS.md](https://cookbook.openai.com/articles/codex_exec_plans) with TOON-enhanced parsing for dependency visualization.
 
 <!--TOON:meta{version,format,updated}:
 1.0,plans-md+toon,2026-05-20
@@ -270,8 +270,7 @@ Tasks:
 **Goal:** The agent can execute a multi-step site build from a single prompt,
 using all available abilities (built-in + discovered from plugins).
 
-**Status (2026-05-13):** Obsolete. Site Builder mode was removed in beads
-`sd-ai-dh0`. Onboarding now consolidates into the Setup Assistant agent
+**Status (2026-05-13):** Obsolete. Site Builder mode was removed (sd-ai-dh0). Onboarding now consolidates into the Setup Assistant agent
 (`Models/Agent::ONBOARDING_AGENT_SLUG`); its stored system prompt drives the
 discovery flow. Multi-step orchestration is now an Agent-driven concern, not
 a dedicated builder mode. If a future task revives orchestrated builds, it


### PR DESCRIPTION
## Summary

Removes all beads (bd) integration following the 2026-05-21 incident where bd github sync bulk-created 80 duplicate GitHub issues (#1605-#1684, all since closed).

## Changes

- `AGENTS.md`: Remove the entire BEADS INTEGRATION block. Update Session Completion to use GitHub issues directly. Add explicit prohibition: "Do NOT use bd, beads, or any local issue tracker."
- `todo/PLANS.md`: Remove Beads dependency visualization reference from header.

## Infrastructure removed (outside git)

- bd binary removed from /usr/local/bin/bd
- All .beads/ directories removed from 11 repos (archived to /tmp/opencode/beads-backup/)
- Beads git hooks uninstalled
- All 17 open beads issues closed with descriptive reasons

## Incident context

Root cause: bd github sync ran for the first time against a beads DB with 81 open issues that had no external_ref (GitHub issue number). It created new GitHub issues for all 81, most duplicating already-closed work tracked via the parallel issue-sync-helper.sh system. No other repos were affected.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.25 plugin for [OpenCode](https://opencode.ai) v1.15.7 with claude-haiku-4-5 spent 58m and 38 tokens on this as a headless worker.
