### PR TITLE
fix(benchmark): normalize assertion URL to active site

### DIFF
--- a/includes/Benchmark/AssertionEngine.php
+++ b/includes/Benchmark/AssertionEngine.php
@@ -670,6 +670,8 @@ class AssertionEngine {
 		string $expected_output_pattern,
 		int $expected_exit_code
 	): array {
+		$command = self::normalize_wp_cli_benchmark_url( $command );
+
 		// Auto-inject --user=<admin> when the caller didn't pass one. WC CLI
 		// commands (and any others gated on capabilities) fail with 401
 		// otherwise because the external `wp` invocation has no logged-in user.
@@ -709,6 +711,31 @@ class AssertionEngine {
 			'expected' => $expected_desc,
 			'actual'   => $pass ? 'passed' : $actual_desc,
 		);
+	}
+
+	/**
+	 * Replace historical benchmark fixture URLs with the active WordPress URL.
+	 *
+	 * Several benchmark definitions predate the shared local development domain
+	 * and still include `--url=wp-multisite-waas.test`. External WP-CLI
+	 * assertion processes must target the same site that the benchmark agent just
+	 * modified, otherwise valid work is scored as a failure because WP-CLI cannot
+	 * resolve the old fixture host.
+	 *
+	 * @param string $command WP-CLI command (without 'wp' prefix).
+	 * @return string Command with the benchmark URL normalized when needed.
+	 */
+	private static function normalize_wp_cli_benchmark_url( string $command ): string {
+		if ( false === strpos( $command, 'wp-multisite-waas.test' ) ) {
+			return $command;
+		}
+
+		$site_url = untrailingslashit( (string) preg_replace( '#^https?://#', '', home_url( '/' ) ) );
+		if ( '' === $site_url ) {
+			return $command;
+		}
+
+		return str_replace( 'wp-multisite-waas.test', $site_url, $command );
 	}
 
 	/**

--- a/tests/SdAiAgent/Benchmark/AssertionEngineTest.php
+++ b/tests/SdAiAgent/Benchmark/AssertionEngineTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Tests\Benchmark;
 
 use SdAiAgent\Benchmark\AssertionEngine;
+use ReflectionMethod;
 use WP_REST_Response;
 use WP_REST_Server;
 use WP_UnitTestCase;
@@ -115,5 +116,20 @@ class AssertionEngineTest extends WP_UnitTestCase {
 		$this->assertSame( 0, $result['failed'] );
 		$this->assertTrue( $result['results'][0]['pass'] );
 		$this->assertSame( 'found at route: /sd-ai-agent-test-exact/v1/events', $result['results'][0]['actual'] );
+	}
+
+	/**
+	 * Test WP-CLI assertions target the active local site instead of old fixture URLs.
+	 */
+	public function test_wp_cli_benchmark_url_normalizes_historical_fixture_host(): void {
+		$method = new ReflectionMethod( AssertionEngine::class, 'normalize_wp_cli_benchmark_url' );
+		$method->setAccessible( true );
+
+		$command    = 'post list --post_type=page --url=wp-multisite-waas.test';
+		$normalized = (string) $method->invoke( null, $command );
+		$site_url   = untrailingslashit( (string) preg_replace( '#^https?://#', '', home_url( '/' ) ) );
+
+		$this->assertStringNotContainsString( 'wp-multisite-waas.test', $normalized );
+		$this->assertStringContainsString( '--url=' . $site_url, $normalized );
 	}
 }


### PR DESCRIPTION
## Summary

- Normalize historical benchmark WP-CLI assertion URLs (`wp-multisite-waas.test`) to the active WordPress `home_url()` host before running external `wp` assertions.
- Add focused PHPUnit coverage for URL normalization.
- Re-ran the benchmark matrix enough to confirm the URL fix and filed follow-up issues for unrelated failures found during the resumed run.

## Verification

- `npm run test:php -- --filter AssertionEngineTest` — OK (3 tests, 10 assertions).
- `npm run lint:php` — OK (8/8 files).
- `wp sd-ai-agent benchmark run --suite=functional-v1 --provider=ultimate-ai-connector-anthropic-max --model=claude-sonnet-4-6 --log-dir=/home/dave/Git/superdav-ai-agent-worktrees/fix-benchmark-url-runtime/tests/benchmark/logs` — rerun reached assertions using the active local site.
- Remaining suites run under `tests/benchmark/logs/2026-05-26_*_claude-sonnet-4-6/`; credentialed suite `2026-05-26_082857_claude-sonnet-4-6` passed 7/7 assertions.

## Follow-ups filed

- #1861 — boolean tool-result serialization provider error.
- #1862 — `apm-013` skips `switch-plugin` despite explicit prompt.
- #1863 — `au-001` omits `detect-fresh-install`.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 8m and 117,141 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced WP-CLI benchmark command handling by implementing URL normalization that replaces legacy fixture hostnames with the active WordPress installation's URL for more accurate benchmark execution.

* **Tests**
  * Added test coverage for benchmark command URL normalization functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1864?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->