### PR TITLE
fix: hide unavailable wp-cli tool

### DIFF
--- a/includes/Abilities/WpCliAbilities.php
+++ b/includes/Abilities/WpCliAbilities.php
@@ -173,6 +173,10 @@ class WpCliAbilities {
 			return;
 		}
 
+		if ( ! self::is_available() ) {
+			return;
+		}
+
 		if ( wp_has_ability_category( self::CATEGORY ) ) {
 			return;
 		}
@@ -192,7 +196,15 @@ class WpCliAbilities {
 	 * @return void
 	 */
 	public static function register_ability(): void {
-		if ( ! function_exists( 'wp_register_ability' ) ) {
+		if ( ! function_exists( 'wp_register_ability' ) || ! function_exists( 'wp_has_ability_category' ) ) {
+			return;
+		}
+
+		if ( ! self::is_available() ) {
+			return;
+		}
+
+		if ( ! wp_has_ability_category( self::CATEGORY ) ) {
 			return;
 		}
 
@@ -615,6 +627,23 @@ class WpCliAbilities {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Determine whether the WP-CLI ability should be advertised this request.
+	 *
+	 * Runtime execution keeps its own guards because the filesystem or filters
+	 * may change between ability registration and invocation. This preflight is
+	 * only used to avoid exposing an unusable tool to the model.
+	 *
+	 * @return bool
+	 */
+	public static function is_available(): bool {
+		if ( ! self::is_proc_open_available() ) {
+			return false;
+		}
+
+		return ! is_wp_error( self::find_wp_cli() );
 	}
 
 	/**

--- a/includes/Tools/ToolDiscovery.php
+++ b/includes/Tools/ToolDiscovery.php
@@ -298,18 +298,24 @@ class ToolDiscovery {
 
 		// Filter against actually-registered, non-disabled abilities so
 		// callers don't have to recheck.
-		if ( ! function_exists( 'wp_get_ability' ) ) {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
 			return array();
 		}
+
+		$registered = array();
+		foreach ( wp_get_abilities() as $ability ) {
+			if ( $ability instanceof \WP_Ability ) {
+				$registered[ $ability->get_name() ] = true;
+			}
+		}
+
 		$perms  = self::tool_permissions();
 		$result = array();
 		foreach ( $names as $name ) {
 			if ( 'disabled' === ( $perms[ $name ] ?? 'auto' ) ) {
 				continue;
 			}
-			// @phpstan-ignore-next-line
-			$ability = wp_get_ability( $name );
-			if ( $ability instanceof \WP_Ability ) {
+			if ( isset( $registered[ $name ] ) ) {
 				$result[] = $name;
 			}
 		}

--- a/tests/SdAiAgent/Abilities/WpCliAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/WpCliAbilitiesTest.php
@@ -43,6 +43,8 @@ class WpCliAbilitiesTest extends WP_UnitTestCase {
 		wp_set_current_user( $this->admin_id );
 
 		WpCliAbilities::reset_binary_cache();
+		$this->unregister_wp_cli_ability();
+		$this->unregister_wp_cli_category();
 	}
 
 	/**
@@ -60,6 +62,8 @@ class WpCliAbilitiesTest extends WP_UnitTestCase {
 		}
 
 		WpCliAbilities::reset_binary_cache();
+		$this->unregister_wp_cli_ability();
+		$this->unregister_wp_cli_category();
 
 		parent::tear_down();
 	}
@@ -76,6 +80,83 @@ class WpCliAbilitiesTest extends WP_UnitTestCase {
 	 */
 	private function disable_path_scan(): void {
 		add_filter( 'sd_ai_agent_wp_cli_scan_path', '__return_false' );
+	}
+
+	/**
+	 * Registration should not expose wp-cli/execute when proc_open is blocked.
+	 */
+	public function test_register_ability_skips_when_proc_open_unavailable(): void {
+		add_filter( 'sd_ai_agent_wp_cli_proc_open_available', '__return_false' );
+
+		$this->register_wp_cli_ability_in_context();
+
+		$this->assertFalse( $this->is_wp_cli_ability_registered() );
+	}
+
+	/**
+	 * Registration should not expose wp-cli/execute when no usable binary exists.
+	 */
+	public function test_register_ability_skips_when_binary_unavailable(): void {
+		$empty = $this->make_temp_dir();
+		add_filter(
+			'sd_ai_agent_wp_cli_candidates',
+			static function () use ( $empty ): array {
+				return array( $empty . '/missing-wp', $empty . '/missing.phar' );
+			}
+		);
+		add_filter(
+			'sd_ai_agent_wp_cli_binary',
+			static function (): string {
+				return '';
+			}
+		);
+		$this->disable_path_scan();
+
+		$this->register_wp_cli_ability_in_context();
+
+		$this->assertFalse( $this->is_wp_cli_ability_registered() );
+	}
+
+	/**
+	 * A valid filtered binary should expose wp-cli/execute normally.
+	 */
+	public function test_register_ability_registers_when_binary_available(): void {
+		$fake = $this->create_fake_phar();
+		add_filter(
+			'sd_ai_agent_wp_cli_binary',
+			static function () use ( $fake ): string {
+				return $fake;
+			}
+		);
+
+		$this->register_wp_cli_category_in_context();
+		$this->register_wp_cli_ability_in_context();
+
+		$this->assertTrue( $this->is_wp_cli_ability_registered() );
+	}
+
+	/**
+	 * The WP-CLI category should not be advertised by itself when unavailable.
+	 */
+	public function test_register_category_skips_when_binary_unavailable(): void {
+		$empty = $this->make_temp_dir();
+		add_filter(
+			'sd_ai_agent_wp_cli_candidates',
+			static function () use ( $empty ): array {
+				return array( $empty . '/missing-wp', $empty . '/missing.phar' );
+			}
+		);
+		add_filter(
+			'sd_ai_agent_wp_cli_binary',
+			static function (): string {
+				return '';
+			}
+		);
+		$this->disable_path_scan();
+
+		$this->register_wp_cli_category_in_context();
+
+		$this->assertFalse( wp_has_ability_category( 'wp-cli' ) );
 	}
 
 	/**
@@ -269,6 +350,85 @@ class WpCliAbilitiesTest extends WP_UnitTestCase {
 		$ref = new \ReflectionMethod( WpCliAbilities::class, 'find_wp_cli' );
 		$ref->setAccessible( true );
 		return $ref->invoke( null );
+	}
+
+	/**
+	 * Invoke WP-CLI ability registration under the hook context required by core.
+	 *
+	 * @return void
+	 */
+	private function register_wp_cli_ability_in_context(): void {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Standard WordPress hook stack global.
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_init';
+
+		try {
+			WpCliAbilities::register_ability();
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+	}
+
+	/**
+	 * Invoke WP-CLI category registration under the hook context required by core.
+	 *
+	 * @return void
+	 */
+	private function register_wp_cli_category_in_context(): void {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Standard WordPress hook stack global.
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_categories_init';
+
+		try {
+			WpCliAbilities::register_category();
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+	}
+
+	/**
+	 * Remove the WP-CLI ability so registration tests start from a clean slate.
+	 *
+	 * @return void
+	 */
+	private function unregister_wp_cli_ability(): void {
+		if ( function_exists( 'wp_unregister_ability' ) && $this->is_wp_cli_ability_registered() ) {
+			wp_unregister_ability( 'wp-cli/execute' );
+		}
+	}
+
+	/**
+	 * Remove the WP-CLI category so category registration tests are isolated.
+	 *
+	 * @return void
+	 */
+	private function unregister_wp_cli_category(): void {
+		if (
+			function_exists( 'wp_unregister_ability_category' )
+			&& function_exists( 'wp_has_ability_category' )
+			&& wp_has_ability_category( 'wp-cli' )
+		) {
+			wp_unregister_ability_category( 'wp-cli' );
+		}
+	}
+
+	/**
+	 * Check the full registry without triggering wp_get_ability() not-found notices.
+	 *
+	 * @return bool
+	 */
+	private function is_wp_cli_ability_registered(): bool {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			return false;
+		}
+
+		foreach ( wp_get_abilities() as $ability ) {
+			if ( $ability instanceof \WP_Ability && 'wp-cli/execute' === $ability->get_name() ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
+++ b/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
@@ -170,6 +170,21 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 		$this->assertContains( 'sd-ai-agent/update-global-styles', $tier_1 );
 	}
 
+	public function test_tier_1_omits_wp_cli_when_ability_is_not_registered(): void {
+		if ( function_exists( 'wp_unregister_ability' ) && function_exists( 'wp_get_abilities' ) ) {
+			foreach ( wp_get_abilities() as $ability ) {
+				if ( $ability instanceof \WP_Ability && 'wp-cli/execute' === $ability->get_name() ) {
+					wp_unregister_ability( 'wp-cli/execute' );
+					break;
+				}
+			}
+		}
+
+		$tier_1 = ToolDiscovery::tier_1_for_run();
+
+		$this->assertNotContains( 'wp-cli/execute', $tier_1 );
+	}
+
 	public function test_tier_1_promotes_recently_used_abilities(): void {
 		// Pick an ability that exists in this install.
 		AbilityUsageTracker::record( 'sd-ai-agent/get-plugins' );


### PR DESCRIPTION
## Summary
- Skip `wp-cli/execute` ability and category registration when `proc_open` is unavailable or no usable WP-CLI binary is found.
- Require the WP-CLI category to be registered before advertising the ability, avoiding an unusable direct tool surface.
- Filter Tier 1 tool discovery from `wp_get_abilities()` so missing abilities are omitted without `wp_get_ability()` not-found notices.
- Add PHPUnit coverage for WP-CLI registration gating and ToolDiscovery omission.

## Browser-agent smoke
- Switched the local `superdav-ai-agent` plugin symlink to this worktree and logged into `http://wordpress.local:8080/wp-admin/` with `agent-browser`.
- Opened `admin.php?page=sd-ai-agent#/chat`.
- Result: browser-agent could load WP admin, but the AI Agent app root stayed blank because admin assets 404 from the existing admin-route issue (#1868): `/wp-content/plugins/home/dave/Git/superdav-ai-agent/build/admin-page.js`.
- Restored the local plugin symlink to `/home/dave/Git/superdav-ai-agent` after the smoke.

## Worker self-verification
- PHPUnit: Tests: 3454, Assertions: 13930, Errors: 0, Failures: 0, Skipped: 112, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

## Additional verification
- `npm run test:php -- --filter WpCliAbilitiesTest` — OK, 11 tests, 46 assertions
- `npm run test:php -- --filter ToolDiscoveryTest` — OK, 26 tests, 67 assertions

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.4 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 7h 43m and 111,419 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WP-CLI capabilities are now only advertised when WP-CLI execution is available on the current system.
  * Tool discovery now accurately filters tools based on registered abilities.

* **Tests**
  * Added comprehensive test coverage for WP-CLI availability detection and tool discovery behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1897?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->