### PR TITLE
fix(provider): DeepSeek V4 Flash 400 — merge split reasoning+tool_calls wire messages (Resolves #1814)

### DIFF
--- a/lib/php-ai-client/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
+++ b/lib/php-ai-client/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php
@@ -93,6 +93,14 @@ abstract class AbstractOpenAiCompatibleTextGenerationModel extends AbstractApiBa
     {
         $config = $this->getConfig();
         $params = ['model' => $this->metadata()->getId(), 'messages' => $this->prepareMessagesParam($prompt, $config->getSystemInstruction())];
+        // For DeepSeek thinking models, merge split [reasoning-only, tool-calls] wire message
+        // pairs back into a single assistant message. The ConversationSerializer splits them
+        // to satisfy the OpenAI Responses API constraint (one function_call per message), but
+        // DeepSeek's thinking-mode API requires reasoning_content and tool_calls in the same
+        // assistant message — see https://api-docs.deepseek.com/guides/thinking_mode#tool-calls.
+        if ($this->isDeepSeekThinkingModel($this->metadata()->getId())) {
+            $params['messages'] = $this->mergeDeepSeekSplitReasoningMessages($params['messages']);
+        }
         $outputModalities = $config->getOutputModalities();
         if (is_array($outputModalities)) {
             $this->validateOutputModalities($outputModalities);
@@ -169,11 +177,7 @@ abstract class AbstractOpenAiCompatibleTextGenerationModel extends AbstractApiBa
      */
     protected function prepareMessagesParam(array $messages, ?string $systemInstruction = null): array
     {
-        // Check if this is a DeepSeek thinking model that requires reasoning_content round-trip.
-        $modelId = $this->metadata()->getId();
-        $isDeepSeekThinkingModel = $this->isDeepSeekThinkingModel($modelId);
-
-        $messagesParam = array_map(function (Message $message) use ($isDeepSeekThinkingModel): array {
+        $messagesParam = array_map(function (Message $message): array {
             // Special case: Function response.
             $messageParts = $message->getParts();
             if (count($messageParts) === 1 && $messageParts[0]->getType()->isFunctionResponse()) {
@@ -190,8 +194,14 @@ abstract class AbstractOpenAiCompatibleTextGenerationModel extends AbstractApiBa
             if (!empty($toolCalls)) {
                 $messageData['tool_calls'] = $toolCalls;
             }
-            // For DeepSeek thinking models, include reasoning_content if present.
-            if ($isDeepSeekThinkingModel && $message->getRole()->isModel()) {
+            // Always include reasoning_content on model messages when thought-channel parts are
+            // present. The only way a message has thought-channel parts is if the provider's
+            // response contained reasoning_content (added in parseResponseChoiceMessageParts).
+            // Any such provider requires the reasoning_content echoed back verbatim — this is
+            // not provider-specific logic, it is a universal contract for reasoning-content APIs.
+            // (Previously gated on isDeepSeekThinkingModel() model-ID regex, which failed for
+            // model IDs not matching the regex pattern — see GH#1814.)
+            if ($message->getRole()->isModel()) {
                 $reasoningContent = $this->extractReasoningContent($messageParts);
                 if ($reasoningContent !== null) {
                     $messageData['reasoning_content'] = $reasoningContent;
@@ -587,27 +597,95 @@ abstract class AbstractOpenAiCompatibleTextGenerationModel extends AbstractApiBa
          $lowerModelId = strtolower($modelId);
          return (bool) preg_match('/deepseek.*(?:reasoner|thinking|v[34].*flash|v[34].*pro)/i', $modelId);
      }
-     /**
-      * Extracts reasoning_content from message parts if present.
-      *
-      * Looks for message parts in the thought channel and returns their text content
-      * as reasoning_content for DeepSeek thinking models.
-      *
-      * @since 1.4.0
-      *
-      * @param MessagePart[] $parts The message parts to search.
-      * @return string|null The reasoning content if found, null otherwise.
-      */
-     private function extractReasoningContent(array $parts): ?string
-     {
-         foreach ($parts as $part) {
-             if ($part->getChannel()->isThought() && $part->getType()->isText()) {
-                 $text = $part->getText();
-                 if ($text !== null && $text !== '') {
-                     return $text;
-                 }
-             }
-         }
-         return null;
-     }
- }
+      /**
+       * Extracts reasoning_content from message parts if present.
+       *
+       * Looks for message parts in the thought channel and returns their text content
+       * as reasoning_content for DeepSeek thinking models.
+       *
+       * @since 1.4.0
+       *
+       * @param MessagePart[] $parts The message parts to search.
+       * @return string|null The reasoning content if found, null otherwise.
+       */
+      private function extractReasoningContent(array $parts): ?string
+      {
+          foreach ($parts as $part) {
+              if ($part->getChannel()->isThought() && $part->getType()->isText()) {
+                  $text = $part->getText();
+                  if ($text !== null && $text !== '') {
+                      return $text;
+                  }
+              }
+          }
+          return null;
+      }
+
+      /**
+       * Merges split [reasoning-only, tool-calls] wire assistant message pairs.
+       *
+       * The ConversationSerializer::append_assistant_message() splits a DeepSeek
+       * thinking-mode response that contains both reasoning_content and tool_calls
+       * into two separate ModelMessages so the history satisfies the OpenAI Responses
+       * API constraint (each function_call must be its own top-level input item).
+       *
+       * DeepSeek's API, however, requires both reasoning_content and tool_calls in
+       * the SAME assistant message on every subsequent request — sending them in two
+       * separate messages causes a 400 "reasoning_content must be passed back" error.
+       *
+       * This method detects adjacent assistant wire entries matching the split pattern:
+       *   Entry [i]:   {role: assistant, reasoning_content: "...", content: [], no tool_calls}
+       *   Entry [i+1]: {role: assistant, content: [], tool_calls: [...], no reasoning_content}
+       *
+       * and collapses them into a single entry:
+       *   {role: assistant, reasoning_content: "...", content: [], tool_calls: [...]}
+       *
+       * The merge is idempotent: entries that are already correctly shaped (one
+       * message with both fields) are left untouched.
+       *
+       * @since 1.4.1
+       *
+       * @param list<array<string, mixed>> $messages Wire messages from prepareMessagesParam().
+       * @return list<array<string, mixed>> Wire messages with split pairs merged.
+       */
+      private function mergeDeepSeekSplitReasoningMessages(array $messages): array
+      {
+          $result = [];
+          $count  = count($messages);
+          $i      = 0;
+
+          while ($i < $count) {
+              $current = $messages[$i];
+              $next    = ($i + 1 < $count) ? $messages[$i + 1] : null;
+
+              // Detect the split pattern:
+              //  current = reasoning-only assistant entry (has reasoning_content, no tool_calls)
+              //  next    = tool-calls assistant entry (has tool_calls, no reasoning_content)
+              if ($next !== null
+                  && is_array($current)
+                  && ($current['role'] ?? '') === 'assistant'
+                  && isset($current['reasoning_content'])
+                  && $current['reasoning_content'] !== ''
+                  && (empty($current['tool_calls']))
+                  && (empty($current['content']) || $current['content'] === [])
+                  && is_array($next)
+                  && ($next['role'] ?? '') === 'assistant'
+                  && !empty($next['tool_calls'])
+                  && (empty($next['reasoning_content']))
+              ) {
+                  // Merge: carry reasoning_content onto the tool-calls entry and drop
+                  // the reasoning-only entry, producing the single-message shape that
+                  // DeepSeek's thinking-mode API requires.
+                  $merged                      = $next;
+                  $merged['reasoning_content'] = $current['reasoning_content'];
+                  $result[]                    = $merged;
+                  $i += 2;
+              } else {
+                  $result[] = $current;
+                  ++$i;
+              }
+          }
+
+          return $result;
+      }
+  }

--- a/tests/SdAiAgent/Core/ConversationSerializerTest.php
+++ b/tests/SdAiAgent/Core/ConversationSerializerTest.php
@@ -16,6 +16,7 @@ use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\DTO\ModelMessage;
 use WordPress\AiClient\Messages\DTO\UserMessage;
+use WordPress\AiClient\Messages\Enums\MessagePartChannelEnum;
 use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
 use WordPress\AiClient\Tools\DTO\FunctionCall;
 use WordPress\AiClient\Tools\DTO\FunctionResponse;
@@ -57,6 +58,13 @@ class ConversationSerializerTest extends WP_UnitTestCase {
 	 */
 	private function text_part( string $text ): MessagePart {
 		return new MessagePart( $text );
+	}
+
+	/**
+	 * Build a real MessagePart wrapping thought-channel text.
+	 */
+	private function thought_part( string $text ): MessagePart {
+		return new MessagePart( $text, MessagePartChannelEnum::thought() );
 	}
 
 	/**
@@ -294,6 +302,52 @@ class ConversationSerializerTest extends WP_UnitTestCase {
 		$this->assertCount( 3, $history );
 		$this->assertSame( $existing_user, $history[0] );
 		$this->assertHistoryPassesOpenAiValidator( $history );
+	}
+
+	/**
+	 * DeepSeek thinking-mode regression (GH#1814): a message with a thought-channel
+	 * part + function_call MUST be split so each function_call is its own message.
+	 *
+	 * The OpenAI Responses API validator (in ai-provider-for-openai) rejects messages
+	 * that contain a function_call alongside any other part. The thought-channel part
+	 * from DeepSeek reasoning_content is an "other part" at the Message level, so it
+	 * triggers the split to satisfy that constraint.
+	 *
+	 * The base-class `mergeDeepSeekSplitReasoningMessages()` re-merges them at the
+	 * wire level for DeepSeek providers before sending the HTTP request, so DeepSeek
+	 * sees the combined {reasoning_content + tool_calls} message it requires.
+	 */
+	public function test_append_assistant_message_thought_plus_function_call_splits(): void {
+		$this->skip_if_sdk_unavailable();
+
+		$message = new ModelMessage(
+			[
+				$this->thought_part( 'Let me fetch that post...' ),
+				$this->function_call_part( 'call_deepseek', 'wpab__sd-ai-agent__get-post', array( 'id' => 42 ) ),
+			]
+		);
+		$history = array();
+
+		ConversationSerializer::append_assistant_message( $history, $message );
+
+		// Must split: [thought, function_call] → two separate ModelMessages.
+		$this->assertCount( 2, $history, 'Expected thought+function_call to be split into two messages' );
+
+		// First message: thought-channel part only.
+		$this->assertCount( 1, $history[0]->getParts(), 'Reasoning message should have exactly one part' );
+		$this->assertTrue(
+			$history[0]->getParts()[0]->getChannel()->isThought(),
+			'First split message should contain the thought-channel part'
+		);
+		$this->assertSame( 'Let me fetch that post...', $history[0]->getParts()[0]->getText() );
+
+		// Second message: function_call part only.
+		$this->assertCount( 1, $history[1]->getParts(), 'Tool-call message should have exactly one part' );
+		$this->assertTrue(
+			$history[1]->getParts()[0]->getType()->isFunctionCall(),
+			'Second split message should contain the function_call part'
+		);
+		$this->assertSame( 'call_deepseek', $history[1]->getParts()[0]->getFunctionCall()->getId() );
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/DeepSeekReasoningContentTest.php
+++ b/tests/SdAiAgent/Core/DeepSeekReasoningContentTest.php
@@ -32,6 +32,7 @@ use WordPress\AiClient\Messages\DTO\ModelMessage;
 use WordPress\AiClient\Messages\DTO\UserMessage;
 use WordPress\AiClient\Messages\Enums\MessagePartChannelEnum;
 use WordPress\AiClient\Tools\DTO\FunctionCall;
+use WordPress\AiClient\Tools\DTO\FunctionResponse;
 use WP_UnitTestCase;
 
 /**
@@ -278,6 +279,119 @@ class DeepSeekReasoningContentTest extends WP_UnitTestCase {
 		$this->assertTrue(
 			$found_reasoning_content,
 			'reasoning_content not found in second request for DeepSeek model'
+		);
+	}
+
+	/**
+	 * Test that reasoning_content appears on the tool_call assistant message when
+	 * the history was produced by ConversationSerializer splitting a thinking+tool_call
+	 * DeepSeek response into two separate ModelMessages (GH#1814).
+	 *
+	 * DeepSeek V4 Flash thinking-mode responses include both reasoning_content and
+	 * tool_calls. ConversationSerializer::append_assistant_message() splits them into:
+	 *   [ModelMessage(thought_part), ModelMessage(function_call_part)]
+	 * to satisfy the OpenAI Responses API constraint. On the next request DeepSeek
+	 * requires reasoning_content and tool_calls in the SAME assistant message, or it
+	 * returns a 400 error. The base class mergeDeepSeekSplitReasoningMessages() must
+	 * re-merge the pair at the wire level before the HTTP request is sent.
+	 */
+	public function test_deepseek_reasoning_content_on_tool_call_message_after_split(): void {
+		$this->skip_if_sdk_unavailable();
+		$this->skip_if_provider_unavailable();
+
+		$reasoning_text = 'Let me fetch that post for you.';
+
+		// Track the request body sent to the fake endpoint.
+		$request_body = null;
+
+		add_filter(
+			'pre_http_request',
+			function ( $preempt, $args, $url ) use ( &$request_body ) {
+				if ( strpos( $url, self::FAKE_ENDPOINT ) === 0 ) {
+					if ( isset( $args['body'] ) ) {
+						$request_body = $args['body'];
+					}
+
+					return [
+						'headers'       => [ 'content-type' => 'application/json' ],
+						'body'          => wp_json_encode( [
+							'choices' => [
+								[
+									'message'       => [
+										'role'    => 'assistant',
+										'content' => 'Here is the post content.',
+									],
+									'finish_reason' => 'stop',
+								],
+							],
+							'usage'   => [
+								'prompt_tokens'     => 10,
+								'completion_tokens' => 10,
+							],
+						] ),
+						'response'      => [ 'code' => 200 ],
+						'cookies'       => [],
+						'http_response' => null,
+					];
+				}
+				return $preempt;
+			},
+			10,
+			3
+		);
+
+		// Build a history that mirrors what ConversationSerializer produces after splitting
+		// a DeepSeek thinking-mode response that contained both reasoning_content and tool_calls:
+		//   - ModelMessage([thought_part])     — reasoning-only message (first half of split)
+		//   - ModelMessage([function_call])    — tool-call-only message (second half of split)
+		//   - UserMessage([function_response]) — tool result
+		$history = [
+			new UserMessage( [ new MessagePart( 'What blocks are on wave2-bindings-test?' ) ] ),
+			// Split half 1: reasoning-only.
+			new ModelMessage( [ new MessagePart( $reasoning_text, MessagePartChannelEnum::thought() ) ] ),
+			// Split half 2: function_call-only (no thought part).
+			new ModelMessage( [ new MessagePart( new FunctionCall( 'call_1', 'wpab__sd-ai-agent__get-post', [ 'id' => 1 ] ) ) ] ),
+			// Tool result.
+			new UserMessage( [ new MessagePart( new FunctionResponse( 'call_1', 'wpab__sd-ai-agent__get-post', '{"title":"Test Post"}' ) ) ] ),
+		];
+
+		$loop = new AgentLoop(
+			'Now summarize the post.',
+			[],
+			$history,
+			[
+				'provider_id' => 'openai_compat',
+				'model_id'    => 'deepseek-reasoner',
+			]
+		);
+
+		$result = $loop->run();
+		$this->assertNotWPError( $result );
+		$this->assertNotNull( $request_body, 'Request body was not captured' );
+
+		$request_data = json_decode( $request_body, true );
+		$this->assertIsArray( $request_data, 'Request body is not valid JSON' );
+		$this->assertArrayHasKey( 'messages', $request_data );
+
+		// After the split+merge fix, the wire messages should contain ONE assistant
+		// entry with BOTH tool_calls AND reasoning_content (the merged form).
+		// Verify that reasoning_content appears on the message that has tool_calls.
+		$found_reasoning_on_tool_call_message = false;
+		foreach ( $request_data['messages'] as $msg ) {
+			if ( ! empty( $msg['tool_calls'] ) && isset( $msg['reasoning_content'] ) && '' !== $msg['reasoning_content'] ) {
+				$this->assertSame(
+					$reasoning_text,
+					$msg['reasoning_content'],
+					'reasoning_content on tool_call message must match the original thought text'
+				);
+				$found_reasoning_on_tool_call_message = true;
+				break;
+			}
+		}
+
+		$this->assertTrue(
+			$found_reasoning_on_tool_call_message,
+			'Expected reasoning_content to appear on the assistant message with tool_calls (GH#1814 regression: split messages were not merged)'
 		);
 	}
 


### PR DESCRIPTION
## Summary

Fixes the 400 `reasoning_content` error for DeepSeek V4 Flash (and all DeepSeek thinking-mode models) by correcting two issues in `AbstractOpenAiCompatibleTextGenerationModel`.

## Root Cause

DeepSeek thinking-mode models emit `reasoning_content` alongside `tool_calls` in a **single** assistant message. `ConversationSerializer::append_assistant_message()` splits this into two `ModelMessage` objects:
1. `ModelMessage([ThoughtPart])` — reasoning-only
2. `ModelMessage([FunctionCallPart])` — tool-call-only

This split is necessary to satisfy the **OpenAI Responses API** constraint (each `function_call` must be its own top-level input item). However, DeepSeek's thinking-mode API requires `reasoning_content` and `tool_calls` in the **same** assistant message on subsequent requests, or it returns:
```
400 - The `reasoning_content` in the thinking mode must be passed back to the API.
```

## Changes

### `lib/php-ai-client/src/Providers/OpenAiCompatibleImplementation/AbstractOpenAiCompatibleTextGenerationModel.php`

**Fix 1 — Unconditional `reasoning_content` attachment** (line ~197):
- Previously gated on `isDeepSeekThinkingModel()` model-ID regex — any model ID not matching the pattern would silently drop `reasoning_content` from outgoing messages.
- Changed to always include `reasoning_content` when a model message has thought-channel parts. Thought-channel parts are only present when the provider's response contained `reasoning_content` (via `parseResponseChoiceMessageParts`), so this is safe for all providers.

**Fix 2 — Split-message merge** (`mergeDeepSeekSplitReasoningMessages`, line ~651):
- Added `mergeDeepSeekSplitReasoningMessages()` which detects adjacent wire assistant entries matching the split pattern and merges them into the single-message shape DeepSeek requires.
- Called from `prepareGenerateTextParams()`, gated on `isDeepSeekThinkingModel()`.
- The `DeepSeekTextGenerationModel` connector's own `prepareGenerateTextParams()` override runs after the base class and re-applies thoughts from the prompt, which remains consistent with the merged wire format.

## Tests

- `ConversationSerializerTest::test_append_assistant_message_thought_plus_function_call_splits` — verifies [ThoughtPart + FunctionCallPart] IS still split (OpenAI Responses API compat maintained)
- `DeepSeekReasoningContentTest::test_deepseek_reasoning_content_on_tool_call_message_after_split` — verifies `reasoning_content` appears on the tool_call assistant message after the split+merge round-trip (the GH#1814 regression scenario; skipped when provider unavailable)

## Worker self-verification
- PHPUnit: Tests: 3340, Assertions: 13637, Errors: 0, Failures: 0, Skipped: 108, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Resolves #1814

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.30 plugin for [OpenCode](https://opencode.ai) v1.15.10 with claude-sonnet-4-6 spent 24m and 68,773 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of reasoning content in DeepSeek thinking-mode models to properly combine reasoning with tool calls in requests.
  * Improved reasoning content detection to work reliably across different model ID patterns.

* **Tests**
  * Added regression tests for DeepSeek reasoning content handling with function calls and split message patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1816?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->