### PR TITLE
GH#1756: feat: per-post rate limiting (write 10/min, rewrite 2/min)

### DIFF
--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -21,6 +21,7 @@ use SdAiAgent\Core\BlockRenderer;
 use SdAiAgent\Core\BlockTreeAddress;
 use SdAiAgent\Core\BlockValidator;
 use SdAiAgent\Core\PatternInserter;
+use SdAiAgent\Core\RateLimiter;
 use SdAiAgent\Core\RevisionGuard;
 use SdAiAgent\Models\MarkdownToBlocks;
 
@@ -2387,6 +2388,15 @@ class BlockAbilities {
 			);
 		}
 
+		// Rate limit check (write bucket, per-post).
+		if ( ! $dry_run ) {
+			$rate_check = RateLimiter::check( 'write', $post_id );
+
+			if ( is_wp_error( $rate_check ) ) {
+				return $rate_check;
+			}
+		}
+
 		$post = get_post( $post_id );
 
 		if ( ! $post ) {
@@ -2440,6 +2450,9 @@ class BlockAbilities {
 			}
 
 			clean_post_cache( $post_id );
+
+			// Record rate-limit tick after successful write.
+			RateLimiter::record( 'write', $post_id );
 		}
 
 		return [
@@ -2485,6 +2498,16 @@ class BlockAbilities {
 				__( 'updates must be an array.', 'superdav-ai-agent' ),
 				[ 'status' => 400 ]
 			);
+		}
+
+		// Rate limit check (write bucket, per-post).
+		// Atomic batch ticks once per batch, not per op.
+		if ( ! $dry_run ) {
+			$rate_check = RateLimiter::check( 'write', $post_id );
+
+			if ( is_wp_error( $rate_check ) ) {
+				return $rate_check;
+			}
 		}
 
 		$post = get_post( $post_id );
@@ -2548,6 +2571,9 @@ class BlockAbilities {
 			if ( is_wp_error( $update_result ) ) {
 				return $update_result;
 			}
+
+			// Record one rate-limit tick per batch (not per op).
+			RateLimiter::record( 'write', $post_id );
 		}
 
 		return [
@@ -2619,15 +2645,11 @@ class BlockAbilities {
 			return $guard;
 		}
 
-		// ── Rate limit (guarded — ships before t264) ──────────────────
-		// @phpstan-ignore-next-line
-		if ( class_exists( '\SdAiAgent\Core\RateLimiter' ) ) {
-			/** @var \WP_Error|true $rate_check */
-			// @phpstan-ignore-next-line
-			$rate_check = \SdAiAgent\Core\RateLimiter::check( $post_id, 'rewrite' );
-			if ( is_wp_error( $rate_check ) ) {
-				return $rate_check;
-			}
+		// ── Rate limit (rewrite bucket, per-post) ────────────────────
+		$rate_check = RateLimiter::check( 'rewrite', $post_id );
+
+		if ( is_wp_error( $rate_check ) ) {
+			return $rate_check;
 		}
 
 		// ── Validate and normalize blocks ─────────────────────────────
@@ -2671,12 +2693,8 @@ class BlockAbilities {
 			return $update_result;
 		}
 
-		// ── Record rate-limit hit (guarded) ───────────────────────────
-		// @phpstan-ignore-next-line
-		if ( class_exists( '\SdAiAgent\Core\RateLimiter' ) ) {
-			// @phpstan-ignore-next-line
-			\SdAiAgent\Core\RateLimiter::record( $post_id, 'rewrite' );
-		}
+		// Record rate-limit tick after successful rewrite.
+		RateLimiter::record( 'rewrite', $post_id );
 
 		return [
 			'success'     => true,
@@ -2790,6 +2808,15 @@ class BlockAbilities {
 				__( 'post_id is required and must be a positive integer.', 'superdav-ai-agent' ),
 				[ 'status' => 400 ]
 			);
+		}
+
+		// Rate limit check (write bucket, per-post).
+		if ( ! $dry_run ) {
+			$rate_check = RateLimiter::check( 'write', $post_id );
+
+			if ( is_wp_error( $rate_check ) ) {
+				return $rate_check;
+			}
 		}
 
 		if ( null === $pattern || ( is_string( $pattern ) && '' === $pattern ) ) {
@@ -3018,6 +3045,9 @@ class BlockAbilities {
 			if ( is_wp_error( $update_result ) ) {
 				return $update_result;
 			}
+
+			// Record rate-limit tick after successful write.
+			RateLimiter::record( 'write', $post_id );
 		}
 
 		return [

--- a/includes/Abilities/PostAbilities.php
+++ b/includes/Abilities/PostAbilities.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Abilities;
 
 use SdAiAgent\Core\BlockValidator;
+use SdAiAgent\Core\RateLimiter;
 use SdAiAgent\Core\RevisionGuard;
 use SdAiAgent\Models\MarkdownToBlocks;
 use WP_Error;
@@ -803,6 +804,13 @@ class PostAbilities {
 	 * @return array<string, mixed>|WP_Error
 	 */
 	public static function handle_create_post( array $input ) {
+		// Rate limit check (write bucket, per-user for creates).
+		$rate_check = RateLimiter::check( 'write', get_current_user_id() );
+
+		if ( is_wp_error( $rate_check ) ) {
+			return $rate_check;
+		}
+
 		// @phpstan-ignore-next-line
 		$title       = sanitize_text_field( $input['title'] ?? '' );
 		$raw_content = $input['content'] ?? '';
@@ -860,6 +868,9 @@ class PostAbilities {
 			}
 			return $post_id;
 		}
+
+		// Record rate-limit tick after successful create (per-user).
+		RateLimiter::record( 'write', get_current_user_id() );
 
 		// Assign categories.
 		$categories = $input['categories'] ?? [];
@@ -1003,6 +1014,13 @@ class PostAbilities {
 			return new WP_Error( 'ai_agent_empty_post_id', __( 'post_id is required.', 'superdav-ai-agent' ) );
 		}
 
+		// Rate limit check (write bucket, per-post).
+		$rate_check = RateLimiter::check( 'write', $post_id );
+
+		if ( is_wp_error( $rate_check ) ) {
+			return $rate_check;
+		}
+
 		$switched = false;
 
 		if ( ! empty( $site_url ) && is_multisite() ) {
@@ -1078,6 +1096,9 @@ class PostAbilities {
 			}
 			return $result;
 		}
+
+		// Record rate-limit tick after successful write.
+		RateLimiter::record( 'write', $post_id );
 
 		// Update categories if provided.
 		if ( isset( $input['categories'] ) && is_array( $input['categories'] ) ) {

--- a/includes/Core/RateLimiter.php
+++ b/includes/Core/RateLimiter.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Per-post, per-bucket rate limiter.
+ *
+ * Two buckets:
+ *   - `write`:   10 ops / 60s / post (edit-block-tree, update-blocks, update-post, etc.)
+ *   - `rewrite`: 2 ops / 60s / post  (rewrite-post-blocks)
+ *
+ * Storage: WP transient `sd_ai_agent_rl_{bucket}_{entity_id}` containing a
+ * JSON array of Unix timestamps for ops within the last 60s. Old entries are
+ * pruned on each check.
+ *
+ * Adapted from ~/Git/block-mcp/wordpress-plugin/gk-block-api/includes/class-block-writer.php:111-180
+ * (GPL-2.0-or-later — compatible).
+ *
+ * @package SdAiAgent\Core
+ * @license GPL-2.0-or-later
+ * @see     https://github.com/Ultimate-Multisite/superdav-ai-agent/issues/1756
+ */
+
+namespace SdAiAgent\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Rate limiter for per-post write operations.
+ *
+ * All methods are static. The class holds no per-instance state.
+ */
+class RateLimiter {
+
+	/**
+	 * Default rate limits per bucket (ops per window).
+	 *
+	 * @var array<string, int>
+	 */
+	private const DEFAULT_LIMITS = [
+		'write'   => 10,
+		'rewrite' => 2,
+	];
+
+	/**
+	 * Rolling window size in seconds.
+	 *
+	 * @var int
+	 */
+	public const WINDOW_SECONDS = 60;
+
+	/**
+	 * Transient key prefix.
+	 *
+	 * @var string
+	 */
+	private const TRANSIENT_PREFIX = 'sd_ai_agent_rl_';
+
+	/**
+	 * Check whether a new operation is within the rate limit.
+	 *
+	 * Reads the transient for the given bucket + entity, prunes entries older
+	 * than WINDOW_SECONDS, and compares the remaining count against the limit.
+	 *
+	 * Returns `true` when the operation is allowed. Returns a `rate_limit_exceeded`
+	 * WP_Error when the limit has been reached.
+	 *
+	 * @param string $bucket    Bucket name ('write' or 'rewrite').
+	 * @param int    $entity_id Post ID (or user ID for create-post).
+	 * @return true|\WP_Error True when allowed, WP_Error when rate-limited.
+	 */
+	public static function check( string $bucket, int $entity_id ): true|\WP_Error {
+		$limits = self::get_limits();
+		$limit  = $limits[ $bucket ] ?? 0;
+
+		if ( $limit <= 0 ) {
+			// Unknown bucket or zero limit — allow by default.
+			return true;
+		}
+
+		$key    = self::transient_key( $bucket, $entity_id );
+		$now    = time();
+		$window = self::WINDOW_SECONDS;
+		$cutoff = $now - $window;
+		$raw    = get_transient( $key );
+		$ticks  = self::parse_ticks( $raw, $cutoff );
+
+		if ( count( $ticks ) < $limit ) {
+			return true;
+		}
+
+		// Limit exceeded — compute retry_after_seconds.
+		// The oldest tick still in the window determines when a slot opens.
+		$oldest_tick = min( $ticks );
+		$retry_after = ( $oldest_tick + $window ) - $now;
+		$retry_after = max( 1, $retry_after );
+
+		return new \WP_Error(
+			'rate_limit_exceeded',
+			__( 'Rate limit exceeded for this post.', 'superdav-ai-agent' ),
+			[
+				'status'              => 429,
+				'bucket'              => $bucket,
+				'limit'               => $limit,
+				'window_seconds'      => $window,
+				'retry_after_seconds' => $retry_after,
+				'post_id'             => $entity_id,
+			]
+		);
+	}
+
+	/**
+	 * Record a successful operation tick.
+	 *
+	 * Appends the current timestamp to the transient for the given bucket + entity.
+	 * Prunes entries older than WINDOW_SECONDS before storing.
+	 *
+	 * @param string $bucket    Bucket name ('write' or 'rewrite').
+	 * @param int    $entity_id Post ID (or user ID for create-post).
+	 */
+	public static function record( string $bucket, int $entity_id ): void {
+		$key    = self::transient_key( $bucket, $entity_id );
+		$now    = time();
+		$cutoff = $now - self::WINDOW_SECONDS;
+		$raw    = get_transient( $key );
+		$ticks  = self::parse_ticks( $raw, $cutoff );
+
+		$ticks[] = $now;
+
+		// Store with a TTL of WINDOW_SECONDS so stale transients auto-expire.
+		$json = wp_json_encode( $ticks );
+
+		if ( false !== $json ) {
+			set_transient( $key, $json, self::WINDOW_SECONDS );
+		}
+	}
+
+	/**
+	 * Get the current rate limits, applying the `sd_ai_agent_rate_limits` filter.
+	 *
+	 * @return array<string, int> Bucket name => max ops per window.
+	 */
+	public static function get_limits(): array {
+		/**
+		 * Filter rate limits per bucket.
+		 *
+		 * Return an associative array of bucket name => max ops per window.
+		 * Only 'write' and 'rewrite' buckets are currently checked.
+		 *
+		 * @param array<string, int> $limits Default limits.
+		 */
+		$limits = apply_filters( 'sd_ai_agent_rate_limits', self::DEFAULT_LIMITS );
+
+		if ( ! is_array( $limits ) ) {
+			return self::DEFAULT_LIMITS;
+		}
+
+		// Ensure all values are positive integers.
+		$sanitized = [];
+		foreach ( $limits as $bucket => $value ) {
+			if ( is_string( $bucket ) && is_int( $value ) && $value > 0 ) {
+				$sanitized[ $bucket ] = $value;
+			}
+		}
+
+		return ! empty( $sanitized ) ? $sanitized : self::DEFAULT_LIMITS;
+	}
+
+	/**
+	 * Build the transient key for a bucket + entity pair.
+	 *
+	 * @param string $bucket    Bucket name.
+	 * @param int    $entity_id Entity (post or user) ID.
+	 * @return string Transient key.
+	 */
+	private static function transient_key( string $bucket, int $entity_id ): string {
+		return self::TRANSIENT_PREFIX . $bucket . '_' . $entity_id;
+	}
+
+	/**
+	 * Parse stored tick data from a transient value.
+	 *
+	 * Decodes the JSON array and prunes entries older than $cutoff.
+	 *
+	 * @param mixed $raw    Raw transient value (false when absent, string when present).
+	 * @param int   $cutoff Unix timestamp cutoff — entries at or before this are discarded.
+	 * @return int[] Array of valid timestamps within the window.
+	 */
+	private static function parse_ticks( mixed $raw, int $cutoff ): array {
+		if ( false === $raw || ! is_string( $raw ) ) {
+			return [];
+		}
+
+		$decoded = json_decode( $raw, true );
+
+		if ( ! is_array( $decoded ) ) {
+			return [];
+		}
+
+		$valid = [];
+
+		foreach ( $decoded as $ts ) {
+			if ( is_int( $ts ) && $ts > $cutoff ) {
+				$valid[] = $ts;
+			}
+		}
+
+		return $valid;
+	}
+}

--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -80,6 +80,49 @@ final class RestController {
 	 * All domain controllers are now DI-managed and register their own
 	 * routes via #[REST_Handler] or #[Handler] + #[Action(rest_api_init)].
 	 */
+	/**
+	 * Add `Retry-After` header to 429 (rate_limit_exceeded) REST responses.
+	 *
+	 * When a WP_Error with code `rate_limit_exceeded` is converted to a REST
+	 * response by WordPress core, this filter reads `retry_after_seconds`
+	 * from the error data and sets the `Retry-After` HTTP header. This
+	 * allows clients (and the AI agent) to honour the backoff signal.
+	 *
+	 * @param WP_REST_Response|\WP_HTTP_Response $result  REST response.
+	 * @return WP_REST_Response|\WP_HTTP_Response Modified response (header added if applicable).
+	 */
+	#[Action( tag: 'rest_post_dispatch', priority: 10 )]
+	public static function add_retry_after_header( $result ) {
+		if ( ! $result instanceof WP_REST_Response ) {
+			return $result;
+		}
+
+		if ( 429 !== $result->get_status() ) {
+			return $result;
+		}
+
+		$data = $result->get_data();
+
+		if ( ! is_array( $data ) ) {
+			return $result;
+		}
+
+		// WP_Error→REST conversion puts error data under 'data'.
+		$error_data = $data['data'] ?? [];
+
+		if ( ! is_array( $error_data ) ) {
+			return $result;
+		}
+
+		$retry_after = $error_data['retry_after_seconds'] ?? null;
+
+		if ( is_int( $retry_after ) && $retry_after > 0 ) {
+			$result->header( 'Retry-After', (string) $retry_after );
+		}
+
+		return $result;
+	}
+
 	#[Action( tag: 'rest_api_init', priority: 10 )]
 	public function register_routes(): void {
 

--- a/tests/SdAiAgent/Core/RateLimiterTest.php
+++ b/tests/SdAiAgent/Core/RateLimiterTest.php
@@ -1,0 +1,440 @@
+<?php
+/**
+ * Test case for RateLimiter (GH#1756).
+ *
+ * Covers the acceptance criteria:
+ *   AC1: 11th edit-block-tree on the same post within 60s returns rate_limit_exceeded.
+ *   AC2: Rewrite bucket independent of write bucket.
+ *   AC3: Atomic batch of 30 ops counts as 1 tick.
+ *   AC4: Per-post isolation: post A unaffected by post B's bucket.
+ *   AC5: HTTP response carries Retry-After header when 429.
+ *   AC6: Filter sd_ai_agent_rate_limits overrides the caps.
+ *   AC7: Transient pruning: entries > 60s old discarded on next check.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ * @see     https://github.com/Ultimate-Multisite/superdav-ai-agent/issues/1756
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\RateLimiter;
+use WP_UnitTestCase;
+
+/**
+ * Unit tests for RateLimiter.
+ *
+ * Uses WP_UnitTestCase so WordPress transient functions are available.
+ */
+class RateLimiterTest extends WP_UnitTestCase {
+
+	/**
+	 * Clean up rate-limit transients between tests.
+	 */
+	public function tear_down(): void {
+		// Clean up all transients used in tests.
+		$buckets   = [ 'write', 'rewrite' ];
+		$entity_ids = [ 156, 200, 999, 1, 2, 42 ];
+
+		foreach ( $buckets as $bucket ) {
+			foreach ( $entity_ids as $entity_id ) {
+				delete_transient( 'sd_ai_agent_rl_' . $bucket . '_' . $entity_id );
+			}
+		}
+
+		// Remove any filters we added.
+		remove_all_filters( 'sd_ai_agent_rate_limits' );
+
+		parent::tear_down();
+	}
+
+	// ── AC1: Write bucket limit ───────────────────────────────────────────
+
+	/**
+	 * First 10 writes on a post are allowed.
+	 */
+	public function test_write_bucket_allows_within_limit(): void {
+		$post_id = 156;
+
+		for ( $i = 0; $i < 10; $i++ ) {
+			$check = RateLimiter::check( 'write', $post_id );
+			$this->assertTrue( $check, "Write $i should be allowed" );
+			RateLimiter::record( 'write', $post_id );
+		}
+	}
+
+	/**
+	 * 11th write on the same post within 60s returns rate_limit_exceeded.
+	 */
+	public function test_write_bucket_blocks_at_limit(): void {
+		$post_id = 156;
+
+		// Fill up the bucket.
+		for ( $i = 0; $i < 10; $i++ ) {
+			RateLimiter::record( 'write', $post_id );
+		}
+
+		$check = RateLimiter::check( 'write', $post_id );
+		$this->assertWPError( $check );
+		$this->assertSame( 'rate_limit_exceeded', $check->get_error_code() );
+
+		$data = $check->get_error_data();
+		$this->assertIsArray( $data );
+		$this->assertSame( 429, $data['status'] );
+		$this->assertSame( 'write', $data['bucket'] );
+		$this->assertSame( 10, $data['limit'] );
+		$this->assertSame( 60, $data['window_seconds'] );
+		$this->assertArrayHasKey( 'retry_after_seconds', $data );
+		$this->assertGreaterThan( 0, $data['retry_after_seconds'] );
+		$this->assertSame( $post_id, $data['post_id'] );
+	}
+
+	// ── AC2: Bucket independence ──────────────────────────────────────────
+
+	/**
+	 * Rewrite bucket is independent of write bucket.
+	 */
+	public function test_rewrite_bucket_independent_of_write(): void {
+		$post_id = 156;
+
+		// Fill the write bucket to capacity.
+		for ( $i = 0; $i < 10; $i++ ) {
+			RateLimiter::record( 'write', $post_id );
+		}
+
+		// Write bucket should be blocked.
+		$write_check = RateLimiter::check( 'write', $post_id );
+		$this->assertWPError( $write_check );
+
+		// Rewrite bucket should still be available.
+		$rewrite_check = RateLimiter::check( 'rewrite', $post_id );
+		$this->assertTrue( $rewrite_check );
+	}
+
+	/**
+	 * Rewrite bucket has its own limit (2/60s).
+	 */
+	public function test_rewrite_bucket_limit(): void {
+		$post_id = 156;
+
+		// Fill the rewrite bucket.
+		RateLimiter::record( 'rewrite', $post_id );
+		RateLimiter::record( 'rewrite', $post_id );
+
+		// 3rd rewrite should be blocked.
+		$check = RateLimiter::check( 'rewrite', $post_id );
+		$this->assertWPError( $check );
+		$this->assertSame( 'rate_limit_exceeded', $check->get_error_code() );
+
+		$data = $check->get_error_data();
+		$this->assertIsArray( $data );
+		$this->assertSame( 'rewrite', $data['bucket'] );
+		$this->assertSame( 2, $data['limit'] );
+	}
+
+	/**
+	 * Write bucket not affected by rewrite bucket usage.
+	 */
+	public function test_write_bucket_independent_of_rewrite(): void {
+		$post_id = 156;
+
+		// Fill the rewrite bucket.
+		RateLimiter::record( 'rewrite', $post_id );
+		RateLimiter::record( 'rewrite', $post_id );
+
+		// Write bucket should still be available.
+		$check = RateLimiter::check( 'write', $post_id );
+		$this->assertTrue( $check );
+	}
+
+	// ── AC4: Per-post isolation ───────────────────────────────────────────
+
+	/**
+	 * Post 200 is unaffected by post 156's bucket.
+	 */
+	public function test_per_post_isolation(): void {
+		$post_a = 156;
+		$post_b = 200;
+
+		// Fill post A's write bucket to capacity.
+		for ( $i = 0; $i < 10; $i++ ) {
+			RateLimiter::record( 'write', $post_a );
+		}
+
+		// Post A should be blocked.
+		$check_a = RateLimiter::check( 'write', $post_a );
+		$this->assertWPError( $check_a );
+
+		// Post B should be unaffected.
+		$check_b = RateLimiter::check( 'write', $post_b );
+		$this->assertTrue( $check_b );
+	}
+
+	// ── AC5: Retry-After header ───────────────────────────────────────────
+
+	/**
+	 * Rate limit error includes retry_after_seconds suitable for Retry-After header.
+	 */
+	public function test_retry_after_seconds_populated(): void {
+		$post_id = 156;
+
+		// Fill the write bucket.
+		for ( $i = 0; $i < 10; $i++ ) {
+			RateLimiter::record( 'write', $post_id );
+		}
+
+		$check = RateLimiter::check( 'write', $post_id );
+		$this->assertWPError( $check );
+
+		$data = $check->get_error_data();
+		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( 'retry_after_seconds', $data );
+
+		// The retry_after should be between 1 and 60 seconds (the window).
+		$retry = $data['retry_after_seconds'];
+		$this->assertGreaterThanOrEqual( 1, $retry );
+		$this->assertLessThanOrEqual( RateLimiter::WINDOW_SECONDS, $retry );
+	}
+
+	/**
+	 * RestController Retry-After header is added for 429 responses.
+	 */
+	public function test_rest_controller_adds_retry_after_header(): void {
+		$response = new \WP_REST_Response(
+			[
+				'code'    => 'rate_limit_exceeded',
+				'message' => 'Rate limit exceeded for this post.',
+				'data'    => [
+					'status'              => 429,
+					'bucket'              => 'write',
+					'limit'               => 10,
+					'retry_after_seconds' => 42,
+					'post_id'             => 156,
+				],
+			],
+			429
+		);
+
+		// Call the filter directly (simulates rest_post_dispatch).
+		$result = \SdAiAgent\REST\RestController::add_retry_after_header( $response );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $result );
+		$headers = $result->get_headers();
+		$this->assertArrayHasKey( 'Retry-After', $headers );
+		$this->assertSame( '42', $headers['Retry-After'] );
+	}
+
+	/**
+	 * RestController does not add Retry-After for non-429 responses.
+	 */
+	public function test_rest_controller_no_retry_after_on_200(): void {
+		$response = new \WP_REST_Response( [ 'success' => true ], 200 );
+
+		$result = \SdAiAgent\REST\RestController::add_retry_after_header( $response );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $result );
+		$headers = $result->get_headers();
+		$this->assertArrayNotHasKey( 'Retry-After', $headers );
+	}
+
+	// ── AC6: Filter overrides ─────────────────────────────────────────────
+
+	/**
+	 * sd_ai_agent_rate_limits filter raises the cap.
+	 */
+	public function test_filter_overrides_limits(): void {
+		$post_id = 999;
+
+		add_filter(
+			'sd_ai_agent_rate_limits',
+			static function (): array {
+				return [ 'write' => 100, 'rewrite' => 2 ];
+			}
+		);
+
+		// Fill default limit (10) — should still be allowed with filter raising to 100.
+		for ( $i = 0; $i < 10; $i++ ) {
+			RateLimiter::record( 'write', $post_id );
+		}
+
+		$check = RateLimiter::check( 'write', $post_id );
+		$this->assertTrue( $check, 'Should be allowed: filter raised limit to 100' );
+	}
+
+	/**
+	 * sd_ai_agent_rate_limits filter can lower the cap.
+	 */
+	public function test_filter_lowers_limits(): void {
+		$post_id = 999;
+
+		add_filter(
+			'sd_ai_agent_rate_limits',
+			static function (): array {
+				return [ 'write' => 3, 'rewrite' => 1 ];
+			}
+		);
+
+		// 3 writes should be allowed.
+		for ( $i = 0; $i < 3; $i++ ) {
+			RateLimiter::record( 'write', $post_id );
+		}
+
+		// 4th write should be blocked.
+		$check = RateLimiter::check( 'write', $post_id );
+		$this->assertWPError( $check );
+		$this->assertSame( 'rate_limit_exceeded', $check->get_error_code() );
+	}
+
+	/**
+	 * Invalid filter return value falls back to defaults.
+	 */
+	public function test_filter_invalid_returns_defaults(): void {
+		$post_id = 42;
+
+		add_filter(
+			'sd_ai_agent_rate_limits',
+			static function (): string {
+				return 'invalid';
+			}
+		);
+
+		// Default write limit (10) should apply.
+		for ( $i = 0; $i < 10; $i++ ) {
+			RateLimiter::record( 'write', $post_id );
+		}
+
+		$check = RateLimiter::check( 'write', $post_id );
+		$this->assertWPError( $check );
+	}
+
+	// ── AC7: Transient pruning ────────────────────────────────────────────
+
+	/**
+	 * Entries older than 60s are pruned on next check.
+	 */
+	public function test_transient_pruning_old_entries(): void {
+		$post_id = 156;
+		$key     = 'sd_ai_agent_rl_write_' . $post_id;
+
+		// Seed the transient with timestamps that are more than 60s old.
+		$old_time = time() - 120; // 2 minutes ago.
+		$ticks    = [];
+
+		for ( $i = 0; $i < 10; $i++ ) {
+			$ticks[] = $old_time + $i;
+		}
+
+		set_transient( $key, wp_json_encode( $ticks ), RateLimiter::WINDOW_SECONDS );
+
+		// All old entries should be pruned — check should allow.
+		$check = RateLimiter::check( 'write', $post_id );
+		$this->assertTrue( $check, 'Should be allowed after old entries are pruned' );
+	}
+
+	/**
+	 * Mix of old and new entries: only new entries count.
+	 */
+	public function test_transient_pruning_mixed_entries(): void {
+		$post_id = 156;
+		$key     = 'sd_ai_agent_rl_write_' . $post_id;
+
+		$now      = time();
+		$old_time = $now - 120; // 2 minutes ago.
+
+		// 8 old entries + 2 recent entries = only 2 should remain.
+		$ticks = [];
+
+		for ( $i = 0; $i < 8; $i++ ) {
+			$ticks[] = $old_time + $i;
+		}
+
+		$ticks[] = $now - 10; // 10 seconds ago.
+		$ticks[] = $now - 5;  // 5 seconds ago.
+
+		set_transient( $key, wp_json_encode( $ticks ), RateLimiter::WINDOW_SECONDS );
+
+		// Only 2 entries within the window — should allow.
+		$check = RateLimiter::check( 'write', $post_id );
+		$this->assertTrue( $check, 'Should be allowed: only 2 entries within window' );
+	}
+
+	// ── AC3: Atomic batch single tick ─────────────────────────────────────
+
+	/**
+	 * Recording once per batch (not per op) — 1 record call for 30 ops.
+	 */
+	public function test_atomic_batch_single_tick(): void {
+		$post_id = 156;
+
+		// Simulate 10 batches of 30 ops each (but only 1 record per batch).
+		for ( $i = 0; $i < 10; $i++ ) {
+			$check = RateLimiter::check( 'write', $post_id );
+			$this->assertTrue( $check, "Batch $i should be allowed" );
+			// Batch of 30 ops records only 1 tick.
+			RateLimiter::record( 'write', $post_id );
+		}
+
+		// 11th batch should be blocked.
+		$check = RateLimiter::check( 'write', $post_id );
+		$this->assertWPError( $check );
+		$this->assertSame( 'rate_limit_exceeded', $check->get_error_code() );
+	}
+
+	// ── Edge cases ────────────────────────────────────────────────────────
+
+	/**
+	 * Unknown bucket returns true (allow by default).
+	 */
+	public function test_unknown_bucket_allows(): void {
+		$check = RateLimiter::check( 'nonexistent', 156 );
+		$this->assertTrue( $check );
+	}
+
+	/**
+	 * get_limits() returns filtered limits.
+	 */
+	public function test_get_limits_returns_defaults(): void {
+		$limits = RateLimiter::get_limits();
+
+		$this->assertArrayHasKey( 'write', $limits );
+		$this->assertArrayHasKey( 'rewrite', $limits );
+		$this->assertSame( 10, $limits['write'] );
+		$this->assertSame( 2, $limits['rewrite'] );
+	}
+
+	/**
+	 * Record then check — single record does not block.
+	 */
+	public function test_single_record_does_not_block(): void {
+		$post_id = 1;
+
+		RateLimiter::record( 'write', $post_id );
+
+		$check = RateLimiter::check( 'write', $post_id );
+		$this->assertTrue( $check );
+	}
+
+	/**
+	 * Check without any records returns true.
+	 */
+	public function test_check_empty_returns_true(): void {
+		$check = RateLimiter::check( 'write', 2 );
+		$this->assertTrue( $check );
+	}
+
+	/**
+	 * Malformed transient data is handled gracefully.
+	 */
+	public function test_malformed_transient_handled(): void {
+		$key = 'sd_ai_agent_rl_write_156';
+
+		// Set a malformed value.
+		set_transient( $key, 'not-json', RateLimiter::WINDOW_SECONDS );
+
+		$check = RateLimiter::check( 'write', 156 );
+		$this->assertTrue( $check, 'Malformed transient should be treated as empty' );
+	}
+}


### PR DESCRIPTION
## Summary

Add per-post, per-bucket rate limiter with two buckets: write (10 ops/60s/post) and rewrite (2 ops/60s/post). Transient-backed storage, automatic pruning, filterable limits via sd_ai_agent_rate_limits filter. Wired into edit-block-tree, update-blocks, insert-pattern, update-post, and create-post. REST controller adds Retry-After header on 429 responses. 20 tests covering all acceptance criteria.

## Files Changed

includes/Abilities/BlockAbilities.php,includes/Abilities/PostAbilities.php,includes/Core/RateLimiter.php,includes/REST/RestController.php,tests/SdAiAgent/Core/RateLimiterTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify: PHP lint clean, PHPStan 0 errors, PHPUnit 3036 tests (20 new RateLimiter tests, 68 assertions; 3 pre-existing PluginBuilder failures unrelated to this PR), JS/CSS lint clean, build succeeded.

Resolves #1756


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with claude-opus-4-6 spent 17m and 28,025 tokens on this as a headless worker.