### PR TITLE
GH#1882: fix: limit benchmark URL normalization to url options

### DIFF
--- a/includes/Benchmark/AssertionEngine.php
+++ b/includes/Benchmark/AssertionEngine.php
@@ -735,7 +735,54 @@ class AssertionEngine {
 			return $command;
 		}
 
-		return str_replace( 'wp-multisite-waas.test', $site_url, $command );
+		$rewrite_url = static function ( array $matches ) use ( $site_url ): string {
+			$leading = (string) $matches[1];
+			$option  = (string) $matches[2];
+			$quote   = '';
+			$value   = '';
+
+			if ( isset( $matches[3] ) && '' !== $matches[3] ) {
+				$quote = '"';
+				$value = (string) $matches[3];
+			} elseif ( isset( $matches[4] ) && '' !== $matches[4] ) {
+				$quote = "'";
+				$value = (string) $matches[4];
+			} else {
+				$value = (string) $matches[5];
+			}
+
+			$value = self::normalize_wp_cli_benchmark_url_value( $value, $site_url );
+
+			return $leading . $option . $quote . $value . $quote;
+		};
+
+		$command = (string) preg_replace_callback(
+			'/(^|\s)(--url=)(?:"([^"]*)"|\'([^\']*)\'|(\S+))/',
+			$rewrite_url,
+			$command
+		);
+
+		return (string) preg_replace_callback(
+			'/(^|\s)(--url\s+)(?:"([^"]*)"|\'([^\']*)\'|(\S+))/',
+			$rewrite_url,
+			$command
+		);
+	}
+
+	/**
+	 * Normalize the historical benchmark fixture host inside one WP-CLI URL value.
+	 *
+	 * @param string $value    WP-CLI --url option value.
+	 * @param string $site_url Active site URL without a scheme.
+	 * @return string URL option value with the fixture host replaced when present.
+	 */
+	private static function normalize_wp_cli_benchmark_url_value( string $value, string $site_url ): string {
+		return (string) preg_replace(
+			'~^(https?://)?wp-multisite-waas\.test(?=[:/?#]|$)~',
+			'${1}' . $site_url,
+			$value,
+			1
+		);
 	}
 
 	/**

--- a/tests/SdAiAgent/Benchmark/AssertionEngineTest.php
+++ b/tests/SdAiAgent/Benchmark/AssertionEngineTest.php
@@ -132,4 +132,45 @@ class AssertionEngineTest extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'wp-multisite-waas.test', $normalized );
 		$this->assertStringContainsString( '--url=' . $site_url, $normalized );
 	}
+
+	/**
+	 * Test WP-CLI URL normalization only rewrites --url option values.
+	 */
+	public function test_wp_cli_benchmark_url_leaves_non_url_occurrences_untouched(): void {
+		$method = new ReflectionMethod( AssertionEngine::class, 'normalize_wp_cli_benchmark_url' );
+		$method->setAccessible( true );
+
+		$command    = 'option get wp-multisite-waas.test --url=wp-multisite-waas.test';
+		$normalized = (string) $method->invoke( null, $command );
+		$site_url   = untrailingslashit( (string) preg_replace( '#^https?://#', '', home_url( '/' ) ) );
+
+		$this->assertSame( 'option get wp-multisite-waas.test --url=' . $site_url, $normalized );
+	}
+
+	/**
+	 * Test WP-CLI URL normalization handles separate quoted --url option values.
+	 */
+	public function test_wp_cli_benchmark_url_normalizes_separate_quoted_url_values(): void {
+		$method = new ReflectionMethod( AssertionEngine::class, 'normalize_wp_cli_benchmark_url' );
+		$method->setAccessible( true );
+
+		$command    = 'post list --url "https://wp-multisite-waas.test/subsite" --field=ID';
+		$normalized = (string) $method->invoke( null, $command );
+		$site_url   = untrailingslashit( (string) preg_replace( '#^https?://#', '', home_url( '/' ) ) );
+
+		$this->assertSame( 'post list --url "https://' . $site_url . '/subsite" --field=ID', $normalized );
+	}
+
+	/**
+	 * Test WP-CLI URL normalization does not rewrite fixture text in URL paths.
+	 */
+	public function test_wp_cli_benchmark_url_only_rewrites_fixture_host(): void {
+		$method = new ReflectionMethod( AssertionEngine::class, 'normalize_wp_cli_benchmark_url' );
+		$method->setAccessible( true );
+
+		$command    = 'post list --url=example.test/wp-multisite-waas.test';
+		$normalized = (string) $method->invoke( null, $command );
+
+		$this->assertSame( $command, $normalized );
+	}
 }


### PR DESCRIPTION
## Summary

Limited historical benchmark host replacement to WP-CLI --url option values, preserving unrelated command text and only rewriting the URL host portion. Added regression coverage for --url=VALUE, quoted --url VALUE, non-url occurrences, and fixture text in URL paths.

## Files Changed

includes/Benchmark/AssertionEngine.php,tests/SdAiAgent/Benchmark/AssertionEngineTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify (PHPUnit: Tests: 3436, Assertions: 13863, Errors: 0, Failures: 0, Skipped: 112, Incomplete: 4; PHP/JS/CSS lint clean; PHPStan 0 errors; build succeeded with existing webpack size warnings)

Resolves #1882


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 11m and 96,865 tokens on this as a headless worker.