### PR TITLE
GH#1869: fix: fall back from stale block refs

### DIFF
--- a/includes/Core/BlockTreeAddress.php
+++ b/includes/Core/BlockTreeAddress.php
@@ -46,15 +46,20 @@ class BlockTreeAddress {
 		if ( isset( $args['ref'] ) && is_string( $args['ref'] ) && '' !== $args['ref'] ) {
 			$found = BlockReferences::find_by_ref( $blocks, $args['ref'] );
 
-			if ( null === $found ) {
+			if ( null !== $found ) {
+				return $found['path'];
+			}
+
+			// Ref values are persisted best-effort by get-page-blocks and can be stale
+			// when a caller also supplied the path/flat_index from that same response.
+			// Fall through to the secondary address instead of failing immediately.
+			if ( ! isset( $args['path'] ) && ! array_key_exists( 'flat_index', $args ) ) {
 				return new \WP_Error(
 					'block_not_found',
 					sprintf( "Block ref '%s' not found in the block tree.", $args['ref'] ),
 					[ 'status' => 404 ]
 				);
 			}
-
-			return $found['path'];
 		}
 
 		// Priority 2: explicit path.

--- a/tests/SdAiAgent/Abilities/EditBlockTreeAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/EditBlockTreeAbilityTest.php
@@ -198,6 +198,29 @@ class EditBlockTreeAbilityTest extends WP_UnitTestCase {
 		$this->assertSame( 3, $named[1]['attrs']['level'] ?? null );
 	}
 
+	/**
+	 * edit-block-tree falls back to path when the supplied ref is not present.
+	 */
+	public function test_update_attrs_falls_back_to_path_when_ref_is_missing(): void {
+		$post_id = $this->create_post_with_blocks();
+
+		$result = BlockAbilities::handle_edit_block_tree( [
+			'post_id'    => $post_id,
+			'op'         => 'update-attrs',
+			'ref'        => 'blk_staleref',
+			'path'       => [ 1 ],
+			'attributes' => [ 'level' => 4 ],
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['success'] );
+
+		$updated = get_post( $post_id );
+		$blocks  = parse_blocks( $updated->post_content );
+		$named   = array_values( array_filter( $blocks, static fn( $b ) => ! empty( $b['blockName'] ) ) );
+		$this->assertSame( 4, $named[1]['attrs']['level'] ?? null );
+	}
+
 	// ── duplicate integration ──────────────────────────────────────────────
 
 	/**

--- a/tests/SdAiAgent/Core/BlockMutatorTest.php
+++ b/tests/SdAiAgent/Core/BlockMutatorTest.php
@@ -177,6 +177,22 @@ class BlockMutatorTest extends WP_UnitTestCase {
 		$this->assertTrue( $result[0]['attrs']['dropCap'] );
 	}
 
+	/**
+	 * update-attrs falls back to path when a supplied ref is stale.
+	 */
+	public function test_update_attrs_falls_back_to_path_when_ref_is_missing(): void {
+		$blocks = [ $this->make_block( 'core/paragraph' ) ];
+
+		$result = BlockMutator::apply( $blocks, 'update-attrs', [
+			'ref'        => 'blk_staleref',
+			'path'       => [ 0 ],
+			'attributes' => [ 'dropCap' => true ],
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result[0]['attrs']['dropCap'] );
+	}
+
 	// ── update-html ───────────────────────────────────────────────────────
 
 	/**


### PR DESCRIPTION
## Summary

Updated block address resolution so a missing/stale ref falls through to supplied path or flat_index, preserving ref-only block_not_found behavior. Added core and edit-block-tree regression coverage for stale refs with path fallback.

## Files Changed

includes/Core/BlockTreeAddress.php,tests/SdAiAgent/Abilities/EditBlockTreeAbilityTest.php,tests/SdAiAgent/Core/BlockMutatorTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused PHPUnit: OK (74 tests, 236 assertions). Full PHPUnit: Tests: 3433, Assertions: 13860, Errors: 0, Failures: 0, Skipped: 112, Incomplete: 4. Lint: PHP/JS/CSS all clean. PHPStan: 0 errors via serial debug run. Build: succeeded with existing asset-size warnings.

Resolves #1869


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 51m and 101,071 tokens on this as a headless worker.