### PR TITLE
fix: correct refs_removed/refs_preserved counters in replace-block-range (#1770)

### DIFF
--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -3313,21 +3313,6 @@ class BlockAbilities {
 		// @phpstan-ignore-next-line
 		$refs_before = self::count_refs_in_tree( $blocks );
 
-		// ── Compute range size for stats ─────────────────────────────
-		$start_path = BlockTreeAddress::resolve( $blocks, [ 'ref' => $start_ref ] );
-
-		if ( is_wp_error( $start_path ) ) {
-			return $start_path;
-		}
-
-		$end_path = BlockTreeAddress::resolve( $blocks, [ 'ref' => $end_ref ] );
-
-		if ( is_wp_error( $end_path ) ) {
-			return $end_path;
-		}
-
-		$range_size = $end_path[ count( $end_path ) - 1 ] - $start_path[ count( $start_path ) - 1 ] + 1;
-
 		// ── Apply mutation ───────────────────────────────────────────
 		// Ensure integer-keyed block array for BlockMutator.
 		$blocks = array_values( $blocks );
@@ -3354,9 +3339,17 @@ class BlockAbilities {
 		$result = $ref_result;
 
 		// ── Compute ref stats ────────────────────────────────────────
+		// Use the post-mutation tree to compute counters correctly.
+		// The previous approach used $range_size = end_idx - start_idx + 1 from
+		// BlockTreeAddress paths. This overcounts when null-blockName placeholder
+		// blocks (whitespace between named blocks) sit between named blocks in the
+		// flat array, inflating the index distance. The post-mutation approach also
+		// correctly accounts for descendant refs inside removed inner-block trees.
+		// @phpstan-ignore-next-line
+		$refs_after     = self::count_refs_in_tree( $result );
 		$refs_added     = count( $new_blocks_raw );
-		$refs_removed   = $range_size;
-		$refs_preserved = $refs_before - $refs_removed;
+		$refs_preserved = $refs_after - $refs_added;
+		$refs_removed   = $refs_before - $refs_preserved;
 
 		// ── Persist (unless dry_run) ─────────────────────────────────
 		if ( ! $dry_run ) {

--- a/tests/SdAiAgent/Abilities/BlockAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/BlockAbilitiesTest.php
@@ -933,4 +933,127 @@ class BlockAbilitiesTest extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'ref', $block );
 		$this->assertArrayNotHasKey( 'attributes', $block );
 	}
+
+	// ─── replace-block-range ref counters ────────────────────────
+
+	/**
+	 * refs_removed / refs_preserved counters are correct for flat top-level blocks.
+	 *
+	 * Regression test for GH#1770: the previous formula used
+	 * $range_size = end_idx - start_idx + 1 from BlockTreeAddress paths. This
+	 * overcounts when null-blockName whitespace placeholder blocks sit between
+	 * named blocks in the flat array (B is at index 2, not 1, when a '\n' entry
+	 * sits between A and B). The result was refs_removed=3 / refs_preserved=0
+	 * instead of the correct refs_removed=2 / refs_preserved=1.
+	 *
+	 * @see GH#1770
+	 */
+	public function test_replace_range_counters_flat(): void {
+		$content = implode( "\n\n", [
+			"<!-- wp:paragraph -->\n<p>A</p>\n<!-- /wp:paragraph -->",
+			"<!-- wp:paragraph -->\n<p>B</p>\n<!-- /wp:paragraph -->",
+			"<!-- wp:paragraph -->\n<p>C</p>\n<!-- /wp:paragraph -->",
+		] );
+
+		$post_id = $this->factory()->post->create( [
+			'post_content' => $content,
+			'post_status'  => 'publish',
+		] );
+
+		// Persist refs so replace_block_range can resolve them by ref string.
+		$get_result = BlockAbilities::handle_get_page_blocks( [
+			'post_id'      => $post_id,
+			'persist_refs' => true,
+		] );
+
+		$this->assertIsArray( $get_result );
+		$this->assertCount( 3, $get_result['blocks'], 'should have 3 named blocks (A, B, C)' );
+
+		$refs = array_column( $get_result['blocks'], 'ref' );
+
+		// Replace A + B (indices 0 and 1) with a single merged block.
+		$result = BlockAbilities::handle_replace_block_range( [
+			'post_id'    => $post_id,
+			'start_ref'  => $refs[0], // A
+			'end_ref'    => $refs[1], // B
+			'new_blocks' => [
+				[
+					'blockName' => 'core/paragraph',
+					'attrs'     => [],
+					'innerHTML' => '<p>merged</p>',
+				],
+			],
+		] );
+
+		$this->assertIsArray( $result, 'replace_block_range must return an array, not WP_Error' );
+		$this->assertSame( 1, $result['refs_added'],     'refs_added should be 1 (the merged block)' );
+		$this->assertSame( 2, $result['refs_removed'],   'refs_removed should be 2 (A and B)' );
+		$this->assertSame( 1, $result['refs_preserved'], 'refs_preserved should be 1 (C)' );
+		$this->assertSame( 2, $result['block_count'],    'block_count should be 2 (merged + C)' );
+	}
+
+	/**
+	 * refs_removed correctly counts inner-block refs from the removed range.
+	 *
+	 * When the removed block has innerBlocks, all descendant refs must be
+	 * included in refs_removed (not just the top-level sibling count). In this
+	 * test a core/group with 2 inner paragraphs is replaced by a single flat
+	 * paragraph; refs_removed must be 3 (group + 2 inner blocks), not 1.
+	 *
+	 * handle_get_page_blocks returns top-level blocks with inner blocks nested
+	 * under 'innerBlocks'; the flat count of top-level blocks is 2 (group +
+	 * aftergroup), not 4.
+	 *
+	 * @see GH#1770
+	 */
+	public function test_replace_range_counters_with_nested_innerBlocks(): void {
+		// Group block with 2 inner paragraphs, followed by one top-level paragraph.
+		$content = implode( "\n\n", [
+			"<!-- wp:group -->\n<div class=\"wp-block-group\"><!-- wp:paragraph -->\n<p>Inner 1</p>\n<!-- /wp:paragraph -->\n<!-- wp:paragraph -->\n<p>Inner 2</p>\n<!-- /wp:paragraph --></div>\n<!-- /wp:group -->",
+			"<!-- wp:paragraph -->\n<p>After group</p>\n<!-- /wp:paragraph -->",
+		] );
+
+		$post_id = $this->factory()->post->create( [
+			'post_content' => $content,
+			'post_status'  => 'publish',
+		] );
+
+		// Persist refs. handle_get_page_blocks returns top-level blocks only;
+		// inner blocks are nested under each entry's 'innerBlocks' key.
+		$get_result = BlockAbilities::handle_get_page_blocks( [
+			'post_id'      => $post_id,
+			'persist_refs' => true,
+		] );
+
+		$this->assertIsArray( $get_result );
+		// 2 top-level blocks: group (index 0) and aftergroup paragraph (index 1).
+		$this->assertCount( 2, $get_result['blocks'], 'should have 2 top-level blocks (group and aftergroup)' );
+
+		$group_entry = $get_result['blocks'][0];
+		$this->assertSame( 'core/group', $group_entry['name'], 'first block should be the group' );
+		$this->assertArrayHasKey( 'innerBlocks', $group_entry, 'group must expose innerBlocks in response' );
+		$this->assertCount( 2, $group_entry['innerBlocks'], 'group should have 2 inner paragraph entries' );
+
+		$group_ref = $group_entry['ref'];
+
+		// Replace the group (and implicitly its 2 inner blocks) with a single paragraph.
+		$result = BlockAbilities::handle_replace_block_range( [
+			'post_id'    => $post_id,
+			'start_ref'  => $group_ref,
+			'end_ref'    => $group_ref,
+			'new_blocks' => [
+				[
+					'blockName' => 'core/paragraph',
+					'attrs'     => [],
+					'innerHTML' => '<p>replacement</p>',
+				],
+			],
+		] );
+
+		$this->assertIsArray( $result, 'replace_block_range must return an array, not WP_Error' );
+		$this->assertSame( 1, $result['refs_added'],     'refs_added should be 1 (the replacement block)' );
+		$this->assertSame( 3, $result['refs_removed'],   'refs_removed should be 3 (group + 2 inner paragraphs)' );
+		$this->assertSame( 1, $result['refs_preserved'], 'refs_preserved should be 1 (aftergroup paragraph)' );
+		$this->assertSame( 2, $result['block_count'],    'block_count should be 2 (replacement + aftergroup)' );
+	}
 }


### PR DESCRIPTION
## Summary

Fixes `sd-ai-agent/replace-block-range` reporting incorrect `refs_removed` and `refs_preserved` counters. The mutation itself was correct (`block_count` was right); only the response stats were wrong.

**Root cause:** `parse_blocks` inserts null-blockName placeholder blocks for whitespace between named blocks (e.g. the `\n\n` separator). The previous counter formula used `range_size = end_idx - start_idx + 1` from `BlockTreeAddress` paths. For three flat paragraphs A/B/C, B resolves to index 2 (not 1) because the whitespace null-block occupies index 1. This made `refs_removed = 3` and `refs_preserved = 0` instead of the correct 2 / 1.

**Fix:** Compute counters from the post-mutation tree (refs already assigned) instead of the path-distance formula:

```php
$refs_after     = self::count_refs_in_tree( $result );
$refs_added     = count( $new_blocks_raw );
$refs_preserved = $refs_after - $refs_added;
$refs_removed   = $refs_before - $refs_preserved;
```

This also correctly accounts for descendant refs in inner-block trees of the removed range (issue item 1 in the bug report).

The redundant early `BlockTreeAddress::resolve()` calls (whose sole purpose was computing `$range_size`) are removed — `BlockMutator::replace_range()` already validates refs internally.

## Changes

- `includes/Abilities/BlockAbilities.php`: replace buggy counter formula; remove now-unused path-resolution block
- `tests/SdAiAgent/Abilities/BlockAbilitiesTest.php`: add two regression tests

## Worker self-verification
- PHPUnit: Tests: 3091, Assertions: 8817, Errors: 0, Failures: 0, Skipped: 105
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Resolves #1770

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with claude-sonnet-4-6 spent 27m and 60,549 tokens on this as a headless worker.
