### PR TITLE
GH#1859: fix: prevent widget send button overlap

### DIFF
--- a/src/components/chat-widget/widget.css
+++ b/src/components/chat-widget/widget.css
@@ -1107,14 +1107,27 @@
 	display: flex;
 	min-width: 0;
 	flex: 1;
+	flex-wrap: wrap;
 	align-items: center;
 	gap: 2px;
 }
 
 .sdaa-w-input-toolbar-right {
 	display: flex;
+	position: relative;
+	z-index: 1;
+	flex-shrink: 0;
 	align-items: center;
 	gap: 2px;
+}
+
+.sdaa-w-input-toolbar-left .sdaa-cr-model-chip-wrap {
+	min-width: 0;
+	max-width: 150px;
+}
+
+.sdaa-w-input-toolbar-left .sdaa-cr-model-chip {
+	max-width: 150px;
 }
 
 .sdaa-w-attachments {

--- a/tests/e2e/floating-widget.spec.js
+++ b/tests/e2e/floating-widget.spec.js
@@ -155,6 +155,42 @@ test.describe( 'Floating Widget', () => {
 		await expect( sendButton ).toBeEnabled();
 	} );
 
+	test( 'clicking send submits without opening the agent picker', async ( {
+		page,
+	} ) => {
+		const fab = getFloatingButton( page );
+		await fab.click();
+
+		const panel = getFloatingPanel( page );
+		const input = panel.locator( '.sdaa-w-input-textarea' );
+		const sendButton = panel.getByLabel( 'Send message' );
+		const agentButton = panel.getByRole( 'button', { name: 'General' } );
+
+		await input.fill( 'Say hello only.' );
+		await expect( sendButton ).toBeEnabled();
+
+		if ( await agentButton.isVisible() ) {
+			const sendBox = await sendButton.boundingBox();
+			const agentBox = await agentButton.boundingBox();
+
+			expect( sendBox ).not.toBeNull();
+			expect( agentBox ).not.toBeNull();
+			expect( agentBox.x + agentBox.width ).toBeLessThanOrEqual(
+				sendBox.x
+			);
+		}
+
+		await sendButton.click();
+
+		await expect( input ).toHaveValue( '' );
+		if ( await agentButton.isVisible() ) {
+			await expect( agentButton ).not.toHaveAttribute(
+				'aria-expanded',
+				'true'
+			);
+		}
+	} );
+
 	test( 'pressing Enter submits the message', async ( { page } ) => {
 		const fab = getFloatingButton( page );
 		await fab.click();


### PR DESCRIPTION
## Summary

Constrained the floating widget picker chips and allowed the left toolbar controls to wrap so the send/stop controls keep a separate hit target. Added a Playwright regression that fills the widget input, verifies the agent picker does not overlap the send button, clicks Send message, and asserts the picker stays closed.

## Files Changed

src/components/chat-widget/widget.css,tests/e2e/floating-widget.spec.js

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run lint:js (passed); npm run lint:css (passed); npm run build (passed with existing asset-size warnings); npm run verify (lint + PHPStan passed, PHPUnit failed due local WordPress test database deadlocks/unrelated REST failures: Tests: 3436, Assertions: 13863, Failures: 2, Skipped: 112, Incomplete: 4); npm run test:php rerun also failed due local DB deadlocks/unrelated failures: Tests: 3436, Assertions: 13853, Failures: 2, Skipped: 112, Incomplete: 4); npx playwright test tests/e2e/floating-widget.spec.js did not run because the local Playwright install reported duplicate @playwright/test loader state

Resolves #1859


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 17m and 120,138 tokens on this as a headless worker.