### PR TITLE
test: isolate ToolDiscovery ability registry mutation

### DIFF
--- a/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
+++ b/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
@@ -171,18 +171,30 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 	}
 
 	public function test_tier_1_omits_wp_cli_when_ability_is_not_registered(): void {
-		if ( function_exists( 'wp_unregister_ability' ) && function_exists( 'wp_get_abilities' ) ) {
-			foreach ( wp_get_abilities() as $ability ) {
-				if ( $ability instanceof \WP_Ability && 'wp-cli/execute' === $ability->get_name() ) {
-					wp_unregister_ability( 'wp-cli/execute' );
-					break;
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Test isolates the Abilities API registry mutation.
+		global $_wp_ability_registry;
+		$ability_registry_backup = isset( $_wp_ability_registry ) ? $_wp_ability_registry : null;
+
+		try {
+			if ( function_exists( 'wp_unregister_ability' ) && function_exists( 'wp_get_abilities' ) ) {
+				foreach ( wp_get_abilities() as $ability ) {
+					if ( $ability instanceof \WP_Ability && 'wp-cli/execute' === $ability->get_name() ) {
+						wp_unregister_ability( 'wp-cli/execute' );
+						break;
+					}
 				}
 			}
+
+			$tier_1 = ToolDiscovery::tier_1_for_run();
+
+			$this->assertNotContains( 'wp-cli/execute', $tier_1 );
+		} finally {
+			if ( null === $ability_registry_backup ) {
+				unset( $_wp_ability_registry );
+			} else {
+				$_wp_ability_registry = $ability_registry_backup;
+			}
 		}
-
-		$tier_1 = ToolDiscovery::tier_1_for_run();
-
-		$this->assertNotContains( 'wp-cli/execute', $tier_1 );
 	}
 
 	public function test_tier_1_promotes_recently_used_abilities(): void {


### PR DESCRIPTION
## Summary
- Back up and restore the Abilities API registry around ToolDiscoveryTest::test_tier_1_omits_wp_cli_when_ability_is_not_registered().
- Keep the wp-cli/execute omission assertion isolated so later tests cannot inherit the unregistration.

Resolves #1898

## Worker self-verification
- PHPUnit focused: OK (26 tests, 67 assertions) via npm run test:php -- --filter ToolDiscoveryTest
- PHPUnit full: attempted; local shared test DB repeatedly hit unrelated InnoDB deadlocks/table-reset races in post/user factory tests and plugin-builder isolated WP install checks. Last summary: Tests: 3454, Assertions: 13893, Errors: 2, Failures: 5, Skipped: 114, Incomplete: 4.
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.4 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 18m and 109,184 tokens on this as a headless worker.
