### PR TITLE
feat(abilities): sd-ai-agent/list-allowed-roots (Resolves #1826)

### DIFF
--- a/includes/Abilities/ListAllowedRootsAbility.php
+++ b/includes/Abilities/ListAllowedRootsAbility.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * List Allowed Roots ability.
+ *
+ * Returns the resolved (realpath-normalised) list of filesystem directories
+ * where the AI is permitted to read or write. Deduplicates by resolved path
+ * so symlinked or alternate-mount duplicates collapse to one entry.
+ *
+ * @package SdAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Abilities;
+
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * List Allowed Roots ability.
+ *
+ * @since 1.0.0
+ */
+class ListAllowedRootsAbility extends AbstractAbility {
+
+	protected function label(): string {
+		return __( 'List Allowed Roots', 'superdav-ai-agent' );
+	}
+
+	protected function description(): string {
+		return __( 'Returns the list of filesystem directories where the AI is permitted to read or write. Call this before any file write operation to pick a valid target path without trial-and-error. Returns an associative array of human-readable labels to absolute paths.', 'superdav-ai-agent' );
+	}
+
+	protected function category(): string {
+		return 'sd-ai-agent';
+	}
+
+	protected function input_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [],
+			'required'   => [],
+		];
+	}
+
+	protected function output_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'roots' => [
+					'type'                 => 'object',
+					'description'          => 'Associative array of label => absolute path for each allowed root.',
+					'additionalProperties' => [
+						'type' => 'string',
+					],
+				],
+			],
+		];
+	}
+
+	protected function execute_callback( $input ) {
+		/** @var array<string, mixed> $input */
+		$roots = $this->resolve_allowed_roots();
+
+		return [
+			'roots' => $roots,
+		];
+	}
+
+	protected function permission_callback( $input ): bool {
+		return ToolCapabilities::current_user_can( $this->name );
+	}
+
+	protected function meta(): array {
+		return [
+			'mcp'          => [ 'public' => true ],
+			'annotations'  => [
+				'readonly'    => true,
+				'destructive' => false,
+				'idempotent'  => true,
+			],
+			'show_in_rest' => true,
+		];
+	}
+
+	/**
+	 * Resolve the list of allowed filesystem roots.
+	 *
+	 * Returns an associative array of label => absolute path, deduplicated
+	 * by resolved realpath so symlinked or alternate-mount duplicates collapse.
+	 *
+	 * Roots include:
+	 * - plugins → WP_PLUGIN_DIR
+	 * - themes → get_theme_root()
+	 * - mu-plugins → WPMU_PLUGIN_DIR (only if exists)
+	 * - uploads → wp_upload_dir()['basedir']
+	 * - ai-edits → WP_CONTENT_DIR . '/uploads/ai-edits' (only if exists)
+	 * - Any custom roots registered via sd_ai_agent_allowed_roots filter
+	 *
+	 * @return array<string, string> Associative array of label => resolved path.
+	 */
+	private function resolve_allowed_roots(): array {
+		$raw = [];
+
+		// Standard WordPress roots.
+		$raw['plugins'] = WP_PLUGIN_DIR;
+		$raw['themes']  = get_theme_root();
+		$raw['uploads'] = wp_upload_dir()['basedir'];
+
+		// Optional roots.
+		if ( defined( 'WPMU_PLUGIN_DIR' ) && is_dir( WPMU_PLUGIN_DIR ) ) {
+			$raw['mu-plugins'] = WPMU_PLUGIN_DIR;
+		}
+
+		$ai_edits_dir = WP_CONTENT_DIR . '/uploads/ai-edits';
+		if ( is_dir( $ai_edits_dir ) ) {
+			$raw['ai-edits'] = $ai_edits_dir;
+		}
+
+		/**
+		 * Filter to add custom allowed roots.
+		 *
+		 * @param array<string, string> $raw Associative array of label => path.
+		 * @return array<string, string> Filtered array of label => path.
+		 */
+		$raw = apply_filters( 'sd_ai_agent_allowed_roots', $raw );
+
+		// Deduplicate by resolved realpath.
+		$by_real  = [];
+		$resolved = [];
+
+		foreach ( $raw as $label => $path ) {
+			$real = realpath( $path );
+			if ( false !== $real && is_dir( $real ) && ! isset( $by_real[ $real ] ) ) {
+				$by_real[ $real ]   = true;
+				$resolved[ $label ] = $real;
+			}
+		}
+
+		return $resolved;
+	}
+}

--- a/includes/Bootstrap/AbilitiesHandler.php
+++ b/includes/Bootstrap/AbilitiesHandler.php
@@ -41,8 +41,9 @@ use SdAiAgent\Abilities\GoogleAnalyticsAbilities;
 use SdAiAgent\Abilities\GscAbilities;
 use SdAiAgent\Abilities\ImageAbilities;
 use SdAiAgent\Abilities\InternetSearchAbilities;
-use SdAiAgent\Abilities\SiteScrapeAbility;
 use SdAiAgent\Abilities\KnowledgeAbilities;
+use SdAiAgent\Abilities\ListAllowedRootsAbility;
+use SdAiAgent\Abilities\SiteScrapeAbility;
 use SdAiAgent\Abilities\MarketingAbilities;
 use SdAiAgent\Abilities\MediaAbilities;
 use SdAiAgent\Abilities\MemoryAbilities;
@@ -127,6 +128,14 @@ final class AbilitiesHandler {
 		BlockAbilities::register_abilities();
 		GlobalStylesAbilities::register_abilities();
 		FileAbilities::register_abilities();
+		wp_register_ability(
+			'sd-ai-agent/list-allowed-roots',
+			[
+				'label'         => __( 'List Allowed Roots', 'superdav-ai-agent' ),
+				'description'   => __( 'Returns the list of filesystem directories where the AI is permitted to read or write. Call this before any file write operation to pick a valid target path without trial-and-error.', 'superdav-ai-agent' ),
+				'ability_class' => ListAllowedRootsAbility::class,
+			]
+		);
 		ThemeBuilderAbilities::register_abilities();
 		GitAbilities::register_abilities();
 		// Plugin-download abilities expose download URLs for AI-modified

--- a/tests/SdAiAgent/Abilities/ListAllowedRootsAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/ListAllowedRootsAbilityTest.php
@@ -1,0 +1,296 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Test case for ListAllowedRootsAbility class.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Abilities;
+
+use SdAiAgent\Abilities\ListAllowedRootsAbility;
+use WP_UnitTestCase;
+
+/**
+ * Test ListAllowedRootsAbility functionality.
+ */
+class ListAllowedRootsAbilityTest extends WP_UnitTestCase {
+
+	/**
+	 * Build a ListAllowedRootsAbility instance for testing.
+	 *
+	 * @return ListAllowedRootsAbility
+	 */
+	private function make_ability(): ListAllowedRootsAbility {
+		return new ListAllowedRootsAbility(
+			'sd-ai-agent/list-allowed-roots',
+			[
+				'label'       => 'List Allowed Roots',
+				'description' => 'Returns the list of filesystem directories where the AI is permitted to read or write.',
+			]
+		);
+	}
+
+	// ── execute_callback — basic functionality ────────────────────────────
+
+	/**
+	 * execute_callback() returns array with roots key.
+	 */
+	public function test_execute_returns_roots_array(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$ability = $this->make_ability();
+		$result  = $ability->run( [] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'roots', $result );
+		$this->assertIsArray( $result['roots'] );
+	}
+
+	/**
+	 * execute_callback() includes plugins root.
+	 */
+	public function test_execute_includes_plugins_root(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$ability = $this->make_ability();
+		$result  = $ability->run( [] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'roots', $result );
+		$this->assertArrayHasKey( 'plugins', $result['roots'] );
+		$this->assertIsString( $result['roots']['plugins'] );
+		$this->assertSame( realpath( WP_PLUGIN_DIR ), $result['roots']['plugins'] );
+	}
+
+	/**
+	 * execute_callback() includes themes root.
+	 */
+	public function test_execute_includes_themes_root(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$ability = $this->make_ability();
+		$result  = $ability->run( [] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'roots', $result );
+		$this->assertArrayHasKey( 'themes', $result['roots'] );
+		$this->assertIsString( $result['roots']['themes'] );
+		$this->assertSame( realpath( get_theme_root() ), $result['roots']['themes'] );
+	}
+
+	/**
+	 * execute_callback() includes uploads root.
+	 */
+	public function test_execute_includes_uploads_root(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$ability = $this->make_ability();
+		$result  = $ability->run( [] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'roots', $result );
+		$this->assertArrayHasKey( 'uploads', $result['roots'] );
+		$this->assertIsString( $result['roots']['uploads'] );
+		$uploads_dir = wp_upload_dir();
+		$this->assertSame( realpath( $uploads_dir['basedir'] ), $result['roots']['uploads'] );
+	}
+
+	// ── execute_callback — path resolution ────────────────────────────────
+
+	/**
+	 * execute_callback() returns absolute paths.
+	 */
+	public function test_execute_returns_absolute_paths(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$ability = $this->make_ability();
+		$result  = $ability->run( [] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'roots', $result );
+
+		foreach ( $result['roots'] as $label => $path ) {
+			$this->assertTrue(
+				0 === strpos( $path, '/' ),
+				"Path for label '$label' should be absolute, got: $path"
+			);
+		}
+	}
+
+	/**
+	 * execute_callback() returns realpath-resolved paths.
+	 */
+	public function test_execute_returns_realpath_resolved_paths(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$ability = $this->make_ability();
+		$result  = $ability->run( [] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'roots', $result );
+
+		foreach ( $result['roots'] as $label => $path ) {
+			$this->assertSame(
+				$path,
+				realpath( $path ),
+				"Path for label '$label' should be realpath-resolved, got: $path"
+			);
+		}
+	}
+
+	// ── execute_callback — deduplication ──────────────────────────────────
+
+	/**
+	 * execute_callback() deduplicates by resolved path.
+	 */
+	public function test_execute_deduplicates_by_resolved_path(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		// Add a filter that returns a duplicate path (same as plugins).
+		$callback = function ( $roots ) {
+			$roots['duplicate-plugins'] = WP_PLUGIN_DIR;
+			return $roots;
+		};
+		add_filter( 'sd_ai_agent_allowed_roots', $callback );
+
+		$ability = $this->make_ability();
+		$result  = $ability->run( [] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'roots', $result );
+
+		// Count how many entries resolve to the same path as plugins.
+		$plugins_real = realpath( WP_PLUGIN_DIR );
+		$count        = 0;
+		foreach ( $result['roots'] as $path ) {
+			if ( $path === $plugins_real ) {
+				$count++;
+			}
+		}
+
+		// Should only have one entry for the plugins path.
+		$this->assertSame( 1, $count, 'Duplicate paths should be deduplicated' );
+
+		remove_filter( 'sd_ai_agent_allowed_roots', $callback );
+	}
+
+	// ── execute_callback — optional roots ─────────────────────────────────
+
+	/**
+	 * execute_callback() includes mu-plugins only if directory exists.
+	 */
+	public function test_execute_includes_mu_plugins_only_if_exists(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$ability = $this->make_ability();
+		$result  = $ability->run( [] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'roots', $result );
+
+		if ( defined( 'WPMU_PLUGIN_DIR' ) && is_dir( WPMU_PLUGIN_DIR ) ) {
+			$this->assertArrayHasKey( 'mu-plugins', $result['roots'] );
+		} else {
+			$this->assertArrayNotHasKey( 'mu-plugins', $result['roots'] );
+		}
+	}
+
+	/**
+	 * execute_callback() includes ai-edits only if directory exists.
+	 */
+	public function test_execute_includes_ai_edits_only_if_exists(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$ability = $this->make_ability();
+		$result  = $ability->run( [] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'roots', $result );
+
+		$ai_edits_dir = WP_CONTENT_DIR . '/uploads/ai-edits';
+		if ( is_dir( $ai_edits_dir ) ) {
+			$this->assertArrayHasKey( 'ai-edits', $result['roots'] );
+		} else {
+			$this->assertArrayNotHasKey( 'ai-edits', $result['roots'] );
+		}
+	}
+
+	// ── execute_callback — filter integration ─────────────────────────────
+
+	/**
+	 * execute_callback() respects sd_ai_agent_allowed_roots filter.
+	 */
+	public function test_execute_respects_allowed_roots_filter(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		// Add a custom root via filter.
+		$callback = function ( $roots ) {
+			$roots['custom'] = WP_CONTENT_DIR;
+			return $roots;
+		};
+		add_filter( 'sd_ai_agent_allowed_roots', $callback );
+
+		$ability = $this->make_ability();
+		$result  = $ability->run( [] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'roots', $result );
+		$this->assertArrayHasKey( 'custom', $result['roots'] );
+
+		remove_filter( 'sd_ai_agent_allowed_roots', $callback );
+	}
+
+	// ── execute_callback — result shape ───────────────────────────────────
+
+	/**
+	 * execute_callback() returns expected shape.
+	 */
+	public function test_execute_returns_expected_shape(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$ability = $this->make_ability();
+		$result  = $ability->run( [] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'roots', $result );
+		$this->assertIsArray( $result['roots'] );
+
+		// Each entry should be label => path.
+		foreach ( $result['roots'] as $label => $path ) {
+			$this->assertIsString( $label );
+			$this->assertIsString( $path );
+		}
+	}
+
+	// ── meta ──────────────────────────────────────────────────────────────
+
+	/**
+	 * Ability is marked as readonly and idempotent.
+	 */
+	public function test_ability_is_readonly_and_idempotent(): void {
+		$ability = $this->make_ability();
+		$meta    = $ability->get_meta();
+
+		$this->assertIsArray( $meta );
+		$this->assertArrayHasKey( 'annotations', $meta );
+		$this->assertIsArray( $meta['annotations'] );
+		$this->assertTrue( $meta['annotations']['readonly'] );
+		$this->assertTrue( $meta['annotations']['idempotent'] );
+		$this->assertFalse( $meta['annotations']['destructive'] );
+	}
+}


### PR DESCRIPTION
## Summary

Add a new ability that returns the resolved (realpath-normalised) list of filesystem directories where the AI is permitted to read or write.

## What's Changed

- **New ability**: `sd-ai-agent/list-allowed-roots` returns an associative array of label => absolute path
- **Deduplication**: Symlinked or alternate-mount duplicates collapse to one entry via realpath()
- **Standard roots**: plugins, themes, uploads
- **Optional roots**: mu-plugins (if exists), ai-edits (if exists)
- **Filter support**: Respects `sd_ai_agent_allowed_roots` filter for custom roots
- **Metadata**: Marked as readonly, idempotent, and non-destructive

## Files Changed

- `includes/Abilities/ListAllowedRootsAbility.php` - New ability implementation
- `tests/SdAiAgent/Abilities/ListAllowedRootsAbilityTest.php` - Comprehensive test coverage (12 tests)
- `includes/Bootstrap/AbilitiesHandler.php` - Ability registration

## Testing

```bash
npm run verify
```

## Worker self-verification
- PHPUnit: Tests: 3374, Assertions: 13736, Errors: 90, Failures: 130, Skipped: 108 (pre-existing failures unrelated to this change)
- ListAllowedRootsAbilityTest: 12 tests, 55 assertions, all passing
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded

Resolves #1826

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.18.1 plugin for [OpenCode](https://opencode.ai) v1.15.10 with claude-haiku-4-5 spent 15m and 5,134 tokens on this as a headless worker.
