### PR TITLE
GH#1876: fix: redact WooCommerce order tool responses

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -510,7 +510,7 @@ class AgentLoop {
 				// Truncate then split for OpenAI-compatible providers.
 				$truncated_message = self::truncate_tool_results( $response_message );
 				$this->append_tool_response_to_history( $truncated_message );
-				$this->log_tool_responses( $response_message );
+				$this->log_tool_responses( $truncated_message );
 			} else {
 				// Remove the model's tool call message and tell the model the call was rejected.
 				array_pop( $this->history );
@@ -824,7 +824,7 @@ class AgentLoop {
 						}
 						$truncated_php = self::truncate_tool_results( $php_response );
 						$this->append_tool_response_to_history( $truncated_php );
-						$this->log_tool_responses( $php_response );
+						$this->log_tool_responses( $truncated_php );
 					}
 
 					// Persist loop state so the resume endpoint can reconstruct it.
@@ -913,7 +913,7 @@ class AgentLoop {
 			// providers that only accept one tool result per message).
 			$truncated_message = self::truncate_tool_results( $response_message );
 			$this->append_tool_response_to_history( $truncated_message );
-			$this->log_tool_responses( $response_message );
+			$this->log_tool_responses( $truncated_message );
 
 			// Reset the wall-clock deadline after each productive tool call.
 			// This allows genuinely long tasks (many sequential tool calls) to

--- a/includes/Core/ToolResultTruncator.php
+++ b/includes/Core/ToolResultTruncator.php
@@ -50,8 +50,22 @@ class ToolResultTruncator {
 	 * @return mixed The possibly-truncated result.
 	 */
 	public static function truncate( $result, string $tool_name = '' ) {
+		if ( is_string( $result ) && self::is_woocommerce_order_tool( $tool_name ) ) {
+			$decoded = json_decode( $result, true );
+			if ( JSON_ERROR_NONE === json_last_error() && is_array( $decoded ) ) {
+				$redacted = self::apply_tool_strategy( $decoded, $tool_name );
+				$encoded  = wp_json_encode( $redacted );
+
+				return is_string( $encoded ) ? $encoded : $result;
+			}
+		}
+
 		if ( ! is_array( $result ) ) {
 			return $result;
+		}
+
+		if ( self::is_woocommerce_order_tool( $tool_name ) ) {
+			return self::apply_tool_strategy( $result, $tool_name );
 		}
 
 		// Check if the result is small enough to pass through.
@@ -73,12 +87,17 @@ class ToolResultTruncator {
 	/**
 	 * Apply tool-specific truncation strategies.
 	 *
-	 * @param array<string, mixed> $result    The tool result.
-	 * @param string               $tool_name The tool name.
-	 * @return array<string, mixed> The truncated result.
+	 * @param array<string|int, mixed> $result    The tool result.
+	 * @param string                   $tool_name The tool name.
+	 * @return array<string|int, mixed> The truncated result.
 	 */
 	private static function apply_tool_strategy( array $result, string $tool_name ): array {
 		switch ( $tool_name ) {
+			case 'woocommerce/orders-list':
+			case 'woocommerce/orders-get':
+				$result = self::scrub_woocommerce_order_result( $result );
+				break;
+
 			// Plugin list: keep name + active status + file, drop description/version details.
 			case 'sd-ai-agent/get-plugins':
 				if ( isset( $result['plugins'] ) && is_array( $result['plugins'] ) ) {
@@ -165,6 +184,189 @@ class ToolResultTruncator {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Check whether a tool returns WooCommerce order data with customer PII.
+	 *
+	 * @param string $tool_name Ability name.
+	 * @return bool
+	 */
+	private static function is_woocommerce_order_tool( string $tool_name ): bool {
+		return in_array( $tool_name, array( 'woocommerce/orders-list', 'woocommerce/orders-get' ), true );
+	}
+
+	/**
+	 * Scrub WooCommerce order payloads down to AI-safe audit fields.
+	 *
+	 * @param array<string|int, mixed> $result WooCommerce order result.
+	 * @return array<string|int, mixed> Redacted result.
+	 */
+	private static function scrub_woocommerce_order_result( array $result ): array {
+		if ( self::looks_like_woocommerce_order( $result ) ) {
+			return self::summarize_woocommerce_order( $result );
+		}
+
+		$scrubbed = array();
+		foreach ( $result as $key => $value ) {
+			if ( is_string( $key ) && self::is_sensitive_woocommerce_order_key( $key ) ) {
+				continue;
+			}
+
+			if ( is_array( $value ) ) {
+				$scrubbed[ $key ] = self::scrub_woocommerce_order_result( $value );
+			} else {
+				$scrubbed[ $key ] = $value;
+			}
+		}
+
+		return $scrubbed;
+	}
+
+	/**
+	 * Detect a WooCommerce order object/array.
+	 *
+	 * @param array<string|int, mixed> $value Candidate value.
+	 * @return bool
+	 */
+	private static function looks_like_woocommerce_order( array $value ): bool {
+		return isset( $value['id'] ) && ( isset( $value['status'] ) || isset( $value['billing'] ) || isset( $value['shipping'] ) || isset( $value['line_items'] ) );
+	}
+
+	/**
+	 * Reduce a WooCommerce order to fields needed for non-PII summaries.
+	 *
+	 * @param array<string|int, mixed> $order Raw WooCommerce order.
+	 * @return array<string, mixed> Minimized order.
+	 */
+	private static function summarize_woocommerce_order( array $order ): array {
+		$allowed_order_keys = array(
+			'id',
+			'number',
+			'parent_id',
+			'status',
+			'currency',
+			'currency_symbol',
+			'date_created',
+			'date_created_gmt',
+			'date_modified',
+			'date_modified_gmt',
+			'date_completed',
+			'date_completed_gmt',
+			'date_paid',
+			'date_paid_gmt',
+			'total',
+			'total_tax',
+			'discount_total',
+			'discount_tax',
+			'shipping_total',
+			'shipping_tax',
+			'cart_tax',
+			'customer_id',
+			'created_via',
+			'prices_include_tax',
+			'line_items',
+			'tax_lines',
+			'shipping_lines',
+			'fee_lines',
+			'coupon_lines',
+			'refunds',
+		);
+
+		$summary = array();
+		foreach ( $allowed_order_keys as $key ) {
+			if ( array_key_exists( $key, $order ) ) {
+				$summary[ $key ] = self::summarize_woocommerce_order_field( $key, $order[ $key ] );
+			}
+		}
+
+		$summary['_redacted'] = true;
+
+		return $summary;
+	}
+
+	/**
+	 * Summarize nested WooCommerce order collections.
+	 *
+	 * @param string $key   Field key.
+	 * @param mixed  $value Field value.
+	 * @return mixed Minimized value.
+	 */
+	private static function summarize_woocommerce_order_field( string $key, $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		if ( 'line_items' === $key ) {
+			return self::summarize_woocommerce_line_items( $value );
+		}
+
+		if ( in_array( $key, array( 'tax_lines', 'shipping_lines', 'fee_lines', 'coupon_lines', 'refunds' ), true ) ) {
+			return self::scrub_woocommerce_order_result( $value );
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Keep only product summary data from WooCommerce order line items.
+	 *
+	 * @param array<string|int, mixed> $items Raw line items.
+	 * @return array<string|int, mixed> Minimized line items.
+	 */
+	private static function summarize_woocommerce_line_items( array $items ): array {
+		$allowed_line_item_keys = array( 'id', 'name', 'product_id', 'variation_id', 'quantity', 'sku', 'subtotal', 'subtotal_tax', 'total', 'total_tax' );
+		$summary                = array();
+
+		foreach ( $items as $index => $item ) {
+			if ( ! is_array( $item ) ) {
+				$summary[ $index ] = $item;
+				continue;
+			}
+
+			$line = array();
+			foreach ( $allowed_line_item_keys as $key ) {
+				if ( array_key_exists( $key, $item ) ) {
+					$line[ $key ] = $item[ $key ];
+				}
+			}
+
+			$summary[ $index ] = $line;
+		}
+
+		return $summary;
+	}
+
+	/**
+	 * Check for WooCommerce order keys that can expose customer/contact secrets.
+	 *
+	 * @param string $key Result key.
+	 * @return bool
+	 */
+	private static function is_sensitive_woocommerce_order_key( string $key ): bool {
+		$sensitive_keys = array(
+			'billing',
+			'shipping',
+			'email',
+			'phone',
+			'address_1',
+			'address_2',
+			'city',
+			'state',
+			'postcode',
+			'country',
+			'first_name',
+			'last_name',
+			'company',
+			'customer_ip_address',
+			'customer_user_agent',
+			'transaction_id',
+			'order_key',
+			'cart_hash',
+			'payment_url',
+		);
+
+		return in_array( strtolower( $key ), $sensitive_keys, true );
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/ToolResultTruncatorTest.php
+++ b/tests/SdAiAgent/Core/ToolResultTruncatorTest.php
@@ -286,6 +286,86 @@ class ToolResultTruncatorTest extends WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * Regression: WooCommerce order tools must not expose customer PII even when
+	 * the response is below the generic truncation threshold.
+	 */
+	public function test_woocommerce_orders_list_scrubs_customer_pii_from_small_array(): void {
+		$input = [
+			[
+				'id'                    => 123,
+				'status'                => 'processing',
+				'currency'              => 'GBP',
+				'total'                 => '42.00',
+				'customer_id'           => 456,
+				'order_key'             => 'wc_order_sensitive_key',
+				'transaction_id'        => 'txn_sensitive_id',
+				'customer_ip_address'   => '203.0.113.10',
+				'customer_user_agent'   => 'Sensitive Browser UA',
+				'billing'               => [
+					'email'     => 'customer@example.test',
+					'phone'     => '0123456789',
+					'address_1' => '1 Private Street',
+				],
+				'shipping'              => [
+					'address_1' => '2 Private Street',
+				],
+				'line_items'            => [
+					[
+						'name'       => 'Sample product',
+						'product_id' => 789,
+						'quantity'   => 2,
+						'total'      => '42.00',
+						'meta_data'  => [ [ 'value' => 'engraving with private note' ] ],
+					],
+				],
+			],
+		];
+
+		$result = ToolResultTruncator::truncate( $input, 'woocommerce/orders-list' );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 123, $result[0]['id'] );
+		$this->assertSame( 'processing', $result[0]['status'] );
+		$this->assertSame( '42.00', $result[0]['total'] );
+		$this->assertSame( 456, $result[0]['customer_id'] );
+		$this->assertTrue( $result[0]['_redacted'] );
+		$this->assertArrayNotHasKey( 'billing', $result[0] );
+		$this->assertArrayNotHasKey( 'shipping', $result[0] );
+		$this->assertArrayNotHasKey( 'order_key', $result[0] );
+		$this->assertArrayNotHasKey( 'transaction_id', $result[0] );
+		$this->assertArrayNotHasKey( 'customer_ip_address', $result[0] );
+		$this->assertArrayNotHasKey( 'customer_user_agent', $result[0] );
+		$this->assertArrayNotHasKey( 'meta_data', $result[0]['line_items'][0] );
+	}
+
+	/**
+	 * Regression: WooCommerce order responses can arrive as JSON strings from
+	 * function-response DTOs, so scrub the decoded payload and re-encode it.
+	 */
+	public function test_woocommerce_orders_get_scrubs_json_string_response(): void {
+		$input = wp_json_encode(
+			[
+				'id'                  => 321,
+				'status'              => 'completed',
+				'total'               => '10.00',
+				'billing'             => [ 'email' => 'customer@example.test' ],
+				'customer_ip_address' => '203.0.113.20',
+			]
+		);
+
+		$result = ToolResultTruncator::truncate( (string) $input, 'woocommerce/orders-get' );
+		$this->assertIsString( $result );
+
+		$decoded = json_decode( $result, true );
+		$this->assertIsArray( $decoded );
+		$this->assertSame( 321, $decoded['id'] );
+		$this->assertSame( 'completed', $decoded['status'] );
+		$this->assertTrue( $decoded['_redacted'] );
+		$this->assertArrayNotHasKey( 'billing', $decoded );
+		$this->assertArrayNotHasKey( 'customer_ip_address', $decoded );
+	}
+
 	// ── constants ─────────────────────────────────────────────────────────
 
 	/**


### PR DESCRIPTION
## Summary

Redacted WooCommerce orders-list/orders-get tool results before they are stored in conversation history or progress logs. Added minimized order summaries for array and JSON-string responses while preserving order status, totals, customer ID, dates, and product line summaries.

## Files Changed

includes/Core/AgentLoop.php,includes/Core/ToolResultTruncator.php,tests/SdAiAgent/Core/ToolResultTruncatorTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify (rerun passed: PHPUnit Tests: 3438, Assertions: 13883, Skipped: 112, Incomplete: 4; lint PHP/JS/CSS clean; PHPStan 0 errors; build succeeded with existing webpack size warnings). Focused test: npm run test:php -- --filter ToolResultTruncatorTest (18 tests, 83 assertions).

Resolves #1876


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 16m and 108,949 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced privacy protection: WooCommerce order responses now scrub sensitive customer information while retaining essential order metadata.

* **Tests**
  * Added regression tests to verify customer PII is properly removed from WooCommerce order responses in both structured and JSON string formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1889?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->