### PR TITLE
GH#1862: fix: add switch-plugin dry run preview

### DIFF
--- a/includes/Abilities/WordPressAbilities.php
+++ b/includes/Abilities/WordPressAbilities.php
@@ -215,7 +215,7 @@ class WordPressAbilities {
 			'sd-ai-agent/switch-plugin',
 			[
 				'label'       => __( 'Switch Plugin', 'superdav-ai-agent' ),
-				'description' => __( 'Activate one plugin and optionally deactivate one or more others. Rolls back if activation fails.', 'superdav-ai-agent' ),
+				'description' => __( 'Preview or perform a plugin switch: activate one plugin and optionally deactivate one or more others. Set dry_run=true to exercise or inspect the switch without changing active plugins.', 'superdav-ai-agent' ),
 			]
 		);
 		// @phpstan-ignore-next-line
@@ -390,7 +390,7 @@ class WordPressAbilities {
 				'sd-ai-agent/switch-plugin',
 				[
 					'label'         => __( 'Switch Plugin', 'superdav-ai-agent' ),
-					'description'   => __( 'Activate one plugin and optionally deactivate one or more others. Rolls back if activation fails.', 'superdav-ai-agent' ),
+					'description'   => __( 'Preview or perform a plugin switch: activate one plugin and optionally deactivate one or more others. Set dry_run=true to exercise or inspect the switch without changing active plugins.', 'superdav-ai-agent' ),
 					'ability_class' => SwitchPluginAbility::class,
 				]
 			);
@@ -2082,7 +2082,7 @@ class SwitchPluginAbility extends AbstractAbility {
 	}
 
 	protected function description(): string {
-		return __( 'Activate one plugin and optionally deactivate one or more others atomically. Rolls back deactivations if activation fails. Useful for switching between competing plugins (e.g. SEO plugins, caching plugins).', 'superdav-ai-agent' );
+		return __( 'Preview or perform a plugin switch atomically. Set dry_run=true to exercise the ability, inspect a proposed replacement, or verify what would change without activating or deactivating plugins. Useful for switching between competing plugins (e.g. SEO, caching, or anti-spam plugins).', 'superdav-ai-agent' );
 	}
 
 	protected function input_schema(): array {
@@ -2098,6 +2098,11 @@ class SwitchPluginAbility extends AbstractAbility {
 					'description' => 'Array of slugs or plugin files to deactivate before activating the target.',
 					'items'       => [ 'type' => 'string' ],
 				],
+				'dry_run'    => [
+					'type'        => 'boolean',
+					'description' => 'When true, preview the switch and return what would be activated/deactivated without changing active plugins. Use this for benchmark prompts or safety checks that say not to actually switch.',
+					'default'     => false,
+				],
 			],
 			'required'   => [ 'activate' ],
 		];
@@ -2107,11 +2112,15 @@ class SwitchPluginAbility extends AbstractAbility {
 		return [
 			'type'       => 'object',
 			'properties' => [
-				'status'      => [ 'type' => 'string' ],
-				'message'     => [ 'type' => 'string' ],
-				'activated'   => [ 'type' => 'string' ],
-				'deactivated' => [ 'type' => 'array' ],
-				'rolled_back' => [ 'type' => 'array' ],
+				'status'           => [ 'type' => 'string' ],
+				'message'          => [ 'type' => 'string' ],
+				'activated'        => [ 'type' => 'string' ],
+				'deactivated'      => [ 'type' => 'array' ],
+				'rolled_back'      => [ 'type' => 'array' ],
+				'dry_run'          => [ 'type' => 'boolean' ],
+				'would_activate'   => [ 'type' => 'string' ],
+				'would_deactivate' => [ 'type' => 'array' ],
+				'target_installed' => [ 'type' => 'boolean' ],
 			],
 		];
 	}
@@ -2120,6 +2129,7 @@ class SwitchPluginAbility extends AbstractAbility {
 		/** @var array<string, mixed> $input */
 		$activate_target = isset( $input['activate'] ) ? (string) $input['activate'] : '';
 		$deactivate_list = isset( $input['deactivate'] ) && is_array( $input['deactivate'] ) ? $input['deactivate'] : [];
+		$dry_run         = ! empty( $input['dry_run'] );
 
 		if ( '' === $activate_target ) {
 			return new WP_Error( 'sd_ai_agent_missing_activate', __( '"activate" is required.', 'superdav-ai-agent' ) );
@@ -2132,6 +2142,32 @@ class SwitchPluginAbility extends AbstractAbility {
 		/** @var array<string, array<string, mixed>> $installed */
 		// Resolve activate target to plugin_file.
 		$activate_file = $this->resolve_plugin_file( $activate_target, $installed );
+		if ( $dry_run ) {
+			$deactivate_files = [];
+			foreach ( $deactivate_list as $target ) {
+				$file = $this->resolve_plugin_file( (string) $target, $installed );
+				if ( null !== $file ) {
+					$deactivate_files[] = $file;
+				}
+			}
+
+			return [
+				'status'           => 'preview',
+				'message'          => sprintf(
+					/* translators: 1: plugin target, 2: count of deactivation targets */
+					__( 'Dry run only: would activate "%1$s" and deactivate %2$d plugin(s). No plugins were changed.', 'superdav-ai-agent' ),
+					$activate_file ?? $activate_target,
+					count( $deactivate_files )
+				),
+				'activated'        => '',
+				'deactivated'      => [],
+				'rolled_back'      => [],
+				'dry_run'          => true,
+				'would_activate'   => $activate_file ?? $activate_target,
+				'would_deactivate' => $deactivate_files,
+				'target_installed' => null !== $activate_file,
+			];
+		}
 		if ( null === $activate_file ) {
 			return new WP_Error(
 				'sd_ai_agent_plugin_not_installed',

--- a/tests/SdAiAgent/Abilities/WordPressAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/WordPressAbilitiesTest.php
@@ -9,6 +9,7 @@
 
 namespace SdAiAgent\Tests\Abilities;
 
+use SdAiAgent\Abilities\SwitchPluginAbility;
 use SdAiAgent\Abilities\WordPressAbilities;
 use WP_UnitTestCase;
 
@@ -148,6 +149,40 @@ class WordPressAbilitiesTest extends WP_UnitTestCase {
 		$result = WordPressAbilities::handle_install_plugin( [] );
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
+	}
+
+	/**
+	 * Test switch-plugin exposes a dry-run option for safe benchmark calls.
+	 */
+	public function test_switch_plugin_schema_exposes_dry_run() {
+		$ability = new SwitchPluginAbility( 'sd-ai-agent/switch-plugin' );
+		$schema  = $ability->get_input_schema();
+
+		$this->assertArrayHasKey( 'properties', $schema );
+		$this->assertArrayHasKey( 'dry_run', $schema['properties'] );
+		$this->assertSame( 'boolean', $schema['properties']['dry_run']['type'] );
+		$this->assertStringContainsString( 'without changing active plugins', $schema['properties']['dry_run']['description'] );
+	}
+
+	/**
+	 * Test switch-plugin dry runs preview the target without changing plugins.
+	 */
+	public function test_handle_switch_plugin_dry_run_does_not_change_active_plugins() {
+		$before = get_option( 'active_plugins', [] );
+
+		$result = WordPressAbilities::handle_switch_plugin(
+			[
+				'activate' => 'akismet',
+				'dry_run'  => true,
+			]
+		);
+		$after  = get_option( 'active_plugins', [] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'preview', $result['status'] );
+		$this->assertTrue( $result['dry_run'] );
+		$this->assertArrayHasKey( 'would_activate', $result );
+		$this->assertSame( $before, $after );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Added a dry_run preview mode to sd-ai-agent/switch-plugin, updated its discovery descriptions so safe non-mutating use is discoverable, and covered the schema plus no-mutation behavior in WordPressAbilitiesTest.

## Files Changed

includes/Abilities/WordPressAbilities.php,tests/SdAiAgent/Abilities/WordPressAbilitiesTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify; wp sd-ai-agent benchmark run --question=apm-013 --provider=ultimate-ai-connector-anthropic-max --model=claude-sonnet-4-6 --log-dir=/home/dave/Git/superdav-ai-agent-feature-auto-20260526-031043-gh1862/tests/benchmark/logs/issue-1862

Resolves #1862


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 20m and 113,672 tokens on this as a headless worker.