### PR TITLE
GH#1747: feat: add sd-ai-agent/resolve-url ability (Wave 2.1)

### DIFF
--- a/includes/Abilities/UrlResolverAbilities.php
+++ b/includes/Abilities/UrlResolverAbilities.php
@@ -1,0 +1,214 @@
+<?php
+/**
+ * URL Resolver abilities for the AI agent.
+ *
+ * Provides the sd-ai-agent/resolve-url ability that translates a URL
+ * or post slug into structured post metadata (post_id, post_type,
+ * post_status, edit_link, permalink, title, matched_via).
+ *
+ * @package SdAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Abilities;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Registers and handles the sd-ai-agent/resolve-url ability.
+ *
+ * Resolution order:
+ *  1. url_to_postid() — handles absolute URLs (permalink or query-string style)
+ *     and relative query-string inputs such as ?p=N or ?page_id=N.
+ *  2. get_page_by_path() — fallback for bare slugs or path-like inputs that
+ *     url_to_postid() cannot resolve.
+ *
+ * Cross-host URLs are rejected before any resolution attempt.
+ * Draft / private posts are only returned when the current user holds the
+ * edit_post capability for that specific post.
+ */
+class UrlResolverAbilities {
+
+	/**
+	 * Register the sd-ai-agent/resolve-url ability.
+	 */
+	public static function register_abilities(): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			'sd-ai-agent/resolve-url',
+			[
+				'label'               => __( 'Resolve URL', 'superdav-ai-agent' ),
+				'description'         => __( 'Resolve a URL or post slug to its post ID, type, status, edit link, and permalink. Use before any post-editing ability to look up the post_id without scanning list-posts.', 'superdav-ai-agent' ),
+				'category'            => 'sd-ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'url' => [
+							'type'        => 'string',
+							'description' => 'Full URL (e.g. "https://example.com/about/"), relative query string (e.g. "?p=123"), or bare slug (e.g. "about") to resolve.',
+						],
+					],
+					'required'   => [ 'url' ],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'post_id'     => [ 'type' => 'integer' ],
+						'post_type'   => [ 'type' => 'string' ],
+						'post_status' => [ 'type' => 'string' ],
+						'edit_link'   => [ 'type' => 'string' ],
+						'permalink'   => [ 'type' => 'string' ],
+						'title'       => [ 'type' => 'string' ],
+						'matched_via' => [
+							'type' => 'string',
+							'enum' => [ 'url_to_postid', 'slug_lookup' ],
+						],
+					],
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_resolve_url' ],
+				'permission_callback' => static function (): bool {
+					return (bool) current_user_can( 'edit_posts' );
+				},
+				'meta'                => [
+					'mcp'         => [ 'public' => true ],
+					'annotations' => [
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Execute the resolve-url ability.
+	 *
+	 * @param array<string, mixed> $params Ability parameters; expects 'url' key.
+	 * @return array<string, mixed>|\WP_Error Resolved post data or a WP_Error.
+	 */
+	public static function handle_resolve_url( array $params ): array|\WP_Error {
+		$input = isset( $params['url'] ) ? trim( (string) $params['url'] ) : '';
+
+		if ( '' === $input ) {
+			return new \WP_Error(
+				'missing_url',
+				__( 'The "url" parameter is required.', 'superdav-ai-agent' )
+			);
+		}
+
+		$attempts    = [];
+		$post_id     = 0;
+		$matched_via = '';
+		$is_absolute = str_contains( $input, '://' );
+
+		// Guard: reject cross-host URLs immediately — never resolve external sites.
+		if ( $is_absolute ) {
+			$input_host = (string) wp_parse_url( $input, PHP_URL_HOST );
+			$site_host  = (string) wp_parse_url( home_url(), PHP_URL_HOST );
+			if ( '' !== $input_host && '' !== $site_host && $input_host !== $site_host ) {
+				return new \WP_Error(
+					'external_host',
+					sprintf(
+						/* translators: %s: external hostname */
+						__( 'URL host "%s" does not match this site. Cross-host resolution is not supported.', 'superdav-ai-agent' ),
+						$input_host
+					),
+					[
+						'host'      => $input_host,
+						'site_host' => $site_host,
+					]
+				);
+			}
+		}
+
+		// Strategy 1: url_to_postid() — reliable for absolute URLs and relative
+		// query-string inputs (e.g. ?p=123, ?page_id=456).
+		if ( $is_absolute || str_starts_with( $input, '?' ) || str_starts_with( $input, '/' ) ) {
+			$lookup_url  = $is_absolute ? $input : home_url( $input );
+			$attempts[]  = 'url_to_postid';
+			$resolved_id = url_to_postid( $lookup_url );
+			if ( $resolved_id > 0 ) {
+				$post_id     = $resolved_id;
+				$matched_via = 'url_to_postid';
+			}
+		}
+
+		// Strategy 2: get_page_by_path() — handles bare slugs and hierarchical
+		// slug paths (e.g. "about" or "services/consulting") that url_to_postid()
+		// cannot resolve without rewrite rules.
+		if ( 0 === $post_id ) {
+			if ( $is_absolute ) {
+				// Derive slug from the URL path.
+				$slug = trim( (string) wp_parse_url( $input, PHP_URL_PATH ), '/' );
+			} else {
+				// Strip query string and URL fragment; trim slashes.
+				$without_query = (string) explode( '?', $input )[0];
+				$slug          = trim( (string) explode( '#', $without_query )[0], '/' );
+			}
+
+			if ( '' !== $slug ) {
+				$attempts[]   = 'slug_lookup';
+				$public_types = array_keys( get_post_types( [ 'public' => true ] ) );
+				$post_obj     = get_page_by_path( $slug, OBJECT, $public_types );
+				if ( $post_obj instanceof \WP_Post ) {
+					$post_id     = $post_obj->ID;
+					$matched_via = 'slug_lookup';
+				}
+			}
+		}
+
+		if ( 0 === $post_id ) {
+			return new \WP_Error(
+				'not_found',
+				__( 'No post found for the given URL or slug.', 'superdav-ai-agent' ),
+				[
+					'input'    => $input,
+					'attempts' => $attempts,
+				]
+			);
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post instanceof \WP_Post ) {
+			return new \WP_Error(
+				'not_found',
+				__( 'No post found for the given URL or slug.', 'superdav-ai-agent' ),
+				[
+					'input'    => $input,
+					'attempts' => $attempts,
+				]
+			);
+		}
+
+		// Visibility gate: drafts and private posts require edit_post capability.
+		// Published posts are always returned — no capability check needed.
+		if ( 'publish' !== $post->post_status && ! current_user_can( 'edit_post', $post_id ) ) {
+			return new \WP_Error(
+				'not_found',
+				__( 'No post found for the given URL or slug.', 'superdav-ai-agent' ),
+				[
+					'input'    => $input,
+					'attempts' => $attempts,
+				]
+			);
+		}
+
+		return [
+			'post_id'     => $post_id,
+			'post_type'   => $post->post_type,
+			'post_status' => $post->post_status,
+			'edit_link'   => (string) get_edit_post_link( $post_id, 'raw' ),
+			'permalink'   => (string) get_permalink( $post_id ),
+			'title'       => $post->post_title,
+			'matched_via' => $matched_via,
+		];
+	}
+}

--- a/includes/Bootstrap/AbilitiesHandler.php
+++ b/includes/Bootstrap/AbilitiesHandler.php
@@ -55,6 +55,7 @@ use SdAiAgent\Abilities\SeoAbilities;
 use SdAiAgent\Abilities\SiteHealthAbilities;
 use SdAiAgent\Abilities\SkillAbilities;
 use SdAiAgent\Abilities\ThemeBuilderAbilities;
+use SdAiAgent\Abilities\UrlResolverAbilities;
 use SdAiAgent\Abilities\UserAbilities;
 use SdAiAgent\Abilities\WordPressAbilities;
 use SdAiAgent\Abilities\WpCliAbilities;
@@ -149,6 +150,7 @@ final class AbilitiesHandler {
 		NavigationAbilities::register_abilities();
 		MenuAbilities::register_abilities();
 		PostAbilities::register_abilities();
+		UrlResolverAbilities::register_abilities();
 		CustomPostTypeAbilities::register_abilities();
 		CustomTaxonomyAbilities::register_abilities();
 		UserAbilities::register_abilities();

--- a/tests/SdAiAgent/Abilities/UrlResolverAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/UrlResolverAbilitiesTest.php
@@ -1,0 +1,305 @@
+<?php
+/**
+ * Test case for UrlResolverAbilities class.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Abilities;
+
+use SdAiAgent\Abilities\UrlResolverAbilities;
+use WP_UnitTestCase;
+
+/**
+ * Tests for the sd-ai-agent/resolve-url ability handler.
+ *
+ * Coverage:
+ *  - AC2: Bare slug → get_page_by_path, matched_via "slug_lookup"
+ *  - AC3: ?p=N / ?page_id=N query string → url_to_postid, matched_via "url_to_postid"
+ *  - AC4: Cross-host URL → WP_Error('external_host')
+ *  - AC5: Unknown URL → WP_Error('not_found') with data.attempts
+ *  - AC6: Draft post + edit_post cap → resolved; draft + no cap → not_found
+ */
+class UrlResolverAbilitiesTest extends WP_UnitTestCase {
+
+	// ─── validation ───────────────────────────────────────────────
+
+	/**
+	 * Missing url key → WP_Error('missing_url').
+	 */
+	public function test_handle_resolve_url_missing_url_returns_error(): void {
+		$result = UrlResolverAbilities::handle_resolve_url( [] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'missing_url', $result->get_error_code() );
+	}
+
+	/**
+	 * Empty/whitespace url → WP_Error('missing_url').
+	 */
+	public function test_handle_resolve_url_empty_url_returns_error(): void {
+		$result = UrlResolverAbilities::handle_resolve_url( [ 'url' => '   ' ] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'missing_url', $result->get_error_code() );
+	}
+
+	// ─── AC4: external host ──────────────────────────────────────
+
+	/**
+	 * AC4: Cross-host absolute URL → WP_Error('external_host').
+	 */
+	public function test_handle_resolve_url_cross_host_returns_external_host_error(): void {
+		$result = UrlResolverAbilities::handle_resolve_url(
+			[ 'url' => 'https://completely-different-external-site.example/foo/bar' ]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'external_host', $result->get_error_code() );
+
+		$data = $result->get_error_data();
+		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( 'host', $data );
+		$this->assertArrayHasKey( 'site_host', $data );
+		$this->assertSame( 'completely-different-external-site.example', $data['host'] );
+	}
+
+	// ─── AC5: not_found with attempts ────────────────────────────
+
+	/**
+	 * AC5: Unknown bare slug → WP_Error('not_found') with slug_lookup in attempts.
+	 */
+	public function test_handle_resolve_url_unknown_slug_returns_not_found_with_attempts(): void {
+		$result = UrlResolverAbilities::handle_resolve_url(
+			[ 'url' => 'this-slug-absolutely-does-not-exist-xyz987' ]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'not_found', $result->get_error_code() );
+
+		$data = $result->get_error_data();
+		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( 'attempts', $data );
+		$this->assertContains( 'slug_lookup', $data['attempts'] );
+	}
+
+	/**
+	 * AC5: Unknown absolute URL → WP_Error('not_found') with url_to_postid in attempts.
+	 */
+	public function test_handle_resolve_url_unknown_absolute_url_returns_not_found_with_attempts(): void {
+		$unknown = home_url( '/this-page-does-not-exist-xyz987/' );
+
+		$result = UrlResolverAbilities::handle_resolve_url( [ 'url' => $unknown ] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'not_found', $result->get_error_code() );
+
+		$data = $result->get_error_data();
+		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( 'attempts', $data );
+		$this->assertContains( 'url_to_postid', $data['attempts'] );
+	}
+
+	// ─── AC2: bare slug → slug_lookup ────────────────────────────
+
+	/**
+	 * AC2: Bare slug resolves via get_page_by_path; matched_via is "slug_lookup".
+	 */
+	public function test_handle_resolve_url_bare_slug_resolves_via_slug_lookup(): void {
+		$post_id = $this->factory->post->create( [
+			'post_type'   => 'page',
+			'post_name'   => 'about-us-test-page',
+			'post_title'  => 'About Us',
+			'post_status' => 'publish',
+		] );
+
+		$result = UrlResolverAbilities::handle_resolve_url( [ 'url' => 'about-us-test-page' ] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $post_id, $result['post_id'] );
+		$this->assertSame( 'slug_lookup', $result['matched_via'] );
+	}
+
+	/**
+	 * AC2: Bare slug result contains all expected output keys with correct values.
+	 */
+	public function test_handle_resolve_url_bare_slug_returns_expected_structure(): void {
+		$post_id = $this->factory->post->create( [
+			'post_type'   => 'page',
+			'post_name'   => 'structure-test-page',
+			'post_title'  => 'Structure Test',
+			'post_status' => 'publish',
+		] );
+
+		$result = UrlResolverAbilities::handle_resolve_url( [ 'url' => 'structure-test-page' ] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'post_id', $result );
+		$this->assertArrayHasKey( 'post_type', $result );
+		$this->assertArrayHasKey( 'post_status', $result );
+		$this->assertArrayHasKey( 'edit_link', $result );
+		$this->assertArrayHasKey( 'permalink', $result );
+		$this->assertArrayHasKey( 'title', $result );
+		$this->assertArrayHasKey( 'matched_via', $result );
+
+		$this->assertSame( $post_id, $result['post_id'] );
+		$this->assertSame( 'page', $result['post_type'] );
+		$this->assertSame( 'publish', $result['post_status'] );
+		$this->assertSame( 'Structure Test', $result['title'] );
+	}
+
+	/**
+	 * Bare slug resolves any public post type, not just pages.
+	 */
+	public function test_handle_resolve_url_bare_slug_resolves_post_post_type(): void {
+		$post_id = $this->factory->post->create( [
+			'post_name'   => 'my-test-article',
+			'post_title'  => 'My Test Article',
+			'post_status' => 'publish',
+			'post_type'   => 'post',
+		] );
+
+		$result = UrlResolverAbilities::handle_resolve_url( [ 'url' => 'my-test-article' ] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $post_id, $result['post_id'] );
+		$this->assertSame( 'post', $result['post_type'] );
+		$this->assertSame( 'slug_lookup', $result['matched_via'] );
+	}
+
+	// ─── AC3: ?p=N / ?page_id=N → url_to_postid ─────────────────
+
+	/**
+	 * AC3: Absolute URL with ?p=N query string resolves via url_to_postid.
+	 */
+	public function test_handle_resolve_url_query_string_url_resolves_via_url_to_postid(): void {
+		$post_id = $this->factory->post->create( [
+			'post_title'  => 'Query String Post',
+			'post_status' => 'publish',
+		] );
+
+		$url    = home_url( '?p=' . $post_id );
+		$result = UrlResolverAbilities::handle_resolve_url( [ 'url' => $url ] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $post_id, $result['post_id'] );
+		$this->assertSame( 'url_to_postid', $result['matched_via'] );
+	}
+
+	/**
+	 * AC3: Relative ?p=N (without scheme/host) resolves via url_to_postid.
+	 */
+	public function test_handle_resolve_url_relative_query_string_resolves(): void {
+		$post_id = $this->factory->post->create( [
+			'post_title'  => 'Relative Query Post',
+			'post_status' => 'publish',
+		] );
+
+		$result = UrlResolverAbilities::handle_resolve_url( [ 'url' => '?p=' . $post_id ] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $post_id, $result['post_id'] );
+		$this->assertSame( 'url_to_postid', $result['matched_via'] );
+	}
+
+	/**
+	 * AC3: Absolute URL with ?page_id=N resolves via url_to_postid.
+	 */
+	public function test_handle_resolve_url_page_id_query_string_resolves(): void {
+		$page_id = $this->factory->post->create( [
+			'post_type'   => 'page',
+			'post_title'  => 'Page ID Test',
+			'post_status' => 'publish',
+		] );
+
+		$url    = home_url( '?page_id=' . $page_id );
+		$result = UrlResolverAbilities::handle_resolve_url( [ 'url' => $url ] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $page_id, $result['post_id'] );
+		$this->assertSame( 'url_to_postid', $result['matched_via'] );
+	}
+
+	// ─── AC6: draft visibility ────────────────────────────────────
+
+	/**
+	 * AC6: Draft post is resolved when current user has edit_post capability.
+	 */
+	public function test_handle_resolve_url_draft_post_visible_to_editor(): void {
+		$editor_id = $this->factory->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $editor_id );
+
+		$post_id = $this->factory->post->create( [
+			'post_type'   => 'page',
+			'post_name'   => 'my-draft-page',
+			'post_title'  => 'My Draft',
+			'post_status' => 'draft',
+		] );
+
+		$result = UrlResolverAbilities::handle_resolve_url( [ 'url' => 'my-draft-page' ] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $post_id, $result['post_id'] );
+		$this->assertSame( 'draft', $result['post_status'] );
+	}
+
+	/**
+	 * AC6: Draft post is hidden from a subscriber who lacks edit_post.
+	 */
+	public function test_handle_resolve_url_draft_post_hidden_from_subscriber(): void {
+		$subscriber_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+
+		$this->factory->post->create( [
+			'post_type'   => 'page',
+			'post_name'   => 'hidden-draft-page',
+			'post_title'  => 'Hidden Draft',
+			'post_status' => 'draft',
+		] );
+
+		$result = UrlResolverAbilities::handle_resolve_url( [ 'url' => 'hidden-draft-page' ] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Published post is accessible regardless of capability level.
+	 */
+	public function test_handle_resolve_url_published_post_accessible_to_subscriber(): void {
+		$subscriber_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+
+		$post_id = $this->factory->post->create( [
+			'post_type'   => 'page',
+			'post_name'   => 'public-page-subscriber',
+			'post_title'  => 'Public Page',
+			'post_status' => 'publish',
+		] );
+
+		$result = UrlResolverAbilities::handle_resolve_url( [ 'url' => 'public-page-subscriber' ] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $post_id, $result['post_id'] );
+	}
+
+	// ─── edit_link ────────────────────────────────────────────────
+
+	/**
+	 * edit_link is a non-empty string containing the post ID when user is admin.
+	 */
+	public function test_handle_resolve_url_edit_link_is_non_empty_string(): void {
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$post_id = $this->factory->post->create( [ 'post_status' => 'publish' ] );
+
+		$result = UrlResolverAbilities::handle_resolve_url( [ 'url' => '?p=' . $post_id ] );
+
+		$this->assertIsArray( $result );
+		$this->assertNotEmpty( $result['edit_link'] );
+		$this->assertStringContainsString( (string) $post_id, $result['edit_link'] );
+	}
+}


### PR DESCRIPTION
## Summary

Adds resolve-url ability that maps URL/slug to post metadata. Resolution: url_to_postid then get_page_by_path. Cross-host guard, draft cap check, 15 tests.

## Files Changed

includes/Abilities/UrlResolverAbilities.php,includes/Bootstrap/AbilitiesHandler.php,tests/SdAiAgent/Abilities/UrlResolverAbilitiesTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PHPUnit: 2916 tests, 7996 assertions, 3 pre-existing PluginBuilder MySQL failures, 0 new failures. Lint PHP/JS/CSS clean. PHPStan 0 errors. Build succeeded.

Resolves #1747


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with claude-sonnet-4-6 spent 16m and 40,451 tokens on this as a headless worker.