### PR TITLE
chore(tests): fix pre-existing PluginBuilder/Updater/sandbox failures on main (#1768)

### DIFF
--- a/bin/setup-wp-phpunit.php
+++ b/bin/setup-wp-phpunit.php
@@ -126,6 +126,45 @@ function sd_ai_agent_setup_shell_command(array $parts): string
 }
 
 /**
+ * Read DB_PASSWORD from an existing wp-tests-config.php file.
+ *
+ * When WP_TESTS_DB_PASS is not set in the environment, fall back to the
+ * password already stored in wp-tests-config.php (written once by
+ * install-wp-tests.sh and never overwritten). This prevents a subsequent
+ * `npm run test:php:setup` run — without WP_TESTS_DB_PASS — from
+ * regenerating wp-config.php with an empty password when the test
+ * database was originally set up with a non-empty password.
+ *
+ * That mismatch caused Layer 2 (isolated include) in PluginSandbox to
+ * fail: the WP-CLI subprocess reads wp-config.php (not wp-tests-config.php)
+ * and the wrong password produces "Access denied" → sandbox reports
+ * sd_ai_agent_sandbox_failed → PluginUpdaterTest / PluginBuilderIntegrationTest
+ * failures on every clean run of npm run test:php.
+ *
+ * @param string $tests_dir WordPress test library directory.
+ * @return string|null Password extracted from the config file, or null if not found.
+ */
+function sd_ai_agent_setup_read_config_password(string $tests_dir): ?string
+{
+	$config_file = rtrim($tests_dir, '/') . '/wp-tests-config.php';
+	if (! is_file($config_file)) {
+		return null;
+	}
+
+	$content = file_get_contents($config_file);
+	if (false === $content) {
+		return null;
+	}
+
+	// Match: define( 'DB_PASSWORD', 'value' );
+	if (preg_match("/define\s*\(\s*'DB_PASSWORD'\s*,\s*'([^']*)'\s*\)/", $content, $matches)) {
+		return $matches[1];
+	}
+
+	return null;
+}
+
+/**
  * Recreate the configured test database.
  *
  * @param string $db_name Database name.
@@ -190,10 +229,13 @@ $cache_root  = sd_ai_agent_setup_cache_root();
 $tests_dir   = sd_ai_agent_setup_env('WP_TESTS_DIR') ?? $cache_root . '/wordpress-tests-lib-' . $version_key;
 $core_dir    = sd_ai_agent_setup_env('WP_CORE_DIR') ?? $cache_root . '/wordpress-' . $version_key;
 
-$db_name = sd_ai_agent_setup_env('WP_TESTS_DB_NAME') ?? 'sd_ai_agent_tests';
-$db_user = sd_ai_agent_setup_env('WP_TESTS_DB_USER') ?? 'root';
-$db_pass = sd_ai_agent_setup_env('WP_TESTS_DB_PASS') ?? '';
-$db_host = sd_ai_agent_setup_env('WP_TESTS_DB_HOST') ?? 'localhost';
+$db_name     = sd_ai_agent_setup_env('WP_TESTS_DB_NAME') ?? 'sd_ai_agent_tests';
+$db_user     = sd_ai_agent_setup_env('WP_TESTS_DB_USER') ?? 'root';
+$db_pass_env = sd_ai_agent_setup_env('WP_TESTS_DB_PASS');
+$db_pass     = null !== $db_pass_env
+	? $db_pass_env
+	: (sd_ai_agent_setup_read_config_password($tests_dir) ?? '');
+$db_host     = sd_ai_agent_setup_env('WP_TESTS_DB_HOST') ?? 'localhost';
 $skip_db = 'true' === strtolower(sd_ai_agent_setup_env('WP_TESTS_SKIP_DB_CREATE') ?? 'false');
 
 $installer = $plugin_dir . '/bin/install-wp-tests.sh';


### PR DESCRIPTION
## Summary

Resolves #1768

Fixes the 3 pre-existing test failures that wave-2 workers (PRs #1758-#1767) had to manually baseline-verify on every PR:

- `PluginBuilderIntegrationTest::test_updater_happy_path_replaces_files`
- `PluginUpdaterTest::test_test_staged_passes_for_valid_plugin`
- `PluginUpdaterTest::test_update_replaces_live_plugin_files`

## Root cause

Layer 2 (isolated include) in `PluginSandbox::layer2_isolated_include()` spawns a WP-CLI subprocess with `--path=ABSPATH`. WP-CLI reads `wp-config.php` (not `wp-tests-config.php`). When `npm run test:php:setup` was re-run without `WP_TESTS_DB_PASS`, it overwrote `wp-config.php` with an empty password while `wp-tests-config.php` (written once by `install-wp-tests.sh` and never regenerated) still held the original `root` password. The credential mismatch produced:

    Access denied for user 'root'@'localhost' (using password: NO)

...in every WP-CLI subprocess, which propagated as `sd_ai_agent_sandbox_failed` error code, causing `test_staged()` to return `passed: false` and `update()` to return a `WP_Error`.

## Fix

Added `sd_ai_agent_setup_read_config_password()` to `bin/setup-wp-phpunit.php`. When `WP_TESTS_DB_PASS` is not set in the environment, the function reads `DB_PASSWORD` from the existing `wp-tests-config.php` and uses it for `wp-config.php` generation. This keeps both config files in sync even after a bare `npm run test:php:setup` re-run, regardless of the local MySQL password policy.

No tests were deleted, skipped, or filtered. The root cause was a setup script bug, not a test bug.

## Files changed

- `bin/setup-wp-phpunit.php` -- added `sd_ai_agent_setup_read_config_password()` helper and updated `$db_pass` resolution to fall back to `wp-tests-config.php` when `WP_TESTS_DB_PASS` is not set

## Worker self-verification
- PHPUnit: Tests: 3089, Assertions: 8800, Errors: 0, Failures: 0, Skipped: 105
- Lint:    PHP clean (JS/CSS unaffected)
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with claude-sonnet-4-6 spent 14m and 26,002 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * WordPress testing setup now intelligently reads existing database passwords from configuration files when environment variables are not explicitly provided, reducing manual credential reconfiguration during test environment initialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1773?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->