### PR TITLE
GH#1840: test: stabilize trunk e2e helpers

### DIFF
--- a/tests/e2e/onboarding-theme-builder.spec.js
+++ b/tests/e2e/onboarding-theme-builder.spec.js
@@ -34,7 +34,7 @@
 const { test, expect } = require( '@playwright/test' );
 const path = require( 'path' );
 const fs = require( 'fs' );
-const { execSync } = require( 'child_process' );
+const { execFileSync } = require( 'child_process' );
 const {
 	loginToWordPress,
 	getMessageInput,
@@ -83,16 +83,40 @@ function wpCli( command ) {
 	}
 
 	try {
-		return execSync( `npx wp-env run ${ service } wp ${ command }`, {
-			cwd,
-			encoding: 'utf8',
-			env,
-			stdio: [ 'pipe', 'pipe', 'pipe' ],
-		} ).trim();
+		return execFileSync(
+			'npx',
+			[ 'wp-env', 'run', service, 'wp', ...wpCliArgs( command ) ],
+			{
+				cwd,
+				encoding: 'utf8',
+				env,
+				stdio: [ 'pipe', 'pipe', 'pipe' ],
+			}
+		).trim();
 	} catch {
 		// Non-fatal: log nothing to avoid noise in CI logs.
 		return '';
 	}
+}
+
+/**
+ * Convert the small WP-CLI command subset used by this spec into argv tokens.
+ *
+ * Avoid shell interpolation entirely. Several eval snippets use PHP variables
+ * such as `$dir` and `$data`; passing the command through a shell expands those
+ * names before WP-CLI sees them, producing parse errors like
+ * `unexpected token "=", expecting end of file` on CI.
+ *
+ * @param {string} command - WP-CLI command WITHOUT the `wp` prefix.
+ * @return {string[]} Arguments for `wp`.
+ */
+function wpCliArgs( command ) {
+	const evalMatch = command.match( /^eval\s+"([\s\S]*)"$/ );
+	if ( evalMatch ) {
+		return [ 'eval', evalMatch[ 1 ] ];
+	}
+
+	return command.trim().split( /\s+/ );
 }
 
 /**
@@ -583,27 +607,11 @@ test.describe.serial( 'Theme-builder onboarding flow (Onboarding v2)', () => {
 
 			// ── Server-side assertions ──────────────────────────────────────
 
-			// 1. Active stylesheet via the WP REST Themes API.
-			const activeThemes = await page.evaluate( async () => {
-				const root =
-					( window.wpApiSettings && window.wpApiSettings.root ) ||
-					'/wp-json/';
-				const nonce =
-					( window.wpApiSettings && window.wpApiSettings.nonce ) ||
-					'';
-				try {
-					const resp = await fetch(
-						root + 'wp/v2/themes?status=active',
-						{ headers: { 'X-WP-Nonce': nonce } }
-					);
-					return resp.ok ? resp.json() : [];
-				} catch {
-					return [];
-				}
-			} );
-			expect( activeThemes ).toBeInstanceOf( Array );
-			expect( activeThemes.length ).toBeGreaterThan( 0 );
-			expect( activeThemes[ 0 ].stylesheet ).toBe( 'e2e-test-theme' );
+			// 1. Active stylesheet via WP-CLI. The WordPress core themes REST
+			// endpoint can return an empty list on trunk when theme status filters
+			// change; the stylesheet option is the canonical activation state.
+			const activeStylesheet = wpCli( 'option get stylesheet' );
+			expect( activeStylesheet ).toBe( 'e2e-test-theme' );
 
 			// 2. Theme directory exists on disk.
 			const themeDirExists = wpCli(

--- a/tests/mu-plugins/ai-agent-test-helpers.php
+++ b/tests/mu-plugins/ai-agent-test-helpers.php
@@ -84,6 +84,7 @@ add_action(
 			'\WordPress\AiClient\Providers\Models\DTO\ModelMetadata',
 			'\WordPress\AiClient\Providers\Models\Enums\CapabilityEnum',
 			'\WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication',
+			'\WordPress\AiClient\Providers\Http\Enums\RequestAuthenticationMethod',
 		);
 
 		foreach ( $required_classes as $required_class ) {
@@ -126,7 +127,9 @@ add_action(
 					return new \WordPress\AiClient\Providers\DTO\ProviderMetadata(
 						'e2e-provider',
 						'E2E Provider',
-						\WordPress\AiClient\Providers\Enums\ProviderTypeEnum::cloud()
+						\WordPress\AiClient\Providers\Enums\ProviderTypeEnum::cloud(),
+						null,
+						\WordPress\AiClient\Providers\Http\Enums\RequestAuthenticationMethod::apiKey()
 					);
 				}
 


### PR DESCRIPTION
## Summary

Stabilized the trunk Playwright onboarding spec by running wp-env WP-CLI commands without shell interpolation, switching the active-theme assertion to the canonical stylesheet option, and declaring the E2E SDK provider's API-key auth method so registry authentication no longer throws on trunk.

## Files Changed

tests/e2e/onboarding-theme-builder.spec.js,tests/mu-plugins/ai-agent-test-helpers.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify (PHPUnit: Tests: 3402, Assertions: 13797, Errors: 0, Failures: 0, Skipped: 108, Incomplete: 4; lint clean; PHPStan 0 errors; build succeeded). npx wp-scripts lint-js tests/e2e/onboarding-theme-builder.spec.js --no-ignore. Targeted Playwright spec attempted but wp-env could not start because Docker buildkit cachemounts path was missing on this runner.

Resolves #1840


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.18.1 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 10m and 172,038 tokens on this as a headless worker.

## Worker self-verification
- PHPUnit: Tests: 3402, Assertions: 13797, Errors: 0, Failures: 0, Skipped: 108
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Additional targeted check: `npx wp-scripts lint-js tests/e2e/onboarding-theme-builder.spec.js --no-ignore` passed. Targeted Playwright was attempted but blocked by the local Docker buildkit cachemounts error before wp-env could start.
