### PR TITLE
security(idor): add per-resource edit_post capability checks to ability handlers

### DIFF
--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -2183,6 +2183,14 @@ class BlockAbilities {
 			);
 		}
 
+		// ── Per-resource capability check ──────────────────────────────────────
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return new \WP_Error(
+				'insufficient_capability',
+				__( 'You do not have permission to edit this post.', 'superdav-ai-agent' )
+			);
+		}
+
 		$content = $post->post_content;
 		if ( ! is_string( $content ) || '' === trim( $content ) ) {
 			$response = [
@@ -2991,6 +2999,15 @@ class BlockAbilities {
 			);
 		}
 
+		// ── Per-resource capability check ──────────────────────────────────────
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return new \WP_Error(
+				'insufficient_capability',
+				__( 'You do not have permission to edit this post.', 'superdav-ai-agent' ),
+				[ 'status' => 403 ]
+			);
+		}
+
 		// Optimistic concurrency guard.
 		$expected = isset( $input['expected_revision'] ) ? (string) $input['expected_revision'] : '';
 		$guard    = RevisionGuard::check( $post_id, RevisionGuard::parse_raw( $expected ) );
@@ -3102,6 +3119,15 @@ class BlockAbilities {
 					$post_id
 				),
 				[ 'status' => 404 ]
+			);
+		}
+
+		// ── Per-resource capability check ──────────────────────────────────────
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return new \WP_Error(
+				'insufficient_capability',
+				__( 'You do not have permission to edit this post.', 'superdav-ai-agent' ),
+				[ 'status' => 403 ]
 			);
 		}
 
@@ -3367,6 +3393,15 @@ class BlockAbilities {
 			);
 		}
 
+		// ── Per-resource capability check ──────────────────────────────────────
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return new \WP_Error(
+				'insufficient_capability',
+				__( 'You do not have permission to edit this post.', 'superdav-ai-agent' ),
+				[ 'status' => 403 ]
+			);
+		}
+
 		// ── Optimistic concurrency ────────────────────────────────────
 
 		$expected = isset( $input['expected_revision_id'] ) ? (string) $input['expected_revision_id'] : '';
@@ -3607,6 +3642,15 @@ class BlockAbilities {
 					$post_id
 				),
 				[ 'status' => 404 ]
+			);
+		}
+
+		// ── Per-resource capability check ──────────────────────────────────────
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return new \WP_Error(
+				'insufficient_capability',
+				__( 'You do not have permission to edit this post.', 'superdav-ai-agent' ),
+				[ 'status' => 403 ]
 			);
 		}
 

--- a/includes/Abilities/PostAbilities.php
+++ b/includes/Abilities/PostAbilities.php
@@ -1097,6 +1097,14 @@ class PostAbilities {
 			);
 		}
 
+		// ── Per-resource capability check ──────────────────────────────────────
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return new WP_Error(
+				'insufficient_capability',
+				__( 'You do not have permission to edit this post.', 'superdav-ai-agent' )
+			);
+		}
+
 		// post_type validation (applies only to the id path; slug path already
 		// scoped to the requested type via resolve_to_post_id).
 		// @phpstan-ignore-next-line
@@ -1391,6 +1399,17 @@ class PostAbilities {
 			);
 		}
 
+		// ── Per-resource capability check ──────────────────────────────────────
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			if ( $switched ) {
+				restore_current_blog();
+			}
+			return new WP_Error(
+				'insufficient_capability',
+				__( 'You do not have permission to edit this post.', 'superdav-ai-agent' )
+			);
+		}
+
 		// Optimistic concurrency check (opt-in via expected_revision).
 		$raw_expected = isset( $input['expected_revision'] ) ? (string) $input['expected_revision'] : '';
 		$guard        = RevisionGuard::check( $post_id, RevisionGuard::parse_raw( $raw_expected ) );
@@ -1653,6 +1672,17 @@ class PostAbilities {
 				'ai_agent_post_not_found',
 				/* translators: %d: post ID */
 				sprintf( __( 'Post %d not found.', 'superdav-ai-agent' ), $post_id )
+			);
+		}
+
+		// ── Per-resource capability check ──────────────────────────────────────
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			if ( $switched ) {
+				restore_current_blog();
+			}
+			return new WP_Error(
+				'insufficient_capability',
+				__( 'You do not have permission to edit this post.', 'superdav-ai-agent' )
 			);
 		}
 

--- a/tests/SdAiAgent/Abilities/BlockAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/BlockAbilitiesTest.php
@@ -17,6 +17,16 @@ use WP_UnitTestCase;
  */
 class BlockAbilitiesTest extends WP_UnitTestCase {
 
+	/**
+	 * Set up test environment with admin user.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		// Create an admin user and set as current user for capability checks.
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+	}
+
 	// ─── markdown-to-blocks ───────────────────────────────────────
 
 	/**

--- a/tests/SdAiAgent/Abilities/InsertPatternTest.php
+++ b/tests/SdAiAgent/Abilities/InsertPatternTest.php
@@ -47,6 +47,10 @@ class InsertPatternTest extends WP_UnitTestCase {
 	public function set_up(): void {
 		parent::set_up();
 
+		// Create an admin user and set as current user for capability checks.
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
 		// Register a test pattern for all tests.
 		if ( ! \WP_Block_Patterns_Registry::get_instance()->is_registered( self::TEST_PATTERN ) ) {
 			register_block_pattern(

--- a/tests/SdAiAgent/Abilities/PostAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/PostAbilitiesTest.php
@@ -20,6 +20,10 @@ class PostAbilitiesTest extends WP_UnitTestCase {
 	public function set_up(): void {
 		parent::set_up();
 
+		// Create an admin user and set as current user for capability checks.
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
 		add_filter( 'theme_page_templates', [ $this, 'register_test_page_templates' ] );
 	}
 

--- a/tests/SdAiAgent/Core/BindingsReadSurfaceTest.php
+++ b/tests/SdAiAgent/Core/BindingsReadSurfaceTest.php
@@ -26,6 +26,16 @@ use WP_UnitTestCase;
 class BindingsReadSurfaceTest extends WP_UnitTestCase {
 
 	/**
+	 * Set up test environment with admin user.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		// Create an admin user and set as current user for capability checks.
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+	}
+
+	/**
 	 * get-page-blocks includes bindings and bound_attributes for bound blocks.
 	 */
 	public function test_bound_block_surfaces_bindings_in_response(): void {

--- a/tests/SdAiAgent/Core/BlockMutator/RewritePostBlocksTest.php
+++ b/tests/SdAiAgent/Core/BlockMutator/RewritePostBlocksTest.php
@@ -120,6 +120,18 @@ class RewritePostBlocksTest extends WP_UnitTestCase {
 		return $block;
 	}
 
+	// ── Setup ─────────────────────────────────────────────────────────────
+
+	/**
+	 * Set up test environment with admin user.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		// Create an admin user and set as current user for capability checks.
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+	}
+
 	// ── BlockMutator::validate_rewrite_blocks unit tests ──────────────────
 
 	/**

--- a/tests/SdAiAgent/Core/BlockMutatorBatchTest.php
+++ b/tests/SdAiAgent/Core/BlockMutatorBatchTest.php
@@ -104,6 +104,18 @@ class BlockMutatorBatchTest extends WP_UnitTestCase {
 		return $post_id;
 	}
 
+	// ── Setup ─────────────────────────────────────────────────────────────
+
+	/**
+	 * Set up test environment with admin user.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		// Create an admin user and set as current user for capability checks.
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+	}
+
 	// ── apply_batch() unit tests ──────────────────────────────────────────
 
 	/**


### PR DESCRIPTION
## Summary

Fixes GH#1802: Add per-resource capability checks to prevent IDOR vulnerabilities.

## Changes

Added per-resource capability checks to PostAbilities and BlockAbilities handlers to prevent IDOR (Insecure Direct Object Reference) vulnerabilities.

### PostAbilities
- handle_get_post: Added per-resource check after post fetch
- handle_update_post: Added per-resource check after post fetch  
- handle_delete_post: Added per-resource check after post fetch

### BlockAbilities
- handle_get_page_blocks: Added per-resource check after post fetch
- handle_update_blocks: Added per-resource check after post fetch
- handle_rewrite_post_blocks: Added per-resource check after post fetch
- handle_insert_pattern: Added per-resource check after post fetch
- handle_replace_block_range: Added per-resource check after post fetch
- handle_revert_to_revision: Already has check in BlockMutator::revert_to_revision

### Test Updates
- Added set_up() methods to test classes to create admin users
- Ensures tests run with proper user context for capability checks

## Verification

```
npm run verify
- npm run lint:php: PASS
- composer phpstan: PASS (0 errors)
- npm run test:php: PASS (3191 tests, 9171 assertions)
- npm run build: PASS
```

## Worker self-verification
- PHPUnit: Tests: 3191, Assertions: 9171, Errors: 0, Failures: 0, Skipped: 105
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Resolves #1802

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with claude-haiku-4-5 spent 13m and 3,102 tokens on this as a headless worker.
