### PR TITLE
GH#1886: docs: clarify signed GitHub write guidance

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -57,6 +57,9 @@ working here in OpenCode headless mode:
   framework sync helpers that add the required aidevops signature footer, such as
   `.agents/scripts/issue-sync-helper.sh`, or write the body to a temporary file
   and pass it with `--body-file` after appending the signed footer.
+- Keep the signed body as a real file throughout the same command. Do not use
+  shell heredocs, process substitution, or command substitution to generate the
+  body inline for a `gh` write; the framework signature gate blocks those forms.
 - If the signature helper is unavailable, use the helper fallback path rather
   than retrying the same raw `gh` command; repeated unsigned writes are blocked
   by the framework guard.

--- a/.agents/scripts/commands/feedback-triage.md
+++ b/.agents/scripts/commands/feedback-triage.md
@@ -204,10 +204,13 @@ Report ID: {report_id} (submitted {created_at})
 ```
 
 Write the body to a temp file (avoids quoting hazards with backticks /
-unicode dashes). Do not create the file with a shell heredoc in headless runs;
-use your runtime's file-writing tool, or an existing generated file. Create the
+unicode dashes). In headless runs, create the file with the runtime's
+file-writing tool or an existing generated file; do not use shell heredocs,
+process substitution, or command substitution to inline the body or signature.
+Those forms are rejected by the aidevops GitHub signature gate. Create the
 GitHub issue through the repo helper so the required aidevops signature footer
-is appended automatically. Apply `origin:worker` and `status:available`
+is appended automatically and the fallback signature is used if the framework
+signature helper is unavailable. Apply `origin:worker` and `status:available`
 alongside `bug` so the issue is traceable as feedback-triage output and visible
 to claim routines:
 


### PR DESCRIPTION
## Summary

Clarified headless worker guidance for signed GitHub writes: keep issue bodies as real files, avoid heredocs/process substitution/command substitution for gh writes, and rely on the feedback-triage helper fallback when the framework signature helper is unavailable.

## Files Changed

.agents/AGENTS.md,.agents/scripts/commands/feedback-triage.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify initially reached PHPStan but timed out at Composer's 300s process timeout; reran COMPOSER_PROCESS_TIMEOUT=1200 composer phpstan successfully. npm run test:php passed on rerun after one transient database deadlock. npm run build succeeded with existing webpack size warnings.

Resolves #1886


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 17m and 65,443 tokens on this as a headless worker.