### PR TITLE
GH#1874: fix: align ability routing with direct tool list

### DIFF
--- a/includes/Core/SystemInstructionBuilder.php
+++ b/includes/Core/SystemInstructionBuilder.php
@@ -92,9 +92,11 @@ class SystemInstructionBuilder {
 	 * @return string
 	 */
 	public function build( array $settings, array $ability_names = array() ): string {
+		$ability_names = array_values( array_map( 'strval', $ability_names ) );
+
 		// Use custom system prompt if set, otherwise the built-in default.
 		$custom = $settings['system_prompt'] ?? '';
-		$base   = ! empty( $custom ) ? $custom : self::default_system_instruction();
+		$base   = is_string( $custom ) && '' !== $custom ? $custom : self::default_system_instruction();
 
 		// Append memory section if memories exist.
 		$memory_text = Memory::get_formatted_for_prompt();
@@ -182,7 +184,9 @@ class SystemInstructionBuilder {
 		// Append the Tier-2 ability manifest so the model knows what's
 		// reachable via ability-search / ability-call. This is the heart of
 		// the auto-discovery layer.
-		$manifest = ToolDiscovery::build_manifest_section();
+		$base .= "\n\n" . self::build_tool_routing_section( $ability_names );
+
+		$manifest = ToolDiscovery::build_manifest_section( $ability_names );
 		if ( '' !== $manifest ) {
 			// @phpstan-ignore-next-line
 			$base .= "\n\n" . $manifest;
@@ -255,6 +259,36 @@ class SystemInstructionBuilder {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Build guidance that keeps prompt-only ability mentions aligned with the
+	 * current direct tool surface.
+	 *
+	 * @param string[] $ability_names Direct abilities exposed to the model this turn.
+	 * @return string
+	 */
+	public static function build_tool_routing_section( array $ability_names ): string {
+		$first_party = array_values(
+			array_filter(
+				$ability_names,
+				static fn( string $name ): bool => str_starts_with( $name, 'sd-ai-agent/' )
+			)
+		);
+		sort( $first_party );
+
+		$direct_list = empty( $first_party )
+			? 'none'
+			: implode(
+				', ',
+				array_map( static fn( string $name ): string => '`' . $name . '`', $first_party )
+			);
+
+		return "## Tool routing\n\n"
+			. 'Only call abilities that are present in the current direct tool list. '
+			. 'Active first-party direct tools this turn: ' . $direct_list . ".\n"
+			. 'If any prompt, memory, or manifest text mentions another `sd-ai-agent/<ability>` name, do not emit its direct `wpab__...` tool call. '
+			. 'Use `sd-ai-agent/ability-search` to fetch its schema, then invoke it through `sd-ai-agent/ability-call`.';
 	}
 
 	/**

--- a/includes/Tools/ToolDiscovery.php
+++ b/includes/Tools/ToolDiscovery.php
@@ -324,16 +324,18 @@ class ToolDiscovery {
 	 * prompt every turn. Lists every visible ability that is NOT in Tier 1
 	 * by id + one-line description, grouped by category.
 	 *
+	 * @param list<string> $direct_ability_names Direct abilities exposed this turn.
 	 * @return string An empty string when there are no Tier-2 abilities.
 	 */
-	public static function build_manifest_section(): string {
+	public static function build_manifest_section( array $direct_ability_names = array() ): string { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- list<string> is valid PHPStan but not a native PHP type.
 		if ( ! function_exists( 'wp_get_abilities' ) ) {
 			return '';
 		}
 
-		$tier_1_set = array_flip( self::tier_1_for_run() );
-		$perms      = self::tool_permissions();
-		$by_cat     = array();
+		$tier_1_names = ! empty( $direct_ability_names ) ? $direct_ability_names : self::tier_1_for_run();
+		$tier_1_set   = array_flip( $tier_1_names );
+		$perms        = self::tool_permissions();
+		$by_cat       = array();
 
 		foreach ( wp_get_abilities() as $ability ) {
 			$name = $ability->get_name();

--- a/tests/SdAiAgent/Core/SystemInstructionBuilderTest.php
+++ b/tests/SdAiAgent/Core/SystemInstructionBuilderTest.php
@@ -128,4 +128,32 @@ class SystemInstructionBuilderTest extends WP_UnitTestCase {
 			'Built instruction should include custom system prompt'
 		);
 	}
+
+	/**
+	 * Tool-routing guidance must prevent prompt-only ability names from being
+	 * emitted as direct tool calls when they are absent from the current tool list.
+	 */
+	public function test_build_includes_active_tool_routing_guidance(): void {
+		$builder = new SystemInstructionBuilder();
+
+		$instruction = $builder->build(
+			array(),
+			array(
+				'sd-ai-agent/ability-search',
+				'sd-ai-agent/ability-call',
+				'sd-ai-agent/list-posts',
+			)
+		);
+
+		$this->assertStringContainsString( '## Tool routing', $instruction );
+		$this->assertStringContainsString( '`sd-ai-agent/list-posts`', $instruction );
+		$this->assertStringContainsString(
+			'do not emit its direct `wpab__...` tool call',
+			$instruction
+		);
+		$this->assertStringContainsString(
+			'then invoke it through `sd-ai-agent/ability-call`',
+			$instruction
+		);
+	}
 }

--- a/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
+++ b/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
@@ -342,6 +342,22 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '## Available Abilities', $manifest );
 	}
 
+	public function test_manifest_excludes_current_direct_abilities(): void {
+		$manifest = ToolDiscovery::build_manifest_section(
+			array(
+				'sd-ai-agent/ability-search',
+				'sd-ai-agent/ability-call',
+				'sd-ai-agent/list-posts',
+			)
+		);
+
+		$this->assertStringNotContainsString(
+			'`sd-ai-agent/list-posts`',
+			$manifest,
+			'The manifest must not describe a currently direct ability as Tier 2.'
+		);
+	}
+
 	public function test_manifest_uses_usage_instructions_filter(): void {
 		add_filter(
 			'sd_ai_agent_ability_usage_instructions',


### PR DESCRIPTION
## Summary

Added explicit tool-routing guidance based on the active direct ability list and made the Tier-2 manifest exclude abilities already exposed as direct tools for the current turn.

## Files Changed

includes/Core/SystemInstructionBuilder.php,includes/Tools/ToolDiscovery.php,tests/SdAiAgent/Core/SystemInstructionBuilderTest.php,tests/SdAiAgent/Tools/ToolDiscoveryTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify (with isolated WP_PHPUNIT_CACHE_DIR=/home/dave/.aidevops/.agent-workspace/sandbox/tmp/1779924065-1512999/wp-phpunit-gh1874b and WP_TESTS_DB_NAME=sd_ai_agent_tests_1874b after shared DB contention); PHPUnit: Tests: 3446, Assertions: 13909, Errors: 0, Failures: 0, Skipped: 112, Incomplete: 4; Lint: PHP/JS/CSS all clean; PHPStan: 0 errors; Build: succeeded

Resolves #1874


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.0 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 46m and 195,181 tokens on this as a headless worker.