### PR TITLE
fix(agent-loop): omit temperature for Claude Opus 4.7

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -1114,23 +1114,22 @@ class AgentLoop {
 		// the wrapper's `__call` is guaranteed to exist and the `@method`
 		// declarations on the wrapper enumerate the supported API.
 		//
-		// Reasoning-model exception: OpenAI's reasoning families (gpt-5*,
-		// o1*, o3*, o4*) reject `temperature` outright with HTTP 400
-		// ("Unsupported parameter: 'temperature' is not supported with
-		// this model.") — they only run at the model's implicit sampling
-		// setting. Skip the setter for those model IDs so the request
-		// body omits the field entirely. `max_tokens` is still safe to
-		// send: the SDK translates it to `max_completion_tokens` for the
-		// OpenAI reasoning API.
+		// Model-specific exception: some model families reject or deprecate
+		// `temperature` outright with HTTP 400 even though standard models still
+		// accept it. OpenAI reasoning families (gpt-5*, o1*, o3*, o4*) run at the
+		// model's implicit sampling setting. Anthropic Max Claude Opus 4.7 also
+		// rejects the OpenAI-compatible `temperature` field as deprecated.
+		// Skip the setter for those model IDs so the request body omits the field
+		// entirely. `max_tokens` is still safe to send.
 		//
 		// Resolve the effective model ID (including connector defaults)
-		// before checking if it's a reasoning model, since configure_model()
+		// before checking if it rejects temperature, since configure_model()
 		// may have resolved a default model from the connector.
 		$resolved_model_id = $this->model_id;
 		if ( empty( $resolved_model_id ) && function_exists( 'OpenAiCompatibleConnector\\get_default_model' ) ) {
 			$resolved_model_id = (string) \OpenAiCompatibleConnector\get_default_model();
 		}
-		if ( ! self::is_reasoning_model( $resolved_model_id ) ) {
+		if ( ! self::model_omits_temperature( $resolved_model_id ) ) {
 			$builder->using_temperature( (float) $this->temperature );
 		}
 		$builder->using_max_tokens( $this->get_effective_max_output_tokens() );
@@ -1576,7 +1575,7 @@ class AgentLoop {
 	}
 
 	/**
-	 * Detect OpenAI reasoning models that reject the `temperature` parameter.
+	 * Detect models that reject or deprecate the `temperature` parameter.
 	 *
 	 * Reasoning models from OpenAI (GPT-5 family + o-series) only run at the
 	 * model's implicit sampling setting and respond with HTTP 400 if
@@ -1584,7 +1583,11 @@ class AgentLoop {
 	 *
 	 *     Unsupported parameter: 'temperature' is not supported with this model.
 	 *
-	 * The check is prefix-based and intentionally broad — it covers current
+	 * Anthropic Max Claude Opus 4.7 similarly rejects `temperature` as a
+	 * deprecated field in OpenAI-compatible routing, while older Claude models
+	 * used by existing installs still accept it.
+	 *
+	 * The OpenAI check is prefix-based and intentionally broad — it covers current
 	 * variants (gpt-5, gpt-5.4, gpt-5.4-mini, gpt-5.5, gpt-5.5-pro,
 	 * gpt-5-codex, gpt-5-pro, o1, o1-mini, o3, o3-mini, o4, o4-mini) and any
 	 * future dated/sized snapshots from the same families that follow the
@@ -1596,7 +1599,7 @@ class AgentLoop {
 	 * @param string $model_id The provider-scoped model identifier.
 	 * @return bool True if the model rejects the `temperature` parameter.
 	 */
-	private static function is_reasoning_model( string $model_id ): bool {
+	private static function model_omits_temperature( string $model_id ): bool {
 		$normalised = strtolower( trim( $model_id ) );
 
 		if ( '' === $normalised ) {
@@ -1616,6 +1619,13 @@ class AgentLoop {
 			if ( $normalised === $family || str_starts_with( $normalised, $family . '-' ) ) {
 				return true;
 			}
+		}
+
+		// Claude Opus 4.7 is surfaced by Anthropic Max and rejects `temperature`
+		// with HTTP 400: "`temperature` is deprecated for this model." Match the
+		// dateless ID plus any dated/provider-specific snapshot suffix.
+		if ( $normalised === 'claude-opus-4-7' || str_starts_with( $normalised, 'claude-opus-4-7-' ) ) {
+			return true;
 		}
 
 		return false;

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -1513,8 +1513,10 @@ class AgentLoopTest extends WP_UnitTestCase {
 	/**
 	 * Regression test: `temperature` MUST be omitted from the outgoing
 	 * request body for OpenAI reasoning models, because those endpoints
-	 * reject the field with HTTP 400 ("Unsupported parameter:
-	 * 'temperature' is not supported with this model.").
+	 * reject the field with HTTP 400. OpenAI reasoning models return
+	 * "Unsupported parameter: 'temperature' is not supported with this model.";
+	 * Anthropic Max Claude Opus 4.7 returns "`temperature` is deprecated for
+	 * this model."
 	 *
 	 * Reproduction before the fix (2026-05-16, live OpenAI API):
 	 *
@@ -1523,18 +1525,17 @@ class AgentLoopTest extends WP_UnitTestCase {
 	 *     => Warning: Bad Request (400) - Unsupported parameter:
 	 *        'temperature' is not supported with this model.
 	 *
-	 * The fix adds {@see AgentLoop::is_reasoning_model()} and short-circuits
+	 * The fix adds {@see AgentLoop::model_omits_temperature()} and short-circuits
 	 * the `using_temperature()` call in send_prompt() for any matched ID.
 	 *
 	 * This test exercises the agent loop end-to-end against the fake OpenAI-
-	 * compatible endpoint with model_id = gpt-5.5 and asserts the captured
+	 * compatible endpoint with matched model IDs and asserts the captured
 	 * outgoing JSON body has NO `temperature` key. `max_tokens` is still
-	 * expected because reasoning models accept `max_completion_tokens` and
-	 * the SDK translates `max_tokens` for the OpenAI reasoning endpoint.
+	 * expected because output-token caps remain valid for these models.
 	 *
-	 * @dataProvider reasoning_model_id_provider
+	 * @dataProvider temperature_omitting_model_id_provider
 	 */
-	public function test_builder_omits_temperature_for_reasoning_models( string $model_id ): void {
+	public function test_builder_omits_temperature_for_models_that_reject_it( string $model_id ): void {
 		$this->skip_if_sdk_unavailable();
 
 		// A non-default temperature so the assertion can distinguish "not
@@ -1560,13 +1561,12 @@ class AgentLoopTest extends WP_UnitTestCase {
 			'temperature',
 			$decoded,
 			sprintf(
-				'Reasoning model %s must not receive a `temperature` field — the OpenAI endpoint returns HTTP 400 when it is present.',
+				'Model %s must not receive a `temperature` field — the provider returns HTTP 400 when it is present.',
 				$model_id
 			)
 		);
 
-		// Sanity: max_tokens still goes through (SDK rewrites it to
-		// max_completion_tokens for the reasoning endpoint).
+		// Sanity: max_tokens still goes through.
 		$this->assertArrayHasKey(
 			'max_tokens',
 			$decoded,
@@ -1575,12 +1575,12 @@ class AgentLoopTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider covering the reasoning-model families enumerated by
-	 * {@see AgentLoop::is_reasoning_model()}.
+	 * Data provider covering model families enumerated by
+	 * {@see AgentLoop::model_omits_temperature()}.
 	 *
 	 * @return array<string, array{0:string}>
 	 */
-	public function reasoning_model_id_provider(): array {
+	public function temperature_omitting_model_id_provider(): array {
 		return [
 			'gpt-5'              => [ 'gpt-5' ],
 			'gpt-5.4'            => [ 'gpt-5.4' ],
@@ -1594,13 +1594,15 @@ class AgentLoopTest extends WP_UnitTestCase {
 			'o3'                 => [ 'o3' ],
 			'o3-mini'            => [ 'o3-mini' ],
 			'o4-mini'            => [ 'o4-mini' ],
+			'claude-opus-4-7'    => [ 'claude-opus-4-7' ],
+			'claude-opus-4-7 dated snap' => [ 'claude-opus-4-7-20260513' ],
 		];
 	}
 
 	/**
 	 * Counter-test: `temperature` MUST still reach non-reasoning OpenAI
 	 * models (gpt-4*, gpt-4o, gpt-4.1, gpt-3.5*) and other providers. This
-	 * guards against an over-broad reasoning-model detector accidentally
+	 * guards against an over-broad temperature-omission detector accidentally
 	 * stripping temperature for models that accept it.
 	 *
 	 * @dataProvider non_reasoning_model_id_provider
@@ -1651,6 +1653,8 @@ class AgentLoopTest extends WP_UnitTestCase {
 			'gpt-4.1'           => [ 'gpt-4.1' ],
 			'gpt-3.5-turbo'     => [ 'gpt-3.5-turbo' ],
 			'claude-sonnet-4-6' => [ 'claude-sonnet-4-6' ],
+			'claude-opus-4-6'   => [ 'claude-opus-4-6' ],
+			'claude-opus-4-5'   => [ 'claude-opus-4-5' ],
 			'gemini-2.5-pro'    => [ 'gemini-2.5-pro' ],
 		];
 	}
@@ -2551,32 +2555,32 @@ class AgentLoopTest extends WP_UnitTestCase {
 	}
 
 	// -------------------------------------------------------------------------
-	// is_reasoning_model() direct unit tests
+	// model_omits_temperature() direct unit tests
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Invoke the private static {@see AgentLoop::is_reasoning_model()} helper.
+	 * Invoke the private static {@see AgentLoop::model_omits_temperature()} helper.
 	 *
 	 * @param string $model_id Model ID to classify.
 	 * @return bool Helper return value.
 	 */
-	private function invoke_is_reasoning_model( string $model_id ): bool {
+	private function invoke_model_omits_temperature( string $model_id ): bool {
 		$rc     = new \ReflectionClass( AgentLoop::class );
-		$method = $rc->getMethod( 'is_reasoning_model' );
+		$method = $rc->getMethod( 'model_omits_temperature' );
 		$method->setAccessible( true );
 		return (bool) $method->invoke( null, $model_id );
 	}
 
 	/**
-	 * Direct (no-SDK) coverage of the reasoning-model classifier.
+	 * Direct (no-SDK) coverage of the temperature-omission classifier.
 	 *
-	 * @dataProvider reasoning_model_classification_provider
+	 * @dataProvider temperature_omission_classification_provider
 	 */
-	public function test_is_reasoning_model_classification( string $model_id, bool $expected ): void {
+	public function test_model_omits_temperature_classification( string $model_id, bool $expected ): void {
 		$this->assertSame(
 			$expected,
-			$this->invoke_is_reasoning_model( $model_id ),
-			sprintf( 'is_reasoning_model(%s) should be %s', var_export( $model_id, true ), $expected ? 'true' : 'false' )
+			$this->invoke_model_omits_temperature( $model_id ),
+			sprintf( 'model_omits_temperature(%s) should be %s', var_export( $model_id, true ), $expected ? 'true' : 'false' )
 		);
 	}
 
@@ -2587,7 +2591,7 @@ class AgentLoopTest extends WP_UnitTestCase {
 	 *
 	 * @return array<string, array{0:string, 1:bool}>
 	 */
-	public function reasoning_model_classification_provider(): array {
+	public function temperature_omission_classification_provider(): array {
 		return [
 			// GPT-5 family — all reasoning.
 			'gpt-5'                       => [ 'gpt-5', true ],
@@ -2614,9 +2618,15 @@ class AgentLoopTest extends WP_UnitTestCase {
 			'gpt-4o'                      => [ 'gpt-4o', false ],
 			'gpt-4.1'                     => [ 'gpt-4.1', false ],
 			'gpt-3.5-turbo'               => [ 'gpt-3.5-turbo', false ],
-			// Other providers — must NOT match.
+			// Anthropic Max Claude Opus 4.7 — rejects/deprecates temperature.
+			'claude-opus-4-7'             => [ 'claude-opus-4-7', true ],
+			'claude-opus-4-7-dated'       => [ 'claude-opus-4-7-20260513', true ],
+			'Claude Opus 4.7 uppercase'   => [ 'CLAUDE-OPUS-4-7', true ],
+			'Claude Opus 4.7 padded'      => [ '  claude-opus-4-7  ', true ],
+			// Other providers/models — must NOT match.
 			'claude-sonnet-4-6'           => [ 'claude-sonnet-4-6', false ],
-			'claude-opus-4-7'             => [ 'claude-opus-4-7', false ],
+			'claude-opus-4-6'             => [ 'claude-opus-4-6', false ],
+			'claude-opus-4-5'             => [ 'claude-opus-4-5', false ],
 			'gemini-2.5-pro'              => [ 'gemini-2.5-pro', false ],
 			'deepseek-chat'               => [ 'deepseek-chat', false ],
 			// Defensive negatives — must NOT match (no `-` separator).


### PR DESCRIPTION
## Summary

Fixes the chat failure with Anthropic Max Claude Opus 4.7 where the provider returns:

```text
Error: Bad Request (400) - `temperature` is deprecated for this model.
```

The earlier fix in #1474 only omitted `temperature` for OpenAI reasoning model IDs (`gpt-5*`, `o1*`, `o3*`, `o4*`). This PR generalises that guard to `AgentLoop::model_omits_temperature()` and adds Claude Opus 4.7 (`claude-opus-4-7` plus dated/provider suffixes) to the omission list while keeping temperature for older Claude models.

## Research notes

Anthropic's current models overview identifies Claude Opus 4.7 as the latest Opus model with API ID / alias `claude-opus-4-7`, 1M context, 128k max output, and adaptive thinking support. The observed live provider error shows this new model family rejects the OpenAI-compatible `temperature` field as deprecated, unlike older Claude models already covered by regression tests.

Docs consulted:

- Anthropic Models overview: `https://docs.anthropic.com/en/docs/about-claude/models/overview`
- Anthropic Models API: `https://docs.anthropic.com/en/api/models/list`

## Changes

- `includes/Core/AgentLoop.php`
  - Rename the private classifier from `is_reasoning_model()` to `model_omits_temperature()`.
  - Preserve existing OpenAI reasoning handling.
  - Add Claude Opus 4.7 matching for `claude-opus-4-7` and `claude-opus-4-7-*`.
- `tests/SdAiAgent/Core/AgentLoopTest.php`
  - Add end-to-end request-body coverage proving Claude Opus 4.7 omits `temperature`.
  - Add classifier coverage for dateless, dated, uppercase, and padded Claude Opus 4.7 IDs.
  - Add negative coverage proving Claude Opus 4.6 / 4.5 and Claude Sonnet 4.6 still receive temperature.

## Worker self-verification

```text
- PHPUnit: Tests: 3411, Assertions: 13802, Errors: 0, Failures: 0, Skipped: 112, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
```

Additional targeted check:

```text
vendor/bin/phpunit --filter 'test_model_omits_temperature_classification|test_builder_omits_temperature_for_models_that_reject_it|test_builder_keeps_temperature_for_non_reasoning_models' tests/SdAiAgent/Core/AgentLoopTest.php
=> Tests: 59, Assertions: 36, Skipped: 23, Errors: 0, Failures: 0
```

Full command run:

```text
npm run verify
```

Notes: the full PHPUnit run emitted pre-existing duplicate seed warnings for `sd_ai_agent_custom_tools` and a pre-existing PHP deprecation from `SeoAbilities.php`; the suite still completed with Errors: 0 and Failures: 0.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.0 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 1h 27m and 14,327 tokens on this as a headless worker.
