### PR TITLE
GH#1853: docs: document contributor insight triage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,21 @@ professional, issue-by-issue format:
   backed by a concrete change or test.
 - Close with the resubmission status and any specific reviewer action requested.
 
+### Contributor Insight Triage
+
+When recurring maintainer feedback suggests that automation is missing context,
+turn it into durable, worker-ready guidance instead of relying on chat history:
+
+- Update this `AGENTS.md` when the lesson is repo-wide and should affect every
+  future agent session.
+- Update the narrowest relevant script, workflow, or docs page when the lesson is
+  procedural or command-specific.
+- If the fix is not obvious during the current session, open a GitHub issue brief
+  that names the target files or patterns to inspect, the expected behaviour, and
+  the verification command that should prove the change.
+- Keep instruction changes concrete and actionable; avoid copying vague feedback
+  without translating it into a rule, reference pattern, or testable outcome.
+
 ## Build Commands
 - **Build**: `npm run build` or `npx wp-scripts build` (production)
 - **Dev**: `npm start` or `npx wp-scripts start` (watch mode)


### PR DESCRIPTION
## Summary

Added Contributor Insight Triage guidance to AGENTS.md so recurring maintainer feedback is converted into durable repo instructions, narrow script/docs updates, or worker-ready GitHub issue briefs.

## Files Changed

AGENTS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run test:php:setup; npm run verify (lint JS/CSS/PHP clean; PHPStan 0 errors; PHPUnit: Tests: 3424, Assertions: 13823, Skipped: 112, Incomplete: 4; build succeeded with existing webpack size warnings)

Resolves #1853


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.0 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 11m and 78,148 tokens on this as a headless worker.