### PR TITLE
GH#1791: feat(abilities): bindings field shape consistency across read abilities (t275)

### DIFF
--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -329,7 +329,7 @@ class BlockAbilities {
 			'sd-ai-agent/parse-block-content',
 			[
 				'label'               => __( 'Parse Block Content', 'superdav-ai-agent' ),
-				'description'         => __( 'Parse existing Gutenberg block content into a structured block tree. Provide either a post_id to read from the database, or raw content string.', 'superdav-ai-agent' ),
+				'description'         => __( 'Parse existing Gutenberg block content into a structured block tree. Provide either a post_id to read from the database, or raw content string. Each block entry includes bindings (object|null — the block\'s metadata.bindings map, null when unbound) and bound_attributes (string[] — attribute keys that are bound, empty array when unbound). See allow_bound_writes on mutator abilities for write-lock override.', 'superdav-ai-agent' ),
 				'category'            => 'sd-ai-agent',
 				'input_schema'        => [
 					'type'       => 'object',
@@ -465,7 +465,7 @@ class BlockAbilities {
 			'sd-ai-agent/get-page-blocks',
 			[
 				'label'               => __( 'Get Page Blocks', 'superdav-ai-agent' ),
-				'description'         => __( 'Return the block tree for a post with stable per-block sd_ref UUIDs. Each entry includes flat_index, path, ref, name, attributes, and a text_preview. Set persist_refs: false to read without writing refs back to the post. Use the returned refs with block-mutator abilities to address blocks reliably across multi-step edits. Optional parameters: include_inner_blocks (flatten entire tree to DFS list with depth/parent_ref per entry), outline (minimal response), summary_only (statistics), search (filter by text), block_name (filter by name), render (resolve dynamic blocks), fields (allowlist response fields).', 'superdav-ai-agent' ),
+				'description'         => __( 'Return the block tree for a post with stable per-block sd_ref UUIDs. Each entry includes flat_index, path, ref, name, attributes, text_preview, bindings (object|null — the block\'s metadata.bindings map, null when unbound), and bound_attributes (string[] — attribute keys that are bound, empty array when unbound). When a block has bindings, writes to those attributes are protected by the Block Bindings write-lock unless allow_bound_writes is set on a mutator call. Set persist_refs: false to read without writing refs back to the post. Use the returned refs with block-mutator abilities to address blocks reliably across multi-step edits. Optional parameters: include_inner_blocks (flatten entire tree to DFS list with depth/parent_ref per entry), outline (minimal response), summary_only (statistics), search (filter by text), block_name (filter by name), render (resolve dynamic blocks), fields (allowlist response fields).', 'superdav-ai-agent' ),
 				'category'            => 'sd-ai-agent',
 				'input_schema'        => [
 					'type'       => 'object',
@@ -612,7 +612,7 @@ class BlockAbilities {
 			'sd-ai-agent/edit-block-tree',
 			[
 				'label'               => __( 'Edit Block Tree', 'superdav-ai-agent' ),
-				'description'         => __( 'Mutate a post\'s Gutenberg block tree at a specific block (addressed by ref, path, or flat_index) using one of nine operations: update-attrs, update-html, replace-block, remove-block, wrap-in-group, unwrap-group, insert-child, duplicate, move. Set dry_run: true to validate and preview without writing. Use sd-ai-agent/get-page-blocks first to obtain the refs and structure.', 'superdav-ai-agent' ),
+				'description'         => __( 'Mutate a post\'s Gutenberg block tree at a specific block (addressed by ref, path, or flat_index) using one of nine operations: update-attrs, update-html, replace-block, remove-block, wrap-in-group, unwrap-group, insert-child, duplicate, move. Set dry_run: true to validate and preview without writing. The returned block_tree includes bindings (object|null) and bound_attributes (string[]) on every block — null/[] when the block has no bindings. Use allow_bound_writes: true to override the Block Bindings write-lock. Use sd-ai-agent/get-page-blocks first to obtain the refs and structure.', 'superdav-ai-agent' ),
 				'category'            => 'sd-ai-agent',
 				'input_schema'        => [
 					'type'       => 'object',
@@ -737,7 +737,7 @@ class BlockAbilities {
 			'sd-ai-agent/update-blocks',
 			[
 				'label'               => __( 'Update Blocks (Batch)', 'superdav-ai-agent' ),
-				'description'         => __( 'Apply up to 50 independent block updates atomically inside one WordPress revision, with all-or-nothing pre-flight validation. Each update specifies an operation (update-attrs, update-html, replace-block, remove-block, etc.) and a target block (by ref, path, or flat_index). If any single update fails validation, the entire batch rejects with per-item errors — nothing hits disk. On success, all updates are serialised and written as one revision. Use sd-ai-agent/get-page-blocks first to obtain refs.', 'superdav-ai-agent' ),
+				'description'         => __( 'Apply up to 50 independent block updates atomically inside one WordPress revision, with all-or-nothing pre-flight validation. Each update specifies an operation (update-attrs, update-html, replace-block, remove-block, etc.) and a target block (by ref, path, or flat_index). If any single update fails validation, the entire batch rejects with per-item errors — nothing hits disk. On success, all updates are serialised and written as one revision. The returned block_tree includes bindings (object|null) and bound_attributes (string[]) on every block — null/[] when the block has no bindings. Use allow_bound_writes per update to override the Block Bindings write-lock. Use sd-ai-agent/get-page-blocks first to obtain refs.', 'superdav-ai-agent' ),
 				'category'            => 'sd-ai-agent',
 				'input_schema'        => [
 					'type'       => 'object',
@@ -1939,6 +1939,22 @@ class BlockAbilities {
 				'innerHTML' => trim( $block['innerHTML'] ?? '' ),
 			];
 
+			// Surface Block Bindings API data for shape consistency (t275).
+			// Always emit both fields:
+			// - bindings: object|null (null when no bindings)
+			// - bound_attributes: string[] (empty array when no bindings)
+			// @phpstan-ignore-next-line
+			$attrs_arr = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : [];
+			$meta_arr  = isset( $attrs_arr['metadata'] ) && is_array( $attrs_arr['metadata'] ) ? $attrs_arr['metadata'] : [];
+			$cb        = isset( $meta_arr['bindings'] ) && is_array( $meta_arr['bindings'] ) ? $meta_arr['bindings'] : [];
+			if ( ! empty( $cb ) ) {
+				$result['bindings']         = $cb;
+				$result['bound_attributes'] = array_keys( $cb );
+			} else {
+				$result['bindings']         = null;
+				$result['bound_attributes'] = [];
+			}
+
 			// @phpstan-ignore-next-line
 			if ( ! empty( $block['innerBlocks'] ) ) {
 				// @phpstan-ignore-next-line
@@ -2411,6 +2427,9 @@ class BlockAbilities {
 			}
 
 			// Surface Block Bindings API data (read side).
+			// Always emit both fields for shape consistency (t275):
+			// - bindings: object|null (null when no bindings)
+			// - bound_attributes: string[] (empty array when no bindings)
 			// @phpstan-ignore-next-line
 			$attrs_arr = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : [];
 			$meta_arr  = isset( $attrs_arr['metadata'] ) && is_array( $attrs_arr['metadata'] ) ? $attrs_arr['metadata'] : [];
@@ -2418,6 +2437,9 @@ class BlockAbilities {
 			if ( ! empty( $bindings ) ) {
 				$entry['bindings']         = $bindings;
 				$entry['bound_attributes'] = array_keys( $bindings );
+			} else {
+				$entry['bindings']         = null;
+				$entry['bound_attributes'] = [];
 			}
 
 			// For outline mode, add heading_text if this is a heading block.
@@ -2582,6 +2604,9 @@ class BlockAbilities {
 			}
 
 			// Surface Block Bindings API data (read side).
+			// Always emit both fields for shape consistency (t275):
+			// - bindings: object|null (null when no bindings)
+			// - bound_attributes: string[] (empty array when no bindings)
 			// @phpstan-ignore-next-line
 			$attrs_arr = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : [];
 			$meta_arr  = isset( $attrs_arr['metadata'] ) && is_array( $attrs_arr['metadata'] ) ? $attrs_arr['metadata'] : [];
@@ -2589,6 +2614,9 @@ class BlockAbilities {
 			if ( ! empty( $bindings ) ) {
 				$entry['bindings']         = $bindings;
 				$entry['bound_attributes'] = array_keys( $bindings );
+			} else {
+				$entry['bindings']         = null;
+				$entry['bound_attributes'] = [];
 			}
 
 			// For outline mode, add heading_text if this is a heading block.
@@ -2935,7 +2963,7 @@ class BlockAbilities {
 			'dry_run'    => $dry_run,
 			'op'         => $op,
 			'post_id'    => $post_id,
-			'block_tree' => $new_tree,
+			'block_tree' => self::annotate_bindings_tree( $new_tree ),
 		];
 	}
 
@@ -3066,7 +3094,7 @@ class BlockAbilities {
 			'post_id'     => $post_id,
 			'updates'     => count( $updates ),
 			'revision_id' => RevisionGuard::current_revision_id( $post_id ),
-			'block_tree'  => $new_tree,
+			'block_tree'  => self::annotate_bindings_tree( $new_tree ),
 		];
 	}
 
@@ -3573,7 +3601,7 @@ class BlockAbilities {
 			'pattern_type'    => $pattern_type,
 			'blocks_inserted' => $blocks_inserted,
 			'revision_id'     => RevisionGuard::current_revision_id( $post_id ),
-			'block_tree'      => $blocks,
+			'block_tree'      => self::annotate_bindings_tree( $blocks ),
 		];
 	}
 
@@ -3867,5 +3895,59 @@ class BlockAbilities {
 		}
 
 		return $count;
+	}
+
+	// ─── Bindings annotation helper (t275) ────────────────────────
+
+	/**
+	 * Annotate a raw block tree with canonical bindings fields.
+	 *
+	 * Walks every named block and adds two top-level keys:
+	 * - `bindings`         (object|null) — the `attrs.metadata.bindings` value,
+	 *                      or null when the block has no bindings.
+	 * - `bound_attributes` (string[])    — the attribute keys that are bound,
+	 *                      or an empty array when the block has no bindings.
+	 *
+	 * This ensures every block dict emitted by the plugin's read-surface
+	 * abilities carries the same shape regardless of which ability produced
+	 * it, so agents and MCP clients can type-switch on a single key.
+	 *
+	 * @param array<int|string,mixed> $blocks Raw block tree (output of parse_blocks + assign_refs).
+	 * @return array<int|string,mixed> Block tree with bindings/bound_attributes annotated.
+	 */
+	public static function annotate_bindings_tree( array $blocks ): array {
+		$result = [];
+
+		foreach ( $blocks as $block ) {
+			if ( ! is_array( $block ) ) {
+				$result[] = $block;
+				continue;
+			}
+
+			// Only annotate named blocks (skip null-name whitespace placeholders).
+			if ( ! empty( $block['blockName'] ) ) {
+				$attrs_arr = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : [];
+				$meta_arr  = isset( $attrs_arr['metadata'] ) && is_array( $attrs_arr['metadata'] ) ? $attrs_arr['metadata'] : [];
+				$bindings  = isset( $meta_arr['bindings'] ) && is_array( $meta_arr['bindings'] ) ? $meta_arr['bindings'] : [];
+
+				if ( ! empty( $bindings ) ) {
+					$block['bindings']         = $bindings;
+					$block['bound_attributes'] = array_keys( $bindings );
+				} else {
+					$block['bindings']         = null;
+					$block['bound_attributes'] = [];
+				}
+			}
+
+			// Recurse into inner blocks.
+			$inner = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : [];
+			if ( ! empty( $inner ) ) {
+				$block['innerBlocks'] = self::annotate_bindings_tree( $inner );
+			}
+
+			$result[] = $block;
+		}
+
+		return $result;
 	}
 }

--- a/tests/SdAiAgent/Bootstrap/BindingsFieldConsistencyTest.php
+++ b/tests/SdAiAgent/Bootstrap/BindingsFieldConsistencyTest.php
@@ -1,0 +1,296 @@
+<?php
+/**
+ * Regression guard for Block Bindings field shape consistency (t275).
+ *
+ * Ensures every read path that emits a block dict always includes both:
+ * - `bindings`         (object|null)  — null when the block has no bindings.
+ * - `bound_attributes` (string[])     — empty array when the block has no bindings.
+ *
+ * Covers at least 4 read paths per AC-5:
+ *   1. get-page-blocks (nested mode)
+ *   2. get-page-blocks (flat DFS mode via include_inner_blocks)
+ *   3. parse-block-content
+ *   4. edit-block-tree dry-run
+ *   5. update-blocks dry-run
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ * @see     https://github.com/Ultimate-Multisite/superdav-ai-agent/issues/1791
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Bootstrap;
+
+use SdAiAgent\Abilities\BlockAbilities;
+use SdAiAgent\Core\BlockReferences;
+use WP_UnitTestCase;
+
+/**
+ * Regression guard: bindings + bound_attributes always present on every block dict.
+ */
+class BindingsFieldConsistencyTest extends WP_UnitTestCase {
+
+	/**
+	 * Post ID for tests that need a post with mixed bound/unbound blocks.
+	 *
+	 * @var int
+	 */
+	private int $post_id;
+
+	/**
+	 * Block content with one bound and one unbound paragraph.
+	 *
+	 * @var string
+	 */
+	private string $mixed_content;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		// Grant current user edit_posts capability.
+		$user_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $user_id );
+
+		// Block content: one bound paragraph, one unbound paragraph.
+		$this->mixed_content = '<!-- wp:paragraph {"metadata":{"'
+			. BlockReferences::REF_KEY . '":"blk_bndtest1","bindings":{"content":{"source":"core/post-meta","args":{"key":"subtitle"}}}}} -->'
+			. "\n<p>Bound paragraph</p>\n"
+			. '<!-- /wp:paragraph -->'
+			. "\n\n"
+			. '<!-- wp:paragraph {"metadata":{"'
+			. BlockReferences::REF_KEY . '":"blk_unbtest1"}} -->'
+			. "\n<p>Unbound paragraph</p>\n"
+			. '<!-- /wp:paragraph -->';
+
+		$this->post_id = self::factory()->post->create( [
+			'post_content' => $this->mixed_content,
+			'post_status'  => 'publish',
+		] );
+	}
+
+	// ── Helper ────────────────────────────────────────────────────
+
+	/**
+	 * Assert that a block dict contains both bindings fields with correct types.
+	 *
+	 * @param array<string,mixed> $block      Block dict to check.
+	 * @param bool                $expect_bound Whether the block should have bindings.
+	 * @param string              $context    Human-readable context for assertion messages.
+	 */
+	private function assert_bindings_shape( array $block, bool $expect_bound, string $context ): void {
+		$this->assertArrayHasKey( 'bindings', $block, "{$context}: 'bindings' key must always be present." );
+		$this->assertArrayHasKey( 'bound_attributes', $block, "{$context}: 'bound_attributes' key must always be present." );
+
+		if ( $expect_bound ) {
+			$this->assertIsArray( $block['bindings'], "{$context}: bound block's 'bindings' must be an array (object)." );
+			$this->assertNotEmpty( $block['bindings'], "{$context}: bound block's 'bindings' must not be empty." );
+			$this->assertIsArray( $block['bound_attributes'], "{$context}: 'bound_attributes' must be an array." );
+			$this->assertNotEmpty( $block['bound_attributes'], "{$context}: bound block's 'bound_attributes' must not be empty." );
+
+			// Verify bound_attributes matches bindings keys.
+			$expected_keys = array_keys( $block['bindings'] );
+			sort( $expected_keys );
+			$actual_keys = $block['bound_attributes'];
+			sort( $actual_keys );
+			$this->assertSame( $expected_keys, $actual_keys, "{$context}: bound_attributes must match bindings keys." );
+		} else {
+			$this->assertNull( $block['bindings'], "{$context}: unbound block's 'bindings' must be null." );
+			$this->assertSame( [], $block['bound_attributes'], "{$context}: unbound block's 'bound_attributes' must be []." );
+		}
+	}
+
+	// ── Read path 1: get-page-blocks (nested) ────────────────────
+
+	/**
+	 * @testdox get-page-blocks (nested mode) emits canonical bindings shape on both bound and unbound blocks.
+	 */
+	public function test_get_page_blocks_nested_bindings_shape(): void {
+		$result = BlockAbilities::handle_get_page_blocks( [
+			'post_id'      => $this->post_id,
+			'persist_refs' => false,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'blocks', $result );
+		$this->assertCount( 2, $result['blocks'], 'Expected 2 blocks (1 bound + 1 unbound).' );
+
+		$this->assert_bindings_shape( $result['blocks'][0], true, 'get-page-blocks nested: bound block' );
+		$this->assert_bindings_shape( $result['blocks'][1], false, 'get-page-blocks nested: unbound block' );
+	}
+
+	// ── Read path 2: get-page-blocks (flat DFS) ──────────────────
+
+	/**
+	 * @testdox get-page-blocks (flat DFS mode via include_inner_blocks) emits canonical bindings shape.
+	 */
+	public function test_get_page_blocks_flat_dfs_bindings_shape(): void {
+		$result = BlockAbilities::handle_get_page_blocks( [
+			'post_id'              => $this->post_id,
+			'persist_refs'         => false,
+			'include_inner_blocks' => true,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'blocks', $result );
+		$this->assertCount( 2, $result['blocks'], 'Expected 2 blocks in flat DFS output.' );
+
+		$this->assert_bindings_shape( $result['blocks'][0], true, 'get-page-blocks flat DFS: bound block' );
+		$this->assert_bindings_shape( $result['blocks'][1], false, 'get-page-blocks flat DFS: unbound block' );
+	}
+
+	// ── Read path 3: parse-block-content ─────────────────────────
+
+	/**
+	 * @testdox parse-block-content emits canonical bindings shape on all blocks.
+	 */
+	public function test_parse_block_content_bindings_shape(): void {
+		$result = BlockAbilities::handle_parse_block_content( [
+			'post_id' => $this->post_id,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'blocks', $result );
+		$this->assertCount( 2, $result['blocks'], 'Expected 2 blocks from parse-block-content.' );
+
+		$this->assert_bindings_shape( $result['blocks'][0], true, 'parse-block-content: bound block' );
+		$this->assert_bindings_shape( $result['blocks'][1], false, 'parse-block-content: unbound block' );
+	}
+
+	// ── Read path 4: edit-block-tree dry-run ─────────────────────
+
+	/**
+	 * @testdox edit-block-tree dry-run block_tree includes canonical bindings shape.
+	 */
+	public function test_edit_block_tree_dry_run_bindings_shape(): void {
+		$result = BlockAbilities::handle_edit_block_tree( [
+			'post_id' => $this->post_id,
+			'op'      => 'update-attrs',
+			'ref'     => 'blk_unbtest1',
+			'attributes' => [ 'className' => 'test-class' ],
+			'dry_run' => true,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['success'] );
+		$this->assertArrayHasKey( 'block_tree', $result );
+
+		// Walk the block_tree and check both named blocks.
+		$named_blocks = $this->extract_named_blocks( $result['block_tree'] );
+		$this->assertGreaterThanOrEqual( 2, count( $named_blocks ), 'Expected at least 2 named blocks in block_tree.' );
+
+		// Find bound and unbound blocks by ref.
+		$bound_block   = $this->find_block_by_ref( $named_blocks, 'blk_bndtest1' );
+		$unbound_block = $this->find_block_by_ref( $named_blocks, 'blk_unbtest1' );
+
+		$this->assertNotNull( $bound_block, 'Bound block must exist in dry-run result.' );
+		$this->assertNotNull( $unbound_block, 'Unbound block must exist in dry-run result.' );
+
+		$this->assert_bindings_shape( $bound_block, true, 'edit-block-tree dry-run: bound block' );
+		$this->assert_bindings_shape( $unbound_block, false, 'edit-block-tree dry-run: unbound block' );
+	}
+
+	// ── Read path 5: update-blocks dry-run ───────────────────────
+
+	/**
+	 * @testdox update-blocks dry-run block_tree includes canonical bindings shape.
+	 */
+	public function test_update_blocks_dry_run_bindings_shape(): void {
+		$result = BlockAbilities::handle_update_blocks( [
+			'post_id' => $this->post_id,
+			'updates' => [
+				[
+					'op'         => 'update-attrs',
+					'ref'        => 'blk_unbtest1',
+					'attributes' => [ 'className' => 'test-class' ],
+				],
+			],
+			'dry_run' => true,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['success'] );
+		$this->assertArrayHasKey( 'block_tree', $result );
+
+		$named_blocks = $this->extract_named_blocks( $result['block_tree'] );
+		$this->assertGreaterThanOrEqual( 2, count( $named_blocks ), 'Expected at least 2 named blocks in block_tree.' );
+
+		$bound_block   = $this->find_block_by_ref( $named_blocks, 'blk_bndtest1' );
+		$unbound_block = $this->find_block_by_ref( $named_blocks, 'blk_unbtest1' );
+
+		$this->assertNotNull( $bound_block, 'Bound block must exist in update-blocks dry-run.' );
+		$this->assertNotNull( $unbound_block, 'Unbound block must exist in update-blocks dry-run.' );
+
+		$this->assert_bindings_shape( $bound_block, true, 'update-blocks dry-run: bound block' );
+		$this->assert_bindings_shape( $unbound_block, false, 'update-blocks dry-run: unbound block' );
+	}
+
+	// ── annotate_bindings_tree unit test ─────────────────────────
+
+	/**
+	 * @testdox annotate_bindings_tree adds canonical shape to raw parse_blocks output.
+	 */
+	public function test_annotate_bindings_tree_adds_shape(): void {
+		$blocks = parse_blocks( $this->mixed_content );
+
+		$annotated = BlockAbilities::annotate_bindings_tree( $blocks );
+
+		// Filter to named blocks only.
+		$named = array_filter( $annotated, fn( $b ) => ! empty( $b['blockName'] ) );
+		$named = array_values( $named );
+		$this->assertCount( 2, $named );
+
+		$this->assert_bindings_shape( $named[0], true, 'annotate_bindings_tree: bound block' );
+		$this->assert_bindings_shape( $named[1], false, 'annotate_bindings_tree: unbound block' );
+	}
+
+	// ── Helpers ──────────────────────────────────────────────────
+
+	/**
+	 * Extract all named blocks (non-null blockName) from a raw block tree.
+	 *
+	 * @param array<int,mixed> $blocks Raw block tree.
+	 * @return array<int,array<string,mixed>> Named blocks (flat list).
+	 */
+	private function extract_named_blocks( array $blocks ): array {
+		$result = [];
+
+		foreach ( $blocks as $block ) {
+			if ( ! is_array( $block ) || empty( $block['blockName'] ) ) {
+				continue;
+			}
+
+			$result[] = $block;
+
+			$inner = isset( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ? $block['innerBlocks'] : [];
+			if ( ! empty( $inner ) ) {
+				$result = array_merge( $result, $this->extract_named_blocks( $inner ) );
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Find a block by its sd_ref in a flat list of block dicts.
+	 *
+	 * @param array<int,array<string,mixed>> $blocks Flat list of block dicts.
+	 * @param string                          $ref    Target ref.
+	 * @return array<string,mixed>|null
+	 */
+	private function find_block_by_ref( array $blocks, string $ref ): ?array {
+		foreach ( $blocks as $block ) {
+			$block_ref = $block['attrs']['metadata'][ BlockReferences::REF_KEY ] ?? null;
+
+			if ( $block_ref === $ref ) {
+				return $block;
+			}
+		}
+
+		return null;
+	}
+}

--- a/tests/SdAiAgent/Core/BindingsReadSurfaceTest.php
+++ b/tests/SdAiAgent/Core/BindingsReadSurfaceTest.php
@@ -69,9 +69,14 @@ class BindingsReadSurfaceTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * get-page-blocks does NOT include bindings/bound_attributes for unbound blocks.
+	 * get-page-blocks includes null bindings and empty bound_attributes for unbound blocks (t275).
+	 *
+	 * After the t275 canonical shape alignment, every block dict always includes
+	 * both fields so clients can type-switch on a single key:
+	 * - bindings: null (not absent)
+	 * - bound_attributes: [] (not absent)
 	 */
-	public function test_unbound_block_has_no_bindings_in_response(): void {
+	public function test_unbound_block_has_null_bindings_in_response(): void {
 		$block_content = '<!-- wp:paragraph {"metadata":{"' . BlockReferences::REF_KEY . '":"blk_unbnd001"}} -->'
 			. "\n<p>Normal paragraph</p>\n"
 			. '<!-- /wp:paragraph -->';
@@ -92,9 +97,11 @@ class BindingsReadSurfaceTest extends WP_UnitTestCase {
 
 		$block_entry = $result['blocks'][0];
 
-		// Verify bindings are NOT present.
-		$this->assertArrayNotHasKey( 'bindings', $block_entry );
-		$this->assertArrayNotHasKey( 'bound_attributes', $block_entry );
+		// t275: both fields always present — null/[] when unbound.
+		$this->assertArrayHasKey( 'bindings', $block_entry );
+		$this->assertNull( $block_entry['bindings'] );
+		$this->assertArrayHasKey( 'bound_attributes', $block_entry );
+		$this->assertSame( [], $block_entry['bound_attributes'] );
 	}
 
 	/**

--- a/tools/audit/bindings-field-audit.md
+++ b/tools/audit/bindings-field-audit.md
@@ -1,0 +1,87 @@
+# t275 Audit: Bindings field shape across read abilities
+
+## Audit date
+
+2026-05-24
+
+## Pre-fix matrix
+
+| Read path | Ability | Returns block dict? | `bindings` field | `bound_attributes` field | Shape notes |
+|---|---|---|---|---|---|
+| `get-page-blocks` (nested) | `sd-ai-agent/get-page-blocks` | Yes | Conditional (only when non-empty) | Conditional (only when non-empty) | `flatten_blocks_for_response()` lines 2409-2413 |
+| `get-page-blocks` (flat DFS) | `sd-ai-agent/get-page-blocks` | Yes | Conditional (only when non-empty) | Conditional (only when non-empty) | `flatten_block_tree()` lines 2579-2583 |
+| `parse-block-content` | `sd-ai-agent/parse-block-content` | Yes | MISSING | MISSING | `clean_parsed_blocks()` omitted bindings |
+| `edit-block-tree` (dry-run) | `sd-ai-agent/edit-block-tree` | Yes (raw `block_tree`) | MISSING | MISSING | Raw `BlockMutator::apply()` output |
+| `update-blocks` (dry-run) | `sd-ai-agent/update-blocks` | Yes (raw `block_tree`) | MISSING | MISSING | Raw `BlockMutator::apply_batch()` output |
+| `insert-pattern` | `sd-ai-agent/insert-pattern` | Yes (raw `block_tree`) | MISSING | MISSING | Raw block tree after ref assignment |
+| `validate-block-content` | `sd-ai-agent/validate-block-content` | No (validation results) | N/A | N/A | Returns `results[]` with `blockName`, `isValid`, etc. |
+| `review-block` | `sd-ai-agent/review-block` | No (AI suggestions) | N/A | N/A | Returns `suggestions[]` — not a block dict emitter |
+| `get-block-type` | `sd-ai-agent/get-block-type` | No (type definition) | N/A | N/A | Returns block type metadata, not parsed block instances |
+| `rewrite-post-blocks` | `sd-ai-agent/rewrite-post-blocks` | No (summary stats) | N/A | N/A | Returns `block_count`, `refs_count` — no `block_tree` |
+| `replace-block-range` | `sd-ai-agent/replace-block-range` | No (summary stats) | N/A | N/A | Returns `refs_added/removed/preserved` — no `block_tree` |
+| `revert-to-revision` | `sd-ai-agent/revert-to-revision` | No (summary stats) | N/A | N/A | Returns `refs_reseeded`, `block_count` — no `block_tree` |
+
+## Canonical shape (post-fix)
+
+```json
+{
+  "ref": "blk_xyz",
+  "name": "core/paragraph",
+  "attributes": { "..." : "..." },
+  "bindings": {
+    "content": { "source": "core/post-meta", "args": { "key": "subtitle" } }
+  },
+  "bound_attributes": ["content"]
+}
+```
+
+When a block has **no bindings**:
+
+```json
+{
+  "ref": "blk_abc",
+  "name": "core/paragraph",
+  "attributes": { "..." : "..." },
+  "bindings": null,
+  "bound_attributes": []
+}
+```
+
+### Rules
+
+- `bindings` is always present: `object` (the `attrs.metadata.bindings` map) when bound, `null` when unbound.
+- `bound_attributes` is always present: `string[]` (the attribute keys listed in `bindings`) when bound, `[]` when unbound.
+- Neither field is ever absent from a block dict.
+
+## Changes made
+
+### `BlockAbilities.php`
+
+1. **`flatten_blocks_for_response()`** (get-page-blocks nested mode): Changed from conditional `if (!empty($bindings))` to always-emit with `null`/`[]` fallback.
+
+2. **`flatten_block_tree()`** (get-page-blocks flat DFS mode): Same conditional-to-always change.
+
+3. **`clean_parsed_blocks()`** (parse-block-content): Added bindings extraction from `attrs.metadata.bindings` with canonical `null`/`[]` shape.
+
+4. **`annotate_bindings_tree()`** (new helper): Recursively walks a raw block tree and adds `bindings`/`bound_attributes` to every named block. Applied to:
+   - `handle_edit_block_tree()` — `block_tree` return value
+   - `handle_update_blocks()` — `block_tree` return value
+   - `handle_insert_pattern()` — `block_tree` return value
+
+5. **Ability descriptions**: Updated `get-page-blocks`, `parse-block-content`, `edit-block-tree`, and `update-blocks` descriptions to document the fields and reference `allow_bound_writes`.
+
+### `BindingsReadSurfaceTest.php`
+
+- Updated `test_unbound_block_has_no_bindings_in_response` → `test_unbound_block_has_null_bindings_in_response` to assert `null`/`[]` instead of absent keys.
+
+### `BindingsFieldConsistencyTest.php` (new)
+
+- Regression guard covering 5 read paths: get-page-blocks (nested), get-page-blocks (flat DFS), parse-block-content, edit-block-tree dry-run, update-blocks dry-run.
+- Each path tested with both bound and unbound blocks.
+- `annotate_bindings_tree()` unit test.
+
+## Verification
+
+```bash
+npm run verify   # lint -> phpstan -> test:php -> build
+```


### PR DESCRIPTION
## Summary

Ensures every read path that emits a block dict always includes both `bindings` (object|null) and `bound_attributes` (string[]) fields. When a block has bindings, `bindings` contains the attrs.metadata.bindings map and `bound_attributes` lists the bound attribute keys. When unbound, `bindings` is null and `bound_attributes` is []. Updated 6 read paths: get-page-blocks (nested + flat DFS), parse-block-content, edit-block-tree, update-blocks, insert-pattern. Added annotate_bindings_tree() helper for raw block tree annotation. Updated ability descriptions and existing BindingsReadSurfaceTest. Added comprehensive BindingsFieldConsistencyTest regression guard covering 5+ paths. Committed audit document at tools/audit/bindings-field-audit.md.

## Files Changed

includes/Abilities/BlockAbilities.php,tests/SdAiAgent/Bootstrap/BindingsFieldConsistencyTest.php,tests/SdAiAgent/Core/BindingsReadSurfaceTest.php,tools/audit/bindings-field-audit.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify (lint:php/js/css + phpstan + test:php + build) all clean. Tests: 3237, Assertions: 13434, Errors: 0, Failures: 0, Skipped: 105.

Resolves #1791


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with claude-opus-4-6 spent 14m and 26,202 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Block API operations now consistently include binding metadata fields across all operations (get-page-blocks, parse-block-content, edit-block-tree, update-blocks). Unbound blocks return null/empty defaults ensuring predictable response structures.

* **Tests**
  * Added regression test suite validating bindings field consistency across all block read and write paths.

* **Documentation**
  * Updated documentation reflecting the canonical response shape for bindings metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1808?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->