### PR TITLE
fix(plugin-builder): repair generated plugin paths and PHP

### DIFF
--- a/includes/Abilities/GeneratePluginAbility.php
+++ b/includes/Abilities/GeneratePluginAbility.php
@@ -61,7 +61,7 @@ class GeneratePluginAbility extends AbstractAbility {
 		return [
 			'type'       => 'object',
 			'properties' => [
-				'plan'        => [ 'type' => 'string' ],
+				'plan'        => [ 'type' => 'object' ],
 				'files'       => [ 'type' => 'object' ],
 				'plugin_file' => [ 'type' => 'string' ],
 				'slug'        => [ 'type' => 'string' ],

--- a/includes/PluginBuilder/PluginGenerator.php
+++ b/includes/PluginBuilder/PluginGenerator.php
@@ -172,13 +172,25 @@ INSTRUCTION;
 				continue;
 			}
 
+			$path       = isset( $file_spec['path'] ) ? (string) $file_spec['path'] : '';
+			$normalised = self::normalise_generated_file_path( (string) $plan['slug'], $path, empty( $generated_files ) );
+			if ( is_wp_error( $normalised ) ) {
+				return $normalised;
+			}
+			$file_spec['path'] = $normalised;
+
 			$code = self::generate_file( $plan, $file_spec, $generated_files );
 
 			if ( is_wp_error( $code ) ) {
 				return $code;
 			}
 
-			$path = isset( $file_spec['path'] ) ? (string) $file_spec['path'] : '';
+			$code = self::prepare_generated_php( (string) $code, $plan, $file_spec, $generated_files );
+			if ( is_wp_error( $code ) ) {
+				return $code;
+			}
+
+			$path = (string) $file_spec['path'];
 			if ( '' !== $path ) {
 				$generated_files[ $path ] = (string) $code;
 			}
@@ -451,7 +463,233 @@ INSTRUCTION;
 		return '';
 	}
 
+	/**
+	 * Normalise an AI-supplied generated file path into slug-relative form.
+	 *
+	 * The plugin builder asks models for paths like "slug/slug.php", but models
+	 * sometimes omit the extension and return "slug/slug". Because generated
+	 * files are PHP-only in this flow, missing extensions are repaired before the
+	 * installer can create a directory/file collision such as "slug/slug".
+	 *
+	 * @param string $slug    Plugin slug.
+	 * @param string $path    AI-supplied path.
+	 * @param bool   $is_main Whether this is the first/main generated file.
+	 * @return string|\WP_Error Normalised path, including the slug prefix.
+	 */
+	public static function normalise_generated_file_path( string $slug, string $path, bool $is_main = false ): string|\WP_Error {
+		$slug = sanitize_title( $slug );
+		if ( '' === $slug ) {
+			return new WP_Error(
+				'sd_ai_agent_invalid_slug',
+				__( 'Plugin slug must not be empty.', 'superdav-ai-agent' )
+			);
+		}
+
+		$normalised = ltrim( str_replace( '\\', '/', trim( $path ) ), '/' );
+		if ( '' === $normalised ) {
+			$normalised = $slug . '/' . $slug . '.php';
+		}
+
+		if ( str_contains( $normalised, "\0" ) || str_contains( $normalised, '../' ) ) {
+			return new WP_Error(
+				'sd_ai_agent_invalid_generated_path',
+				__( 'Generated plugin file path is invalid.', 'superdav-ai-agent' )
+			);
+		}
+
+		if ( str_starts_with( $normalised, $slug . '/' ) ) {
+			$normalised = substr( $normalised, strlen( $slug ) + 1 );
+		}
+
+		if ( '' === $normalised ) {
+			$normalised = $slug . '.php';
+		}
+
+		if ( ! str_ends_with( strtolower( $normalised ), '.php' ) ) {
+			$normalised .= '.php';
+		}
+
+		if ( $is_main ) {
+			$basename = basename( $normalised );
+			if ( $slug . '.php' !== $basename && ! str_contains( dirname( $normalised ), '/' ) ) {
+				$normalised = $slug . '.php';
+			}
+		}
+
+		return $slug . '/' . $normalised;
+	}
+
 	// ─── Private helpers ──────────────────────────────────────────────────────
+
+	/**
+	 * Strip wrappers, lint generated PHP, and attempt one bounded repair.
+	 *
+	 * @param string               $code        Generated source.
+	 * @param array<string,mixed>  $plan        Plan array.
+	 * @param array<string,mixed>  $file_spec   File spec.
+	 * @param array<string,string> $prior_files Prior generated files.
+	 * @return string|\WP_Error Prepared PHP source or validation error with source data.
+	 */
+	private static function prepare_generated_php( string $code, array $plan, array $file_spec, array $prior_files ): string|\WP_Error {
+		$path = isset( $file_spec['path'] ) ? (string) $file_spec['path'] : '';
+		$code = self::extract_php_source( $code );
+		$lint = self::lint_php_source( $code );
+		if ( true === $lint['valid'] ) {
+			return $code;
+		}
+
+		$repaired = self::repair_file( $plan, $file_spec, $code, $lint, $prior_files, true );
+		if ( is_wp_error( $repaired ) ) {
+			return $repaired;
+		}
+
+		$repaired = self::extract_php_source( $repaired );
+		$lint     = self::lint_php_source( $repaired );
+		if ( true === $lint['valid'] ) {
+			return $repaired;
+		}
+
+		$regenerated = self::repair_file( $plan, $file_spec, $repaired, $lint, $prior_files, false );
+		if ( is_wp_error( $regenerated ) ) {
+			return $regenerated;
+		}
+
+		$regenerated = self::extract_php_source( $regenerated );
+		$lint        = self::lint_php_source( $regenerated );
+		if ( true === $lint['valid'] ) {
+			return $regenerated;
+		}
+
+		return new WP_Error(
+			'sd_ai_agent_php_syntax_error',
+			sprintf(
+				/* translators: 1: file path 2: error message 3: line number */
+				__( 'PHP syntax error in %1$s: %2$s (line %3$d)', 'superdav-ai-agent' ),
+				$path,
+				$lint['error'] ?? 'Unknown',
+				$lint['line'] ?? 0
+			),
+			array(
+				'file'   => $path,
+				'source' => $regenerated,
+				'lint'   => $lint,
+			)
+		);
+	}
+
+	/**
+	 * Request one syntax repair from the AI client.
+	 *
+	 * @param array<string,mixed>  $plan        Plan array.
+	 * @param array<string,mixed>  $file_spec   File spec.
+	 * @param string               $code        Invalid source.
+	 * @param array<string,mixed>  $lint        Lint result.
+	 * @param array<string,string> $prior_files Prior generated files.
+	 * @param bool                 $include_source Whether to include invalid source in the repair prompt.
+	 * @return string|\WP_Error
+	 */
+	private static function repair_file( array $plan, array $file_spec, string $code, array $lint, array $prior_files, bool $include_source ): string|\WP_Error {
+		$path = isset( $file_spec['path'] ) ? (string) $file_spec['path'] : 'plugin.php';
+
+		$system_instruction = <<<'INSTRUCTION'
+You repair WordPress plugin PHP syntax errors. Return ONLY complete valid PHP code. No markdown fences, explanations, or partial snippets.
+INSTRUCTION;
+
+		$prompt  = $include_source
+			? "Repair this generated WordPress plugin file so php -l/token_get_all parses successfully. Preserve the requested behaviour and plugin header.\n"
+			: "Regenerate this WordPress plugin file from scratch so php -l/token_get_all parses successfully. Return a complete self-contained file with the requested behaviour and plugin header.\n";
+		$prompt .= "File: {$path}\n";
+		$prompt .= 'Plugin slug: ' . (string) ( $plan['slug'] ?? '' ) . "\n";
+		$prompt .= 'Plugin name: ' . (string) ( $plan['name'] ?? '' ) . "\n";
+		$prompt .= 'Plan JSON: ' . (string) wp_json_encode( $plan ) . "\n";
+		$prompt .= 'Lint error: ' . (string) ( $lint['error'] ?? 'Unknown' ) . ' on line ' . (string) ( $lint['line'] ?? 0 ) . "\n";
+		if ( ! empty( $prior_files ) ) {
+			$prompt .= "\nPreviously generated files are available and must remain compatible.\n";
+		}
+		if ( $include_source ) {
+			$prompt .= "\nInvalid source:\n" . $code;
+		}
+
+		$raw = wp_ai_client_prompt( $prompt )
+			->using_system_instruction( $system_instruction )
+			->generate_text();
+
+		if ( is_wp_error( $raw ) ) {
+			return new WP_Error(
+				'sd_ai_agent_php_syntax_error',
+				sprintf(
+					/* translators: 1: file path 2: error message 3: line number */
+					__( 'PHP syntax error in %1$s: %2$s (line %3$d)', 'superdav-ai-agent' ),
+					$path,
+					$lint['error'] ?? 'Unknown',
+					$lint['line'] ?? 0
+				),
+				array(
+					'file'   => $path,
+					'source' => $code,
+					'lint'   => $lint,
+				)
+			);
+		}
+
+		return (string) $raw;
+	}
+
+	/**
+	 * Extract PHP from common markdown wrappers while preserving bare source.
+	 *
+	 * @param string $code Raw model output.
+	 * @return string PHP source.
+	 */
+	private static function extract_php_source( string $code ): string {
+		$trimmed = trim( $code );
+		if ( preg_match( '/```(?:php)?\s*(.*?)```/s', $trimmed, $matches ) ) {
+			$trimmed = trim( $matches[1] );
+		}
+
+		$start = strpos( $trimmed, '<?php' );
+		if ( false !== $start ) {
+			return substr( $trimmed, $start );
+		}
+
+		return $trimmed;
+	}
+
+	/**
+	 * Lint generated PHP source without writing it to disk.
+	 *
+	 * @param string $code PHP source.
+	 * @return array{valid: bool, error?: string, line?: int}
+	 */
+	private static function lint_php_source( string $code ): array {
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_set_error_handler -- Scoped tokeniser guard restored in finally.
+		set_error_handler(
+			static function ( int $severity, string $message, string $file, int $line ): bool {
+				// phpcs:ignore WordPress.Security.EscapeOutput.ExceptionNotEscaped -- ErrorException arguments are not output.
+				throw new \ErrorException( $message, 0, $severity, $file, $line );
+			}
+		);
+
+		try {
+			$tokens = token_get_all( $code, TOKEN_PARSE );
+			unset( $tokens );
+			return array( 'valid' => true );
+		} catch ( \ParseError | \ErrorException $e ) {
+			return array(
+				'valid' => false,
+				'error' => $e->getMessage(),
+				'line'  => $e->getLine(),
+			);
+		} catch ( \Throwable $e ) {
+			return array(
+				'valid' => false,
+				'error' => $e->getMessage(),
+				'line'  => $e->getLine(),
+			);
+		} finally {
+			restore_error_handler();
+		}
+	}
 
 	/**
 	 * Extract a JSON object from possibly-wrapped AI text output.

--- a/includes/PluginBuilder/PluginInstaller.php
+++ b/includes/PluginBuilder/PluginInstaller.php
@@ -466,8 +466,19 @@ class PluginInstaller {
 		// Write each file.
 		$written = [];
 		foreach ( $files as $relative_path => $content ) {
-			// Sanitize path to prevent traversal.
-			$relative_path = ltrim( $relative_path, '/\\' );
+			$validated = self::validate_plugin_path( $slug, (string) $relative_path );
+			if ( is_wp_error( $validated ) ) {
+				return $validated;
+			}
+
+			if ( $slug === $validated ) {
+				return new WP_Error(
+					'sd_ai_agent_invalid_plugin_file_path',
+					__( 'Generated plugin file path must include a file extension.', 'superdav-ai-agent' )
+				);
+			}
+
+			$relative_path = $validated;
 			$abs_path      = trailingslashit( $canonical_plugin_dir ) . $relative_path;
 
 			// Ensure destination is inside plugin dir.
@@ -518,6 +529,20 @@ class PluginInstaller {
 		if ( empty( $plugin_file ) ) {
 			$plugin_file = $slug . '/' . $slug . '.php';
 		}
+
+		$normalised_plugin_file = self::validate_plugin_path( $slug, $plugin_file );
+		if ( is_wp_error( $normalised_plugin_file ) ) {
+			return $normalised_plugin_file;
+		}
+
+		if ( ! self::is_php_file( $normalised_plugin_file ) ) {
+			return new WP_Error(
+				'sd_ai_agent_invalid_plugin_file_path',
+				__( 'Main plugin file path must point to a PHP file.', 'superdav-ai-agent' )
+			);
+		}
+
+		$plugin_file = $slug . '/' . $normalised_plugin_file;
 
 		// Record in database.
 		$now = current_time( 'mysql' );

--- a/tests/SdAiAgent/Abilities/PluginBuilderAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/PluginBuilderAbilitiesTest.php
@@ -50,6 +50,16 @@ class PluginBuilderAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 'sd_ai_agent_empty_description', $result->get_error_code() );
 	}
 
+	/**
+	 * GeneratePluginAbility declares plan as an object to match the returned plan array.
+	 */
+	public function test_generate_plugin_output_schema_matches_plan_array(): void {
+		$ability = new GeneratePluginAbility( 'sd-ai-agent/generate-plugin' );
+		$schema  = $ability->get_output_schema();
+
+		$this->assertSame( 'object', $schema['properties']['plan']['type'] );
+	}
+
 	// ── SandboxTestPluginAbility ───────────────────────────────────────────
 
 	/**

--- a/tests/SdAiAgent/PluginBuilder/PluginGeneratorTest.php
+++ b/tests/SdAiAgent/PluginBuilder/PluginGeneratorTest.php
@@ -146,6 +146,40 @@ RAW;
 		$this->assertSame( '', $result );
 	}
 
+	// ─── normalise_generated_file_path ───────────────────────────────────────
+
+	/**
+	 * The E2E counter prompt regression omitted ".php" from the main-file path.
+	 */
+	public function test_normalise_generated_file_path_repairs_e2e_counter_main_file_without_extension(): void {
+		$result = PluginGenerator::normalise_generated_file_path(
+			'sd-e2e-counter-widget',
+			'sd-e2e-counter-widget/sd-e2e-counter-widget',
+			true
+		);
+
+		$this->assertSame( 'sd-e2e-counter-widget/sd-e2e-counter-widget.php', $result );
+	}
+
+	/**
+	 * Empty AI paths fall back to the canonical main plugin file.
+	 */
+	public function test_normalise_generated_file_path_falls_back_to_canonical_main_file(): void {
+		$result = PluginGenerator::normalise_generated_file_path( 'my-plugin', '', true );
+
+		$this->assertSame( 'my-plugin/my-plugin.php', $result );
+	}
+
+	/**
+	 * Traversal in AI-generated paths is rejected before installation.
+	 */
+	public function test_normalise_generated_file_path_rejects_traversal(): void {
+		$result = PluginGenerator::normalise_generated_file_path( 'my-plugin', '../evil', true );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_invalid_generated_path', $result->get_error_code() );
+	}
+
 	// ─── generate_plan — SDK-unavailable path ─────────────────────────────────
 
 	/**

--- a/tests/SdAiAgent/PluginBuilder/PluginInstallerTest.php
+++ b/tests/SdAiAgent/PluginBuilder/PluginInstallerTest.php
@@ -296,6 +296,31 @@ class PluginInstallerTest extends WP_UnitTestCase {
 		$this->assertFileExists( $this->plugin_dir . $this->test_slug . '.php' );
 	}
 
+	/**
+	 * install() must not create slug/slug as a directory/file when the main path misses .php.
+	 */
+	public function test_install_rejects_e2e_counter_main_file_path_without_php_extension(): void {
+		$slug       = 'sd-e2e-counter-widget';
+		$plugin_dir = trailingslashit( WP_PLUGIN_DIR ) . $slug . '/';
+		$files      = [
+			$slug . '/' . $slug => '<?php /* Plugin Name: SD E2E Counter Widget */',
+		];
+		$this->remove_directory( $plugin_dir );
+
+		$result = PluginInstaller::install(
+			$slug,
+			$files,
+			'Create a shortcode counter plugin with admin Tools page and inline JS.',
+			'{}',
+			$slug . '/' . $slug
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'sd_ai_agent_invalid_plugin_file_path', $result->get_error_code() );
+		$this->assertDirectoryDoesNotExist( $plugin_dir . $slug );
+		$this->remove_directory( $plugin_dir );
+	}
+
 	// ─── update_plugin_files ─────────────────────────────────────────────────
 
 	/**
@@ -404,11 +429,21 @@ class PluginInstallerTest extends WP_UnitTestCase {
 	 * @return void
 	 */
 	private function cleanup_plugin_dir(): void {
-		if ( is_dir( $this->plugin_dir ) ) {
+		$this->remove_directory( $this->plugin_dir );
+	}
+
+	/**
+	 * Remove a directory recursively if it exists.
+	 *
+	 * @param string $directory Directory path.
+	 * @return void
+	 */
+	private function remove_directory( string $directory ): void {
+		if ( is_dir( $directory ) ) {
 			require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-base.php';
 			require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
 			$fs = new \WP_Filesystem_Direct( [] );
-			$fs->rmdir( $this->plugin_dir, true );
+			$fs->rmdir( $directory, true );
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Normalise AI-generated plugin file paths so `sd-e2e-counter-widget/sd-e2e-counter-widget` becomes `sd-e2e-counter-widget/sd-e2e-counter-widget.php` before code generation/installation.
- Add bounded PHP syntax validation and repair/regeneration before generated files are installed; syntax failures now return lint/source data.
- Align `GeneratePluginAbility` output schema with the returned plan object and harden installer main-file validation.

Resolves #1846

## Testing
- `npm run verify`
- WP-CLI smoke through the worktree symlink: `sd-ai-agent/generate-plugin` returned `slug=sd-e2e-counter-widget`, `plugin_file=sd-e2e-counter-widget/sd-e2e-counter-widget.php`, `installed=true`.
- WP-CLI sandbox/activation smoke: `sandbox-test-plugin` returned `passed=true`; `sandbox-activate-plugin` returned `activated=true`.

## Worker self-verification
- PHPUnit: Tests: 3422, Assertions: 13821, Errors: 0, Failures: 0, Skipped: 112, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.0 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 32m and 186,979 tokens on this as a headless worker.
