### PR TITLE
GH#1787: feat(get-page-blocks): add include_inner_blocks flat DFS mode (t274)

### DIFF
--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -465,40 +465,44 @@ class BlockAbilities {
 			'sd-ai-agent/get-page-blocks',
 			[
 				'label'               => __( 'Get Page Blocks', 'superdav-ai-agent' ),
-				'description'         => __( 'Return the block tree for a post with stable per-block sd_ref UUIDs. Each entry includes flat_index, path, ref, name, attributes, and a text_preview. Set persist_refs: false to read without writing refs back to the post. Use the returned refs with block-mutator abilities to address blocks reliably across multi-step edits. Optional parameters: outline (minimal response), summary_only (statistics), search (filter by text), block_name (filter by name), render (resolve dynamic blocks), fields (allowlist response fields).', 'superdav-ai-agent' ),
+				'description'         => __( 'Return the block tree for a post with stable per-block sd_ref UUIDs. Each entry includes flat_index, path, ref, name, attributes, and a text_preview. Set persist_refs: false to read without writing refs back to the post. Use the returned refs with block-mutator abilities to address blocks reliably across multi-step edits. Optional parameters: include_inner_blocks (flatten entire tree to DFS list with depth/parent_ref per entry), outline (minimal response), summary_only (statistics), search (filter by text), block_name (filter by name), render (resolve dynamic blocks), fields (allowlist response fields).', 'superdav-ai-agent' ),
 				'category'            => 'sd-ai-agent',
 				'input_schema'        => [
 					'type'       => 'object',
 					'properties' => [
-						'post_id'      => [
+						'post_id'              => [
 							'type'        => 'integer',
 							'description' => 'Post ID whose block tree should be returned.',
 						],
-						'persist_refs' => [
+						'persist_refs'         => [
 							'type'        => 'boolean',
 							'description' => 'Write newly-assigned sd_ref values back to the post without creating a revision. Default: true. Set to false for a read-only call.',
 						],
-						'outline'      => [
+						'include_inner_blocks' => [
+							'type'        => 'boolean',
+							'description' => 'When true, flatten the entire block tree into a depth-first list. Every nested block appears as its own entry with depth (0 = root) and parent_ref (null for root). The innerBlocks key is omitted from each entry. Default: false (returns nested tree shape).',
+						],
+						'outline'              => [
 							'type'        => 'boolean',
 							'description' => 'Return only flat_index, path, name, and heading_text (if applicable). Omits attributes and innerHTML. Default: false.',
 						],
-						'summary_only' => [
+						'summary_only'         => [
 							'type'        => 'boolean',
 							'description' => 'Return only block_counts (histogram), headings (list with level/text/path), section_markers, and max_depth. Skips per-block details. Default: false.',
 						],
-						'search'       => [
+						'search'               => [
 							'type'        => 'string',
 							'description' => 'Filter blocks by text_preview substring (case-insensitive). Only blocks matching the search term are returned.',
 						],
-						'block_name'   => [
+						'block_name'           => [
 							'type'        => 'string',
 							'description' => 'Filter blocks by exact block name (e.g., "core/heading"). Only matching blocks are returned.',
 						],
-						'render'       => [
+						'render'               => [
 							'type'        => 'boolean',
 							'description' => 'Resolve dynamic blocks, expand shortcodes, and follow synced patterns. Default: false (returns raw markup).',
 						],
-						'fields'       => [
+						'fields'               => [
 							'type'        => 'string',
 							'description' => 'Comma-separated allowlist of response fields (e.g., "name,ref,path"). If omitted, all fields are included.',
 						],
@@ -510,7 +514,7 @@ class BlockAbilities {
 					'properties' => [
 						'blocks'      => [
 							'type'        => 'array',
-							'description' => 'Flat list of blocks (or empty if summary_only). Each item: flat_index (int), path (int[]), ref (string), name (string), attributes (object), text_preview (string).',
+							'description' => 'Block list (or empty if summary_only). Default (nested): top-level entries only with innerBlocks nested. When include_inner_blocks: true: DFS-ordered flat list of all blocks, each with flat_index (int), path (int[]), depth (int), parent_ref (string|null), ref (string), name (string), attributes (object), text_preview (string).',
 						],
 						'block_count' => [ 'type' => 'integer' ],
 						'refs_stored' => [
@@ -2150,14 +2154,15 @@ class BlockAbilities {
 	public static function handle_get_page_blocks( array $input ) {
 		global $wpdb;
 
-		$post_id      = (int) ( $input['post_id'] ?? 0 );
-		$persist_refs = isset( $input['persist_refs'] ) ? (bool) $input['persist_refs'] : true;
-		$outline      = isset( $input['outline'] ) ? (bool) $input['outline'] : false;
-		$summary_only = isset( $input['summary_only'] ) ? (bool) $input['summary_only'] : false;
-		$search       = isset( $input['search'] ) && is_string( $input['search'] ) ? $input['search'] : '';
-		$block_name   = isset( $input['block_name'] ) && is_string( $input['block_name'] ) ? $input['block_name'] : '';
-		$render       = isset( $input['render'] ) ? (bool) $input['render'] : false;
-		$fields       = isset( $input['fields'] ) && is_string( $input['fields'] ) ? $input['fields'] : '';
+		$post_id              = (int) ( $input['post_id'] ?? 0 );
+		$persist_refs         = isset( $input['persist_refs'] ) ? (bool) $input['persist_refs'] : true;
+		$include_inner_blocks = isset( $input['include_inner_blocks'] ) ? (bool) $input['include_inner_blocks'] : false;
+		$outline              = isset( $input['outline'] ) ? (bool) $input['outline'] : false;
+		$summary_only         = isset( $input['summary_only'] ) ? (bool) $input['summary_only'] : false;
+		$search               = isset( $input['search'] ) && is_string( $input['search'] ) ? $input['search'] : '';
+		$block_name           = isset( $input['block_name'] ) && is_string( $input['block_name'] ) ? $input['block_name'] : '';
+		$render               = isset( $input['render'] ) ? (bool) $input['render'] : false;
+		$fields               = isset( $input['fields'] ) && is_string( $input['fields'] ) ? $input['fields'] : '';
 
 		if ( $post_id <= 0 ) {
 			return new \WP_Error(
@@ -2258,11 +2263,21 @@ class BlockAbilities {
 			$blocks = BlockRenderer::render_block_tree( $post_id, $blocks );
 		}
 
-		// Build the flat annotated block list for the response.
+		// Build the annotated block list for the response.
 		$flat_list  = [];
 		$flat_index = 0;
-		// @phpstan-ignore-next-line
-		self::flatten_blocks_for_response( $blocks, [], $flat_index, $flat_list, $outline, $search, $block_name, $render, $fields );
+
+		if ( $include_inner_blocks ) {
+			// Flat DFS mode: every nested block appears as its own entry with
+			// depth and parent_ref fields. innerBlocks is omitted from each entry.
+			// @phpstan-ignore-next-line
+			self::flatten_block_tree( $blocks, [], $flat_index, $flat_list, 0, null, $outline, $search, $block_name, $render, $fields );
+		} else {
+			// Legacy nested mode: top-level blocks only; inner blocks nested
+			// under each entry's innerBlocks key (existing behaviour).
+			// @phpstan-ignore-next-line
+			self::flatten_blocks_for_response( $blocks, [], $flat_index, $flat_list, $outline, $search, $block_name, $render, $fields );
+		}
 
 		return [
 			'blocks'      => $flat_list,
@@ -2438,6 +2453,170 @@ class BlockAbilities {
 			}
 
 			$output[] = $entry;
+		}
+	}
+
+	/**
+	 * Depth-first walk that produces a flat annotated entry per named block,
+	 * including every nested block (used when include_inner_blocks: true).
+	 *
+	 * Unlike flatten_blocks_for_response, each entry includes:
+	 * - depth      (int)         — 0 for root, increments per innerBlocks dive.
+	 * - parent_ref (string|null) — sd_ref of the direct parent, null for root.
+	 * The innerBlocks key is omitted from each entry because every descendant
+	 * appears as its own entry in DFS order.
+	 *
+	 * @param array<int,mixed> $blocks      Parsed blocks at the current level.
+	 * @param int[]            $parent_path Index path to the parent.
+	 * @param int              $flat_index  Running flat counter (by reference).
+	 * @param array<int,mixed> $output      Accumulating flat list (by reference).
+	 * @param int              $depth       Current nesting depth (0 = root).
+	 * @param string|null      $parent_ref  Parent block ref, null for root.
+	 * @param bool             $outline     Return only flat_index, path, name, heading_text.
+	 * @param string           $search      Filter by text_preview substring (case-insensitive).
+	 * @param string           $block_name  Filter by exact block name.
+	 * @param bool             $render      Resolve dynamic blocks and shortcodes.
+	 * @param string           $fields      Comma-separated allowlist of response fields.
+	 */
+	private static function flatten_block_tree(
+		array $blocks,
+		array $parent_path,
+		int &$flat_index,
+		array &$output,
+		int $depth,
+		?string $parent_ref,
+		bool $outline = false,
+		string $search = '',
+		string $block_name = '',
+		bool $render = false,
+		string $fields = ''
+	): void {
+		// Parse the fields allowlist if provided.
+		$allowed_fields = [];
+		if ( '' !== $fields ) {
+			$allowed_fields = array_map( 'trim', explode( ',', $fields ) );
+			$allowed_fields = array_flip( $allowed_fields );
+		}
+
+		foreach ( $blocks as $local_idx => $block ) {
+			// @phpstan-ignore-next-line
+			if ( ! is_array( $block ) || empty( $block['blockName'] ) ) {
+				continue;
+			}
+
+			$current_path = array_merge( $parent_path, [ (int) $local_idx ] );
+			// @phpstan-ignore-next-line
+			$block_name_value = (string) $block['blockName'];
+
+			// Resolve the stable sd_ref for this block.
+			// @phpstan-ignore-next-line
+			$ref = $block['attrs']['metadata'][ BlockReferences::REF_KEY ] ?? null;
+			$ref = is_string( $ref ) && '' !== $ref ? $ref : null;
+
+			// Apply block_name filter — still recurse into inner blocks.
+			if ( '' !== $block_name && $block_name !== $block_name_value ) {
+				// @phpstan-ignore-next-line
+				$inner = $block['innerBlocks'] ?? [];
+				if ( ! empty( $inner ) && is_array( $inner ) ) {
+					// @phpstan-ignore-next-line
+					self::flatten_block_tree( $inner, $current_path, $flat_index, $output, $depth + 1, $ref, $outline, $search, $block_name, $render, $fields );
+				}
+				continue;
+			}
+
+			// text_preview: stripped, decoded, truncated inner HTML.
+			// @phpstan-ignore-next-line
+			$inner_html   = (string) ( $block['innerHTML'] ?? '' );
+			$text_preview = '';
+			if ( '' !== $inner_html ) {
+				$preview = wp_strip_all_tags( $inner_html );
+				$preview = html_entity_decode( $preview, ENT_QUOTES | ENT_HTML5, 'UTF-8' );
+				$preview = (string) preg_replace( '/\s+/', ' ', trim( $preview ) );
+				if ( '' !== $preview ) {
+					$text_preview = mb_substr( $preview, 0, 100 );
+				}
+			}
+
+			// Apply search filter — still recurse into inner blocks.
+			if ( '' !== $search && false === stripos( $text_preview, $search ) ) {
+				// @phpstan-ignore-next-line
+				$inner = $block['innerBlocks'] ?? [];
+				if ( ! empty( $inner ) && is_array( $inner ) ) {
+					// @phpstan-ignore-next-line
+					self::flatten_block_tree( $inner, $current_path, $flat_index, $output, $depth + 1, $ref, $outline, $search, $block_name, $render, $fields );
+				}
+				continue;
+			}
+
+			// Build the flat entry.
+			$entry = [
+				'flat_index' => $flat_index,
+				'path'       => $current_path,
+				'depth'      => $depth,
+				'parent_ref' => $parent_ref,
+				'name'       => $block_name_value,
+			];
+
+			// Surface the stable ref.
+			if ( null !== $ref ) {
+				$entry['ref'] = $ref;
+			}
+
+			// text_preview (non-outline mode).
+			if ( ! $outline && '' !== $text_preview ) {
+				$entry['text_preview'] = $text_preview;
+			}
+
+			// Attributes (non-outline mode).
+			if ( ! $outline ) {
+				// @phpstan-ignore-next-line
+				$entry['attributes'] = $block['attrs'] ?? [];
+			}
+
+			// Surface Block Bindings API data (read side).
+			// @phpstan-ignore-next-line
+			$attrs_arr = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : [];
+			$meta_arr  = isset( $attrs_arr['metadata'] ) && is_array( $attrs_arr['metadata'] ) ? $attrs_arr['metadata'] : [];
+			$bindings  = isset( $meta_arr['bindings'] ) && is_array( $meta_arr['bindings'] ) ? $meta_arr['bindings'] : [];
+			if ( ! empty( $bindings ) ) {
+				$entry['bindings']         = $bindings;
+				$entry['bound_attributes'] = array_keys( $bindings );
+			}
+
+			// For outline mode, add heading_text if this is a heading block.
+			if ( $outline && 'core/heading' === $block_name_value && '' !== $text_preview ) {
+				$entry['heading_text'] = $text_preview;
+			}
+
+			// Surface render fields when render: true was used.
+			if ( $render ) {
+				if ( isset( $block['rendered_html'] ) ) {
+					$entry['rendered_html'] = (string) $block['rendered_html'];
+				}
+				if ( isset( $block['render_error'] ) ) {
+					$entry['render_error'] = (string) $block['render_error'];
+				}
+				if ( isset( $block['rendered_synced_pattern_id'] ) ) {
+					$entry['rendered_synced_pattern_id'] = (int) $block['rendered_synced_pattern_id'];
+				}
+			}
+
+			++$flat_index;
+
+			// Apply fields allowlist if provided.
+			if ( ! empty( $allowed_fields ) ) {
+				$entry = array_intersect_key( $entry, $allowed_fields );
+			}
+
+			$output[] = $entry;
+
+			// Recurse into inner blocks — they go directly into $output (flat DFS).
+			// @phpstan-ignore-next-line
+			$inner = $block['innerBlocks'] ?? [];
+			if ( ! empty( $inner ) && is_array( $inner ) ) {
+				// @phpstan-ignore-next-line
+				self::flatten_block_tree( $inner, $current_path, $flat_index, $output, $depth + 1, $ref, $outline, $search, $block_name, $render, $fields );
+			}
 		}
 	}
 

--- a/tests/SdAiAgent/Abilities/BlockAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/BlockAbilitiesTest.php
@@ -934,6 +934,278 @@ class BlockAbilitiesTest extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'attributes', $block );
 	}
 
+	// ─── include_inner_blocks parameter ──────────────────────────
+
+	/**
+	 * AC1 (include_inner_blocks): default mode (false) is unchanged — regression.
+	 *
+	 * Calling with no include_inner_blocks flag on a post that has a group with
+	 * two inner paragraphs must return 2 top-level entries (group + outer
+	 * paragraph), with the group's innerBlocks nested as before.
+	 *
+	 * @see GH#1787
+	 */
+	public function test_handle_get_page_blocks_default_nested_mode_unchanged(): void {
+		$content = implode( "\n\n", [
+			"<!-- wp:group -->\n<div class=\"wp-block-group\"><!-- wp:paragraph -->\n<p>Inside</p>\n<!-- /wp:paragraph --></div>\n<!-- /wp:group -->",
+			"<!-- wp:paragraph -->\n<p>Outside</p>\n<!-- /wp:paragraph -->",
+		] );
+
+		$post_id = $this->factory()->post->create( [
+			'post_content' => $content,
+			'post_status'  => 'publish',
+		] );
+
+		$result = BlockAbilities::handle_get_page_blocks( [
+			'post_id'      => $post_id,
+			'persist_refs' => false,
+		] );
+
+		$this->assertIsArray( $result );
+		// Default nested mode: 2 top-level blocks.
+		$this->assertCount( 2, $result['blocks'], 'Default mode must return only top-level blocks' );
+
+		$group_entry = $result['blocks'][0];
+		$this->assertSame( 'core/group', $group_entry['name'] );
+		// Inner blocks appear under the group entry's innerBlocks key.
+		$this->assertArrayHasKey( 'innerBlocks', $group_entry, 'Group must have innerBlocks key in default mode' );
+		$this->assertCount( 1, $group_entry['innerBlocks'] );
+
+		$outer = $result['blocks'][1];
+		$this->assertSame( 'core/paragraph', $outer['name'] );
+	}
+
+	/**
+	 * AC2 (include_inner_blocks): flat mode returns DFS-ordered list with all blocks.
+	 *
+	 * Post has: group containing one paragraph, then one top-level paragraph.
+	 * Flat output must be 3 entries in DFS order: group, inner paragraph, outer paragraph.
+	 *
+	 * @see GH#1787
+	 */
+	public function test_handle_get_page_blocks_flat_mode_dfs_order(): void {
+		$content = implode( "\n\n", [
+			"<!-- wp:group -->\n<div class=\"wp-block-group\"><!-- wp:paragraph -->\n<p>Inside</p>\n<!-- /wp:paragraph --></div>\n<!-- /wp:group -->",
+			"<!-- wp:paragraph -->\n<p>Outside</p>\n<!-- /wp:paragraph -->",
+		] );
+
+		$post_id = $this->factory()->post->create( [
+			'post_content' => $content,
+			'post_status'  => 'publish',
+		] );
+
+		$result = BlockAbilities::handle_get_page_blocks( [
+			'post_id'              => $post_id,
+			'persist_refs'         => false,
+			'include_inner_blocks' => true,
+		] );
+
+		$this->assertIsArray( $result );
+		// Flat mode: 3 entries (group + inner paragraph + outer paragraph).
+		$this->assertCount( 3, $result['blocks'], 'Flat mode must include all blocks in DFS order' );
+		$this->assertSame( 3, $result['block_count'] );
+
+		$group = $result['blocks'][0];
+		$inner = $result['blocks'][1];
+		$outer = $result['blocks'][2];
+
+		$this->assertSame( 'core/group', $group['name'], 'First DFS entry must be the group' );
+		$this->assertSame( 'core/paragraph', $inner['name'], 'Second DFS entry must be the inner paragraph' );
+		$this->assertSame( 'core/paragraph', $outer['name'], 'Third DFS entry must be the outer paragraph' );
+
+		$this->assertSame( 0, $group['flat_index'] );
+		$this->assertSame( 1, $inner['flat_index'] );
+		$this->assertSame( 2, $outer['flat_index'] );
+	}
+
+	/**
+	 * AC2b (include_inner_blocks): each flat entry carries correct depth and parent_ref.
+	 *
+	 * Group (depth 0, parent_ref null) → inner paragraph (depth 1, parent_ref = group ref)
+	 * Outer paragraph (depth 0, parent_ref null).
+	 *
+	 * @see GH#1787
+	 */
+	public function test_handle_get_page_blocks_flat_mode_depth_and_parent_ref(): void {
+		$content = implode( "\n\n", [
+			"<!-- wp:group -->\n<div class=\"wp-block-group\"><!-- wp:paragraph -->\n<p>Inside</p>\n<!-- /wp:paragraph --></div>\n<!-- /wp:group -->",
+			"<!-- wp:paragraph -->\n<p>Outside</p>\n<!-- /wp:paragraph -->",
+		] );
+
+		$post_id = $this->factory()->post->create( [
+			'post_content' => $content,
+			'post_status'  => 'publish',
+		] );
+
+		$result = BlockAbilities::handle_get_page_blocks( [
+			'post_id'              => $post_id,
+			'persist_refs'         => false,
+			'include_inner_blocks' => true,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 3, $result['blocks'] );
+
+		$group = $result['blocks'][0];
+		$inner = $result['blocks'][1];
+		$outer = $result['blocks'][2];
+
+		// Each entry must expose depth and parent_ref.
+		$this->assertArrayHasKey( 'depth', $group );
+		$this->assertArrayHasKey( 'parent_ref', $group );
+		$this->assertArrayHasKey( 'depth', $inner );
+		$this->assertArrayHasKey( 'parent_ref', $inner );
+
+		// Group: depth 0, no parent.
+		$this->assertSame( 0, $group['depth'], 'Top-level group must have depth 0' );
+		$this->assertNull( $group['parent_ref'], 'Top-level group must have parent_ref null' );
+
+		// Inner paragraph: depth 1, parent = group.
+		$this->assertSame( 1, $inner['depth'], 'Inner paragraph must have depth 1' );
+		$this->assertSame( $group['ref'], $inner['parent_ref'], 'Inner paragraph parent_ref must equal group ref' );
+
+		// Outer paragraph: depth 0, no parent.
+		$this->assertSame( 0, $outer['depth'], 'Outer paragraph must have depth 0' );
+		$this->assertNull( $outer['parent_ref'], 'Outer paragraph must have parent_ref null' );
+	}
+
+	/**
+	 * AC3 (include_inner_blocks): path reflects index path from root for nested blocks.
+	 *
+	 * Group is at path [0], inner paragraph at path [0, 0], outer paragraph at path [1].
+	 *
+	 * @see GH#1787
+	 */
+	public function test_handle_get_page_blocks_flat_mode_path_correctness(): void {
+		$content = implode( "\n\n", [
+			"<!-- wp:group -->\n<div class=\"wp-block-group\"><!-- wp:paragraph -->\n<p>Inside</p>\n<!-- /wp:paragraph --></div>\n<!-- /wp:group -->",
+			"<!-- wp:paragraph -->\n<p>Outside</p>\n<!-- /wp:paragraph -->",
+		] );
+
+		$post_id = $this->factory()->post->create( [
+			'post_content' => $content,
+			'post_status'  => 'publish',
+		] );
+
+		$result = BlockAbilities::handle_get_page_blocks( [
+			'post_id'              => $post_id,
+			'persist_refs'         => false,
+			'include_inner_blocks' => true,
+		] );
+
+		$group = $result['blocks'][0];
+		$inner = $result['blocks'][1];
+		$outer = $result['blocks'][2];
+
+		// Note: parse_blocks() inserts a null placeholder block for the \n\n
+		// whitespace between the group and the outer paragraph, so the outer
+		// paragraph sits at array index 2 (not 1) in the raw parsed output.
+		$this->assertSame( [ 0 ], $group['path'], 'Group path must be [0]' );
+		$this->assertSame( [ 0, 0 ], $inner['path'], 'Inner paragraph path must be [0, 0]' );
+		$this->assertSame( [ 2 ], $outer['path'], 'Outer paragraph path must be [2] (null whitespace block at index 1)' );
+	}
+
+	/**
+	 * AC4 (include_inner_blocks): every flat entry has a non-null ref.
+	 *
+	 * assign_refs must have run on the entire tree before building the flat list.
+	 *
+	 * @see GH#1787
+	 */
+	public function test_handle_get_page_blocks_flat_mode_all_entries_have_refs(): void {
+		$content = implode( "\n\n", [
+			"<!-- wp:group -->\n<div class=\"wp-block-group\"><!-- wp:paragraph -->\n<p>Inside A</p>\n<!-- /wp:paragraph -->\n<!-- wp:paragraph -->\n<p>Inside B</p>\n<!-- /wp:paragraph --></div>\n<!-- /wp:group -->",
+			"<!-- wp:paragraph -->\n<p>Outside</p>\n<!-- /wp:paragraph -->",
+		] );
+
+		$post_id = $this->factory()->post->create( [
+			'post_content' => $content,
+			'post_status'  => 'publish',
+		] );
+
+		$result = BlockAbilities::handle_get_page_blocks( [
+			'post_id'              => $post_id,
+			'persist_refs'         => false,
+			'include_inner_blocks' => true,
+		] );
+
+		$this->assertCount( 4, $result['blocks'], '1 group + 2 inner paragraphs + 1 outer = 4 entries' );
+
+		foreach ( $result['blocks'] as $idx => $entry ) {
+			$this->assertArrayHasKey( 'ref', $entry, "Entry at flat_index {$idx} must have a ref" );
+			$this->assertMatchesRegularExpression(
+				'/^blk_[A-Za-z0-9\-_]{8}$/',
+				$entry['ref'],
+				"Entry at flat_index {$idx} must have a valid blk_ ref"
+			);
+		}
+	}
+
+	/**
+	 * AC5 (include_inner_blocks): 3-level nesting produces correct depth values.
+	 *
+	 * columns → column → paragraph: depths 0, 1, 2.
+	 *
+	 * @see GH#1787
+	 */
+	public function test_handle_get_page_blocks_flat_mode_three_level_depth(): void {
+		$content = "<!-- wp:columns -->\n<div class=\"wp-block-columns\"><!-- wp:column -->\n<div class=\"wp-block-column\"><!-- wp:paragraph -->\n<p>Deep</p>\n<!-- /wp:paragraph --></div>\n<!-- /wp:column --></div>\n<!-- /wp:columns -->";
+
+		$post_id = $this->factory()->post->create( [
+			'post_content' => $content,
+			'post_status'  => 'publish',
+		] );
+
+		$result = BlockAbilities::handle_get_page_blocks( [
+			'post_id'              => $post_id,
+			'persist_refs'         => false,
+			'include_inner_blocks' => true,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 3, $result['blocks'], 'columns + column + paragraph = 3 entries' );
+
+		$this->assertSame( 0, $result['blocks'][0]['depth'], 'columns depth must be 0' );
+		$this->assertSame( 1, $result['blocks'][1]['depth'], 'column depth must be 1' );
+		$this->assertSame( 2, $result['blocks'][2]['depth'], 'paragraph depth must be 2' );
+
+		// parent_ref chain: columns → column → paragraph.
+		$this->assertNull( $result['blocks'][0]['parent_ref'], 'columns must have null parent_ref' );
+		$this->assertSame( $result['blocks'][0]['ref'], $result['blocks'][1]['parent_ref'], 'column parent_ref must be columns ref' );
+		$this->assertSame( $result['blocks'][1]['ref'], $result['blocks'][2]['parent_ref'], 'paragraph parent_ref must be column ref' );
+	}
+
+	/**
+	 * AC6 (include_inner_blocks): innerBlocks key must NOT appear in flat-mode entries.
+	 *
+	 * @see GH#1787
+	 */
+	public function test_handle_get_page_blocks_flat_mode_no_inner_blocks_key(): void {
+		$content = implode( "\n\n", [
+			"<!-- wp:group -->\n<div class=\"wp-block-group\"><!-- wp:paragraph -->\n<p>Inside</p>\n<!-- /wp:paragraph --></div>\n<!-- /wp:group -->",
+			"<!-- wp:paragraph -->\n<p>Outside</p>\n<!-- /wp:paragraph -->",
+		] );
+
+		$post_id = $this->factory()->post->create( [
+			'post_content' => $content,
+			'post_status'  => 'publish',
+		] );
+
+		$result = BlockAbilities::handle_get_page_blocks( [
+			'post_id'              => $post_id,
+			'persist_refs'         => false,
+			'include_inner_blocks' => true,
+		] );
+
+		foreach ( $result['blocks'] as $entry ) {
+			$this->assertArrayNotHasKey(
+				'innerBlocks',
+				$entry,
+				'Flat mode entries must not have an innerBlocks key'
+			);
+		}
+	}
+
 	// ─── replace-block-range ref counters ────────────────────────
 
 	/**


### PR DESCRIPTION
## Summary

Added include_inner_blocks param to get-page-blocks: when true returns DFS flat list of all blocks with depth/parent_ref fields. New flatten_block_tree() helper. 7 new PHPUnit tests.

## Files Changed

.pr-body-DtUa1n.md,includes/Abilities/BlockAbilities.php,tests/SdAiAgent/Abilities/BlockAbilitiesTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PHPUnit: Tests: 3140, Assertions: 9021, Errors: 0, Failures: 1 (pre-existing AbilitySchemaIntegrityTest - confirmed on base commit), Skipped: 105. Lint: PHP/JS/CSS clean. PHPStan: 0 errors. Build: succeeded.

Resolves #1787


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with claude-sonnet-4-6 spent 19m and 41,135 tokens on this as a headless worker.