### PR TITLE
GH#1851: fix(chat): read proposal function responses

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -1328,21 +1328,27 @@ class AgentLoop {
 	 */
 	private function extract_pending_proposal( Message $response_message ): ?array {
 		foreach ( $response_message->getParts() as $part ) {
-			// @phpstan-ignore-next-line
-			$tool_result = $part->getToolResult();
-			if ( ! $tool_result ) {
+			$function_response = method_exists( $part, 'getFunctionResponse' ) ? $part->getFunctionResponse() : null;
+			if ( ! $function_response ) {
 				continue;
 			}
 
-			// @phpstan-ignore-next-line
-			$result = $tool_result->getResult();
+			$result = $function_response->getResponse();
 			if ( ! is_array( $result ) ) {
 				continue;
 			}
 
-			if ( 'proposal_pending' === ( $result['status'] ?? null ) ) {
-				// @phpstan-ignore-next-line
-				return $result;
+			$proposal = array();
+			foreach ( $result as $key => $value ) {
+				if ( ! is_string( $key ) ) {
+					continue 2;
+				}
+
+				$proposal[ $key ] = $value;
+			}
+
+			if ( 'proposal_pending' === ( $proposal['status'] ?? null ) ) {
+				return $proposal;
 			}
 		}
 

--- a/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
@@ -22,6 +22,9 @@ namespace SdAiAgent\Tests\Core;
 use SdAiAgent\Abilities\Js\JsAbilityCatalog;
 use SdAiAgent\Core\AgentLoop;
 use SdAiAgent\Core\Settings;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\DTO\UserMessage;
+use WordPress\AiClient\Tools\DTO\FunctionResponse;
 use WP_UnitTestCase;
 
 /**
@@ -300,6 +303,47 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'sd_ai_agent_missing_client', $result->get_error_code() );
+	}
+
+	// ── extract_pending_proposal tests ─────────────────────────────────────
+
+	/**
+	 * extract_pending_proposal() uses the SDK FunctionResponse API.
+	 */
+	public function test_extract_pending_proposal_reads_function_response(): void {
+		$loop = new AgentLoop( 'test', array(), array(), array() );
+
+		$reflection = new \ReflectionClass( $loop );
+		$method     = $reflection->getMethod( 'extract_pending_proposal' );
+		$method->setAccessible( true );
+
+		$proposal = array(
+			'status'      => 'proposal_pending',
+			'proposal_id' => 'proposal-1',
+		);
+		$message  = new UserMessage(
+			array(
+				new MessagePart( 'Tool execution finished.' ),
+				new MessagePart( new FunctionResponse( 'call-1', 'wpab__sd-ai-agent__write-file', $proposal ) ),
+			)
+		);
+
+		$this->assertSame( $proposal, $method->invoke( $loop, $message ) );
+	}
+
+	/**
+	 * extract_pending_proposal() does not call removed MessagePart::getToolResult().
+	 */
+	public function test_extract_pending_proposal_ignores_text_part_without_get_tool_result(): void {
+		$loop = new AgentLoop( 'test', array(), array(), array() );
+
+		$reflection = new \ReflectionClass( $loop );
+		$method     = $reflection->getMethod( 'extract_pending_proposal' );
+		$method->setAccessible( true );
+
+		$message = new UserMessage( array( new MessagePart( 'No proposal here.' ) ) );
+
+		$this->assertNull( $method->invoke( $loop, $message ) );
 	}
 
 	// ── Helper methods ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Updated pending proposal extraction to use the WordPress AI Client SDK FunctionResponse API and added regression coverage for MessagePart instances without getToolResult().

## Files Changed

includes/Core/AgentLoop.php,tests/SdAiAgent/Core/AgentLoopClientToolsTest.php

## Runtime Testing

- **Risk level:** Low
- **Verification:** npm run verify

## Worker self-verification
- PHPUnit: Tests: 3424, Assertions: 13823, Errors: 0, Failures: 0, Skipped: 112, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Resolves #1851


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.0 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 11m and 101,075 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined pending proposal detection to use updated system interfaces, improving reliability in handling proposal workflows.

* **Tests**
  * Added comprehensive test coverage for pending proposal extraction to ensure correct behavior across different message scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1852?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->