### PR TITLE
feat(get-post): URL / slug+post_type input parity (t268)

### DIFF
--- a/includes/Abilities/PostAbilities.php
+++ b/includes/Abilities/PostAbilities.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Abilities;
 
+use SdAiAgent\Abilities\UrlResolverAbilities;
 use SdAiAgent\Core\BlockValidator;
 use SdAiAgent\Core\RateLimiter;
 use SdAiAgent\Core\RevisionGuard;
@@ -38,21 +39,33 @@ class PostAbilities {
 			'sd-ai-agent/get-post',
 			[
 				'label'               => __( 'Get Post', 'superdav-ai-agent' ),
-				'description'         => __( 'Retrieve a WordPress post by ID. Returns title, content, excerpt, status, author, categories, tags, featured image, and meta.', 'superdav-ai-agent' ),
+				'description'         => __( 'Retrieve a WordPress post by numeric ID, full URL, or slug + post_type. Exactly one of "id", "url", or "slug" must be supplied. Returns title, content, excerpt, status, author, categories, tags, featured image, and a resolved_via field that identifies how the post was found.', 'superdav-ai-agent' ),
 				'category'            => 'sd-ai-agent',
 				'input_schema'        => [
 					'type'       => 'object',
 					'properties' => [
+						'id'        => [
+							'type'        => 'integer',
+							'description' => 'Numeric post ID. Use this when you already know the ID.',
+						],
 						'post_id'   => [
 							'type'        => 'integer',
-							'description' => 'The ID of the post to retrieve.',
+							'description' => 'Alias for id (deprecated; prefer id).',
+						],
+						'url'       => [
+							'type'        => 'string',
+							'description' => 'Full URL of the post (e.g. "https://example.com/about/"). Resolved via url_to_postid() with a slug fallback. Cross-host URLs are rejected.',
+						],
+						'slug'      => [
+							'type'        => 'string',
+							'description' => 'Post slug (e.g. "about"). Must be paired with post_type to avoid silent cross-type matches.',
 						],
 						'post_type' => [
 							'type'        => 'string',
-							'description' => 'Post type to validate against (default: any).',
+							'description' => 'Post type to look up or validate against (required when slug is provided; default "any" when id is provided).',
 						],
 					],
-					'required'   => [ 'post_id' ],
+					'required'   => [],
 				],
 				'output_schema'       => [
 					'type'       => 'object',
@@ -71,6 +84,11 @@ class PostAbilities {
 						'categories'     => [ 'type' => 'array' ],
 						'tags'           => [ 'type' => 'array' ],
 						'featured_image' => [ 'type' => 'string' ],
+						'resolved_via'   => [
+							'type'        => 'string',
+							'enum'        => [ 'id', 'url_to_postid', 'slug_lookup' ],
+							'description' => 'How the post was located: "id" (numeric ID), "url_to_postid" (URL resolved via url_to_postid()), or "slug_lookup" (resolved via get_page_by_path()).',
+						],
 					],
 				],
 				'meta'                => [
@@ -738,19 +756,72 @@ class PostAbilities {
 	/**
 	 * Handle the get-post ability.
 	 *
-	 * @param array<string, mixed> $input Input with post_id and optional post_type.
+	 * Accepts exactly one of:
+	 *   - id / post_id — numeric post ID (post_id is a deprecated alias).
+	 *   - url          — absolute URL resolved via UrlResolverAbilities.
+	 *   - slug + post_type — slug resolved via get_page_by_path().
+	 *
+	 * @param array<string, mixed> $input Input params.
 	 * @return array<string, mixed>|WP_Error
 	 */
 	public static function handle_get_post( array $input ) {
+		// Normalise id: accept both 'id' and deprecated 'post_id'.
 		// @phpstan-ignore-next-line
-		$post_id = (int) ( $input['post_id'] ?? 0 );
-		// @phpstan-ignore-next-line
-		$post_type = sanitize_text_field( $input['post_type'] ?? 'any' );
+		$id_value   = (int) ( $input['id'] ?? $input['post_id'] ?? 0 );
+		$url_value  = isset( $input['url'] ) ? trim( (string) $input['url'] ) : '';
+		$slug_value = isset( $input['slug'] ) ? trim( (string) $input['slug'] ) : '';
 
-		if ( ! $post_id ) {
-			return new WP_Error( 'ai_agent_empty_post_id', __( 'post_id is required.', 'superdav-ai-agent' ) );
+		// ── XOR guard: exactly one of id / url / slug must be provided ────────
+		$provided = ( $id_value > 0 ? 1 : 0 )
+			+ ( '' !== $url_value ? 1 : 0 )
+			+ ( '' !== $slug_value ? 1 : 0 );
+
+		if ( $provided > 1 ) {
+			return new WP_Error(
+				'too_many_inputs',
+				__( 'Provide exactly one of "id", "url", or "slug" — not multiple.', 'superdav-ai-agent' )
+			);
 		}
 
+		if ( 0 === $provided ) {
+			return new WP_Error(
+				'missing_input',
+				__( 'One of "id", "url", or "slug" is required.', 'superdav-ai-agent' )
+			);
+		}
+
+		// ── Resolve to a post_id ───────────────────────────────────────────────
+		$post_id      = 0;
+		$resolved_via = '';
+
+		if ( $id_value > 0 ) {
+			$post_id      = $id_value;
+			$resolved_via = 'id';
+		} elseif ( '' !== $url_value ) {
+			// Delegate to shared URL resolver.
+			$resolved = UrlResolverAbilities::resolve_to_post_id( [ 'url' => $url_value ], $resolved_via );
+			if ( is_wp_error( $resolved ) ) {
+				return $resolved;
+			}
+			$post_id = $resolved;
+		} else {
+			// Slug + post_type form.
+			// @phpstan-ignore-next-line
+			$post_type_for_slug = isset( $input['post_type'] ) ? trim( (string) $input['post_type'] ) : '';
+			$resolved           = UrlResolverAbilities::resolve_to_post_id(
+				[
+					'slug'      => $slug_value,
+					'post_type' => $post_type_for_slug,
+				],
+				$resolved_via
+			);
+			if ( is_wp_error( $resolved ) ) {
+				return $resolved;
+			}
+			$post_id = $resolved;
+		}
+
+		// ── Fetch post ────────────────────────────────────────────────────────
 		$post = get_post( $post_id );
 
 		if ( ! ( $post instanceof WP_Post ) ) {
@@ -761,11 +832,15 @@ class PostAbilities {
 			);
 		}
 
-		if ( $post_type !== 'any' && $post->post_type !== $post_type ) {
+		// post_type validation (applies only to the id path; slug path already
+		// scoped to the requested type via resolve_to_post_id).
+		// @phpstan-ignore-next-line
+		$post_type_filter = 'id' === $resolved_via ? sanitize_text_field( $input['post_type'] ?? 'any' ) : 'any';
+		if ( 'any' !== $post_type_filter && $post->post_type !== $post_type_filter ) {
 			return new WP_Error(
 				'ai_agent_post_type_mismatch',
 				/* translators: 1: post ID, 2: expected type, 3: actual type */
-				sprintf( __( 'Post %1$d is of type "%2$s", not "%3$s".', 'superdav-ai-agent' ), $post_id, $post->post_type, $post_type )
+				sprintf( __( 'Post %1$d is of type "%2$s", not "%3$s".', 'superdav-ai-agent' ), $post_id, $post->post_type, $post_type_filter )
 			);
 		}
 
@@ -794,6 +869,7 @@ class PostAbilities {
 			'categories'     => is_wp_error( $categories ) ? [] : $categories,
 			'tags'           => is_wp_error( $tags ) ? [] : $tags,
 			'featured_image' => $featured_image_url,
+			'resolved_via'   => $resolved_via,
 		];
 	}
 

--- a/includes/Abilities/UrlResolverAbilities.php
+++ b/includes/Abilities/UrlResolverAbilities.php
@@ -89,29 +89,76 @@ class UrlResolverAbilities {
 	}
 
 	/**
-	 * Execute the resolve-url ability.
+	 * Resolve a URL or slug+post_type input to a WordPress post ID.
 	 *
-	 * @param array<string, mixed> $params Ability parameters; expects 'url' key.
-	 * @return array<string, mixed>|\WP_Error Resolved post data or a WP_Error.
+	 * Accepts two mutually-exclusive input shapes:
+	 *
+	 *   URL form  — [ 'url'  => 'https://example.com/about/' ]
+	 *   Slug form — [ 'slug' => 'about', 'post_type' => 'page' ]
+	 *
+	 * The `$matched_via` output parameter is set to "url_to_postid" or
+	 * "slug_lookup" so callers can include this in their response.
+	 *
+	 * This is the shared resolution core used by both handle_resolve_url() and
+	 * PostAbilities::handle_get_post(). It does NOT apply a per-post visibility
+	 * gate — callers that need draft/private filtering must check that themselves.
+	 *
+	 * @param array<string, mixed> $input      Resolution input (url or slug+post_type).
+	 * @param string               $matched_via Output: how the post_id was found.
+	 * @return int|\WP_Error Post ID (> 0) on success, WP_Error on failure.
 	 */
-	public static function handle_resolve_url( array $params ): array|\WP_Error {
-		$input = isset( $params['url'] ) ? trim( (string) $params['url'] ) : '';
+	public static function resolve_to_post_id( array $input, string &$matched_via = '' ): int|\WP_Error {
 
-		if ( '' === $input ) {
-			return new \WP_Error(
-				'missing_url',
-				__( 'The "url" parameter is required.', 'superdav-ai-agent' )
-			);
+		// ── Slug + post_type form ──────────────────────────────────────────────
+		if ( isset( $input['slug'] ) ) {
+			$slug      = trim( (string) $input['slug'] );
+			$post_type = isset( $input['post_type'] ) ? trim( (string) $input['post_type'] ) : '';
+
+			if ( '' === $post_type ) {
+				return new \WP_Error(
+					'missing_post_type',
+					/* translators: no interpolation */
+					__( '"post_type" is required when "slug" is provided. Specify the post type (e.g. "page") to avoid silent cross-type matches.', 'superdav-ai-agent' )
+				);
+			}
+
+			if ( '' === $slug ) {
+				return new \WP_Error(
+					'not_found',
+					__( 'No post found for the given slug and post_type.', 'superdav-ai-agent' ),
+					[
+						'slug'      => $slug,
+						'post_type' => $post_type,
+					]
+				);
+			}
+
+			$post_obj = get_page_by_path( $slug, OBJECT, $post_type );
+			if ( ! ( $post_obj instanceof \WP_Post ) ) {
+				return new \WP_Error(
+					'not_found',
+					__( 'No post found for the given slug and post_type.', 'superdav-ai-agent' ),
+					[
+						'slug'      => $slug,
+						'post_type' => $post_type,
+					]
+				);
+			}
+
+			$matched_via = 'slug_lookup';
+			return $post_obj->ID;
 		}
 
-		$attempts    = [];
-		$post_id     = 0;
-		$matched_via = '';
-		$is_absolute = str_contains( $input, '://' );
+		// ── URL form ───────────────────────────────────────────────────────────
+		$url_input    = isset( $input['url'] ) ? trim( (string) $input['url'] ) : '';
+		$attempts     = [];
+		$post_id      = 0;
+		$resolved_via = '';
+		$is_absolute  = str_contains( $url_input, '://' );
 
 		// Guard: reject cross-host URLs immediately — never resolve external sites.
 		if ( $is_absolute ) {
-			$input_host = (string) wp_parse_url( $input, PHP_URL_HOST );
+			$input_host = (string) wp_parse_url( $url_input, PHP_URL_HOST );
 			$site_host  = (string) wp_parse_url( home_url(), PHP_URL_HOST );
 			if ( '' !== $input_host && '' !== $site_host && $input_host !== $site_host ) {
 				return new \WP_Error(
@@ -131,13 +178,13 @@ class UrlResolverAbilities {
 
 		// Strategy 1: url_to_postid() — reliable for absolute URLs and relative
 		// query-string inputs (e.g. ?p=123, ?page_id=456).
-		if ( $is_absolute || str_starts_with( $input, '?' ) || str_starts_with( $input, '/' ) ) {
-			$lookup_url  = $is_absolute ? $input : home_url( $input );
+		if ( $is_absolute || str_starts_with( $url_input, '?' ) || str_starts_with( $url_input, '/' ) ) {
+			$lookup_url  = $is_absolute ? $url_input : home_url( $url_input );
 			$attempts[]  = 'url_to_postid';
 			$resolved_id = url_to_postid( $lookup_url );
 			if ( $resolved_id > 0 ) {
-				$post_id     = $resolved_id;
-				$matched_via = 'url_to_postid';
+				$post_id      = $resolved_id;
+				$resolved_via = 'url_to_postid';
 			}
 		}
 
@@ -147,10 +194,10 @@ class UrlResolverAbilities {
 		if ( 0 === $post_id ) {
 			if ( $is_absolute ) {
 				// Derive slug from the URL path.
-				$slug = trim( (string) wp_parse_url( $input, PHP_URL_PATH ), '/' );
+				$slug = trim( (string) wp_parse_url( $url_input, PHP_URL_PATH ), '/' );
 			} else {
 				// Strip query string and URL fragment; trim slashes.
-				$without_query = (string) explode( '?', $input )[0];
+				$without_query = (string) explode( '?', $url_input )[0];
 				$slug          = trim( (string) explode( '#', $without_query )[0], '/' );
 			}
 
@@ -159,8 +206,8 @@ class UrlResolverAbilities {
 				$public_types = array_keys( get_post_types( [ 'public' => true ] ) );
 				$post_obj     = get_page_by_path( $slug, OBJECT, $public_types );
 				if ( $post_obj instanceof \WP_Post ) {
-					$post_id     = $post_obj->ID;
-					$matched_via = 'slug_lookup';
+					$post_id      = $post_obj->ID;
+					$resolved_via = 'slug_lookup';
 				}
 			}
 		}
@@ -170,10 +217,40 @@ class UrlResolverAbilities {
 				'not_found',
 				__( 'No post found for the given URL or slug.', 'superdav-ai-agent' ),
 				[
-					'input'    => $input,
+					'input'    => $url_input,
 					'attempts' => $attempts,
 				]
 			);
+		}
+
+		$matched_via = $resolved_via;
+		return $post_id;
+	}
+
+	/**
+	 * Execute the resolve-url ability.
+	 *
+	 * Delegates resolution to resolve_to_post_id(), then fetches post metadata
+	 * and applies the per-post visibility gate for draft/private posts.
+	 *
+	 * @param array<string, mixed> $params Ability parameters; expects 'url' key.
+	 * @return array<string, mixed>|\WP_Error Resolved post data or a WP_Error.
+	 */
+	public static function handle_resolve_url( array $params ): array|\WP_Error {
+		$input = isset( $params['url'] ) ? trim( (string) $params['url'] ) : '';
+
+		if ( '' === $input ) {
+			return new \WP_Error(
+				'missing_url',
+				__( 'The "url" parameter is required.', 'superdav-ai-agent' )
+			);
+		}
+
+		$matched_via = '';
+		$post_id     = self::resolve_to_post_id( [ 'url' => $input ], $matched_via );
+
+		if ( is_wp_error( $post_id ) ) {
+			return $post_id;
 		}
 
 		$post = get_post( $post_id );
@@ -181,10 +258,7 @@ class UrlResolverAbilities {
 			return new \WP_Error(
 				'not_found',
 				__( 'No post found for the given URL or slug.', 'superdav-ai-agent' ),
-				[
-					'input'    => $input,
-					'attempts' => $attempts,
-				]
+				[ 'input' => $input ]
 			);
 		}
 
@@ -194,10 +268,7 @@ class UrlResolverAbilities {
 			return new \WP_Error(
 				'not_found',
 				__( 'No post found for the given URL or slug.', 'superdav-ai-agent' ),
-				[
-					'input'    => $input,
-					'attempts' => $attempts,
-				]
+				[ 'input' => $input ]
 			);
 		}
 

--- a/tests/SdAiAgent/Abilities/PostAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/PostAbilitiesTest.php
@@ -48,23 +48,27 @@ class PostAbilitiesTest extends WP_UnitTestCase {
 	// ─── handle_get_post ──────────────────────────────────────────
 
 	/**
-	 * Test handle_get_post with missing post_id returns WP_Error.
+	 * Test handle_get_post with empty input returns missing_input WP_Error.
+	 *
+	 * AC5: get-post {} → WP_Error('missing_input').
 	 */
 	public function test_handle_get_post_missing_post_id() {
 		$result = PostAbilities::handle_get_post( [] );
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
-		$this->assertSame( 'ai_agent_empty_post_id', $result->get_error_code() );
+		$this->assertSame( 'missing_input', $result->get_error_code() );
 	}
 
 	/**
-	 * Test handle_get_post with zero post_id returns WP_Error.
+	 * Test handle_get_post with zero id/post_id returns missing_input WP_Error.
+	 *
+	 * Zero is falsy and not a valid post ID; treated as missing input.
 	 */
 	public function test_handle_get_post_zero_post_id() {
 		$result = PostAbilities::handle_get_post( [ 'post_id' => 0 ] );
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
-		$this->assertSame( 'ai_agent_empty_post_id', $result->get_error_code() );
+		$this->assertSame( 'missing_input', $result->get_error_code() );
 	}
 
 	/**
@@ -79,6 +83,8 @@ class PostAbilitiesTest extends WP_UnitTestCase {
 
 	/**
 	 * Test handle_get_post with valid post_id returns expected structure.
+	 *
+	 * AC7: existing id path returns the pre-change shape PLUS resolved_via: "id".
 	 */
 	public function test_handle_get_post_returns_structure() {
 		$post_id = $this->factory->post->create( [
@@ -99,8 +105,10 @@ class PostAbilitiesTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'categories', $result );
 		$this->assertArrayHasKey( 'tags', $result );
 		$this->assertArrayHasKey( 'featured_image', $result );
+		$this->assertArrayHasKey( 'resolved_via', $result );
 		$this->assertSame( $post_id, $result['id'] );
 		$this->assertSame( 'Test Post', $result['title'] );
+		$this->assertSame( 'id', $result['resolved_via'] );
 	}
 
 	/**
@@ -150,6 +158,117 @@ class PostAbilitiesTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result );
 		$this->assertIsArray( $result['categories'] );
 		$this->assertIsArray( $result['tags'] );
+	}
+
+	// ─── handle_get_post — new input forms (t268) ─────────────────
+
+	/**
+	 * AC1: get-post via URL (query-string form) returns resolved_via "url_to_postid".
+	 *
+	 * Uses ?p=N which is reliably resolved by url_to_postid() even in unit tests.
+	 */
+	public function test_handle_get_post_via_url_resolves_and_returns_resolved_via_url_to_postid() {
+		$post_id = $this->factory->post->create( [
+			'post_title'  => 'URL-resolved post',
+			'post_status' => 'publish',
+		] );
+
+		$url    = add_query_arg( 'p', $post_id, home_url( '/' ) );
+		$result = PostAbilities::handle_get_post( [ 'url' => $url ] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $post_id, $result['id'] );
+		$this->assertSame( 'url_to_postid', $result['resolved_via'] );
+	}
+
+	/**
+	 * AC2: get-post via slug+post_type returns correct post and resolved_via "slug_lookup".
+	 */
+	public function test_handle_get_post_via_slug_and_post_type_resolves_correctly() {
+		$post_id = $this->factory->post->create( [
+			'post_title'   => 'About Page',
+			'post_name'    => 't268-about-slug-test',
+			'post_status'  => 'publish',
+			'post_type'    => 'page',
+		] );
+
+		$result = PostAbilities::handle_get_post( [
+			'slug'      => 't268-about-slug-test',
+			'post_type' => 'page',
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $post_id, $result['id'] );
+		$this->assertSame( 'slug_lookup', $result['resolved_via'] );
+	}
+
+	/**
+	 * AC3: get-post with slug but no post_type returns missing_post_type WP_Error.
+	 */
+	public function test_handle_get_post_slug_without_post_type_returns_missing_post_type() {
+		$result = PostAbilities::handle_get_post( [ 'slug' => 'some-slug' ] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'missing_post_type', $result->get_error_code() );
+	}
+
+	/**
+	 * AC4: get-post with more than one of id/url/slug returns too_many_inputs WP_Error.
+	 */
+	public function test_handle_get_post_too_many_inputs_returns_too_many_inputs() {
+		$post_id = $this->factory->post->create( [ 'post_status' => 'publish' ] );
+
+		$result = PostAbilities::handle_get_post( [
+			'id'  => $post_id,
+			'url' => home_url( '/?p=' . $post_id ),
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'too_many_inputs', $result->get_error_code() );
+	}
+
+	/**
+	 * AC6: get-post with a cross-host URL returns external_host WP_Error.
+	 */
+	public function test_handle_get_post_cross_host_url_returns_external_host_error() {
+		$result = PostAbilities::handle_get_post( [
+			'url' => 'https://other.example.invalid/about/',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'external_host', $result->get_error_code() );
+	}
+
+	/**
+	 * AC7: deprecated post_id key is still accepted (backward compatibility).
+	 */
+	public function test_handle_get_post_deprecated_post_id_key_still_works() {
+		$post_id = $this->factory->post->create( [
+			'post_title'  => 'Legacy post_id key',
+			'post_status' => 'publish',
+		] );
+
+		$result = PostAbilities::handle_get_post( [ 'post_id' => $post_id ] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $post_id, $result['id'] );
+		$this->assertSame( 'id', $result['resolved_via'] );
+	}
+
+	/**
+	 * New 'id' key works as canonical alias.
+	 */
+	public function test_handle_get_post_new_id_key_works() {
+		$post_id = $this->factory->post->create( [
+			'post_title'  => 'New id key post',
+			'post_status' => 'publish',
+		] );
+
+		$result = PostAbilities::handle_get_post( [ 'id' => $post_id ] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( $post_id, $result['id'] );
+		$this->assertSame( 'id', $result['resolved_via'] );
 	}
 
 	// ─── handle_create_post ───────────────────────────────────────


### PR DESCRIPTION
## Summary

Extends `sd-ai-agent/get-post` with two new mutually-exclusive input forms, cutting one round trip per agent action for URL/slug-based lookups.

### New input forms

```json
// Form A (existing — now also accepts 'id' as canonical key, 'post_id' deprecated)
{ "id": 156 }

// Form B (new) — URL
{ "url": "https://example.com/about/" }

// Form C (new) — slug + post_type
{ "slug": "about", "post_type": "page" }
```

Exactly one of `id` / `url` / `slug` must be provided. Sending multiple → `too_many_inputs`. Sending none → `missing_input`.

### New output field

`resolved_via: "id" | "url_to_postid" | "slug_lookup"` is added to every successful response.

### Internals

- `UrlResolverAbilities::resolve_to_post_id(array $input, string &$matched_via)` — new public static helper extracted from `handle_resolve_url`. Handles both URL and slug+post_type forms. `handle_resolve_url` delegates to it (fully backward-compatible).
- `PostAbilities::handle_get_post` — XOR guard, then delegates URL/slug resolution to the shared helper, then fetches post as before.
- Test coverage: 7 new test cases for all AC items + updated error-code assertions.

### Pre-existing full-suite failure (not caused by this PR)

`ThirdPartyAbilityNoticeHandlerTest::test_namespace_decision_overrides_heuristic` fails due to test-ordering side effects unrelated to this PR (passes in isolation on `main` — verified with `git stash && npm run test:php -- --filter ThirdPartyAbilityNoticeHandlerTest`).

## Worker self-verification

- PHPUnit: PostAbilitiesTest 54/54 pass; UrlResolverAbilitiesTest 15/15 pass; full suite Tests: 3117, Assertions: 8906, Errors: 0 (from this PR), Failures: 0 (from this PR), Skipped: 105
- Lint:    PHP clean (phpcbf auto-fixed alignment), JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Resolves #1784
For #1780

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with claude-sonnet-4-6 spent 20m and 40,310 tokens on this as a headless worker.
