### PR TITLE
test(block-abilities): fix risky test for legacy block replacement (#1812)

### DIFF
--- a/tests/SdAiAgent/Abilities/BlockAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/BlockAbilitiesTest.php
@@ -191,11 +191,23 @@ class BlockAbilitiesTest extends WP_UnitTestCase {
 
 	/**
 	 * Test handle_list_block_types includes suggested_replacement for legacy blocks.
+	 *
+	 * Uses tier + per_page filters so core/freeform is guaranteed to appear: the
+	 * default per_page=20 sorted alphabetically places core/freeform beyond page 1
+	 * when all core/comment-* blocks are registered, so the unfiltered call
+	 * produced zero assertions (risky test). GH#1812.
 	 */
 	public function test_handle_list_block_types_legacy_block_has_replacement() {
-		$result = BlockAbilities::handle_list_block_types( [] );
+		// Filter to legacy tier with a large per_page so core/freeform is reachable
+		// regardless of total registered block count.
+		$result = BlockAbilities::handle_list_block_types( [
+			'tier'     => 'legacy',
+			'per_page' => 100,
+		] );
 
-		// Find a legacy block (core/freeform is known to be legacy).
+		$this->assertIsArray( $result );
+
+		// Find core/freeform (known legacy block with core/group as replacement).
 		$legacy_block = null;
 		foreach ( $result['block_types'] as $block ) {
 			if ( 'core/freeform' === $block['name'] ) {
@@ -204,12 +216,11 @@ class BlockAbilitiesTest extends WP_UnitTestCase {
 			}
 		}
 
-		if ( $legacy_block ) {
-			$this->assertSame( 'legacy', $legacy_block['tier'] );
-			$this->assertArrayHasKey( 'suggested_replacement', $legacy_block );
-			$this->assertNotNull( $legacy_block['suggested_replacement'] );
-			$this->assertSame( 'core/group', $legacy_block['suggested_replacement'] );
-		}
+		$this->assertNotNull( $legacy_block, 'core/freeform must be registered and appear in legacy-tier results' );
+		$this->assertSame( 'legacy', $legacy_block['tier'] );
+		$this->assertArrayHasKey( 'suggested_replacement', $legacy_block );
+		$this->assertNotNull( $legacy_block['suggested_replacement'] );
+		$this->assertSame( 'core/group', $legacy_block['suggested_replacement'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes the risky (zero-assertion) PHPUnit test `test_handle_list_block_types_legacy_block_has_replacement` reported in GH#1812.

### Root cause

The test called `handle_list_block_types( [] )` which returns the first page of 20 blocks sorted alphabetically. `core/freeform` sits beyond position 20 when all `core/comment-*` blocks are registered, so `$legacy_block` was always `null` and the entire assertion body inside `if ( $legacy_block )` was silently skipped — PHPUnit flagged it as risky.

### Fix

- Added `'tier' => 'legacy', 'per_page' => 100` to the `handle_list_block_types()` call so `core/freeform` is guaranteed to appear regardless of total block count.
- Replaced the `if ( $legacy_block )` guard with an unconditional `assertNotNull( $legacy_block, '...' )` so the test fails clearly if the block is missing rather than silently passing with zero assertions.
- Added a docblock explaining the pagination root cause (GH#1812).

## Worker self-verification
- PHPUnit: Tests: 3338, Assertions: 13630, Errors: 0, Failures: 0, Skipped: 107, Incomplete: 4, Risky: 0
- Lint:    PHP clean
- Build:   not required (test-only change)

Resolves #1812

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.30 plugin for [OpenCode](https://opencode.ai) v1.15.10 with claude-sonnet-4-6 spent 5m and 12,005 tokens on this as a headless worker.
