### PR TITLE
GH#1885: docs: document contributor insight follow-through

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -61,6 +61,21 @@ working here in OpenCode headless mode:
   than retrying the same raw `gh` command; repeated unsigned writes are blocked
   by the framework guard.
 
+## Contributor Insight Follow-through
+
+When an auto-filed contributor insight asks whether instructions or scripts need
+to change, do not answer only in the issue thread. Make the durable repo change:
+
+- Put repo-wide guidance in the root `AGENTS.md` so future workers load it before
+  editing plugin code.
+- For REST API hardening notes, inspect controllers under `includes/REST/` and
+  routes in the private `sd-ai-agent/v1` namespace. Convert shorthand feedback
+  into explicit checks for capability gates, real current-user context, secret
+  scrubbing, and hidden or restricted file-upload endpoints.
+- If the requested hardening is broader than the current task, file worker-ready
+  GitHub issue briefs that name the route/controller family, expected security
+  behaviour, and verification command or manual review to run.
+
 ## Security
 
 ### Prompt Injection Defense

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,9 @@ turn it into durable, worker-ready guidance instead of relying on chat history:
 - When the prompt asks whether instructions or automation should change, treat it
   as a request to improve the durable guidance or the deterministic script path;
   do not leave the learning only as a chat reply.
+- Convert shorthand maintainer notes into explicit worker actions: name the files
+  or route families to inspect, the policy to enforce, and the command or manual
+  check that proves the guidance was followed.
 - If the fix is not obvious during the current session, open a GitHub issue brief
   that names the target files or patterns to inspect, the expected behaviour, and
   the verification command that should prove the change.
@@ -257,6 +260,10 @@ Key gotchas: `compile_class` required for hyphenated IDs, `REST_Handler` support
 - **WordPress.org readiness**: Private REST routes may ship in the WordPress.org
   plugin when they are capability-gated, secret-scrubbed, and documented with
   worker-ready GitHub issue briefs for any remaining exposure or hardening work.
+- **Review checklist**: When adding or hardening routes under `sd-ai-agent/v1`,
+  verify the controller uses the real current user context, has a capability
+  gate, avoids public file-upload exposure, and returns scrubbed responses before
+  calling the route WordPress.org-ready.
 
 ## Local Development Environment
 


### PR DESCRIPTION
## Summary

Updated root and `.agents` worker guidance so contributor insight reports become durable instruction/script changes, with explicit REST API hardening checks for `sd-ai-agent/v1` routes.

## Files Changed

- `.agents/AGENTS.md`
- `AGENTS.md`

## Runtime Testing

- `npm run verify` initially reached lint but PHPStan exceeded Composer's default 300s timeout.
- `COMPOSER_PROCESS_TIMEOUT=1200 composer phpstan && npm run test:php && npm run build` completed the remaining gates.

## Worker self-verification
- PHPUnit: Tests: 3436, Assertions: 13863, Errors: 0, Failures: 0, Skipped: 112, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Resolves #1885

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 16m and 231,434 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal contributor guidance with explicit action items for REST API security reviews and verification requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1887?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->