### PR TITLE
GH#1877: docs: document contributor insight guidance

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches: [main]
     paths-ignore:
-      - '**.md'
       - 'docs/**'
       - '.github/ISSUE_TEMPLATE/**'
       - 'TODO.md'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches: [main]
     paths-ignore:
-      - '**.md'
       - 'docs/**'
       - '.github/ISSUE_TEMPLATE/**'
       - 'TODO.md'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,9 @@ turn it into durable, worker-ready guidance instead of relying on chat history:
   future agent session.
 - Update the narrowest relevant script, workflow, or docs page when the lesson is
   procedural or command-specific.
+- When the prompt asks whether instructions or automation should change, treat it
+  as a request to improve the durable guidance or the deterministic script path;
+  do not leave the learning only as a chat reply.
 - If the fix is not obvious during the current session, open a GitHub issue brief
   that names the target files or patterns to inspect, the expected behaviour, and
   the verification command that should prove the change.
@@ -231,6 +234,9 @@ Key gotchas: `compile_class` required for hyphenated IDs, `REST_Handler` support
   `ai-provider-for-anthropic-max` or other connector plugins), reload credentials
   from the registry/options at request time via `ProviderCredentialLoader::load()`
   and let `/providers` build its response fresh.
+- Treat third-party provider option names as open-ended. Do not depend on a fixed
+  list of option keys to invalidate provider state; prefer the connector registry,
+  provider credential loader, and request-time option reads.
 - If provider discovery appears stale, fix the credential-loading path or remove
   redundant caching; do not whitelist individual option keys as a cache
   invalidation strategy.
@@ -248,6 +254,9 @@ Key gotchas: `compile_class` required for hyphenated IDs, `REST_Handler` support
 - **Endpoint Visibility**: The `sd-ai-agent/v1` namespace is private to the plugin.
   Do not expose internal implementation details, debug endpoints, or experimental
   features in the public REST API. Use capability checks to gate all endpoints.
+- **WordPress.org readiness**: Private REST routes may ship in the WordPress.org
+  plugin when they are capability-gated, secret-scrubbed, and documented with
+  worker-ready GitHub issue briefs for any remaining exposure or hardening work.
 
 ## Local Development Environment
 


### PR DESCRIPTION
## Summary

- Updated `AGENTS.md` contributor-insight triage so maintainer requests to improve instructions or automation become durable guidance or deterministic script changes.
- Documented provider discovery guidance to treat third-party option names as open-ended and reload credentials at request time instead of relying on fixed cache invalidation keys.
- Added REST API WordPress.org readiness guidance for capability-gated, secret-scrubbed private routes and worker-ready follow-up issue briefs.
- Updated required CI workflow path filters so root instruction changes such as `AGENTS.md` trigger the required PHPUnit, static analysis, lint, and build checks instead of leaving merge-required checks permanently expected.

## Worker self-verification
- PHPUnit: Tests: 3433, Assertions: 13860, Errors: 0, Failures: 0, Skipped: 112, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Resolves #1877
