### PR TITLE
fix: protect enricher dispatch from third-party exceptions (Resolves #1819)

### DIFF
--- a/includes/Core/BlockEnricherRegistry.php
+++ b/includes/Core/BlockEnricherRegistry.php
@@ -145,11 +145,25 @@ final class BlockEnricherRegistry {
 		$enriched = [];
 
 		foreach ( $this->enrichers as $enricher ) {
-			if ( $enricher->supports( $block_name ) ) {
-				$data = $enricher->enrich( $block, $context );
-				if ( ! empty( $data ) ) {
-					$enriched[ $enricher->get_id() ] = $data;
+			try {
+				if ( ! $enricher->supports( $block_name ) ) {
+					continue;
 				}
+				$data = $enricher->enrich( $block, $context );
+			} catch ( \Throwable $e ) {
+				// Log the exception and continue to the next enricher.
+				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				error_log(
+					sprintf(
+						'Block enricher %s failed: %s',
+						$enricher->get_id(),
+						$e->getMessage()
+					)
+				);
+				continue;
+			}
+			if ( ! empty( $data ) ) {
+				$enriched[ $enricher->get_id() ] = $data;
 			}
 		}
 


### PR DESCRIPTION
## Summary

Wrapped enricher invocations in try-catch to prevent a single plugin exception from aborting the get-page-blocks pipeline. Exceptions are logged with the enricher ID and the pipeline continues to the next enricher.

## Changes

- Added try-catch around `supports()` and `enrich()` calls in BlockEnricherRegistry::enrich()
- Exceptions are logged with enricher ID and message
- Pipeline continues to next enricher on failure

## Verification

- PHPUnit: Tests: 3340, Assertions: 13637, Errors: 0, Failures: 0, Skipped: 108
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded

## Worker self-verification
- PHPUnit: Tests: 3340, Assertions: 13637, Errors: 0, Failures: 0, Skipped: 108
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.17.31 plugin for [OpenCode](https://opencode.ai) v1.15.10 with claude-haiku-4-5 spent 4m and 5,069 tokens on this as a headless worker.
