### PR TITLE
GH#1873: fix: make adev-005 file benchmark use accessible file

### DIFF
--- a/includes/Benchmark/BenchmarkSuite.php
+++ b/includes/Benchmark/BenchmarkSuite.php
@@ -1490,7 +1490,7 @@ class BenchmarkSuite {
 				'id'         => 'adev-005',
 				'category'   => 'files',
 				'max_turns'  => 12,
-				'prompt'     => 'Use file-list to list the contents of the current plugin directory (path "."). Then use file-search (glob filename matcher) to find any PHP files matching the pattern "*Abilities.php". Then use file-read on the first match and report its first 20 lines back.',
+				'prompt'     => 'Use file-list to list the contents of the wp-content root directory (path "."). Then use file-search (glob filename matcher) to find the root index.php file with the pattern "index.php". Then use file-read on that match and report its first 20 lines back.',
 				'assertions' => array(
 					array(
 						'type'        => 'tool_called',

--- a/tests/SdAiAgent/Benchmark/BenchmarkSuiteTest.php
+++ b/tests/SdAiAgent/Benchmark/BenchmarkSuiteTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Test case for benchmark suite definitions.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Benchmark;
+
+use SdAiAgent\Benchmark\BenchmarkSuite;
+use WP_UnitTestCase;
+
+/**
+ * Test benchmark suite question definitions.
+ */
+class BenchmarkSuiteTest extends WP_UnitTestCase {
+
+	/**
+	 * Test adev-005 targets a file available under the file ability wp-content root.
+	 */
+	public function test_adev_005_uses_accessible_wp_content_root_file(): void {
+		$questions = BenchmarkSuite::get_questions( 'abilities-developer-v1' );
+		$question  = null;
+
+		foreach ( $questions as $candidate ) {
+			if ( 'adev-005' === ( $candidate['id'] ?? '' ) ) {
+				$question = $candidate;
+				break;
+			}
+		}
+
+		$this->assertIsArray( $question );
+
+		$prompt = (string) $question['prompt'];
+		$this->assertStringContainsString( 'path "."', $prompt );
+		$this->assertStringContainsString( 'pattern "index.php"', $prompt );
+		$this->assertStringNotContainsString( '*Abilities.php', $prompt );
+	}
+}


### PR DESCRIPTION
## Summary

Updated the adev-005 developer benchmark prompt to search for wp-content/index.php instead of plugin-local *Abilities.php files, and added a BenchmarkSuite regression test covering the accessible prompt target.

## Files Changed

includes/Benchmark/BenchmarkSuite.php,tests/SdAiAgent/Benchmark/BenchmarkSuiteTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** - PHPUnit: Tests: 3447, Assertions: 13914, Errors: 0, Failures: 0, Skipped: 112, Incomplete: 4\n- Lint: PHP/JS/CSS all clean via npm run verify\n- PHPStan: 0 errors via npm run verify\n- Build: succeeded via npm run verify\n- Benchmark: wp sd-ai-agent benchmark run --question=adev-005 --provider=ultimate-ai-connector-anthropic-max --model=claude-sonnet-4-6 --log-dir=tests/benchmark/logs passed 3/3 assertions with sd-ai-agent/file-read called

Resolves #1873


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.0 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 13m and 84,232 tokens on this as a headless worker.