### PR TITLE
feat: add sd-ai-agent/list-terms ability for taxonomy term discovery

### DIFF
--- a/includes/Abilities/TaxonomyAbilities.php
+++ b/includes/Abilities/TaxonomyAbilities.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Taxonomy term abilities for the AI agent.
+ *
+ * Provides abilities to list taxonomy terms for AI-assisted
+ * content management workflows.
+ *
+ * @package SdAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Abilities;
+
+use WP_Error;
+use WP_Term;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Taxonomy term abilities.
+ *
+ * Houses the sd-ai-agent/list-terms ability and future term-management
+ * operations. Keeps CustomTaxonomyAbilities focused on taxonomy-schema
+ * registration; this class handles term-level read operations.
+ *
+ * @since 1.3.6
+ */
+class TaxonomyAbilities {
+
+	/**
+	 * Maximum allowed per_page value.
+	 */
+	const MAX_PER_PAGE = 200;
+
+	/**
+	 * Allowed orderby values.
+	 *
+	 * @var string[]
+	 */
+	const ALLOWED_ORDERBY = [ 'name', 'slug', 'count', 'term_id' ];
+
+	/**
+	 * Register all taxonomy term abilities.
+	 */
+	public static function register_abilities(): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			'sd-ai-agent/list-terms',
+			[
+				'label'               => __( 'List Taxonomy Terms', 'superdav-ai-agent' ),
+				'description'         => __( 'List terms for a given taxonomy with optional search, pagination, hierarchy, and ordering filters. Use this to discover term IDs before assigning them to posts. Returns term_id, name, slug, count, parent, and description for each term.', 'superdav-ai-agent' ),
+				'category'            => 'sd-ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'taxonomy'   => [
+							'type'        => 'string',
+							'description' => 'The taxonomy slug to list terms for (e.g. "category", "post_tag"). Default: "category".',
+						],
+						'search'     => [
+							'type'        => 'string',
+							'description' => 'Optional fuzzy-match filter applied to term name.',
+						],
+						'hide_empty' => [
+							'type'        => 'boolean',
+							'description' => 'Exclude terms with zero assigned posts. Default: false.',
+						],
+						'per_page'   => [
+							'type'        => 'integer',
+							'description' => 'Number of terms per page (1–200). Default: 50.',
+						],
+						'page'       => [
+							'type'        => 'integer',
+							'description' => '1-based page number. Default: 1.',
+						],
+						'parent'     => [
+							'type'        => 'integer',
+							'description' => 'Restrict to direct children of this term ID. 0 = top-level terms only.',
+						],
+						'orderby'    => [
+							'type'        => 'string',
+							'description' => 'Sort field: name, slug, count, term_id. Default: name.',
+						],
+						'order'      => [
+							'type'        => 'string',
+							'description' => 'Sort direction: ASC or DESC. Default: ASC.',
+						],
+					],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'taxonomy' => [ 'type' => 'string' ],
+						'total'    => [ 'type' => 'integer' ],
+						'page'     => [ 'type' => 'integer' ],
+						'per_page' => [ 'type' => 'integer' ],
+						'items'    => [
+							'type'  => 'array',
+							'items' => [
+								'type'       => 'object',
+								'properties' => [
+									'term_id'     => [ 'type' => 'integer' ],
+									'name'        => [ 'type' => 'string' ],
+									'slug'        => [ 'type' => 'string' ],
+									'count'       => [ 'type' => 'integer' ],
+									'parent'      => [ 'type' => 'integer' ],
+									'description' => [ 'type' => 'string' ],
+								],
+							],
+						],
+					],
+				],
+				'meta'                => [
+					'mcp'          => [ 'public' => true ],
+					'annotations'  => [
+						'readonly'   => true,
+						'idempotent' => true,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_list_terms' ],
+				'permission_callback' => function (): bool {
+					return current_user_can( 'edit_posts' );
+				},
+			]
+		);
+	}
+
+	/**
+	 * Handle the list-terms ability.
+	 *
+	 * Returns a paginated list of terms for the requested taxonomy.
+	 * Public taxonomies are accessible to any user with edit_posts;
+	 * private taxonomies additionally require the taxonomy's manage_terms cap.
+	 *
+	 * @param array<string, mixed> $input Input with taxonomy, search, hide_empty, per_page, page, parent, orderby, and order.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function handle_list_terms( array $input ) {
+		$taxonomy = ( isset( $input['taxonomy'] ) && '' !== (string) $input['taxonomy'] )
+			? sanitize_key( (string) $input['taxonomy'] )
+			: 'category';
+
+		// Validate taxonomy exists.
+		if ( ! taxonomy_exists( $taxonomy ) ) {
+			return new WP_Error(
+				'taxonomy_not_found',
+				/* translators: %s: taxonomy slug */
+				sprintf( __( 'Taxonomy "%s" does not exist.', 'superdav-ai-agent' ), $taxonomy )
+			);
+		}
+
+		// Guard private taxonomies: require the taxonomy's manage_terms cap.
+		$taxonomy_obj = get_taxonomy( $taxonomy );
+		if ( $taxonomy_obj && ! (bool) $taxonomy_obj->public && ! current_user_can( $taxonomy_obj->cap->manage_terms ) ) {
+			return new WP_Error(
+				'insufficient_capability',
+				/* translators: %s: taxonomy slug */
+				sprintf( __( 'You do not have permission to list terms for taxonomy "%s".', 'superdav-ai-agent' ), $taxonomy )
+			);
+		}
+
+		// Validate per_page before querying.
+		$per_page = isset( $input['per_page'] ) ? (int) $input['per_page'] : 50;
+		if ( $per_page > self::MAX_PER_PAGE ) {
+			return new WP_Error(
+				'per_page_too_large',
+				/* translators: %d: maximum per_page value */
+				sprintf( __( 'per_page must not exceed %d.', 'superdav-ai-agent' ), self::MAX_PER_PAGE )
+			);
+		}
+		$per_page = max( 1, $per_page );
+		$page     = isset( $input['page'] ) ? max( 1, (int) $input['page'] ) : 1;
+		$offset   = ( $page - 1 ) * $per_page;
+
+		// Validate orderby.
+		$orderby = 'name';
+		if ( isset( $input['orderby'] ) && in_array( $input['orderby'], self::ALLOWED_ORDERBY, true ) ) {
+			$orderby = $input['orderby'];
+		}
+
+		// Validate order.
+		$order = 'ASC';
+		if ( isset( $input['order'] ) && 'DESC' === strtoupper( (string) $input['order'] ) ) {
+			$order = 'DESC';
+		}
+
+		$hide_empty = isset( $input['hide_empty'] ) ? (bool) $input['hide_empty'] : false;
+
+		// Build base query args shared by both the count and paginated queries.
+		$base_args = [
+			'taxonomy'   => $taxonomy,
+			'hide_empty' => $hide_empty,
+			'orderby'    => $orderby,
+			'order'      => $order,
+		];
+
+		if ( isset( $input['search'] ) && '' !== (string) $input['search'] ) {
+			$base_args['search'] = sanitize_text_field( (string) $input['search'] );
+		}
+
+		if ( isset( $input['parent'] ) ) {
+			$base_args['parent'] = (int) $input['parent'];
+		}
+
+		// Count query — omit number/offset so total reflects all matching terms.
+		$count_args           = $base_args;
+		$count_args['fields'] = 'count';
+		$count_result         = get_terms( $count_args );
+		$total                = is_wp_error( $count_result ) ? 0 : (int) $count_result;
+
+		// Paginated query.
+		$query_args           = $base_args;
+		$query_args['number'] = $per_page;
+		$query_args['offset'] = $offset;
+		$terms                = get_terms( $query_args );
+
+		if ( is_wp_error( $terms ) ) {
+			return $terms;
+		}
+
+		$items = [];
+		foreach ( is_array( $terms ) ? $terms : [] as $term ) {
+			if ( ! ( $term instanceof WP_Term ) ) {
+				continue;
+			}
+			$items[] = [
+				'term_id'     => (int) $term->term_id,
+				'name'        => (string) $term->name,
+				'slug'        => (string) $term->slug,
+				'count'       => (int) $term->count,
+				'parent'      => (int) $term->parent,
+				'description' => (string) $term->description,
+			];
+		}
+
+		return [
+			'taxonomy' => $taxonomy,
+			'total'    => $total,
+			'page'     => $page,
+			'per_page' => $per_page,
+			'items'    => $items,
+		];
+	}
+}

--- a/includes/Bootstrap/AbilitiesHandler.php
+++ b/includes/Bootstrap/AbilitiesHandler.php
@@ -27,6 +27,7 @@ use SdAiAgent\Abilities\BlockAbilities;
 use SdAiAgent\Abilities\ContentAbilities;
 use SdAiAgent\Abilities\CustomPostTypeAbilities;
 use SdAiAgent\Abilities\CustomTaxonomyAbilities;
+use SdAiAgent\Abilities\TaxonomyAbilities;
 use SdAiAgent\Abilities\DatabaseAbilities;
 use SdAiAgent\Abilities\DesignSystemAbilities;
 use SdAiAgent\Abilities\EditorialAbilities;
@@ -151,6 +152,7 @@ final class AbilitiesHandler {
 		PostAbilities::register_abilities();
 		CustomPostTypeAbilities::register_abilities();
 		CustomTaxonomyAbilities::register_abilities();
+		TaxonomyAbilities::register_abilities();
 		UserAbilities::register_abilities();
 		MediaAbilities::register_abilities();
 		EditorialAbilities::register_abilities();

--- a/tests/SdAiAgent/Abilities/TaxonomyAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/TaxonomyAbilitiesTest.php
@@ -1,0 +1,368 @@
+<?php
+/**
+ * Test case for TaxonomyAbilities class.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Abilities;
+
+use SdAiAgent\Abilities\TaxonomyAbilities;
+use WP_UnitTestCase;
+
+/**
+ * Test TaxonomyAbilities handler methods.
+ */
+class TaxonomyAbilitiesTest extends WP_UnitTestCase {
+
+	/**
+	 * Slug for the private taxonomy registered in tests that require it.
+	 *
+	 * @var string
+	 */
+	private string $private_tax = 'sd_ai_agent_test_private';
+
+	/**
+	 * Administrator user ID for tests that require elevated capabilities.
+	 *
+	 * @var int
+	 */
+	private int $admin_id;
+
+	/**
+	 * Set up shared test state.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $this->admin_id );
+	}
+
+	/**
+	 * Tear down test state: restore unauthenticated user and unregister test taxonomy.
+	 */
+	public function tearDown(): void {
+		wp_set_current_user( 0 );
+		if ( taxonomy_exists( $this->private_tax ) ) {
+			unregister_taxonomy( $this->private_tax );
+		}
+		parent::tearDown();
+	}
+
+	// ─── handle_list_terms ─────────────────────────────────────────────────
+
+	/**
+	 * Test default call (no input) returns the category taxonomy with Uncategorized.
+	 */
+	public function test_default_category_returns_uncategorized(): void {
+		$result = TaxonomyAbilities::handle_list_terms( [] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'category', $result['taxonomy'] );
+
+		$names = array_column( $result['items'], 'name' );
+		$this->assertContains( 'Uncategorized', $names );
+	}
+
+	/**
+	 * Test response contains all expected top-level keys.
+	 */
+	public function test_returns_expected_structure(): void {
+		$result = TaxonomyAbilities::handle_list_terms( [ 'taxonomy' => 'category' ] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'taxonomy', $result );
+		$this->assertArrayHasKey( 'total', $result );
+		$this->assertArrayHasKey( 'page', $result );
+		$this->assertArrayHasKey( 'per_page', $result );
+		$this->assertArrayHasKey( 'items', $result );
+		$this->assertIsArray( $result['items'] );
+		$this->assertIsInt( $result['total'] );
+		$this->assertIsInt( $result['page'] );
+		$this->assertIsInt( $result['per_page'] );
+	}
+
+	/**
+	 * Test each item contains the required fields with correct types.
+	 */
+	public function test_item_structure(): void {
+		$result = TaxonomyAbilities::handle_list_terms( [ 'taxonomy' => 'category' ] );
+
+		$this->assertNotEmpty( $result['items'], 'Expected at least the Uncategorized term.' );
+
+		$item = $result['items'][0];
+		$this->assertArrayHasKey( 'term_id', $item );
+		$this->assertArrayHasKey( 'name', $item );
+		$this->assertArrayHasKey( 'slug', $item );
+		$this->assertArrayHasKey( 'count', $item );
+		$this->assertArrayHasKey( 'parent', $item );
+		$this->assertArrayHasKey( 'description', $item );
+		$this->assertIsInt( $item['term_id'] );
+		$this->assertIsString( $item['name'] );
+		$this->assertIsString( $item['slug'] );
+		$this->assertIsInt( $item['count'] );
+		$this->assertIsInt( $item['parent'] );
+		$this->assertIsString( $item['description'] );
+	}
+
+	/**
+	 * Test search parameter narrows results to matching terms.
+	 */
+	public function test_search_narrows_results(): void {
+		$unique = 'zzsrch' . uniqid();
+		$this->factory->term->create( [
+			'taxonomy' => 'category',
+			'name'     => $unique . '-alpha',
+		] );
+		$this->factory->term->create( [
+			'taxonomy' => 'category',
+			'name'     => 'totally-different-' . uniqid(),
+		] );
+
+		$result = TaxonomyAbilities::handle_list_terms( [
+			'taxonomy' => 'category',
+			'search'   => $unique,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 1, $result['total'] );
+		$this->assertSame( $unique . '-alpha', $result['items'][0]['name'] );
+	}
+
+	/**
+	 * Test per_page and page inputs are reflected in the response and items count.
+	 */
+	public function test_pagination_metadata_correct(): void {
+		$prefix = 'zzpag' . uniqid();
+		for ( $i = 1; $i <= 5; $i++ ) {
+			$this->factory->term->create( [
+				'taxonomy' => 'category',
+				'name'     => $prefix . '-term-' . $i,
+			] );
+		}
+
+		$result = TaxonomyAbilities::handle_list_terms( [
+			'taxonomy' => 'category',
+			'search'   => $prefix,
+			'per_page' => 2,
+			'page'     => 1,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 5, $result['total'], 'Total must reflect unpaginated count.' );
+		$this->assertCount( 2, $result['items'] );
+		$this->assertSame( 1, $result['page'] );
+		$this->assertSame( 2, $result['per_page'] );
+	}
+
+	/**
+	 * Test total is consistent across pages (reflects unpaginated count).
+	 */
+	public function test_total_is_unpaginated(): void {
+		$prefix = 'zztot' . uniqid();
+		for ( $i = 1; $i <= 3; $i++ ) {
+			$this->factory->term->create( [
+				'taxonomy' => 'category',
+				'name'     => $prefix . '-term-' . $i,
+			] );
+		}
+
+		$page1 = TaxonomyAbilities::handle_list_terms( [
+			'taxonomy' => 'category',
+			'search'   => $prefix,
+			'per_page' => 2,
+			'page'     => 1,
+		] );
+
+		$page2 = TaxonomyAbilities::handle_list_terms( [
+			'taxonomy' => 'category',
+			'search'   => $prefix,
+			'per_page' => 2,
+			'page'     => 2,
+		] );
+
+		$this->assertSame( 3, $page1['total'] );
+		$this->assertSame( 3, $page2['total'] );
+		$this->assertCount( 2, $page1['items'] );
+		$this->assertCount( 1, $page2['items'] );
+	}
+
+	/**
+	 * Test parent parameter returns only direct children of the given term.
+	 */
+	public function test_parent_filter_returns_direct_children(): void {
+		$parent_id = $this->factory->term->create( [
+			'taxonomy' => 'category',
+			'name'     => 'zzpar-' . uniqid(),
+		] );
+		$child_id  = $this->factory->term->create( [
+			'taxonomy' => 'category',
+			'name'     => 'zzchild-' . uniqid(),
+			'parent'   => $parent_id,
+		] );
+
+		$result = TaxonomyAbilities::handle_list_terms( [
+			'taxonomy' => 'category',
+			'parent'   => $parent_id,
+		] );
+
+		$this->assertIsArray( $result );
+		$term_ids = array_column( $result['items'], 'term_id' );
+		$this->assertContains( $child_id, $term_ids );
+		$this->assertNotContains( $parent_id, $term_ids );
+	}
+
+	/**
+	 * Test unknown taxonomy slug returns WP_Error with taxonomy_not_found code.
+	 */
+	public function test_unknown_taxonomy_returns_error(): void {
+		$result = TaxonomyAbilities::handle_list_terms( [
+			'taxonomy' => 'totally_nonexistent_taxonomy_xyz_9999',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'taxonomy_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Test private taxonomy without manage_terms cap returns insufficient_capability.
+	 */
+	public function test_private_taxonomy_without_cap_returns_error(): void {
+		register_taxonomy(
+			$this->private_tax,
+			[ 'post' ],
+			[
+				'public'       => false,
+				'capabilities' => [
+					'manage_terms' => 'manage_options',
+					'edit_terms'   => 'manage_options',
+					'delete_terms' => 'manage_options',
+					'assign_terms' => 'manage_options',
+				],
+			]
+		);
+
+		$subscriber_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+
+		$result = TaxonomyAbilities::handle_list_terms( [ 'taxonomy' => $this->private_tax ] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'insufficient_capability', $result->get_error_code() );
+
+		// Restore admin for subsequent assertions or tearDown.
+		wp_set_current_user( $this->admin_id );
+	}
+
+	/**
+	 * Test private taxonomy with manage_terms capability returns valid results.
+	 */
+	public function test_private_taxonomy_with_cap_returns_results(): void {
+		register_taxonomy(
+			$this->private_tax,
+			[ 'post' ],
+			[
+				'public'       => false,
+				'capabilities' => [
+					'manage_terms' => 'manage_options',
+					'edit_terms'   => 'manage_options',
+					'delete_terms' => 'manage_options',
+					'assign_terms' => 'manage_options',
+				],
+			]
+		);
+
+		// Admin has manage_options.
+		$result = TaxonomyAbilities::handle_list_terms( [ 'taxonomy' => $this->private_tax ] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'items', $result );
+		$this->assertSame( $this->private_tax, $result['taxonomy'] );
+	}
+
+	/**
+	 * Test hide_empty excludes terms with zero assigned posts.
+	 *
+	 * Freshly created terms have count = 0. With hide_empty false both terms
+	 * appear; with hide_empty true both are excluded.
+	 */
+	public function test_hide_empty_excludes_zero_count_terms(): void {
+		$prefix = 'zzhide' . uniqid();
+		$this->factory->term->create( [
+			'taxonomy' => 'category',
+			'name'     => $prefix . '-a',
+		] );
+		$this->factory->term->create( [
+			'taxonomy' => 'category',
+			'name'     => $prefix . '-b',
+		] );
+
+		$result_all = TaxonomyAbilities::handle_list_terms( [
+			'taxonomy'   => 'category',
+			'search'     => $prefix,
+			'hide_empty' => false,
+		] );
+		$this->assertSame( 2, $result_all['total'] );
+
+		$result_empty = TaxonomyAbilities::handle_list_terms( [
+			'taxonomy'   => 'category',
+			'search'     => $prefix,
+			'hide_empty' => true,
+		] );
+		$this->assertSame( 0, $result_empty['total'] );
+	}
+
+	/**
+	 * Test per_page greater than 200 returns WP_Error with per_page_too_large code.
+	 */
+	public function test_per_page_too_large_returns_error(): void {
+		$result = TaxonomyAbilities::handle_list_terms( [
+			'taxonomy' => 'category',
+			'per_page' => 500,
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'per_page_too_large', $result->get_error_code() );
+	}
+
+	/**
+	 * Test per_page of exactly 200 is accepted and reflected in the response.
+	 */
+	public function test_per_page_200_is_accepted(): void {
+		$result = TaxonomyAbilities::handle_list_terms( [
+			'taxonomy' => 'category',
+			'per_page' => 200,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 200, $result['per_page'] );
+	}
+
+	/**
+	 * Test orderby term_id with order ASC returns terms sorted ascending by ID.
+	 */
+	public function test_orderby_term_id_asc(): void {
+		$prefix = 'zzord' . uniqid();
+		for ( $i = 1; $i <= 3; $i++ ) {
+			$this->factory->term->create( [
+				'taxonomy' => 'category',
+				'name'     => $prefix . '-' . $i,
+			] );
+		}
+
+		$result = TaxonomyAbilities::handle_list_terms( [
+			'taxonomy' => 'category',
+			'search'   => $prefix,
+			'orderby'  => 'term_id',
+			'order'    => 'ASC',
+		] );
+
+		$this->assertIsArray( $result );
+		$result_ids = array_column( $result['items'], 'term_id' );
+		$sorted     = $result_ids;
+		sort( $sorted );
+		$this->assertSame( $sorted, $result_ids, 'Items should be sorted by term_id ASC.' );
+	}
+}


### PR DESCRIPTION
## Summary

Implements the `sd-ai-agent/list-terms` ability (Wave 2.4 / t258). Agents can now discover taxonomy term IDs without falling back to raw `db-query` SQL.

## What changed

**New ability: `sd-ai-agent/list-terms`**
- Returns `term_id`, `name`, `slug`, `count`, `parent`, `description` per term.
- Input parameters: `taxonomy` (default `"category"`), `search`, `hide_empty`, `per_page` (1–200, default 50), `page` (default 1), `parent` (direct-children filter), `orderby` (name/slug/count/term_id), `order` (ASC/DESC).
- Unknown taxonomy → `WP_Error('taxonomy_not_found')`.
- Private taxonomy without `manage_terms` cap → `WP_Error('insufficient_capability')`.
- `per_page` > 200 → `WP_Error('per_page_too_large')`.
- `total` in response always reflects the unpaginated match count.

## Files

| File | Action |
| --- | --- |
| `includes/Abilities/TaxonomyAbilities.php` | New — houses `list-terms` and future term-level ops |
| `includes/Bootstrap/AbilitiesHandler.php` | Modified — registers `TaxonomyAbilities` |
| `tests/SdAiAgent/Abilities/TaxonomyAbilitiesTest.php` | New — 14 tests covering all acceptance criteria |

## Worker self-verification
- PHPUnit: Tests: 14, Assertions: 56, Errors: 0, Failures: 0 (filtered to `TaxonomyAbilitiesTest`)
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Pre-existing full-suite failures (OnboardingManager, PluginBuilder, RestController) were already failing on `main` before this branch — verified with `git stash` baseline run.

Resolves #1750
For #1739

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with claude-sonnet-4-6 spent 22m and 40,561 tokens on this as a headless worker.
