### PR TITLE
feat: t250 — dual-storage block detection and enforcement (Resolves #1713)

### DIFF
--- a/includes/Core/BlockMutator.php
+++ b/includes/Core/BlockMutator.php
@@ -220,7 +220,7 @@ class BlockMutator {
 					} else {
 						$block['innerContent'] = self::rebuild_inner_content_with_html( $block, $safe_html );
 					}
-				} elseif ( is_array( $block ) && HtmlTransformer::is_supported( isset( $block['blockName'] ) && is_string( $block['blockName'] ) ? $block['blockName'] : '' ) ) {
+				} elseif ( HtmlTransformer::is_supported( isset( $block['blockName'] ) && is_string( $block['blockName'] ) ? $block['blockName'] : '' ) ) {
 					// Auto-transform innerHTML when attribute changes imply HTML structure changes.
 					$block = HtmlTransformer::apply( $block, $args['attributes'] );
 				}

--- a/includes/Core/BlockMutator.php
+++ b/includes/Core/BlockMutator.php
@@ -25,6 +25,7 @@ declare(strict_types=1);
  * @package SdAiAgent\Core
  * @license GPL-2.0-or-later
  * @see     https://github.com/Ultimate-Multisite/superdav-ai-agent/issues/1708
+ * @see     https://github.com/Ultimate-Multisite/superdav-ai-agent/issues/1713
  */
 
 namespace SdAiAgent\Core;
@@ -158,13 +159,48 @@ class BlockMutator {
 			);
 		}
 
+		// Dual-storage guard: blocks that duplicate state across attributes and
+		// innerHTML must have both sides updated together to prevent silent corruption.
+		$target = BlockTreeAddress::get_block_at_path( $blocks, $path );
+
+		if ( is_array( $target ) ) {
+			$block_name = isset( $target['blockName'] ) && is_string( $target['blockName'] ) ? $target['blockName'] : '';
+
+			if ( '' !== $block_name && DualStorageRegistry::is_dual_storage( $block_name ) ) {
+				if ( ! isset( $args['innerHTML'] ) || ! is_string( $args['innerHTML'] ) ) {
+					return new \WP_Error(
+						'dual_storage_requires_both',
+						sprintf(
+							"'%s' stores data in both attributes and innerHTML. Supply both 'attributes' and 'innerHTML' in a single update to avoid silent corruption.",
+							$block_name
+						),
+						[
+							'status'     => 400,
+							'block_name' => $block_name,
+						]
+					);
+				}
+			}
+		}
+
 		$merge = isset( $args['merge'] ) ? (bool) $args['merge'] : true;
+
+		// When innerHTML is also supplied (required for dual-storage blocks),
+		// sanitize it now so the closure captures the safe value.
+		$safe_html = isset( $args['innerHTML'] ) && is_string( $args['innerHTML'] )
+			? wp_kses_post( $args['innerHTML'] )
+			: null;
 
 		return self::mutate_at_path(
 			$blocks,
 			$path,
-			static function ( array $siblings, int $idx ) use ( $args, $merge ) {
-				$block    = $siblings[ $idx ];
+			static function ( array $siblings, int $idx ) use ( $args, $merge, $safe_html ) {
+				$block = $siblings[ $idx ];
+
+				if ( ! is_array( $block ) ) {
+					return $siblings;
+				}
+
 				$existing = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : [];
 
 				if ( $merge ) {
@@ -173,8 +209,19 @@ class BlockMutator {
 					$block['attrs'] = $args['attributes'];
 				}
 
-				// Auto-transform innerHTML when attribute changes imply HTML structure changes.
-				if ( is_array( $block ) && HtmlTransformer::is_supported( isset( $block['blockName'] ) && is_string( $block['blockName'] ) ? $block['blockName'] : '' ) ) {
+				// Apply the HTML side when explicitly supplied (dual-storage blocks require both).
+				// When the caller provides innerHTML directly, they own both sides — skip HtmlTransformer.
+				if ( null !== $safe_html ) {
+					$block['innerHTML'] = $safe_html;
+					$inner_blocks       = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : [];
+
+					if ( empty( $inner_blocks ) ) {
+						$block['innerContent'] = [ $safe_html ];
+					} else {
+						$block['innerContent'] = self::rebuild_inner_content_with_html( $block, $safe_html );
+					}
+				} elseif ( is_array( $block ) && HtmlTransformer::is_supported( isset( $block['blockName'] ) && is_string( $block['blockName'] ) ? $block['blockName'] : '' ) ) {
+					// Auto-transform innerHTML when attribute changes imply HTML structure changes.
 					$block = HtmlTransformer::apply( $block, $args['attributes'] );
 				}
 
@@ -203,12 +250,41 @@ class BlockMutator {
 			);
 		}
 
+		// Dual-storage guard: blocks that duplicate state across attributes and
+		// innerHTML must have both sides updated together to prevent silent corruption.
+		$target = BlockTreeAddress::get_block_at_path( $blocks, $path );
+
+		if ( is_array( $target ) ) {
+			$block_name = isset( $target['blockName'] ) && is_string( $target['blockName'] ) ? $target['blockName'] : '';
+
+			if ( '' !== $block_name && DualStorageRegistry::is_dual_storage( $block_name ) ) {
+				if ( ! isset( $args['attributes'] ) || ! is_array( $args['attributes'] ) ) {
+					return new \WP_Error(
+						'dual_storage_requires_both',
+						sprintf(
+							"'%s' stores data in both attributes and innerHTML. Supply both 'attributes' and 'innerHTML' in a single update to avoid silent corruption.",
+							$block_name
+						),
+						[
+							'status'     => 400,
+							'block_name' => $block_name,
+						]
+					);
+				}
+			}
+		}
+
 		$safe_html = wp_kses_post( $args['innerHTML'] );
+
+		// When attributes are also supplied (required for dual-storage blocks),
+		// capture the merge flag and attrs for the closure.
+		$extra_attrs = isset( $args['attributes'] ) && is_array( $args['attributes'] ) ? $args['attributes'] : null;
+		$merge       = isset( $args['merge'] ) ? (bool) $args['merge'] : true;
 
 		return self::mutate_at_path(
 			$blocks,
 			$path,
-			static function ( array $siblings, int $idx ) use ( $safe_html ) {
+			static function ( array $siblings, int $idx ) use ( $safe_html, $extra_attrs, $merge ) {
 				$block = $siblings[ $idx ];
 
 				if ( ! is_array( $block ) ) {
@@ -225,6 +301,12 @@ class BlockMutator {
 				} else {
 					// Preserve innerContent null slots for innerBlocks; replace HTML portions only.
 					$block['innerContent'] = self::rebuild_inner_content_with_html( $block, $safe_html );
+				}
+
+				// Apply the attributes side when supplied (dual-storage blocks require both).
+				if ( null !== $extra_attrs ) {
+					$existing       = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : [];
+					$block['attrs'] = $merge ? array_merge( $existing, $extra_attrs ) : $extra_attrs;
 				}
 
 				$siblings[ $idx ] = $block;

--- a/includes/Core/DualStorageRegistry.php
+++ b/includes/Core/DualStorageRegistry.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Dual-storage block registry.
+ *
+ * Maintains a list of block names that store the same data in **both**
+ * `attributes` and `innerHTML`. Updating only one side leaves the block in a
+ * permanently inconsistent state, so any `update-attrs` or `update-html`
+ * operation on a dual-storage block must supply both sides.
+ *
+ * The list is hard-coded with known offenders and is extensible via the
+ * `sd_ai_agent_block_dual_storage_blocks` filter. A stretch scan helper can
+ * walk published posts and auto-detect additional candidates.
+ *
+ * @package SdAiAgent\Core
+ * @license GPL-2.0-or-later
+ * @see     https://github.com/Ultimate-Multisite/superdav-ai-agent/issues/1713
+ */
+
+namespace SdAiAgent\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Dual-storage block registry.
+ *
+ * All public methods are static. The class holds no per-instance state.
+ */
+class DualStorageRegistry {
+
+	/**
+	 * WordPress option key for the cached scan result.
+	 *
+	 * @var string
+	 */
+	const SCAN_OPTION = 'sd_ai_agent_dual_storage_detected';
+
+	/**
+	 * Hard-coded list of known dual-storage block names.
+	 *
+	 * These blocks duplicate their data across both `attributes` and `innerHTML`.
+	 * Updating only one side silently corrupts the block until the user
+	 * manually fixes it in the editor.
+	 *
+	 * @var string[]
+	 */
+	const KNOWN_BLOCKS = [
+		'yoast/faq-block',
+		'yoast/how-to-block',
+	];
+
+	// ── Public API ────────────────────────────────────────────────────────
+
+	/**
+	 * Return the full list of dual-storage block names.
+	 *
+	 * Applies the `sd_ai_agent_block_dual_storage_blocks` filter so third-party
+	 * plugins can register their own dual-storage blocks.
+	 *
+	 * @return string[] Unique list of block names.
+	 */
+	public static function get_blocks(): array {
+		/**
+		 * Filter the list of dual-storage block names.
+		 *
+		 * A dual-storage block stores the same data in both `attributes` and
+		 * `innerHTML`. Blocks added here will be subject to the same enforcement
+		 * as the hard-coded list: any `update-attrs` or `update-html` operation
+		 * must supply both sides or it will be rejected with `dual_storage_requires_both`.
+		 *
+		 * @param string[] $blocks Array of block names (e.g. 'yoast/faq-block').
+		 */
+		$blocks = (array) apply_filters( 'sd_ai_agent_block_dual_storage_blocks', self::KNOWN_BLOCKS );
+
+		// Ensure all entries are non-empty strings and deduplicate.
+		$blocks = array_values(
+			array_unique(
+				array_filter( $blocks, static fn( $v ) => is_string( $v ) && '' !== $v )
+			)
+		);
+
+		return $blocks;
+	}
+
+	/**
+	 * Return true when $block_name is a dual-storage block.
+	 *
+	 * @param string $block_name Block name (e.g. 'yoast/faq-block').
+	 * @return bool
+	 */
+	public static function is_dual_storage( string $block_name ): bool {
+		return in_array( $block_name, self::get_blocks(), true );
+	}
+
+	// ── Scan helper (stretch) ─────────────────────────────────────────────
+
+	/**
+	 * Scan all published posts and detect dual-storage candidates.
+	 *
+	 * A block is flagged as a candidate when at least one of its non-empty
+	 * attribute string values also appears verbatim inside its `innerHTML`.
+	 * This heuristic catches blocks that embed the same text in both stores.
+	 *
+	 * The detected list is stored in a site option and can be retrieved via
+	 * {@see DualStorageRegistry::get_detected_blocks()}. The hard-coded list
+	 * is kept separate — detected blocks are _additional_ candidates that may
+	 * require manual review before enforcement.
+	 *
+	 * @param int $batch_size Maximum number of posts to scan. Default 500.
+	 * @return string[] Detected block names (unique, sorted).
+	 */
+	public static function scan( int $batch_size = 500 ): array {
+		$offset   = 0;
+		$detected = [];
+		$known    = self::get_blocks();
+
+		while ( true ) {
+			$posts = get_posts(
+				[
+					'post_status'    => 'publish',
+					'post_type'      => 'any',
+					'posts_per_page' => min( $batch_size, 50 ),
+					'offset'         => $offset,
+					'fields'         => 'all',
+					'no_found_rows'  => true,
+				]
+			);
+
+			if ( empty( $posts ) ) {
+				break;
+			}
+
+			foreach ( $posts as $post ) {
+				if ( ! has_blocks( $post->post_content ) ) {
+					continue;
+				}
+
+				$blocks   = parse_blocks( $post->post_content );
+				$detected = array_merge( $detected, self::detect_in_tree( $blocks, $known ) );
+			}
+
+			$offset += count( $posts );
+
+			if ( $offset >= $batch_size ) {
+				break;
+			}
+		}
+
+		$detected = array_values( array_unique( $detected ) );
+		sort( $detected );
+
+		update_option( self::SCAN_OPTION, $detected, false );
+
+		return $detected;
+	}
+
+	/**
+	 * Return previously cached scan results (empty array if scan not yet run).
+	 *
+	 * @return string[]
+	 */
+	public static function get_detected_blocks(): array {
+		$stored = get_option( self::SCAN_OPTION, [] );
+
+		if ( ! is_array( $stored ) ) {
+			return [];
+		}
+
+		// Ensure the returned list is always string[].
+		return array_values( array_filter( $stored, 'is_string' ) );
+	}
+
+	/**
+	 * Clear the stored scan cache.
+	 *
+	 * @return void
+	 */
+	public static function delete_scan_cache(): void {
+		delete_option( self::SCAN_OPTION );
+	}
+
+	// ── Private helpers ───────────────────────────────────────────────────
+
+	/**
+	 * Recursively walk a parsed block tree and collect dual-storage candidates
+	 * not already in $known.
+	 *
+	 * @param array<array-key,mixed> $blocks Parse-blocks output (may have int|string keys).
+	 * @param string[]               $known  Already-known dual-storage block names to skip.
+	 * @return string[] Newly detected block names.
+	 */
+	private static function detect_in_tree( array $blocks, array $known ): array {
+		$found = [];
+
+		foreach ( $blocks as $block ) {
+			if ( ! is_array( $block ) ) {
+				continue;
+			}
+
+			$name       = isset( $block['blockName'] ) && is_string( $block['blockName'] ) ? $block['blockName'] : '';
+			$attrs      = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : [];
+			$inner_html = isset( $block['innerHTML'] ) && is_string( $block['innerHTML'] ) ? $block['innerHTML'] : '';
+
+			if ( '' !== $name && ! in_array( $name, $known, true ) && ! in_array( $name, $found, true ) ) {
+				if ( self::attrs_overlap_html( $attrs, $inner_html ) ) {
+					$found[] = $name;
+				}
+			}
+
+			// Recurse into innerBlocks.
+			if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+				$child_found = self::detect_in_tree( $block['innerBlocks'], array_merge( $known, $found ) );
+				$found       = array_merge( $found, $child_found );
+			}
+		}
+
+		return $found;
+	}
+
+	/**
+	 * Return true when any non-empty string attribute value appears in $html.
+	 *
+	 * @param array<string,mixed> $attrs      Block attributes (may be nested).
+	 * @param string              $inner_html Block innerHTML.
+	 * @return bool
+	 */
+	private static function attrs_overlap_html( array $attrs, string $inner_html ): bool {
+		if ( '' === $inner_html ) {
+			return false;
+		}
+
+		foreach ( self::flatten_strings( $attrs ) as $value ) {
+			if ( '' !== $value && str_contains( $inner_html, $value ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Recursively collect all non-empty string leaf values from a nested array.
+	 *
+	 * @param mixed $data Array or scalar to flatten.
+	 * @return string[]
+	 */
+	private static function flatten_strings( mixed $data ): array {
+		if ( is_string( $data ) ) {
+			return [ $data ];
+		}
+
+		if ( ! is_array( $data ) ) {
+			return [];
+		}
+
+		$strings = [];
+
+		foreach ( $data as $value ) {
+			$strings = array_merge( $strings, self::flatten_strings( $value ) );
+		}
+
+		return $strings;
+	}
+}

--- a/tests/SdAiAgent/Core/BlockMutatorTest.php
+++ b/tests/SdAiAgent/Core/BlockMutatorTest.php
@@ -15,6 +15,7 @@
  * @subpackage Tests
  * @license GPL-2.0-or-later
  * @see     https://github.com/Ultimate-Multisite/superdav-ai-agent/issues/1708
+ * @see     https://github.com/Ultimate-Multisite/superdav-ai-agent/issues/1713
  */
 
 declare(strict_types=1);
@@ -24,6 +25,7 @@ namespace SdAiAgent\Tests\Core;
 use SdAiAgent\Core\BlockMutator;
 use SdAiAgent\Core\BlockReferences;
 use SdAiAgent\Core\BlockTreeAddress;
+use SdAiAgent\Core\DualStorageRegistry;
 use WP_UnitTestCase;
 
 /**
@@ -686,5 +688,170 @@ class BlockMutatorTest extends WP_UnitTestCase {
 		$this->assertFalse( BlockTreeAddress::is_strict_ancestor( [ 1 ], [ 0, 1 ] ) );
 		$this->assertFalse( BlockTreeAddress::is_strict_ancestor( [ 0, 1 ], [ 0, 1 ] ) ); // Equal, not strict ancestor.
 		$this->assertFalse( BlockTreeAddress::is_strict_ancestor( [ 0, 1, 2 ], [ 0, 1 ] ) );
+	}
+
+	// ── Dual-storage enforcement (GH#1713) ────────────────────────────────
+
+	/**
+	 * update-attrs on a dual-storage block without innerHTML returns dual_storage_requires_both (AC1).
+	 */
+	public function test_update_attrs_dual_storage_without_html_returns_error(): void {
+		$block  = $this->make_block( 'yoast/faq-block', [ 'questions' => [] ] );
+		$result = BlockMutator::apply(
+			[ $block ],
+			'update-attrs',
+			[
+				'path'       => [ 0 ],
+				'attributes' => [ 'questions' => [ [ 'id' => 'q1', 'question' => 'Q?', 'answer' => 'A.' ] ] ],
+				// No innerHTML — must be rejected.
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'dual_storage_requires_both', $result->get_error_code() );
+
+		$data = $result->get_error_data();
+		$this->assertSame( 'yoast/faq-block', $data['block_name'] );
+		$this->assertSame( 400, $data['status'] );
+	}
+
+	/**
+	 * update-html on a dual-storage block without attributes returns dual_storage_requires_both (AC2).
+	 */
+	public function test_update_html_dual_storage_without_attrs_returns_error(): void {
+		$block  = $this->make_block( 'yoast/faq-block', [ 'questions' => [] ], [], '<div class="schema-faq"></div>' );
+		$result = BlockMutator::apply(
+			[ $block ],
+			'update-html',
+			[
+				'path'      => [ 0 ],
+				'innerHTML' => '<div class="schema-faq"><p>Updated</p></div>',
+				// No attributes — must be rejected.
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'dual_storage_requires_both', $result->get_error_code() );
+
+		$data = $result->get_error_data();
+		$this->assertSame( 'yoast/faq-block', $data['block_name'] );
+		$this->assertSame( 400, $data['status'] );
+	}
+
+	/**
+	 * update-attrs + innerHTML on a dual-storage block succeeds and updates both sides (AC3).
+	 */
+	public function test_update_attrs_dual_storage_with_both_sides_succeeds(): void {
+		$block  = $this->make_block( 'yoast/faq-block', [ 'questions' => [] ], [], '<div class="schema-faq"></div>' );
+		$result = BlockMutator::apply(
+			[ $block ],
+			'update-attrs',
+			[
+				'path'       => [ 0 ],
+				'attributes' => [ 'questions' => [ [ 'id' => 'q1', 'question' => 'Q?', 'answer' => 'A.' ] ] ],
+				'innerHTML'  => '<div class="schema-faq"><p>A.</p></div>',
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'yoast/faq-block', $result[0]['blockName'] );
+		$this->assertNotEmpty( $result[0]['attrs']['questions'] );
+		$this->assertStringContainsString( 'A.', $result[0]['innerHTML'] );
+	}
+
+	/**
+	 * update-html + attributes on a dual-storage block succeeds and updates both sides (AC3).
+	 */
+	public function test_update_html_dual_storage_with_both_sides_succeeds(): void {
+		$block  = $this->make_block( 'yoast/faq-block', [ 'questions' => [] ], [], '<div class="schema-faq"></div>' );
+		$result = BlockMutator::apply(
+			[ $block ],
+			'update-html',
+			[
+				'path'       => [ 0 ],
+				'innerHTML'  => '<div class="schema-faq"><p>Updated answer</p></div>',
+				'attributes' => [ 'questions' => [ [ 'id' => 'q1', 'question' => 'Q?', 'answer' => 'Updated answer' ] ] ],
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'yoast/faq-block', $result[0]['blockName'] );
+		$this->assertStringContainsString( 'Updated answer', $result[0]['innerHTML'] );
+		$this->assertNotEmpty( $result[0]['attrs']['questions'] );
+	}
+
+	/**
+	 * update-attrs on a non-dual-storage block (core/heading) is unaffected (AC4).
+	 */
+	public function test_update_attrs_non_dual_storage_block_unaffected(): void {
+		$block  = $this->make_block( 'core/heading', [ 'level' => 2 ] );
+		$result = BlockMutator::apply(
+			[ $block ],
+			'update-attrs',
+			[
+				'path'       => [ 0 ],
+				'attributes' => [ 'level' => 3 ],
+				// No innerHTML — fine for non-dual-storage blocks.
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 3, $result[0]['attrs']['level'] );
+	}
+
+	/**
+	 * update-html on a non-dual-storage block without attributes is unaffected (AC4).
+	 */
+	public function test_update_html_non_dual_storage_block_unaffected(): void {
+		$block  = $this->make_block( 'core/paragraph' );
+		$result = BlockMutator::apply(
+			[ $block ],
+			'update-html',
+			[
+				'path'      => [ 0 ],
+				'innerHTML' => '<p>New text</p>',
+				// No attributes — fine for non-dual-storage blocks.
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( '<p>New text</p>', $result[0]['innerHTML'] );
+	}
+
+	/**
+	 * yoast/how-to-block also triggers dual-storage enforcement (hard-coded list).
+	 */
+	public function test_how_to_block_also_enforced(): void {
+		$block  = $this->make_block( 'yoast/how-to-block' );
+		$result = BlockMutator::apply(
+			[ $block ],
+			'update-attrs',
+			[
+				'path'       => [ 0 ],
+				'attributes' => [ 'steps' => [] ],
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'dual_storage_requires_both', $result->get_error_code() );
+	}
+
+	/**
+	 * error data block_name is populated correctly.
+	 */
+	public function test_dual_storage_error_data_contains_block_name(): void {
+		$block  = $this->make_block( 'yoast/how-to-block' );
+		$result = BlockMutator::apply(
+			[ $block ],
+			'update-html',
+			[
+				'path'      => [ 0 ],
+				'innerHTML' => '<div></div>',
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$data = $result->get_error_data();
+		$this->assertSame( 'yoast/how-to-block', $data['block_name'] );
 	}
 }

--- a/tests/SdAiAgent/Core/DualStorageRegistryTest.php
+++ b/tests/SdAiAgent/Core/DualStorageRegistryTest.php
@@ -1,0 +1,281 @@
+<?php
+/**
+ * Test case for DualStorageRegistry (GH#1713).
+ *
+ * Covers the acceptance criteria from the issue:
+ *   AC1: update-attrs on yoast/faq-block without innerHTML → 400 dual_storage_requires_both.
+ *   AC2: update-html on yoast/faq-block without attributes → same error.
+ *   AC3: Combined { attributes, innerHTML } update succeeds.
+ *   AC4: update-attrs on core/heading is unaffected.
+ *   AC5: Filter sd_ai_agent_block_dual_storage_blocks lets a plugin add a block name.
+ *   AC6: Scan helper populates a cached option distinct from the hard-coded list.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ * @see     https://github.com/Ultimate-Multisite/superdav-ai-agent/issues/1713
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\DualStorageRegistry;
+use WP_UnitTestCase;
+
+/**
+ * Integration tests for DualStorageRegistry.
+ *
+ * Uses WP_UnitTestCase so WP functions (add_filter, get_option, etc.) are available.
+ */
+class DualStorageRegistryTest extends WP_UnitTestCase {
+
+	/**
+	 * Clean up filters and cached options after each test.
+	 *
+	 * @return void
+	 */
+	public function tear_down(): void {
+		remove_all_filters( 'sd_ai_agent_block_dual_storage_blocks' );
+		DualStorageRegistry::delete_scan_cache();
+		parent::tear_down();
+	}
+
+	// ── get_blocks / hard-coded list ──────────────────────────────────────
+
+	/**
+	 * get_blocks returns the hard-coded Yoast blocks by default.
+	 */
+	public function test_get_blocks_contains_known_yoast_blocks(): void {
+		$blocks = DualStorageRegistry::get_blocks();
+
+		$this->assertContains( 'yoast/faq-block', $blocks );
+		$this->assertContains( 'yoast/how-to-block', $blocks );
+	}
+
+	/**
+	 * get_blocks returns an array of strings with no duplicates.
+	 */
+	public function test_get_blocks_returns_unique_strings(): void {
+		$blocks = DualStorageRegistry::get_blocks();
+
+		$this->assertIsArray( $blocks );
+		$this->assertSame( count( $blocks ), count( array_unique( $blocks ) ) );
+
+		foreach ( $blocks as $name ) {
+			$this->assertIsString( $name );
+			$this->assertNotEmpty( $name );
+		}
+	}
+
+	// ── is_dual_storage ───────────────────────────────────────────────────
+
+	/**
+	 * is_dual_storage returns true for known Yoast blocks.
+	 */
+	public function test_is_dual_storage_true_for_known_blocks(): void {
+		$this->assertTrue( DualStorageRegistry::is_dual_storage( 'yoast/faq-block' ) );
+		$this->assertTrue( DualStorageRegistry::is_dual_storage( 'yoast/how-to-block' ) );
+	}
+
+	/**
+	 * is_dual_storage returns false for standard core blocks.
+	 */
+	public function test_is_dual_storage_false_for_core_blocks(): void {
+		$this->assertFalse( DualStorageRegistry::is_dual_storage( 'core/heading' ) );
+		$this->assertFalse( DualStorageRegistry::is_dual_storage( 'core/paragraph' ) );
+		$this->assertFalse( DualStorageRegistry::is_dual_storage( 'core/image' ) );
+	}
+
+	/**
+	 * is_dual_storage returns false for an unknown block.
+	 */
+	public function test_is_dual_storage_false_for_unknown_block(): void {
+		$this->assertFalse( DualStorageRegistry::is_dual_storage( 'acme/unknown-block' ) );
+		$this->assertFalse( DualStorageRegistry::is_dual_storage( '' ) );
+	}
+
+	// ── Filter hook (AC5) ─────────────────────────────────────────────────
+
+	/**
+	 * sd_ai_agent_block_dual_storage_blocks filter extends the list.
+	 */
+	public function test_filter_adds_block_to_list(): void {
+		add_filter(
+			'sd_ai_agent_block_dual_storage_blocks',
+			static function ( array $blocks ): array {
+				$blocks[] = 'acme/faq-block';
+				return $blocks;
+			}
+		);
+
+		$blocks = DualStorageRegistry::get_blocks();
+
+		$this->assertContains( 'acme/faq-block', $blocks );
+		$this->assertTrue( DualStorageRegistry::is_dual_storage( 'acme/faq-block' ) );
+	}
+
+	/**
+	 * Filter-added block triggers dual_storage_requires_both enforcement in BlockMutator.
+	 */
+	public function test_filter_added_block_triggers_enforcement(): void {
+		add_filter(
+			'sd_ai_agent_block_dual_storage_blocks',
+			static function ( array $blocks ): array {
+				$blocks[] = 'acme/custom-block';
+				return $blocks;
+			}
+		);
+
+		$block  = $this->make_block( 'acme/custom-block' );
+		$result = \SdAiAgent\Core\BlockMutator::apply(
+			[ $block ],
+			'update-attrs',
+			[
+				'path'       => [ 0 ],
+				'attributes' => [ 'title' => 'Hello' ],
+				// No innerHTML — should be rejected.
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'dual_storage_requires_both', $result->get_error_code() );
+
+		$data = $result->get_error_data();
+		$this->assertSame( 'acme/custom-block', $data['block_name'] );
+	}
+
+	/**
+	 * Filter that returns non-array values is gracefully handled.
+	 */
+	public function test_filter_non_array_values_are_ignored(): void {
+		add_filter(
+			'sd_ai_agent_block_dual_storage_blocks',
+			static function (): array {
+				// Mix in non-string values that should be filtered out.
+				return [ 'yoast/faq-block', 123, null, '', 'yoast/faq-block' ];
+			}
+		);
+
+		$blocks = DualStorageRegistry::get_blocks();
+
+		// Only the valid string survives; empty string and non-strings are dropped.
+		// Duplicates are removed.
+		$this->assertContains( 'yoast/faq-block', $blocks );
+		$this->assertNotContains( '', $blocks );
+		$this->assertSame( count( $blocks ), count( array_unique( $blocks ) ) );
+	}
+
+	// ── Scan helper (AC6) ─────────────────────────────────────────────────
+
+	/**
+	 * Scan helper returns an array (may be empty on a site with no matching posts).
+	 */
+	public function test_scan_returns_array(): void {
+		$result = DualStorageRegistry::scan();
+		$this->assertIsArray( $result );
+	}
+
+	/**
+	 * Scan result is stored in a site option distinct from the hard-coded list.
+	 */
+	public function test_scan_stores_result_in_option(): void {
+		DualStorageRegistry::delete_scan_cache();
+
+		// Before scan: option not set.
+		$before = get_option( DualStorageRegistry::SCAN_OPTION, 'not-set' );
+		$this->assertSame( 'not-set', $before );
+
+		// After scan: option is an array.
+		DualStorageRegistry::scan();
+		$after = get_option( DualStorageRegistry::SCAN_OPTION );
+		$this->assertIsArray( $after );
+	}
+
+	/**
+	 * Scan detects a block where an attribute value appears verbatim in innerHTML.
+	 */
+	public function test_scan_detects_dual_storage_candidate(): void {
+		// Create a published post with a block that overlaps attribute text in innerHTML.
+		$answer_text = 'This is the answer to the question.';
+		$block_content = sprintf(
+			'<!-- wp:acme/overlap-block %s -->
+<div class="acme-overlap-block"><p>%s</p></div>
+<!-- /wp:acme/overlap-block -->',
+			wp_json_encode( [ 'answer' => $answer_text ] ),
+			$answer_text
+		);
+
+		$this->factory()->post->create(
+			[
+				'post_content' => $block_content,
+				'post_status'  => 'publish',
+			]
+		);
+
+		$detected = DualStorageRegistry::scan( 100 );
+
+		$this->assertContains( 'acme/overlap-block', $detected );
+	}
+
+	/**
+	 * get_detected_blocks returns empty array before first scan.
+	 */
+	public function test_get_detected_blocks_empty_before_scan(): void {
+		DualStorageRegistry::delete_scan_cache();
+		$this->assertSame( [], DualStorageRegistry::get_detected_blocks() );
+	}
+
+	/**
+	 * get_detected_blocks returns the cached result after scan.
+	 */
+	public function test_get_detected_blocks_returns_cached_result(): void {
+		DualStorageRegistry::scan();
+		$cached = DualStorageRegistry::get_detected_blocks();
+		$this->assertIsArray( $cached );
+	}
+
+	/**
+	 * delete_scan_cache clears the stored option.
+	 */
+	public function test_delete_scan_cache_clears_option(): void {
+		DualStorageRegistry::scan();
+		$this->assertIsArray( get_option( DualStorageRegistry::SCAN_OPTION ) );
+
+		DualStorageRegistry::delete_scan_cache();
+		$this->assertFalse( get_option( DualStorageRegistry::SCAN_OPTION ) );
+	}
+
+	/**
+	 * Scan result does not include hard-coded known blocks (separate lists).
+	 */
+	public function test_scan_result_is_distinct_from_hard_coded_list(): void {
+		// Even if yoast markup somehow appears, the known list is kept separate.
+		// The scan helper only reports NEW candidates (not already in get_blocks()).
+		$detected = DualStorageRegistry::scan();
+
+		// Hard-coded blocks should not appear in detected (they are excluded by design).
+		$this->assertNotContains( 'yoast/faq-block', $detected );
+		$this->assertNotContains( 'yoast/how-to-block', $detected );
+	}
+
+	// ── Helpers ────────────────────────────────────────────────────────────
+
+	/**
+	 * Build a minimal parsed-block array for a given block name.
+	 *
+	 * @param string              $name  Block name.
+	 * @param array<string,mixed> $attrs Block attributes.
+	 * @param string              $html  innerHTML.
+	 * @return array<string,mixed>
+	 */
+	private function make_block( string $name, array $attrs = [], string $html = '<p>Content</p>' ): array {
+		return [
+			'blockName'    => $name,
+			'attrs'        => $attrs,
+			'innerBlocks'  => [],
+			'innerHTML'    => $html,
+			'innerContent' => [ $html ],
+		];
+	}
+}


### PR DESCRIPTION
## Summary

Implements t250 — Tier 2.7: dual-storage block detection + enforcement (GH#1713).

Blocks like `yoast/faq-block` and `yoast/how-to-block` duplicate their data across both `attributes` and `innerHTML`. Updating only one side silently corrupts the block: the editor reads `attributes.questions[0].answer` first, but the rendered preview uses the innerHTML copy. The corruption persists until manually fixed in the editor.

## Changes

### New: `includes/Core/DualStorageRegistry`
- Hard-coded starter list: `yoast/faq-block`, `yoast/how-to-block`
- `sd_ai_agent_block_dual_storage_blocks` filter for third-party plugin extension
- `is_dual_storage(string $block_name): bool` for mutator integration
- Stretch scan helper: walks published posts, detects attr/innerHTML overlap candidates, caches result in `sd_ai_agent_dual_storage_detected` site option (distinct from hard-coded list)

### Modified: `includes/Core/BlockMutator`
- `op_update_attrs`: rejects one-sided attr-only update on a dual-storage block with `dual_storage_requires_both` (HTTP 400, `data.block_name`). When both `attributes` and `innerHTML` are supplied, applies both in a single mutation pass.
- `op_update_html`: same enforcement. Rejects HTML-only update; applies both when both sides are present.

### New: `tests/SdAiAgent/Core/DualStorageRegistryTest` (15 tests, 33 assertions)
Covers: hard-coded list contents, `is_dual_storage` for known/unknown/empty names, filter extension and downstream BlockMutator enforcement, scan helper option storage, detected-vs-hard-coded list isolation, scan candidate detection via attr/HTML overlap.

### Modified: `tests/SdAiAgent/Core/BlockMutatorTest` (+7 tests, +22 assertions)
Covers: update-attrs on yoast/faq-block without innerHTML → 400, update-html without attrs → 400, combined update succeeds on both sides, core/heading and core/paragraph unaffected, yoast/how-to-block enforced, error data.block_name populated.

## Acceptance criteria verification

| # | Criterion | Status |
|---|-----------|--------|
| 1 | `update-attrs` on `yoast/faq-block` without innerHTML → HTTP 400 `dual_storage_requires_both` with `data.block_name` | `test_update_attrs_dual_storage_without_html_returns_error` |
| 2 | `update-html` on `yoast/faq-block` without attributes → same error | `test_update_html_dual_storage_without_attrs_returns_error` |
| 3 | Combined `{attributes, innerHTML}` update succeeds | `test_update_attrs_dual_storage_with_both_sides_succeeds`, `test_update_html_dual_storage_with_both_sides_succeeds` |
| 4 | `update-attrs` on `core/heading` unaffected | `test_update_attrs_non_dual_storage_block_unaffected` |
| 5 | `sd_ai_agent_block_dual_storage_blocks` filter extends enforcement | `test_filter_adds_block_to_list`, `test_filter_added_block_triggers_enforcement` |
| 6 | Scan helper populates cached option distinct from hard-coded list | `test_scan_stores_result_in_option`, `test_scan_result_is_distinct_from_hard_coded_list`, `test_scan_detects_dual_storage_candidate` |
| 7 | Tests cover all paths; full suite green | see self-verification |

## Worker self-verification
- PHPUnit: Tests: 2800, Assertions: 7641, Errors: 0, Failures: 3 (pre-existing PluginUpdaterTest DB-connection failures, present on main — verified with `git stash && npm run test:php`), Skipped: 104
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Resolves #1713

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.28 plugin for [OpenCode](https://opencode.ai) v1.15.7 with claude-sonnet-4-6 spent 23m and 37,251 tokens on this as a headless worker.
