### PR TITLE
GH#1790: feat(abilities): add missing type entries to ability schemas (t272)

### DIFF
--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -661,6 +661,7 @@ class BlockAbilities {
 							'description' => 'For replace-block, insert-child: the full block definition (blockName, attrs, innerHTML, innerBlocks).',
 						],
 						'position'           => [
+							'type'        => [ 'integer', 'string' ],
 							'description' => 'For insert-child: 0-based index to insert at (default: end). For move: "before" or "after" the destination block (default: "after").',
 						],
 						'destination'        => [
@@ -915,6 +916,7 @@ class BlockAbilities {
 							'description' => 'Post ID to insert the pattern into.',
 						],
 						'pattern'              => [
+							'type'        => [ 'string', 'integer' ],
 							'description' => 'Pattern identifier: registered pattern slug (e.g. "core/quote"), numeric synced pattern ID (42), or prefixed form ("wp-block:42", "synced:42").',
 						],
 						'anchor'               => [

--- a/includes/Abilities/OptionsAbilities.php
+++ b/includes/Abilities/OptionsAbilities.php
@@ -173,7 +173,10 @@ class GetOptionAbility extends AbstractAbility {
 			'type'       => 'object',
 			'properties' => [
 				'option_name' => [ 'type' => 'string' ],
-				'value'       => [],
+				'value'       => [
+					'type'        => [ 'string', 'number', 'integer', 'boolean', 'array', 'object', 'null' ],
+					'description' => 'The option value. Type varies by option.',
+				],
 				'exists'      => [ 'type' => 'boolean' ],
 			],
 		];

--- a/includes/Abilities/WordPressAbilities.php
+++ b/includes/Abilities/WordPressAbilities.php
@@ -1019,7 +1019,10 @@ class RunPhpAbility extends AbstractAbility {
 		return [
 			'type'       => 'object',
 			'properties' => [
-				'result' => [],
+				'result' => [
+					'type'        => [ 'string', 'number', 'integer', 'boolean', 'array', 'object', 'null' ],
+					'description' => 'The function return value. Type varies by function.',
+				],
 				'output' => [ 'type' => 'string' ],
 			],
 		];

--- a/tests/SdAiAgent/Bootstrap/AbilitySchemaIntegrityTest.php
+++ b/tests/SdAiAgent/Bootstrap/AbilitySchemaIntegrityTest.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * Regression guard: every sd-ai-agent/* ability schema property must have a 'type'.
+ *
+ * WP core's rest_validate_value_from_schema() reads $args['type'] on every
+ * schema node. A missing 'type' emits "Undefined array key 'type'" notices
+ * that pollute logs and fail strict deprecation gates. This test walks every
+ * registered sd-ai-agent/* ability's input_schema and output_schema and
+ * asserts that every nested property definition includes a 'type' entry.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ * @see https://github.com/Ultimate-Multisite/superdav-ai-agent/issues/1790
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Bootstrap;
+
+use SdAiAgent\Abilities\AiImageAbilities;
+use SdAiAgent\Abilities\BlockAbilities;
+use SdAiAgent\Abilities\ContentAbilities;
+use SdAiAgent\Abilities\CustomPostTypeAbilities;
+use SdAiAgent\Abilities\CustomTaxonomyAbilities;
+use SdAiAgent\Abilities\DatabaseAbilities;
+use SdAiAgent\Abilities\DesignSystemAbilities;
+use SdAiAgent\Abilities\EditorialAbilities;
+use SdAiAgent\Abilities\FeedbackAbilities;
+use SdAiAgent\Abilities\FileAbilities;
+use SdAiAgent\Abilities\GitAbilities;
+use SdAiAgent\Abilities\GlobalStylesAbilities;
+use SdAiAgent\Abilities\GoogleAnalyticsAbilities;
+use SdAiAgent\Abilities\GscAbilities;
+use SdAiAgent\Abilities\ImageAbilities;
+use SdAiAgent\Abilities\InternetSearchAbilities;
+use SdAiAgent\Abilities\KnowledgeAbilities;
+use SdAiAgent\Abilities\MarketingAbilities;
+use SdAiAgent\Abilities\MediaAbilities;
+use SdAiAgent\Abilities\MemoryAbilities;
+use SdAiAgent\Abilities\MenuAbilities;
+use SdAiAgent\Abilities\NavigationAbilities;
+use SdAiAgent\Abilities\OptionsAbilities;
+use SdAiAgent\Abilities\PostAbilities;
+use SdAiAgent\Abilities\SeoAbilities;
+use SdAiAgent\Abilities\SiteHealthAbilities;
+use SdAiAgent\Abilities\SkillAbilities;
+use SdAiAgent\Abilities\TaxonomyAbilities;
+use SdAiAgent\Abilities\UploadMediaAbility;
+use SdAiAgent\Abilities\UrlResolverAbilities;
+use SdAiAgent\Abilities\UserAbilities;
+use SdAiAgent\Abilities\WordPressAbilities;
+use SdAiAgent\Abilities\WpRestAbilities;
+use SdAiAgent\Tools\ToolDiscovery;
+use WP_UnitTestCase;
+
+/**
+ * Assert every nested property in every sd-ai-agent/* ability schema has 'type'.
+ */
+class AbilitySchemaIntegrityTest extends WP_UnitTestCase {
+
+	/**
+	 * Skip when WP 7.0+ Abilities API is unavailable.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		if ( ! function_exists( 'wp_register_ability' ) || ! function_exists( 'wp_get_abilities' ) || ! function_exists( 'wp_get_ability' ) ) {
+			$this->markTestSkipped( 'WP 7.0+ Abilities API (wp_register_ability / wp_get_ability / wp_get_abilities) not available.' );
+		}
+	}
+
+	/**
+	 * Every property in every sd-ai-agent/* ability's input_schema and
+	 * output_schema must declare a 'type' key.
+	 *
+	 * Procedure:
+	 * 1. Register all sd-ai-agent/* ability groups if not already registered.
+	 * 2. Walk every registered ability's input_schema and output_schema.
+	 * 3. Recursively assert every property definition includes 'type'.
+	 */
+	public function test_every_ability_schema_property_has_type(): void {
+		$this->ensure_abilities_registered();
+
+		$violations    = array();
+		$checked_count = 0;
+
+		/** @var \WP_Ability $ability */
+		foreach ( wp_get_abilities() as $ability ) {
+			$name = $ability->get_name();
+
+			if ( ! str_starts_with( $name, 'sd-ai-agent/' ) ) {
+				continue;
+			}
+
+			++$checked_count;
+
+			foreach ( array( 'input_schema', 'output_schema' ) as $kind ) {
+				$method = 'input_schema' === $kind ? 'get_input_schema' : 'get_output_schema';
+				$schema = $ability->$method();
+
+				if ( empty( $schema ) ) {
+					continue;
+				}
+
+				$missing = $this->find_properties_missing_type( $schema, "{$name}.{$kind}" );
+				if ( ! empty( $missing ) ) {
+					$violations = array_merge( $violations, $missing );
+				}
+			}
+		}
+
+		$this->assertGreaterThan( 0, $checked_count, 'Expected at least one sd-ai-agent/* ability to be registered.' );
+
+		$this->assertSame(
+			array(),
+			$violations,
+			sprintf(
+				"Found %d schema propert%s missing 'type':\n  - %s",
+				count( $violations ),
+				1 === count( $violations ) ? 'y' : 'ies',
+				implode( "\n  - ", $violations )
+			)
+		);
+	}
+
+	/**
+	 * Recursively walk a schema and return paths of properties missing 'type'.
+	 *
+	 * @param mixed  $schema Schema node (array, stdClass, or scalar).
+	 * @param string $path   Dot-path for error messages (e.g. "sd-ai-agent/edit-block-tree.input_schema.properties.position").
+	 * @return string[] List of dot-paths where 'type' is missing.
+	 */
+	private function find_properties_missing_type( mixed $schema, string $path ): array {
+		$missing = array();
+
+		if ( ! is_array( $schema ) ) {
+			return $missing;
+		}
+
+		// Walk properties — each child must have 'type'.
+		if ( isset( $schema['properties'] ) && is_array( $schema['properties'] ) && ! empty( $schema['properties'] ) ) {
+			foreach ( $schema['properties'] as $prop_name => $prop_def ) {
+				$prop_path = "{$path}.properties.{$prop_name}";
+
+				if ( ! is_array( $prop_def ) ) {
+					// Scalar or stdClass — skip (non-standard but harmless).
+					continue;
+				}
+
+				if ( empty( $prop_def ) ) {
+					// Empty array means no type defined.
+					$missing[] = $prop_path;
+					continue;
+				}
+
+				if ( ! array_key_exists( 'type', $prop_def ) ) {
+					$missing[] = $prop_path;
+				}
+
+				// Recurse into nested properties and items.
+				$nested = $this->find_properties_missing_type( $prop_def, $prop_path );
+				$missing = array_merge( $missing, $nested );
+			}
+		}
+
+		// Recurse into items (for array schemas).
+		if ( isset( $schema['items'] ) && is_array( $schema['items'] ) && ! empty( $schema['items'] ) ) {
+			$nested = $this->find_properties_missing_type( $schema['items'], "{$path}.items" );
+			$missing = array_merge( $missing, $nested );
+		}
+
+		// Recurse into combiners (anyOf, oneOf, allOf).
+		foreach ( array( 'anyOf', 'oneOf', 'allOf' ) as $combiner ) {
+			if ( isset( $schema[ $combiner ] ) && is_array( $schema[ $combiner ] ) ) {
+				foreach ( $schema[ $combiner ] as $idx => $sub ) {
+					$nested = $this->find_properties_missing_type( $sub, "{$path}.{$combiner}[{$idx}]" );
+					$missing = array_merge( $missing, $nested );
+				}
+			}
+		}
+
+		return $missing;
+	}
+
+	/**
+	 * Register all sd-ai-agent/* ability groups if not already registered.
+	 *
+	 * Uses the same inline registration pattern as SdAiAgentPublicFlagTest
+	 * to avoid depending on the DI container bootstrap ordering.
+	 */
+	private function ensure_abilities_registered(): void {
+		// If abilities are already registered (full-suite run), skip.
+		if ( null !== wp_get_ability( 'sd-ai-agent/memory-save' ) ) {
+			return;
+		}
+
+		// Push the hook onto $wp_current_filter so wp_register_ability()
+		// accepts calls outside the normal hook callback context.
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Standard WordPress test global.
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_init';
+
+		MemoryAbilities::register_abilities();
+		SkillAbilities::register_abilities();
+		KnowledgeAbilities::register_abilities();
+		PostAbilities::register_abilities();
+		BlockAbilities::register_abilities();
+		ContentAbilities::register_abilities();
+		FileAbilities::register_abilities();
+		MediaAbilities::register_abilities();
+		UserAbilities::register_abilities();
+		OptionsAbilities::register_abilities();
+		MenuAbilities::register_abilities();
+		SiteHealthAbilities::register_abilities();
+		EditorialAbilities::register_abilities();
+		SeoAbilities::register_abilities();
+		MarketingAbilities::register_abilities();
+		FeedbackAbilities::register_abilities();
+		NavigationAbilities::register_abilities();
+		CustomPostTypeAbilities::register_abilities();
+		CustomTaxonomyAbilities::register_abilities();
+		DatabaseAbilities::register_abilities();
+		DesignSystemAbilities::register_abilities();
+		GlobalStylesAbilities::register_abilities();
+		GoogleAnalyticsAbilities::register_abilities();
+		GscAbilities::register_abilities();
+		InternetSearchAbilities::register_abilities();
+		ImageAbilities::register_abilities();
+		WordPressAbilities::register_abilities();
+		GitAbilities::register_abilities();
+		TaxonomyAbilities::register_abilities();
+		UploadMediaAbility::register_abilities();
+		UrlResolverAbilities::register_abilities();
+		WpRestAbilities::register_abilities();
+
+		// Meta-tools.
+		ToolDiscovery::register_abilities();
+
+		// Also register image abilities via their static register() methods.
+		if ( class_exists( \SdAiAgent\Abilities\ImageAbilities\StockImageAbility::class ) ) {
+			\SdAiAgent\Abilities\ImageAbilities\StockImageAbility::register();
+		}
+		if ( class_exists( AiImageAbilities::class ) ) {
+			AiImageAbilities::register_abilities();
+		}
+
+		array_pop( $wp_current_filter );
+	}
+}

--- a/tools/audit/schema-type-audit.php
+++ b/tools/audit/schema-type-audit.php
@@ -1,0 +1,235 @@
+<?php
+/**
+ * Audit ability schema properties for missing 'type' entries.
+ *
+ * Tokenizes PHP files under includes/Abilities/ and includes/REST/,
+ * locates 'properties' => [] or array() blocks, and reports any
+ * child property that is missing a 'type' key.
+ *
+ * Handles both [] and array() syntax.
+ *
+ * Usage: php tools/audit/schema-type-audit.php [plugin-root]
+ *
+ * @package SdAiAgent
+ * @license GPL-2.0-or-later
+ * @see https://github.com/Ultimate-Multisite/superdav-ai-agent/issues/1790
+ */
+
+// phpcs:disable WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
+// phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited
+
+declare(strict_types=1);
+
+$base = $argv[1] ?? '.';
+chdir( $base );
+
+/**
+ * Find schema properties missing 'type' in a PHP file.
+ *
+ * @param string $file Path to the PHP file to scan.
+ * @return array<int, array{file: string, propLine: int, childName: string, childLine: int}>
+ */
+function find_missing_types( string $file ): array {
+	$tokens   = token_get_all( file_get_contents( $file ) );
+	$findings = [];
+	$count    = count( $tokens );
+
+	for ( $i = 0; $i < $count; $i++ ) {
+		if ( ! is_array( $tokens[ $i ] ) ) {
+			continue;
+		}
+		if ( $tokens[ $i ][0] !== T_CONSTANT_ENCAPSED_STRING ) {
+			continue;
+		}
+
+		$val = trim( $tokens[ $i ][1], "'\"" );
+		if ( 'properties' !== $val ) {
+			continue;
+		}
+
+		$prop_line = $tokens[ $i ][2];
+
+		// Find => after 'properties'.
+		$j = $i + 1;
+		while ( $j < $count && is_array( $tokens[ $j ] ) && in_array( $tokens[ $j ][0], [ T_WHITESPACE, T_COMMENT, T_DOC_COMMENT ], true ) ) {
+			++$j;
+		}
+		if ( $j >= $count || ! is_array( $tokens[ $j ] ) || $tokens[ $j ][0] !== T_DOUBLE_ARROW ) {
+			continue;
+		}
+		++$j;
+
+		// Skip whitespace.
+		while ( $j < $count && is_array( $tokens[ $j ] ) && $tokens[ $j ][0] === T_WHITESPACE ) {
+			++$j;
+		}
+		if ( $j >= $count ) {
+			continue;
+		}
+
+		// Check for (object) cast before [].
+		$has_object_cast = false;
+		if ( is_array( $tokens[ $j ] ) && $tokens[ $j ][0] === T_OBJECT_CAST ) {
+			$has_object_cast = true;
+			++$j;
+			while ( $j < $count && is_array( $tokens[ $j ] ) && $tokens[ $j ][0] === T_WHITESPACE ) {
+				++$j;
+			}
+		}
+
+		// Determine opener type: [ or array(.
+		$is_short_array = ! is_array( $tokens[ $j ] ) && '[' === $tokens[ $j ];
+		$is_long_array  = is_array( $tokens[ $j ] ) && $tokens[ $j ][0] === T_ARRAY;
+
+		if ( $is_long_array ) {
+			// Skip to (.
+			++$j;
+			while ( $j < $count && is_array( $tokens[ $j ] ) && $tokens[ $j ][0] === T_WHITESPACE ) {
+				++$j;
+			}
+			if ( $j >= $count || '(' !== $tokens[ $j ] ) {
+				continue;
+			}
+		} elseif ( ! $is_short_array ) {
+			continue;
+		}
+
+		// $j now points to the opening [ or (.
+		$depth              = 0;
+		$current_child_name = null;
+		$current_child_line = 0;
+		$child_has_type     = false;
+		$children           = [];
+
+		$k = $j;
+		while ( $k < $count ) {
+			$tok     = $tokens[ $k ];
+			$tok_str = is_array( $tok ) ? $tok[1] : $tok;
+
+			// Track depth.
+			if ( '[' === $tok_str || '(' === $tok_str ) {
+				++$depth;
+			}
+			if ( ']' === $tok_str || ')' === $tok_str ) {
+				--$depth;
+				if ( 0 === $depth ) {
+					if ( null !== $current_child_name ) {
+						$children[ $current_child_name ] = [
+							'line'    => $current_child_line,
+							'hasType' => $child_has_type,
+						];
+					}
+					break;
+				}
+			}
+
+			// At depth 1: property key names.
+			if ( 1 === $depth && is_array( $tok ) && $tok[0] === T_CONSTANT_ENCAPSED_STRING ) {
+				$child_key = trim( $tok[1], "'\"" );
+				$peek      = $k + 1;
+				while ( $peek < $count && is_array( $tokens[ $peek ] ) && $tokens[ $peek ][0] === T_WHITESPACE ) {
+					++$peek;
+				}
+				if ( $peek < $count && is_array( $tokens[ $peek ] ) && $tokens[ $peek ][0] === T_DOUBLE_ARROW ) {
+					if ( null !== $current_child_name ) {
+						$children[ $current_child_name ] = [
+							'line'    => $current_child_line,
+							'hasType' => $child_has_type,
+						];
+					}
+					$current_child_name = $child_key;
+					$current_child_line = $tok[2];
+					$child_has_type     = false;
+				}
+			}
+
+			// At depth 2: check for 'type' key inside a child property.
+			if ( 2 === $depth && null !== $current_child_name && is_array( $tok ) && $tok[0] === T_CONSTANT_ENCAPSED_STRING ) {
+				$key_val = trim( $tok[1], "'\"" );
+				if ( 'type' === $key_val ) {
+					$peek = $k + 1;
+					while ( $peek < $count && is_array( $tokens[ $peek ] ) && $tokens[ $peek ][0] === T_WHITESPACE ) {
+						++$peek;
+					}
+					if ( $peek < $count && is_array( $tokens[ $peek ] ) && $tokens[ $peek ][0] === T_DOUBLE_ARROW ) {
+						$child_has_type = true;
+					}
+				}
+			}
+
+			++$k;
+		}
+
+		// Skip empty or (object) [] blocks.
+		if ( $has_object_cast && empty( $children ) ) {
+			continue;
+		}
+		if ( empty( $children ) ) {
+			continue;
+		}
+
+		foreach ( $children as $name => $info ) {
+			if ( ! $info['hasType'] ) {
+				$findings[] = [
+					'file'      => $file,
+					'propLine'  => $prop_line,
+					'childName' => $name,
+					'childLine' => $info['line'],
+				];
+			}
+		}
+	}
+
+	return $findings;
+}
+
+$dirs         = [ 'includes/Abilities', 'includes/REST' ];
+$all_findings = [];
+
+foreach ( $dirs as $dir ) {
+	if ( ! is_dir( $dir ) ) {
+		continue;
+	}
+	$iterator = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $dir ) );
+	foreach ( $iterator as $file_info ) {
+		if ( 'php' !== $file_info->getExtension() ) {
+			continue;
+		}
+		$path     = $file_info->getPathname();
+		$findings = find_missing_types( $path );
+		foreach ( $findings as $f ) {
+			$all_findings[] = $f;
+		}
+	}
+}
+
+echo "=== Schema Audit: Properties Missing 'type' ===\n\n";
+echo 'Found ' . count( $all_findings ) . " properties missing 'type':\n\n";
+
+if ( empty( $all_findings ) ) {
+	exit( 0 );
+}
+
+// Group by file.
+$by_file = [];
+foreach ( $all_findings as $f ) {
+	$rel               = str_replace( './', '', $f['file'] );
+	$by_file[ $rel ][] = $f;
+}
+
+ksort( $by_file );
+foreach ( $by_file as $file => $findings ) {
+	echo "--- {$file} ---\n";
+	foreach ( $findings as $f ) {
+		printf(
+			"  Line %-4d: '%s' (in 'properties' block at line %d)\n",
+			$f['childLine'],
+			$f['childName'],
+			$f['propLine']
+		);
+	}
+	echo "\n";
+}
+
+exit( 1 );


### PR DESCRIPTION
## Summary

Audit and fix 4 schema properties missing the required type key across 3 ability files. Added type entries to position (edit-block-tree), pattern (insert-pattern), value (get-option output), and result (run-php output). Added regression test (AbilitySchemaIntegrityTest) and audit script (tools/audit/schema-type-audit.php).

## Files Changed

includes/Abilities/BlockAbilities.php,includes/Abilities/OptionsAbilities.php,includes/Abilities/WordPressAbilities.php,tests/SdAiAgent/Bootstrap/AbilitySchemaIntegrityTest.php,tools/audit/schema-type-audit.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify: lint PHP/JS/CSS clean, PHPStan 0 errors (260 files), PHPUnit 3111 tests (8 errors and 2 failures are pre-existing on main in unchanged files), build succeeded. New AbilitySchemaIntegrityTest passes. Audit script reports zero findings.

Resolves #1790


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with claude-opus-4-6 spent 22m and 36,290 tokens on this as a headless worker.