### PR TITLE
feat: t252 — Tier 3.9 server-side instructions addendum (per-site rule string)

### DIFF
--- a/includes/Admin/UnifiedAdminMenu.php
+++ b/includes/Admin/UnifiedAdminMenu.php
@@ -305,22 +305,22 @@ class UnifiedAdminMenu {
 			'sd-ai-agent-unified-admin',
 			'sdAiAgentData',
 			array(
-				'currentUserId'       => get_current_user_id(),
-				'currentUserName'     => $current_user->display_name,
-				'restNamespace'       => 'sd-ai-agent/v1',
-				'ajaxUrl'             => admin_url( 'admin-ajax.php' ),
-				'nonce'               => wp_create_nonce( 'wp_rest' ),
-				'initialRoute'        => self::getCurrentRoute(),
-				'menuItems'           => self::getMenuItems(),
-				'connectorsUrl'       => self::getConnectorsUrl(),
-				'connectorsAvailable' => self::hasNativeConnectorsPage() || self::hasGutenbergConnectorsPage() ? '1' : '',
-				'onboarding_complete' => \SdAiAgent\Core\OnboardingManager::is_complete(),
+				'currentUserId'        => get_current_user_id(),
+				'currentUserName'      => $current_user->display_name,
+				'restNamespace'        => 'sd-ai-agent/v1',
+				'ajaxUrl'              => admin_url( 'admin-ajax.php' ),
+				'nonce'                => wp_create_nonce( 'wp_rest' ),
+				'initialRoute'         => self::getCurrentRoute(),
+				'menuItems'            => self::getMenuItems(),
+				'connectorsUrl'        => self::getConnectorsUrl(),
+				'connectorsAvailable'  => self::hasNativeConnectorsPage() || self::hasGutenbergConnectorsPage() ? '1' : '',
+				'onboarding_complete'  => \SdAiAgent\Core\OnboardingManager::is_complete(),
 				// Provider trace is a debug-only feature. The JS settings page reads
 				// this flag to show or hide the Provider Trace tab.
-				'wpDebug'             => defined( 'WP_DEBUG' ) && WP_DEBUG ? '1' : '',
+				'wpDebug'              => defined( 'WP_DEBUG' ) && WP_DEBUG ? '1' : '',
 				// Feature flags — mirrors Features::all() so JS can gate UI sections
 				// without waiting for the /settings REST response.
-				'features'            => Features::all(),
+				'features'             => Features::all(),
 				// Instructions addendum data for the Settings UI.
 				'instructionsAddendum' => array(
 					'value'      => InstructionsAddendum::get_addendum(),

--- a/includes/Admin/UnifiedAdminMenu.php
+++ b/includes/Admin/UnifiedAdminMenu.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Admin;
 
 use SdAiAgent\Core\Features;
+use SdAiAgent\Core\InstructionsAddendum;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -320,6 +321,13 @@ class UnifiedAdminMenu {
 				// Feature flags — mirrors Features::all() so JS can gate UI sections
 				// without waiting for the /settings REST response.
 				'features'            => Features::all(),
+				// Instructions addendum data for the Settings UI.
+				'instructionsAddendum' => array(
+					'value'      => InstructionsAddendum::get_addendum(),
+					'updated_at' => InstructionsAddendum::get_updated_at(),
+					'max_length' => InstructionsAddendum::MAX_LENGTH,
+					'endpoint'   => rest_url( 'sd-ai-agent/v1/instructions' ),
+				),
 			)
 		);
 	}

--- a/includes/Core/InstructionsAddendum.php
+++ b/includes/Core/InstructionsAddendum.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Per-site MCP server instructions addendum.
+ *
+ * Stores an admin-editable string that the MCP server appends to its baseline
+ * `serverInfo.instructions` at handshake time, letting a site encode style
+ * conventions — callout class names, code-block themes, heading hierarchy rules
+ * — once and have every connected MCP client receive them without re-discovery.
+ *
+ * The string supplements (does not replace) the existing Skills / Knowledge
+ * plane: those handle RAG-style lookup; this is a tiny always-on prefix.
+ *
+ * @package SdAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manages the per-site instructions addendum.
+ *
+ * All public-facing read paths sanitize on the way out (belt-and-braces) so
+ * options written outside our sanitize_callback (direct update_option call,
+ * database restore from an older schema, etc.) are still safe.
+ */
+final class InstructionsAddendum {
+
+	/**
+	 * WP option key.
+	 *
+	 * Public read via the REST endpoint by design — the value reaches every
+	 * connected MCP client at handshake. Admins MUST NOT put secrets in this
+	 * field; UI copy warns about this.
+	 */
+	const OPTION_KEY = 'sd_ai_agent_instructions';
+
+	/**
+	 * Companion option tracking the last update timestamp (unix seconds).
+	 *
+	 * Stored separately so REST callers can distinguish "never set" (0) from
+	 * "explicitly cleared" (>0, empty addendum), and so a wipe-on-empty save
+	 * still emits a fresh timestamp.
+	 */
+	const UPDATED_AT_OPTION = 'sd_ai_agent_instructions_updated_at';
+
+	/**
+	 * Maximum allowed length, counted in UTF-8 characters (not bytes).
+	 *
+	 * Hard-enforced on save and again on REST-read as defense in depth.
+	 * All checks/truncations use mb_strlen / mb_substr with 'UTF-8' so
+	 * emoji, CJK, and accented Latin are not split mid-codepoint.
+	 *
+	 * Sized to ~500 tokens of English text — cheap enough to prepend to
+	 * every LLM session while fitting a useful style-rules list.
+	 */
+	const MAX_LENGTH = 2000;
+
+	/**
+	 * Rate-limit window for the public REST endpoint (requests per minute per
+	 * remote IP).
+	 *
+	 * Deters scraping without affecting legitimate clients, which cache at
+	 * max-age=60 and hit the endpoint once per session.
+	 */
+	const RATE_LIMIT_PER_MIN = 30;
+
+	/**
+	 * Return the stored addendum, sanitized at read time as belt-and-braces.
+	 *
+	 * @return string Empty string when no addendum is set.
+	 */
+	public static function get_addendum(): string {
+		$raw = (string) get_option( self::OPTION_KEY, '' );
+		if ( '' === $raw ) {
+			return '';
+		}
+		return self::sanitize( $raw );
+	}
+
+	/**
+	 * Return the timestamp (unix seconds) of the last successful save.
+	 *
+	 * Zero when no value has ever been saved.
+	 *
+	 * @return int
+	 */
+	public static function get_updated_at(): int {
+		return (int) get_option( self::UPDATED_AT_OPTION, 0 );
+	}
+
+	/**
+	 * Save the addendum. Sanitizes input, enforces length cap, updates the
+	 * companion timestamp.
+	 *
+	 * @param mixed $value Raw input.
+	 *
+	 * @return true|\WP_Error True on success; WP_Error('addendum_too_long')
+	 *                        when input exceeds MAX_LENGTH after sanitize.
+	 */
+	public static function set_addendum( $value ) {
+		$clean = self::sanitize( $value );
+
+		// Length check fires after sanitize so HTML stripping doesn't
+		// accidentally push a 1990-char input over the limit; the 2000-char
+		// budget is the post-sanitize character count that reaches clients.
+		if ( mb_strlen( $clean, 'UTF-8' ) > self::MAX_LENGTH ) {
+			return new \WP_Error(
+				'addendum_too_long',
+				sprintf(
+					/* translators: 1: max length, 2: submitted length */
+					__( 'Instructions addendum is too long: %2$d characters (max %1$d).', 'superdav-ai-agent' ),
+					self::MAX_LENGTH,
+					mb_strlen( $clean, 'UTF-8' )
+				),
+				array( 'status' => 400 )
+			);
+		}
+
+		update_option( self::OPTION_KEY, $clean, false );
+		update_option( self::UPDATED_AT_OPTION, time(), false );
+		return true;
+	}
+
+	/**
+	 * Sanitize an addendum value.
+	 *
+	 * Strips HTML tags, PHP, WordPress shortcodes, and ASCII C0/C1 control
+	 * characters (preserving \t, \n, \r for markdown indentation and bullet
+	 * lists). Normalizes CRLF/CR to LF. Truncates to MAX_LENGTH.
+	 *
+	 * What this does NOT do:
+	 * - Render markdown. Output is sent verbatim to MCP clients.
+	 * - Strip Unicode control characters beyond ASCII C0/C1 ranges (Bidi
+	 *   marks, zero-width chars). The TypeScript MCP client does an
+	 *   additional pass for those where they have higher injection signal.
+	 *
+	 * @param mixed $value Raw input.
+	 *
+	 * @return string Sanitized string (may be empty).
+	 */
+	public static function sanitize( $value ): string {
+		if ( is_array( $value ) || is_object( $value ) ) {
+			return '';
+		}
+		$str = (string) $value;
+		if ( '' === $str ) {
+			return '';
+		}
+
+		// Strip HTML/PHP tags. wp_strip_all_tags( $str, false ) does NOT
+		// collapse whitespace (second arg=true would; we override).
+		$str = wp_strip_all_tags( $str, false );
+
+		// Strip WordPress shortcodes — defence against pasting [do_something]
+		// and being surprised it doesn't execute (it can't, we never call
+		// do_shortcode() on this value, but stripping removes the question).
+		$str = strip_shortcodes( $str );
+
+		// Strip C0 control chars except \t (0x09), \n (0x0A), \r (0x0D).
+		// Also strips DEL (0x7F).
+		$str = (string) preg_replace( '/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/u', '', $str );
+
+		// Normalize CRLF / CR line endings to LF.
+		$str = str_replace( array( "\r\n", "\r" ), "\n", $str );
+
+		// Trim outer whitespace — leading/trailing newlines from a paste
+		// don't carry meaning and waste token budget.
+		$str = trim( $str );
+
+		// Length cap last so it operates on post-sanitize size. Use mb_*
+		// variants so truncation never lands inside a UTF-8 codepoint.
+		if ( mb_strlen( $str, 'UTF-8' ) > self::MAX_LENGTH ) {
+			$str = mb_substr( $str, 0, self::MAX_LENGTH, 'UTF-8' );
+		}
+
+		return $str;
+	}
+
+	/**
+	 * Sanitize callback for register_setting().
+	 *
+	 * Wraps sanitize() + length truncation for the Settings API on form submit.
+	 * Over-length input is silently truncated here (the Settings API has no
+	 * per-field WP_Error path; use add_settings_error() if needed).
+	 *
+	 * @param mixed $value Raw input from $_POST.
+	 *
+	 * @return string
+	 */
+	public static function sanitize_callback( $value ): string {
+		$clean = self::sanitize( $value );
+
+		// Touch the timestamp so REST consumers see the save even when the
+		// value itself didn't change (admin re-saving to refresh the ts).
+		update_option( self::UPDATED_AT_OPTION, time(), false );
+
+		return $clean;
+	}
+
+	/**
+	 * Check (and record) the per-IP rate limit for the public read endpoint.
+	 *
+	 * Uses a 60-second sliding-window transient keyed by a SHA-256 prefix of
+	 * the remote IP (PII minimization — raw IP never touches the options table).
+	 * Returns false when the request count within the last 60 s exceeds
+	 * RATE_LIMIT_PER_MIN; caller should respond 429.
+	 *
+	 * @param string $ip Remote IP (caller passes $_SERVER['REMOTE_ADDR']).
+	 *
+	 * @return bool True when the request is permitted; false when exhausted.
+	 */
+	public static function check_rate_limit( string $ip ): bool {
+		// Hash the IP to keep the transient key short and avoid storing PII.
+		$key = 'sd_ai_agent_instr_rl_' . substr( hash( 'sha256', $ip ), 0, 12 );
+
+		$now    = time();
+		$window = 60;
+		$bucket = get_transient( $key );
+		if ( ! is_array( $bucket ) ) {
+			$bucket = array();
+		}
+
+		// Drop entries outside the rolling window.
+		$bucket = array_values(
+			array_filter(
+				$bucket,
+				static function ( $ts ) use ( $now, $window ): bool {
+					return is_numeric( $ts ) && ( $now - (int) $ts ) < $window;
+				}
+			)
+		);
+
+		if ( count( $bucket ) >= self::RATE_LIMIT_PER_MIN ) {
+			return false;
+		}
+
+		$bucket[] = $now;
+		// Slightly longer TTL than the window so the bucket survives until
+		// every entry has aged out, even with no further requests.
+		set_transient( $key, $bucket, $window * 2 );
+		return true;
+	}
+}

--- a/includes/Core/InstructionsAddendum.php
+++ b/includes/Core/InstructionsAddendum.php
@@ -71,7 +71,8 @@ final class InstructionsAddendum {
 	const RATE_LIMIT_PER_MIN = 30;
 
 	/**
-	 * Return the stored addendum, sanitized at read time as belt-and-braces.
+	 * Return the stored addendum, sanitized and truncated at read time as
+	 * belt-and-braces (protects against options written outside our callbacks).
 	 *
 	 * @return string Empty string when no addendum is set.
 	 */
@@ -80,7 +81,7 @@ final class InstructionsAddendum {
 		if ( '' === $raw ) {
 			return '';
 		}
-		return self::sanitize( $raw );
+		return self::maybe_truncate( self::sanitize( $raw ) );
 	}
 
 	/**
@@ -132,7 +133,13 @@ final class InstructionsAddendum {
 	 *
 	 * Strips HTML tags, PHP, WordPress shortcodes, and ASCII C0/C1 control
 	 * characters (preserving \t, \n, \r for markdown indentation and bullet
-	 * lists). Normalizes CRLF/CR to LF. Truncates to MAX_LENGTH.
+	 * lists). Normalizes CRLF/CR to LF. Trims outer whitespace.
+	 *
+	 * Does NOT truncate to MAX_LENGTH — callers that need truncation (the
+	 * Settings API sanitize_callback and the belt-and-braces read path) apply
+	 * it themselves with self::maybe_truncate(). set_addendum() must see the
+	 * full post-sanitize length so it can return WP_Error('addendum_too_long')
+	 * rather than silently losing characters.
 	 *
 	 * What this does NOT do:
 	 * - Render markdown. Output is sent verbatim to MCP clients.
@@ -173,28 +180,40 @@ final class InstructionsAddendum {
 		// don't carry meaning and waste token budget.
 		$str = trim( $str );
 
-		// Length cap last so it operates on post-sanitize size. Use mb_*
-		// variants so truncation never lands inside a UTF-8 codepoint.
-		if ( mb_strlen( $str, 'UTF-8' ) > self::MAX_LENGTH ) {
-			$str = mb_substr( $str, 0, self::MAX_LENGTH, 'UTF-8' );
-		}
+		return $str;
+	}
 
+	/**
+	 * Truncate a sanitized string to MAX_LENGTH UTF-8 characters.
+	 *
+	 * Uses mb_substr so truncation never lands inside a multi-byte codepoint
+	 * sequence (emoji, CJK, accented Latin would otherwise produce a mojibake
+	 * tail that breaks downstream JSON parsers).
+	 *
+	 * @param string $str Post-sanitize string.
+	 *
+	 * @return string String at most MAX_LENGTH UTF-8 characters long.
+	 */
+	private static function maybe_truncate( string $str ): string {
+		if ( mb_strlen( $str, 'UTF-8' ) > self::MAX_LENGTH ) {
+			return mb_substr( $str, 0, self::MAX_LENGTH, 'UTF-8' );
+		}
 		return $str;
 	}
 
 	/**
 	 * Sanitize callback for register_setting().
 	 *
-	 * Wraps sanitize() + length truncation for the Settings API on form submit.
-	 * Over-length input is silently truncated here (the Settings API has no
-	 * per-field WP_Error path; use add_settings_error() if needed).
+	 * Wraps sanitize() + silent truncation for the Settings API on form submit.
+	 * Over-length input is silently truncated to MAX_LENGTH here (the Settings
+	 * API has no per-field WP_Error path without add_settings_error()).
 	 *
 	 * @param mixed $value Raw input from $_POST.
 	 *
 	 * @return string
 	 */
 	public static function sanitize_callback( $value ): string {
-		$clean = self::sanitize( $value );
+		$clean = self::maybe_truncate( self::sanitize( $value ) );
 
 		// Touch the timestamp so REST consumers see the save even when the
 		// value itself didn't change (admin re-saving to refresh the ts).

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -51,6 +51,7 @@ use SdAiAgent\REST\ConnectorsController;
 use SdAiAgent\REST\ChangesController;
 use SdAiAgent\REST\FeedbackController;
 use SdAiAgent\REST\KnowledgeController;
+use SdAiAgent\REST\InstructionsController;
 use SdAiAgent\REST\McpController;
 use SdAiAgent\REST\MemoryController;
 use SdAiAgent\REST\RestController;
@@ -110,6 +111,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		BlockValidatorController::class,
 		FeedbackController::class,
 		TraceController::class,
+		InstructionsController::class,
 		McpController::class,
 		RestController::class,
 		ToolController::class,

--- a/includes/REST/InstructionsController.php
+++ b/includes/REST/InstructionsController.php
@@ -89,7 +89,8 @@ final class InstructionsController {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function handle_get( WP_REST_Request $request ) {
-		$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? (string) $_SERVER['REMOTE_ADDR'] : ''; // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+		$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( (string) $_SERVER['REMOTE_ADDR'] ) ) : '';
 
 		if ( '' !== $ip && ! InstructionsAddendum::check_rate_limit( $ip ) ) {
 			return new WP_Error(

--- a/includes/REST/InstructionsController.php
+++ b/includes/REST/InstructionsController.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * REST controller for the per-site instructions addendum.
+ *
+ * Exposes two routes:
+ *
+ *   GET  /wp-json/sd-ai-agent/v1/instructions
+ *     Public, rate-limited per IP (30 req/min), cached max-age=60.
+ *     Returns { addendum: string, updated_at: int }.
+ *
+ *   POST /wp-json/sd-ai-agent/v1/instructions
+ *     Authenticated (manage_options). Saves or clears the addendum.
+ *     Accepts { addendum: string }.
+ *
+ * @package SdAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\REST;
+
+use SdAiAgent\Core\InstructionsAddendum;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Manages the instructions addendum REST endpoints.
+ */
+#[Handler(
+	container: 'sd-ai-agent',
+	context: Handler::CTX_REST,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class InstructionsController {
+
+	use PermissionTrait;
+
+	/**
+	 * Register REST routes.
+	 */
+	#[Action( tag: 'rest_api_init', priority: 10 )]
+	public function register_routes(): void {
+
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/instructions',
+			array(
+				// GET — public, rate-limited.
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'handle_get' ),
+					'permission_callback' => '__return_true',
+				),
+				// POST — authenticated save.
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'handle_post' ),
+					'permission_callback' => array( $this, 'check_permission' ),
+					'args'                => array(
+						'addendum' => array(
+							'required'          => true,
+							'type'              => 'string',
+							'sanitize_callback' => static fn( $v ) => (string) $v,
+							'description'       => __( 'Per-site instructions addendum (max 2000 UTF-8 chars).', 'superdav-ai-agent' ),
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Handle GET /instructions.
+	 *
+	 * Public endpoint, rate-limited 30 req/min per IP. Returns the current
+	 * addendum and its companion timestamp with Cache-Control: public, max-age=60.
+	 *
+	 * @param WP_REST_Request $request Incoming REST request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function handle_get( WP_REST_Request $request ) {
+		$ip = isset( $_SERVER['REMOTE_ADDR'] ) ? (string) $_SERVER['REMOTE_ADDR'] : ''; // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders
+
+		if ( '' !== $ip && ! InstructionsAddendum::check_rate_limit( $ip ) ) {
+			return new WP_Error(
+				'rate_limit_exceeded',
+				__( 'Too many requests. Please wait before trying again.', 'superdav-ai-agent' ),
+				array( 'status' => 429 )
+			);
+		}
+
+		$response = new WP_REST_Response(
+			array(
+				'addendum'   => InstructionsAddendum::get_addendum(),
+				'updated_at' => InstructionsAddendum::get_updated_at(),
+			),
+			200
+		);
+
+		$response->header( 'Cache-Control', 'public, max-age=60' );
+
+		return $response;
+	}
+
+	/**
+	 * Handle POST /instructions.
+	 *
+	 * Authenticated endpoint (manage_options). Saves or clears the addendum.
+	 * Returns the persisted addendum and updated timestamp.
+	 *
+	 * @param WP_REST_Request $request Incoming REST request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function handle_post( WP_REST_Request $request ) {
+		$value  = $request->get_param( 'addendum' );
+		$result = InstructionsAddendum::set_addendum( $value );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return new WP_REST_Response(
+			array(
+				'addendum'   => InstructionsAddendum::get_addendum(),
+				'updated_at' => InstructionsAddendum::get_updated_at(),
+			),
+			200
+		);
+	}
+}

--- a/includes/REST/McpController.php
+++ b/includes/REST/McpController.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace SdAiAgent\REST;
 
 use SdAiAgent\Core\AbilityVisibility;
+use SdAiAgent\Core\InstructionsAddendum;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -61,6 +62,15 @@ final class McpController extends XWP_REST_Controller {
 	}
 
 	/**
+	 * Baseline instructions string prepended to every MCP handshake response.
+	 *
+	 * Describes the server's capabilities and conventions at a high level.
+	 * The per-site instructions addendum (InstructionsAddendum::get_addendum())
+	 * is appended after this baseline at handshake time.
+	 */
+	const BASELINE_INSTRUCTIONS = 'This is the Superdav AI Agent MCP server. It exposes WordPress site capabilities as MCP tools. Use list_tools to discover available tools, then call_tool to invoke them.';
+
+	/**
 	 * Dispatch an MCP request to the appropriate handler.
 	 *
 	 * @param WP_REST_Request $request The REST request.
@@ -82,6 +92,9 @@ final class McpController extends XWP_REST_Controller {
 		/** @var array<string, mixed> $params */
 
 		switch ( $method ) {
+			case 'initialize':
+				return self::handle_initialize();
+
 			case 'list_tools':
 				return self::handle_list_tools();
 
@@ -93,7 +106,7 @@ final class McpController extends XWP_REST_Controller {
 					'ai_agent_mcp_unknown_method',
 					sprintf(
 						/* translators: %s: MCP method name */
-						__( 'Unknown MCP method: %s. Supported methods: list_tools, call_tool.', 'superdav-ai-agent' ),
+						__( 'Unknown MCP method: %s. Supported methods: initialize, list_tools, call_tool.', 'superdav-ai-agent' ),
 						// @phpstan-ignore-next-line
 						$method
 					),
@@ -120,6 +133,40 @@ final class McpController extends XWP_REST_Controller {
 				'type'     => 'object',
 				'default'  => array(),
 			),
+		);
+	}
+
+	/**
+	 * Handle the initialize MCP method (handshake).
+	 *
+	 * Returns serverInfo.instructions composed from the baseline constant
+	 * plus the admin-configured per-site addendum (empty string when none
+	 * has been set). The addendum is appended with a blank-line separator so
+	 * MCP clients can parse it as a distinct section.
+	 *
+	 * @return WP_REST_Response
+	 */
+	private static function handle_initialize(): WP_REST_Response {
+		$baseline = self::BASELINE_INSTRUCTIONS;
+		$addendum = InstructionsAddendum::get_addendum();
+
+		$instructions = '' !== $addendum
+			? $baseline . "\n\n" . $addendum
+			: $baseline;
+
+		return new WP_REST_Response(
+			[
+				'protocol_version' => self::MCP_PROTOCOL_VERSION,
+				'server_info'      => [
+					'name'         => 'superdav-ai-agent',
+					'version'      => defined( 'SD_AI_AGENT_VERSION' ) ? (string) constant( 'SD_AI_AGENT_VERSION' ) : '',
+					'instructions' => $instructions,
+				],
+				'capabilities'     => [
+					'tools' => new \stdClass(),
+				],
+			],
+			200
 		);
 	}
 

--- a/tests/SdAiAgent/Core/InstructionsAddendumTest.php
+++ b/tests/SdAiAgent/Core/InstructionsAddendumTest.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Test case for InstructionsAddendum class.
+ *
+ * Coverage:
+ *   - get_addendum() returns empty string by default.
+ *   - set_addendum() persists value and updates timestamp.
+ *   - set_addendum() clears value on empty string but still bumps timestamp.
+ *   - set_addendum() returns WP_Error('addendum_too_long') for input > MAX_LENGTH.
+ *   - sanitize() strips HTML, shortcodes, and C0 control characters.
+ *   - sanitize() preserves \t and \n (markdown whitespace).
+ *   - sanitize() normalizes CRLF/CR to LF.
+ *   - sanitize() truncates at MAX_LENGTH (UTF-8 character-safe, not byte-safe).
+ *   - sanitize() handles multi-byte characters (emoji, CJK, accented Latin).
+ *   - sanitize_callback() silently truncates over-length input.
+ *   - check_rate_limit() permits requests within RATE_LIMIT_PER_MIN.
+ *   - check_rate_limit() blocks when limit is exceeded.
+ *   - check_rate_limit() isolates buckets by IP.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests\Core
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\InstructionsAddendum;
+use WP_UnitTestCase;
+
+/**
+ * Test InstructionsAddendum functionality.
+ */
+class InstructionsAddendumTest extends WP_UnitTestCase {
+
+	/**
+	 * Clean up options and transients after each test.
+	 */
+	public function tear_down(): void {
+		parent::tear_down();
+		delete_option( InstructionsAddendum::OPTION_KEY );
+		delete_option( InstructionsAddendum::UPDATED_AT_OPTION );
+		// Clear any rate-limit transients created during tests.
+		// We cannot know the exact keys (they use a hash of the IP), so
+		// we rely on set_transient() + WordPress test cleanup.
+	}
+
+	// -----------------------------------------------------------------------
+	// get_addendum / set_addendum
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Default value is empty string before any save.
+	 */
+	public function test_get_addendum_returns_empty_string_by_default(): void {
+		$this->assertSame( '', InstructionsAddendum::get_addendum() );
+	}
+
+	/**
+	 * Saving a value persists it and can be retrieved.
+	 */
+	public function test_set_and_get_addendum_round_trip(): void {
+		$value = "Use class `is-style-info` for callouts.\nHeadings start at H2.";
+		$result = InstructionsAddendum::set_addendum( $value );
+		$this->assertTrue( $result );
+		$this->assertSame( $value, InstructionsAddendum::get_addendum() );
+	}
+
+	/**
+	 * Saving bumps the timestamp companion option.
+	 */
+	public function test_set_addendum_updates_timestamp(): void {
+		$before = time();
+		InstructionsAddendum::set_addendum( 'Hello.' );
+		$after = time();
+
+		$ts = InstructionsAddendum::get_updated_at();
+		$this->assertGreaterThanOrEqual( $before, $ts );
+		$this->assertLessThanOrEqual( $after, $ts );
+	}
+
+	/**
+	 * Saving an empty string clears the value but still bumps the timestamp.
+	 */
+	public function test_set_addendum_empty_clears_value_and_bumps_timestamp(): void {
+		InstructionsAddendum::set_addendum( 'Initial value.' );
+
+		$ts_before = InstructionsAddendum::get_updated_at();
+		// Sleep 1s so the timestamp can change.
+		sleep( 1 );
+
+		$result = InstructionsAddendum::set_addendum( '' );
+		$this->assertTrue( $result );
+		$this->assertSame( '', InstructionsAddendum::get_addendum() );
+		$this->assertGreaterThan( $ts_before, InstructionsAddendum::get_updated_at() );
+	}
+
+	/**
+	 * Over-length input returns WP_Error('addendum_too_long').
+	 */
+	public function test_set_addendum_too_long_returns_wp_error(): void {
+		// Build a string of MAX_LENGTH + 1 plain ASCII characters.
+		$value  = str_repeat( 'x', InstructionsAddendum::MAX_LENGTH + 1 );
+		$result = InstructionsAddendum::set_addendum( $value );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'addendum_too_long', $result->get_error_code() );
+	}
+
+	/**
+	 * Exactly MAX_LENGTH characters are accepted.
+	 */
+	public function test_set_addendum_at_max_length_succeeds(): void {
+		$value  = str_repeat( 'a', InstructionsAddendum::MAX_LENGTH );
+		$result = InstructionsAddendum::set_addendum( $value );
+		$this->assertTrue( $result );
+	}
+
+	// -----------------------------------------------------------------------
+	// sanitize()
+	// -----------------------------------------------------------------------
+
+	/**
+	 * HTML tags are stripped.
+	 */
+	public function test_sanitize_strips_html(): void {
+		$input  = '<b>Bold</b> and <script>alert(1)</script> text.';
+		$result = InstructionsAddendum::sanitize( $input );
+		$this->assertStringNotContainsString( '<b>', $result );
+		$this->assertStringNotContainsString( '<script>', $result );
+		$this->assertStringContainsString( 'Bold', $result );
+		$this->assertStringContainsString( 'text.', $result );
+	}
+
+	/**
+	 * WordPress shortcodes are stripped.
+	 */
+	public function test_sanitize_strips_shortcodes(): void {
+		$input  = '[gallery id="1"] Some text [/gallery].';
+		$result = InstructionsAddendum::sanitize( $input );
+		$this->assertStringNotContainsString( '[gallery', $result );
+		$this->assertStringContainsString( 'Some text', $result );
+	}
+
+	/**
+	 * C0 control characters (except \t, \n, \r) are stripped.
+	 */
+	public function test_sanitize_strips_c0_control_characters(): void {
+		// NUL, BEL, SOH — should be removed.
+		$input  = "Before\x00\x07\x01After";
+		$result = InstructionsAddendum::sanitize( $input );
+		$this->assertSame( 'BeforeAfter', $result );
+	}
+
+	/**
+	 * Tabs and newlines are preserved (needed for markdown indentation).
+	 */
+	public function test_sanitize_preserves_tab_and_newline(): void {
+		$input  = "Line one\n\tIndented line\n";
+		$result = InstructionsAddendum::sanitize( $input );
+		$this->assertStringContainsString( "\n", $result );
+		$this->assertStringContainsString( "\t", $result );
+	}
+
+	/**
+	 * CRLF line endings are normalized to LF.
+	 */
+	public function test_sanitize_normalizes_crlf_to_lf(): void {
+		$input  = "Line one\r\nLine two\r";
+		$result = InstructionsAddendum::sanitize( $input );
+		$this->assertStringNotContainsString( "\r", $result );
+		$this->assertStringContainsString( "Line one\nLine two", $result );
+	}
+
+	/**
+	 * Input longer than MAX_LENGTH is truncated to exactly MAX_LENGTH chars.
+	 */
+	public function test_sanitize_truncates_to_max_length(): void {
+		$input  = str_repeat( 'a', InstructionsAddendum::MAX_LENGTH + 100 );
+		$result = InstructionsAddendum::sanitize( $input );
+		$this->assertSame( InstructionsAddendum::MAX_LENGTH, mb_strlen( $result, 'UTF-8' ) );
+	}
+
+	/**
+	 * Multi-byte truncation is codepoint-safe (does not split a UTF-8 sequence).
+	 *
+	 * Each emoji is 1 codepoint but 4 bytes. If the truncation used substr()
+	 * instead of mb_substr(), the result would be a broken byte sequence.
+	 */
+	public function test_sanitize_truncates_multibyte_without_splitting(): void {
+		// Each 🎉 is U+1F389 (4 bytes, 1 codepoint).
+		$emoji  = "\xF0\x9F\x8E\x89"; // 🎉
+		$input  = str_repeat( $emoji, InstructionsAddendum::MAX_LENGTH + 5 );
+		$result = InstructionsAddendum::sanitize( $input );
+
+		// Result must be exactly MAX_LENGTH codepoints.
+		$this->assertSame( InstructionsAddendum::MAX_LENGTH, mb_strlen( $result, 'UTF-8' ) );
+		// Result must be valid UTF-8 (no broken sequences).
+		$this->assertNotFalse( mb_detect_encoding( $result, 'UTF-8', true ) );
+	}
+
+	/**
+	 * CJK characters (3 bytes each) are counted as single characters.
+	 *
+	 * A string of MAX_LENGTH+1 CJK characters exceeds the limit even if
+	 * set_addendum() uses mb_strlen, so it must return WP_Error.
+	 */
+	public function test_set_addendum_cjk_over_limit_returns_error(): void {
+		// Each CJK character U+4E00 is 3 bytes but 1 codepoint.
+		$cjk   = "\xE4\xB8\x80"; // 一
+		$value = str_repeat( $cjk, InstructionsAddendum::MAX_LENGTH + 1 );
+		$this->assertSame( InstructionsAddendum::MAX_LENGTH + 1, mb_strlen( $value, 'UTF-8' ) );
+
+		$result = InstructionsAddendum::set_addendum( $value );
+		$this->assertWPError( $result );
+		$this->assertSame( 'addendum_too_long', $result->get_error_code() );
+	}
+
+	/**
+	 * sanitize() returns empty string for array/object input.
+	 */
+	public function test_sanitize_returns_empty_for_non_string(): void {
+		$this->assertSame( '', InstructionsAddendum::sanitize( array( 'foo' ) ) );
+		$this->assertSame( '', InstructionsAddendum::sanitize( new \stdClass() ) );
+	}
+
+	// -----------------------------------------------------------------------
+	// sanitize_callback()
+	// -----------------------------------------------------------------------
+
+	/**
+	 * sanitize_callback() silently truncates over-length input (Settings API).
+	 */
+	public function test_sanitize_callback_truncates_silently(): void {
+		$long   = str_repeat( 'b', InstructionsAddendum::MAX_LENGTH + 50 );
+		$result = InstructionsAddendum::sanitize_callback( $long );
+		$this->assertSame( InstructionsAddendum::MAX_LENGTH, mb_strlen( $result, 'UTF-8' ) );
+	}
+
+	/**
+	 * sanitize_callback() touches the updated_at timestamp.
+	 */
+	public function test_sanitize_callback_bumps_timestamp(): void {
+		$before = time();
+		InstructionsAddendum::sanitize_callback( 'Some rules.' );
+		$after = time();
+
+		$ts = InstructionsAddendum::get_updated_at();
+		$this->assertGreaterThanOrEqual( $before, $ts );
+		$this->assertLessThanOrEqual( $after, $ts );
+	}
+
+	// -----------------------------------------------------------------------
+	// check_rate_limit()
+	// -----------------------------------------------------------------------
+
+	/**
+	 * Requests within the rate limit are permitted.
+	 */
+	public function test_check_rate_limit_permits_within_budget(): void {
+		$ip = '192.0.2.1';
+		// First request must be permitted.
+		$this->assertTrue( InstructionsAddendum::check_rate_limit( $ip ) );
+	}
+
+	/**
+	 * Requests exceeding RATE_LIMIT_PER_MIN are blocked.
+	 */
+	public function test_check_rate_limit_blocks_when_exceeded(): void {
+		$ip = '192.0.2.2';
+
+		// Exhaust the budget.
+		for ( $i = 0; $i < InstructionsAddendum::RATE_LIMIT_PER_MIN; $i++ ) {
+			InstructionsAddendum::check_rate_limit( $ip );
+		}
+
+		// The next request must be blocked.
+		$this->assertFalse( InstructionsAddendum::check_rate_limit( $ip ) );
+	}
+
+	/**
+	 * Different IPs have independent rate-limit buckets.
+	 */
+	public function test_check_rate_limit_isolates_by_ip(): void {
+		$ip_a = '192.0.2.10';
+		$ip_b = '192.0.2.11';
+
+		// Exhaust ip_a's budget.
+		for ( $i = 0; $i < InstructionsAddendum::RATE_LIMIT_PER_MIN; $i++ ) {
+			InstructionsAddendum::check_rate_limit( $ip_a );
+		}
+
+		// ip_a is now blocked.
+		$this->assertFalse( InstructionsAddendum::check_rate_limit( $ip_a ) );
+
+		// ip_b must still be permitted.
+		$this->assertTrue( InstructionsAddendum::check_rate_limit( $ip_b ) );
+	}
+
+	// -----------------------------------------------------------------------
+	// get_updated_at()
+	// -----------------------------------------------------------------------
+
+	/**
+	 * get_updated_at() returns 0 when the option has never been written.
+	 */
+	public function test_get_updated_at_returns_zero_by_default(): void {
+		$this->assertSame( 0, InstructionsAddendum::get_updated_at() );
+	}
+}

--- a/tests/SdAiAgent/Core/InstructionsAddendumTest.php
+++ b/tests/SdAiAgent/Core/InstructionsAddendumTest.php
@@ -135,12 +135,20 @@ class InstructionsAddendumTest extends WP_UnitTestCase {
 
 	/**
 	 * WordPress shortcodes are stripped.
+	 *
+	 * Uses a self-closing fake shortcode to avoid WordPress's known
+	 * [gallery] shortcode, which would consume the text between open/close
+	 * tags. Unregistered shortcodes are also stripped by strip_shortcodes().
 	 */
 	public function test_sanitize_strips_shortcodes(): void {
-		$input  = '[gallery id="1"] Some text [/gallery].';
+		// Register a fake shortcode so strip_shortcodes() sees it.
+		add_shortcode( 'sd-ai-agent-fake-test-sc', '__return_false' );
+		$input  = '[sd-ai-agent-fake-test-sc id="1"] Some text.';
 		$result = InstructionsAddendum::sanitize( $input );
-		$this->assertStringNotContainsString( '[gallery', $result );
-		$this->assertStringContainsString( 'Some text', $result );
+		remove_shortcode( 'sd-ai-agent-fake-test-sc' );
+
+		$this->assertStringNotContainsString( '[sd-ai-agent-fake-test-sc', $result );
+		$this->assertStringContainsString( 'Some text.', $result );
 	}
 
 	/**
@@ -174,25 +182,35 @@ class InstructionsAddendumTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Input longer than MAX_LENGTH is truncated to exactly MAX_LENGTH chars.
+	 * sanitize() alone does NOT truncate — truncation is the responsibility
+	 * of callers (sanitize_callback for Settings API, get_addendum for reads).
 	 */
-	public function test_sanitize_truncates_to_max_length(): void {
+	public function test_sanitize_does_not_truncate(): void {
 		$input  = str_repeat( 'a', InstructionsAddendum::MAX_LENGTH + 100 );
 		$result = InstructionsAddendum::sanitize( $input );
+		$this->assertSame( InstructionsAddendum::MAX_LENGTH + 100, mb_strlen( $result, 'UTF-8' ) );
+	}
+
+	/**
+	 * sanitize_callback() truncates over-length input to exactly MAX_LENGTH chars.
+	 */
+	public function test_sanitize_callback_truncates_to_max_length(): void {
+		$input  = str_repeat( 'a', InstructionsAddendum::MAX_LENGTH + 100 );
+		$result = InstructionsAddendum::sanitize_callback( $input );
 		$this->assertSame( InstructionsAddendum::MAX_LENGTH, mb_strlen( $result, 'UTF-8' ) );
 	}
 
 	/**
-	 * Multi-byte truncation is codepoint-safe (does not split a UTF-8 sequence).
+	 * Multi-byte truncation in sanitize_callback() is codepoint-safe.
 	 *
 	 * Each emoji is 1 codepoint but 4 bytes. If the truncation used substr()
 	 * instead of mb_substr(), the result would be a broken byte sequence.
 	 */
-	public function test_sanitize_truncates_multibyte_without_splitting(): void {
+	public function test_sanitize_callback_truncates_multibyte_without_splitting(): void {
 		// Each 🎉 is U+1F389 (4 bytes, 1 codepoint).
 		$emoji  = "\xF0\x9F\x8E\x89"; // 🎉
 		$input  = str_repeat( $emoji, InstructionsAddendum::MAX_LENGTH + 5 );
-		$result = InstructionsAddendum::sanitize( $input );
+		$result = InstructionsAddendum::sanitize_callback( $input );
 
 		// Result must be exactly MAX_LENGTH codepoints.
 		$this->assertSame( InstructionsAddendum::MAX_LENGTH, mb_strlen( $result, 'UTF-8' ) );


### PR DESCRIPTION
## Summary

Implements #1715 — adds a 2000-char admin-editable instructions addendum surfaced at the MCP handshake so a site can encode style conventions (callout class names, code-block themes, heading hierarchy rules) once and have every connected MCP client receive them without a tool call.

## Changes

**New files**
- `includes/Core/InstructionsAddendum.php` — self-contained class: `get_addendum()`, `set_addendum()`, `sanitize()`, `sanitize_callback()`, `check_rate_limit()`. `sanitize()` strips HTML/shortcodes/C0 control chars but does **not** truncate; `set_addendum()` can therefore correctly return `WP_Error('addendum_too_long')` on > 2000 UTF-8 chars; `sanitize_callback()` (Settings API) and `get_addendum()` (belt-and-braces read) truncate via `maybe_truncate()`.
- `includes/REST/InstructionsController.php` — `GET /sd-ai-agent/v1/instructions` (public, `Cache-Control: public, max-age=60`, 30 req/min per IP) and `POST` (manage_options, saves addendum).
- `tests/SdAiAgent/Core/InstructionsAddendumTest.php` — 22 tests: sanitize, set/get round-trip, WP_Error on over-length, multi-byte truncation safety (emoji + CJK), rate-limit isolation by IP, sanitize_callback truncation.

**Modified files**
- `includes/REST/McpController.php` — adds `initialize` MCP method returning `serverInfo.instructions = BASELINE_INSTRUCTIONS + '\n\n' + addendum`.
- `includes/Plugin.php` — registers `InstructionsController` in the DI handlers array.
- `includes/Admin/UnifiedAdminMenu.php` — adds `instructionsAddendum` block (value, updated_at, max_length, endpoint URL) to `sdAiAgentData` localized script for the React settings page to consume.

## Acceptance criteria checklist

- [x] Saving persists to option, updates `sd_ai_agent_instructions_updated_at`
- [x] Saving > 2000 UTF-8 chars returns `WP_Error('addendum_too_long')` (emoji/CJK split-safe)
- [x] Saving empty string clears value but still bumps timestamp
- [x] `GET /sd-ai-agent/v1/instructions` returns `{ addendum, updated_at }` with `Cache-Control: public, max-age=60`
- [x] Public endpoint enforces 30 req/min per IP (transient-backed); excess returns HTTP 429
- [x] `McpController::initialize` returns addendum appended after baseline instructions
- [x] Sanitization on both read and write (defence-in-depth)

## Pre-existing failures (not introduced by this PR)

`PluginBuilderIntegrationTest::test_updater_happy_path_replaces_files` and two `PluginUpdaterTest` cases fail on this machine due to `Access denied for user 'root'@'localhost'` — MySQL credentials issue unrelated to this PR. These 3 tests also fail on the base commit before my changes.

## Worker self-verification

- PHPUnit: Tests: 2601, Assertions: 7150, Errors: 0, Failures: 3 (pre-existing PluginBuilder MySQL), Skipped: 104
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Resolves #1715

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.28 plugin for [OpenCode](https://opencode.ai) v1.15.7 with claude-sonnet-4-6 spent 24m and 42,318 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added instructions addendum feature for administrators to set supplementary instructions for MCP server initialization
  * Addendum values persist in site settings and are appended to baseline instructions during protocol handshake
  * Includes rate limiting on public read access and input validation with HTML/shortcode removal and character length enforcement

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1719?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->