### PR TITLE
GH#1782: feat(blocks): block enrichers framework + core/image enricher (t266)

### DIFF
--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Abilities;
 
 use SdAiAgent\Core\BlockContentPolicy;
+use SdAiAgent\Core\BlockEnricherRegistry;
 use SdAiAgent\Core\BlockInventory;
 use SdAiAgent\Core\BlockMutator;
 use SdAiAgent\Core\BlockReferences;
@@ -31,6 +32,37 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class BlockAbilities {
+
+	/**
+	 * Block enricher registry instance.
+	 *
+	 * Set by AbilitiesHandler during init; used by handle_get_page_blocks
+	 * to enrich the block tree before serialisation.
+	 *
+	 * @var BlockEnricherRegistry|null
+	 */
+	private static ?BlockEnricherRegistry $enricher_registry = null;
+
+	/**
+	 * Set the block enricher registry instance.
+	 *
+	 * Called by AbilitiesHandler to inject the singleton registry
+	 * before ability callbacks fire.
+	 *
+	 * @param BlockEnricherRegistry $registry The registry instance.
+	 */
+	public static function set_enricher_registry( BlockEnricherRegistry $registry ): void {
+		self::$enricher_registry = $registry;
+	}
+
+	/**
+	 * Get the block enricher registry instance.
+	 *
+	 * @return BlockEnricherRegistry|null The registry, or null if not yet set.
+	 */
+	public static function get_enricher_registry(): ?BlockEnricherRegistry {
+		return self::$enricher_registry;
+	}
 
 	/**
 	 * Register all block-related abilities.
@@ -2287,6 +2319,20 @@ class BlockAbilities {
 			$blocks = BlockRenderer::render_block_tree( $post_id, $blocks );
 		}
 
+		// Enrich blocks with derived metadata (e.g. image srcset, sizes).
+		// Fires the registration action once per request, then walks the
+		// block tree through all registered enrichers. The enriched data
+		// is placed under `block.enriched.<enricher_id>` so it never
+		// collides with `attributes` or `innerHTML`.
+		if ( null !== self::$enricher_registry ) {
+			self::$enricher_registry->fire_registration_action();
+			$enricher_context = [
+				'post_id' => $post_id,
+				'render'  => $render,
+			];
+			$blocks           = self::$enricher_registry->enrich_block_tree( $blocks, $enricher_context );
+		}
+
 		// Build the annotated block list for the response.
 		$flat_list  = [];
 		$flat_index = 0;
@@ -2463,6 +2509,11 @@ class BlockAbilities {
 				}
 			}
 
+			// Surface enriched data from block enrichers (t266).
+			if ( isset( $block['enriched'] ) && is_array( $block['enriched'] ) && ! empty( $block['enriched'] ) ) {
+				$entry['enriched'] = $block['enriched'];
+			}
+
 			++$flat_index;
 
 			// Recurse into inner blocks (depth is naturally capped by PHP stack + MAX_DEPTH).
@@ -2635,6 +2686,11 @@ class BlockAbilities {
 				if ( isset( $block['rendered_synced_pattern_id'] ) ) {
 					$entry['rendered_synced_pattern_id'] = (int) $block['rendered_synced_pattern_id'];
 				}
+			}
+
+			// Surface enriched data from block enrichers (t266).
+			if ( isset( $block['enriched'] ) && is_array( $block['enriched'] ) && ! empty( $block['enriched'] ) ) {
+				$entry['enriched'] = $block['enriched'];
 			}
 
 			++$flat_index;

--- a/includes/Bootstrap/AbilitiesHandler.php
+++ b/includes/Bootstrap/AbilitiesHandler.php
@@ -24,6 +24,8 @@ namespace SdAiAgent\Bootstrap;
 
 use SdAiAgent\Abilities\AiImageAbilities;
 use SdAiAgent\Abilities\BlockAbilities;
+use SdAiAgent\Core\BlockEnricherRegistry;
+use SdAiAgent\Enrichers\CoreImageEnricher;
 use SdAiAgent\Abilities\ContentAbilities;
 use SdAiAgent\Abilities\CustomPostTypeAbilities;
 use SdAiAgent\Abilities\CustomTaxonomyAbilities;
@@ -112,6 +114,16 @@ final class AbilitiesHandler {
 		ContentAbilities::register_abilities();
 		MarketingAbilities::register_abilities();
 		GoogleAnalyticsAbilities::register_abilities();
+		// Wire the block enricher registry before registering block
+		// abilities so handle_get_page_blocks can use it. The registry
+		// is created once (singleton per request), the core/image
+		// enricher is registered by default, and the third-party
+		// `sd_ai_agent_register_block_enrichers` action fires lazily
+		// on the first get-page-blocks call.
+		$enricher_registry = new BlockEnricherRegistry();
+		$enricher_registry->register( new CoreImageEnricher() );
+		BlockAbilities::set_enricher_registry( $enricher_registry );
+
 		BlockAbilities::register_abilities();
 		GlobalStylesAbilities::register_abilities();
 		FileAbilities::register_abilities();

--- a/includes/Core/BlockEnricherInterface.php
+++ b/includes/Core/BlockEnricherInterface.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Interface for block enrichers.
+ *
+ * Enrichers augment the read-side output of `get-page-blocks` with
+ * derived metadata specific to a block type. Each enricher inspects
+ * the block name and optionally returns additional fields under the
+ * `enriched.<enricher_id>` key.
+ *
+ * Third-party plugins can implement this interface and register their
+ * enrichers via the `sd_ai_agent_register_block_enrichers` action.
+ *
+ * @package SdAiAgent\Core
+ * @license GPL-2.0-or-later
+ * @since   1.13.0
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Contract for block enrichers.
+ *
+ * Each enricher provides:
+ * - A unique identifier (used as the key under `enriched.<id>`).
+ * - A `supports()` check against the block name.
+ * - An `enrich()` method that returns a key-value map of derived data.
+ */
+interface BlockEnricherInterface {
+
+	/**
+	 * Return the unique enricher identifier.
+	 *
+	 * This ID is used as the key under `enriched.<id>` in the block
+	 * response. Must be a non-empty string using only lowercase
+	 * alphanumeric characters and underscores.
+	 *
+	 * @return string Enricher identifier (e.g. 'core_image').
+	 */
+	public function get_id(): string;
+
+	/**
+	 * Check whether this enricher supports the given block name.
+	 *
+	 * @param string $block_name Block name (e.g. 'core/image').
+	 * @return bool True if this enricher should run for the block.
+	 */
+	public function supports( string $block_name ): bool;
+
+	/**
+	 * Enrich a block with derived metadata.
+	 *
+	 * The returned associative array is placed under
+	 * `block.enriched.<get_id()>` in the read response. The enricher
+	 * must never throw — return an appropriate fallback (e.g.
+	 * `['missing' => true]`) instead.
+	 *
+	 * @param array<string,mixed> $block   Parsed block array (blockName, attrs, innerHTML, innerBlocks).
+	 * @param array<string,mixed> $context Request context (e.g. post_id, render flag).
+	 * @return array<string,mixed> Enrichment data to attach.
+	 */
+	public function enrich( array $block, array $context ): array;
+}

--- a/includes/Core/BlockEnricherRegistry.php
+++ b/includes/Core/BlockEnricherRegistry.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * Registry for block enrichers.
+ *
+ * Manages a collection of BlockEnricherInterface instances and runs
+ * them against parsed blocks during read-side serialisation (e.g.
+ * `get-page-blocks`). Each enricher's output is namespaced under
+ * `block.enriched.<enricher_id>` so it never collides with `attributes`
+ * or `innerHTML`.
+ *
+ * Third-party plugins can register enrichers via the
+ * `sd_ai_agent_register_block_enrichers` action which receives this
+ * registry instance.
+ *
+ * @package SdAiAgent\Core
+ * @license GPL-2.0-or-later
+ * @since   1.13.0
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Block enricher registry and dispatcher.
+ *
+ * Registration order matters: when multiple enrichers support the same
+ * block name, they are run in registration order. If two enrichers
+ * share the same `get_id()`, the later registration wins (overwrites).
+ */
+final class BlockEnricherRegistry {
+
+	/**
+	 * Registered enrichers keyed by their ID.
+	 *
+	 * Preserves insertion order for deterministic dispatch.
+	 *
+	 * @var array<string,BlockEnricherInterface>
+	 */
+	private array $enrichers = [];
+
+	/**
+	 * Whether the third-party registration action has been fired.
+	 *
+	 * @var bool
+	 */
+	private bool $action_fired = false;
+
+	/**
+	 * Register an enricher.
+	 *
+	 * If an enricher with the same ID is already registered, it is
+	 * silently replaced (last-write-wins).
+	 *
+	 * @param BlockEnricherInterface $enricher The enricher to register.
+	 */
+	public function register( BlockEnricherInterface $enricher ): void {
+		$this->enrichers[ $enricher->get_id() ] = $enricher;
+	}
+
+	/**
+	 * Unregister an enricher by ID.
+	 *
+	 * @param string $enricher_id The enricher ID to remove.
+	 * @return bool True if the enricher was found and removed.
+	 */
+	public function unregister( string $enricher_id ): bool {
+		if ( ! isset( $this->enrichers[ $enricher_id ] ) ) {
+			return false;
+		}
+
+		unset( $this->enrichers[ $enricher_id ] );
+
+		return true;
+	}
+
+	/**
+	 * Check whether an enricher with the given ID is registered.
+	 *
+	 * @param string $enricher_id The enricher ID.
+	 * @return bool
+	 */
+	public function has( string $enricher_id ): bool {
+		return isset( $this->enrichers[ $enricher_id ] );
+	}
+
+	/**
+	 * Get all registered enricher IDs.
+	 *
+	 * @return string[]
+	 */
+	public function get_registered_ids(): array {
+		return array_keys( $this->enrichers );
+	}
+
+	/**
+	 * Fire the third-party registration action.
+	 *
+	 * Called once per request before the first enrich() call. Allows
+	 * third-party plugins to register their enrichers via:
+	 *
+	 *   add_action( 'sd_ai_agent_register_block_enrichers', function( $registry ) {
+	 *       $registry->register( new My_Custom_Enricher() );
+	 *   } );
+	 */
+	public function fire_registration_action(): void {
+		if ( $this->action_fired ) {
+			return;
+		}
+
+		$this->action_fired = true;
+
+		/**
+		 * Fires when block enrichers should be registered.
+		 *
+		 * @since 1.13.0
+		 *
+		 * @param BlockEnricherRegistry $registry The enricher registry instance.
+		 */
+		do_action( 'sd_ai_agent_register_block_enrichers', $this );
+	}
+
+	/**
+	 * Enrich a single parsed block.
+	 *
+	 * Walks all registered enrichers in registration order and calls
+	 * `enrich()` on those whose `supports()` returns true for the
+	 * block's name. Results are collected under the `enriched` key.
+	 *
+	 * @param array<string,mixed> $block   Parsed block array.
+	 * @param array<string,mixed> $context Request context.
+	 * @return array<string,mixed> The block array with `enriched` key added (if any enricher matched).
+	 */
+	public function enrich( array $block, array $context ): array {
+		$block_name = (string) ( $block['blockName'] ?? '' );
+
+		if ( '' === $block_name ) {
+			return $block;
+		}
+
+		$enriched = [];
+
+		foreach ( $this->enrichers as $enricher ) {
+			if ( $enricher->supports( $block_name ) ) {
+				$data = $enricher->enrich( $block, $context );
+				if ( ! empty( $data ) ) {
+					$enriched[ $enricher->get_id() ] = $data;
+				}
+			}
+		}
+
+		if ( ! empty( $enriched ) ) {
+			$block['enriched'] = $enriched;
+		}
+
+		return $block;
+	}
+
+	/**
+	 * Enrich a full block tree recursively.
+	 *
+	 * Walks the block tree depth-first, enriching each named block
+	 * and recursing into innerBlocks.
+	 *
+	 * @param array<int|string,mixed> $blocks  Parsed block tree.
+	 * @param array<string,mixed>     $context Request context.
+	 * @return array<int|string,mixed> Enriched block tree.
+	 */
+	public function enrich_block_tree( array $blocks, array $context ): array {
+		foreach ( $blocks as $idx => $block ) {
+			if ( ! is_array( $block ) || empty( $block['blockName'] ) ) {
+				continue;
+			}
+
+			// Enrich the block itself.
+			$blocks[ $idx ] = $this->enrich( $block, $context );
+
+			// Recurse into inner blocks.
+			if ( ! empty( $blocks[ $idx ]['innerBlocks'] ) && is_array( $blocks[ $idx ]['innerBlocks'] ) ) {
+				// @phpstan-ignore-next-line -- innerBlocks is always int-keyed from parse_blocks().
+				$blocks[ $idx ]['innerBlocks'] = $this->enrich_block_tree(
+					$blocks[ $idx ]['innerBlocks'],
+					$context
+				);
+			}
+		}
+
+		return $blocks;
+	}
+}

--- a/includes/Enrichers/CoreImageEnricher.php
+++ b/includes/Enrichers/CoreImageEnricher.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * Core Image block enricher.
+ *
+ * Enriches `core/image` blocks with attachment metadata so agents get
+ * srcset, sizes, alt text, intrinsic dimensions, and more without a
+ * separate round-trip to the attachment endpoint.
+ *
+ * Inspired by block-mcp's `class-core-image-enricher.php` (GPL-2.0+).
+ *
+ * @package SdAiAgent\Enrichers
+ * @license GPL-2.0-or-later
+ * @since   1.13.0
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Enrichers;
+
+use SdAiAgent\Core\BlockEnricherInterface;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Enricher for `core/image` blocks.
+ *
+ * Populates `block.enriched.core_image` with:
+ * - attachment_id, url, alt, width, height, aspect_ratio
+ * - mime_type, srcset, sizes, filesize_bytes
+ * - missing (bool) — true when the attachment is unavailable
+ */
+final class CoreImageEnricher implements BlockEnricherInterface {
+
+	/**
+	 * The block name this enricher targets.
+	 */
+	private const BLOCK_NAME = 'core/image';
+
+	/**
+	 * Enricher identifier used as the key under `enriched.<id>`.
+	 */
+	private const ENRICHER_ID = 'core_image';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_id(): string {
+		return self::ENRICHER_ID;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function supports( string $block_name ): bool {
+		return self::BLOCK_NAME === $block_name;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function enrich( array $block, array $context ): array {
+		$attrs         = isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : [];
+		$attachment_id = isset( $attrs['id'] ) ? (int) $attrs['id'] : 0;
+
+		// No attachment ID in attributes → missing.
+		if ( 0 === $attachment_id ) {
+			return [ 'missing' => true ];
+		}
+
+		// Verify the attachment post exists and is an attachment.
+		$attachment = get_post( $attachment_id );
+		if ( ! $attachment || 'attachment' !== $attachment->post_type ) {
+			return [
+				'attachment_id' => $attachment_id,
+				'missing'       => true,
+			];
+		}
+
+		// Fetch attachment metadata.
+		$metadata = wp_get_attachment_metadata( $attachment_id );
+		if ( empty( $metadata ) || ! is_array( $metadata ) ) {
+			return [
+				'attachment_id' => $attachment_id,
+				'missing'       => true,
+			];
+		}
+
+		$width  = isset( $metadata['width'] ) ? (int) $metadata['width'] : 0;
+		$height = isset( $metadata['height'] ) ? (int) $metadata['height'] : 0;
+
+		// If the block specifies a sizeSlug, use the intermediate size dimensions.
+		$size_slug = isset( $attrs['sizeSlug'] ) ? (string) $attrs['sizeSlug'] : '';
+		if ( '' !== $size_slug && isset( $metadata['sizes'][ $size_slug ] ) ) {
+			$size = $metadata['sizes'][ $size_slug ];
+			if ( isset( $size['width'] ) ) {
+				$width = (int) $size['width'];
+			}
+			if ( isset( $size['height'] ) ) {
+				$height = (int) $size['height'];
+			}
+		}
+
+		// Build the URL.
+		$url = (string) wp_get_attachment_url( $attachment_id );
+
+		// Alt text from attachment meta.
+		$alt = (string) get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
+
+		// Compute aspect ratio as a simplified fraction.
+		$aspect_ratio = self::compute_aspect_ratio( $width, $height );
+
+		// MIME type.
+		$mime_type = (string) $attachment->post_mime_type;
+
+		// Srcset and sizes.
+		$srcset = '';
+		$sizes  = '';
+		if ( $width > 0 && $height > 0 ) {
+			$image_src = [ $url, $width, $height, false ];
+			$srcset    = (string) wp_calculate_image_srcset( [ $width, $height ], $url, $metadata, $attachment_id );
+			$sizes     = (string) wp_calculate_image_sizes( [ $width, $height ], $url, $metadata, $attachment_id );
+		}
+
+		// File size from metadata or filesystem.
+		$filesize_bytes = isset( $metadata['filesize'] ) ? (int) $metadata['filesize'] : 0;
+		if ( 0 === $filesize_bytes ) {
+			$file = get_attached_file( $attachment_id );
+			if ( is_string( $file ) && file_exists( $file ) ) {
+				$filesize_bytes = (int) filesize( $file );
+			}
+		}
+
+		return [
+			'attachment_id'  => $attachment_id,
+			'url'            => $url,
+			'alt'            => $alt,
+			'width'          => $width,
+			'height'         => $height,
+			'aspect_ratio'   => $aspect_ratio,
+			'mime_type'      => $mime_type,
+			'srcset'         => $srcset,
+			'sizes'          => $sizes,
+			'filesize_bytes' => $filesize_bytes,
+			'missing'        => false,
+		];
+	}
+
+	/**
+	 * Compute a simplified aspect ratio string (e.g. "3:2", "16:9").
+	 *
+	 * Returns an empty string when either dimension is zero.
+	 *
+	 * @param int $width  Image width.
+	 * @param int $height Image height.
+	 * @return string Simplified aspect ratio or empty string.
+	 */
+	private static function compute_aspect_ratio( int $width, int $height ): string {
+		if ( 0 === $width || 0 === $height ) {
+			return '';
+		}
+
+		$gcd = self::gcd( $width, $height );
+
+		return ( $width / $gcd ) . ':' . ( $height / $gcd );
+	}
+
+	/**
+	 * Compute the greatest common divisor of two positive integers.
+	 *
+	 * @param int $a First integer.
+	 * @param int $b Second integer.
+	 * @return int GCD.
+	 */
+	private static function gcd( int $a, int $b ): int {
+		$a = abs( $a );
+		$b = abs( $b );
+
+		while ( 0 !== $b ) {
+			$t = $b;
+			$b = $a % $b;
+			$a = $t;
+		}
+
+		return $a;
+	}
+}

--- a/tests/SdAiAgent/Core/BlockEnricherRegistryTest.php
+++ b/tests/SdAiAgent/Core/BlockEnricherRegistryTest.php
@@ -1,0 +1,359 @@
+<?php
+/**
+ * Test case for BlockEnricherRegistry (t266).
+ *
+ * Covers:
+ * - Register/unregister/has/get_registered_ids.
+ * - Dispatch order (registration order preserved).
+ * - Multiple enrichers per block name.
+ * - Last-write-wins when two enrichers share the same ID.
+ * - Third-party action hook fires once.
+ * - enrich_block_tree recurses into innerBlocks.
+ * - Blocks without matching enrichers are left unchanged.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\BlockEnricherInterface;
+use SdAiAgent\Core\BlockEnricherRegistry;
+use WP_UnitTestCase;
+
+/**
+ * Unit tests for BlockEnricherRegistry.
+ */
+class BlockEnricherRegistryTest extends WP_UnitTestCase {
+
+	// ── Helpers ────────────────────────────────────────────────────────────
+
+	/**
+	 * Create a stub enricher implementing BlockEnricherInterface.
+	 *
+	 * @param string               $id         Enricher ID.
+	 * @param string               $block_name Block name to support.
+	 * @param array<string,mixed>  $data       Data to return from enrich().
+	 * @return BlockEnricherInterface
+	 */
+	private function make_enricher( string $id, string $block_name, array $data = [] ): BlockEnricherInterface {
+		return new class( $id, $block_name, $data ) implements BlockEnricherInterface {
+			private string $id;
+			private string $block_name;
+			/** @var array<string,mixed> */
+			private array $data;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param string              $id         Enricher ID.
+			 * @param string              $block_name Block name.
+			 * @param array<string,mixed> $data       Enrichment data.
+			 */
+			public function __construct( string $id, string $block_name, array $data ) {
+				$this->id         = $id;
+				$this->block_name = $block_name;
+				$this->data       = $data;
+			}
+
+			public function get_id(): string {
+				return $this->id;
+			}
+
+			public function supports( string $block_name ): bool {
+				return $this->block_name === $block_name;
+			}
+
+			public function enrich( array $block, array $context ): array {
+				return $this->data;
+			}
+		};
+	}
+
+	/**
+	 * Build a minimal parsed-block array.
+	 *
+	 * @param string              $name         Block name.
+	 * @param array<string,mixed> $attrs        Block attributes.
+	 * @param array<int,mixed>    $inner_blocks Inner blocks.
+	 * @return array<string,mixed>
+	 */
+	private function make_block( string $name, array $attrs = [], array $inner_blocks = [] ): array {
+		return [
+			'blockName'    => $name,
+			'attrs'        => $attrs,
+			'innerBlocks'  => $inner_blocks,
+			'innerHTML'    => '<p>test</p>',
+			'innerContent' => [ '<p>test</p>' ],
+		];
+	}
+
+	// ── Registration ──────────────────────────────────────────────────────
+
+	/**
+	 * register() adds an enricher; has() returns true.
+	 */
+	public function test_register_and_has(): void {
+		$registry = new BlockEnricherRegistry();
+		$enricher = $this->make_enricher( 'test_a', 'core/paragraph' );
+
+		$this->assertFalse( $registry->has( 'test_a' ) );
+		$registry->register( $enricher );
+		$this->assertTrue( $registry->has( 'test_a' ) );
+	}
+
+	/**
+	 * unregister() removes an enricher; returns true when found.
+	 */
+	public function test_unregister(): void {
+		$registry = new BlockEnricherRegistry();
+		$enricher = $this->make_enricher( 'test_b', 'core/image' );
+
+		$registry->register( $enricher );
+		$this->assertTrue( $registry->unregister( 'test_b' ) );
+		$this->assertFalse( $registry->has( 'test_b' ) );
+	}
+
+	/**
+	 * unregister() returns false for unknown ID.
+	 */
+	public function test_unregister_unknown_returns_false(): void {
+		$registry = new BlockEnricherRegistry();
+		$this->assertFalse( $registry->unregister( 'nonexistent' ) );
+	}
+
+	/**
+	 * get_registered_ids() returns all registered enricher IDs.
+	 */
+	public function test_get_registered_ids(): void {
+		$registry = new BlockEnricherRegistry();
+		$registry->register( $this->make_enricher( 'alpha', 'core/paragraph' ) );
+		$registry->register( $this->make_enricher( 'beta', 'core/heading' ) );
+
+		$ids = $registry->get_registered_ids();
+		$this->assertContains( 'alpha', $ids );
+		$this->assertContains( 'beta', $ids );
+		$this->assertCount( 2, $ids );
+	}
+
+	// ── Dispatch ──────────────────────────────────────────────────────────
+
+	/**
+	 * enrich() adds enriched.<id> for matching blocks.
+	 */
+	public function test_enrich_adds_enriched_key(): void {
+		$registry = new BlockEnricherRegistry();
+		$registry->register( $this->make_enricher( 'test_para', 'core/paragraph', [ 'word_count' => 42 ] ) );
+
+		$block  = $this->make_block( 'core/paragraph' );
+		$result = $registry->enrich( $block, [] );
+
+		$this->assertArrayHasKey( 'enriched', $result );
+		$this->assertArrayHasKey( 'test_para', $result['enriched'] );
+		$this->assertSame( 42, $result['enriched']['test_para']['word_count'] );
+	}
+
+	/**
+	 * enrich() does not add enriched key for non-matching blocks.
+	 */
+	public function test_enrich_skips_non_matching_blocks(): void {
+		$registry = new BlockEnricherRegistry();
+		$registry->register( $this->make_enricher( 'test_img', 'core/image', [ 'url' => 'test.jpg' ] ) );
+
+		$block  = $this->make_block( 'core/heading' );
+		$result = $registry->enrich( $block, [] );
+
+		$this->assertArrayNotHasKey( 'enriched', $result );
+	}
+
+	/**
+	 * enrich() skips blocks without a blockName.
+	 */
+	public function test_enrich_skips_empty_block_name(): void {
+		$registry = new BlockEnricherRegistry();
+		$registry->register( $this->make_enricher( 'test_para', 'core/paragraph', [ 'x' => 1 ] ) );
+
+		$block = [
+			'blockName'    => null,
+			'attrs'        => [],
+			'innerBlocks'  => [],
+			'innerHTML'    => '',
+			'innerContent' => [],
+		];
+
+		$result = $registry->enrich( $block, [] );
+		$this->assertArrayNotHasKey( 'enriched', $result );
+	}
+
+	/**
+	 * Multiple enrichers per block name — all fire in registration order.
+	 */
+	public function test_multiple_enrichers_per_block(): void {
+		$registry = new BlockEnricherRegistry();
+		$registry->register( $this->make_enricher( 'enricher_a', 'core/image', [ 'source' => 'a' ] ) );
+		$registry->register( $this->make_enricher( 'enricher_b', 'core/image', [ 'source' => 'b' ] ) );
+
+		$block  = $this->make_block( 'core/image' );
+		$result = $registry->enrich( $block, [] );
+
+		$this->assertArrayHasKey( 'enriched', $result );
+		$this->assertSame( 'a', $result['enriched']['enricher_a']['source'] );
+		$this->assertSame( 'b', $result['enriched']['enricher_b']['source'] );
+	}
+
+	/**
+	 * Last-write-wins: re-registering with the same ID replaces.
+	 */
+	public function test_last_write_wins_same_id(): void {
+		$registry = new BlockEnricherRegistry();
+		$registry->register( $this->make_enricher( 'dup', 'core/paragraph', [ 'v' => 1 ] ) );
+		$registry->register( $this->make_enricher( 'dup', 'core/paragraph', [ 'v' => 2 ] ) );
+
+		$block  = $this->make_block( 'core/paragraph' );
+		$result = $registry->enrich( $block, [] );
+
+		$this->assertSame( 2, $result['enriched']['dup']['v'] );
+		$this->assertCount( 1, $registry->get_registered_ids() );
+	}
+
+	// ── enrich_block_tree ─────────────────────────────────────────────────
+
+	/**
+	 * enrich_block_tree() recurses into innerBlocks.
+	 */
+	public function test_enrich_block_tree_recurses(): void {
+		$registry = new BlockEnricherRegistry();
+		$registry->register( $this->make_enricher( 'img_data', 'core/image', [ 'url' => 'nested.jpg' ] ) );
+
+		$inner_image = $this->make_block( 'core/image', [ 'id' => 1 ] );
+		$group       = $this->make_block( 'core/group', [], [ $inner_image ] );
+		$tree        = [ $group ];
+
+		$result = $registry->enrich_block_tree( $tree, [] );
+
+		// The root group should not have enriched (no enricher for core/group).
+		$this->assertArrayNotHasKey( 'enriched', $result[0] );
+
+		// The inner image block should be enriched.
+		$this->assertArrayHasKey( 'enriched', $result[0]['innerBlocks'][0] );
+		$this->assertSame( 'nested.jpg', $result[0]['innerBlocks'][0]['enriched']['img_data']['url'] );
+	}
+
+	/**
+	 * enrich_block_tree() handles mixed block types.
+	 */
+	public function test_enrich_block_tree_mixed_types(): void {
+		$registry = new BlockEnricherRegistry();
+		$registry->register( $this->make_enricher( 'para_meta', 'core/paragraph', [ 'chars' => 100 ] ) );
+
+		$blocks = [
+			$this->make_block( 'core/paragraph' ),
+			$this->make_block( 'core/heading' ),
+			$this->make_block( 'core/paragraph' ),
+		];
+
+		$result = $registry->enrich_block_tree( $blocks, [] );
+
+		$this->assertArrayHasKey( 'enriched', $result[0] );
+		$this->assertArrayNotHasKey( 'enriched', $result[1] );
+		$this->assertArrayHasKey( 'enriched', $result[2] );
+	}
+
+	// ── Action hook ───────────────────────────────────────────────────────
+
+	/**
+	 * fire_registration_action() fires the action with the registry instance.
+	 */
+	public function test_fire_registration_action_fires_once(): void {
+		$registry = new BlockEnricherRegistry();
+		$call_count = 0;
+		$received_registry = null;
+
+		add_action(
+			'sd_ai_agent_register_block_enrichers',
+			function ( $reg ) use ( &$call_count, &$received_registry ) {
+				++$call_count;
+				$received_registry = $reg;
+			}
+		);
+
+		$registry->fire_registration_action();
+		$registry->fire_registration_action(); // Should not fire again.
+
+		$this->assertSame( 1, $call_count );
+		$this->assertSame( $registry, $received_registry );
+	}
+
+	/**
+	 * Third-party enricher registered via action hook is invoked.
+	 */
+	public function test_third_party_enricher_via_action(): void {
+		$registry = new BlockEnricherRegistry();
+		$enricher = $this->make_enricher( 'third_party', 'core/quote', [ 'citation' => 'test' ] );
+
+		add_action(
+			'sd_ai_agent_register_block_enrichers',
+			function ( BlockEnricherRegistry $reg ) use ( $enricher ) {
+				$reg->register( $enricher );
+			}
+		);
+
+		$registry->fire_registration_action();
+
+		$this->assertTrue( $registry->has( 'third_party' ) );
+
+		$block  = $this->make_block( 'core/quote' );
+		$result = $registry->enrich( $block, [] );
+
+		$this->assertSame( 'test', $result['enriched']['third_party']['citation'] );
+	}
+
+	// ── Context passthrough ───────────────────────────────────────────────
+
+	/**
+	 * Context is passed through to the enricher's enrich() method.
+	 */
+	public function test_context_passed_to_enricher(): void {
+		$captured_context = null;
+		$enricher = new class( $captured_context ) implements BlockEnricherInterface {
+			/** @var array<string,mixed>|null */
+			private $captured;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param array<string,mixed>|null &$captured Reference for capturing context.
+			 */
+			public function __construct( &$captured ) {
+				$this->captured = &$captured;
+			}
+
+			public function get_id(): string {
+				return 'ctx_test';
+			}
+
+			public function supports( string $block_name ): bool {
+				return 'core/paragraph' === $block_name;
+			}
+
+			public function enrich( array $block, array $context ): array {
+				$this->captured = $context;
+
+				return [ 'ok' => true ];
+			}
+		};
+
+		$registry = new BlockEnricherRegistry();
+		$registry->register( $enricher );
+
+		$block   = $this->make_block( 'core/paragraph' );
+		$context = [ 'post_id' => 42, 'render' => true ];
+		$registry->enrich( $block, $context );
+
+		$this->assertSame( 42, $captured_context['post_id'] );
+		$this->assertTrue( $captured_context['render'] );
+	}
+}

--- a/tests/SdAiAgent/Enrichers/CoreImageEnricherTest.php
+++ b/tests/SdAiAgent/Enrichers/CoreImageEnricherTest.php
@@ -1,0 +1,313 @@
+<?php
+/**
+ * Test case for CoreImageEnricher (t266).
+ *
+ * Covers:
+ * - Populated attachment metadata → all fields present.
+ * - Missing attachment (deleted) → missing: true, no URL fields.
+ * - Missing attrs.id → missing: true.
+ * - Non-image blocks → enricher does not fire (supports() returns false).
+ * - sizeSlug override → uses intermediate size dimensions.
+ * - Aspect ratio computation.
+ * - Alt text from attachment meta.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Enrichers;
+
+use SdAiAgent\Enrichers\CoreImageEnricher;
+use WP_UnitTestCase;
+
+/**
+ * Integration tests for CoreImageEnricher.
+ *
+ * Uses WP_UnitTestCase so attachment factory and metadata functions
+ * are available.
+ */
+class CoreImageEnricherTest extends WP_UnitTestCase {
+
+	/**
+	 * The enricher under test.
+	 *
+	 * @var CoreImageEnricher
+	 */
+	private CoreImageEnricher $enricher;
+
+	/**
+	 * Set up the enricher instance before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->enricher = new CoreImageEnricher();
+	}
+
+	// ── Interface contract ────────────────────────────────────────────────
+
+	/**
+	 * get_id() returns 'core_image'.
+	 */
+	public function test_get_id(): void {
+		$this->assertSame( 'core_image', $this->enricher->get_id() );
+	}
+
+	/**
+	 * supports() returns true for core/image.
+	 */
+	public function test_supports_core_image(): void {
+		$this->assertTrue( $this->enricher->supports( 'core/image' ) );
+	}
+
+	/**
+	 * supports() returns false for non-image blocks.
+	 */
+	public function test_does_not_support_other_blocks(): void {
+		$this->assertFalse( $this->enricher->supports( 'core/paragraph' ) );
+		$this->assertFalse( $this->enricher->supports( 'core/heading' ) );
+		$this->assertFalse( $this->enricher->supports( 'core/gallery' ) );
+		$this->assertFalse( $this->enricher->supports( 'core/cover' ) );
+	}
+
+	// ── Missing id attr ───────────────────────────────────────────────────
+
+	/**
+	 * Block with no attrs.id → missing: true.
+	 */
+	public function test_missing_id_attr(): void {
+		$block = [
+			'blockName'    => 'core/image',
+			'attrs'        => [],
+			'innerBlocks'  => [],
+			'innerHTML'    => '<figure class="wp-block-image"><img src="foo.jpg"/></figure>',
+			'innerContent' => [ '<figure class="wp-block-image"><img src="foo.jpg"/></figure>' ],
+		];
+
+		$result = $this->enricher->enrich( $block, [] );
+
+		$this->assertTrue( $result['missing'] );
+		$this->assertArrayNotHasKey( 'url', $result );
+		$this->assertArrayNotHasKey( 'width', $result );
+	}
+
+	/**
+	 * Block with attrs.id = 0 → missing: true.
+	 */
+	public function test_zero_id_attr(): void {
+		$block = [
+			'blockName'    => 'core/image',
+			'attrs'        => [ 'id' => 0 ],
+			'innerBlocks'  => [],
+			'innerHTML'    => '',
+			'innerContent' => [],
+		];
+
+		$result = $this->enricher->enrich( $block, [] );
+
+		$this->assertTrue( $result['missing'] );
+	}
+
+	// ── Deleted attachment ────────────────────────────────────────────────
+
+	/**
+	 * Block with attrs.id pointing to a deleted attachment → missing: true.
+	 */
+	public function test_deleted_attachment(): void {
+		$block = [
+			'blockName'    => 'core/image',
+			'attrs'        => [ 'id' => 999999 ],
+			'innerBlocks'  => [],
+			'innerHTML'    => '',
+			'innerContent' => [],
+		];
+
+		$result = $this->enricher->enrich( $block, [] );
+
+		$this->assertTrue( $result['missing'] );
+		$this->assertSame( 999999, $result['attachment_id'] );
+		$this->assertArrayNotHasKey( 'url', $result );
+	}
+
+	/**
+	 * Block with attrs.id pointing to a non-attachment post → missing: true.
+	 */
+	public function test_non_attachment_post(): void {
+		$post_id = self::factory()->post->create( [ 'post_type' => 'post' ] );
+
+		$block = [
+			'blockName'    => 'core/image',
+			'attrs'        => [ 'id' => $post_id ],
+			'innerBlocks'  => [],
+			'innerHTML'    => '',
+			'innerContent' => [],
+		];
+
+		$result = $this->enricher->enrich( $block, [] );
+
+		$this->assertTrue( $result['missing'] );
+		$this->assertSame( $post_id, $result['attachment_id'] );
+	}
+
+	// ── Populated attachment ──────────────────────────────────────────────
+
+	/**
+	 * Block with a valid attachment → all expected fields populated.
+	 */
+	public function test_populated_attachment(): void {
+		$attachment_id = self::factory()->attachment->create_upload_object(
+			DIR_TESTDATA . '/images/canola.jpg'
+		);
+
+		// Ensure metadata is populated.
+		$metadata = wp_get_attachment_metadata( $attachment_id );
+		$this->assertIsArray( $metadata, 'Attachment metadata should be populated by upload' );
+
+		$block = [
+			'blockName'    => 'core/image',
+			'attrs'        => [ 'id' => $attachment_id ],
+			'innerBlocks'  => [],
+			'innerHTML'    => '',
+			'innerContent' => [],
+		];
+
+		$result = $this->enricher->enrich( $block, [] );
+
+		$this->assertFalse( $result['missing'] );
+		$this->assertSame( $attachment_id, $result['attachment_id'] );
+		$this->assertNotEmpty( $result['url'] );
+		$this->assertIsInt( $result['width'] );
+		$this->assertIsInt( $result['height'] );
+		$this->assertGreaterThan( 0, $result['width'] );
+		$this->assertGreaterThan( 0, $result['height'] );
+		$this->assertNotEmpty( $result['aspect_ratio'] );
+		$this->assertStringContainsString( ':', $result['aspect_ratio'] );
+		$this->assertSame( 'image/jpeg', $result['mime_type'] );
+		$this->assertArrayHasKey( 'srcset', $result );
+		$this->assertArrayHasKey( 'sizes', $result );
+		$this->assertArrayHasKey( 'filesize_bytes', $result );
+	}
+
+	/**
+	 * Alt text is surfaced from attachment meta.
+	 */
+	public function test_alt_text(): void {
+		$attachment_id = self::factory()->attachment->create_upload_object(
+			DIR_TESTDATA . '/images/canola.jpg'
+		);
+
+		update_post_meta( $attachment_id, '_wp_attachment_image_alt', 'Beautiful canola field' );
+
+		$block = [
+			'blockName'    => 'core/image',
+			'attrs'        => [ 'id' => $attachment_id ],
+			'innerBlocks'  => [],
+			'innerHTML'    => '',
+			'innerContent' => [],
+		];
+
+		$result = $this->enricher->enrich( $block, [] );
+
+		$this->assertSame( 'Beautiful canola field', $result['alt'] );
+	}
+
+	// ── sizeSlug override ─────────────────────────────────────────────────
+
+	/**
+	 * When sizeSlug is set and matches an intermediate size, dimensions
+	 * reflect the intermediate size, not the original.
+	 */
+	public function test_size_slug_override(): void {
+		$attachment_id = self::factory()->attachment->create_upload_object(
+			DIR_TESTDATA . '/images/canola.jpg'
+		);
+
+		$metadata = wp_get_attachment_metadata( $attachment_id );
+		$this->assertIsArray( $metadata );
+
+		// Find a valid intermediate size slug.
+		$size_slug = null;
+		if ( ! empty( $metadata['sizes'] ) ) {
+			$size_slug = array_key_first( $metadata['sizes'] );
+		}
+
+		if ( null === $size_slug ) {
+			$this->markTestSkipped( 'No intermediate sizes available for test image.' );
+		}
+
+		$block = [
+			'blockName'    => 'core/image',
+			'attrs'        => [
+				'id'       => $attachment_id,
+				'sizeSlug' => $size_slug,
+			],
+			'innerBlocks'  => [],
+			'innerHTML'    => '',
+			'innerContent' => [],
+		];
+
+		$result = $this->enricher->enrich( $block, [] );
+
+		$this->assertFalse( $result['missing'] );
+		// The returned dimensions should match the intermediate size.
+		$expected_width  = (int) $metadata['sizes'][ $size_slug ]['width'];
+		$expected_height = (int) $metadata['sizes'][ $size_slug ]['height'];
+		$this->assertSame( $expected_width, $result['width'] );
+		$this->assertSame( $expected_height, $result['height'] );
+	}
+
+	// ── Aspect ratio ──────────────────────────────────────────────────────
+
+	/**
+	 * Aspect ratio is correctly simplified.
+	 */
+	public function test_aspect_ratio_simplified(): void {
+		$attachment_id = self::factory()->attachment->create_upload_object(
+			DIR_TESTDATA . '/images/canola.jpg'
+		);
+
+		$block = [
+			'blockName'    => 'core/image',
+			'attrs'        => [ 'id' => $attachment_id ],
+			'innerBlocks'  => [],
+			'innerHTML'    => '',
+			'innerContent' => [],
+		];
+
+		$result = $this->enricher->enrich( $block, [] );
+
+		// Verify aspect_ratio is a valid ratio string (e.g. "3:2", "16:9").
+		$this->assertMatchesRegularExpression( '/^\d+:\d+$/', $result['aspect_ratio'] );
+	}
+
+	// ── Attachment without metadata ──────────────────────────────────────
+
+	/**
+	 * Attachment that exists but has no metadata → missing: true.
+	 */
+	public function test_attachment_without_metadata(): void {
+		// Create an attachment without uploading a file (no metadata).
+		$attachment_id = self::factory()->attachment->create( [
+			'post_mime_type' => 'image/jpeg',
+			'post_title'     => 'Test attachment',
+		] );
+
+		// Explicitly delete metadata if any was auto-created.
+		delete_post_meta( $attachment_id, '_wp_attachment_metadata' );
+
+		$block = [
+			'blockName'    => 'core/image',
+			'attrs'        => [ 'id' => $attachment_id ],
+			'innerBlocks'  => [],
+			'innerHTML'    => '',
+			'innerContent' => [],
+		];
+
+		$result = $this->enricher->enrich( $block, [] );
+
+		$this->assertTrue( $result['missing'] );
+		$this->assertSame( $attachment_id, $result['attachment_id'] );
+	}
+}


### PR DESCRIPTION
## Summary

Adds a block enricher framework with BlockEnricherInterface contract, BlockEnricherRegistry for registration/dispatch, and a CoreImageEnricher that populates enriched.core_image with attachment metadata (url, alt, width, height, srcset, sizes, aspect_ratio, mime_type, filesize_bytes). Wired into get-page-blocks after rendering, before flattening. Third-party extension via sd_ai_agent_register_block_enrichers action. Includes 21 tests across registry and enricher.

## Worker self-verification
- PHPUnit: Tests: 3338, Assertions: 13624, Errors: 0, Failures: 0, Skipped: 107
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

## Files Changed

- **New:** `includes/Core/BlockEnricherInterface.php` — enricher contract
- **New:** `includes/Core/BlockEnricherRegistry.php` — registry + dispatch
- **New:** `includes/Enrichers/CoreImageEnricher.php` — core/image enricher
- **Modified:** `includes/Abilities/BlockAbilities.php` — wire enricher into get-page-blocks
- **Modified:** `includes/Bootstrap/AbilitiesHandler.php` — bind registry + register core/image
- **New:** `tests/SdAiAgent/Core/BlockEnricherRegistryTest.php` — 11 tests
- **New:** `tests/SdAiAgent/Enrichers/CoreImageEnricherTest.php` — 10 tests

## Runtime Testing

- **Risk level:** Low (new read-side extension, no write-side changes)
- **Verification:** npm run verify (lint → phpstan → test:php → build) all clean.

Resolves #1782
For #1780

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.29 plugin for [OpenCode](https://opencode.ai) v1.15.10 with claude-opus-4-6 spent 14m and 28,419 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Block enrichment system enables blocks to include enriched metadata output
- Image blocks now provide enhanced properties including attachment dimensions, computed aspect ratio, alt text, file size information, and responsive image source sets
- Third-party developers can register custom enrichers to extend block metadata capabilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1810?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->