### PR TITLE
GH#1736: feat: add tier/score/suggested_replacement fields to list-block-types

### DIFF
--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -81,38 +81,58 @@ class BlockAbilities {
 				'label'               => __( 'List Block Types', 'superdav-ai-agent' ),
 				'description'         => __( 'List registered Gutenberg block types. Filter by category or search term. Returns block names, titles, descriptions, and categories.', 'superdav-ai-agent' ),
 				'category'            => 'sd-ai-agent',
-				'input_schema'        => [
-					'type'       => 'object',
-					'properties' => [
-						'category' => [
-							'type'        => 'string',
-							'description' => 'Filter by block category slug (e.g. "text", "media", "design").',
-						],
-						'search'   => [
-							'type'        => 'string',
-							'description' => 'Search term to filter block types by name, title, or keywords.',
-						],
-						'per_page' => [
-							'type'        => 'integer',
-							'description' => 'Results per page (default: 20).',
-						],
-						'page'     => [
-							'type'        => 'integer',
-							'description' => 'Page number (default: 1).',
-						],
+			'input_schema'        => [
+				'type'       => 'object',
+				'properties' => [
+					'category' => [
+						'type'        => 'string',
+						'description' => 'Filter by block category slug (e.g. "text", "media", "design").',
 					],
-					'required'   => [],
-				],
-				'output_schema'       => [
-					'type'       => 'object',
-					'properties' => [
-						'block_types' => [ 'type' => 'array' ],
-						'total'       => [ 'type' => 'integer' ],
-						'page'        => [ 'type' => 'integer' ],
-						'per_page'    => [ 'type' => 'integer' ],
-						'categories'  => [ 'type' => 'object' ],
+					'search'   => [
+						'type'        => 'string',
+						'description' => 'Search term to filter block types by name, title, or keywords.',
+					],
+					'tier'     => [
+						'type'        => 'string',
+						'description' => 'Filter by tier: "preferred", "acceptable", "avoid", or "legacy".',
+						'enum'        => [ 'preferred', 'acceptable', 'avoid', 'legacy' ],
+					],
+					'per_page' => [
+						'type'        => 'integer',
+						'description' => 'Results per page (default: 20).',
+					],
+					'page'     => [
+						'type'        => 'integer',
+						'description' => 'Page number (default: 1).',
 					],
 				],
+				'required'   => [],
+			],
+			'output_schema'       => [
+				'type'       => 'object',
+				'properties' => [
+					'block_types' => [
+						'type'  => 'array',
+						'items' => [
+							'type'       => 'object',
+							'properties' => [
+								'name'                  => [ 'type' => 'string' ],
+								'title'                 => [ 'type' => 'string' ],
+								'description'           => [ 'type' => 'string' ],
+								'category'              => [ 'type' => 'string' ],
+								'keywords'              => [ 'type' => 'array' ],
+								'score'                 => [ 'type' => 'integer' ],
+								'tier'                  => [ 'type' => 'string' ],
+								'suggested_replacement' => [ 'type' => [ 'string', 'null' ] ],
+							],
+						],
+					],
+					'total'       => [ 'type' => 'integer' ],
+					'page'        => [ 'type' => 'integer' ],
+					'per_page'    => [ 'type' => 'integer' ],
+					'categories'  => [ 'type' => 'object' ],
+				],
+			],
 				'meta'                => [
 					'mcp'         => [ 'public' => true ],
 					'annotations' => [
@@ -804,7 +824,7 @@ class BlockAbilities {
 	/**
 	 * Handle listing block types.
 	 *
-	 * @param array<string,mixed> $input Input with optional category, search, per_page, page.
+	 * @param array<string,mixed> $input Input with optional category, search, tier, per_page, page.
 	 * @return array<string,mixed> Result with block_types, total, and categories.
 	 */
 	public static function handle_list_block_types( array $input ): array {
@@ -814,6 +834,8 @@ class BlockAbilities {
 		$category = $input['category'] ?? '';
 		// @phpstan-ignore-next-line
 		$search = strtolower( $input['search'] ?? '' );
+		// @phpstan-ignore-next-line
+		$tier = $input['tier'] ?? '';
 		// @phpstan-ignore-next-line
 		$per_page = max( 1, min( 100, (int) ( $input['per_page'] ?? 20 ) ) );
 		// @phpstan-ignore-next-line
@@ -847,12 +869,30 @@ class BlockAbilities {
 				}
 			}
 
+			// Get tier and score for this block.
+			$score = BlockContentPolicy::get_namespace_score( $name );
+			$block_tier = BlockContentPolicy::score_to_tier( $score );
+
+			// Filter by tier if specified.
+			if ( ! empty( $tier ) && $block_tier !== $tier ) {
+				continue;
+			}
+
+			// Get suggested replacement if block is in legacy or avoid tier.
+			$suggested_replacement = null;
+			if ( in_array( $block_tier, [ 'legacy', 'avoid' ], true ) ) {
+				$suggested_replacement = BlockContentPolicy::get_replacement( $name );
+			}
+
 			$filtered[] = [
-				'name'        => $name,
-				'title'       => $block->title ?? '',
-				'description' => $block->description ?? '',
-				'category'    => $block->category ?? '',
-				'keywords'    => $block->keywords ?? [],
+				'name'                  => $name,
+				'title'                 => $block->title ?? '',
+				'description'           => $block->description ?? '',
+				'category'              => $block->category ?? '',
+				'keywords'              => $block->keywords ?? [],
+				'score'                 => $score,
+				'tier'                  => $block_tier,
+				'suggested_replacement' => $suggested_replacement,
 			];
 		}
 

--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -81,58 +81,58 @@ class BlockAbilities {
 				'label'               => __( 'List Block Types', 'superdav-ai-agent' ),
 				'description'         => __( 'List registered Gutenberg block types. Filter by category or search term. Returns block names, titles, descriptions, and categories.', 'superdav-ai-agent' ),
 				'category'            => 'sd-ai-agent',
-			'input_schema'        => [
-				'type'       => 'object',
-				'properties' => [
-					'category' => [
-						'type'        => 'string',
-						'description' => 'Filter by block category slug (e.g. "text", "media", "design").',
-					],
-					'search'   => [
-						'type'        => 'string',
-						'description' => 'Search term to filter block types by name, title, or keywords.',
-					],
-					'tier'     => [
-						'type'        => 'string',
-						'description' => 'Filter by tier: "preferred", "acceptable", "avoid", or "legacy".',
-						'enum'        => [ 'preferred', 'acceptable', 'avoid', 'legacy' ],
-					],
-					'per_page' => [
-						'type'        => 'integer',
-						'description' => 'Results per page (default: 20).',
-					],
-					'page'     => [
-						'type'        => 'integer',
-						'description' => 'Page number (default: 1).',
-					],
-				],
-				'required'   => [],
-			],
-			'output_schema'       => [
-				'type'       => 'object',
-				'properties' => [
-					'block_types' => [
-						'type'  => 'array',
-						'items' => [
-							'type'       => 'object',
-							'properties' => [
-								'name'                  => [ 'type' => 'string' ],
-								'title'                 => [ 'type' => 'string' ],
-								'description'           => [ 'type' => 'string' ],
-								'category'              => [ 'type' => 'string' ],
-								'keywords'              => [ 'type' => 'array' ],
-								'score'                 => [ 'type' => 'integer' ],
-								'tier'                  => [ 'type' => 'string' ],
-								'suggested_replacement' => [ 'type' => [ 'string', 'null' ] ],
-							],
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'category' => [
+							'type'        => 'string',
+							'description' => 'Filter by block category slug (e.g. "text", "media", "design").',
+						],
+						'search'   => [
+							'type'        => 'string',
+							'description' => 'Search term to filter block types by name, title, or keywords.',
+						],
+						'tier'     => [
+							'type'        => 'string',
+							'description' => 'Filter by tier: "preferred", "acceptable", "avoid", or "legacy".',
+							'enum'        => [ 'preferred', 'acceptable', 'avoid', 'legacy' ],
+						],
+						'per_page' => [
+							'type'        => 'integer',
+							'description' => 'Results per page (default: 20).',
+						],
+						'page'     => [
+							'type'        => 'integer',
+							'description' => 'Page number (default: 1).',
 						],
 					],
-					'total'       => [ 'type' => 'integer' ],
-					'page'        => [ 'type' => 'integer' ],
-					'per_page'    => [ 'type' => 'integer' ],
-					'categories'  => [ 'type' => 'object' ],
+					'required'   => [],
 				],
-			],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'block_types' => [
+							'type'  => 'array',
+							'items' => [
+								'type'       => 'object',
+								'properties' => [
+									'name'        => [ 'type' => 'string' ],
+									'title'       => [ 'type' => 'string' ],
+									'description' => [ 'type' => 'string' ],
+									'category'    => [ 'type' => 'string' ],
+									'keywords'    => [ 'type' => 'array' ],
+									'score'       => [ 'type' => 'integer' ],
+									'tier'        => [ 'type' => 'string' ],
+									'suggested_replacement' => [ 'type' => [ 'string', 'null' ] ],
+								],
+							],
+						],
+						'total'       => [ 'type' => 'integer' ],
+						'page'        => [ 'type' => 'integer' ],
+						'per_page'    => [ 'type' => 'integer' ],
+						'categories'  => [ 'type' => 'object' ],
+					],
+				],
 				'meta'                => [
 					'mcp'         => [ 'public' => true ],
 					'annotations' => [
@@ -870,7 +870,7 @@ class BlockAbilities {
 			}
 
 			// Get tier and score for this block.
-			$score = BlockContentPolicy::get_namespace_score( $name );
+			$score      = BlockContentPolicy::get_namespace_score( $name );
 			$block_tier = BlockContentPolicy::score_to_tier( $score );
 
 			// Filter by tier if specified.

--- a/tests/SdAiAgent/Abilities/BlockAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/BlockAbilitiesTest.php
@@ -163,6 +163,75 @@ class BlockAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 5, $result['per_page'] );
 	}
 
+	/**
+	 * Test handle_list_block_types includes tier and score fields.
+	 */
+	public function test_handle_list_block_types_includes_tier_and_score() {
+		$result = BlockAbilities::handle_list_block_types( [] );
+
+		if ( ! empty( $result['block_types'] ) ) {
+			$block = $result['block_types'][0];
+			$this->assertArrayHasKey( 'score', $block );
+			$this->assertArrayHasKey( 'tier', $block );
+			$this->assertIsInt( $block['score'] );
+			$this->assertIsString( $block['tier'] );
+			$this->assertContains( $block['tier'], [ 'preferred', 'acceptable', 'avoid', 'legacy' ] );
+		}
+	}
+
+	/**
+	 * Test handle_list_block_types includes suggested_replacement for legacy blocks.
+	 */
+	public function test_handle_list_block_types_legacy_block_has_replacement() {
+		$result = BlockAbilities::handle_list_block_types( [] );
+
+		// Find a legacy block (core/freeform is known to be legacy).
+		$legacy_block = null;
+		foreach ( $result['block_types'] as $block ) {
+			if ( 'core/freeform' === $block['name'] ) {
+				$legacy_block = $block;
+				break;
+			}
+		}
+
+		if ( $legacy_block ) {
+			$this->assertSame( 'legacy', $legacy_block['tier'] );
+			$this->assertArrayHasKey( 'suggested_replacement', $legacy_block );
+			$this->assertNotNull( $legacy_block['suggested_replacement'] );
+			$this->assertSame( 'core/group', $legacy_block['suggested_replacement'] );
+		}
+	}
+
+	/**
+	 * Test handle_list_block_types with tier filter.
+	 */
+	public function test_handle_list_block_types_tier_filter() {
+		$result = BlockAbilities::handle_list_block_types( [
+			'tier' => 'preferred',
+		] );
+
+		$this->assertIsArray( $result );
+		// All results should have tier 'preferred'.
+		foreach ( $result['block_types'] as $block ) {
+			$this->assertSame( 'preferred', $block['tier'] );
+		}
+	}
+
+	/**
+	 * Test handle_list_block_types with avoid tier filter.
+	 */
+	public function test_handle_list_block_types_avoid_tier_filter() {
+		$result = BlockAbilities::handle_list_block_types( [
+			'tier' => 'avoid',
+		] );
+
+		$this->assertIsArray( $result );
+		// All results should have tier 'avoid'.
+		foreach ( $result['block_types'] as $block ) {
+			$this->assertSame( 'avoid', $block['tier'] );
+		}
+	}
+
 	// ─── get-block-type ───────────────────────────────────────────
 
 	/**


### PR DESCRIPTION
## Summary

Added tier, score, and suggested_replacement fields to the list-block-types ability response. Implemented optional tier filter parameter to allow filtering blocks by tier (preferred/acceptable/avoid/legacy). Updated output schema documentation.

## Files Changed

includes/Abilities/BlockAbilities.php,tests/SdAiAgent/Abilities/BlockAbilitiesTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified with manual tests: basic call returns all fields, tier filter works correctly, legacy blocks show suggested replacements, preferred blocks return correct scores.

Resolves #1736


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.28 plugin for [OpenCode](https://opencode.ai) v1.15.7 with claude-haiku-4-5 spent 9m and 1,835 tokens on this as a headless worker.