### PR TITLE
GH#1860: fix: log create-post changes

### DIFF
--- a/includes/Abilities/PostAbilities.php
+++ b/includes/Abilities/PostAbilities.php
@@ -15,6 +15,7 @@ namespace SdAiAgent\Abilities;
 
 use SdAiAgent\Abilities\UrlResolverAbilities;
 use SdAiAgent\Core\BlockValidator;
+use SdAiAgent\Core\ChangeLogger;
 use SdAiAgent\Core\RateLimiter;
 use SdAiAgent\Core\RevisionGuard;
 use SdAiAgent\Models\MarkdownToBlocks;
@@ -1254,6 +1255,11 @@ class PostAbilities {
 			foreach ( $meta as $key => $value ) {
 				update_post_meta( $post_id, sanitize_key( $key ), $value );
 			}
+		}
+
+		$created_post = get_post( $post_id );
+		if ( $created_post instanceof WP_Post ) {
+			ChangeLogger::record_post_created( $post_id, $created_post );
 		}
 
 		$permalink = get_permalink( $post_id );

--- a/includes/Core/ChangeLogger.php
+++ b/includes/Core/ChangeLogger.php
@@ -101,6 +101,37 @@ class ChangeLogger {
 	}
 
 	/**
+	 * Record a newly created post while AI change logging is active.
+	 *
+	 * WordPress core's post_updated hook only captures before/after field
+	 * transitions for existing posts. A successful wp_insert_post() therefore
+	 * needs an explicit creation marker so the Changes UI can audit and revert
+	 * agent-created content.
+	 *
+	 * @param int      $post_id      Created post ID.
+	 * @param \WP_Post $post         Created post object.
+	 * @param string   $ability_name Ability slug to record when no active ability name is set.
+	 */
+	public static function record_post_created( int $post_id, \WP_Post $post, string $ability_name = 'sd-ai-agent/create-post' ): void {
+		if ( ! self::$active ) {
+			return;
+		}
+
+		ChangesLog::record(
+			[
+				'session_id'   => self::$session_id,
+				'object_type'  => $post->post_type,
+				'object_id'    => $post_id,
+				'object_title' => $post->post_title,
+				'ability_name' => self::$ability_name ?: $ability_name,
+				'field_name'   => 'post_created',
+				'before_value' => '',
+				'after_value'  => $post->post_title,
+			]
+		);
+	}
+
+	/**
 	 * Cache of post meta before-values, keyed by "{object_id}:{meta_key}".
 	 *
 	 * Read via array-key access in on_updated_post_meta().

--- a/includes/Services/ChangeRevertService.php
+++ b/includes/Services/ChangeRevertService.php
@@ -225,6 +225,19 @@ final class ChangeRevertService {
 			default:
 				// Handle all registered WordPress post types (post, page, CPTs).
 				if ( post_type_exists( $change->object_type ) ) {
+					if ( 'post_created' === $change->field_name && '' === $change->before_value ) {
+						$result = wp_trash_post( (int) $change->object_id );
+						if ( false === $result ) {
+							return new WP_Error(
+								'post_creation_revert_failed',
+								__( 'Failed to move the created post to the trash.', 'superdav-ai-agent' ),
+								array( 'status' => 500 )
+							);
+						}
+
+						return true;
+					}
+
 					$result = wp_update_post(
 						array(
 							'ID'                => (int) $change->object_id,

--- a/tests/SdAiAgent/Abilities/PostAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/PostAbilitiesTest.php
@@ -10,6 +10,7 @@
 namespace SdAiAgent\Tests\Abilities;
 
 use SdAiAgent\Abilities\PostAbilities;
+use SdAiAgent\Core\ChangeLogger;
 use WP_UnitTestCase;
 
 /**
@@ -391,6 +392,43 @@ class PostAbilitiesTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result );
 		$meta_value = get_post_meta( $result['post_id'], 'custom_key', true );
 		$this->assertSame( 'custom_value', $meta_value );
+	}
+
+	/**
+	 * Test handle_create_post records an AI changes-log row when logging is active.
+	 */
+	public function test_handle_create_post_records_change_log_entry_when_active(): void {
+		ChangeLogger::begin( 123 );
+		try {
+			$result = PostAbilities::handle_create_post( [
+				'title'   => 'Logged Agent Draft',
+				'content' => 'Created through the create-post ability.',
+				'status'  => 'draft',
+			] );
+		} finally {
+			ChangeLogger::end();
+		}
+
+		$this->assertIsArray( $result );
+
+		global $wpdb;
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE object_id = %d AND field_name = %s',
+				$wpdb->prefix . 'sd_ai_agent_changes_log',
+				$result['post_id'],
+				'post_created'
+			)
+		);
+
+		$this->assertNotNull( $row );
+		$this->assertSame( '123', (string) $row->session_id );
+		$this->assertSame( 'post', $row->object_type );
+		$this->assertSame( 'Logged Agent Draft', $row->object_title );
+		$this->assertSame( 'sd-ai-agent/create-post', $row->ability_name );
+		$this->assertSame( '', $row->before_value );
+		$this->assertSame( 'Logged Agent Draft', $row->after_value );
+		$this->assertSame( '1', (string) $row->revertable );
 	}
 
 	// ─── handle_update_post ───────────────────────────────────────

--- a/tests/SdAiAgent/Services/ChangeRevertServiceTest.php
+++ b/tests/SdAiAgent/Services/ChangeRevertServiceTest.php
@@ -107,6 +107,29 @@ class ChangeRevertServiceTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * apply_revert() moves a post-created change marker to the trash.
+	 */
+	public function test_apply_revert_post_created_marker_trashes_post(): void {
+		$post_id = self::factory()->post->create( [
+			'post_title'  => 'Agent Created Draft',
+			'post_status' => 'draft',
+		] );
+
+		$change = $this->make_change( [
+			'object_type'  => 'post',
+			'object_id'    => $post_id,
+			'field_name'   => 'post_created',
+			'before_value' => '',
+			'after_value'  => 'Agent Created Draft',
+		] );
+
+		$result = ChangeRevertService::apply_revert( $change );
+
+		$this->assertTrue( $result );
+		$this->assertSame( 'trash', get_post_status( $post_id ) );
+	}
+
+	/**
 	 * apply_revert() restores a PAGE field — object_type 'page' must work via
 	 * post_type_exists() fallback (BUG-4 fix).
 	 */


### PR DESCRIPTION
## Summary

Recorded successful sd-ai-agent/create-post mutations with a post_created changes-log marker and added revert handling to trash agent-created posts.

## Files Changed

includes/Abilities/PostAbilities.php,includes/Core/ChangeLogger.php,includes/Services/ChangeRevertService.php,tests/SdAiAgent/Abilities/PostAbilitiesTest.php,tests/SdAiAgent/Services/ChangeRevertServiceTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify (PHPUnit: Tests: 3440, Assertions: 13894, Skipped: 112, Incomplete: 4; lint/PHPStan/build passed)

Resolves #1860


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 12m and 97,277 tokens on this as a headless worker.