### PR TITLE
GH#1878: fix: add signed feedback issue creation

### DIFF
--- a/.agents/scripts/commands/feedback-triage.md
+++ b/.agents/scripts/commands/feedback-triage.md
@@ -204,12 +204,15 @@ Report ID: {report_id} (submitted {created_at})
 ```
 
 Write the body to a temp file (avoids quoting hazards with backticks /
-heredocs / unicode dashes) and create the issue. Apply `origin:worker` and
-`status:available` alongside `bug` so the issue is traceable as
-feedback-triage output and visible to claim routines:
+unicode dashes). Do not create the file with a shell heredoc in headless runs;
+use your runtime's file-writing tool, or an existing generated file. Create the
+GitHub issue through the repo helper so the required aidevops signature footer
+is appended automatically. Apply `origin:worker` and `status:available`
+alongside `bug` so the issue is traceable as feedback-triage output and visible
+to claim routines:
 
 ```bash
-gh issue create -R Ultimate-Multisite/sd-ai-agent \
+.agents/scripts/issue-sync-helper.sh --repo Ultimate-Multisite/sd-ai-agent create-signed-issue \
   --title "<concise bug title>" \
   --body-file /tmp/opencode/r020-triage/issue-<id>-body.md \
   --label "bug,origin:worker,status:available"
@@ -259,7 +262,7 @@ r020 triage complete: <N> reports processed.
 
 - `feedback-triage.sh fetch` HTTP error → log and stop. Do not attempt partial triage.
 - `feedback-triage.sh get <id>` HTTP error → skip report, log the error, continue with next.
-- `gh issue create` failure → do NOT update report status. Log and continue.
+- `create-signed-issue` failure → do NOT update report status. Log and continue.
 - Missing credentials → stop immediately (Step 1 guard).
 
 ## Privacy

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -188,6 +188,50 @@ gh_create_label() {
 	gh label create "$name" --repo "$repo" --color "$color" --description "$desc" --force 2>/dev/null || true
 }
 
+cmd_create_signed_issue() {
+	local title="" body_file="" labels="" assignee=""
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--title)
+			title="${2:-}"
+			shift 2
+			;;
+		--body-file)
+			body_file="${2:-}"
+			shift 2
+			;;
+		--label)
+			labels="${2:-}"
+			shift 2
+			;;
+		--assignee)
+			assignee="${2:-}"
+			shift 2
+			;;
+		*)
+			print_error "Unknown create-signed-issue option: $arg"
+			return 1
+			;;
+		esac
+	done
+
+	_init_cmd || return 1
+	if [[ -z "$title" || -z "$body_file" || -z "$labels" ]]; then
+		print_error "create-signed-issue requires --title, --body-file, and --label"
+		return 1
+	fi
+	if [[ ! -f "$body_file" ]]; then
+		print_error "Body file not found: $body_file"
+		return 1
+	fi
+
+	local body
+	body=$(<"$body_file") || return 1
+	_gh_issue_create_signed "$_CMD_REPO" "$title" "$body" "$labels" "$assignee"
+	return $?
+}
+
 gh_find_issue_by_title() {
 	local repo="$1" prefix="$2" state="${3:-all}" limit="${4:-50}"
 	gh issue list --repo "$repo" --state "$state" --limit "$limit" \
@@ -751,13 +795,16 @@ cmd_help() {
 	cat <<'EOF'
 Issue Sync Helper — stateless TODO.md <-> GitHub Issues sync via gh CLI.
 Usage: issue-sync-helper.sh [command] [options]
-Commands: push [tNNN] | enrich [tNNN] | pull | close [tNNN] | reconcile | status | help
+Commands: push [tNNN] | enrich [tNNN] | pull | close [tNNN] | reconcile | status | create-signed-issue | help
 Options: --repo SLUG | --dry-run | --verbose | --force (skip evidence on close)
          --force-push (allow bulk push outside CI — use with caution, risk of duplicates)
+
+create-signed-issue options: --title TITLE --body-file PATH --label LABELS [--assignee LOGIN]
 
 Note: Bulk push (no task ID) is CI-only by default to prevent duplicate issues.
       Use 'push <task_id>' for single tasks, or --force-push to override.
 EOF
+	return 0
 }
 
 main() {
@@ -798,7 +845,9 @@ main() {
 	case "$command" in
 	push) cmd_push "${positional_args[1]:-}" ;; enrich) cmd_enrich "${positional_args[1]:-}" ;;
 	pull) cmd_pull ;; close) cmd_close "${positional_args[1]:-}" ;;
-	reconcile) cmd_reconcile ;; status) cmd_status ;; help) cmd_help ;;
+	reconcile) cmd_reconcile ;; status) cmd_status ;;
+	create-signed-issue) cmd_create_signed_issue "${positional_args[@]:1}" ;;
+	help) cmd_help ;;
 	*)
 		print_error "Unknown command: $command"
 		cmd_help


### PR DESCRIPTION
## Summary

Added issue-sync-helper create-signed-issue to append the aidevops signature footer via --body-file, and updated feedback-triage SOP to route GitHub issue creation through that helper instead of raw gh issue create/heredoc-prone flows.

## Files Changed

.agents/scripts/commands/feedback-triage.md,.agents/scripts/issue-sync-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify; bash -n .agents/scripts/issue-sync-helper.sh; shellcheck .agents/scripts/issue-sync-helper.sh

Resolves #1878


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 10m and 87,262 tokens on this as a headless worker.