### PR TITLE
GH#1881: test: ensure site health option cleanup

### DIFF
--- a/tests/SdAiAgent/Abilities/SiteHealthAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/SiteHealthAbilitiesTest.php
@@ -408,14 +408,16 @@ class SiteHealthAbilitiesTest extends WP_UnitTestCase {
 		update_option( OnboardingManager::TRIGGERED_OPTION, true, false );
 		update_option( SiteScanner::STATUS_OPTION, [ 'status' => 'complete' ], false );
 
-		$result = SiteHealthAbilities::handle_detect_fresh_install( [] );
+		try {
+			$result = SiteHealthAbilities::handle_detect_fresh_install( [] );
 
-		$this->assertTrue( $result['onboarding_complete'] );
-		$this->assertTrue( $result['onboarding_triggered'] );
-		$this->assertSame( 'complete', $result['site_scan_status'] );
-
-		delete_option( OnboardingManager::COMPLETE_OPTION );
-		delete_option( OnboardingManager::TRIGGERED_OPTION );
-		delete_option( SiteScanner::STATUS_OPTION );
+			$this->assertTrue( $result['onboarding_complete'] );
+			$this->assertTrue( $result['onboarding_triggered'] );
+			$this->assertSame( 'complete', $result['site_scan_status'] );
+		} finally {
+			delete_option( OnboardingManager::COMPLETE_OPTION );
+			delete_option( OnboardingManager::TRIGGERED_OPTION );
+			delete_option( SiteScanner::STATUS_OPTION );
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Wrap the SiteHealthAbilities onboarding-context test assertions in try/finally so onboarding and scanner options are always deleted after the test, even if an assertion fails.

## Files Changed

tests/SdAiAgent/Abilities/SiteHealthAbilitiesTest.php

## Worker self-verification
- PHPUnit: Tests: 3433, Assertions: 13860, Errors: 0, Failures: 0, Skipped: 112, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

## Runtime Testing

- **Risk level:** Low (test cleanup-only change)
- **Verification:** npm run verify passed. Build completed with existing webpack asset-size warnings.

Resolves #1881

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 10m and 91,151 tokens on this as a headless worker.