### PR TITLE
feat: t247 Tier 1.4 - Optimistic concurrency via If-Match revision_id (Resolves #1710)

### DIFF
--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -16,6 +16,7 @@ namespace SdAiAgent\Abilities;
 use SdAiAgent\Core\BlockInventory;
 use SdAiAgent\Core\BlockReferences;
 use SdAiAgent\Core\BlockValidator;
+use SdAiAgent\Core\RevisionGuard;
 use SdAiAgent\Models\MarkdownToBlocks;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -464,6 +465,10 @@ class BlockAbilities {
 						'refs_stored' => [
 							'type'        => 'boolean',
 							'description' => 'True when new refs were persisted to the post.',
+						],
+						'revision_id' => [
+							'type'        => 'integer',
+							'description' => 'Current latest revision ID for the post. Pass this as expected_revision (or If-Match header) on follow-up write calls to enable optimistic concurrency control.',
 						],
 						'error'       => [ 'type' => 'string' ],
 					],
@@ -1402,6 +1407,7 @@ class BlockAbilities {
 				'blocks'      => [],
 				'block_count' => 0,
 				'refs_stored' => false,
+				'revision_id' => RevisionGuard::current_revision_id( $post_id ),
 			];
 		}
 
@@ -1454,6 +1460,7 @@ class BlockAbilities {
 			'blocks'      => $flat_list,
 			'block_count' => $flat_index,
 			'refs_stored' => $refs_stored,
+			'revision_id' => RevisionGuard::current_revision_id( $post_id ),
 		];
 	}
 

--- a/includes/Abilities/PostAbilities.php
+++ b/includes/Abilities/PostAbilities.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Abilities;
 
 use SdAiAgent\Core\BlockValidator;
+use SdAiAgent\Core\RevisionGuard;
 use SdAiAgent\Models\MarkdownToBlocks;
 use WP_Error;
 use WP_Post;
@@ -229,16 +230,24 @@ class PostAbilities {
 							'type'        => 'string',
 							'description' => 'Subsite URL for multisite. Omit for the main site.',
 						],
+						'expected_revision' => [
+							'type'        => [ 'integer', 'string' ],
+							'description' => 'Optimistic concurrency guard. Pass the revision_id returned by get-page-blocks (or the If-Match header value). If the post has been modified since you read it, the call returns HTTP 412 stale_revision with the current_revision_id so you can re-fetch and retry. Omit to skip the check (backward-compatible).',
+						],
 					],
 					'required'   => [ 'post_id' ],
 				],
 				'output_schema'       => [
 					'type'       => 'object',
 					'properties' => [
-						'post_id'   => [ 'type' => 'integer' ],
-						'permalink' => [ 'type' => 'string' ],
-						'status'    => [ 'type' => 'string' ],
-						'post_type' => [ 'type' => 'string' ],
+						'post_id'     => [ 'type' => 'integer' ],
+						'permalink'   => [ 'type' => 'string' ],
+						'status'      => [ 'type' => 'string' ],
+						'post_type'   => [ 'type' => 'string' ],
+						'revision_id' => [
+							'type'        => 'integer',
+							'description' => 'Latest revision ID after the write. Use as expected_revision for the next write.',
+						],
 					],
 				],
 				'meta'                => [
@@ -265,17 +274,21 @@ class PostAbilities {
 				'input_schema'        => [
 					'type'       => 'object',
 					'properties' => [
-						'post_id'  => [
+						'post_id'           => [
 							'type'        => 'integer',
 							'description' => 'The ID of the post or page to append to.',
 						],
-						'content'  => [
+						'content'           => [
 							'type'        => 'string',
 							'description' => 'Block markup to append. Must be complete, self-contained blocks (each opening comment paired with its closing comment). A leading newline is recommended to separate from the previous section.',
 						],
-						'site_url' => [
+						'site_url'          => [
 							'type'        => 'string',
 							'description' => 'Subsite URL for multisite. Omit for the main site.',
+						],
+						'expected_revision' => [
+							'type'        => [ 'integer', 'string' ],
+							'description' => 'Optimistic concurrency guard. Pass the revision_id returned by get-page-blocks. If the post has been modified since you read it, the call returns HTTP 412 stale_revision with the current_revision_id so you can re-fetch and retry. Omit to skip the check (backward-compatible).',
 						],
 					],
 					'required'   => [ 'post_id', 'content' ],
@@ -287,6 +300,10 @@ class PostAbilities {
 						'permalink'      => [ 'type' => 'string' ],
 						'appended_bytes' => [ 'type' => 'integer' ],
 						'total_bytes'    => [ 'type' => 'integer' ],
+						'revision_id'    => [
+							'type'        => 'integer',
+							'description' => 'Latest revision ID after the write. Use as expected_revision for the next write.',
+						],
 					],
 				],
 				'meta'                => [
@@ -1015,6 +1032,16 @@ class PostAbilities {
 			);
 		}
 
+		// Optimistic concurrency check (opt-in via expected_revision).
+		$raw_expected = isset( $input['expected_revision'] ) ? (string) $input['expected_revision'] : '';
+		$guard        = RevisionGuard::check( $post_id, RevisionGuard::parse_raw( $raw_expected ) );
+		if ( is_wp_error( $guard ) ) {
+			if ( $switched ) {
+				restore_current_blog();
+			}
+			return $guard;
+		}
+
 		$post_data = [ 'ID' => $post_id ];
 
 		if ( isset( $input['title'] ) ) {
@@ -1092,10 +1119,11 @@ class PostAbilities {
 		}
 
 		$response = [
-			'post_id'   => $post_id,
-			'permalink' => $permalink ?: '',
-			'status'    => $updated_post instanceof WP_Post ? $updated_post->post_status : '',
-			'post_type' => $updated_post instanceof WP_Post ? $updated_post->post_type : '',
+			'post_id'     => $post_id,
+			'permalink'   => $permalink ?: '',
+			'status'      => $updated_post instanceof WP_Post ? $updated_post->post_status : '',
+			'post_type'   => $updated_post instanceof WP_Post ? $updated_post->post_type : '',
+			'revision_id' => RevisionGuard::current_revision_id( $post_id ),
 		];
 
 		// GH#1584 follow-up: re-validate after update so the model knows
@@ -1166,6 +1194,16 @@ class PostAbilities {
 			);
 		}
 
+		// Optimistic concurrency check (opt-in via expected_revision).
+		$raw_expected = isset( $input['expected_revision'] ) ? (string) $input['expected_revision'] : '';
+		$guard        = RevisionGuard::check( $post_id, RevisionGuard::parse_raw( $raw_expected ) );
+		if ( is_wp_error( $guard ) ) {
+			if ( $switched ) {
+				restore_current_blog();
+			}
+			return $guard;
+		}
+
 		$existing       = (string) $post->post_content;
 		$appended_bytes = strlen( $content );
 
@@ -1207,6 +1245,7 @@ class PostAbilities {
 			'permalink'      => $permalink,
 			'appended_bytes' => $appended_bytes,
 			'total_bytes'    => $total_bytes,
+			'revision_id'    => RevisionGuard::current_revision_id( $post_id ),
 		];
 	}
 

--- a/includes/Core/RevisionGuard.php
+++ b/includes/Core/RevisionGuard.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Optimistic-concurrency guard for block-write endpoints.
+ *
+ * Provides a thin, stateless utility for wiring optimistic-concurrency
+ * control into REST and Ability write paths. Callers supply an
+ * `If-Match` header or an `expected_revision` body field; the guard
+ * verifies the post's current revision still matches before the write
+ * proceeds.  Missing header → skip check → backward compatible.
+ *
+ * Usage (REST route handler):
+ *
+ *   $guard = RevisionGuard::check( $post_id, RevisionGuard::parse_if_match( $request ) );
+ *   if ( is_wp_error( $guard ) ) {
+ *       return $guard; // 412 or 400
+ *   }
+ *   // … proceed with write …
+ *   return [ ..., 'revision_id' => RevisionGuard::current_revision_id( $post_id ) ];
+ *
+ * Usage (Ability handler — no WP_REST_Request available):
+ *
+ *   $expected = isset( $input['expected_revision'] ) ? (string) $input['expected_revision'] : '';
+ *   $guard    = RevisionGuard::check( $post_id, RevisionGuard::parse_raw( $expected ) );
+ *   if ( is_wp_error( $guard ) ) {
+ *       return $guard;
+ *   }
+ *
+ * @package SdAiAgent\Core
+ * @license GPL-2.0-or-later
+ * @see     https://github.com/Ultimate-Multisite/superdav-ai-agent/issues/1710
+ */
+
+namespace SdAiAgent\Core;
+
+use WP_Error;
+use WP_REST_Request;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Stateless optimistic-concurrency helper.
+ *
+ * All methods are static so callers do not need a DI container instance.
+ */
+class RevisionGuard {
+
+	/**
+	 * Return the latest revision post-ID for a post.
+	 *
+	 * Uses `wp_get_post_revisions()` ordered DESC, limit 1.
+	 * Returns 0 when the post has no revisions yet (e.g. auto-draft).
+	 *
+	 * @param int $post_id Post being inspected.
+	 * @return int Revision post ID, or 0 when no revisions exist.
+	 */
+	public static function current_revision_id( int $post_id ): int {
+		$revisions = wp_get_post_revisions(
+			$post_id,
+			[
+				'posts_per_page' => 1,
+				'orderby'        => 'date',
+				'order'          => 'DESC',
+			]
+		);
+
+		// wp_get_post_revisions() returns an array keyed by revision post IDs
+		// when no 'fields' override is used. key() retrieves the first array
+		// key without the WP_Post cast ambiguity that reset() + (int) triggers.
+		if ( is_array( $revisions ) && ! empty( $revisions ) ) {
+			return (int) key( $revisions );
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Extract and parse an expected-revision value from a REST request.
+	 *
+	 * Precedence: `If-Match` header → `expected_revision` body/query param.
+	 * Delegates to {@see self::parse_raw()} for validation.
+	 *
+	 * Returns null  when neither source is present (no-op / back-compat).
+	 * Returns int   when the value is valid.
+	 * Returns WP_Error (400 `invalid_if_match`) when a value is present but malformed.
+	 *
+	 * @param WP_REST_Request $request Incoming REST request.
+	 * @return int|null|WP_Error Parsed revision ID, null (absent), or 400 error.
+	 */
+	public static function parse_if_match( WP_REST_Request $request ): int|null|WP_Error {
+		$raw = '';
+
+		// If-Match header takes precedence.
+		$header = $request->get_header( 'if_match' );
+		if ( is_string( $header ) && '' !== $header ) {
+			$raw = $header;
+		}
+
+		// Body / query param fallback for transports that cannot set headers.
+		if ( '' === $raw ) {
+			$body_field = $request->get_param( 'expected_revision' );
+			if ( null !== $body_field && '' !== (string) $body_field ) {
+				$raw = (string) $body_field;
+			}
+		}
+
+		if ( '' === $raw ) {
+			return null; // No If-Match — back-compat pass-through.
+		}
+
+		return self::parse_raw( $raw );
+	}
+
+	/**
+	 * Parse a raw If-Match string (no WP_REST_Request context).
+	 *
+	 * Accepts: bare integer `"123"`, weak ETag `W/"123"`, or strong ETag `"123"`.
+	 * Returns null for empty string, int for valid form, WP_Error 400 for garbage.
+	 *
+	 * @param string $raw Raw header / field value.
+	 * @return int|null|WP_Error
+	 */
+	public static function parse_raw( string $raw ): int|null|WP_Error {
+		if ( '' === $raw ) {
+			return null;
+		}
+
+		// Strip RFC 7232 ETag wrappers: W/"123" → 123, "123" → 123.
+		$normalized = trim( $raw );
+		if ( str_starts_with( $normalized, 'W/' ) ) {
+			$normalized = trim( substr( $normalized, 2 ) );
+		}
+		$normalized = trim( $normalized, '"' );
+
+		if ( ! preg_match( '/^[0-9]+$/', $normalized ) ) {
+			return new WP_Error(
+				'invalid_if_match',
+				__( 'If-Match must be a revision ID (integer), optionally wrapped as W/"<id>" or "<id>".', 'superdav-ai-agent' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		return (int) $normalized;
+	}
+
+	/**
+	 * Precondition check for a write operation.
+	 *
+	 * When `$expected` is null, the check is skipped (opt-in, back-compat).
+	 * When `$expected` matches the post's current revision, returns true.
+	 * When `$expected` does not match, returns a 412 WP_Error with
+	 * `data.current_revision_id` so the caller can re-fetch and retry.
+	 *
+	 * @param int      $post_id  Post being written.
+	 * @param int|null $expected Parsed revision ID, or null to skip.
+	 * @return true|WP_Error true = proceed; WP_Error 412 = stale; WP_Error 400 = invalid.
+	 */
+	public static function check( int $post_id, int|null|WP_Error $expected ): true|WP_Error {
+		// Surface upstream parse errors (400 invalid_if_match) immediately.
+		if ( is_wp_error( $expected ) ) {
+			return $expected;
+		}
+
+		// Null → no If-Match supplied → back-compat pass-through.
+		if ( null === $expected ) {
+			return true;
+		}
+
+		$current = self::current_revision_id( $post_id );
+
+		if ( $expected !== $current ) {
+			return new WP_Error(
+				'stale_revision',
+				__( 'The post has changed since you fetched it. Re-fetch with get-page-blocks and retry.', 'superdav-ai-agent' ),
+				[
+					'status'              => 412,
+					'current_revision_id' => $current,
+					'expected_revision'   => $expected,
+				]
+			);
+		}
+
+		return true;
+	}
+}

--- a/tests/SdAiAgent/Core/RevisionGuardTest.php
+++ b/tests/SdAiAgent/Core/RevisionGuardTest.php
@@ -1,0 +1,262 @@
+<?php
+/**
+ * Test case for RevisionGuard (GH#1710).
+ *
+ * Covers the acceptance criteria from the issue:
+ *
+ *  AC2: Stale If-Match returns 412 stale_revision with data.current_revision_id.
+ *  AC3: Matching If-Match succeeds normally (returns true).
+ *  AC4: Missing If-Match succeeds normally (back-compat, returns true).
+ *  AC5: Weak ETag form W/"123" parses correctly.
+ *  AC6: Malformed If-Match returns 400 invalid_if_match.
+ *  AC7: parse_if_match() reads both If-Match header and expected_revision body.
+ *  AC8: current_revision_id() returns 0 for a post with no revisions and a
+ *       positive int after wp_update_post() creates one.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ * @see     https://github.com/Ultimate-Multisite/superdav-ai-agent/issues/1710
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\RevisionGuard;
+use WP_REST_Request;
+use WP_UnitTestCase;
+
+/**
+ * Tests for RevisionGuard optimistic concurrency control.
+ */
+class RevisionGuardTest extends WP_UnitTestCase {
+
+	// ── parse_raw ──────────────────────────────────────────────────────────
+
+	/**
+	 * Empty string returns null (no If-Match → back-compat pass-through).
+	 */
+	public function test_parse_raw_empty_returns_null(): void {
+		$this->assertNull( RevisionGuard::parse_raw( '' ) );
+	}
+
+	/**
+	 * Bare integer string returns the integer.
+	 */
+	public function test_parse_raw_bare_integer(): void {
+		$this->assertSame( 123, RevisionGuard::parse_raw( '123' ) );
+	}
+
+	/**
+	 * Weak ETag form W/"123" is normalised correctly.
+	 */
+	public function test_parse_raw_weak_etag(): void {
+		$this->assertSame( 456, RevisionGuard::parse_raw( 'W/"456"' ) );
+	}
+
+	/**
+	 * Strong ETag form "123" is normalised correctly.
+	 */
+	public function test_parse_raw_strong_etag(): void {
+		$this->assertSame( 789, RevisionGuard::parse_raw( '"789"' ) );
+	}
+
+	/**
+	 * Surrounding whitespace is tolerated.
+	 */
+	public function test_parse_raw_whitespace_trimmed(): void {
+		$this->assertSame( 42, RevisionGuard::parse_raw( '  42  ' ) );
+	}
+
+	/**
+	 * Non-numeric garbage returns a 400 WP_Error with code invalid_if_match.
+	 *
+	 * Covers AC6 (malformed If-Match → 400).
+	 */
+	public function test_parse_raw_garbage_returns_400(): void {
+		$result = RevisionGuard::parse_raw( 'garbage' );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'invalid_if_match', $result->get_error_code() );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * W/"not-a-number" (non-digit content inside ETag wrapper) is also invalid.
+	 */
+	public function test_parse_raw_weak_etag_nonnumeric_returns_400(): void {
+		$result = RevisionGuard::parse_raw( 'W/"abc"' );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'invalid_if_match', $result->get_error_code() );
+	}
+
+	// ── check ──────────────────────────────────────────────────────────────
+
+	/**
+	 * check() with null expected skips the check (back-compat).
+	 *
+	 * Covers AC4 (missing If-Match → pass-through).
+	 */
+	public function test_check_null_expected_passes(): void {
+		$post_id = $this->factory->post->create();
+		$this->assertTrue( RevisionGuard::check( $post_id, null ) );
+	}
+
+	/**
+	 * check() propagates an upstream WP_Error (e.g. 400 from parse_raw).
+	 */
+	public function test_check_propagates_upstream_wp_error(): void {
+		$post_id = $this->factory->post->create();
+		$error   = new \WP_Error( 'invalid_if_match', 'bad', [ 'status' => 400 ] );
+		$result  = RevisionGuard::check( $post_id, $error );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'invalid_if_match', $result->get_error_code() );
+	}
+
+	/**
+	 * check() with a matching revision returns true.
+	 *
+	 * Covers AC3 (matching If-Match → proceed).
+	 */
+	public function test_check_matching_revision_passes(): void {
+		$post_id = $this->factory->post->create();
+
+		// Create a revision so current_revision_id() returns something non-zero.
+		wp_update_post( [ 'ID' => $post_id, 'post_title' => 'Rev 1' ] );
+
+		$current = RevisionGuard::current_revision_id( $post_id );
+		$this->assertGreaterThan( 0, $current, 'Precondition: a revision must exist' );
+
+		$this->assertTrue( RevisionGuard::check( $post_id, $current ) );
+	}
+
+	/**
+	 * check() with a stale revision returns HTTP 412 stale_revision with
+	 * data.current_revision_id.
+	 *
+	 * Covers AC2 (stale If-Match → 412 with current_revision_id).
+	 */
+	public function test_check_stale_revision_returns_412(): void {
+		$post_id = $this->factory->post->create();
+		wp_update_post( [ 'ID' => $post_id, 'post_title' => 'Rev 1' ] );
+
+		$current = RevisionGuard::current_revision_id( $post_id );
+		$this->assertGreaterThan( 0, $current );
+
+		$stale  = $current - 1; // A revision ID that no longer matches.
+		$result = RevisionGuard::check( $post_id, $stale );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'stale_revision', $result->get_error_code() );
+
+		$data = $result->get_error_data();
+		$this->assertIsArray( $data );
+		$this->assertSame( 412, $data['status'] );
+		$this->assertSame( $current, $data['current_revision_id'] );
+	}
+
+	// ── current_revision_id ────────────────────────────────────────────────
+
+	/**
+	 * A freshly created post (auto-draft) with no revisions returns 0.
+	 *
+	 * Note: wp-env / test suite may or may not save an initial revision
+	 * depending on configuration; we verify the return type is always int.
+	 */
+	public function test_current_revision_id_returns_int(): void {
+		$post_id = $this->factory->post->create();
+		$result  = RevisionGuard::current_revision_id( $post_id );
+		$this->assertIsInt( $result );
+	}
+
+	/**
+	 * After an update, current_revision_id() returns a positive integer.
+	 */
+	public function test_current_revision_id_positive_after_update(): void {
+		$post_id = $this->factory->post->create();
+		wp_update_post( [ 'ID' => $post_id, 'post_title' => 'Updated title' ] );
+
+		$result = RevisionGuard::current_revision_id( $post_id );
+		$this->assertGreaterThan( 0, $result );
+	}
+
+	// ── parse_if_match ─────────────────────────────────────────────────────
+
+	/**
+	 * parse_if_match() reads the If-Match header when present.
+	 *
+	 * Covers AC7 (parse_if_match reads header and body param).
+	 */
+	public function test_parse_if_match_reads_header(): void {
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/test' );
+		$request->set_header( 'If-Match', '321' );
+
+		$result = RevisionGuard::parse_if_match( $request );
+		$this->assertSame( 321, $result );
+	}
+
+	/**
+	 * parse_if_match() reads the If-Match header in W/"..." form.
+	 *
+	 * Covers AC5 (weak ETag form W/"123" parses correctly).
+	 */
+	public function test_parse_if_match_reads_weak_etag_header(): void {
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/test' );
+		$request->set_header( 'If-Match', 'W/"999"' );
+
+		$result = RevisionGuard::parse_if_match( $request );
+		$this->assertSame( 999, $result );
+	}
+
+	/**
+	 * parse_if_match() falls back to the expected_revision body param when no header.
+	 *
+	 * Covers AC7 (body param fallback).
+	 */
+	public function test_parse_if_match_falls_back_to_body_param(): void {
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/test' );
+		$request->set_body_params( [ 'expected_revision' => '555' ] );
+
+		$result = RevisionGuard::parse_if_match( $request );
+		$this->assertSame( 555, $result );
+	}
+
+	/**
+	 * parse_if_match() returns null when neither header nor body param is present.
+	 *
+	 * Covers AC4 (missing If-Match → back-compat pass-through).
+	 */
+	public function test_parse_if_match_returns_null_when_absent(): void {
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/test' );
+
+		$result = RevisionGuard::parse_if_match( $request );
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * parse_if_match() header takes precedence over body param.
+	 */
+	public function test_parse_if_match_header_wins_over_body(): void {
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/test' );
+		$request->set_header( 'If-Match', '100' );
+		$request->set_body_params( [ 'expected_revision' => '200' ] );
+
+		$result = RevisionGuard::parse_if_match( $request );
+		$this->assertSame( 100, $result );
+	}
+
+	/**
+	 * parse_if_match() with a malformed header value returns 400 WP_Error.
+	 *
+	 * Covers AC6 (malformed If-Match → 400).
+	 */
+	public function test_parse_if_match_malformed_header_returns_400(): void {
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/test' );
+		$request->set_header( 'If-Match', 'garbage' );
+
+		$result = RevisionGuard::parse_if_match( $request );
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'invalid_if_match', $result->get_error_code() );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+	}
+}


### PR DESCRIPTION
## Summary

Implements optimistic concurrency control for block-write endpoints so concurrent agents or agent+human sessions detect stale overwrites instead of silently losing work.

### Changes

**New: `includes/Core/RevisionGuard.php`**
- `current_revision_id(int $post_id): int` — fetches latest WP revision ID (0 when none)
- `parse_raw(string $raw): int|null|WP_Error` — accepts `123`, `W/"123"`, or `"123"`; returns 400 on garbage
- `parse_if_match(WP_REST_Request $req): int|null|WP_Error` — reads `If-Match` header with `expected_revision` body param fallback
- `check(int $post_id, int|null|WP_Error $expected): true|WP_Error` — 412 on mismatch, propagates 400 upstream errors, no-op on null (back-compat)

**Modified: `includes/Abilities/BlockAbilities.php`**
- `get-page-blocks` now returns `revision_id` in output schema and handler response so callers can capture it and pass as `expected_revision` on follow-up writes.

**Modified: `includes/Abilities/PostAbilities.php`**
- `update-post`: adds optional `expected_revision` input, wires `RevisionGuard::check()` before the write, returns `revision_id` in success response
- `append-post-content`: same pattern

**New: `tests/SdAiAgent/Core/RevisionGuardTest.php`**
- 19 tests, 31 assertions

## Acceptance criteria

- [x] AC1: Read endpoints (`get-page-blocks`) return `revision_id` in payload
- [x] AC2: Stale `If-Match: 123` against post with revision 456 returns HTTP 412 `stale_revision` with `data.current_revision_id = 456`; no DB write
- [x] AC3: Matching `If-Match` succeeds normally
- [x] AC4: No `If-Match` supplied succeeds normally (back-compat)
- [x] AC5: Weak ETag form `W/"123"` parses correctly
- [x] AC6: Malformed `If-Match` (garbage) returns HTTP 400 `invalid_if_match`
- [x] AC7: Tests cover all paths

## Worker self-verification
- PHPUnit: Tests: 2696, Assertions: 7373, Errors: 0, Failures: 3 (pre-existing DB connection failures in PluginUpdaterTest unrelated to this PR), Skipped: 104
- RevisionGuardTest: 19 tests, 31 assertions, all pass (0 warnings, 0 errors)
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.28 plugin for [OpenCode](https://opencode.ai) v1.15.7 with claude-sonnet-4-6 spent 23m and 36,299 tokens on this with the user in an interactive session.
