### PR TITLE
feat: add sd-ai-agent/revert-to-revision ability (#1749)

### DIFF
--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -988,6 +988,68 @@ class BlockAbilities {
 		);
 
 		wp_register_ability(
+			'sd-ai-agent/revert-to-revision',
+			[
+				'label'               => __( 'Revert to Revision', 'superdav-ai-agent' ),
+				'description'         => __( 'Roll back a post to a specific revision ID. Symmetric undo for every block-write ability that returns a revision_id. Calls wp_restore_post_revision, creates a new revision with the old content, and reseeds all sd_ref UUIDs so restored blocks get fresh, collision-free refs. Optional expected_current_revision_id provides optimistic concurrency: if the post has changed since you last fetched it the call is rejected with revision_stale.', 'superdav-ai-agent' ),
+				'category'            => 'sd-ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'post_id'                      => [
+							'type'        => 'integer',
+							'description' => 'Post ID to revert.',
+						],
+						'revision_id'                  => [
+							'type'        => 'integer',
+							'description' => 'Revision ID to restore. Must belong to post_id.',
+						],
+						'expected_current_revision_id' => [
+							'type'        => 'integer',
+							'description' => 'Optional optimistic concurrency guard. Pass the revision_id from get-page-blocks to ensure no intervening edits have occurred. If the current revision does not match, the call is rejected with revision_stale.',
+						],
+					],
+					'required'   => [ 'post_id', 'revision_id' ],
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'post_id'                 => [ 'type' => 'integer' ],
+						'reverted_to_revision_id' => [
+							'type'        => 'integer',
+							'description' => 'The revision ID that was restored.',
+						],
+						'new_revision_id'         => [
+							'type'        => 'integer',
+							'description' => 'The new revision ID created by wp_restore_post_revision.',
+						],
+						'refs_reseeded'           => [
+							'type'        => 'integer',
+							'description' => 'Number of blocks that received a fresh sd_ref after the revert.',
+						],
+						'block_count'             => [
+							'type'        => 'integer',
+							'description' => 'Total number of named blocks in the restored post.',
+						],
+						'error'                   => [ 'type' => 'string' ],
+					],
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_revert_to_revision' ],
+				'permission_callback' => function () {
+					return current_user_can( 'edit_posts' );
+				},
+				'meta'                => [
+					'mcp'         => [ 'public' => true ],
+					'annotations' => [
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => false,
+					],
+				],
+			]
+		);
+
+		wp_register_ability(
 			'sd-ai-agent/replace-block-range',
 			[
 				'label'               => __( 'Replace Block Range', 'superdav-ai-agent' ),
@@ -3326,6 +3388,61 @@ class BlockAbilities {
 			'block_count'    => $block_count,
 			'dry_run'        => $dry_run,
 		];
+	}
+
+	// ─── revert-to-revision handler ───────────────────────────────
+
+	/**
+	 * Handle the sd-ai-agent/revert-to-revision ability.
+	 *
+	 * Validates input, applies the write-bucket rate limit, and delegates to
+	 * BlockMutator::revert_to_revision() which performs the actual revision
+	 * restore, cap check, and ref reseeding.
+	 *
+	 * @param array<string,mixed> $input Ability input.
+	 * @return array<string,mixed>|\WP_Error Result array or WP_Error.
+	 */
+	public static function handle_revert_to_revision( array $input ) {
+		$post_id     = (int) ( $input['post_id'] ?? 0 );
+		$revision_id = (int) ( $input['revision_id'] ?? 0 );
+		$expected    = isset( $input['expected_current_revision_id'] )
+			? (int) $input['expected_current_revision_id']
+			: null;
+
+		// ── Input validation ─────────────────────────────────────────
+		if ( $post_id <= 0 ) {
+			return new \WP_Error(
+				'missing_post_id',
+				__( 'post_id is required and must be a positive integer.', 'superdav-ai-agent' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		if ( $revision_id <= 0 ) {
+			return new \WP_Error(
+				'missing_revision_id',
+				__( 'revision_id is required and must be a positive integer.', 'superdav-ai-agent' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		// ── Rate limit (write bucket, per-post) ──────────────────────
+		$rate_check = RateLimiter::check( 'write', $post_id );
+		if ( is_wp_error( $rate_check ) ) {
+			return $rate_check;
+		}
+
+		// ── Delegate to BlockMutator ──────────────────────────────────
+		$result = BlockMutator::revert_to_revision( $post_id, $revision_id, $expected );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		// Record rate-limit tick after successful revert.
+		RateLimiter::record( 'write', $post_id );
+
+		return $result;
 	}
 
 	// ─── Tree-counting helpers ────────────────────────────────────

--- a/includes/Core/BlockMutator.php
+++ b/includes/Core/BlockMutator.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 /**
  * Block tree mutator — 9-op vocabulary.
  *
- * Pure-function tree transforms: no WP DB writes occur here. All methods
- * accept a parsed block tree (output of parse_blocks()) and return either a
- * new tree array or a WP_Error.
+ * Primarily pure-function tree transforms: most methods accept a parsed block
+ * tree (output of parse_blocks()) and return either a new tree array or a
+ * WP_Error. The exception is revert_to_revision(), which calls
+ * wp_restore_post_revision() and BlockReferences::reseed_for_post() as part
+ * of its symmetry role with the block-write abilities.
  *
  * Supported operations:
  *   update-attrs    — merge/replace a block's `attributes`.
@@ -683,6 +685,168 @@ class BlockMutator {
 		}
 
 		return $result;
+	}
+
+	// ── Revert to revision ───────────────────────────────────────────────
+
+	/**
+	 * Revert a post to a specific revision.
+	 *
+	 * Validates capabilities and revision ownership, applies optional optimistic
+	 * concurrency control, calls wp_restore_post_revision(), and reseeds all
+	 * block sd_ref values so the restored content uses collision-free refs.
+	 *
+	 * NOTE: Unlike the other BlockMutator methods, this method performs DB
+	 * writes because the revert operation is inherently stateful (it calls
+	 * wp_restore_post_revision, which creates a new revision). The class-level
+	 * pure-function contract applies to the tree-mutation ops (apply, apply_batch,
+	 * replace_range). This method is intentionally placed here because it is the
+	 * logical inverse of the block-write operations that already live here.
+	 *
+	 * @param int      $post_id                     Post ID to revert.
+	 * @param int      $revision_id                 Revision ID to restore.
+	 * @param int|null $expected_current_revision_id Optional optimistic-concurrency guard. When
+	 *                                               provided, the post's latest revision must match
+	 *                                               this value or the method returns `revision_stale`.
+	 * @return array<string,mixed>|\WP_Error Result on success, WP_Error on failure.
+	 */
+	public static function revert_to_revision(
+		int $post_id,
+		int $revision_id,
+		?int $expected_current_revision_id = null
+	) {
+		// ── 1. Load and validate post ────────────────────────────────
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return new \WP_Error(
+				'post_not_found',
+				sprintf(
+					/* translators: %d: post ID */
+					__( 'Post %d not found.', 'superdav-ai-agent' ),
+					$post_id
+				),
+				[ 'status' => 404 ]
+			);
+		}
+
+		// ── 2. Capability check (post) ───────────────────────────────
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return new \WP_Error(
+				'insufficient_capability',
+				__( 'You do not have permission to edit this post.', 'superdav-ai-agent' ),
+				[ 'status' => 403 ]
+			);
+		}
+
+		// ── 3. Load and validate revision ────────────────────────────
+		$revision = get_post( $revision_id );
+		if ( ! $revision || 'revision' !== $revision->post_type ) {
+			return new \WP_Error(
+				'revision_not_found',
+				sprintf(
+					/* translators: %d: revision ID */
+					__( 'Revision %d not found.', 'superdav-ai-agent' ),
+					$revision_id
+				),
+				[ 'status' => 404 ]
+			);
+		}
+
+		// ── 4. Revision must belong to this post ─────────────────────
+		$revision_parent = wp_is_post_revision( $revision_id );
+		if ( false === $revision_parent || (int) $revision_parent !== $post_id ) {
+			return new \WP_Error(
+				'revision_post_mismatch',
+				sprintf(
+					/* translators: 1: revision ID, 2: post ID */
+					__( 'Revision %1$d does not belong to post %2$d.', 'superdav-ai-agent' ),
+					$revision_id,
+					$post_id
+				),
+				[ 'status' => 400 ]
+			);
+		}
+
+		// ── 5. Capability check (revision itself) ────────────────────
+		if ( ! current_user_can( 'edit_post', $revision_id ) ) {
+			return new \WP_Error(
+				'insufficient_capability',
+				__( 'You do not have permission to restore this revision.', 'superdav-ai-agent' ),
+				[ 'status' => 403 ]
+			);
+		}
+
+		// ── 6. Optimistic concurrency guard ──────────────────────────
+		if ( null !== $expected_current_revision_id ) {
+			$current_rev = RevisionGuard::current_revision_id( $post_id );
+			if ( $current_rev !== $expected_current_revision_id ) {
+				return new \WP_Error(
+					'revision_stale',
+					__( 'The post has changed since you fetched it. Re-fetch with get-page-blocks and retry.', 'superdav-ai-agent' ),
+					[
+						'status'              => 412,
+						'current_revision_id' => $current_rev,
+						'expected_revision'   => $expected_current_revision_id,
+					]
+				);
+			}
+		}
+
+		// ── 7. Restore the revision ───────────────────────────────────
+		$restore_result = wp_restore_post_revision( $revision_id );
+		if ( false === $restore_result ) {
+			return new \WP_Error(
+				'revert_failed',
+				__( 'wp_restore_post_revision() failed. The post content was not changed.', 'superdav-ai-agent' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		// Get the new revision ID created by the restore.
+		$new_revision_id = RevisionGuard::current_revision_id( $post_id );
+
+		// ── 8. Reseed refs in the restored content ────────────────────
+		$refs_reseeded = BlockReferences::reseed_for_post( $post_id );
+
+		// ── 9. Count total blocks in the restored content ─────────────
+		$post_after  = get_post( $post_id );
+		$block_count = 0;
+		if ( $post_after ) {
+			// @phpstan-ignore-next-line
+			$blocks_after = parse_blocks( $post_after->post_content );
+			if ( is_array( $blocks_after ) ) {
+				$block_count = self::count_named_blocks( $blocks_after );
+			}
+		}
+
+		return [
+			'post_id'                 => $post_id,
+			'reverted_to_revision_id' => $revision_id,
+			'new_revision_id'         => $new_revision_id,
+			'refs_reseeded'           => $refs_reseeded,
+			'block_count'             => $block_count,
+		];
+	}
+
+	/**
+	 * Count all named (non-freeform) blocks in a tree recursively.
+	 *
+	 * @param array<int|string,mixed> $blocks Block tree.
+	 * @return int Total named block count.
+	 */
+	private static function count_named_blocks( array $blocks ): int {
+		$count = 0;
+		foreach ( $blocks as $block ) {
+			if ( ! is_array( $block ) || empty( $block['blockName'] ) ) {
+				continue;
+			}
+			++$count;
+			$inner = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : [];
+			if ( ! empty( $inner ) ) {
+				$count += self::count_named_blocks( $inner );
+			}
+		}
+		return $count;
 	}
 
 	// ── Structural validators ─────────────────────────────────────────────

--- a/includes/Core/BlockReferences.php
+++ b/includes/Core/BlockReferences.php
@@ -202,7 +202,140 @@ class BlockReferences {
 		return true;
 	}
 
+	/**
+	 * Re-seed all sd_ref values in a post after a content replacement (e.g. after a revert).
+	 *
+	 * Strips every existing sd_ref from the current post_content, assigns fresh
+	 * collision-free refs to every block, and writes the result back directly to
+	 * the DB without creating a revision (refs are editor-only metadata, not
+	 * user-authored content). Returns the number of blocks that received a ref,
+	 * or 0 on any failure.
+	 *
+	 * This is called by BlockMutator::revert_to_revision() after
+	 * wp_restore_post_revision() so that refs embedded in the old revision content
+	 * are replaced before they can collide with refs in other posts.
+	 *
+	 * @param int $post_id Post ID to reseed.
+	 * @return int Number of blocks that received a fresh sd_ref, or 0 on failure.
+	 */
+	public static function reseed_for_post( int $post_id ): int {
+		global $wpdb;
+
+		if ( ! function_exists( 'parse_blocks' ) || ! function_exists( 'serialize_blocks' ) ) {
+			return 0;
+		}
+
+		$post = get_post( $post_id );
+		if ( ! $post ) {
+			return 0;
+		}
+
+		// @phpstan-ignore-next-line
+		$blocks = parse_blocks( $post->post_content );
+		if ( ! is_array( $blocks ) ) {
+			return 0;
+		}
+
+		// Strip all existing refs so every block receives a fresh, collision-free one.
+		$stripped = self::strip_refs_tree( $blocks );
+
+		// Assign fresh refs.
+		$result = self::assign_refs( $stripped );
+		if ( is_wp_error( $result ) ) {
+			return 0;
+		}
+
+		// Count how many named blocks received a ref.
+		$count = self::count_ref_blocks( $result );
+
+		// Persist via direct DB write — no revision, no filters.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$updated = $wpdb->update(
+			$wpdb->posts,
+			// @phpstan-ignore-next-line
+			[ 'post_content' => serialize_blocks( $result ) ],
+			[ 'ID' => $post_id ],
+			[ '%s' ],
+			[ '%d' ]
+		);
+
+		if ( false === $updated ) {
+			return 0;
+		}
+
+		clean_post_cache( $post_id );
+
+		return $count;
+	}
+
 	// ── Internal helpers ──────────────────────────────────────────────────
+
+	/**
+	 * Recursively strip all sd_ref values from a block tree.
+	 *
+	 * Returns a new tree with the sd_ref key removed from every block's
+	 * `attrs.metadata` so a fresh reseed can assign collision-free refs.
+	 *
+	 * @param array<int|string,mixed> $blocks Block tree.
+	 * @return array<int|string,mixed> Tree with refs stripped.
+	 */
+	private static function strip_refs_tree( array $blocks ): array {
+		$result = [];
+
+		foreach ( $blocks as $block ) {
+			if ( ! is_array( $block ) ) {
+				continue;
+			}
+
+			if ( isset( $block['attrs']['metadata'][ self::REF_KEY ] ) ) {
+				unset( $block['attrs']['metadata'][ self::REF_KEY ] );
+				// Clean up empty metadata array.
+				if ( isset( $block['attrs']['metadata'] ) && empty( $block['attrs']['metadata'] ) ) {
+					unset( $block['attrs']['metadata'] );
+				}
+			}
+
+			$inner = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : [];
+			if ( ! empty( $inner ) ) {
+				$block['innerBlocks'] = self::strip_refs_tree( $inner );
+			}
+
+			$result[] = $block;
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Count named blocks carrying a non-empty sd_ref in a block tree.
+	 *
+	 * @param array<int|string,mixed> $blocks Block tree.
+	 * @return int Count of blocks with sd_ref set.
+	 */
+	private static function count_ref_blocks( array $blocks ): int {
+		$count = 0;
+
+		foreach ( $blocks as $block ) {
+			if ( ! is_array( $block ) || empty( $block['blockName'] ) ) {
+				continue;
+			}
+
+			$metadata = isset( $block['attrs']['metadata'] ) && is_array( $block['attrs']['metadata'] )
+				? $block['attrs']['metadata']
+				: [];
+
+			if ( ! empty( $metadata[ self::REF_KEY ] ) ) {
+				++$count;
+			}
+
+			$inner = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : [];
+			if ( ! empty( $inner ) ) {
+				$count += self::count_ref_blocks( $inner );
+			}
+		}
+
+		return $count;
+	}
 
 	/**
 	 * Collect all existing sd_ref values in a block tree (pre-flight dedup).

--- a/tests/SdAiAgent/Abilities/RevertToRevisionTest.php
+++ b/tests/SdAiAgent/Abilities/RevertToRevisionTest.php
@@ -1,0 +1,470 @@
+<?php
+/**
+ * Test case for the sd-ai-agent/revert-to-revision ability handler (GH#1749).
+ *
+ * Covers:
+ *   AC1: Happy path — revert succeeds, new revision created, content matches old revision.
+ *   AC2: Revision belonging to a different post → revision_post_mismatch.
+ *   AC3: expected_current_revision_id mismatch → revision_stale.
+ *   AC4: User without edit_post capability → insufficient_capability.
+ *   AC5: All blocks receive fresh sd_ref values after revert (refs_reseeded > 0).
+ *   Validation: missing/invalid post_id, revision_id, nonexistent post/revision.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ * @see     https://github.com/Ultimate-Multisite/superdav-ai-agent/issues/1749
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Abilities;
+
+use SdAiAgent\Abilities\BlockAbilities;
+use SdAiAgent\Core\BlockMutator;
+use SdAiAgent\Core\RevisionGuard;
+use WP_UnitTestCase;
+
+/**
+ * Integration tests for BlockAbilities::handle_revert_to_revision.
+ *
+ * Uses WP_UnitTestCase so real posts, revisions, and WordPress functions
+ * are available.
+ */
+class RevertToRevisionTest extends WP_UnitTestCase {
+
+	/**
+	 * Administrator user ID used for all tests.
+	 *
+	 * @var int
+	 */
+	private int $admin_id;
+
+	/**
+	 * Set up an administrator user context before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $this->admin_id );
+	}
+
+	/**
+	 * Restore user context after each test.
+	 */
+	public function tear_down(): void {
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	// ── Helpers ────────────────────────────────────────────────────────────
+
+	/**
+	 * Create a published post with a single paragraph block.
+	 *
+	 * @param string $text Paragraph text.
+	 * @return int Post ID.
+	 */
+	private function create_post_with_content( string $text = 'Original content' ): int {
+		$content = serialize_blocks( [
+			[
+				'blockName'    => 'core/paragraph',
+				'attrs'        => [],
+				'innerBlocks'  => [],
+				'innerHTML'    => '<p>' . esc_html( $text ) . '</p>',
+				'innerContent' => [ '<p>' . esc_html( $text ) . '</p>' ],
+			],
+		] );
+
+		$post_id = self::factory()->post->create( [
+			'post_content' => $content,
+			'post_status'  => 'publish',
+		] );
+
+		$this->assertIsInt( $post_id );
+		$this->assertGreaterThan( 0, $post_id );
+
+		return $post_id;
+	}
+
+	/**
+	 * Update a post with new paragraph content.
+	 *
+	 * Returns the post's latest revision ID after the update (or 0 if no
+	 * revisions exist yet). Does NOT assert that a new revision was created —
+	 * the test environment may merge rapid revisions within the same second.
+	 *
+	 * @param int    $post_id Post ID to update.
+	 * @param string $text    New paragraph text.
+	 * @return int Post-update current revision ID.
+	 */
+	private function update_post_content( int $post_id, string $text ): int {
+		$content = serialize_blocks( [
+			[
+				'blockName'    => 'core/paragraph',
+				'attrs'        => [],
+				'innerBlocks'  => [],
+				'innerHTML'    => '<p>' . esc_html( $text ) . '</p>',
+				'innerContent' => [ '<p>' . esc_html( $text ) . '</p>' ],
+			],
+		] );
+
+		wp_update_post( [
+			'ID'           => $post_id,
+			'post_content' => $content,
+		] );
+
+		return RevisionGuard::current_revision_id( $post_id );
+	}
+
+	// ── Input validation ──────────────────────────────────────────────────
+
+	/**
+	 * Missing post_id returns WP_Error with code missing_post_id.
+	 */
+	public function test_missing_post_id_returns_error(): void {
+		$result = BlockAbilities::handle_revert_to_revision( [
+			'revision_id' => 999,
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'missing_post_id', $result->get_error_code() );
+	}
+
+	/**
+	 * Missing revision_id returns WP_Error with code missing_revision_id.
+	 */
+	public function test_missing_revision_id_returns_error(): void {
+		$result = BlockAbilities::handle_revert_to_revision( [
+			'post_id' => 1,
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'missing_revision_id', $result->get_error_code() );
+	}
+
+	/**
+	 * Nonexistent post returns WP_Error with code post_not_found.
+	 */
+	public function test_nonexistent_post_returns_error(): void {
+		$result = BlockAbilities::handle_revert_to_revision( [
+			'post_id'     => 999999,
+			'revision_id' => 1,
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'post_not_found', $result->get_error_code() );
+	}
+
+	/**
+	 * Nonexistent revision returns WP_Error with code revision_not_found.
+	 */
+	public function test_nonexistent_revision_returns_error(): void {
+		$post_id = $this->create_post_with_content();
+
+		$result = BlockAbilities::handle_revert_to_revision( [
+			'post_id'     => $post_id,
+			'revision_id' => 999999,
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'revision_not_found', $result->get_error_code() );
+	}
+
+	// ── AC1: Happy path ───────────────────────────────────────────────────
+
+	/**
+	 * AC1: Revert to a known revision succeeds; content matches the old revision.
+	 *
+	 * Two updates are needed: the first creates a revision with C1 ("Version one");
+	 * the second creates a revision with C2 ("Version two") as the current state.
+	 * Reverting to the first revision restores C1.
+	 */
+	public function test_happy_path_revert_restores_content(): void {
+		$post_id = $this->create_post_with_content( 'Version zero' );
+
+		// First update → revision R1 captures "Version one".
+		$this->update_post_content( $post_id, 'Version one' );
+
+		// Second update → revision R2 captures "Version two"; current = R2.
+		$this->update_post_content( $post_id, 'Version two' );
+
+		// Get the oldest revision (R1 — content: "Version one").
+		$revisions = wp_get_post_revisions( $post_id, [ 'orderby' => 'ID', 'order' => 'ASC' ] );
+		$this->assertNotEmpty( $revisions, 'Post should have at least one revision' );
+		$first_revision = reset( $revisions );
+
+		$result = BlockAbilities::handle_revert_to_revision( [
+			'post_id'     => $post_id,
+			'revision_id' => $first_revision->ID,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'post_id', $result );
+		$this->assertArrayHasKey( 'reverted_to_revision_id', $result );
+		$this->assertArrayHasKey( 'new_revision_id', $result );
+		$this->assertArrayHasKey( 'refs_reseeded', $result );
+		$this->assertArrayHasKey( 'block_count', $result );
+
+		$this->assertSame( $post_id, $result['post_id'] );
+		$this->assertSame( $first_revision->ID, $result['reverted_to_revision_id'] );
+		$this->assertGreaterThan( 0, $result['new_revision_id'] );
+
+		// Post content should now contain "Version one" (the content of R1).
+		$post = get_post( $post_id );
+		$this->assertStringContainsString( 'Version one', $post->post_content );
+	}
+
+	/**
+	 * AC1: block_count reflects the number of named blocks in the restored post.
+	 */
+	public function test_block_count_matches_restored_blocks(): void {
+		$post_id = $this->create_post_with_content( 'Original' );
+		$this->update_post_content( $post_id, 'Single block post' );
+		$this->update_post_content( $post_id, 'Updated content' );
+
+		$revisions      = wp_get_post_revisions( $post_id, [ 'orderby' => 'ID', 'order' => 'ASC' ] );
+		$first_revision = reset( $revisions );
+
+		$result = BlockAbilities::handle_revert_to_revision( [
+			'post_id'     => $post_id,
+			'revision_id' => $first_revision->ID,
+		] );
+
+		$this->assertIsArray( $result );
+		// Single-paragraph post → 1 block.
+		$this->assertSame( 1, $result['block_count'] );
+	}
+
+	// ── AC2: Revision belongs to wrong post ───────────────────────────────
+
+	/**
+	 * AC2: Revision belonging to a different post returns revision_post_mismatch.
+	 */
+	public function test_wrong_post_revision_returns_mismatch_error(): void {
+		$post_a = $this->create_post_with_content( 'Post A original' );
+		$post_b = $this->create_post_with_content( 'Post B original' );
+
+		// Create a revision on post B.
+		$this->update_post_content( $post_b, 'Post B updated' );
+		$revisions_b      = wp_get_post_revisions( $post_b, [ 'orderby' => 'ID', 'order' => 'ASC' ] );
+		$first_revision_b = reset( $revisions_b );
+
+		// Attempt to revert post A using a revision from post B.
+		$result = BlockAbilities::handle_revert_to_revision( [
+			'post_id'     => $post_a,
+			'revision_id' => $first_revision_b->ID,
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'revision_post_mismatch', $result->get_error_code() );
+	}
+
+	// ── AC3: Optimistic concurrency ───────────────────────────────────────
+
+	/**
+	 * AC3: Stale expected_current_revision_id returns revision_stale with
+	 * current_revision_id in the error data so callers can re-fetch and retry.
+	 *
+	 * Passes a clearly-invalid expected_current_revision_id (PHP_INT_MAX) which
+	 * will never match any real revision, making the test immune to timing
+	 * issues in the test environment's revision merging behaviour.
+	 */
+	public function test_stale_concurrency_returns_error(): void {
+		$post_id = $this->create_post_with_content( 'Initial' );
+
+		// Create at least one revision to have a valid target.
+		$this->update_post_content( $post_id, 'First update' );
+		$revisions  = wp_get_post_revisions( $post_id, [ 'orderby' => 'ID', 'order' => 'ASC' ] );
+		$target_rev = reset( $revisions );
+		$this->assertNotEmpty( $revisions, 'Post should have at least one revision after update' );
+
+		$current_rev = RevisionGuard::current_revision_id( $post_id );
+
+		// Pass a clearly wrong expected_current_revision_id (PHP_INT_MAX never
+		// matches a real WordPress post ID), so we reliably trigger stale.
+		$result = BlockAbilities::handle_revert_to_revision( [
+			'post_id'                      => $post_id,
+			'revision_id'                  => $target_rev->ID,
+			'expected_current_revision_id' => PHP_INT_MAX,
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'revision_stale', $result->get_error_code() );
+
+		// Error data must include current_revision_id so the caller can retry.
+		$data = $result->get_error_data( 'revision_stale' );
+		$this->assertIsArray( $data );
+		$this->assertArrayHasKey( 'current_revision_id', $data );
+		// current_revision_id in error data should match the actual current revision.
+		$this->assertSame( $current_rev, $data['current_revision_id'] );
+	}
+
+	/**
+	 * Matching expected_current_revision_id allows the revert to proceed.
+	 */
+	public function test_correct_concurrency_allows_revert(): void {
+		$post_id = $this->create_post_with_content( 'Concurrency test original' );
+		$this->update_post_content( $post_id, 'Concurrency state A' );
+		$this->update_post_content( $post_id, 'Concurrency state B' );
+
+		$current_rev = RevisionGuard::current_revision_id( $post_id );
+
+		$revisions  = wp_get_post_revisions( $post_id, [ 'orderby' => 'ID', 'order' => 'ASC' ] );
+		$target_rev = reset( $revisions );
+
+		// Pass the correct current revision → should succeed.
+		$result = BlockAbilities::handle_revert_to_revision( [
+			'post_id'                      => $post_id,
+			'revision_id'                  => $target_rev->ID,
+			'expected_current_revision_id' => $current_rev,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'new_revision_id', $result );
+	}
+
+	// ── AC4: Capability check ────────────────────────────────────────────
+
+	/**
+	 * AC4: User without edit_post capability returns insufficient_capability.
+	 */
+	public function test_insufficient_capability_returns_error(): void {
+		$post_id = $this->create_post_with_content( 'Privileged post' );
+		$this->update_post_content( $post_id, 'Admin edit A' );
+		$this->update_post_content( $post_id, 'Admin edit B' );
+
+		$revisions = wp_get_post_revisions( $post_id, [ 'orderby' => 'ID', 'order' => 'ASC' ] );
+		$this->assertNotEmpty( $revisions, 'Post should have at least one revision' );
+		$first_revision = reset( $revisions );
+
+		// Switch to a subscriber who cannot edit posts.
+		$subscriber_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+
+		$result = BlockAbilities::handle_revert_to_revision( [
+			'post_id'     => $post_id,
+			'revision_id' => $first_revision->ID,
+		] );
+
+		// Restore admin before assertions (so failure doesn't bleed into other tests).
+		wp_set_current_user( $this->admin_id );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'insufficient_capability', $result->get_error_code() );
+	}
+
+	// ── AC5: Ref reseeding ────────────────────────────────────────────────
+
+	/**
+	 * AC5: All blocks receive fresh sd_ref values after the revert.
+	 *
+	 * refs_reseeded > 0 and every block in the post has a valid blk_* ref.
+	 */
+	public function test_refs_reseeded_after_revert(): void {
+		$post_id = $this->create_post_with_content( 'Ref test original' );
+
+		// Assign refs to the initial content.
+		BlockAbilities::handle_get_page_blocks( [
+			'post_id'      => $post_id,
+			'persist_refs' => true,
+		] );
+
+		// First update → R1 with "Ref test state A".
+		$this->update_post_content( $post_id, 'Ref test state A' );
+
+		// Second update → R2 with "Ref test state B" (current).
+		$this->update_post_content( $post_id, 'Ref test state B' );
+
+		// R1 has "Ref test state A" (different from current "Ref test state B").
+		$revisions      = wp_get_post_revisions( $post_id, [ 'orderby' => 'ID', 'order' => 'ASC' ] );
+		$first_revision = reset( $revisions );
+
+		$result = BlockAbilities::handle_revert_to_revision( [
+			'post_id'     => $post_id,
+			'revision_id' => $first_revision->ID,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertGreaterThan( 0, $result['refs_reseeded'], 'refs_reseeded should be > 0 after revert' );
+
+		// For a flat single-block post, refs_reseeded and block_count should agree.
+		$this->assertSame( $result['block_count'], $result['refs_reseeded'] );
+
+		// Verify every block in the post now carries a valid sd_ref.
+		$page_result = BlockAbilities::handle_get_page_blocks( [
+			'post_id'      => $post_id,
+			'persist_refs' => false,
+		] );
+
+		$this->assertIsArray( $page_result );
+		$this->assertNotEmpty( $page_result['blocks'] );
+
+		foreach ( $page_result['blocks'] as $block ) {
+			$this->assertArrayHasKey( 'ref', $block, "Block '{$block['name']}' should have a ref after revert." );
+			$this->assertNotEmpty( $block['ref'] );
+			$this->assertStringStartsWith( 'blk_', $block['ref'] );
+		}
+	}
+
+	// ── Return value structure ────────────────────────────────────────────
+
+	/**
+	 * new_revision_id differs from reverted_to_revision_id (restore creates a new rev).
+	 *
+	 * Two updates are needed so R1's content differs from the current post content.
+	 * When the reverted content is different from the current, wp_restore_post_revision
+	 * calls wp_update_post which creates a new revision with a larger ID.
+	 */
+	public function test_new_revision_differs_from_source_revision(): void {
+		$post_id = $this->create_post_with_content( 'Original state' );
+		// R1: "First edit"
+		$this->update_post_content( $post_id, 'First edit' );
+		// R2: "Second edit" (current)
+		$this->update_post_content( $post_id, 'Second edit' );
+
+		// R1 is the oldest revision (content = "First edit"), which differs from current ("Second edit").
+		$revisions      = wp_get_post_revisions( $post_id, [ 'orderby' => 'ID', 'order' => 'ASC' ] );
+		$first_revision = reset( $revisions );
+
+		$result = BlockAbilities::handle_revert_to_revision( [
+			'post_id'     => $post_id,
+			'revision_id' => $first_revision->ID,
+		] );
+
+		$this->assertIsArray( $result );
+		// wp_restore_post_revision calls wp_update_post which creates a new revision.
+		// The new revision ID is always larger than the source revision ID.
+		$this->assertGreaterThan(
+			$result['reverted_to_revision_id'],
+			$result['new_revision_id'],
+			'wp_restore_post_revision creates a new revision; new_revision_id must be greater than the source.'
+		);
+	}
+
+	// ── BlockMutator::revert_to_revision direct test ──────────────────────
+
+	/**
+	 * BlockMutator::revert_to_revision returns all required keys on success.
+	 */
+	public function test_block_mutator_revert_returns_expected_keys(): void {
+		$post_id = $this->create_post_with_content( 'Direct mutator test' );
+		$this->update_post_content( $post_id, 'Mutator state A' );
+		$this->update_post_content( $post_id, 'Mutator state B' );
+
+		$revisions      = wp_get_post_revisions( $post_id, [ 'orderby' => 'ID', 'order' => 'ASC' ] );
+		$first_revision = reset( $revisions );
+
+		$result = BlockMutator::revert_to_revision( $post_id, $first_revision->ID );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'post_id', $result );
+		$this->assertArrayHasKey( 'reverted_to_revision_id', $result );
+		$this->assertArrayHasKey( 'new_revision_id', $result );
+		$this->assertArrayHasKey( 'refs_reseeded', $result );
+		$this->assertArrayHasKey( 'block_count', $result );
+		$this->assertSame( $post_id, $result['post_id'] );
+		$this->assertSame( $first_revision->ID, $result['reverted_to_revision_id'] );
+	}
+}


### PR DESCRIPTION
## Summary

Add `sd-ai-agent/revert-to-revision` — symmetric undo for every wave-1 block-write that already returns `revision_id`. Calls `wp_restore_post_revision`, creates a new revision with the old content, and reseeds all `sd_ref` UUIDs in the restored post.

## Files changed

| File | Change |
|------|--------|
| `includes/Core/BlockReferences.php` | Add `reseed_for_post()` + private helpers |
| `includes/Core/BlockMutator.php` | Add `revert_to_revision()` + `count_named_blocks()` |
| `includes/Abilities/BlockAbilities.php` | Register ability + `handle_revert_to_revision()` |
| `tests/SdAiAgent/Abilities/RevertToRevisionTest.php` | New — 13 integration tests |

## Behaviour

1. Cap check: `current_user_can('edit_post', $post_id)` AND on the revision itself.
2. `wp_is_post_revision($revision_id)` must equal $post_id — else `revision_post_mismatch`.
3. Optional `expected_current_revision_id` for optimistic concurrency — `revision_stale` on mismatch.
4. Calls `wp_restore_post_revision($revision_id)`.
5. Reseeds `sd_ref` for every block via `BlockReferences::reseed_for_post()`.
6. Returns `new_revision_id`, `refs_reseeded`, `block_count`.

Rate-limited against the write bucket (10/min/post), same as other block writes.

## Worker self-verification
- PHPUnit: Tests: 3089, Assertions: 8789, Errors: 0, Failures: 3, Skipped: 107
  (3 failures are pre-existing PluginBuilder DB-connection issues — failing on main before this PR)
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded (webpack compiled with 2 warnings — pre-existing)

For #1739
Resolves #1749

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with claude-sonnet-4-6 spent 27m and 65,864 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the ability to revert posts to previous revisions with automatic restoration of block references
  * Implemented optimistic concurrency control to detect and reject attempts to revert to stale revision states

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1767?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->