### PR TITLE
GH#1857: fix(admin): localize command palette label

### DIFF
--- a/includes/Admin/UnifiedAdminMenu.php
+++ b/includes/Admin/UnifiedAdminMenu.php
@@ -365,6 +365,7 @@ class UnifiedAdminMenu {
 		wp_enqueue_script( 'wp-commands' );
 
 		$page_url = wp_json_encode( admin_url( 'admin.php?page=' . self::SLUG ) );
+		$label    = wp_json_encode( __( 'Interact with AI', 'superdav-ai-agent' ) );
 		$inline   = "( function () {\n"
 			. "\t'use strict';\n"
 			. "\tif ( typeof wp === 'undefined' || ! wp.data ) {\n"
@@ -373,7 +374,7 @@ class UnifiedAdminMenu {
 			. "\ttry {\n"
 			. "\t\twp.data.dispatch( 'core/commands' ).registerCommand( {\n"
 			. "\t\t\tname: 'sd-ai-agent/open',\n"
-			. "\t\t\tlabel: 'Interact with AI',\n"
+			. "\t\t\tlabel: " . $label . ",\n"
 			. "\t\t\tcallback: function ( { close } ) {\n"
 			. "\t\t\t\tclose();\n"
 			. "\t\t\t\twindow.location.href = " . $page_url . ";\n"


### PR DESCRIPTION
## Summary

Localized the WordPress command palette label by JSON-encoding the translated PHP string and injecting it into the inline wp-commands registration.

## Files Changed

includes/Admin/UnifiedAdminMenu.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify (PHPUnit: Tests: 3424, Assertions: 13823, Errors: 0, Failures: 0, Skipped: 112, Incomplete: 4; lint clean; PHPStan 0 errors; build succeeded with existing webpack size warnings)

Resolves #1857


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.2 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 6m and 37,698 tokens on this as a headless worker.