### PR TITLE
fix: close Block Bindings write-lock bypass in update-html/replace-block/remove-block/replace-range/rewrite-post-blocks (#1769)

### DIFF
--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -2806,6 +2806,20 @@ class BlockAbilities {
 			return $rate_check;
 		}
 
+		// ── Block Bindings write-lock: existing content ───────────────
+		// Check that none of the post's CURRENT blocks are bound, to prevent a
+		// full-page rewrite from silently overwriting bound blocks even when the
+		// new payload contains no bindings. The new-payload check happens below
+		// inside validate_rewrite_blocks.
+		$existing_content = is_string( $post->post_content ) ? $post->post_content : '';
+		// @phpstan-ignore-next-line
+		$existing_blocks = parse_blocks( $existing_content );
+		// @phpstan-ignore-next-line
+		$existing_check = BlockMutator::assert_existing_tree_not_bound( $existing_blocks, $allow_bound_writes );
+		if ( is_wp_error( $existing_check ) ) {
+			return $existing_check;
+		}
+
 		// ── Validate and normalize blocks ─────────────────────────────
 		// @phpstan-ignore-next-line
 		$validated = BlockMutator::validate_rewrite_blocks( $blocks, $allow_bound_writes );

--- a/includes/Core/BlockMutator.php
+++ b/includes/Core/BlockMutator.php
@@ -171,7 +171,7 @@ class BlockMutator {
 				$result = self::op_replace_block( $blocks, $path, $args );
 				break;
 			case 'remove-block':
-				$result = self::op_remove_block( $blocks, $path );
+				$result = self::op_remove_block( $blocks, $path, $args );
 				break;
 			case 'wrap-in-group':
 				$result = self::op_wrap_in_group( $blocks, $path, $args );
@@ -657,6 +657,25 @@ class BlockMutator {
 			$normalized_new[] = $normalized;
 		}
 
+		// ── 7a. Block Bindings write-lock: check existing range members ──
+		// The new_blocks validation above only inspects the incoming replacements.
+		// An agent can bypass the policy by overwriting an existing bound block
+		// (e.g. a core/paragraph with metadata.bindings.content) with unbound
+		// content. Check every block in the start_idx..end_idx range and reject
+		// unless allow_bound_writes is true.
+		if ( ! $allow_bound_writes ) {
+			for ( $i = $start_idx; $i <= $end_idx; $i++ ) {
+				$range_block_path = array_merge( $start_parent, [ $i ] );
+				$existing_block   = BlockTreeAddress::get_block_at_path( $blocks, $range_block_path );
+				if ( is_array( $existing_block ) ) {
+					$range_check = self::assert_block_not_bound( $existing_block, false );
+					if ( is_wp_error( $range_check ) ) {
+						return $range_check;
+					}
+				}
+			}
+		}
+
 		// ── 8. Perform the atomic splice ─────────────────────────────
 		$result = self::mutate_at_path(
 			$blocks,
@@ -963,6 +982,110 @@ class BlockMutator {
 		);
 	}
 
+	/**
+	 * Assert that a write does not target a block with any Block Bindings.
+	 *
+	 * This is a block-level guard (stricter than the per-attribute check in
+	 * `assert_no_bound_attribute_writes`). If the target block has ANY entry
+	 * under `attrs.metadata.bindings`, the operation is rejected unless
+	 * `$allow_bound_writes` is explicitly true.
+	 *
+	 * Used by `update-html`, `replace-block`, and `remove-block` — ops that
+	 * replace or delete the block wholesale rather than updating individual
+	 * attributes.
+	 *
+	 * @param array<int|string,mixed> $block              The target block array.
+	 * @param bool                    $allow_bound_writes Explicit override flag.
+	 * @return true|\WP_Error True when the op is safe, WP_Error on violation.
+	 */
+	public static function assert_block_not_bound( array $block, bool $allow_bound_writes ): true|\WP_Error {
+		if ( $allow_bound_writes ) {
+			return true;
+		}
+
+		$attrs    = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : [];
+		$metadata = isset( $attrs['metadata'] ) && is_array( $attrs['metadata'] ) ? $attrs['metadata'] : [];
+		$bindings = isset( $metadata['bindings'] ) && is_array( $metadata['bindings'] ) ? $metadata['bindings'] : [];
+
+		if ( empty( $bindings ) ) {
+			return true;
+		}
+
+		$ref = $metadata[ BlockReferences::REF_KEY ] ?? null;
+
+		return new \WP_Error(
+			'bound_block_write_blocked',
+			sprintf(
+				/* translators: 1: comma-separated list of bound binding keys */
+				__( 'Block has Block Bindings (%s); pass allow_bound_writes:true to override.', 'superdav-ai-agent' ),
+				implode( ', ', array_keys( $bindings ) )
+			),
+			[
+				'status'    => 409,
+				'bindings'  => array_keys( $bindings ),
+				'block_ref' => is_string( $ref ) ? $ref : '',
+			]
+		);
+	}
+
+	/**
+	 * Check a block tree (e.g. existing post blocks) for any block with bindings.
+	 *
+	 * Returns the first `bound_block_write_blocked` WP_Error encountered, or
+	 * `true` when no blocks in the tree are bound. Used by
+	 * `assert_existing_tree_not_bound` to guard full-page rewrite operations
+	 * where the EXISTING post content (not the new payload) is being replaced.
+	 *
+	 * @param array<string,mixed> $block Block definition (may include innerBlocks).
+	 * @return true|\WP_Error True when no bound blocks found; WP_Error on first hit.
+	 */
+	private static function check_bound_blocks_tree( array $block ): true|\WP_Error {
+		$check = self::assert_block_not_bound( $block, false );
+		if ( is_wp_error( $check ) ) {
+			return $check;
+		}
+
+		$inner = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : [];
+		foreach ( $inner as $child ) {
+			if ( is_array( $child ) ) {
+				$child_check = self::check_bound_blocks_tree( $child );
+				if ( is_wp_error( $child_check ) ) {
+					return $child_check;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Assert that no block in the existing post tree has Block Bindings.
+	 *
+	 * Called by the `rewrite-post-blocks` handler to guard against full-page
+	 * rewrites that silently overwrite bound blocks in the current content.
+	 * The NEW blocks payload is validated separately by `validate_rewrite_blocks`.
+	 *
+	 * @param array<int,mixed> $blocks             Parsed existing block tree (from parse_blocks).
+	 * @param bool             $allow_bound_writes Pass-through override flag.
+	 * @return true|\WP_Error True when safe, WP_Error when any bound block is found.
+	 */
+	public static function assert_existing_tree_not_bound( array $blocks, bool $allow_bound_writes ): true|\WP_Error {
+		if ( $allow_bound_writes ) {
+			return true;
+		}
+
+		foreach ( $blocks as $block ) {
+			if ( is_array( $block ) ) {
+				$check = self::check_bound_blocks_tree( $block );
+				if ( is_wp_error( $check ) ) {
+					return $check;
+				}
+			}
+		}
+
+		return true;
+	}
+
 	// ── Operations ────────────────────────────────────────────────────────
 
 	/**
@@ -1087,16 +1210,17 @@ class BlockMutator {
 			);
 		}
 
-		// Block Bindings write-lock: if attributes are also supplied (dual-storage),
-		// check they don't collide with bound keys.
-		if ( isset( $args['attributes'] ) && is_array( $args['attributes'] ) ) {
-			$target_for_bindings = BlockTreeAddress::get_block_at_path( $blocks, $path );
-			if ( is_array( $target_for_bindings ) ) {
-				$allow_bound_writes = isset( $args['allow_bound_writes'] ) ? (bool) $args['allow_bound_writes'] : false;
-				$bindings_check     = self::assert_no_bound_attribute_writes( $target_for_bindings, $args['attributes'], $allow_bound_writes );
-				if ( is_wp_error( $bindings_check ) ) {
-					return $bindings_check;
-				}
+		// Block Bindings write-lock: block-level guard.
+		// Reject any innerHTML update on a block that has ANY binding unless
+		// allow_bound_writes is explicitly true. For paragraph blocks, `content`
+		// maps to innerHTML — so a raw innerHTML write silently bypasses the
+		// policy even when attributes are not supplied.
+		$allow_bound_writes  = isset( $args['allow_bound_writes'] ) ? (bool) $args['allow_bound_writes'] : false;
+		$target_for_bindings = BlockTreeAddress::get_block_at_path( $blocks, $path );
+		if ( is_array( $target_for_bindings ) ) {
+			$bindings_check = self::assert_block_not_bound( $target_for_bindings, $allow_bound_writes );
+			if ( is_wp_error( $bindings_check ) ) {
+				return $bindings_check;
 			}
 		}
 
@@ -1182,6 +1306,17 @@ class BlockMutator {
 			);
 		}
 
+		// Block Bindings write-lock: block-level guard.
+		// Reject swapping a bound target block unless allow_bound_writes is true.
+		$allow_bound_writes  = isset( $args['allow_bound_writes'] ) ? (bool) $args['allow_bound_writes'] : false;
+		$target_for_bindings = BlockTreeAddress::get_block_at_path( $blocks, $path );
+		if ( is_array( $target_for_bindings ) ) {
+			$bindings_check = self::assert_block_not_bound( $target_for_bindings, $allow_bound_writes );
+			if ( is_wp_error( $bindings_check ) ) {
+				return $bindings_check;
+			}
+		}
+
 		$new_block = self::normalize_block( $args['block_def'] );
 
 		// Enforce tier policy on the replacement block tree.
@@ -1215,11 +1350,23 @@ class BlockMutator {
 	/**
 	 * Delete a block from its parent (remove-block op).
 	 *
-	 * @param array<int,mixed> $blocks Parsed block tree.
-	 * @param int[]            $path   Resolved target path.
+	 * @param array<int,mixed>    $blocks Parsed block tree.
+	 * @param int[]               $path   Resolved target path.
+	 * @param array<string,mixed> $args   Optional. Supports `allow_bound_writes` (bool).
 	 * @return array<int|string,mixed>|\WP_Error
 	 */
-	private static function op_remove_block( array $blocks, array $path ) {
+	private static function op_remove_block( array $blocks, array $path, array $args = [] ) {
+		// Block Bindings write-lock: block-level guard.
+		// Reject removing a bound block unless allow_bound_writes is true.
+		$allow_bound_writes  = isset( $args['allow_bound_writes'] ) ? (bool) $args['allow_bound_writes'] : false;
+		$target_for_bindings = BlockTreeAddress::get_block_at_path( $blocks, $path );
+		if ( is_array( $target_for_bindings ) ) {
+			$bindings_check = self::assert_block_not_bound( $target_for_bindings, $allow_bound_writes );
+			if ( is_wp_error( $bindings_check ) ) {
+				return $bindings_check;
+			}
+		}
+
 		return self::mutate_at_path(
 			$blocks,
 			$path,

--- a/tests/SdAiAgent/Core/BindingsWriteLockTest.php
+++ b/tests/SdAiAgent/Core/BindingsWriteLockTest.php
@@ -229,7 +229,10 @@ class BindingsWriteLockTest extends WP_UnitTestCase {
 	// ── AC5: replace-block removing binding → subsequent writes allowed ────
 
 	/**
-	 * After replace-block removes bindings, writing the previously bound key succeeds.
+	 * After replace-block (with allow_bound_writes) removes bindings, subsequent writes succeed.
+	 *
+	 * As of GH#1769, replace-block on a bound target requires allow_bound_writes:true
+	 * because the block-level write-lock is now enforced for all mutating ops.
 	 */
 	public function test_replace_block_removes_binding_then_write_succeeds(): void {
 		$bindings = [
@@ -238,6 +241,7 @@ class BindingsWriteLockTest extends WP_UnitTestCase {
 		$blocks = [ $this->make_bound_block( 'core/paragraph', 'blk_replace1', $bindings ) ];
 
 		// Replace with a new block that has no bindings.
+		// allow_bound_writes: true is required because the TARGET block is bound.
 		$new_block_def = [
 			'blockName'    => 'core/paragraph',
 			'attrs'        => [
@@ -249,8 +253,9 @@ class BindingsWriteLockTest extends WP_UnitTestCase {
 		];
 
 		$result = BlockMutator::apply( $blocks, 'replace-block', [
-			'ref'       => 'blk_replace1',
-			'block_def' => $new_block_def,
+			'ref'                => 'blk_replace1',
+			'block_def'          => $new_block_def,
+			'allow_bound_writes' => true,
 		] );
 
 		$this->assertIsArray( $result );

--- a/tests/SdAiAgent/Core/BlockMutator/ReplaceRangeTest.php
+++ b/tests/SdAiAgent/Core/BlockMutator/ReplaceRangeTest.php
@@ -714,4 +714,109 @@ class ReplaceRangeTest extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( '<script>', $result[1]['innerHTML'] );
 		$this->assertStringContainsString( 'Safe text', $result[1]['innerHTML'] );
 	}
+
+	// ── GH#1769: existing bound blocks in range must be rejected ──
+
+	/**
+	 * replace_range rejects when an EXISTING block in the range is bound (GH#1769).
+	 *
+	 * Before the fix, the binding check only applied to new_blocks. An agent
+	 * could replace a bound paragraph with unbound content without triggering
+	 * the policy guard.
+	 */
+	public function test_existing_bound_block_in_range_rejects_without_override(): void {
+		// Build a tree where blk_para1 has a binding.
+		$bound_para = [
+			'blockName'    => 'core/paragraph',
+			'attrs'        => [
+				'metadata' => [
+					BlockReferences::REF_KEY => 'blk_para1',
+					'bindings'               => [
+						'content' => [
+							'source' => 'core/post-meta',
+							'args'   => [ 'key' => 'foo_meta' ],
+						],
+					],
+				],
+			],
+			'innerBlocks'  => [],
+			'innerHTML'    => '<p>placeholder</p>',
+			'innerContent' => [ '<p>placeholder</p>' ],
+		];
+
+		$blocks = [
+			$this->make_ref_block( 'core/heading', 'blk_heading', [ 'level' => 2 ], '<h2>Title</h2>' ),
+			$bound_para,
+			$this->make_ref_block( 'core/paragraph', 'blk_para2', [], '<p>Second</p>' ),
+		];
+
+		$new_block = [
+			'blockName'    => 'core/paragraph',
+			'attrs'        => [],
+			'innerBlocks'  => [],
+			'innerHTML'    => '<p>replacement</p>',
+			'innerContent' => [ '<p>replacement</p>' ],
+		];
+
+		$result = BlockMutator::replace_range(
+			$blocks,
+			'blk_para1',
+			'blk_para1',
+			[ $new_block ]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'bound_block_write_blocked', $result->get_error_code() );
+		$data = $result->get_error_data();
+		$this->assertSame( 409, $data['status'] );
+		$this->assertContains( 'content', $data['bindings'] );
+	}
+
+	/**
+	 * replace_range with allow_bound_writes:true allows overwriting a bound existing block (GH#1769).
+	 */
+	public function test_existing_bound_block_in_range_with_override_succeeds(): void {
+		$bound_para = [
+			'blockName'    => 'core/paragraph',
+			'attrs'        => [
+				'metadata' => [
+					BlockReferences::REF_KEY => 'blk_para1',
+					'bindings'               => [
+						'content' => [
+							'source' => 'core/post-meta',
+							'args'   => [ 'key' => 'foo_meta' ],
+						],
+					],
+				],
+			],
+			'innerBlocks'  => [],
+			'innerHTML'    => '<p>placeholder</p>',
+			'innerContent' => [ '<p>placeholder</p>' ],
+		];
+
+		$blocks = [
+			$this->make_ref_block( 'core/heading', 'blk_heading', [ 'level' => 2 ], '<h2>Title</h2>' ),
+			$bound_para,
+			$this->make_ref_block( 'core/paragraph', 'blk_para2', [], '<p>Second</p>' ),
+		];
+
+		$new_block = [
+			'blockName'    => 'core/paragraph',
+			'attrs'        => [],
+			'innerBlocks'  => [],
+			'innerHTML'    => '<p>replacement</p>',
+			'innerContent' => [ '<p>replacement</p>' ],
+		];
+
+		$result = BlockMutator::replace_range(
+			$blocks,
+			'blk_para1',
+			'blk_para1',
+			[ $new_block ],
+			true // allow_bound_writes.
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertNotInstanceOf( \WP_Error::class, $result );
+	}
 }

--- a/tests/SdAiAgent/Core/BlockMutator/RewritePostBlocksTest.php
+++ b/tests/SdAiAgent/Core/BlockMutator/RewritePostBlocksTest.php
@@ -604,4 +604,90 @@ class RewritePostBlocksTest extends WP_UnitTestCase {
 		$this->assertNotSame( $stale_ref, $new_ref, 'Stale refs must be replaced with fresh ones.' );
 		$this->assertStringStartsWith( 'blk_', $new_ref );
 	}
+
+	// ── GH#1769: existing post content with bound blocks ──────────────────
+
+	/**
+	 * rewrite-post-blocks rejects when the EXISTING post has a bound block (GH#1769).
+	 *
+	 * Before the fix, an agent could overwrite a bound block by supplying a
+	 * clean (unbound) replacement payload, because the guard only checked
+	 * the new blocks, not the existing ones.
+	 */
+	public function test_handler_existing_bound_block_rejects_without_override(): void {
+		// Create a post whose current content contains a bound paragraph.
+		$bound_content = serialize_blocks( [
+			[
+				'blockName'    => 'core/paragraph',
+				'attrs'        => [
+					'metadata' => [
+						'bindings' => [
+							'content' => [
+								'source' => 'core/post-meta',
+								'args'   => [ 'key' => 'foo_meta' ],
+							],
+						],
+					],
+				],
+				'innerBlocks'  => [],
+				'innerHTML'    => '<p>placeholder</p>',
+				'innerContent' => [ '<p>placeholder</p>' ],
+			],
+		] );
+
+		$post_id = self::factory()->post->create( [
+			'post_content' => $bound_content,
+			'post_status'  => 'publish',
+		] );
+
+		// Try to rewrite with a clean (unbound) payload.
+		$result = BlockAbilities::handle_rewrite_post_blocks( [
+			'post_id' => $post_id,
+			'blocks'  => $this->make_blocks( 1 ),
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'bound_block_write_blocked', $result->get_error_code() );
+		$data = $result->get_error_data();
+		$this->assertSame( 409, $data['status'] );
+		$this->assertContains( 'content', $data['bindings'] );
+	}
+
+	/**
+	 * rewrite-post-blocks with allow_bound_writes:true allows overwriting a bound existing block (GH#1769).
+	 */
+	public function test_handler_existing_bound_block_with_override_succeeds(): void {
+		$bound_content = serialize_blocks( [
+			[
+				'blockName'    => 'core/paragraph',
+				'attrs'        => [
+					'metadata' => [
+						'bindings' => [
+							'content' => [
+								'source' => 'core/post-meta',
+								'args'   => [ 'key' => 'foo_meta' ],
+							],
+						],
+					],
+				],
+				'innerBlocks'  => [],
+				'innerHTML'    => '<p>placeholder</p>',
+				'innerContent' => [ '<p>placeholder</p>' ],
+			],
+		] );
+
+		$post_id = self::factory()->post->create( [
+			'post_content' => $bound_content,
+			'post_status'  => 'publish',
+		] );
+
+		$result = BlockAbilities::handle_rewrite_post_blocks( [
+			'post_id'            => $post_id,
+			'blocks'             => $this->make_blocks( 1 ),
+			'allow_bound_writes' => true,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['success'] );
+	}
 }

--- a/tests/SdAiAgent/Core/BlockMutatorTest.php
+++ b/tests/SdAiAgent/Core/BlockMutatorTest.php
@@ -1003,4 +1003,184 @@ class BlockMutatorTest extends WP_UnitTestCase {
 		// No _warnings key for preferred blocks.
 		$this->assertArrayNotHasKey( '_warnings', $result );
 	}
+
+	// ── Block Bindings write-lock bypass fixes (GH#1769) ─────────────────
+
+	/**
+	 * Build a bound paragraph block (metadata.bindings.content set).
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function make_bound_paragraph(): array {
+		return [
+			'blockName'    => 'core/paragraph',
+			'attrs'        => [
+				'metadata' => [
+					'bindings' => [
+						'content' => [
+							'source' => 'core/post-meta',
+							'args'   => [ 'key' => 'foo_meta' ],
+						],
+					],
+				],
+			],
+			'innerBlocks'  => [],
+			'innerHTML'    => '<p>placeholder</p>',
+			'innerContent' => [ '<p>placeholder</p>' ],
+		];
+	}
+
+	/**
+	 * update-html with only innerHTML on a bound paragraph is rejected (GH#1769).
+	 *
+	 * Before the fix, a raw innerHTML write bypassed the Block Bindings
+	 * write-lock because the guard only fired when `attributes` was also
+	 * supplied. Now the block-level check always fires.
+	 */
+	public function test_update_html_on_bound_paragraph_rejects_without_override(): void {
+		$blocks = [ $this->make_bound_paragraph() ];
+
+		$result = BlockMutator::apply( $blocks, 'update-html', [
+			'path'      => [ 0 ],
+			'innerHTML' => '<p>hacked</p>',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'bound_block_write_blocked', $result->get_error_code() );
+		$data = $result->get_error_data();
+		$this->assertSame( 409, $data['status'] );
+		$this->assertContains( 'content', $data['bindings'] );
+	}
+
+	/**
+	 * update-html on a bound block with allow_bound_writes:true succeeds (GH#1769).
+	 */
+	public function test_update_html_on_bound_block_with_override_succeeds(): void {
+		$blocks = [ $this->make_bound_paragraph() ];
+
+		$result = BlockMutator::apply( $blocks, 'update-html', [
+			'path'              => [ 0 ],
+			'innerHTML'         => '<p>override</p>',
+			'allow_bound_writes' => true,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( '<p>override</p>', $result[0]['innerHTML'] );
+	}
+
+	/**
+	 * replace-block on a bound target is rejected (GH#1769).
+	 */
+	public function test_replace_block_on_bound_target_rejects_without_override(): void {
+		$blocks = [ $this->make_bound_paragraph() ];
+
+		$result = BlockMutator::apply( $blocks, 'replace-block', [
+			'path'      => [ 0 ],
+			'block_def' => $this->make_block( 'core/heading', [ 'level' => 2 ], [], '<h2>New</h2>' ),
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'bound_block_write_blocked', $result->get_error_code() );
+		$data = $result->get_error_data();
+		$this->assertSame( 409, $data['status'] );
+		$this->assertContains( 'content', $data['bindings'] );
+	}
+
+	/**
+	 * replace-block on a bound target with allow_bound_writes:true succeeds (GH#1769).
+	 */
+	public function test_replace_block_on_bound_target_with_override_succeeds(): void {
+		$blocks = [ $this->make_bound_paragraph() ];
+
+		$result = BlockMutator::apply( $blocks, 'replace-block', [
+			'path'               => [ 0 ],
+			'block_def'          => $this->make_block( 'core/heading', [ 'level' => 2 ], [], '<h2>New</h2>' ),
+			'allow_bound_writes' => true,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'core/heading', $result[0]['blockName'] );
+	}
+
+	/**
+	 * remove-block on a bound target is rejected (GH#1769).
+	 */
+	public function test_remove_block_on_bound_target_rejects_without_override(): void {
+		$blocks = [
+			$this->make_bound_paragraph(),
+			$this->make_block( 'core/paragraph', [], [], '<p>Keep</p>' ),
+		];
+
+		$result = BlockMutator::apply( $blocks, 'remove-block', [
+			'path' => [ 0 ],
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'bound_block_write_blocked', $result->get_error_code() );
+		$data = $result->get_error_data();
+		$this->assertSame( 409, $data['status'] );
+		$this->assertContains( 'content', $data['bindings'] );
+	}
+
+	/**
+	 * remove-block on a bound target with allow_bound_writes:true succeeds (GH#1769).
+	 */
+	public function test_remove_block_on_bound_target_with_override_succeeds(): void {
+		$blocks = [
+			$this->make_bound_paragraph(),
+			$this->make_block( 'core/paragraph', [], [], '<p>Keep</p>' ),
+		];
+
+		$result = BlockMutator::apply( $blocks, 'remove-block', [
+			'path'               => [ 0 ],
+			'allow_bound_writes' => true,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		$this->assertSame( '<p>Keep</p>', $result[0]['innerHTML'] );
+	}
+
+	/**
+	 * apply_batch: per-item allow_bound_writes:true unlocks a bound block (GH#1769).
+	 *
+	 * Verifies that a batch with a single update-html targeting a bound block
+	 * succeeds when the per-item allow_bound_writes flag is set.
+	 */
+	public function test_apply_batch_update_html_per_item_allow_bound_writes_unlocks(): void {
+		$blocks = [ $this->make_bound_paragraph() ];
+
+		$result = BlockMutator::apply_batch( $blocks, [
+			[
+				'op'                 => 'update-html',
+				'path'               => [ 0 ],
+				'innerHTML'          => '<p>override</p>',
+				'allow_bound_writes' => true,
+			],
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( '<p>override</p>', $result[0]['innerHTML'] );
+	}
+
+	/**
+	 * apply_batch: update-html on bound block without override fails with per-item error (GH#1769).
+	 */
+	public function test_apply_batch_update_html_bound_block_without_override_fails(): void {
+		$blocks = [ $this->make_bound_paragraph() ];
+
+		$result = BlockMutator::apply_batch( $blocks, [
+			[
+				'op'        => 'update-html',
+				'path'      => [ 0 ],
+				'innerHTML' => '<p>hacked</p>',
+			],
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'batch_validation_failed', $result->get_error_code() );
+		$data = $result->get_error_data();
+		$this->assertNotEmpty( $data['errors'] );
+		$this->assertSame( 'bound_block_write_blocked', $data['errors'][0]['code'] );
+	}
 }


### PR DESCRIPTION
## Summary

Closes the Block Bindings write-lock bypass identified in #1769. The write-lock added in t259/PR #1763 was bypassable through three of the five mutating ops in `update-blocks`/`edit-block-tree`, plus two additional paths in `replace-block-range` and `rewrite-post-blocks`.

## Root cause

`BlockMutator::assert_no_bound_attribute_writes` (per-key check) was only invoked from:
- `op_update_html` **only when `attributes` was also supplied** — innerHTML-only writes bypassed it entirely
- `op_update_attrs` (always — this was correct)

Not invoked from:
- `op_update_html` when only `innerHTML` is supplied
- `op_replace_block` (no binding check at all)
- `op_remove_block` (no binding check at all)
- `replace_range`: only checked NEW blocks, not the EXISTING blocks being overwritten
- `handle_rewrite_post_blocks`: only checked the new payload, not the current post's blocks

## Changes

### `includes/Core/BlockMutator.php`
- **Add `assert_block_not_bound()`** — block-level guard: if the target block has ANY entry in `attrs.metadata.bindings`, reject the operation unless `allow_bound_writes:true`. Error code: `bound_block_write_blocked` (409).
- **Add `check_bound_blocks_tree()` + `assert_existing_tree_not_bound()`** — recursive helpers for checking an existing post's block tree.
- **`op_update_html`** — replace the attributes-only branch check with `assert_block_not_bound` at the top of the method (covers both innerHTML-only AND attributes+innerHTML cases).
- **`op_replace_block`** — add `assert_block_not_bound` on the target block before swap.
- **`op_remove_block`** — add `$args` parameter + `assert_block_not_bound` on target; update dispatch call.
- **`replace_range` step 7a** — iterate existing range members (start_idx..end_idx) and call `assert_block_not_bound` on each before the splice.

### `includes/Abilities/BlockAbilities.php`
- **`handle_rewrite_post_blocks`** — call `assert_existing_tree_not_bound` on the parsed existing post blocks before `validate_rewrite_blocks`.

## Tests (10 new + 1 updated)

| File | New tests |
|---|---|
| `tests/SdAiAgent/Core/BlockMutatorTest.php` | 8 new: update-html/replace-block/remove-block bypass paths + per-item apply_batch override |
| `tests/SdAiAgent/Core/BlockMutator/ReplaceRangeTest.php` | 2 new: existing bound block in range rejected/allowed with override |
| `tests/SdAiAgent/Core/BlockMutator/RewritePostBlocksTest.php` | 2 new: existing post with bound block rejected/allowed with override |
| `tests/SdAiAgent/Core/BindingsWriteLockTest.php` | 1 updated: AC5 test now passes `allow_bound_writes:true` (required since replace-block on a bound target is now blocked) |

## Worker self-verification
- PHPUnit: Tests: 3101, Assertions: 8837, Errors: 0, Failures: 0, Skipped: 105
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Resolves #1769

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with claude-sonnet-4-6 spent 29m and 44,089 tokens on this as a headless worker.
