### PR TITLE
GH#1899: fix: rename block validation repairs property

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -122,6 +122,7 @@ class AgentLoop {
 	private $tool_call_log = array();
 
 	/** @var array<int, array<string, mixed>> Posts that still require block-validation repair. */
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase -- Project property naming guidance requires camelCase.
 	private array $pendingBlockValidationRepairs = array();
 
 	/** @var float */

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -122,7 +122,7 @@ class AgentLoop {
 	private $tool_call_log = array();
 
 	/** @var array<int, array<string, mixed>> Posts that still require block-validation repair. */
-	private array $pending_block_validation_repairs = array();
+	private array $pendingBlockValidationRepairs = array();
 
 	/** @var float */
 	private $temperature;
@@ -757,7 +757,7 @@ class AgentLoop {
 				// update-post self-repair loop. The system prompt already instructs
 				// this behaviour; this guard catches models that ignore that instruction
 				// after seeing a block_validation.invalidBlocks response.
-				if ( ! empty( $this->pending_block_validation_repairs ) ) {
+				if ( ! empty( $this->pendingBlockValidationRepairs ) ) {
 					if ( $iterations > 0 ) {
 						$this->inject_block_validation_repair_guidance();
 						continue;
@@ -2173,11 +2173,11 @@ class AgentLoop {
 
 		$invalid_blocks = (int) ( $validation['invalidBlocks'] ?? 0 );
 		if ( $invalid_blocks <= 0 ) {
-			unset( $this->pending_block_validation_repairs[ $post_id ] );
+			unset( $this->pendingBlockValidationRepairs[ $post_id ] );
 			return;
 		}
 
-		$this->pending_block_validation_repairs[ $post_id ] = array(
+		$this->pendingBlockValidationRepairs[ $post_id ] = array(
 			'post_id'        => $post_id,
 			'tool_name'      => $normalized_name,
 			'invalidBlocks'  => $invalid_blocks,
@@ -2190,7 +2190,7 @@ class AgentLoop {
 	 * Inject a hard self-repair instruction after invalid block validation.
 	 */
 	private function inject_block_validation_repair_guidance(): void {
-		$pending = array_values( $this->pending_block_validation_repairs );
+		$pending = array_values( $this->pendingBlockValidationRepairs );
 		$lines   = array(
 			'Block validation self-repair is required before you report success.',
 			'One or more create-post/update-post responses returned block_validation.invalidBlocks > 0.',
@@ -2233,7 +2233,7 @@ class AgentLoop {
 	private function append_unresolved_block_validation_warning( string $reply ): string {
 		$lines = array( '', __( 'Unresolved block validation:', 'superdav-ai-agent' ) );
 
-		foreach ( $this->pending_block_validation_repairs as $repair ) {
+		foreach ( $this->pendingBlockValidationRepairs as $repair ) {
 			$lines[] = sprintf(
 				/* translators: 1: post ID, 2: invalid block count. */
 				__( '- Post ID %1$d still has %2$d invalid block(s).', 'superdav-ai-agent' ),

--- a/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
@@ -370,7 +370,7 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 			)
 		);
 
-		$prop = $reflection->getProperty( 'pending_block_validation_repairs' );
+		$prop = $reflection->getProperty( 'pendingBlockValidationRepairs' );
 		$prop->setAccessible( true );
 		$pending = $prop->getValue( $loop );
 
@@ -412,7 +412,7 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 			)
 		);
 
-		$prop = $reflection->getProperty( 'pending_block_validation_repairs' );
+		$prop = $reflection->getProperty( 'pendingBlockValidationRepairs' );
 		$prop->setAccessible( true );
 
 		$this->assertSame( array(), $prop->getValue( $loop ) );
@@ -425,7 +425,7 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 		$loop = new AgentLoop( 'test', array(), array(), array() );
 
 		$reflection = new \ReflectionClass( $loop );
-		$pending    = $reflection->getProperty( 'pending_block_validation_repairs' );
+		$pending    = $reflection->getProperty( 'pendingBlockValidationRepairs' );
 		$pending->setAccessible( true );
 		$pending->setValue(
 			$loop,


### PR DESCRIPTION
## Summary

Renamed AgentLoop's pending block-validation repair property to camelCase and updated reflection-based tests to reference the new property name. Added a narrow PHPCS inline exception because the repository's project guidance requires PHP properties to use camelCase while WPCS otherwise enforces snake_case.

## Files Changed

includes/Core/AgentLoop.php,tests/SdAiAgent/Core/AgentLoopClientToolsTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify (lint and PHPStan passed; PHPUnit failed due shared WordPress test database deadlocks/missing tables unrelated to this property-only change: Tests: 3454, Assertions: 13906, Failures: 4, Skipped: 112, Incomplete: 4; isolated reruns were attempted but the shared wp-tests config continued to target the shared database or lacked DB credentials); npm run build (succeeded with existing asset-size warnings)

Resolves #1899


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.4 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 16m and 106,320 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code style improvements for improved consistency and maintainability.

* **Tests**
  * Updated test assertions to reflect internal refactoring.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1900?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->