### PR TITLE
feat(revision-guard): revision_id null for revisionless posts (t273)

### DIFF
--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -517,8 +517,8 @@ class BlockAbilities {
 							'description' => 'True when new refs were persisted to the post.',
 						],
 						'revision_id' => [
-							'type'        => 'integer',
-							'description' => 'Current latest revision ID for the post. Pass this as expected_revision (or If-Match header) on follow-up write calls to enable optimistic concurrency control.',
+							'type'        => [ 'integer', 'null' ],
+							'description' => 'Current latest revision ID for the post. null when the post has no revisions yet (freshly created). Pass this as expected_revision (or If-Match header) on follow-up write calls to enable optimistic concurrency control.',
 						],
 						'summary'     => [
 							'type'        => 'object',
@@ -783,8 +783,8 @@ class BlockAbilities {
 							],
 						],
 						'expected_revision' => [
-							'type'        => 'integer',
-							'description' => 'Expected revision ID for optimistic concurrency. Pass the revision_id from get-page-blocks to prevent writes against a stale post.',
+							'type'        => [ 'integer', 'null' ],
+							'description' => 'Expected revision ID for optimistic concurrency. Pass the revision_id from get-page-blocks to prevent writes against a stale post. Pass null (or omit) to skip the check.',
 						],
 						'dry_run'           => [
 							'type'        => 'boolean',
@@ -806,8 +806,8 @@ class BlockAbilities {
 							'description' => 'Number of updates applied.',
 						],
 						'revision_id' => [
-							'type'        => 'integer',
-							'description' => 'Post revision ID after the write (or current if dry_run).',
+							'type'        => [ 'integer', 'null' ],
+							'description' => 'Post revision ID after the write (or current if dry_run). null when the post has no revisions yet.',
 						],
 						'block_tree'  => [
 							'type'        => 'array',
@@ -853,8 +853,8 @@ class BlockAbilities {
 							],
 						],
 						'expected_revision_id' => [
-							'type'        => 'integer',
-							'description' => 'Expected revision ID for optimistic concurrency control. Pass the revision_id from get-page-blocks to prevent writes against a stale post.',
+							'type'        => [ 'integer', 'null' ],
+							'description' => 'Expected revision ID for optimistic concurrency control. Pass the revision_id from get-page-blocks to prevent writes against a stale post. Pass null (or omit) to skip the check.',
 						],
 						'allow_bound_writes'   => [
 							'type'        => 'boolean',
@@ -872,8 +872,8 @@ class BlockAbilities {
 						],
 						'post_id'     => [ 'type' => 'integer' ],
 						'revision_id' => [
-							'type'        => 'integer',
-							'description' => 'Post revision ID after the write.',
+							'type'        => [ 'integer', 'null' ],
+							'description' => 'Post revision ID after the write. null when the post has no revisions yet.',
 						],
 						'block_count' => [
 							'type'        => 'integer',
@@ -933,8 +933,8 @@ class BlockAbilities {
 							'description' => 'Stable sd_ref UUID of the target block. Required when anchor is after_ref, before_ref, or first_child_of_ref.',
 						],
 						'expected_revision_id' => [
-							'type'        => 'integer',
-							'description' => 'Expected revision ID for optimistic concurrency control. Pass the revision_id from get-page-blocks.',
+							'type'        => [ 'integer', 'null' ],
+							'description' => 'Expected revision ID for optimistic concurrency control. Pass the revision_id from get-page-blocks. Pass null (or omit) to skip the check.',
 						],
 						'dry_run'              => [
 							'type'        => 'boolean',
@@ -962,8 +962,8 @@ class BlockAbilities {
 							'description' => 'Number of top-level blocks inserted.',
 						],
 						'revision_id'     => [
-							'type'        => 'integer',
-							'description' => 'Current revision ID after the write.',
+							'type'        => [ 'integer', 'null' ],
+							'description' => 'Current revision ID after the write. null when the post has no revisions yet.',
 						],
 						'block_tree'      => [
 							'type'        => 'array',
@@ -1005,8 +1005,8 @@ class BlockAbilities {
 							'description' => 'Revision ID to restore. Must belong to post_id.',
 						],
 						'expected_current_revision_id' => [
-							'type'        => 'integer',
-							'description' => 'Optional optimistic concurrency guard. Pass the revision_id from get-page-blocks to ensure no intervening edits have occurred. If the current revision does not match, the call is rejected with revision_stale.',
+							'type'        => [ 'integer', 'null' ],
+							'description' => 'Optional optimistic concurrency guard. Pass the revision_id from get-page-blocks to ensure no intervening edits have occurred. If the current revision does not match, the call is rejected with revision_stale. Pass null (or omit) to skip the check.',
 						],
 					],
 					'required'   => [ 'post_id', 'revision_id' ],
@@ -1084,8 +1084,8 @@ class BlockAbilities {
 							],
 						],
 						'expected_revision_id' => [
-							'type'        => 'integer',
-							'description' => 'Expected revision ID for optimistic concurrency. Pass the revision_id from get-page-blocks.',
+							'type'        => [ 'integer', 'null' ],
+							'description' => 'Expected revision ID for optimistic concurrency. Pass the revision_id from get-page-blocks. Pass null (or omit) to skip the check.',
 						],
 						'allow_bound_writes'   => [
 							'type'        => 'boolean',
@@ -1103,8 +1103,8 @@ class BlockAbilities {
 					'properties' => [
 						'post_id'        => [ 'type' => 'integer' ],
 						'revision_id'    => [
-							'type'        => 'integer',
-							'description' => 'Revision ID after the write (or current if dry_run).',
+							'type'        => [ 'integer', 'null' ],
+							'description' => 'Revision ID after the write (or current if dry_run). null when the post has no revisions yet.',
 						],
 						'refs_added'     => [
 							'type'        => 'integer',

--- a/includes/Abilities/PostAbilities.php
+++ b/includes/Abilities/PostAbilities.php
@@ -246,8 +246,8 @@ class PostAbilities {
 						'status'      => [ 'type' => 'string' ],
 						'post_type'   => [ 'type' => 'string' ],
 						'revision_id' => [
-							'type'        => 'integer',
-							'description' => 'Latest revision ID after the write. Use as expected_revision for the next write.',
+							'type'        => [ 'integer', 'null' ],
+							'description' => 'Latest revision ID after the write. null when the post has no revisions yet. Use as expected_revision for the next write.',
 						],
 					],
 				],
@@ -302,8 +302,8 @@ class PostAbilities {
 						'appended_bytes' => [ 'type' => 'integer' ],
 						'total_bytes'    => [ 'type' => 'integer' ],
 						'revision_id'    => [
-							'type'        => 'integer',
-							'description' => 'Latest revision ID after the write. Use as expected_revision for the next write.',
+							'type'        => [ 'integer', 'null' ],
+							'description' => 'Latest revision ID after the write. null when the post has no revisions yet. Use as expected_revision for the next write.',
 						],
 					],
 				],

--- a/includes/Core/RevisionGuard.php
+++ b/includes/Core/RevisionGuard.php
@@ -52,12 +52,17 @@ class RevisionGuard {
 	 * Return the latest revision post-ID for a post.
 	 *
 	 * Uses `wp_get_post_revisions()` ordered DESC, limit 1.
-	 * Returns 0 when the post has no revisions yet (e.g. auto-draft).
+	 * Returns null when the post has no revisions yet (e.g. freshly-inserted
+	 * post with no prior edits). Callers that propagate this value into a
+	 * response should use `[ 'integer', 'null' ]` as the JSON schema type.
+	 * Callers that consume it as a precondition (expected_revision_id /
+	 * expected_current_revision_id) should treat null as "no precondition".
 	 *
 	 * @param int $post_id Post being inspected.
-	 * @return int Revision post ID, or 0 when no revisions exist.
+	 * @return int|null Revision post ID, or null when no revisions exist.
+	 * @see https://github.com/Ultimate-Multisite/superdav-ai-agent/issues/1786
 	 */
-	public static function current_revision_id( int $post_id ): int {
+	public static function current_revision_id( int $post_id ): ?int {
 		$revisions = wp_get_post_revisions(
 			$post_id,
 			[
@@ -74,7 +79,7 @@ class RevisionGuard {
 			return (int) key( $revisions );
 		}
 
-		return 0;
+		return null;
 	}
 
 	/**

--- a/tests/SdAiAgent/Abilities/BlockAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/BlockAbilitiesTest.php
@@ -1056,4 +1056,81 @@ class BlockAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 1, $result['refs_preserved'], 'refs_preserved should be 1 (aftergroup paragraph)' );
 		$this->assertSame( 2, $result['block_count'],    'block_count should be 2 (replacement + aftergroup)' );
 	}
+
+	// ─── Revisionless-post (GH#1786) ──────────────────────────────
+
+	/**
+	 * AC1: get-page-blocks on a freshly-inserted post returns revision_id: null.
+	 *
+	 * @see https://github.com/Ultimate-Multisite/superdav-ai-agent/issues/1786
+	 */
+	public function test_get_page_blocks_revision_id_null_for_fresh_post(): void {
+		$post_id = $this->factory->post->create( [
+			'post_content' => '<!-- wp:paragraph --><p>fresh content</p><!-- /wp:paragraph -->',
+			'post_status'  => 'publish',
+		] );
+
+		// Delete any auto-generated revisions to ensure a clean revisionless state.
+		foreach ( wp_get_post_revisions( $post_id ) as $rev ) {
+			wp_delete_post_revision( $rev->ID );
+		}
+
+		$result = BlockAbilities::handle_get_page_blocks( [ 'post_id' => $post_id ] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'revision_id', $result );
+		$this->assertNull( $result['revision_id'], 'revision_id must be null when the post has no revisions' );
+	}
+
+	/**
+	 * AC2: update-blocks with expected_revision: null on a revisionless post succeeds.
+	 * AC3: After the write, get-page-blocks returns an integer revision_id.
+	 *
+	 * @see https://github.com/Ultimate-Multisite/superdav-ai-agent/issues/1786
+	 */
+	public function test_update_blocks_null_expected_revision_on_fresh_post_succeeds(): void {
+		$post_id = $this->factory->post->create( [
+			'post_content' => '<!-- wp:paragraph --><p>original</p><!-- /wp:paragraph -->',
+			'post_status'  => 'publish',
+		] );
+
+		// Strip revisions so we start revisionless.
+		foreach ( wp_get_post_revisions( $post_id ) as $rev ) {
+			wp_delete_post_revision( $rev->ID );
+		}
+
+		// Persist refs first so update-blocks can resolve them.
+		$get = BlockAbilities::handle_get_page_blocks( [
+			'post_id'      => $post_id,
+			'persist_refs' => true,
+		] );
+		$this->assertIsArray( $get );
+		$this->assertNull( $get['revision_id'], 'pre-condition: revisionless post returns null revision_id' );
+
+		// Obtain the ref of the first block for the update-html op.
+		$this->assertNotEmpty( $get['blocks'], 'post must have at least one block' );
+		$first_ref = $get['blocks'][0]['ref'] ?? null;
+		$this->assertNotEmpty( $first_ref, 'first block must have a ref after persist_refs' );
+
+		// update-blocks with expected_revision omitted (i.e. null) — must succeed.
+		$result = BlockAbilities::handle_update_blocks( [
+			'post_id' => $post_id,
+			'updates' => [
+				[
+					'op'        => 'update-html',
+					'ref'       => $first_ref,
+					'innerHTML' => '<p>updated original</p>',
+				],
+			],
+		] );
+
+		$this->assertIsArray( $result, 'update-blocks with null expected_revision must not return WP_Error on a fresh post' );
+		$this->assertTrue( $result['success'] ?? false );
+
+		// After the write a real revision exists → revision_id must be a positive int.
+		$get_after = BlockAbilities::handle_get_page_blocks( [ 'post_id' => $post_id ] );
+		$this->assertIsArray( $get_after );
+		$this->assertIsInt( $get_after['revision_id'], 'After a write, revision_id must be an integer' );
+		$this->assertGreaterThan( 0, $get_after['revision_id'] );
+	}
 }

--- a/tests/SdAiAgent/Abilities/RevertToRevisionTest.php
+++ b/tests/SdAiAgent/Abilities/RevertToRevisionTest.php
@@ -443,6 +443,57 @@ class RevertToRevisionTest extends WP_UnitTestCase {
 		);
 	}
 
+	// ── GH#1786: null expected_current_revision_id ────────────────────────
+
+	/**
+	 * AC4 (GH#1786): expected_current_revision_id: null skips the precondition
+	 * and allows the revert to proceed.
+	 *
+	 * @see https://github.com/Ultimate-Multisite/superdav-ai-agent/issues/1786
+	 */
+	public function test_null_expected_current_revision_id_skips_precondition(): void {
+		$post_id = $this->create_post_with_content( 'Null precondition original' );
+		$this->update_post_content( $post_id, 'Null precondition state A' );
+		$this->update_post_content( $post_id, 'Null precondition state B' );
+
+		$revisions  = wp_get_post_revisions( $post_id, [ 'orderby' => 'ID', 'order' => 'ASC' ] );
+		$target_rev = reset( $revisions );
+
+		// Explicitly passing null must not trigger stale_revision.
+		$result = BlockAbilities::handle_revert_to_revision( [
+			'post_id'                      => $post_id,
+			'revision_id'                  => $target_rev->ID,
+			'expected_current_revision_id' => null,
+		] );
+
+		$this->assertIsArray( $result, 'Null expected_current_revision_id must allow the revert (no WP_Error)' );
+		$this->assertArrayHasKey( 'new_revision_id', $result );
+	}
+
+	/**
+	 * AC5 (GH#1786): expected_current_revision_id: 0 must produce revision_stale
+	 * because 0 is a concrete value that should not match any real revision ID.
+	 *
+	 * @see https://github.com/Ultimate-Multisite/superdav-ai-agent/issues/1786
+	 */
+	public function test_zero_expected_current_revision_id_produces_stale_revision(): void {
+		$post_id = $this->create_post_with_content( 'Zero precondition original' );
+		$this->update_post_content( $post_id, 'Zero precondition state A' );
+
+		$revisions  = wp_get_post_revisions( $post_id, [ 'orderby' => 'ID', 'order' => 'ASC' ] );
+		$target_rev = reset( $revisions );
+
+		// 0 is never a real revision ID; current revision is a positive integer → mismatch.
+		$result = BlockAbilities::handle_revert_to_revision( [
+			'post_id'                      => $post_id,
+			'revision_id'                  => $target_rev->ID,
+			'expected_current_revision_id' => 0,
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result, 'expected_current_revision_id: 0 must return revision_stale' );
+		$this->assertSame( 'revision_stale', $result->get_error_code() );
+	}
+
 	// ── BlockMutator::revert_to_revision direct test ──────────────────────
 
 	/**

--- a/tests/SdAiAgent/Core/RevisionGuardTest.php
+++ b/tests/SdAiAgent/Core/RevisionGuardTest.php
@@ -10,8 +10,8 @@
  *  AC5: Weak ETag form W/"123" parses correctly.
  *  AC6: Malformed If-Match returns 400 invalid_if_match.
  *  AC7: parse_if_match() reads both If-Match header and expected_revision body.
- *  AC8: current_revision_id() returns 0 for a post with no revisions and a
- *       positive int after wp_update_post() creates one.
+ *  AC8: current_revision_id() returns null for a post with no revisions and a
+ *       positive int after wp_update_post() creates one (GH#1786).
  *
  * @package SdAiAgent
  * @subpackage Tests
@@ -158,15 +158,24 @@ class RevisionGuardTest extends WP_UnitTestCase {
 	// ── current_revision_id ────────────────────────────────────────────────
 
 	/**
-	 * A freshly created post (auto-draft) with no revisions returns 0.
+	 * A freshly inserted post with no revisions returns null.
 	 *
-	 * Note: wp-env / test suite may or may not save an initial revision
-	 * depending on configuration; we verify the return type is always int.
+	 * Covers GH#1786 / AC8: revisionless posts must return null (not 0) so
+	 * the natural get-page-blocks → update-blocks chain works without
+	 * triggering a false stale_revision on the very first write.
 	 */
-	public function test_current_revision_id_returns_int(): void {
+	public function test_current_revision_id_null_for_revisionless_post(): void {
+		// wp_insert_post with a published status does not create a revision by
+		// itself; only wp_update_post (or a second save) triggers one.
 		$post_id = $this->factory->post->create();
-		$result  = RevisionGuard::current_revision_id( $post_id );
-		$this->assertIsInt( $result );
+
+		// Strip any auto-created revision so the test is environment-agnostic.
+		foreach ( wp_get_post_revisions( $post_id ) as $rev ) {
+			wp_delete_post_revision( $rev->ID );
+		}
+
+		$result = RevisionGuard::current_revision_id( $post_id );
+		$this->assertNull( $result, 'current_revision_id() must return null when no revisions exist' );
 	}
 
 	/**
@@ -177,6 +186,7 @@ class RevisionGuardTest extends WP_UnitTestCase {
 		wp_update_post( [ 'ID' => $post_id, 'post_title' => 'Updated title' ] );
 
 		$result = RevisionGuard::current_revision_id( $post_id );
+		$this->assertIsInt( $result );
 		$this->assertGreaterThan( 0, $result );
 	}
 
@@ -258,5 +268,33 @@ class RevisionGuardTest extends WP_UnitTestCase {
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'invalid_if_match', $result->get_error_code() );
 		$this->assertSame( 400, $result->get_error_data()['status'] );
+	}
+
+	// ── check() with null current revision ────────────────────────────────
+
+	/**
+	 * check() with expected=0 on a revisionless post returns stale_revision.
+	 *
+	 * Covers GH#1786 AC5: expected_current_revision_id=0 must not accidentally
+	 * match the null returned for a post with no revisions.
+	 * The error data must carry current_revision_id: null.
+	 */
+	public function test_check_stale_when_expected_is_zero_and_no_revisions(): void {
+		$post_id = $this->factory->post->create();
+
+		// Ensure no revisions exist so current_revision_id() returns null.
+		foreach ( wp_get_post_revisions( $post_id ) as $rev ) {
+			wp_delete_post_revision( $rev->ID );
+		}
+
+		$result = RevisionGuard::check( $post_id, 0 );
+
+		$this->assertInstanceOf( \WP_Error::class, $result, 'Expected 0 against a revisionless post must trigger stale_revision' );
+		$this->assertSame( 'stale_revision', $result->get_error_code() );
+
+		$data = $result->get_error_data( 'stale_revision' );
+		$this->assertIsArray( $data );
+		$this->assertSame( 412, $data['status'] );
+		$this->assertNull( $data['current_revision_id'], 'current_revision_id must be null for a revisionless post' );
 	}
 }


### PR DESCRIPTION
## Summary

Fixes the footgun where freshly-created posts (no revisions yet) returned `revision_id: 0` from `get-page-blocks`. Passing that `0` back into any write ability as `expected_revision` immediately triggered `stale_revision` (412) because `0` never matches a real revision ID, breaking the natural read → write loop on new posts.

**Fix:** Option A from the brief — `revision_id: null` when no revisions exist. `null` is already the documented "no precondition" sentinel: `expected_revision: null` (or field omitted) skips the check.

## Changes

- **`RevisionGuard::current_revision_id()`** — return type `int` → `?int`; returns `null` instead of `0` when `wp_get_post_revisions` is empty.
- **Output schemas** — all abilities that emit `revision_id` in their response (`get-page-blocks`, `update-blocks`, `rewrite-post-blocks`, `insert-pattern`, `replace-block-range`, `update-post`, `append-post-content`) now declare `'type' => ['integer', 'null']`.
- **Input schemas** — `expected_revision`, `expected_revision_id`, and `expected_current_revision_id` fields all accept `null` (no precondition).
- **`RevisionGuard::check()`** — no logic changes needed; `0 !== null` naturally produces `stale_revision` (AC5), and `null === $expected` already short-circuits to pass-through (AC4).
- PHPCS auto-fixed indentation in `BlockAbilities.php` and `PostAbilities.php`.

## Tests added

- `RevisionGuardTest::test_current_revision_id_null_for_revisionless_post` — AC8 (GH#1786)
- `RevisionGuardTest::test_check_stale_when_expected_is_zero_and_no_revisions` — AC5 (0 ≠ null → stale)
- `BlockAbilitiesTest::test_get_page_blocks_revision_id_null_for_fresh_post` — AC1
- `BlockAbilitiesTest::test_update_blocks_null_expected_revision_on_fresh_post_succeeds` — AC2 + AC3
- `RevertToRevisionTest::test_null_expected_current_revision_id_skips_precondition` — AC4
- `RevertToRevisionTest::test_zero_expected_current_revision_id_produces_stale_revision` — AC5

## Worker self-verification

- PHPUnit: Tests: 3115, Assertions: 8914, Errors: 0, Failures: 1 (pre-existing on main — `test_handle_list_block_types_legacy_block_has_replacement` has 0 assertions), Skipped: 105
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

**Pre-existing failure proof:** the same `Failures: 1, Risky: 1` result appears on the main branch before this PR's changes (confirmed by `git stash && npm run test:php`).

Resolves #1786
For #1780

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with claude-sonnet-4-6 spent 27m and 41,935 tokens on this as a headless worker.
