### PR TITLE
GH#1904: docs: document REST hardening guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,6 +248,9 @@ Key gotchas: `compile_class` required for hyphenated IDs, `REST_Handler` support
 - **Secret Scrubbing**: All REST endpoints must scrub sensitive data (API keys, tokens,
   credentials) from responses and logs. Never expose provider credentials, user secrets,
   or internal configuration in REST output.
+- **Internal namespace block**: Keep `sd-ai-agent/v1` unavailable to the agent-facing
+  `wp-rest/execute` ability. This plugin must not call its own private REST controllers
+  through the internal dispatcher; use direct service/controller calls instead.
 - **File Upload Restrictions**: Hide or restrict file upload endpoints from public access.
   File upload functionality should be gated behind capability checks and only exposed
   to authenticated users with explicit permissions.
@@ -264,6 +267,11 @@ Key gotchas: `compile_class` required for hyphenated IDs, `REST_Handler` support
   verify the controller uses the real current user context, has a capability
   gate, avoids public file-upload exposure, and returns scrubbed responses before
   calling the route WordPress.org-ready.
+- **Follow-up issue briefs**: If a REST hardening pass finds remaining exposure,
+  file worker-ready GitHub issue briefs that name the route/controller, the missing
+  guard or scrubber, the expected safe behaviour, and the exact verification command
+  (for example PHPCS/PHPUnit plus a REST request proving unauthorized users are
+  blocked and secrets are redacted).
 
 ## Local Development Environment
 


### PR DESCRIPTION
## Summary

Updated AGENTS.md REST API security guidance to keep sd-ai-agent/v1 blocked from the agent-facing wp-rest/execute ability and to require worker-ready follow-up issue briefs when REST hardening finds remaining exposure.

## Files Changed

AGENTS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify (passes: lint JS/CSS/PHP, PHPStan 0 errors, PHPUnit Tests: 3454, Assertions: 13930, Skipped: 112, Incomplete: 4, build succeeded with existing webpack size warnings)

## Worker self-verification
- PHPUnit: Tests: 3454, Assertions: 13930, Errors: 0, Failures: 0, Skipped: 112, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Resolves #1904


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.4 plugin for [OpenCode](https://opencode.ai) v1.15.11 with gpt-5.5 spent 13m and 77,916 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Expanded REST API security guidance with enhanced constraints on internal dispatch behavior to improve overall API security posture.
* Established documentation requirements for workers to create issue briefs detailing security gaps, missing protections, and verification commands for REST API hardening.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1906?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->