### PR TITLE
feat: enforce block tier policy on edit-block-tree and update-blocks write paths

### DIFF
--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -2089,7 +2089,7 @@ class BlockAbilities {
 	 *
 	 * This is called before apply_batch() to ensure all-or-nothing rejection.
 	 *
-	 * @param array<int,mixed> $updates Array of update specs from handle_update_blocks.
+	 * @param array<mixed,mixed> $updates Array of update specs from handle_update_blocks.
 	 * @return null|\WP_Error null on success, WP_Error on first policy violation.
 	 */
 	private static function preflight_tier_policy( array $updates ): ?\WP_Error {
@@ -2159,6 +2159,16 @@ class BlockAbilities {
 		return null;
 	}
 
+	/**
+	 * Handle the sd-ai-agent/edit-block-tree ability.
+	 *
+	 * Loads the post's block tree, applies the requested mutation via
+	 * BlockMutator::apply(), and (unless dry_run) persists the result
+	 * directly to the DB without creating a revision.
+	 *
+	 * @param array<string,mixed> $input Ability input.
+	 * @return array<string,mixed>|\WP_Error Result array or WP_Error.
+	 */
 	public static function handle_edit_block_tree( array $input ) {
 		global $wpdb;
 

--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -1802,6 +1802,88 @@ class BlockAbilities {
 	 * @param array<string,mixed> $input Ability input.
 	 * @return array<string,mixed>|\WP_Error Result array or WP_Error.
 	 */
+
+	// ─── Tier policy helpers ──────────────────────────────────────────
+
+	/**
+	 * Pre-flight check: enforce tier policy on all insert/replace/wrap operations in a batch.
+	 *
+	 * Walks through the updates array and validates any insert-child, replace-block,
+	 * or wrap-in-group operations against BlockContentPolicy. Returns null on success
+	 * (all operations pass policy), or a WP_Error on the first violation.
+	 *
+	 * This is called before apply_batch() to ensure all-or-nothing rejection.
+	 *
+	 * @param array<int,mixed> $updates Array of update specs from handle_update_blocks.
+	 * @return null|\WP_Error null on success, WP_Error on first policy violation.
+	 */
+	private static function preflight_tier_policy( array $updates ): ?\WP_Error {
+		foreach ( $updates as $idx => $update ) {
+			if ( ! is_array( $update ) ) {
+				continue;
+			}
+
+			$op = isset( $update['op'] ) && is_string( $update['op'] ) ? $update['op'] : '';
+
+			// Only check insert/replace/wrap operations.
+			if ( ! in_array( $op, [ 'insert-child', 'replace-block', 'wrap-in-group' ], true ) ) {
+				continue;
+			}
+
+			// Get the block_def (insert-child and replace-block have it).
+			$block_def = isset( $update['block_def'] ) && is_array( $update['block_def'] ) ? $update['block_def'] : null;
+
+			if ( null === $block_def ) {
+				// wrap-in-group doesn't have block_def, so skip it (it wraps existing blocks).
+				continue;
+			}
+
+			// Recursively check the block_def and its innerBlocks.
+			$policy_result = self::check_block_def_policy( $block_def, false );
+
+			if ( is_wp_error( $policy_result ) ) {
+				// Return the error immediately — all-or-nothing rejection.
+				return $policy_result;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Recursively check a block definition against tier policy.
+	 *
+	 * @param array<string,mixed> $block_def Block definition.
+	 * @param bool                $is_update  True when updating (legacy allowed).
+	 * @return null|\WP_Error null on success, WP_Error on first violation.
+	 */
+	private static function check_block_def_policy( array $block_def, bool $is_update ): ?\WP_Error {
+		$block_name = isset( $block_def['blockName'] ) && is_string( $block_def['blockName'] ) ? $block_def['blockName'] : '';
+
+		if ( '' !== $block_name ) {
+			$policy_result = BlockContentPolicy::check_insert( $block_name, $is_update );
+
+			if ( is_wp_error( $policy_result ) ) {
+				return $policy_result;
+			}
+		}
+
+		// Recurse into innerBlocks.
+		$inner = isset( $block_def['innerBlocks'] ) && is_array( $block_def['innerBlocks'] ) ? $block_def['innerBlocks'] : [];
+
+		foreach ( $inner as $child ) {
+			if ( is_array( $child ) ) {
+				$child_result = self::check_block_def_policy( $child, $is_update );
+
+				if ( is_wp_error( $child_result ) ) {
+					return $child_result;
+				}
+			}
+		}
+
+		return null;
+	}
+
 	public static function handle_edit_block_tree( array $input ) {
 		global $wpdb;
 
@@ -1952,6 +2034,13 @@ class BlockAbilities {
 
 		if ( ! is_array( $blocks ) ) {
 			$blocks = [];
+		}
+
+		// Pre-flight: enforce tier policy on all insert/replace/wrap operations.
+		// This ensures all-or-nothing rejection before any mutations.
+		$policy_errors = self::preflight_tier_policy( $updates );
+		if ( is_wp_error( $policy_errors ) ) {
+			return $policy_errors;
 		}
 
 		// All-or-nothing batch validation + mutation.

--- a/includes/Core/BlockMutator.php
+++ b/includes/Core/BlockMutator.php
@@ -586,10 +586,16 @@ class BlockMutator {
 
 		$new_block = self::normalize_block( $args['block_def'] );
 
+		// Enforce tier policy on the replacement block tree.
+		$policy_result = self::enforce_tier_policy( $new_block, false );
+		if ( is_wp_error( $policy_result ) ) {
+			return $policy_result;
+		}
+
 		// Apply wp_kses_post to innerHTML in the replacement block tree.
 		$new_block = self::sanitize_block_tree( $new_block );
 
-		return self::mutate_at_path(
+		$result = self::mutate_at_path(
 			$blocks,
 			$path,
 			static function ( array $siblings, int $idx ) use ( $new_block ) {
@@ -597,6 +603,15 @@ class BlockMutator {
 				return $siblings;
 			}
 		);
+
+		// Merge policy warnings into the result if present.
+		if ( is_array( $policy_result ) && isset( $policy_result['warnings'] ) ) {
+			if ( is_array( $result ) ) {
+				$result['_warnings'] = $policy_result['warnings'];
+			}
+		}
+
+		return $result;
 	}
 
 	/**
@@ -629,7 +644,24 @@ class BlockMutator {
 	private static function op_wrap_in_group( array $blocks, array $path, array $args ) {
 		$group_attrs = isset( $args['attributes'] ) && is_array( $args['attributes'] ) ? $args['attributes'] : [];
 
-		return self::mutate_at_path(
+		// Note: wrap-in-group creates a core/group (preferred tier) around an existing block,
+		// so we don't need to enforce policy on the group itself. The wrapped block is already
+		// in the tree and was validated when inserted. However, we still validate for consistency.
+		$group = [
+			'blockName'    => 'core/group',
+			'attrs'        => $group_attrs,
+			'innerBlocks'  => [],
+			'innerHTML'    => '',
+			'innerContent' => [ null ],
+		];
+
+		// Validate the group structure (should always pass since core/group is preferred).
+		$policy_result = self::enforce_tier_policy( $group, false );
+		if ( is_wp_error( $policy_result ) ) {
+			return $policy_result;
+		}
+
+		$result = self::mutate_at_path(
 			$blocks,
 			$path,
 			static function ( array $siblings, int $idx ) use ( $group_attrs ) {
@@ -647,6 +679,8 @@ class BlockMutator {
 				return $siblings;
 			}
 		);
+
+		return $result;
 	}
 
 	/**
@@ -705,11 +739,18 @@ class BlockMutator {
 		}
 
 		$new_child = self::normalize_block( $args['block_def'] );
+
+		// Enforce tier policy on the new child block tree.
+		$policy_result = self::enforce_tier_policy( $new_child, false );
+		if ( is_wp_error( $policy_result ) ) {
+			return $policy_result;
+		}
+
 		$new_child = self::sanitize_block_tree( $new_child );
 
 		$position = isset( $args['position'] ) ? (int) $args['position'] : null;
 
-		return self::mutate_at_path(
+		$result = self::mutate_at_path(
 			$blocks,
 			$path,
 			static function ( array $siblings, int $idx ) use ( $new_child, $position ) {
@@ -748,6 +789,15 @@ class BlockMutator {
 				return $siblings;
 			}
 		);
+
+		// Merge policy warnings into the result if present.
+		if ( is_array( $policy_result ) && isset( $policy_result['warnings'] ) ) {
+			if ( is_array( $result ) ) {
+				$result['_warnings'] = $policy_result['warnings'];
+			}
+		}
+
+		return $result;
 	}
 
 	/**
@@ -1037,6 +1087,78 @@ class BlockMutator {
 		}
 
 		return $dst_path;
+	}
+
+	// ── Tier policy enforcement ──────────────────────────────────────────
+
+	/**
+	 * Enforce block tier policy on a block definition and its descendants.
+	 *
+	 * Walks the block tree recursively, calling BlockContentPolicy::check_insert()
+	 * on every block name. Returns null on success (all blocks pass policy).
+	 * Returns a WP_Error on the first policy violation (legacy block on insert).
+	 * Aggregates avoid-tier warnings in the returned array.
+	 *
+	 * @param array<string,mixed> $block_def Block definition (may include innerBlocks).
+	 * @param bool                $is_update  True when updating existing blocks (legacy allowed).
+	 * @return null|array<string,mixed>|\WP_Error
+	 *         null on success (no violations, no warnings).
+	 *         array with 'warnings' key if avoid-tier blocks found.
+	 *         WP_Error if legacy-tier block found on insert.
+	 */
+	private static function enforce_tier_policy( array $block_def, bool $is_update = false ) {
+		$warnings = [];
+
+		// Recursively check this block and all descendants.
+		$result = self::walk_tier_policy( $block_def, $is_update, $warnings );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		// Return null if no warnings, or array with warnings.
+		return empty( $warnings ) ? null : [ 'warnings' => $warnings ];
+	}
+
+	/**
+	 * Recursively walk a block tree and collect tier policy violations.
+	 *
+	 * @param array<string,mixed> $block    Block definition.
+	 * @param bool                $is_update True when updating (legacy allowed).
+	 * @param array<int,mixed>    $warnings  Accumulated warnings (passed by reference).
+	 * @return null|\WP_Error null on success, WP_Error on first legacy violation.
+	 */
+	private static function walk_tier_policy( array $block, bool $is_update, array &$warnings ): ?\WP_Error {
+		$block_name = isset( $block['blockName'] ) && is_string( $block['blockName'] ) ? $block['blockName'] : '';
+
+		if ( '' !== $block_name ) {
+			$policy_result = BlockContentPolicy::check_insert( $block_name, $is_update );
+
+			if ( is_wp_error( $policy_result ) ) {
+				// Legacy block on insert — reject immediately.
+				return $policy_result;
+			}
+
+			if ( is_array( $policy_result ) && isset( $policy_result['warnings'] ) ) {
+				// Avoid-tier block — accumulate warnings.
+				$warnings = array_merge( $warnings, $policy_result['warnings'] );
+			}
+		}
+
+		// Recurse into innerBlocks.
+		$inner = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : [];
+
+		foreach ( $inner as $child ) {
+			if ( is_array( $child ) ) {
+				$child_result = self::walk_tier_policy( $child, $is_update, $warnings );
+
+				if ( is_wp_error( $child_result ) ) {
+					return $child_result;
+				}
+			}
+		}
+
+		return null;
 	}
 
 	// ── Block normalization helpers ───────────────────────────────────────

--- a/tests/SdAiAgent/Core/BlockMutatorBatchTest.php
+++ b/tests/SdAiAgent/Core/BlockMutatorBatchTest.php
@@ -694,4 +694,120 @@ class BlockMutatorBatchTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result );
 		$this->assertCount( BlockMutator::MAX_BATCH_SIZE, $result );
 	}
+
+	// ── Tier policy enforcement tests (GH#1735) ────────────────────────────
+
+	/**
+	 * Batch with one legacy insert-child item is entirely rejected.
+	 *
+	 * AC1: Batch with one legacy item → entire batch rejected, no disk write.
+	 */
+	public function test_batch_with_legacy_insert_child_rejected(): void {
+		$blocks = [
+			$this->make_ref_block( 'core/paragraph', 'blk_p1', [], '<p>Para 1</p>' ),
+			$this->make_ref_block( 'core/paragraph', 'blk_p2', [], '<p>Para 2</p>' ),
+		];
+
+		$updates = [
+			[
+				'op'  => 'update-attrs',
+				'ref' => 'blk_p1',
+				'attributes' => [ 'className' => 'updated' ],
+			],
+			[
+				'op'        => 'insert-child',
+				'ref'       => 'blk_p2',
+				'block_def' => [
+					'blockName' => 'core/freeform',
+					'attrs'     => [],
+					'innerHTML' => 'legacy block',
+				],
+			],
+		];
+
+		$result = BlockMutator::apply_batch( $blocks, $updates );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'batch_validation_failed', $result->get_error_code() );
+
+		$data = $result->get_error_data();
+		$this->assertArrayHasKey( 'errors', $data );
+		$this->assertNotEmpty( $data['errors'] );
+
+		// The error should be for the second update (index 1).
+		$error = $data['errors'][0];
+		$this->assertSame( 1, $error['index'] );
+		$this->assertSame( 'legacy_block', $error['code'] );
+	}
+
+	/**
+	 * Batch with one legacy replace-block item is entirely rejected.
+	 *
+	 * AC2: Batch with legacy replace-block → entire batch rejected.
+	 */
+	public function test_batch_with_legacy_replace_block_rejected(): void {
+		$blocks = [
+			$this->make_ref_block( 'core/paragraph', 'blk_p1', [], '<p>Para 1</p>' ),
+		];
+
+		$updates = [
+			[
+				'op'        => 'replace-block',
+				'ref'       => 'blk_p1',
+				'block_def' => [
+					'blockName' => 'core/legacy-widget',
+					'attrs'     => [],
+					'innerHTML' => '',
+				],
+			],
+		];
+
+		$result = BlockMutator::apply_batch( $blocks, $updates );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'batch_validation_failed', $result->get_error_code() );
+
+		$data = $result->get_error_data();
+		$this->assertArrayHasKey( 'errors', $data );
+		$error = $data['errors'][0];
+		$this->assertSame( 'legacy_block', $error['code'] );
+	}
+
+	/**
+	 * Batch with all preferred blocks succeeds.
+	 *
+	 * AC3: Batch with all preferred blocks → success.
+	 */
+	public function test_batch_with_all_preferred_blocks_succeeds(): void {
+		$blocks = [
+			$this->make_ref_block( 'core/paragraph', 'blk_p1', [], '<p>Para 1</p>' ),
+			$this->make_ref_block( 'core/paragraph', 'blk_p2', [], '<p>Para 2</p>' ),
+		];
+
+		$updates = [
+			[
+				'op'        => 'insert-child',
+				'ref'       => 'blk_p1',
+				'block_def' => [
+					'blockName' => 'core/paragraph',
+					'attrs'     => [],
+					'innerHTML' => '<p>New child</p>',
+				],
+			],
+			[
+				'op'        => 'replace-block',
+				'ref'       => 'blk_p2',
+				'block_def' => [
+					'blockName' => 'core/heading',
+					'attrs'     => [ 'level' => 2 ],
+					'innerHTML' => '<h2>Heading</h2>',
+				],
+			],
+		];
+
+		$result = BlockMutator::apply_batch( $blocks, $updates );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 2, $result );
+	}
 }

--- a/tests/SdAiAgent/Core/BlockMutatorTest.php
+++ b/tests/SdAiAgent/Core/BlockMutatorTest.php
@@ -854,4 +854,153 @@ class BlockMutatorTest extends WP_UnitTestCase {
 		$data = $result->get_error_data();
 		$this->assertSame( 'yoast/how-to-block', $data['block_name'] );
 	}
+
+	// ── Tier policy enforcement tests (GH#1735) ────────────────────────────
+
+	/**
+	 * insert-child with legacy block (core/freeform) is rejected.
+	 *
+	 * AC1: insert-child of core/freeform → WP_Error('legacy_block') with suggested_replacement.
+	 */
+	public function test_insert_child_legacy_block_rejected(): void {
+		$group  = $this->make_block( 'core/group' );
+		$result = BlockMutator::apply(
+			[ $group ],
+			'insert-child',
+			[
+				'path'      => [ 0 ],
+				'block_def' => [
+					'blockName' => 'core/freeform',
+					'attrs'     => [],
+					'innerHTML' => 'test',
+				],
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'legacy_block', $result->get_error_code() );
+
+		$data = $result->get_error_data();
+		$this->assertSame( 'core/freeform', $data['block_name'] );
+		$this->assertSame( 5, $data['score'] );
+		$this->assertSame( 'legacy', $data['tier'] );
+		$this->assertNotEmpty( $data['suggested_replacement'] );
+	}
+
+	/**
+	 * replace-block with legacy block (core/legacy-widget) is rejected.
+	 *
+	 * AC2: replace-block to core/legacy-widget → WP_Error('legacy_block').
+	 */
+	public function test_replace_block_legacy_block_rejected(): void {
+		$block  = $this->make_block( 'core/paragraph' );
+		$result = BlockMutator::apply(
+			[ $block ],
+			'replace-block',
+			[
+				'path'       => [ 0 ],
+				'block_def'  => [
+					'blockName' => 'core/legacy-widget',
+					'attrs'     => [],
+					'innerHTML' => '',
+				],
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'legacy_block', $result->get_error_code() );
+
+		$data = $result->get_error_data();
+		$this->assertSame( 'core/legacy-widget', $data['block_name'] );
+		$this->assertSame( 5, $data['score'] );
+		$this->assertSame( 'legacy', $data['tier'] );
+	}
+
+	/**
+	 * insert-child with nested legacy block is rejected.
+	 *
+	 * AC3: insert-child with innerBlocks containing legacy blocks → WP_Error.
+	 */
+	public function test_insert_child_nested_legacy_block_rejected(): void {
+		$group  = $this->make_block( 'core/group' );
+		$result = BlockMutator::apply(
+			[ $group ],
+			'insert-child',
+			[
+				'path'      => [ 0 ],
+				'block_def' => [
+					'blockName'   => 'core/group',
+					'attrs'       => [],
+					'innerBlocks' => [
+						[
+							'blockName' => 'core/freeform',
+							'attrs'     => [],
+							'innerHTML' => 'nested legacy',
+						],
+					],
+					'innerHTML'    => '',
+					'innerContent' => [ null ],
+				],
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'legacy_block', $result->get_error_code() );
+	}
+
+	/**
+	 * insert-child with avoid-tier block succeeds with warnings.
+	 *
+	 * AC4: insert-child with core/html (avoid tier) → success with _warnings.
+	 */
+	public function test_insert_child_avoid_tier_block_succeeds_with_warnings(): void {
+		$group  = $this->make_block( 'core/group' );
+		$result = BlockMutator::apply(
+			[ $group ],
+			'insert-child',
+			[
+				'path'      => [ 0 ],
+				'block_def' => [
+					'blockName' => 'core/html',
+					'attrs'     => [],
+					'innerHTML' => '<div>test</div>',
+				],
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( '_warnings', $result );
+		$this->assertIsArray( $result['_warnings'] );
+		$this->assertNotEmpty( $result['_warnings'] );
+
+		$warning = $result['_warnings'][0];
+		$this->assertSame( 'avoid_block', $warning['code'] );
+		$this->assertSame( 'core/html', $warning['block_name'] );
+	}
+
+	/**
+	 * replace-block with preferred block succeeds without warnings.
+	 *
+	 * AC5: replace-block with core/paragraph (preferred) → success, no warnings.
+	 */
+	public function test_replace_block_preferred_block_succeeds(): void {
+		$block  = $this->make_block( 'core/freeform' );
+		$result = BlockMutator::apply(
+			[ $block ],
+			'replace-block',
+			[
+				'path'       => [ 0 ],
+				'block_def'  => [
+					'blockName' => 'core/paragraph',
+					'attrs'     => [],
+					'innerHTML' => '<p>New text</p>',
+				],
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'core/paragraph', $result[0]['blockName'] );
+		// No _warnings key for preferred blocks.
+		$this->assertArrayNotHasKey( '_warnings', $result );
+	}
 }


### PR DESCRIPTION
Resolves #1735

## Summary

Implements tier policy enforcement on all block insertion/replacement operations to prevent legacy blocks from being inserted via edit-block-tree and update-blocks write paths.

## Changes

- Add enforce_tier_policy() helper to BlockMutator that recursively validates block definitions against BlockContentPolicy
- Call enforce_tier_policy() from insert-child, replace-block, and wrap-in-group operations to reject legacy-tier blocks on insert
- Add preflight_tier_policy() to BlockAbilities for pre-flight validation of batch operations before apply_batch()
- Surface aggregated avoid-tier warnings in operation responses via _warnings key
- All-or-nothing batch rejection: if any item violates policy, entire batch fails

## Verification

- PHPUnit: Tests: 2881, Assertions: 7847, Errors: 0, Failures: 3 (pre-existing)
- Lint: PHP/JS/CSS all clean
- PHPStan: 3 errors (pre-existing in handle_edit_block_tree/handle_update_blocks)
- Build: succeeded

## New Tests

- insert-child with legacy block (core/freeform) → WP_Error('legacy_block')
- replace-block with legacy block (core/legacy-widget) → WP_Error
- insert-child with nested legacy blocks → WP_Error
- insert-child with avoid-tier block (core/html) → success with _warnings
- replace-block with preferred block → success without warnings
- Batch with legacy insert-child → entire batch rejected
- Batch with legacy replace-block → entire batch rejected
- Batch with all preferred blocks → success
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.28 plugin for [OpenCode](https://opencode.ai) v1.15.7 with claude-haiku-4-5 spent 9m and 5,817 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch block updates run tier-policy validation before applying changes; a single invalid item rejects the whole batch.
  * Replacement/insert operations validate block trees and surface avoid-tier warnings on successful mutations.

* **Bug Fixes**
  * Prevents executing batch mutations when a policy violation is detected.

* **Tests**
  * Added integration and unit tests covering legacy-block rejection, nested legacy detection, avoid-tier warnings, and successful preferred-block batches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1740?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->