### PR TITLE
GH#1711: feat: auto-transform block innerHTML on attribute changes

### DIFF
--- a/includes/Core/BlockMutator.php
+++ b/includes/Core/BlockMutator.php
@@ -62,6 +62,12 @@ class BlockMutator {
 	/**
 	 * Apply a single mutation operation to a parsed block tree.
 	 *
+	 * For `update-attrs` on supported static blocks, HtmlTransformer automatically
+	 * rewrites innerHTML to stay consistent with the new attribute values. For
+	 * unsupported static blocks, a `_warnings` key is added to the result array
+	 * containing `static_block_attrs_changed` so the caller knows innerHTML may
+	 * need manual updating.
+	 *
 	 * @param array<int,mixed>    $blocks Parsed block tree (parse_blocks() output).
 	 * @param string              $op     Operation name (one of VALID_OPS).
 	 * @param array<string,mixed> $args   Operation arguments including the address.
@@ -89,7 +95,24 @@ class BlockMutator {
 
 		switch ( $op ) {
 			case 'update-attrs':
-				return self::op_update_attrs( $blocks, $path, $args );
+				$result = self::op_update_attrs( $blocks, $path, $args );
+
+				if ( is_wp_error( $result ) ) {
+					return $result;
+				}
+
+				// Emit static_block_attrs_changed warning for unsupported blocks.
+				$target = BlockTreeAddress::get_block_at_path( $blocks, $path );
+
+				if ( null !== $target
+					&& isset( $target['blockName'] ) && is_string( $target['blockName'] )
+					&& '' !== $target['blockName']
+					&& ! HtmlTransformer::is_supported( $target['blockName'] )
+				) {
+					$result['_warnings'] = [ 'static_block_attrs_changed' ];
+				}
+
+				return $result;
 			case 'update-html':
 				return self::op_update_html( $blocks, $path, $args );
 			case 'replace-block':
@@ -148,6 +171,11 @@ class BlockMutator {
 					$block['attrs'] = array_merge( $existing, $args['attributes'] );
 				} else {
 					$block['attrs'] = $args['attributes'];
+				}
+
+				// Auto-transform innerHTML when attribute changes imply HTML structure changes.
+				if ( is_array( $block ) && HtmlTransformer::is_supported( isset( $block['blockName'] ) && is_string( $block['blockName'] ) ? $block['blockName'] : '' ) ) {
+					$block = HtmlTransformer::apply( $block, $args['attributes'] );
 				}
 
 				$siblings[ $idx ] = $block;

--- a/includes/Core/HtmlTransformer.php
+++ b/includes/Core/HtmlTransformer.php
@@ -1,0 +1,633 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Block attribute ↔ innerHTML auto-synchronization.
+ *
+ * Pure-function transforms: when an `update-attrs` op changes an attribute
+ * that has a structural HTML counterpart, this class rewrites the block's
+ * `innerHTML` (and `innerContent`) to stay consistent — preventing the
+ * "comment marker says `level: 2` but inner tag is `<h3>`" desync that
+ * breaks the block editor on reopen.
+ *
+ * Adapted from ~/Git/block-mcp/wordpress-plugin/gk-block-api/includes/class-html-transformer.php
+ * (GPL-2.0-or-later — compatible). Namespace and method signatures adjusted per AGENTS.md.
+ *
+ * @package SdAiAgent\Core
+ * @license GPL-2.0-or-later
+ * @see     https://github.com/Ultimate-Multisite/superdav-ai-agent/issues/1711
+ */
+
+namespace SdAiAgent\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * HTML transformer for block attribute ↔ innerHTML synchronization.
+ *
+ * All entry points are static. The class holds no per-instance state.
+ */
+class HtmlTransformer {
+
+	/**
+	 * Block types that have known attribute → innerHTML transforms.
+	 *
+	 * Used by the mutator to decide whether to call apply() and whether
+	 * to emit a `static_block_attrs_changed` warning for uncovered blocks.
+	 *
+	 * @var string[]
+	 */
+	const SUPPORTED_BLOCKS = [
+		'core/heading',
+		'core/list',
+		'core/group',
+		'core/button',
+		'core/image',
+		'core/spacer',
+		'core/details',
+		'core/quote',
+		'core/audio',
+		'core/video',
+		'core/code',
+		'core/preformatted',
+		'core/paragraph',
+	];
+
+	/**
+	 * Apply attribute → innerHTML transforms for a block.
+	 *
+	 * Returns the block with updated `innerHTML` and `innerContent` if any
+	 * transforms applied, or the block unchanged if none did. All output
+	 * is run through `wp_kses_post()`.
+	 *
+	 * @param array<string,mixed> $block         Parsed block array.
+	 * @param array<string,mixed> $changed_attrs The attributes that were changed.
+	 * @return array<string,mixed> Block with synchronized innerHTML.
+	 */
+	public static function apply( array $block, array $changed_attrs ): array {
+		$block_name   = isset( $block['blockName'] ) && is_string( $block['blockName'] ) ? $block['blockName'] : '';
+		$current_html = isset( $block['innerHTML'] ) && is_string( $block['innerHTML'] ) ? $block['innerHTML'] : '';
+
+		if ( '' === $block_name || '' === $current_html ) {
+			return $block;
+		}
+
+		$new_html = self::transform_html( $block_name, $changed_attrs, $current_html );
+
+		if ( null === $new_html ) {
+			return $block;
+		}
+
+		// Sanitize final output.
+		$new_html = wp_kses_post( $new_html );
+
+		$block['innerHTML'] = $new_html;
+
+		// Rebuild innerContent to match the updated HTML.
+		$block['innerContent'] = self::rebuild_inner_content( $block, $new_html );
+
+		return $block;
+	}
+
+	/**
+	 * Check whether a block type has known transforms.
+	 *
+	 * @param string $block_name Block type name.
+	 * @return bool
+	 */
+	public static function is_supported( string $block_name ): bool {
+		return in_array( $block_name, self::SUPPORTED_BLOCKS, true );
+	}
+
+	// ── Transform engine ─────────────────────────────────────────────────
+
+	/**
+	 * Compute the transformed HTML for a block, or null if no transform applies.
+	 *
+	 * Categories:
+	 * 1. Tag name swaps (regex — WP_HTML_Tag_Processor can't change tag names).
+	 * 2. HTML attribute transforms (WP_HTML_Tag_Processor).
+	 * 3. CSS inline style transforms (WP_HTML_Tag_Processor).
+	 * 4. Text content transforms (regex for inner text replacement).
+	 *
+	 * @param string              $block_name    Block type name.
+	 * @param array<string,mixed> $changed_attrs Attributes being set.
+	 * @param string              $current_html  Current innerHTML.
+	 * @return string|null Transformed HTML, or null if no transform applies.
+	 */
+	private static function transform_html( string $block_name, array $changed_attrs, string $current_html ): ?string {
+		$html = $current_html;
+
+		// ── 1. Tag name swaps ────────────────────────────────────────────
+
+		$html = self::transform_heading_level( $block_name, $changed_attrs, $html );
+		$html = self::transform_list_ordered( $block_name, $changed_attrs, $html );
+		$html = self::transform_group_tag( $block_name, $changed_attrs, $html );
+
+		// ── 2. HTML attribute transforms ─────────────────────────────────
+
+		$html = self::transform_button_url( $block_name, $changed_attrs, $html );
+		$html = self::transform_image_attrs( $block_name, $changed_attrs, $html );
+		$html = self::transform_details_open( $block_name, $changed_attrs, $html );
+		$html = self::transform_media_booleans( $block_name, $changed_attrs, $html );
+
+		// ── 3. CSS inline style transforms ───────────────────────────────
+
+		$html = self::transform_spacer_styles( $block_name, $changed_attrs, $html );
+
+		// ── 4. Text content transforms ───────────────────────────────────
+
+		$html = self::transform_content_text( $block_name, $changed_attrs, $html );
+		$html = self::transform_button_text( $block_name, $changed_attrs, $html );
+		$html = self::transform_quote_citation( $block_name, $changed_attrs, $html );
+
+		return $html !== $current_html ? $html : null;
+	}
+
+	// ── Tag name swaps ───────────────────────────────────────────────────
+
+	/**
+	 * Transform core/heading level attribute to matching <hN> tag.
+	 *
+	 * @param string              $block_name    Block type.
+	 * @param array<string,mixed> $changed_attrs Changed attributes.
+	 * @param string              $html          Current HTML.
+	 * @return string Updated HTML.
+	 */
+	private static function transform_heading_level( string $block_name, array $changed_attrs, string $html ): string {
+		if ( 'core/heading' !== $block_name || ! array_key_exists( 'level', $changed_attrs ) ) {
+			return $html;
+		}
+
+		$new_level = (int) $changed_attrs['level'];
+
+		if ( $new_level < 1 || $new_level > 6 ) {
+			return $html;
+		}
+
+		$html = (string) preg_replace( '/<h[1-6](\s|>)/i', '<h' . $new_level . '$1', $html );
+		$html = (string) preg_replace( '/<\/h[1-6]>/i', '</h' . $new_level . '>', $html );
+
+		return $html;
+	}
+
+	/**
+	 * Transform core/list ordered attribute to <ul>/<ol> tag swap.
+	 *
+	 * Only swaps the FIRST opening and LAST closing tag to preserve nested lists.
+	 *
+	 * @param string              $block_name    Block type.
+	 * @param array<string,mixed> $changed_attrs Changed attributes.
+	 * @param string              $html          Current HTML.
+	 * @return string Updated HTML.
+	 */
+	private static function transform_list_ordered( string $block_name, array $changed_attrs, string $html ): string {
+		if ( 'core/list' !== $block_name || ! array_key_exists( 'ordered', $changed_attrs ) ) {
+			return $html;
+		}
+
+		if ( $changed_attrs['ordered'] ) {
+			$html = (string) preg_replace( '/<ul(\s|>)/i', '<ol$1', $html, 1 );
+			$html = (string) preg_replace( '/<\/ul>(?!.*<\/ul>)/is', '</ol>', $html );
+		} else {
+			$html = (string) preg_replace( '/<ol(\s|>)/i', '<ul$1', $html, 1 );
+			$html = (string) preg_replace( '/<\/ol>(?!.*<\/ol>)/is', '</ul>', $html );
+		}
+
+		return $html;
+	}
+
+	/**
+	 * Transform core/group tagName attribute to wrapper tag swap.
+	 *
+	 * @param string              $block_name    Block type.
+	 * @param array<string,mixed> $changed_attrs Changed attributes.
+	 * @param string              $html          Current HTML.
+	 * @return string Updated HTML.
+	 */
+	private static function transform_group_tag( string $block_name, array $changed_attrs, string $html ): string {
+		if ( 'core/group' !== $block_name || ! array_key_exists( 'tagName', $changed_attrs ) ) {
+			return $html;
+		}
+
+		$container_tags = [ 'div', 'section', 'aside', 'main', 'header', 'footer', 'article', 'nav' ];
+		$new_tag        = sanitize_key( (string) $changed_attrs['tagName'] );
+
+		if ( ! in_array( $new_tag, $container_tags, true ) ) {
+			return $html;
+		}
+
+		$tag_pattern = implode( '|', $container_tags );
+
+		$html = (string) preg_replace(
+			'/^(\s*)<(' . $tag_pattern . ')(\s|>)/i',
+			'$1<' . $new_tag . '$3',
+			$html
+		);
+		$html = (string) preg_replace(
+			'/<\/(' . $tag_pattern . ')>(\s*)$/i',
+			'</' . $new_tag . '>$2',
+			$html
+		);
+
+		return $html;
+	}
+
+	// ── HTML attribute transforms ────────────────────────────────────────
+
+	/**
+	 * Transform core/button url attribute to <a href> update.
+	 *
+	 * Preserves class, target, and rel attributes on the anchor tag.
+	 *
+	 * @param string              $block_name    Block type.
+	 * @param array<string,mixed> $changed_attrs Changed attributes.
+	 * @param string              $html          Current HTML.
+	 * @return string Updated HTML.
+	 */
+	private static function transform_button_url( string $block_name, array $changed_attrs, string $html ): string {
+		if ( 'core/button' !== $block_name || ! array_key_exists( 'url', $changed_attrs ) ) {
+			return $html;
+		}
+
+		$processor = new \WP_HTML_Tag_Processor( $html );
+
+		while ( $processor->next_tag() ) {
+			$tag = $processor->get_tag();
+
+			if ( null !== $tag && 'A' === strtoupper( $tag ) ) {
+				$processor->set_attribute( 'href', (string) $changed_attrs['url'] );
+				break;
+			}
+		}
+
+		return $processor->get_updated_html();
+	}
+
+	/**
+	 * Transform core/image url, alt, and id attributes.
+	 *
+	 * - `url` → <img src>
+	 * - `alt` → <img alt>
+	 * - `id`  → <img class> rewriting `wp-image-{old}` to `wp-image-{new}`
+	 *
+	 * @param string              $block_name    Block type.
+	 * @param array<string,mixed> $changed_attrs Changed attributes.
+	 * @param string              $html          Current HTML.
+	 * @return string Updated HTML.
+	 */
+	private static function transform_image_attrs( string $block_name, array $changed_attrs, string $html ): string {
+		if ( 'core/image' !== $block_name ) {
+			return $html;
+		}
+
+		$has_url = array_key_exists( 'url', $changed_attrs );
+		$has_alt = array_key_exists( 'alt', $changed_attrs );
+		$has_id  = array_key_exists( 'id', $changed_attrs );
+
+		if ( ! $has_url && ! $has_alt && ! $has_id ) {
+			return $html;
+		}
+
+		$processor = new \WP_HTML_Tag_Processor( $html );
+
+		while ( $processor->next_tag() ) {
+			$tag = $processor->get_tag();
+
+			if ( null === $tag || 'IMG' !== strtoupper( $tag ) ) {
+				continue;
+			}
+
+			if ( $has_url ) {
+				$processor->set_attribute( 'src', (string) $changed_attrs['url'] );
+			}
+
+			if ( $has_alt ) {
+				$processor->set_attribute( 'alt', (string) $changed_attrs['alt'] );
+			}
+
+			if ( $has_id ) {
+				$new_id    = (int) $changed_attrs['id'];
+				$old_class = $processor->get_attribute( 'class' );
+
+				if ( is_string( $old_class ) ) {
+					$new_class = (string) preg_replace(
+						'/wp-image-\d+/',
+						'wp-image-' . $new_id,
+						$old_class
+					);
+					$processor->set_attribute( 'class', $new_class );
+				}
+			}
+
+			break; // First <img> only.
+		}
+
+		return $processor->get_updated_html();
+	}
+
+	/**
+	 * Transform core/details showContent attribute to <details open> toggle.
+	 *
+	 * @param string              $block_name    Block type.
+	 * @param array<string,mixed> $changed_attrs Changed attributes.
+	 * @param string              $html          Current HTML.
+	 * @return string Updated HTML.
+	 */
+	private static function transform_details_open( string $block_name, array $changed_attrs, string $html ): string {
+		if ( 'core/details' !== $block_name || ! array_key_exists( 'showContent', $changed_attrs ) ) {
+			return $html;
+		}
+
+		$processor = new \WP_HTML_Tag_Processor( $html );
+
+		if ( $processor->next_tag( [ 'tag_name' => 'details' ] ) ) {
+			if ( filter_var( $changed_attrs['showContent'], FILTER_VALIDATE_BOOLEAN ) ) {
+				$processor->set_attribute( 'open', true );
+			} else {
+				$processor->remove_attribute( 'open' );
+			}
+		}
+
+		return $processor->get_updated_html();
+	}
+
+	/**
+	 * Transform core/audio and core/video boolean attributes.
+	 *
+	 * Handles `loop`, `autoplay`, and `controls`.
+	 *
+	 * @param string              $block_name    Block type.
+	 * @param array<string,mixed> $changed_attrs Changed attributes.
+	 * @param string              $html          Current HTML.
+	 * @return string Updated HTML.
+	 */
+	private static function transform_media_booleans( string $block_name, array $changed_attrs, string $html ): string {
+		if ( ! in_array( $block_name, [ 'core/audio', 'core/video' ], true ) ) {
+			return $html;
+		}
+
+		$bool_attrs = [ 'loop', 'autoplay', 'controls' ];
+		$media_tags = [ 'audio', 'video' ];
+
+		foreach ( $bool_attrs as $attr ) {
+			if ( ! array_key_exists( $attr, $changed_attrs ) ) {
+				continue;
+			}
+
+			$enable    = filter_var( $changed_attrs[ $attr ], FILTER_VALIDATE_BOOLEAN );
+			$processor = new \WP_HTML_Tag_Processor( $html );
+
+			while ( $processor->next_tag() ) {
+				$raw_tag = $processor->get_tag();
+
+				if ( null === $raw_tag ) {
+					continue;
+				}
+
+				$tag = strtolower( $raw_tag );
+
+				if ( ! in_array( $tag, $media_tags, true ) ) {
+					continue;
+				}
+
+				if ( $enable ) {
+					$processor->set_attribute( $attr, true );
+				} else {
+					$processor->remove_attribute( $attr );
+				}
+
+				break; // First match only.
+			}
+
+			$html = $processor->get_updated_html();
+		}
+
+		return $html;
+	}
+
+	// ── CSS inline style transforms ──────────────────────────────────────
+
+	/**
+	 * Transform core/spacer height and width attributes to inline styles.
+	 *
+	 * @param string              $block_name    Block type.
+	 * @param array<string,mixed> $changed_attrs Changed attributes.
+	 * @param string              $html          Current HTML.
+	 * @return string Updated HTML.
+	 */
+	private static function transform_spacer_styles( string $block_name, array $changed_attrs, string $html ): string {
+		if ( 'core/spacer' !== $block_name ) {
+			return $html;
+		}
+
+		$css_map = [
+			'height' => 'height',
+			'width'  => 'width',
+		];
+
+		foreach ( $css_map as $block_attr => $css_prop ) {
+			if ( ! array_key_exists( $block_attr, $changed_attrs ) ) {
+				continue;
+			}
+
+			$new_val   = sanitize_text_field( (string) $changed_attrs[ $block_attr ] );
+			$processor = new \WP_HTML_Tag_Processor( $html );
+
+			if ( ! $processor->next_tag() ) {
+				continue;
+			}
+
+			$style = $processor->get_attribute( 'style' );
+
+			if ( ! is_string( $style ) || false === strpos( $style, $css_prop ) ) {
+				continue;
+			}
+
+			$new_style = (string) preg_replace_callback(
+				'/(?<![-\w])' . preg_quote( $css_prop, '/' ) . '\s*:\s*[^;"]+(;?)/',
+				static function ( array $matches ) use ( $css_prop, $new_val ): string {
+					return $css_prop . ':' . $new_val . $matches[1];
+				},
+				$style
+			);
+
+			$processor->set_attribute( 'style', $new_style );
+			$html = $processor->get_updated_html();
+		}
+
+		return $html;
+	}
+
+	// ── Text content transforms ──────────────────────────────────────────
+
+	/**
+	 * Transform content attribute on text blocks.
+	 *
+	 * Applies to core/code, core/preformatted, core/paragraph, core/heading.
+	 *
+	 * @param string              $block_name    Block type.
+	 * @param array<string,mixed> $changed_attrs Changed attributes.
+	 * @param string              $html          Current HTML.
+	 * @return string Updated HTML.
+	 */
+	private static function transform_content_text( string $block_name, array $changed_attrs, string $html ): string {
+		$content_blocks = [
+			'core/heading',
+			'core/paragraph',
+			'core/code',
+			'core/preformatted',
+		];
+
+		if ( ! in_array( $block_name, $content_blocks, true ) || ! array_key_exists( 'content', $changed_attrs ) ) {
+			return $html;
+		}
+
+		$new_content = wp_kses_post( (string) $changed_attrs['content'] );
+
+		$result = preg_replace_callback(
+			'/^(\s*<[^>]+>)(.*?)(<\/[^>]+>\s*)$/is',
+			static function ( array $matches ) use ( $new_content ): string {
+				return $matches[1] . $new_content . $matches[3];
+			},
+			$html
+		);
+
+		return is_string( $result ) ? $result : $html;
+	}
+
+	/**
+	 * Transform core/button text attribute to <a> inner text.
+	 *
+	 * @param string              $block_name    Block type.
+	 * @param array<string,mixed> $changed_attrs Changed attributes.
+	 * @param string              $html          Current HTML.
+	 * @return string Updated HTML.
+	 */
+	private static function transform_button_text( string $block_name, array $changed_attrs, string $html ): string {
+		if ( 'core/button' !== $block_name || ! array_key_exists( 'text', $changed_attrs ) ) {
+			return $html;
+		}
+
+		$new_text = wp_kses_post( (string) $changed_attrs['text'] );
+
+		$result = preg_replace_callback(
+			'/(<a[^>]*>)(.*?)(<\/a>)/is',
+			static function ( array $matches ) use ( $new_text ): string {
+				return $matches[1] . $new_text . $matches[3];
+			},
+			$html
+		);
+
+		return is_string( $result ) ? $result : $html;
+	}
+
+	/**
+	 * Transform core/quote citation attribute to <cite> element.
+	 *
+	 * If a <cite> element exists, replaces its content.
+	 * If no <cite> exists and citation is non-empty, appends one before </blockquote>.
+	 *
+	 * @param string              $block_name    Block type.
+	 * @param array<string,mixed> $changed_attrs Changed attributes.
+	 * @param string              $html          Current HTML.
+	 * @return string Updated HTML.
+	 */
+	private static function transform_quote_citation( string $block_name, array $changed_attrs, string $html ): string {
+		if ( 'core/quote' !== $block_name || ! array_key_exists( 'citation', $changed_attrs ) ) {
+			return $html;
+		}
+
+		$new_citation = wp_kses_post( (string) $changed_attrs['citation'] );
+
+		if ( preg_match( '/<cite[^>]*>.*?<\/cite>/is', $html ) ) {
+			$result = preg_replace_callback(
+				'/(<cite[^>]*>).*?(<\/cite>)/is',
+				static function ( array $matches ) use ( $new_citation ): string {
+					return $matches[1] . $new_citation . $matches[2];
+				},
+				$html
+			);
+
+			return is_string( $result ) ? $result : $html;
+		}
+
+		if ( '' !== $new_citation ) {
+			$result = preg_replace_callback(
+				'/(<\/blockquote>\s*$)/i',
+				static function ( array $matches ) use ( $new_citation ): string {
+					return '<cite>' . $new_citation . '</cite>' . $matches[1];
+				},
+				$html
+			);
+
+			return is_string( $result ) ? $result : $html;
+		}
+
+		return $html;
+	}
+
+	// ── innerContent rebuild ─────────────────────────────────────────────
+
+	/**
+	 * Rebuild innerContent array to match new innerHTML.
+	 *
+	 * Preserves null placeholders for innerBlocks.
+	 *
+	 * @param array<string,mixed> $block    Block array.
+	 * @param string              $new_html New innerHTML.
+	 * @return list<string|null> Updated innerContent.
+	 */
+	private static function rebuild_inner_content( array $block, string $new_html ): array {
+		$inner_blocks = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : [];
+		$icont        = isset( $block['innerContent'] ) && is_array( $block['innerContent'] ) ? $block['innerContent'] : [];
+
+		if ( empty( $inner_blocks ) ) {
+			return [ $new_html ];
+		}
+
+		// Count existing null placeholders.
+		$null_count = 0;
+
+		foreach ( $icont as $piece ) {
+			if ( null === $piece ) {
+				++$null_count;
+			}
+		}
+
+		if ( 0 === $null_count ) {
+			return [ $new_html ];
+		}
+
+		// For container blocks, split HTML into opening wrapper + closing wrapper
+		// and place nulls between them (one per child).
+		$first_close = strpos( $new_html, '>' );
+
+		if ( false !== $first_close ) {
+			$opening = substr( $new_html, 0, $first_close + 1 );
+			$closing = substr( $new_html, $first_close + 1 );
+
+			$result = [ $opening ];
+
+			for ( $i = 0; $i < $null_count; $i++ ) {
+				$result[] = null;
+			}
+
+			$result[] = $closing;
+
+			return $result;
+		}
+
+		// Fallback: preserve structure, replace string chunks.
+		return array_values(
+			array_map(
+				static function ( $piece ) use ( $new_html ) {
+					return null === $piece ? null : $new_html;
+				},
+				$icont
+			)
+		);
+	}
+}

--- a/tests/SdAiAgent/Core/HtmlTransformerTest.php
+++ b/tests/SdAiAgent/Core/HtmlTransformerTest.php
@@ -1,0 +1,641 @@
+<?php
+/**
+ * Test case for HtmlTransformer (GH#1711).
+ *
+ * Covers the acceptance criteria from the issue:
+ *   AC1: core/heading level ↔ <hN> tag sync.
+ *   AC2: core/list ordered ↔ <ul>/<ol> tag sync.
+ *   AC3: core/group tagName ↔ wrapper tag sync.
+ *   AC4: core/button url ↔ <a href>; text ↔ link text.
+ *   AC5: core/image url/alt/id ↔ <img> attributes.
+ *   AC6: Unknown block returns unchanged.
+ *   AC7: static_block_attrs_changed warning for unsupported blocks.
+ *   AC8: wp_kses_post on final output.
+ *   AC9: Full PHPUnit + lint + phpstan clean.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ * @see     https://github.com/Ultimate-Multisite/superdav-ai-agent/issues/1711
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\BlockMutator;
+use SdAiAgent\Core\HtmlTransformer;
+use WP_UnitTestCase;
+
+/**
+ * Unit tests for HtmlTransformer.
+ *
+ * Uses WP_UnitTestCase so wp_kses_post(), WP_HTML_Tag_Processor, and other
+ * WP functions are available.
+ */
+class HtmlTransformerTest extends WP_UnitTestCase {
+
+	// ── Helpers ────────────────────────────────────────────────────────────
+
+	/**
+	 * Build a minimal parsed-block array.
+	 *
+	 * @param string              $name        Block name.
+	 * @param array<string,mixed> $attrs       Block attributes.
+	 * @param array<int,mixed>    $inner_blocks Inner blocks.
+	 * @param string              $inner_html  innerHTML string.
+	 * @return array<string,mixed>
+	 */
+	private function make_block(
+		string $name,
+		array $attrs = [],
+		array $inner_blocks = [],
+		string $inner_html = '<p>Content</p>'
+	): array {
+		$inner_content = [];
+
+		foreach ( $inner_blocks as $ignored ) {
+			$inner_content[] = null;
+		}
+
+		if ( empty( $inner_blocks ) ) {
+			$inner_content = [ $inner_html ];
+		}
+
+		return [
+			'blockName'    => $name,
+			'attrs'        => $attrs,
+			'innerBlocks'  => $inner_blocks,
+			'innerHTML'    => $inner_html,
+			'innerContent' => $inner_content,
+		];
+	}
+
+	// ── core/heading (AC1) ───────────────────────────────────────────────
+
+	/**
+	 * AC1: Heading level 2 → 3 rewrites <h2> to <h3>.
+	 */
+	public function test_heading_level_2_to_3(): void {
+		$block  = $this->make_block( 'core/heading', [ 'level' => 2 ], [], '<h2>Hello World</h2>' );
+		$result = HtmlTransformer::apply( $block, [ 'level' => 3 ] );
+
+		$this->assertSame( '<h3>Hello World</h3>', $result['innerHTML'] );
+	}
+
+	/**
+	 * Heading level 5 → 1 rewrites all opening and closing tags.
+	 */
+	public function test_heading_level_5_to_1(): void {
+		$block  = $this->make_block( 'core/heading', [ 'level' => 5 ], [], '<h5 class="has-text-align-center">Title</h5>' );
+		$result = HtmlTransformer::apply( $block, [ 'level' => 1 ] );
+
+		$this->assertSame( '<h1 class="has-text-align-center">Title</h1>', $result['innerHTML'] );
+	}
+
+	/**
+	 * Heading with invalid level (0) leaves HTML unchanged.
+	 */
+	public function test_heading_invalid_level(): void {
+		$block  = $this->make_block( 'core/heading', [ 'level' => 2 ], [], '<h2>Hello</h2>' );
+		$result = HtmlTransformer::apply( $block, [ 'level' => 0 ] );
+
+		$this->assertSame( '<h2>Hello</h2>', $result['innerHTML'] );
+	}
+
+	/**
+	 * Heading innerContent is rebuilt to match new innerHTML.
+	 */
+	public function test_heading_inner_content_rebuilt(): void {
+		$block  = $this->make_block( 'core/heading', [ 'level' => 2 ], [], '<h2>Test</h2>' );
+		$result = HtmlTransformer::apply( $block, [ 'level' => 4 ] );
+
+		$this->assertSame( [ '<h4>Test</h4>' ], $result['innerContent'] );
+	}
+
+	// ── core/list (AC2) ──────────────────────────────────────────────────
+
+	/**
+	 * AC2: List ordered:true converts <ul> to <ol>.
+	 */
+	public function test_list_unordered_to_ordered(): void {
+		$html   = '<ul><li>Item 1</li><li>Item 2</li></ul>';
+		$block  = $this->make_block( 'core/list', [ 'ordered' => false ], [], $html );
+		$result = HtmlTransformer::apply( $block, [ 'ordered' => true ] );
+
+		$this->assertStringContainsString( '<ol>', $result['innerHTML'] );
+		$this->assertStringContainsString( '</ol>', $result['innerHTML'] );
+		$this->assertStringNotContainsString( '<ul>', $result['innerHTML'] );
+		$this->assertStringNotContainsString( '</ul>', $result['innerHTML'] );
+	}
+
+	/**
+	 * List ordered:false converts <ol> to <ul>.
+	 */
+	public function test_list_ordered_to_unordered(): void {
+		$html   = '<ol><li>Item 1</li><li>Item 2</li></ol>';
+		$block  = $this->make_block( 'core/list', [ 'ordered' => true ], [], $html );
+		$result = HtmlTransformer::apply( $block, [ 'ordered' => false ] );
+
+		$this->assertStringContainsString( '<ul>', $result['innerHTML'] );
+		$this->assertStringContainsString( '</ul>', $result['innerHTML'] );
+		$this->assertStringNotContainsString( '<ol>', $result['innerHTML'] );
+	}
+
+	/**
+	 * List with nested lists only swaps outer tags.
+	 */
+	public function test_list_nested_preserves_inner(): void {
+		$html   = '<ul><li>Top<ul><li>Nested</li></ul></li></ul>';
+		$block  = $this->make_block( 'core/list', [ 'ordered' => false ], [], $html );
+		$result = HtmlTransformer::apply( $block, [ 'ordered' => true ] );
+
+		// Outer should be <ol>, inner should remain <ul>.
+		$this->assertStringStartsWith( '<ol>', $result['innerHTML'] );
+		$this->assertStringContainsString( '<ul><li>Nested</li></ul>', $result['innerHTML'] );
+	}
+
+	// ── core/group (AC3) ─────────────────────────────────────────────────
+
+	/**
+	 * AC3: Group tagName:'section' rewrites wrapper tag.
+	 */
+	public function test_group_tag_div_to_section(): void {
+		$html   = '<div class="wp-block-group"></div>';
+		$block  = $this->make_block( 'core/group', [ 'tagName' => 'div' ], [], $html );
+		$result = HtmlTransformer::apply( $block, [ 'tagName' => 'section' ] );
+
+		$this->assertStringContainsString( '<section', $result['innerHTML'] );
+		$this->assertStringContainsString( '</section>', $result['innerHTML'] );
+		$this->assertStringNotContainsString( '<div', $result['innerHTML'] );
+	}
+
+	/**
+	 * Group rejects invalid tagName (stays unchanged).
+	 */
+	public function test_group_invalid_tag_name(): void {
+		$html   = '<div class="wp-block-group"></div>';
+		$block  = $this->make_block( 'core/group', [ 'tagName' => 'div' ], [], $html );
+		$result = HtmlTransformer::apply( $block, [ 'tagName' => 'script' ] );
+
+		$this->assertSame( $html, $result['innerHTML'] );
+	}
+
+	/**
+	 * Group supports nav tagName.
+	 */
+	public function test_group_tag_to_nav(): void {
+		$html   = '<div class="wp-block-group"></div>';
+		$block  = $this->make_block( 'core/group', [ 'tagName' => 'div' ], [], $html );
+		$result = HtmlTransformer::apply( $block, [ 'tagName' => 'nav' ] );
+
+		$this->assertStringContainsString( '<nav', $result['innerHTML'] );
+		$this->assertStringContainsString( '</nav>', $result['innerHTML'] );
+	}
+
+	// ── core/button (AC4) ────────────────────────────────────────────────
+
+	/**
+	 * AC4: Button url change rewrites <a href>.
+	 */
+	public function test_button_url_change(): void {
+		$html   = '<div class="wp-block-button"><a class="wp-block-button__link" href="https://old.example.com" target="_blank" rel="noopener">Click</a></div>';
+		$block  = $this->make_block( 'core/button', [ 'url' => 'https://old.example.com' ], [], $html );
+		$result = HtmlTransformer::apply( $block, [ 'url' => 'https://new.example.com' ] );
+
+		$this->assertStringContainsString( 'href="https://new.example.com"', $result['innerHTML'] );
+		// Preserves other attributes.
+		$this->assertStringContainsString( 'class="wp-block-button__link"', $result['innerHTML'] );
+		$this->assertStringContainsString( 'target="_blank"', $result['innerHTML'] );
+		$this->assertStringContainsString( 'rel="noopener"', $result['innerHTML'] );
+	}
+
+	/**
+	 * AC4: Button text change rewrites link text.
+	 */
+	public function test_button_text_change(): void {
+		$html   = '<div class="wp-block-button"><a class="wp-block-button__link" href="https://example.com">Old Text</a></div>';
+		$block  = $this->make_block( 'core/button', [ 'text' => 'Old Text' ], [], $html );
+		$result = HtmlTransformer::apply( $block, [ 'text' => 'New Text' ] );
+
+		$this->assertStringContainsString( '>New Text</a>', $result['innerHTML'] );
+	}
+
+	/**
+	 * Button combined url + text change updates both.
+	 */
+	public function test_button_url_and_text_change(): void {
+		$html   = '<div class="wp-block-button"><a class="wp-block-button__link" href="https://old.example.com">Click</a></div>';
+		$block  = $this->make_block( 'core/button', [], [], $html );
+		$result = HtmlTransformer::apply( $block, [
+			'url'  => 'https://new.example.com',
+			'text' => 'New Button',
+		] );
+
+		$this->assertStringContainsString( 'href="https://new.example.com"', $result['innerHTML'] );
+		$this->assertStringContainsString( '>New Button</a>', $result['innerHTML'] );
+	}
+
+	// ── core/image (AC5) ─────────────────────────────────────────────────
+
+	/**
+	 * AC5: Image url change rewrites <img src>.
+	 */
+	public function test_image_url_change(): void {
+		$html   = '<figure class="wp-block-image"><img src="https://old.example.com/img.jpg" alt="Photo" class="wp-image-42" /></figure>';
+		$block  = $this->make_block( 'core/image', [ 'url' => 'https://old.example.com/img.jpg' ], [], $html );
+		$result = HtmlTransformer::apply( $block, [ 'url' => 'https://new.example.com/img.png' ] );
+
+		$this->assertStringContainsString( 'src="https://new.example.com/img.png"', $result['innerHTML'] );
+	}
+
+	/**
+	 * Image alt change rewrites <img alt>.
+	 */
+	public function test_image_alt_change(): void {
+		$html   = '<figure class="wp-block-image"><img src="https://example.com/img.jpg" alt="Old Alt" class="wp-image-42" /></figure>';
+		$block  = $this->make_block( 'core/image', [ 'alt' => 'Old Alt' ], [], $html );
+		$result = HtmlTransformer::apply( $block, [ 'alt' => 'New Alt Description' ] );
+
+		$this->assertStringContainsString( 'alt="New Alt Description"', $result['innerHTML'] );
+	}
+
+	/**
+	 * AC5: Image id change rewrites wp-image-{id} class.
+	 */
+	public function test_image_id_change(): void {
+		$html   = '<figure class="wp-block-image"><img src="https://example.com/img.jpg" alt="Photo" class="wp-image-42" /></figure>';
+		$block  = $this->make_block( 'core/image', [ 'id' => 42 ], [], $html );
+		$result = HtmlTransformer::apply( $block, [ 'id' => 99 ] );
+
+		$this->assertStringContainsString( 'wp-image-99', $result['innerHTML'] );
+		$this->assertStringNotContainsString( 'wp-image-42', $result['innerHTML'] );
+	}
+
+	/**
+	 * Image combined url + alt + id updates all attributes.
+	 */
+	public function test_image_combined_changes(): void {
+		$html   = '<figure class="wp-block-image"><img src="https://old.example.com/old.jpg" alt="Old" class="wp-image-10" /></figure>';
+		$block  = $this->make_block( 'core/image', [], [], $html );
+		$result = HtmlTransformer::apply( $block, [
+			'url' => 'https://new.example.com/new.jpg',
+			'alt' => 'New Alt',
+			'id'  => 50,
+		] );
+
+		$this->assertStringContainsString( 'src="https://new.example.com/new.jpg"', $result['innerHTML'] );
+		$this->assertStringContainsString( 'alt="New Alt"', $result['innerHTML'] );
+		$this->assertStringContainsString( 'wp-image-50', $result['innerHTML'] );
+	}
+
+	// ── core/spacer ──────────────────────────────────────────────────────
+
+	/**
+	 * Spacer height change rewrites inline style.
+	 */
+	public function test_spacer_height_change(): void {
+		$html   = '<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>';
+		$block  = $this->make_block( 'core/spacer', [ 'height' => '100px' ], [], $html );
+		$result = HtmlTransformer::apply( $block, [ 'height' => '200px' ] );
+
+		$this->assertStringContainsString( 'height:200px', $result['innerHTML'] );
+		$this->assertStringNotContainsString( 'height:100px', $result['innerHTML'] );
+	}
+
+	/**
+	 * Spacer width change rewrites inline style.
+	 */
+	public function test_spacer_width_change(): void {
+		$html   = '<div style="height:50px;width:100px" aria-hidden="true" class="wp-block-spacer"></div>';
+		$block  = $this->make_block( 'core/spacer', [ 'width' => '100px' ], [], $html );
+		$result = HtmlTransformer::apply( $block, [ 'width' => '300px' ] );
+
+		$this->assertStringContainsString( 'width:300px', $result['innerHTML'] );
+	}
+
+	// ── core/details ─────────────────────────────────────────────────────
+
+	/**
+	 * Details showContent:true adds `open` attribute.
+	 */
+	public function test_details_show_content_true(): void {
+		$html   = '<details class="wp-block-details"><summary>Title</summary><p>Content</p></details>';
+		$block  = $this->make_block( 'core/details', [ 'showContent' => false ], [], $html );
+		$result = HtmlTransformer::apply( $block, [ 'showContent' => true ] );
+
+		$this->assertStringContainsString( '<details', $result['innerHTML'] );
+		$this->assertStringContainsString( 'open', $result['innerHTML'] );
+	}
+
+	/**
+	 * Details showContent:false removes `open` attribute.
+	 */
+	public function test_details_show_content_false(): void {
+		$html   = '<details class="wp-block-details" open><summary>Title</summary><p>Content</p></details>';
+		$block  = $this->make_block( 'core/details', [ 'showContent' => true ], [], $html );
+		$result = HtmlTransformer::apply( $block, [ 'showContent' => false ] );
+
+		$this->assertStringNotContainsString( ' open', $result['innerHTML'] );
+	}
+
+	// ── core/quote ───────────────────────────────────────────────────────
+
+	/**
+	 * Quote citation update replaces existing <cite>.
+	 */
+	public function test_quote_citation_update(): void {
+		$html   = '<blockquote class="wp-block-quote"><p>A wise quote.</p><cite>Old Author</cite></blockquote>';
+		$block  = $this->make_block( 'core/quote', [ 'citation' => 'Old Author' ], [], $html );
+		$result = HtmlTransformer::apply( $block, [ 'citation' => 'New Author' ] );
+
+		$this->assertStringContainsString( '<cite>New Author</cite>', $result['innerHTML'] );
+		$this->assertStringNotContainsString( 'Old Author', $result['innerHTML'] );
+	}
+
+	/**
+	 * Quote citation adds <cite> when none exists.
+	 */
+	public function test_quote_citation_add(): void {
+		$html   = '<blockquote class="wp-block-quote"><p>A wise quote.</p></blockquote>';
+		$block  = $this->make_block( 'core/quote', [], [], $html );
+		$result = HtmlTransformer::apply( $block, [ 'citation' => 'New Author' ] );
+
+		$this->assertStringContainsString( '<cite>New Author</cite>', $result['innerHTML'] );
+	}
+
+	// ── core/audio & core/video ──────────────────────────────────────────
+
+	/**
+	 * Audio loop:true sets loop attribute.
+	 */
+	public function test_audio_loop_enable(): void {
+		$html   = '<figure class="wp-block-audio"><audio controls src="https://example.com/audio.mp3"></audio></figure>';
+		$block  = $this->make_block( 'core/audio', [ 'loop' => false ], [], $html );
+		$result = HtmlTransformer::apply( $block, [ 'loop' => true ] );
+
+		$this->assertStringContainsString( 'loop', $result['innerHTML'] );
+	}
+
+	/**
+	 * Video autoplay:true sets autoplay attribute.
+	 */
+	public function test_video_autoplay_enable(): void {
+		$html   = '<figure class="wp-block-video"><video controls src="https://example.com/video.mp4"></video></figure>';
+		$block  = $this->make_block( 'core/video', [], [], $html );
+		$result = HtmlTransformer::apply( $block, [ 'autoplay' => true ] );
+
+		$this->assertStringContainsString( 'autoplay', $result['innerHTML'] );
+	}
+
+	/**
+	 * Audio controls:false removes controls attribute.
+	 */
+	public function test_audio_controls_disable(): void {
+		$html   = '<figure class="wp-block-audio"><audio controls src="https://example.com/audio.mp3"></audio></figure>';
+		$block  = $this->make_block( 'core/audio', [ 'controls' => true ], [], $html );
+		$result = HtmlTransformer::apply( $block, [ 'controls' => false ] );
+
+		$this->assertStringNotContainsString( 'controls', $result['innerHTML'] );
+	}
+
+	// ── core/code & core/preformatted & core/paragraph ───────────────────
+
+	/**
+	 * Code content update replaces inner text.
+	 */
+	public function test_code_content_update(): void {
+		$html   = '<pre class="wp-block-code"><code>old code here</code></pre>';
+		$block  = $this->make_block( 'core/code', [ 'content' => 'old code here' ], [], $html );
+		$result = HtmlTransformer::apply( $block, [ 'content' => 'new code here' ] );
+
+		$this->assertStringContainsString( 'new code here', $result['innerHTML'] );
+	}
+
+	/**
+	 * Preformatted content update replaces inner text.
+	 */
+	public function test_preformatted_content_update(): void {
+		$html   = '<pre class="wp-block-preformatted">old text</pre>';
+		$block  = $this->make_block( 'core/preformatted', [ 'content' => 'old text' ], [], $html );
+		$result = HtmlTransformer::apply( $block, [ 'content' => 'new formatted text' ] );
+
+		$this->assertStringContainsString( 'new formatted text', $result['innerHTML'] );
+	}
+
+	/**
+	 * Paragraph content update replaces inner text.
+	 */
+	public function test_paragraph_content_update(): void {
+		$html   = '<p>old paragraph text</p>';
+		$block  = $this->make_block( 'core/paragraph', [ 'content' => 'old paragraph text' ], [], $html );
+		$result = HtmlTransformer::apply( $block, [ 'content' => 'new paragraph text' ] );
+
+		$this->assertSame( '<p>new paragraph text</p>', $result['innerHTML'] );
+	}
+
+	// ── Unknown block / no-op guard (AC6) ────────────────────────────────
+
+	/**
+	 * AC6: Unknown block returns the block unchanged.
+	 */
+	public function test_unknown_block_noop(): void {
+		$block  = $this->make_block( 'my-plugin/custom-block', [ 'foo' => 'bar' ], [], '<div>Custom</div>' );
+		$result = HtmlTransformer::apply( $block, [ 'foo' => 'baz' ] );
+
+		$this->assertSame( '<div>Custom</div>', $result['innerHTML'] );
+	}
+
+	/**
+	 * Supported block with irrelevant attr changes returns unchanged.
+	 */
+	public function test_supported_block_irrelevant_attr_noop(): void {
+		$block  = $this->make_block( 'core/heading', [ 'level' => 2, 'textAlign' => 'left' ], [], '<h2>Hello</h2>' );
+		$result = HtmlTransformer::apply( $block, [ 'textAlign' => 'center' ] );
+
+		$this->assertSame( '<h2>Hello</h2>', $result['innerHTML'] );
+	}
+
+	/**
+	 * is_supported returns true for known blocks.
+	 */
+	public function test_is_supported_true(): void {
+		$this->assertTrue( HtmlTransformer::is_supported( 'core/heading' ) );
+		$this->assertTrue( HtmlTransformer::is_supported( 'core/list' ) );
+		$this->assertTrue( HtmlTransformer::is_supported( 'core/image' ) );
+		$this->assertTrue( HtmlTransformer::is_supported( 'core/button' ) );
+		$this->assertTrue( HtmlTransformer::is_supported( 'core/spacer' ) );
+	}
+
+	/**
+	 * is_supported returns false for unknown blocks.
+	 */
+	public function test_is_supported_false(): void {
+		$this->assertFalse( HtmlTransformer::is_supported( 'my-plugin/custom' ) );
+		$this->assertFalse( HtmlTransformer::is_supported( 'core/columns' ) );
+	}
+
+	// ── static_block_attrs_changed warning (AC7) ─────────────────────────
+
+	/**
+	 * AC7: update-attrs on unsupported block emits static_block_attrs_changed warning.
+	 */
+	public function test_mutator_warns_unsupported_block(): void {
+		$blocks = [
+			$this->make_block( 'core/table', [ 'hasHeader' => false ], [], '<figure class="wp-block-table"><table></table></figure>' ),
+		];
+
+		$result = BlockMutator::apply( $blocks, 'update-attrs', [
+			'path'       => [ 0 ],
+			'attributes' => [ 'hasHeader' => true ],
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( '_warnings', $result );
+		$this->assertContains( 'static_block_attrs_changed', $result['_warnings'] );
+	}
+
+	/**
+	 * update-attrs on a supported block does NOT emit the warning.
+	 */
+	public function test_mutator_no_warning_supported_block(): void {
+		$blocks = [
+			$this->make_block( 'core/heading', [ 'level' => 2 ], [], '<h2>Hello</h2>' ),
+		];
+
+		$result = BlockMutator::apply( $blocks, 'update-attrs', [
+			'path'       => [ 0 ],
+			'attributes' => [ 'level' => 3 ],
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayNotHasKey( '_warnings', $result );
+	}
+
+	// ── wp_kses_post sanitization (AC8) ──────────────────────────────────
+
+	/**
+	 * AC8: Final output runs through wp_kses_post (scripts stripped).
+	 */
+	public function test_kses_strips_script_from_content(): void {
+		$html   = '<p>Hello</p>';
+		$block  = $this->make_block( 'core/paragraph', [], [], $html );
+		$result = HtmlTransformer::apply( $block, [ 'content' => 'Safe text<script>alert(1)</script>' ] );
+
+		$this->assertStringNotContainsString( '<script>', $result['innerHTML'] );
+		$this->assertStringContainsString( 'Safe text', $result['innerHTML'] );
+	}
+
+	// ── Integration: update-attrs triggers auto-transform ────────────────
+
+	/**
+	 * AC1 integration: update-attrs on heading auto-transforms innerHTML.
+	 */
+	public function test_mutator_heading_auto_transform(): void {
+		$blocks = [
+			$this->make_block( 'core/heading', [ 'level' => 2 ], [], '<h2>Hello World</h2>' ),
+		];
+
+		$result = BlockMutator::apply( $blocks, 'update-attrs', [
+			'path'       => [ 0 ],
+			'attributes' => [ 'level' => 3 ],
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 3, $result[0]['attrs']['level'] );
+		$this->assertSame( '<h3>Hello World</h3>', $result[0]['innerHTML'] );
+	}
+
+	/**
+	 * AC2 integration: update-attrs on list auto-transforms innerHTML.
+	 */
+	public function test_mutator_list_auto_transform(): void {
+		$html   = '<ul><li>Item 1</li><li>Item 2</li></ul>';
+		$blocks = [
+			$this->make_block( 'core/list', [ 'ordered' => false ], [], $html ),
+		];
+
+		$result = BlockMutator::apply( $blocks, 'update-attrs', [
+			'path'       => [ 0 ],
+			'attributes' => [ 'ordered' => true ],
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result[0]['attrs']['ordered'] );
+		$this->assertStringContainsString( '<ol>', $result[0]['innerHTML'] );
+	}
+
+	/**
+	 * AC4 integration: update-attrs on button auto-transforms href.
+	 */
+	public function test_mutator_button_auto_transform(): void {
+		$html   = '<div class="wp-block-button"><a class="wp-block-button__link" href="https://old.example.com">Click</a></div>';
+		$blocks = [
+			$this->make_block( 'core/button', [ 'url' => 'https://old.example.com' ], [], $html ),
+		];
+
+		$result = BlockMutator::apply( $blocks, 'update-attrs', [
+			'path'       => [ 0 ],
+			'attributes' => [ 'url' => 'https://new.example.com' ],
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertStringContainsString( 'href="https://new.example.com"', $result[0]['innerHTML'] );
+	}
+
+	/**
+	 * AC5 integration: update-attrs on image auto-transforms src, alt, class.
+	 */
+	public function test_mutator_image_auto_transform(): void {
+		$html   = '<figure class="wp-block-image"><img src="https://old.example.com/old.jpg" alt="Old" class="wp-image-10" /></figure>';
+		$blocks = [
+			$this->make_block( 'core/image', [ 'url' => 'https://old.example.com/old.jpg', 'id' => 10 ], [], $html ),
+		];
+
+		$result = BlockMutator::apply( $blocks, 'update-attrs', [
+			'path'       => [ 0 ],
+			'attributes' => [ 'id' => 50 ],
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertStringContainsString( 'wp-image-50', $result[0]['innerHTML'] );
+		$this->assertStringNotContainsString( 'wp-image-10', $result[0]['innerHTML'] );
+	}
+
+	// ── Edge cases ───────────────────────────────────────────────────────
+
+	/**
+	 * Empty innerHTML returns block unchanged.
+	 */
+	public function test_empty_inner_html_noop(): void {
+		$block  = $this->make_block( 'core/heading', [ 'level' => 2 ], [], '' );
+		$result = HtmlTransformer::apply( $block, [ 'level' => 3 ] );
+
+		$this->assertSame( '', $result['innerHTML'] );
+	}
+
+	/**
+	 * Empty blockName returns block unchanged.
+	 */
+	public function test_empty_block_name_noop(): void {
+		$block  = $this->make_block( '', [], [], '<p>Content</p>' );
+		$result = HtmlTransformer::apply( $block, [ 'level' => 3 ] );
+
+		$this->assertSame( '<p>Content</p>', $result['innerHTML'] );
+	}
+
+	/**
+	 * Container block with innerBlocks preserves null slots in innerContent.
+	 */
+	public function test_container_inner_content_preserves_nulls(): void {
+		$child  = $this->make_block( 'core/paragraph', [], [], '<p>Child</p>' );
+		$html   = '<div class="wp-block-group"></div>';
+		$block  = $this->make_block( 'core/group', [ 'tagName' => 'div' ], [ $child ], $html );
+		$result = HtmlTransformer::apply( $block, [ 'tagName' => 'section' ] );
+
+		// innerContent should have opening HTML, null (for child), closing HTML.
+		$null_count = count( array_filter( $result['innerContent'], 'is_null' ) );
+		$this->assertSame( 1, $null_count );
+		$this->assertStringContainsString( '<section', $result['innerContent'][0] );
+	}
+}


### PR DESCRIPTION
## Summary

## What
Added HtmlTransformer class that auto-synchronizes block innerHTML when update-attrs changes attributes with structural HTML counterparts. Integrated with BlockMutator's update-attrs operation.

## Supported blocks
- **core/heading** — level ↔ `<hN>` tag
- **core/list** — ordered ↔ `<ul>`/`<ol>`
- **core/group** — tagName ↔ wrapper tag (div/section/header/footer/main/aside/nav/article)
- **core/button** — url ↔ `<a href>`; text ↔ link text
- **core/image** — url/alt/id ↔ `<img>` src/alt/class
- **core/spacer** — height/width ↔ inline style
- **core/details** — showContent ↔ `<details open>`
- **core/quote** — citation ↔ `<cite>` element
- **core/audio/video** — loop/autoplay/controls ↔ boolean attributes
- **core/code/preformatted/paragraph** — content ↔ inner text

## Files changed
- **New:** `includes/Core/HtmlTransformer.php` (620 LOC) — per-block transforms
- **Modified:** `includes/Core/BlockMutator.php` — calls HtmlTransformer after update-attrs; emits `_warnings: ['static_block_attrs_changed']` for unsupported blocks
- **New:** `tests/SdAiAgent/Core/HtmlTransformerTest.php` (43 tests) — all acceptance criteria covered

## Worker self-verification
- PHPUnit: Tests: 2820, Assertions: 7663, Errors: 0, Failures: 3 (pre-existing PluginUpdater DB failures, confirmed on main), Skipped: 104
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded

## Files Changed

includes/Core/BlockMutator.php,includes/Core/HtmlTransformer.php,tests/SdAiAgent/Core/HtmlTransformerTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify (lint:php, lint:js, lint:css, phpstan, test:php, build). All 43 new HtmlTransformerTest tests pass. All 40 existing BlockMutatorTest tests pass. 3 pre-existing PluginUpdater failures confirmed on main.

Resolves #1711


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.28 plugin for [OpenCode](https://opencode.ai) v1.15.7 with claude-opus-4-6 spent 14m and 31,875 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Block HTML automatically synchronizes with attribute changes, ensuring visual consistency across heading levels, list formatting, image properties, button URLs, text content, spacer dimensions, quote citations, and audio/video configurations.

* **Tests**
  * Added comprehensive test coverage for HTML synchronization during attribute updates, including validation of supported blocks, warning generation for unsupported blocks, and edge case handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1730?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->