### PR TITLE
feat(chat): command palette (Cmd/Ctrl+K) entry (Resolves #1828)

### DIFF
--- a/includes/Admin/UnifiedAdminMenu.php
+++ b/includes/Admin/UnifiedAdminMenu.php
@@ -163,6 +163,7 @@ class UnifiedAdminMenu {
 
 		// Hook for enqueuing assets.
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueueAssets' ) );
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueueCommands' ) );
 	}
 
 	/**
@@ -330,6 +331,50 @@ class UnifiedAdminMenu {
 				),
 			)
 		);
+	}
+
+	/**
+	 * Register the "Interact with AI" command in the WordPress command palette.
+	 *
+	 * Registers a command palette entry (Cmd/Ctrl+K) that navigates to the chat page.
+	 * Only available to users with manage_options capability and only on screens
+	 * where wp-commands is registered.
+	 *
+	 * @param string $hook_suffix The current admin page hook suffix.
+	 */
+	public static function enqueueCommands( string $hook_suffix ): void {
+		if ( ! current_user_can( self::CAPABILITY ) ) {
+			return;
+		}
+
+		// Guard: wp-commands script must be registered on this screen.
+		if ( ! wp_script_is( 'wp-commands', 'registered' ) ) {
+			return;
+		}
+
+		wp_enqueue_script( 'wp-commands' );
+
+		$page_url = wp_json_encode( admin_url( 'admin.php?page=' . self::SLUG ) );
+		$inline   = "( function () {\n"
+			. "\t'use strict';\n"
+			. "\tif ( typeof wp === 'undefined' || ! wp.data ) {\n"
+			. "\t\treturn;\n"
+			. "\t}\n"
+			. "\ttry {\n"
+			. "\t\twp.data.dispatch( 'core/commands' ).registerCommand( {\n"
+			. "\t\t\tname: 'sd-ai-agent/open',\n"
+			. "\t\t\tlabel: 'Interact with AI',\n"
+			. "\t\t\tcallback: function ( { close } ) {\n"
+			. "\t\t\t\tclose();\n"
+			. "\t\t\t\twindow.location.href = " . $page_url . ";\n"
+			. "\t\t\t},\n"
+			. "\t\t} );\n"
+			. "\t} catch ( _e ) {\n"
+			. "\t\t// wp-commands store not available on this page.\n"
+			. "\t}\n"
+			. '} )();';
+
+		wp_add_inline_script( 'wp-commands', $inline );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Register 'Interact with AI' command in WordPress command palette so the chat is launchable from anywhere in WP-Admin without navigating to the menu item.

## Changes

- Add `enqueueCommands()` method to `UnifiedAdminMenu`
- Register command via `wp.data.dispatch('core/commands').registerCommand()`
- Guard with `manage_options` capability check
- Guard with `wp_script_is('wp-commands', 'registered')` check
- Inline script uses IIFE with try/catch for safety
- URL is escaped via `wp_json_encode()` to prevent XSS

## Worker self-verification

- PHPUnit: Tests: 3362, Assertions: 13685, Errors: 0, Failures: 0, Skipped: 108
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded

## Testing

Manual verification:
1. Visit `/wp-admin/index.php`
2. Press Cmd+K (macOS) / Ctrl+K (Linux/Windows)
3. Type "Interact" — entry should appear
4. Selecting it loads the chat page

Resolves #1828

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.18.1 plugin for [OpenCode](https://opencode.ai) v1.15.10 with claude-haiku-4-5 spent 7m and 6,580 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command palette shortcut (Cmd/Ctrl+K) to access the AI agent feature. Administrators can now quickly launch the AI interaction tool using the "Interact with AI" command from the unified admin menu.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1839?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->