### PR TITLE
security(uploads): add WP_DISABLE_UPLOADS and multisite_can_upload() guards to upload abilities (GH#1803)

### DIFF
--- a/includes/Abilities/ImageAbilities.php
+++ b/includes/Abilities/ImageAbilities.php
@@ -489,6 +489,21 @@ INSTRUCTION;
 	 * @return array{attachment_id: int, url: string, filename: string, title: string, description: string, alt_text: string, mime_type: string}|\WP_Error Array with 'attachment_id' on success, WP_Error on failure.
 	 */
 	public static function sideload_from_base64( array $input ) {
+		// Check if uploads are disabled site-wide or by multisite restrictions.
+		if ( defined( 'WP_DISABLE_UPLOADS' ) && WP_DISABLE_UPLOADS ) {
+			return new WP_Error(
+				'uploads_disabled',
+				__( 'File uploads are disabled on this site.', 'superdav-ai-agent' )
+			);
+		}
+
+		if ( is_multisite() && ! multisite_can_upload() ) {
+			return new WP_Error(
+				'uploads_disabled',
+				__( 'File uploads are disabled for this site in a multisite network.', 'superdav-ai-agent' )
+			);
+		}
+
 		// Accept 'data_base64' (unified ability) or 'data' (legacy ability).
 		// @phpstan-ignore-next-line
 		$data = (string) ( $input['data_base64'] ?? $input['data'] ?? '' );

--- a/includes/Abilities/ImageAbilities.php
+++ b/includes/Abilities/ImageAbilities.php
@@ -497,7 +497,7 @@ INSTRUCTION;
 			);
 		}
 
-		if ( is_multisite() && ! multisite_can_upload() ) {
+		if ( is_multisite() && function_exists( 'multisite_can_upload' ) && ! multisite_can_upload() ) {
 			return new WP_Error(
 				'uploads_disabled',
 				__( 'File uploads are disabled for this site in a multisite network.', 'superdav-ai-agent' )

--- a/includes/Abilities/MediaAbilities.php
+++ b/includes/Abilities/MediaAbilities.php
@@ -346,7 +346,7 @@ class MediaAbilities {
 			);
 		}
 
-		if ( is_multisite() && ! multisite_can_upload() ) {
+		if ( is_multisite() && function_exists( 'multisite_can_upload' ) && ! multisite_can_upload() ) {
 			return new WP_Error(
 				'uploads_disabled',
 				__( 'File uploads are disabled for this site in a multisite network.', 'superdav-ai-agent' )

--- a/includes/Abilities/MediaAbilities.php
+++ b/includes/Abilities/MediaAbilities.php
@@ -338,6 +338,21 @@ class MediaAbilities {
 	 * @return array{attachment_id: int, url: string, title: string, mime_type: string, file_size: int}|WP_Error
 	 */
 	public static function sideload_from_url( array $input ) {
+		// Check if uploads are disabled site-wide or by multisite restrictions.
+		if ( defined( 'WP_DISABLE_UPLOADS' ) && WP_DISABLE_UPLOADS ) {
+			return new WP_Error(
+				'uploads_disabled',
+				__( 'File uploads are disabled on this site.', 'superdav-ai-agent' )
+			);
+		}
+
+		if ( is_multisite() && ! multisite_can_upload() ) {
+			return new WP_Error(
+				'uploads_disabled',
+				__( 'File uploads are disabled for this site in a multisite network.', 'superdav-ai-agent' )
+			);
+		}
+
 		// @phpstan-ignore-next-line
 		$url = esc_url_raw( $input['url'] ?? '' );
 		// @phpstan-ignore-next-line

--- a/includes/Abilities/UploadMediaAbility.php
+++ b/includes/Abilities/UploadMediaAbility.php
@@ -218,7 +218,7 @@ class UploadMediaAbility {
 		}
 
 		// Check multisite upload restrictions.
-		if ( is_multisite() && ! multisite_can_upload() ) {
+		if ( is_multisite() && function_exists( 'multisite_can_upload' ) && ! multisite_can_upload() ) {
 			return new WP_Error(
 				'uploads_disabled',
 				__( 'File uploads are disabled for this site in a multisite network.', 'superdav-ai-agent' )

--- a/includes/Abilities/UploadMediaAbility.php
+++ b/includes/Abilities/UploadMediaAbility.php
@@ -162,6 +162,12 @@ class UploadMediaAbility {
 	 * @return array<string, mixed>|WP_Error
 	 */
 	public static function handle_upload_media( array $input ) {
+		// Check if uploads are disabled site-wide or by multisite restrictions.
+		$uploads_disabled = self::check_uploads_disabled();
+		if ( is_wp_error( $uploads_disabled ) ) {
+			return $uploads_disabled;
+		}
+
 		// @phpstan-ignore-next-line
 		$source = sanitize_key( $input['source'] ?? '' );
 
@@ -189,6 +195,37 @@ class UploadMediaAbility {
 					)
 				);
 		}
+	}
+
+	// ─── Uploads-disabled guard ──────────────────────────────────────────────
+
+	/**
+	 * Check if uploads are disabled site-wide or by multisite restrictions.
+	 *
+	 * Returns WP_Error if uploads are disabled, otherwise returns true.
+	 *
+	 * @since 1.10.0
+	 *
+	 * @return true|WP_Error True if uploads are enabled, WP_Error if disabled.
+	 */
+	private static function check_uploads_disabled() {
+		// Check WP_DISABLE_UPLOADS constant (site-wide disable).
+		if ( defined( 'WP_DISABLE_UPLOADS' ) && WP_DISABLE_UPLOADS ) {
+			return new WP_Error(
+				'uploads_disabled',
+				__( 'File uploads are disabled on this site.', 'superdav-ai-agent' )
+			);
+		}
+
+		// Check multisite upload restrictions.
+		if ( is_multisite() && ! multisite_can_upload() ) {
+			return new WP_Error(
+				'uploads_disabled',
+				__( 'File uploads are disabled for this site in a multisite network.', 'superdav-ai-agent' )
+			);
+		}
+
+		return true;
 	}
 
 	// ─── Source handlers ─────────────────────────────────────────────────────

--- a/tests/SdAiAgent/Abilities/UploadMediaAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/UploadMediaAbilityTest.php
@@ -567,4 +567,72 @@ class UploadMediaAbilityTest extends WP_UnitTestCase {
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'missing_data', $result->get_error_code() );
 	}
+
+	// ─── uploads disabled guard ──────────────────────────────────────────────
+
+	/**
+	 * When WP_DISABLE_UPLOADS is true, upload-media returns uploads_disabled error.
+	 *
+	 * GH#1803: upload abilities must check WP_DISABLE_UPLOADS before attempting uploads.
+	 */
+	public function test_upload_media_with_wp_disable_uploads_returns_error() {
+		// Define WP_DISABLE_UPLOADS if not already defined.
+		if ( ! defined( 'WP_DISABLE_UPLOADS' ) ) {
+			define( 'WP_DISABLE_UPLOADS', true );
+		}
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- test data encoding
+		$png_b64 = base64_encode( self::minimal_png_bytes() );
+
+		$result = UploadMediaAbility::handle_upload_media( [
+			'source'      => 'base64',
+			'data_base64' => $png_b64,
+			'mime_type'   => 'image/png',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'uploads_disabled', $result->get_error_code() );
+	}
+
+	/**
+	 * sideload_from_base64 checks WP_DISABLE_UPLOADS before processing.
+	 *
+	 * GH#1803: legacy import-base64-image ability must also check WP_DISABLE_UPLOADS.
+	 */
+	public function test_sideload_from_base64_with_wp_disable_uploads_returns_error() {
+		// Define WP_DISABLE_UPLOADS if not already defined.
+		if ( ! defined( 'WP_DISABLE_UPLOADS' ) ) {
+			define( 'WP_DISABLE_UPLOADS', true );
+		}
+
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- test data encoding
+		$png_b64 = base64_encode( self::minimal_png_bytes() );
+
+		$result = ImageAbilities::sideload_from_base64( [
+			'data_base64' => $png_b64,
+			'mime_type'   => 'image/png',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'uploads_disabled', $result->get_error_code() );
+	}
+
+	/**
+	 * sideload_from_url checks WP_DISABLE_UPLOADS before processing.
+	 *
+	 * GH#1803: legacy upload-media-from-url ability must also check WP_DISABLE_UPLOADS.
+	 */
+	public function test_sideload_from_url_with_wp_disable_uploads_returns_error() {
+		// Define WP_DISABLE_UPLOADS if not already defined.
+		if ( ! defined( 'WP_DISABLE_UPLOADS' ) ) {
+			define( 'WP_DISABLE_UPLOADS', true );
+		}
+
+		$result = MediaAbilities::sideload_from_url( [
+			'url' => 'https://example.com/image.jpg',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'uploads_disabled', $result->get_error_code() );
+	}
 }


### PR DESCRIPTION
## Summary

Added guards to check `WP_DISABLE_UPLOADS` constant and `multisite_can_upload()` function before attempting file uploads in all upload abilities.

## Changes

- Added `check_uploads_disabled()` helper method to `UploadMediaAbility` class
- Added uploads-disabled checks to `ImageAbilities::sideload_from_base64()`
- Added uploads-disabled checks to `MediaAbilities::sideload_from_url()`
- Returns `WP_Error('uploads_disabled', ...)` when uploads are disabled site-wide or by multisite restrictions
- Added 3 test cases for uploads-disabled scenarios

## Verification

- Lint: PASS
- PHPStan: PASS
- Build: PASS
- Tests: Added 3 new test cases for uploads-disabled guard

## Resolves

Resolves #1803

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with claude-haiku-4-5 spent 7m and 3,506 tokens on this as a headless worker.
