### PR TITLE
GH#1875: fix: enforce block validation repair guard

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -121,6 +121,9 @@ class AgentLoop {
 	/** @var list<array<string, mixed>> Logged tool call activity. */
 	private $tool_call_log = array();
 
+	/** @var array<int, array<string, mixed>> Posts that still require block-validation repair. */
+	private array $pending_block_validation_repairs = array();
+
 	/** @var float */
 	private $temperature;
 
@@ -747,6 +750,20 @@ class AgentLoop {
 					$reply = $result->toText();
 				} catch ( \RuntimeException $e ) {
 					$reply = '';
+				}
+
+				// If a prior create/update saved invalid block markup, do not let the
+				// model report success until it has attempted the documented
+				// update-post self-repair loop. The system prompt already instructs
+				// this behaviour; this guard catches models that ignore that instruction
+				// after seeing a block_validation.invalidBlocks response.
+				if ( ! empty( $this->pending_block_validation_repairs ) ) {
+					if ( $iterations > 0 ) {
+						$this->inject_block_validation_repair_guidance();
+						continue;
+					}
+
+					$reply = $this->append_unresolved_block_validation_warning( $reply );
 				}
 
 				// If the response is empty or whitespace-only after tool results,
@@ -2114,6 +2131,8 @@ class AgentLoop {
 		foreach ( $message->getParts() as $part ) {
 			$response = $part->getFunctionResponse();
 			if ( $response ) {
+				$this->track_block_validation_response( $response->getName(), $response->getResponse() );
+
 				$this->tool_call_log[] = array(
 					'type'     => 'response',
 					'id'       => $response->getId(),
@@ -2124,6 +2143,120 @@ class AgentLoop {
 		}
 
 		$this->fire_progress();
+	}
+
+	/**
+	 * Track create/update responses that require block-validation self-repair.
+	 *
+	 * @param string $tool_name Ability/tool name as returned by the SDK.
+	 * @param mixed  $response  Tool response payload.
+	 */
+	private function track_block_validation_response( string $tool_name, $response ): void {
+		if ( ! is_array( $response ) ) {
+			return;
+		}
+
+		$normalized_name = self::normalize_logged_tool_name( $tool_name );
+		if ( ! in_array( $normalized_name, array( 'sd-ai-agent/create-post', 'sd-ai-agent/update-post' ), true ) ) {
+			return;
+		}
+
+		$post_id = (int) ( $response['post_id'] ?? 0 );
+		if ( $post_id <= 0 ) {
+			return;
+		}
+
+		$validation = $response['block_validation'] ?? null;
+		if ( ! is_array( $validation ) ) {
+			return;
+		}
+
+		$invalid_blocks = (int) ( $validation['invalidBlocks'] ?? 0 );
+		if ( $invalid_blocks <= 0 ) {
+			unset( $this->pending_block_validation_repairs[ $post_id ] );
+			return;
+		}
+
+		$this->pending_block_validation_repairs[ $post_id ] = array(
+			'post_id'        => $post_id,
+			'tool_name'      => $normalized_name,
+			'invalidBlocks'  => $invalid_blocks,
+			'firstInvalid'   => $validation['firstInvalid'] ?? null,
+			'recommendation' => (string) ( $validation['recommendation'] ?? '' ),
+		);
+	}
+
+	/**
+	 * Inject a hard self-repair instruction after invalid block validation.
+	 */
+	private function inject_block_validation_repair_guidance(): void {
+		$pending = array_values( $this->pending_block_validation_repairs );
+		$lines   = array(
+			'Block validation self-repair is required before you report success.',
+			'One or more create-post/update-post responses returned block_validation.invalidBlocks > 0.',
+			'Your next action must be sd-ai-agent/update-post for each listed post_id, '
+				. 'with content rebuilt by replacing each invalid block originalContent '
+				. 'with expectedContent from block_validation.results[].',
+			'Do not provide a final success response until a follow-up update-post '
+				. 'response returns block_validation.invalidBlocks = 0. If repair is '
+				. 'impossible, explicitly report the unresolved post_id and invalid block count.',
+			'',
+			'Pending repairs:',
+		);
+
+		foreach ( $pending as $repair ) {
+			$lines[] = sprintf(
+				'- post_id %1$d from %2$s: invalidBlocks=%3$d',
+				(int) ( $repair['post_id'] ?? 0 ),
+				(string) ( $repair['tool_name'] ?? '' ),
+				(int) ( $repair['invalidBlocks'] ?? 0 )
+			);
+		}
+
+		$this->history[] = new UserMessage( array( new MessagePart( implode( "\n", $lines ) ) ) );
+
+		$this->tool_call_log[] = array(
+			'type'    => 'guardrail',
+			'reason'  => 'block_validation_repair_required',
+			'pending' => $pending,
+		);
+
+		$this->fire_progress();
+	}
+
+	/**
+	 * Append an explicit warning when the loop cannot spend another repair turn.
+	 *
+	 * @param string $reply Current assistant reply.
+	 * @return string Reply with unresolved-validation disclosure.
+	 */
+	private function append_unresolved_block_validation_warning( string $reply ): string {
+		$lines = array( '', __( 'Unresolved block validation:', 'superdav-ai-agent' ) );
+
+		foreach ( $this->pending_block_validation_repairs as $repair ) {
+			$lines[] = sprintf(
+				/* translators: 1: post ID, 2: invalid block count. */
+				__( '- Post ID %1$d still has %2$d invalid block(s).', 'superdav-ai-agent' ),
+				(int) ( $repair['post_id'] ?? 0 ),
+				(int) ( $repair['invalidBlocks'] ?? 0 )
+			);
+		}
+
+		return rtrim( $reply ) . "\n\n" . implode( "\n", $lines );
+	}
+
+	/**
+	 * Normalize SDK function names back to canonical ability names when possible.
+	 *
+	 * @param string $tool_name Name from a FunctionCall/FunctionResponse.
+	 * @return string Canonical-ish ability name.
+	 */
+	private static function normalize_logged_tool_name( string $tool_name ): string {
+		if ( str_starts_with( $tool_name, 'wpab__sd-ai-agent__' ) ) {
+			return 'sd-ai-agent/' . substr( $tool_name, strlen( 'wpab__sd-ai-agent__' ) );
+		}
+
+		return $tool_name;
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
@@ -346,6 +346,111 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 		$this->assertNull( $method->invoke( $loop, $message ) );
 	}
 
+	// ── block_validation self-repair guard tests ───────────────────────────
+
+	/**
+	 * Invalid create/update block validation responses are tracked for repair.
+	 */
+	public function test_block_validation_response_tracks_pending_repair(): void {
+		$loop = new AgentLoop( 'test', array(), array(), array() );
+
+		$reflection = new \ReflectionClass( $loop );
+		$method     = $reflection->getMethod( 'track_block_validation_response' );
+		$method->setAccessible( true );
+
+		$method->invoke(
+			$loop,
+			'wpab__sd-ai-agent__create-post',
+			array(
+				'post_id'          => 42,
+				'block_validation' => array(
+					'isValid'       => false,
+					'invalidBlocks' => 2,
+				),
+			)
+		);
+
+		$prop = $reflection->getProperty( 'pending_block_validation_repairs' );
+		$prop->setAccessible( true );
+		$pending = $prop->getValue( $loop );
+
+		$this->assertArrayHasKey( 42, $pending );
+		$this->assertSame( 'sd-ai-agent/create-post', $pending[42]['tool_name'] );
+		$this->assertSame( 2, $pending[42]['invalidBlocks'] );
+	}
+
+	/**
+	 * A clean update-post validation response clears a pending repair for the post.
+	 */
+	public function test_clean_block_validation_response_clears_pending_repair(): void {
+		$loop = new AgentLoop( 'test', array(), array(), array() );
+
+		$reflection = new \ReflectionClass( $loop );
+		$method     = $reflection->getMethod( 'track_block_validation_response' );
+		$method->setAccessible( true );
+
+		$method->invoke(
+			$loop,
+			'sd-ai-agent/create-post',
+			array(
+				'post_id'          => 42,
+				'block_validation' => array(
+					'isValid'       => false,
+					'invalidBlocks' => 1,
+				),
+			)
+		);
+		$method->invoke(
+			$loop,
+			'sd-ai-agent/update-post',
+			array(
+				'post_id'          => 42,
+				'block_validation' => array(
+					'isValid'       => true,
+					'invalidBlocks' => 0,
+				),
+			)
+		);
+
+		$prop = $reflection->getProperty( 'pending_block_validation_repairs' );
+		$prop->setAccessible( true );
+
+		$this->assertSame( array(), $prop->getValue( $loop ) );
+	}
+
+	/**
+	 * The guard injects an explicit update-post instruction into history.
+	 */
+	public function test_block_validation_guard_injects_repair_guidance(): void {
+		$loop = new AgentLoop( 'test', array(), array(), array() );
+
+		$reflection = new \ReflectionClass( $loop );
+		$pending    = $reflection->getProperty( 'pending_block_validation_repairs' );
+		$pending->setAccessible( true );
+		$pending->setValue(
+			$loop,
+			array(
+				42 => array(
+					'post_id'       => 42,
+					'tool_name'     => 'sd-ai-agent/create-post',
+					'invalidBlocks' => 3,
+				),
+			)
+		);
+
+		$method = $reflection->getMethod( 'inject_block_validation_repair_guidance' );
+		$method->setAccessible( true );
+		$method->invoke( $loop );
+
+		$history = $reflection->getProperty( 'history' );
+		$history->setAccessible( true );
+		$messages = $history->getValue( $loop );
+
+		$this->assertCount( 1, $messages );
+		$this->assertStringContainsString( 'sd-ai-agent/update-post', $messages[0]->getParts()[0]->getText() );
+		$this->assertStringContainsString( 'post_id 42', $messages[0]->getParts()[0]->getText() );
+	}
+
 	// ── Helper methods ────────────────────────────────────────────────────
 
 	/**


### PR DESCRIPTION
## Summary

Added an AgentLoop guard that tracks invalid block_validation responses from create-post/update-post, injects a required update-post self-repair turn before final success, clears pending repairs after clean validation, and discloses unresolved invalid blocks when no repair turn remains. Added AgentLoop guard tests for tracking, clearing, and injected guidance.

## Files Changed

includes/Core/AgentLoop.php,tests/SdAiAgent/Core/AgentLoopClientToolsTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** WP_PHPUNIT_CACHE_DIR=/home/dave/.aidevops/.agent-workspace/sandbox/tmp/1779920852-982824/opencode/wp-phpunit-gh1875 npm run verify (PHPUnit: Tests: 3443, Assertions: 13901, Errors: 0, Failures: 0, Skipped: 112, Incomplete: 4; lint clean; PHPStan 0 errors; build succeeded)

Resolves #1875


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.5 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 28m and 161,367 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced post validation: The AI agent now monitors block validation issues when creating or updating posts and automatically attempts to resolve them. Unresolved issues are reported to users.

* **Tests**
  * Added test coverage for the enhanced validation system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->