### PR TITLE
GH#1844: fix: canonicalise filesystem mkdir paths

### DIFF
--- a/includes/Abilities/FileAbilities.php
+++ b/includes/Abilities/FileAbilities.php
@@ -19,6 +19,7 @@ use SdAiAgent\Core\ChangeLogger;
 use SdAiAgent\Core\Database;
 use SdAiAgent\Core\Features;
 use SdAiAgent\Core\Filesystem\FileModGate;
+use SdAiAgent\Core\Filesystem\PathCanonicalizer;
 use SdAiAgent\Core\Health\PostMutationHealthCheck;
 use SdAiAgent\Core\Settings;
 use SdAiAgent\Models\ChangesLog;
@@ -281,14 +282,19 @@ abstract class AbstractFileAbility extends AbstractAbility {
 			);
 		}
 
-		if ( strpos( $real_path, $wp_content_real ) !== 0 ) {
+		if ( ! PathCanonicalizer::path_is_inside( $real_path, $wp_content_real ) ) {
 			return new WP_Error(
 				'sd_ai_agent_path_traversal',
 				__( 'Access denied: path is outside wp-content directory.', 'superdav-ai-agent' )
 			);
 		}
 
-		return $full_path;
+		$canonical = PathCanonicalizer::canonicalize_missing_path_inside( $full_path, $wp_content_real );
+		if ( is_wp_error( $canonical ) ) {
+			return $canonical;
+		}
+
+		return $canonical;
 	}
 
 	/**

--- a/includes/Core/Filesystem/PathCanonicalizer.php
+++ b/includes/Core/Filesystem/PathCanonicalizer.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Filesystem path canonicalisation helpers.
+ *
+ * @package SdAiAgent\Core\Filesystem
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Core\Filesystem;
+
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Canonicalises paths whose final target may not exist yet.
+ *
+ * WordPress core's wp_mkdir_p() refuses paths containing unresolved `..`
+ * segments. This helper resolves the nearest existing ancestor with realpath()
+ * and appends the still-missing suffix after rejecting traversal outside an
+ * allowed root.
+ */
+class PathCanonicalizer {
+
+	/**
+	 * Canonicalise a path by resolving its nearest existing ancestor.
+	 *
+	 * @param string $path Absolute path to canonicalise. The path may not exist.
+	 * @return string|WP_Error Canonical absolute path, or WP_Error on failure.
+	 */
+	public static function canonicalize_missing_path( string $path ): string|WP_Error {
+		$path = str_replace( '\\', '/', $path );
+		if ( '' === trim( $path ) || str_contains( $path, "\0" ) ) {
+			return new WP_Error(
+				'sd_ai_agent_invalid_path',
+				__( 'Path contains invalid characters.', 'superdav-ai-agent' )
+			);
+		}
+
+		$existing = $path;
+		$suffix   = [];
+		while ( ! file_exists( $existing ) && $existing !== dirname( $existing ) ) {
+			$suffix[] = basename( $existing );
+			$existing = dirname( $existing );
+		}
+
+		$real_existing = realpath( $existing );
+		if ( false === $real_existing ) {
+			return new WP_Error(
+				'sd_ai_agent_path_resolve_failed',
+				__( 'Cannot resolve path.', 'superdav-ai-agent' )
+			);
+		}
+
+		$canonical = rtrim( str_replace( '\\', '/', $real_existing ), '/' );
+		foreach ( array_reverse( $suffix ) as $segment ) {
+			if ( '' === $segment || '.' === $segment || '..' === $segment ) {
+				return new WP_Error(
+					'sd_ai_agent_path_traversal',
+					__( 'Path contains directory traversal sequences.', 'superdav-ai-agent' )
+				);
+			}
+			$canonical .= '/' . $segment;
+		}
+
+		return $canonical;
+	}
+
+	/**
+	 * Canonicalise a path and assert it stays inside an allowed root.
+	 *
+	 * @param string $path Absolute path to canonicalise.
+	 * @param string $root Existing allowed root directory.
+	 * @return string|WP_Error Canonical absolute path, or WP_Error on failure.
+	 */
+	public static function canonicalize_missing_path_inside( string $path, string $root ): string|WP_Error {
+		$canonical = self::canonicalize_missing_path( $path );
+		if ( is_wp_error( $canonical ) ) {
+			return $canonical;
+		}
+
+		$root_real = realpath( $root );
+		if ( false === $root_real ) {
+			return new WP_Error(
+				'sd_ai_agent_path_resolve_failed',
+				__( 'Cannot resolve allowed root.', 'superdav-ai-agent' )
+			);
+		}
+
+		if ( ! self::path_is_inside( $canonical, $root_real ) ) {
+			return new WP_Error(
+				'sd_ai_agent_path_traversal',
+				__( 'Path escapes the allowed root directory.', 'superdav-ai-agent' )
+			);
+		}
+
+		return $canonical;
+	}
+
+	/**
+	 * Check whether a path is equal to or inside a directory.
+	 *
+	 * @param string $path      Path to check.
+	 * @param string $directory Directory boundary.
+	 * @return bool True when path is inside directory.
+	 */
+	public static function path_is_inside( string $path, string $directory ): bool {
+		$path      = rtrim( str_replace( '\\', '/', $path ), '/' );
+		$directory = rtrim( str_replace( '\\', '/', $directory ), '/' );
+
+		return $path === $directory || str_starts_with( $path, $directory . '/' );
+	}
+}

--- a/includes/PluginBuilder/PluginInstaller.php
+++ b/includes/PluginBuilder/PluginInstaller.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace SdAiAgent\PluginBuilder;
 
 use SdAiAgent\Core\Database;
+use SdAiAgent\Core\Filesystem\PathCanonicalizer;
 use WP_Error;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -276,7 +277,12 @@ class PluginInstaller {
 		$updated = [];
 		foreach ( $normalised_files as $relative_path => $content ) {
 			$abs_path = $plugin_dir . $relative_path;
-			wp_mkdir_p( dirname( $abs_path ) );
+			$dir      = PathCanonicalizer::canonicalize_missing_path_inside( dirname( $abs_path ), $plugin_dir );
+			if ( is_wp_error( $dir ) ) {
+				return $dir;
+			}
+
+			wp_mkdir_p( $dir );
 
 			// Validate PHP syntax before writing.
 			if ( self::is_php_file( $relative_path ) ) {
@@ -443,12 +449,17 @@ class PluginInstaller {
 			);
 		}
 
+		$canonical_plugin_dir = PathCanonicalizer::canonicalize_missing_path_inside( $plugin_dir, $canonical_plugins );
+		if ( is_wp_error( $canonical_plugin_dir ) ) {
+			return $canonical_plugin_dir;
+		}
+
 		// Create plugin directory.
-		if ( ! wp_mkdir_p( $plugin_dir ) ) {
+		if ( ! wp_mkdir_p( $canonical_plugin_dir ) ) {
 			return new WP_Error(
 				'sd_ai_agent_mkdir_failed',
 				/* translators: %s: directory path */
-				sprintf( __( 'Could not create plugin directory: %s', 'superdav-ai-agent' ), $plugin_dir )
+				sprintf( __( 'Could not create plugin directory: %s', 'superdav-ai-agent' ), $canonical_plugin_dir )
 			);
 		}
 
@@ -457,10 +468,14 @@ class PluginInstaller {
 		foreach ( $files as $relative_path => $content ) {
 			// Sanitize path to prevent traversal.
 			$relative_path = ltrim( $relative_path, '/\\' );
-			$abs_path      = realpath( $plugin_dir ) . '/' . $relative_path;
+			$abs_path      = trailingslashit( $canonical_plugin_dir ) . $relative_path;
 
 			// Ensure destination is inside plugin dir.
-			$dest_real = dirname( $abs_path );
+			$dest_real = PathCanonicalizer::canonicalize_missing_path_inside( dirname( $abs_path ), $canonical_plugin_dir );
+			if ( is_wp_error( $dest_real ) ) {
+				return $dest_real;
+			}
+
 			if ( false === wp_mkdir_p( $dest_real ) ) {
 				return new WP_Error(
 					'sd_ai_agent_mkdir_failed',

--- a/includes/PluginBuilder/PluginUpdater.php
+++ b/includes/PluginBuilder/PluginUpdater.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 namespace SdAiAgent\PluginBuilder;
 
 use SdAiAgent\Core\Filesystem\FileModGate;
+use SdAiAgent\Core\Filesystem\PathCanonicalizer;
 use WP_Error;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -42,7 +43,7 @@ class PluginUpdater {
 	private function backups_root(): string {
 		$uploads = wp_upload_dir( null, false );
 		$basedir = ! empty( $uploads['basedir'] ) ? (string) $uploads['basedir'] : WP_CONTENT_DIR . '/uploads';
-		return trailingslashit( $basedir ) . 'sd-ai-backups/';
+		return trailingslashit( $this->canonicalize_base_dir( $basedir ) ) . 'sd-ai-backups/';
 	}
 
 	/**
@@ -53,7 +54,22 @@ class PluginUpdater {
 	private function staging_root(): string {
 		$uploads = wp_upload_dir( null, false );
 		$basedir = ! empty( $uploads['basedir'] ) ? (string) $uploads['basedir'] : WP_CONTENT_DIR . '/uploads';
-		return trailingslashit( $basedir ) . 'sd-ai-staging/';
+		return trailingslashit( $this->canonicalize_base_dir( $basedir ) ) . 'sd-ai-staging/';
+	}
+
+	/**
+	 * Canonicalise an uploads-based root while keeping a safe fallback.
+	 *
+	 * @param string $basedir Uploads base directory.
+	 * @return string Canonical path when resolvable, otherwise original path.
+	 */
+	private function canonicalize_base_dir( string $basedir ): string {
+		$canonical = PathCanonicalizer::canonicalize_missing_path( $basedir );
+		if ( is_wp_error( $canonical ) ) {
+			return $basedir;
+		}
+
+		return (string) $canonical;
 	}
 
 	/**
@@ -65,7 +81,15 @@ class PluginUpdater {
 	 * @return string
 	 */
 	private function plugin_dir_path( string $slug ): string {
-		return trailingslashit( WP_PLUGIN_DIR ) . $slug . '/';
+		$path        = trailingslashit( WP_PLUGIN_DIR ) . $slug . '/';
+		$canonical   = PathCanonicalizer::canonicalize_missing_path( $path );
+		$plugin_root = realpath( WP_PLUGIN_DIR );
+
+		if ( is_wp_error( $canonical ) || false === $plugin_root || ! PathCanonicalizer::path_is_inside( (string) $canonical, $plugin_root ) ) {
+			return $path;
+		}
+
+		return trailingslashit( (string) $canonical );
 	}
 
 	/**
@@ -148,7 +172,13 @@ class PluginUpdater {
 		foreach ( $modified_files as $relative_path => $content ) {
 			$relative_path = ltrim( (string) $relative_path, '/\\' );
 			$abs_path      = $staging_dir . $relative_path;
-			wp_mkdir_p( dirname( $abs_path ) );
+			$dir           = PathCanonicalizer::canonicalize_missing_path_inside( dirname( $abs_path ), $staging_dir );
+			if ( is_wp_error( $dir ) ) {
+				$this->remove_directory( $staging_dir );
+				return $dir;
+			}
+
+			wp_mkdir_p( $dir );
 
 			// Validate PHP syntax before writing.
 			if ( $this->is_php_file( $relative_path ) ) {
@@ -494,6 +524,19 @@ class PluginUpdater {
 	 * @return true|\WP_Error
 	 */
 	private function copy_directory( string $source, string $destination ): bool|\WP_Error {
+		$source_real = realpath( $source );
+		if ( false === $source_real ) {
+			return new WP_Error(
+				'sd_ai_agent_path_resolve_failed',
+				__( 'Cannot resolve source directory.', 'superdav-ai-agent' )
+			);
+		}
+
+		$destination = PathCanonicalizer::canonicalize_missing_path( $destination );
+		if ( is_wp_error( $destination ) ) {
+			return $destination;
+		}
+
 		if ( ! wp_mkdir_p( $destination ) ) {
 			return new WP_Error(
 				'sd_ai_agent_mkdir_failed',
@@ -503,7 +546,7 @@ class PluginUpdater {
 		}
 
 		$iterator = new \RecursiveIteratorIterator(
-			new \RecursiveDirectoryIterator( $source, \RecursiveDirectoryIterator::SKIP_DOTS ),
+			new \RecursiveDirectoryIterator( $source_real, \RecursiveDirectoryIterator::SKIP_DOTS ),
 			\RecursiveIteratorIterator::SELF_FIRST
 		);
 
@@ -514,9 +557,13 @@ class PluginUpdater {
 				continue;
 			}
 
-			$dest_path = $destination . str_replace( $source, '', $real_path );
+			$dest_path = $destination . str_replace( $source_real, '', $real_path );
 
 			if ( $item->isDir() ) {
+				$dest_path = PathCanonicalizer::canonicalize_missing_path_inside( $dest_path, $destination );
+				if ( is_wp_error( $dest_path ) ) {
+					return $dest_path;
+				}
 				wp_mkdir_p( $dest_path );
 			} else {
 				copy( $real_path, $dest_path );

--- a/tests/SdAiAgent/Core/Filesystem/PathCanonicalizerTest.php
+++ b/tests/SdAiAgent/Core/Filesystem/PathCanonicalizerTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Test case for filesystem path canonicalisation helpers.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Core\Filesystem;
+
+use SdAiAgent\Core\Filesystem\PathCanonicalizer;
+use WP_UnitTestCase;
+
+/**
+ * Tests PathCanonicalizer.
+ */
+class PathCanonicalizerTest extends WP_UnitTestCase {
+
+	/**
+	 * Temporary base directory.
+	 *
+	 * @var string
+	 */
+	private string $base_dir;
+
+	/**
+	 * Set up temporary directories.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->base_dir = trailingslashit( sys_get_temp_dir() ) . 'sd-ai-agent-path-canonicalizer';
+		$this->remove_dir( $this->base_dir );
+		wp_mkdir_p( $this->base_dir . '/content/plugins' );
+		wp_mkdir_p( $this->base_dir . '/outside' );
+	}
+
+	/**
+	 * Tear down temporary directories.
+	 */
+	public function tearDown(): void {
+		$this->remove_dir( $this->base_dir );
+		parent::tearDown();
+	}
+
+	/**
+	 * Paths with parent-dir references are canonicalised before mkdir use.
+	 */
+	public function test_canonicalize_missing_path_resolves_parent_segments(): void {
+		$path = $this->base_dir . '/content/../content/plugins/probe-plugin/includes';
+
+		$result = PathCanonicalizer::canonicalize_missing_path( $path );
+
+		$this->assertIsString( $result );
+		$this->assertSame( $this->base_dir . '/content/plugins/probe-plugin/includes', $result );
+	}
+
+	/**
+	 * Missing child suffixes are appended after resolving the nearest ancestor.
+	 */
+	public function test_canonicalize_missing_path_inside_appends_missing_suffix(): void {
+		$root = $this->base_dir . '/content/plugins';
+		$path = $this->base_dir . '/content/../content/plugins/probe-plugin/deep/dir';
+
+		$result = PathCanonicalizer::canonicalize_missing_path_inside( $path, $root );
+
+		$this->assertIsString( $result );
+		$this->assertSame( $root . '/probe-plugin/deep/dir', $result );
+	}
+
+	/**
+	 * Canonicalisation rejects paths that resolve outside the allowed root.
+	 */
+	public function test_canonicalize_missing_path_inside_rejects_traversal_outside_root(): void {
+		$root = $this->base_dir . '/content/plugins';
+		$path = $this->base_dir . '/content/plugins/../../outside/probe-plugin';
+
+		$result = PathCanonicalizer::canonicalize_missing_path_inside( $path, $root );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'sd_ai_agent_path_traversal', $result->get_error_code() );
+	}
+
+	/**
+	 * Recursively remove a directory using WP_Filesystem_Direct.
+	 *
+	 * @param string $dir Directory path.
+	 * @return void
+	 */
+	private function remove_dir( string $dir ): void {
+		if ( ! is_dir( $dir ) ) {
+			return;
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
+		require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
+
+		$fs = new \WP_Filesystem_Direct( [] );
+		$fs->rmdir( $dir, true );
+	}
+}


### PR DESCRIPTION
## Summary

Added a shared PathCanonicalizer that resolves nearest existing ancestors before appending safe missing suffixes, then applied it to file abilities, generated plugin installation/update mkdir paths, and sandboxed backup/staging copies so WP_CONTENT_DIR/WP_PLUGIN_DIR paths containing ../ are normalised before wp_mkdir_p().

## Files Changed

includes/Abilities/FileAbilities.php,includes/Core/Filesystem/PathCanonicalizer.php,includes/PluginBuilder/PluginInstaller.php,includes/PluginBuilder/PluginUpdater.php,tests/SdAiAgent/Core/Filesystem/PathCanonicalizerTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify (PHPUnit: Tests: 3405, Assertions: 13803, Errors: 0, Failures: 0, Skipped: 108, Incomplete: 4; Lint PHP/JS/CSS clean; PHPStan 0 errors; Build succeeded with existing webpack size warnings). Targeted: npm run test:php -- --filter PathCanonicalizerTest (OK: 3 tests, 6 assertions). Manual wp eval generate-plugin was attempted but this dev site's active plugin resolved to /home/dave/Git/superdav-ai-agent instead of the worker worktree, so it exercised the pre-fix checkout and reproduced the original mkdir failure.

Resolves #1844


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.0 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 15m and 125,524 tokens on this as a headless worker.