### PR TITLE
test(rate-limiter): add set_up() pre-test isolation to fix order-dependent flake (#1811)

### DIFF
--- a/tests/SdAiAgent/Core/RateLimiterTest.php
+++ b/tests/SdAiAgent/Core/RateLimiterTest.php
@@ -39,23 +39,63 @@ use WP_UnitTestCase;
 class RateLimiterTest extends WP_UnitTestCase {
 
 	/**
+	 * Buckets and entity IDs covered by this test class.
+	 *
+	 * Centralised here so set_up() and tear_down() stay in sync when new
+	 * entity IDs are added to test methods.
+	 *
+	 * @var string[]
+	 */
+	private const CLEANUP_BUCKETS = [ 'write', 'rewrite' ];
+
+	/**
+	 * @var int[]
+	 */
+	private const CLEANUP_ENTITY_IDS = [ 1, 2, 42, 156, 200, 999 ];
+
+	/**
+	 * Ensure a clean slate before every test.
+	 *
+	 * WP_UnitTestCase wraps each test in a database transaction that is rolled
+	 * back in tearDown(). The ROLLBACK restores rows that were deleted inside
+	 * the transaction — including the delete_transient() calls made by the
+	 * PREVIOUS test's tear_down(). On the next test the wp_cache may be empty
+	 * (flushed by WP), but the options table still carries the rolled-back
+	 * transient; the next cache-miss read from the DB then finds unexpected
+	 * prior-test state. Adding the same cleanup in set_up() prevents this
+	 * leakage regardless of ROLLBACK semantics or run order.
+	 *
+	 * @see https://github.com/Ultimate-Multisite/superdav-ai-agent/issues/1811
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->flush_rate_limit_transients();
+	}
+
+	/**
 	 * Clean up rate-limit transients between tests.
 	 */
 	public function tear_down(): void {
-		// Clean up all transients used in tests.
-		$buckets   = [ 'write', 'rewrite' ];
-		$entity_ids = [ 156, 200, 999, 1, 2, 42 ];
-
-		foreach ( $buckets as $bucket ) {
-			foreach ( $entity_ids as $entity_id ) {
-				delete_transient( 'sd_ai_agent_rl_' . $bucket . '_' . $entity_id );
-			}
-		}
+		$this->flush_rate_limit_transients();
 
 		// Remove any filters we added.
 		remove_all_filters( 'sd_ai_agent_rate_limits' );
 
 		parent::tear_down();
+	}
+
+	/**
+	 * Delete all rate-limit transients used by this test class.
+	 *
+	 * Called from both set_up() and tear_down() so every test starts and ends
+	 * with a clean transient state.
+	 */
+	private function flush_rate_limit_transients(): void {
+		foreach ( self::CLEANUP_BUCKETS as $bucket ) {
+			foreach ( self::CLEANUP_ENTITY_IDS as $entity_id ) {
+				delete_transient( 'sd_ai_agent_rl_' . $bucket . '_' . $entity_id );
+			}
+		}
 	}
 
 	// ── AC1: Write bucket limit ───────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the order-dependent test failure in `RateLimiterTest::test_retry_after_clamped_to_minimum_one` that reproduced in the full PHPUnit suite but passed in isolation (surfaced in wave-3 closeout run on main at `f18c638`).

## Root cause

`RateLimiterTest` had a `tear_down()` that deleted rate-limit transients after each test but **no `set_up()` mirror**. In the full suite, `WP_UnitTestCase` wraps each test in a DB transaction rolled back in `tearDown()`. That ROLLBACK can restore transient rows that were deleted inside the previous test's `tear_down()`. On the next test, the wp_cache may be empty (flushed by WP) but the options table still carries the rolled-back value. A cache-miss then reads the unexpected prior-test state from the DB.

`test_retry_after_clamped_to_minimum_one` seeds ticks at exactly `$now - WINDOW_SECONDS + 1` — one second from the prune boundary. Leaked recent-tick state from a prior test (or even a single PHP second elapsing between `set_transient()` and `check()`'s `time()` call under full-suite load) causes the strict `$ts > $cutoff` comparison to prune all 10 boundary ticks, making `count($ticks) = 0 < 10` and returning `true` instead of the expected `WP_Error`.

## Fix

Option (b) from issue: add `set_up()` that calls the same `flush_rate_limit_transients()` helper as `tear_down()`. Both entry points guarantee a clean transient slate regardless of ROLLBACK semantics or run order. The cleanup lists are extracted into private `CLEANUP_BUCKETS` and `CLEANUP_ENTITY_IDS` constants so the two callers remain in sync automatically.

No production code changes required — isolation/teardown fix only, as described in the issue.

## Files changed

- `tests/SdAiAgent/Core/RateLimiterTest.php` — add `set_up()`, extract `flush_rate_limit_transients()` private helper, define `CLEANUP_BUCKETS` / `CLEANUP_ENTITY_IDS` constants

## Worker self-verification

- PHPUnit: Tests: 3338, Assertions: 13624, Errors: 0, Failures: 0, Skipped: 107
- Lint:    PHP clean
- PHPStan: 0 errors
- Build:   n/a (test-only change)

Resolves #1811

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.30 plugin for [OpenCode](https://opencode.ai) v1.15.10 with claude-sonnet-4-6 spent 11m and 31,338 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation for rate-limiter tests by refactoring transient cleanup logic.

---

**Note:** This release includes only internal testing infrastructure improvements with no user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1813?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->