### PR TITLE
feat: plugin-discovery guidance + pending session fixes

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -1607,7 +1607,7 @@ class AgentLoop {
 	 *
 	 *     Unsupported parameter: 'temperature' is not supported with this model.
 	 *
-	 * Anthropic Max Claude Opus 4.7 similarly rejects `temperature` as a
+	 * Anthropic Max Claude Opus 4.7 and 4.8 similarly reject `temperature` as a
 	 * deprecated field in OpenAI-compatible routing, while older Claude models
 	 * used by existing installs still accept it.
 	 *
@@ -1645,11 +1645,13 @@ class AgentLoop {
 			}
 		}
 
-		// Claude Opus 4.7 is surfaced by Anthropic Max and rejects `temperature`
-		// with HTTP 400: "`temperature` is deprecated for this model." Match the
-		// dateless ID plus any dated/provider-specific snapshot suffix.
-		if ( $normalised === 'claude-opus-4-7' || str_starts_with( $normalised, 'claude-opus-4-7-' ) ) {
-			return true;
+		// Claude Opus 4.7 and 4.8 (Anthropic Max) reject `temperature` with HTTP
+		// 400: "`temperature` is deprecated for this model." Match the dateless
+		// IDs plus any dated/provider-specific snapshot suffixes.
+		foreach ( array( 'claude-opus-4-7', 'claude-opus-4-8' ) as $opus_prefix ) {
+			if ( $normalised === $opus_prefix || str_starts_with( $normalised, $opus_prefix . '-' ) ) {
+				return true;
+			}
 		}
 
 		return false;

--- a/includes/Core/PluginRecommendations.php
+++ b/includes/Core/PluginRecommendations.php
@@ -134,6 +134,50 @@ class PluginRecommendations {
 					. 'instead of raw HTML form elements. '
 					. 'Raw form elements inside core/html are not editable and break accessibility.',
 			),
+			/*
+			 * BuddyPress — community / dating / social-network use cases.
+			 *
+			 * When a session asks for member directories, dating sites,
+			 * private messaging between users, activity feeds, friend
+			 * connections, or community profiles, building from scratch
+			 * with custom DB tables and AJAX endpoints reproduces work
+			 * BuddyPress already does — audited at ~100k installs and
+			 * covering password reset, email verification, blocking,
+			 * abuse reporting, pagination, and GDPR exports for free.
+			 *
+			 * No HTML pattern is registered: BuddyPress is suggested at
+			 * the planning level (system prompt) rather than as a
+			 * core/html block replacement.
+			 *
+			 * See session #25 (NerdLove dating site) for the trace that
+			 * motivated adding this recommendation: the agent hand-built
+			 * ~2,000 LOC of profile/messaging code, hit the tool-call
+			 * cap, and never considered search-plugin-directory or
+			 * install-plugin.
+			 */
+			new PluginRecommendation(
+				name: 'BuddyPress',
+				plugin_slug: 'buddypress',
+				blocks: [],
+				guidance: "## Community, dating, member profiles, private messaging\n\n"
+					. 'When the user asks for a dating site, social network, member directory, '
+					. 'community, private messaging between users, friend connections, activity feed, '
+					. 'or extended member profiles, prefer **BuddyPress** (plugin_slug: `buddypress`) '
+					. "over hand-built user-meta tables, custom messaging tables, and bespoke AJAX endpoints.\n\n"
+					. "Recommended workflow:\n"
+					. "1. `sd-ai-agent/search-plugin-directory` with the relevant keyword(s) to confirm options and read recent ratings/installs.\n"
+					. "2. `sd-ai-agent/install-plugin` with `slug: \"buddypress\"` and `activate: true`.\n"
+					. "3. Customise via:\n"
+					. "   - `xprofile` field groups (gender, seeking, age, location, bio, interests) — set up with WP-CLI or the BuddyPress admin.\n"
+					. "   - Theme template overrides under `buddypress/` in the active theme to apply brand styling.\n"
+					. "   - Filters such as `bp_after_has_members_parse_args` for gender/orientation filtering.\n"
+					. "4. Reuse BuddyPress's built-in messages component instead of a custom `wp_*nlc_messages` table.\n\n"
+					. 'Only build from scratch when the user explicitly rejects BuddyPress or when a constraint '
+					. '(license, multisite-network mode, headless API-only stack) rules it out. State the reason '
+					. 'in the response before writing custom plugin scaffolding.',
+				html_patterns: [],
+				html_policy_message: '',
+			),
 		];
 
 		/*

--- a/includes/Core/SystemInstructionBuilder.php
+++ b/includes/Core/SystemInstructionBuilder.php
@@ -220,6 +220,13 @@ class SystemInstructionBuilder {
 		if ( self::has_content_generation_ability( $ability_names ) ) {
 			// @phpstan-ignore-next-line
 			$base .= "\n\n" . self::build_working_cadence_section();
+
+			// Build-vs-install: nudge the model to consider existing wp.org
+			// plugins for multi-file features before hand-coding from scratch.
+			// Gated on content-generation abilities so it only appears in
+			// sessions that could realistically build a plugin/theme.
+			// @phpstan-ignore-next-line
+			$base .= "\n\n" . self::build_build_vs_install_section( $ability_names );
 		}
 
 		// Suggestion chips: instruct the AI to append follow-up suggestions.
@@ -289,6 +296,87 @@ class SystemInstructionBuilder {
 			. 'Active first-party direct tools this turn: ' . $direct_list . ".\n"
 			. 'If any prompt, memory, or manifest text mentions another `sd-ai-agent/<ability>` name, do not emit its direct `wpab__...` tool call. '
 			. 'Use `sd-ai-agent/ability-search` to fetch its schema, then invoke it through `sd-ai-agent/ability-call`.';
+	}
+
+	/**
+	 * Build the "## Build vs install" planning section.
+	 *
+	 * Reminds the model to check the wp.org plugin directory and consider
+	 * existing solutions before hand-coding multi-file features. Trace
+	 * evidence (session #25, NerdLove dating site) showed the agent writing
+	 * ~2,000 LOC of custom plugin code without ever calling
+	 * sd-ai-agent/search-plugin-directory, sd-ai-agent/recommend-plugin, or
+	 * sd-ai-agent/install-plugin — abilities that ship in this very plugin.
+	 *
+	 * Also surfaces the batching reminder: 56 serial `wp-cli` calls to seed
+	 * 6 demo users (one per meta key) burned half the tool-call budget when
+	 * a single `run-php` or `db-query` would have done the same work.
+	 *
+	 * Section is empty when none of the relevant abilities are active so the
+	 * advice does not hallucinate tools that aren't reachable.
+	 *
+	 * @since 1.20.0
+	 *
+	 * @param string[] $ability_names Names of active Tier-1 abilities for this turn.
+	 * @return string Formatted Markdown section, or empty string when no
+	 *                relevant plugin-discovery ability is active.
+	 */
+	public static function build_build_vs_install_section( array $ability_names ): string {
+		$discovery_abilities = [
+			'sd-ai-agent/search-plugin-directory',
+			'sd-ai-agent/recommend-plugin',
+			'sd-ai-agent/install-plugin',
+		];
+		$batching_abilities  = [
+			'sd-ai-agent/run-php',
+			'sd-ai-agent/db-query',
+		];
+
+		$has_discovery = false;
+		foreach ( $discovery_abilities as $name ) {
+			if ( in_array( $name, $ability_names, true ) ) {
+				$has_discovery = true;
+				break;
+			}
+		}
+
+		if ( ! $has_discovery ) {
+			return '';
+		}
+
+		$batching_active = array_values(
+			array_filter(
+				$batching_abilities,
+				static fn( string $name ): bool => in_array( $name, $ability_names, true )
+			)
+		);
+
+		$section = "## Build vs install\n\n"
+			. 'For multi-file features (e.g. dating sites, member directories, forums, marketplaces, LMS, booking systems, '
+			. 'membership sites, messaging systems, anything that would require custom DB tables or several new PHP classes), '
+			. "**plan before you build**:\n\n"
+			. "1. Call `sd-ai-agent/search-plugin-directory` with 2–3 keyword variants relevant to the feature.\n"
+			. "2. Optionally call `sd-ai-agent/recommend-plugin` with a category like `community`, `commerce`, `forms`, or `lms`.\n"
+			. "3. Weigh the candidates against the user's stated constraints (free, no monetisation, headless, multisite, etc.).\n"
+			. "4. Only hand-build when no existing plugin covers ≥60% of the feature surface, **or** when the user explicitly rejects installing third-party plugins. State the reason in your response before writing custom code.\n"
+			. "5. Prefer `sd-ai-agent/install-plugin` for wp.org plugins. Use `sd-ai-agent/generate-plugin` only for genuinely novel functionality the directory does not cover.\n\n"
+			. 'Hand-building reproduces work that audited plugins (password reset, email verification, '
+			. 'abuse reporting, blocking, pagination, GDPR exports) already do — and consumes the tool-call '
+			. 'budget on bespoke code that ships less safely than a battle-tested plugin.';
+
+		if ( ! empty( $batching_active ) ) {
+			$batching_list = implode(
+				' or ',
+				array_map( static fn( string $name ): string => '`' . $name . '`', $batching_active )
+			);
+			$section      .= "\n\n### Seeding & batch updates\n\n"
+				. 'When inserting or updating more than ~5 rows of data (demo users, taxonomy terms, meta keys, options), '
+				. 'use a single ' . $batching_list . ' call instead of N serial `wp-cli` invocations. '
+				. 'One `UPDATE` / `INSERT … VALUES` or one `update_user_meta()` loop in `run-php` does the same '
+				. 'work as dozens of `wp user meta update` calls and leaves tool-call budget for verification and polish.';
+		}
+
+		return $section;
 	}
 
 	/**

--- a/includes/Tools/ToolDiscovery.php
+++ b/includes/Tools/ToolDiscovery.php
@@ -94,6 +94,38 @@ class ToolDiscovery {
 	);
 
 	/**
+	 * Request-scoped flag tracking whether at least one keyword (non-`select:`)
+	 * `ability-search` call has been observed in the current PHP request.
+	 *
+	 * Used by {@see handle_ability_search()} to attach a discovery hint when a
+	 * session's `select:` lookups arrive before any keyword discovery has
+	 * happened — the pattern that misses sibling abilities like
+	 * `sd-ai-agent/search-plugin-directory` and
+	 * `sd-ai-agent/install-plugin` (see session #25, NerdLove dating site).
+	 *
+	 * AgentLoop processes a full agentic turn inside one PHP request, so this
+	 * flag captures "first discovery decision this turn" semantics without
+	 * persisting across HTTP requests.
+	 *
+	 * @since 1.20.0
+	 * @var bool
+	 */
+	private static bool $keyword_search_seen_this_request = false;
+
+	/**
+	 * Reset the keyword-search tracking flag.
+	 *
+	 * Intended for use in unit tests so each test starts with a clean state.
+	 *
+	 * @since 1.20.0
+	 *
+	 * @return void
+	 */
+	public static function reset_keyword_search_state(): void {
+		self::$keyword_search_seen_this_request = false;
+	}
+
+	/**
 	 * Register the meta-tool abilities.
 	 *
 	 * @deprecated Preserved for back-compat. The DI handler (ToolDiscoveryHandler)
@@ -551,8 +583,29 @@ class ToolDiscovery {
 					}
 				}
 			}
-			return self::format_search_response( $query_raw, $found, count( $found ) );
+
+			$discovery_hint = '';
+			if ( ! self::$keyword_search_seen_this_request ) {
+				// First ability-search this request is a `select:` lookup —
+				// the model pre-committed to a set of abilities by name
+				// without checking whether broader / better-fit options
+				// exist. Nudge it to do at least one keyword pass.
+				// Regression: session #25 (NerdLove dating site) — first
+				// search was `select:list-allowed-roots,generate-plugin`,
+				// never followed by a `dating`, `messaging`, or `community`
+				// keyword search, so search-plugin-directory and
+				// install-plugin were never considered.
+				$discovery_hint = 'You used `select:` to fetch abilities by exact id without a prior keyword search this turn. '
+					. 'If you are scoping a multi-file feature, consider also running a keyword `ability-search` '
+					. '(e.g. "install plugin", "WordPress directory", "messaging", "community", "members") to surface '
+					. 'related abilities you may not have considered, such as `sd-ai-agent/search-plugin-directory` and `sd-ai-agent/install-plugin`.';
+			}
+			return self::format_search_response( $query_raw, $found, count( $found ), $discovery_hint );
 		}
+
+		// Mark that a keyword (non-select) search has been performed this
+		// request so subsequent `select:` calls do not trigger the hint.
+		self::$keyword_search_seen_this_request = true;
 
 		// `+substr keyword` required-substring form.
 		$require = '';
@@ -670,7 +723,7 @@ class ToolDiscovery {
 	 * @param int           $total     Total matches before slicing.
 	 * @return array<string, mixed>
 	 */
-	private static function format_search_response( string $query, array $abilities, int $total ): array {
+	private static function format_search_response( string $query, array $abilities, int $total, string $discovery_hint = '' ): array {
 		$results = array();
 		foreach ( $abilities as $ability ) {
 			$name   = $ability->get_name();
@@ -698,13 +751,19 @@ class ToolDiscovery {
 			$results[] = $result;
 		}
 
-		return array(
+		$response = array(
 			'query'   => $query,
 			'total'   => $total,
 			'count'   => count( $results ),
 			'results' => $results,
 			'hint'    => 'Use sd-ai-agent/ability-call with the chosen `id` and an `arguments` object that matches `input_schema`.',
 		);
+
+		if ( '' !== $discovery_hint ) {
+			$response['discovery_hint'] = $discovery_hint;
+		}
+
+		return $response;
 	}
 
 	// ─── ability-call handler ────────────────────────────────────────────

--- a/src/components/chat-redesign/message-items.js
+++ b/src/components/chat-redesign/message-items.js
@@ -34,6 +34,7 @@ import {
 	parseSuggestions,
 } from './message-helpers';
 import { linkifyText } from '../../utils/linkify';
+import { copyToClipboard } from '../../utils/clipboard';
 
 /**
  *
@@ -188,7 +189,7 @@ export function UserMessage( { msg, index } ) {
 		if ( ! text ) {
 			return;
 		}
-		navigator.clipboard.writeText( text ).then( () => {
+		copyToClipboard( text ).then( () => {
 			setCopied( true );
 			setTimeout( () => setCopied( false ), 1500 );
 		} );
@@ -370,7 +371,7 @@ export function AssistantMessage( {
 		if ( ! cleanText ) {
 			return;
 		}
-		navigator.clipboard.writeText( cleanText ).then( () => {
+		copyToClipboard( cleanText ).then( () => {
 			setCopied( true );
 			setTimeout( () => setCopied( false ), 1500 );
 		} );

--- a/src/components/code-block.js
+++ b/src/components/code-block.js
@@ -5,6 +5,11 @@ import { useState, useCallback, useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
+ * Internal dependencies
+ */
+import { copyToClipboard } from '../utils/clipboard';
+
+/**
  * CodeMirror 6 core
  */
 import { EditorView, lineNumbers } from '@codemirror/view';
@@ -194,7 +199,7 @@ export default function CodeBlock( { language, children } ) {
 	}, [ code, language ] );
 
 	const handleCopy = useCallback( () => {
-		navigator.clipboard.writeText( code ).then( () => {
+		copyToClipboard( code ).then( () => {
 			setCopied( true );
 			setTimeout( () => setCopied( false ), 2000 );
 		} );

--- a/src/components/message-actions.js
+++ b/src/components/message-actions.js
@@ -11,6 +11,7 @@ import { Icon, copy, pencil, redo, check, thumbsDown } from '@wordpress/icons';
  * Internal dependencies
  */
 import STORE_NAME from '../store';
+import { copyToClipboard } from '../utils/clipboard';
 
 /**
  * Per-message action buttons (Copy, Edit, Regenerate, Thumbs-down).
@@ -52,7 +53,7 @@ export default function MessageActions( { message, index, onThumbsDown } ) {
 		.join( '' );
 
 	const handleCopy = useCallback( () => {
-		navigator.clipboard.writeText( text || '' ).then( () => {
+		copyToClipboard( text || '' ).then( () => {
 			setCopied( true );
 			setTimeout( () => setCopied( false ), 2000 );
 		} );

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -232,6 +232,12 @@ export const actions = {
 		return async ( { dispatch, select } ) => {
 			let attempts = 0;
 			const maxAttempts = 200;
+			// Counts consecutive *transient* network/5xx failures so a dead
+			// endpoint cannot loop silently forever. Reset on every successful
+			// poll. Terminal 404 (job_not_found) bypasses this counter and
+			// triggers an immediate session reload + UI clear.
+			let consecutiveErrors = 0;
+			const maxConsecutiveErrors = 8;
 			let lastToolCallsLength = 0;
 			let visibilityPaused = false;
 			let resumeCallback = null;
@@ -294,6 +300,10 @@ export const actions = {
 					const result = await apiFetch( {
 						path: `/sd-ai-agent/v1/job/${ jobId }`,
 					} );
+
+					// Successful poll — reset the transient-error counter so
+					// only *consecutive* failures count toward the cap.
+					consecutiveErrors = 0;
 
 					if ( result.status === 'processing' ) {
 						// Update per-session job state for ALL sessions.
@@ -780,8 +790,96 @@ export const actions = {
 						// Mark successful completion so the ding can fire below.
 						lastStatusComplete = true;
 					}
-				} catch {
-					// Network blip — keep polling with backoff.
+				} catch ( err ) {
+					// Classify the failure so the customer is always told
+					// what happened instead of staring at "Composing reply…".
+					//
+					// Terminal: 404 sd_ai_agent_job_not_found. The server
+					// deletes both the job transient and the active-job DB
+					// row in the same response that delivers status=complete
+					// or status=error (SessionController::handle_job_status).
+					// Any in-flight poll that races that cleanup, OR any
+					// poll that arrives after the transient TTL expired
+					// while the DB row was reaped by the cleanup cron,
+					// will hit this branch. The agent loop has already
+					// persisted its messages to the session, so reload the
+					// session from the DB instead of silently looping.
+					const status = err?.data?.status;
+					const code = err?.code;
+					const isJobMissing =
+						status === 404 ||
+						code === 'sd_ai_agent_job_not_found' ||
+						code === 'rest_no_route';
+
+					if ( isJobMissing ) {
+						let reloadFailed = false;
+						try {
+							const session = await apiFetch( {
+								path: `/sd-ai-agent/v1/sessions/${ sessionId }`,
+							} );
+							if ( select.getCurrentSessionId() === sessionId ) {
+								dispatch.setCurrentSession(
+									session.id,
+									session.messages || [],
+									session.tool_calls || []
+								);
+							}
+						} catch {
+							reloadFailed = true;
+						}
+
+						unsubscribeVisibility();
+						clearActiveJob( sessionId );
+						if ( select.getCurrentSessionId() === sessionId ) {
+							if ( reloadFailed ) {
+								dispatch.appendMessage( {
+									role: 'system',
+									parts: [
+										{
+											text: __(
+												'The job finished but the result could not be retrieved. Reload the page to see the latest messages.',
+												'superdav-ai-agent'
+											),
+										},
+									],
+								} );
+							}
+							dispatch.setSending( false );
+							dispatch.setLiveToolCalls( [] );
+							dispatch.drainMessageQueue();
+						}
+						dispatch.setCurrentJobId( null );
+						dispatch.setSessionJob( sessionId, null );
+						return;
+					}
+
+					// Transient (network blip, 5xx, parse error). Retry with
+					// backoff but cap consecutive failures so a dead endpoint
+					// cannot keep the user trapped on the sending spinner.
+					consecutiveErrors++;
+					if ( consecutiveErrors >= maxConsecutiveErrors ) {
+						unsubscribeVisibility();
+						clearActiveJob( sessionId );
+						if ( select.getCurrentSessionId() === sessionId ) {
+							dispatch.appendMessage( {
+								role: 'system',
+								parts: [
+									{
+										text: __(
+											'Error: Lost connection to the server while waiting for the job to finish. Reload the page to see if anything was saved.',
+											'superdav-ai-agent'
+										),
+									},
+								],
+							} );
+							dispatch.setSending( false );
+							dispatch.setLiveToolCalls( [] );
+						}
+						dispatch.setCurrentJobId( null );
+						dispatch.setSessionJob( sessionId, null );
+						return;
+					}
+
 					await new Promise( ( resolve ) =>
 						setTimeout( resolve, getInterval( attempts ) )
 					);

--- a/src/utils/clipboard.js
+++ b/src/utils/clipboard.js
@@ -1,0 +1,37 @@
+/**
+ * Copies text to the clipboard.
+ *
+ * navigator.clipboard (Clipboard API) is only available in secure contexts
+ * (HTTPS or localhost). On plain HTTP origins the object is undefined and
+ * calling .writeText() throws a TypeError. This helper tries the modern API
+ * first and falls back to the legacy document.execCommand path so copy
+ * buttons work during local HTTP development as well as in production.
+ *
+ * @param {string} text Text to copy.
+ * @return {Promise<void>} Resolves when the copy succeeds, rejects on failure.
+ */
+export function copyToClipboard( text ) {
+	if ( navigator.clipboard ) {
+		return navigator.clipboard.writeText( text );
+	}
+
+	// Fallback for non-secure contexts (HTTP, e.g. http://wordpress.local).
+	return new Promise( ( resolve, reject ) => {
+		const el = document.createElement( 'textarea' );
+		el.value = text;
+		// Keep the element out of the viewport and layout flow.
+		el.style.cssText =
+			'position:fixed;top:-9999px;left:-9999px;opacity:0;pointer-events:none';
+		el.setAttribute( 'readonly', '' );
+		document.body.appendChild( el );
+		el.focus();
+		el.select();
+		const ok = document.execCommand( 'copy' );
+		document.body.removeChild( el );
+		if ( ok ) {
+			resolve();
+		} else {
+			reject( new Error( 'execCommand copy failed' ) );
+		}
+	} );
+}

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -1596,6 +1596,8 @@ class AgentLoopTest extends WP_UnitTestCase {
 			'o4-mini'            => [ 'o4-mini' ],
 			'claude-opus-4-7'    => [ 'claude-opus-4-7' ],
 			'claude-opus-4-7 dated snap' => [ 'claude-opus-4-7-20260513' ],
+			'claude-opus-4-8'    => [ 'claude-opus-4-8' ],
+			'claude-opus-4-8 dated snap' => [ 'claude-opus-4-8-20260513' ],
 		];
 	}
 
@@ -2618,11 +2620,14 @@ class AgentLoopTest extends WP_UnitTestCase {
 			'gpt-4o'                      => [ 'gpt-4o', false ],
 			'gpt-4.1'                     => [ 'gpt-4.1', false ],
 			'gpt-3.5-turbo'               => [ 'gpt-3.5-turbo', false ],
-			// Anthropic Max Claude Opus 4.7 — rejects/deprecates temperature.
+			// Anthropic Max Claude Opus 4.7 and 4.8 — rejects/deprecates temperature.
 			'claude-opus-4-7'             => [ 'claude-opus-4-7', true ],
 			'claude-opus-4-7-dated'       => [ 'claude-opus-4-7-20260513', true ],
 			'Claude Opus 4.7 uppercase'   => [ 'CLAUDE-OPUS-4-7', true ],
 			'Claude Opus 4.7 padded'      => [ '  claude-opus-4-7  ', true ],
+			'claude-opus-4-8'             => [ 'claude-opus-4-8', true ],
+			'claude-opus-4-8-dated'       => [ 'claude-opus-4-8-20260513', true ],
+			'Claude Opus 4.8 uppercase'   => [ 'CLAUDE-OPUS-4-8', true ],
 			// Other providers/models — must NOT match.
 			'claude-sonnet-4-6'           => [ 'claude-sonnet-4-6', false ],
 			'claude-opus-4-6'             => [ 'claude-opus-4-6', false ],

--- a/tests/SdAiAgent/Core/BlockContentPolicyTest.php
+++ b/tests/SdAiAgent/Core/BlockContentPolicyTest.php
@@ -591,6 +591,35 @@ class BlockContentPolicyTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The default registry should include the BuddyPress recommendation so
+	 * sessions asking for dating / community / member-profile / messaging
+	 * features see it in the system prompt and reach for
+	 * sd-ai-agent/install-plugin instead of hand-building.
+	 *
+	 * Regression: session #25 (NerdLove dating site) — agent never
+	 * considered BuddyPress and hit the tool-call cap mid-build.
+	 */
+	public function test_build_system_prompt_section_contains_buddypress(): void {
+		$section = PluginRecommendations::build_system_prompt_section();
+
+		$this->assertStringContainsString(
+			'BuddyPress',
+			$section,
+			'Section should advertise BuddyPress for community/dating/member-profile use cases.'
+		);
+		$this->assertStringContainsString(
+			'buddypress',
+			$section,
+			'Section should reference the canonical wp.org slug so install-plugin can be invoked.'
+		);
+		$this->assertStringContainsString(
+			'install-plugin',
+			$section,
+			'Section should nudge the model toward sd-ai-agent/install-plugin instead of hand-coding.'
+		);
+	}
+
+	/**
 	 * build_system_prompt_section() should return an empty string when the
 	 * registry is empty.
 	 *
@@ -640,8 +669,10 @@ class BlockContentPolicyTest extends WP_UnitTestCase {
 
 		$all = PluginRecommendations::get_all();
 
-		$this->assertCount( 2, $all, 'Filter should allow adding a second recommendation.' );
-		$this->assertSame( 'WooCommerce', $all[1]->name );
+		// Default registry has Jetpack Forms + BuddyPress; the filter
+		// appends WooCommerce, so the total is 3 and WooCommerce is last.
+		$this->assertCount( 3, $all, 'Filter should allow adding a third recommendation on top of the defaults.' );
+		$this->assertSame( 'WooCommerce', $all[2]->name );
 
 		remove_all_filters( 'sd_ai_agent_plugin_recommendations' );
 	}

--- a/tests/SdAiAgent/Core/SystemInstructionBuilderTest.php
+++ b/tests/SdAiAgent/Core/SystemInstructionBuilderTest.php
@@ -156,4 +156,95 @@ class SystemInstructionBuilderTest extends WP_UnitTestCase {
 			$instruction
 		);
 	}
+
+	/**
+	 * The build-vs-install section should appear when plugin-discovery
+	 * abilities are active, nudging the model to search wp.org before
+	 * hand-coding multi-file features.
+	 *
+	 * Regression: session #25 (NerdLove dating site) — agent wrote ~2,000
+	 * LOC of custom plugin code without ever calling search-plugin-directory
+	 * or install-plugin.
+	 */
+	public function test_build_vs_install_section_present_when_discovery_active(): void {
+		$section = SystemInstructionBuilder::build_build_vs_install_section(
+			array(
+				'sd-ai-agent/search-plugin-directory',
+				'sd-ai-agent/install-plugin',
+			)
+		);
+
+		$this->assertStringContainsString( '## Build vs install', $section );
+		$this->assertStringContainsString( 'sd-ai-agent/search-plugin-directory', $section );
+		$this->assertStringContainsString( 'sd-ai-agent/install-plugin', $section );
+		$this->assertStringContainsString( '60%', $section );
+	}
+
+	/**
+	 * The build-vs-install section should be empty when no plugin-discovery
+	 * ability is active so the prompt does not advertise unreachable tools.
+	 */
+	public function test_build_vs_install_section_empty_without_discovery(): void {
+		$section = SystemInstructionBuilder::build_build_vs_install_section(
+			array(
+				'sd-ai-agent/list-posts',
+				'sd-ai-agent/create-post',
+			)
+		);
+
+		$this->assertSame( '', $section );
+	}
+
+	/**
+	 * The seeding/batching sub-section should appear when run-php or db-query
+	 * is active alongside plugin-discovery abilities. Targets the failure mode
+	 * where the agent made 56 serial wp-cli calls to seed 6 demo profiles.
+	 */
+	public function test_build_vs_install_section_includes_batching_when_runphp_active(): void {
+		$section = SystemInstructionBuilder::build_build_vs_install_section(
+			array(
+				'sd-ai-agent/search-plugin-directory',
+				'sd-ai-agent/run-php',
+			)
+		);
+
+		$this->assertStringContainsString( '### Seeding & batch updates', $section );
+		$this->assertStringContainsString( 'sd-ai-agent/run-php', $section );
+		$this->assertStringContainsString( 'serial `wp-cli` invocations', $section );
+	}
+
+	/**
+	 * The seeding/batching sub-section should be absent when neither run-php
+	 * nor db-query is in the ability list.
+	 */
+	public function test_build_vs_install_section_omits_batching_when_no_bulk_ability(): void {
+		$section = SystemInstructionBuilder::build_build_vs_install_section(
+			array(
+				'sd-ai-agent/search-plugin-directory',
+			)
+		);
+
+		$this->assertStringNotContainsString( '### Seeding & batch updates', $section );
+	}
+
+	/**
+	 * The build() method should integrate the new section when a
+	 * content-generation ability and a plugin-discovery ability are both
+	 * active (the realistic dating-site / theme-build scenario).
+	 */
+	public function test_build_includes_build_vs_install_section_for_content_sessions(): void {
+		$builder = new SystemInstructionBuilder();
+
+		$instruction = $builder->build(
+			array(),
+			array(
+				'sd-ai-agent/scaffold-block-theme',
+				'sd-ai-agent/file-write',
+				'sd-ai-agent/search-plugin-directory',
+				'sd-ai-agent/install-plugin',
+			)
+		);
+
+		$this->assertStringContainsString( '## Build vs install', $instruction );
+	}
 }

--- a/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
+++ b/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
@@ -38,6 +38,7 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 		parent::set_up();
 		AbilityUsageTracker::reset();
 		ToolDiscovery::reset_schema_cache();
+		ToolDiscovery::reset_keyword_search_state();
 		IdenticalFailureTracker::reset();
 
 		// Most abilities require admin caps in their permission callbacks.
@@ -70,6 +71,7 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 		remove_all_filters( 'sd_ai_agent_ability_usage_instructions_for' );
 		AbilityUsageTracker::reset();
 		ToolDiscovery::reset_schema_cache();
+		ToolDiscovery::reset_keyword_search_state();
 		IdenticalFailureTracker::reset();
 	}
 
@@ -264,6 +266,66 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 
 		$section = ToolDiscovery::recently_fetched_section();
 		$this->assertStringContainsString( 'get-plugins', $section );
+	}
+
+	/**
+	 * When a session's *first* ability-search this request is a `select:`
+	 * lookup, the response should carry a discovery_hint nudging the model
+	 * to also run a keyword search. Regression: session #25 (NerdLove
+	 * dating site) — agent ran `select:list-allowed-roots,generate-plugin`
+	 * as its first ability-search after the user asked for a dating site,
+	 * never followed up with keyword discovery, and so never considered
+	 * install-plugin or search-plugin-directory.
+	 */
+	public function test_ability_search_emits_discovery_hint_for_first_select_lookup(): void {
+		$result = ToolDiscovery::handle_ability_search(
+			[ 'query' => 'select:sd-ai-agent/get-plugins' ]
+		);
+
+		$this->assertArrayHasKey(
+			'discovery_hint',
+			$result,
+			'First-select lookups should attach a discovery_hint.'
+		);
+		$this->assertStringContainsString(
+			'keyword',
+			$result['discovery_hint'],
+			'Hint should suggest a keyword search.'
+		);
+		$this->assertStringContainsString(
+			'sd-ai-agent/search-plugin-directory',
+			$result['discovery_hint'],
+			'Hint should name the alternative plugin-discovery ability.'
+		);
+	}
+
+	/**
+	 * When a keyword search has already happened this request, subsequent
+	 * `select:` lookups should NOT carry the hint — the model has already
+	 * done the broader discovery pass.
+	 */
+	public function test_ability_search_omits_discovery_hint_after_keyword_search(): void {
+		ToolDiscovery::handle_ability_search( [ 'query' => 'plugins' ] );
+
+		$result = ToolDiscovery::handle_ability_search(
+			[ 'query' => 'select:sd-ai-agent/get-plugins' ]
+		);
+
+		$this->assertArrayNotHasKey(
+			'discovery_hint',
+			$result,
+			'After a keyword search this request, select: lookups should not re-trigger the hint.'
+		);
+	}
+
+	/**
+	 * Plain keyword searches must never carry the discovery_hint — only
+	 * `select:` lookups arriving before any keyword discovery do.
+	 */
+	public function test_ability_search_does_not_emit_discovery_hint_for_keyword_query(): void {
+		$result = ToolDiscovery::handle_ability_search( [ 'query' => 'plugins' ] );
+
+		$this->assertArrayNotHasKey( 'discovery_hint', $result );
 	}
 
 	// ── ability-call ──────────────────────────────────────────────────


### PR DESCRIPTION
## Why

The conversation trace in `wp_sd_ai_agent_sessions` row 25 (NerdLove dating
site) showed the agent hand-coding a ~2,000-LOC custom dating plugin from
scratch, hitting the 256 tool-call cap mid-build, and never once calling the
`sd-ai-agent/search-plugin-directory`, `sd-ai-agent/recommend-plugin`, or
`sd-ai-agent/install-plugin` abilities that are registered in this very
plugin. It also spent 56 serial `wp user meta update` calls seeding 6 demo
users — work that one `run-php` or batched `db-query` would have done in a
single tool call.

The trace identified five mechanisms that drove the agent down the
hand-coding path:

1. `PluginRecommendations` only had one entry (Jetpack Forms) — nothing
   nudged the model toward BuddyPress for community / dating / messaging.
2. The model's very first `ability-search` query was `select:list-allowed-roots,generate-plugin` — a name-lookup, not keyword discovery.
3. The system prompt had no "plan before you build" rule.
4. There was no guidance on batching `wp-cli` / user-meta writes.
5. Phase-1 sunk cost (an already-scaffolded block theme) discouraged a pivot.

This PR addresses items 1–4 with concrete code changes plus three pending
fixes carried over from prior sessions.

## What changed

### Plugin-discovery improvements

1. **BuddyPress recommendation** added to `PluginRecommendations::get_all()`
   so the "## Plugin Recommendations" section of the system prompt advertises
   BuddyPress for dating / community / member-profile / messaging sessions
   and points the model at `search-plugin-directory` + `install-plugin`.
2. **`## Build vs install` system-prompt section** in
   `SystemInstructionBuilder::build_build_vs_install_section()`. Fires when
   any of `search-plugin-directory`, `recommend-plugin`, or `install-plugin`
   are reachable AND a content-generation ability is active. Tells the model
   to search wp.org first, weigh candidates against user constraints, and
   only hand-build when no plugin covers ≥60% of the feature surface.
3. **Seeding & batching sub-section** appended when `run-php` or `db-query`
   is also reachable. Targets the 56-serial-`wp-cli` pattern explicitly.
4. **`discovery_hint` on `ability-search`** when the first ability-search of
   the current PHP request is a `select:` lookup with no prior keyword
   search. Threaded through `format_search_response()` as an optional key so
   existing callers see no change. A keyword search arms a request-scoped
   flag that disarms the hint.

### Pending fixes from other sessions

5. **`fix: extend temperature-unsupported guard to Claude Opus 4.8`** —
   Anthropic Max Opus 4.8 rejects `temperature` with HTTP 400 the same way
   4.7 does. Generalised the AgentLoop guard plus data providers.
6. **`fix: copy buttons work over HTTP via clipboard fallback`** —
   `navigator.clipboard` is undefined on plain HTTP origins like
   `http://wordpress.local`, so every Copy button in the chat UI silently
   threw. Extracted `src/utils/clipboard.js` with an `execCommand` fallback
   and routed the four call sites through it.
7. **`fix: surface job-poll terminal failures instead of looping silently`** —
   the session-job poller previously swallowed every error with `catch {}` and
   re-tried for the full 200-attempt window. Two failure modes (404
   `sd_ai_agent_job_not_found` and ≥8 consecutive network blips) now stop the
   poll, reload the session from the DB or show a system-message, and clear
   the active-job state instead of trapping the user on "Composing reply…".

## Files changed

```
includes/Core/AgentLoop.php
includes/Core/PluginRecommendations.php
includes/Core/SystemInstructionBuilder.php
includes/Tools/ToolDiscovery.php
src/components/chat-redesign/message-items.js
src/components/code-block.js
src/components/message-actions.js
src/store/slices/jobSlice.js
src/utils/clipboard.js                (new)
tests/SdAiAgent/Core/AgentLoopTest.php
tests/SdAiAgent/Core/BlockContentPolicyTest.php
tests/SdAiAgent/Core/SystemInstructionBuilderTest.php
tests/SdAiAgent/Tools/ToolDiscoveryTest.php
```

## Verification

Quoted directly from the local run (`npm run verify` equivalent run as
four steps because the build's `composer install --no-dev` wipes phpunit
mid-suite when run in parallel):

## Worker self-verification

- PHPUnit: `Tests: 3468, Assertions: 13940, Failures: 3, Skipped: 116, Incomplete: 4`
  - The 3 failures are **pre-existing on `main`** — verified by `git stash`,
    `git checkout main`, re-run on the same three tests. They are
    `PluginUpdaterTest::test_test_staged_passes_for_valid_plugin`,
    `PluginUpdaterTest::test_update_replaces_live_plugin_files`,
    `PluginBuilderIntegrationTest::test_updater_happy_path_replaces_files`,
    all reporting the same sandbox-include error
    `Error: 'wp-config.php' not found.` and unrelated to anything in this PR.
    No `PluginBuilder` / `PluginUpdater` source or test file is modified.
  - All four newly added tests pass:
    `BlockContentPolicyTest::test_build_system_prompt_section_contains_buddypress`,
    `SystemInstructionBuilderTest::test_build_vs_install_section_*` (4 tests),
    `ToolDiscoveryTest::test_ability_search_*_discovery_hint*` (3 tests).
  - The existing `test_filter_allows_third_party_recommendations` was updated
    from `assertCount(2)` to `assertCount(3)` to reflect the new BuddyPress
    default entry alongside Jetpack Forms.
- Lint: PHP/JS/CSS all clean.
- PHPStan: 0 errors.
- Build: succeeded (`superdav-ai-agent.zip` archived).

## Expected behaviour on next dating-style session

Re-running the NerdLove prompt with this change in place should produce, on
the first turn after the user asks for a dating site:

1. The system prompt includes `## Build vs install` and
   `## Plugin Recommendations` (with BuddyPress).
2. If the model still tries a `select:` lookup first, the response carries
   a `discovery_hint` pointing it at `search-plugin-directory` and
   `install-plugin`.
3. The model has a clear path: `search-plugin-directory → install-plugin
   buddypress → xprofile + theme overrides`, with all the
   pagination/blocking/abuse/GDPR plumbing already present.

## Related

- Trace evidence: `wp_sd_ai_agent_sessions.id = 25` (`NerdLove dating site`,
  Claude Opus 4.8, 321 messages, ~160 tool calls, hit cap and needed
  re-prompt).
- Reference files inspected: `includes/Core/PluginRecommendations.php:94`,
  `includes/Core/SystemInstructionBuilder.php:208`,
  `includes/Tools/ToolDiscovery.php:529`,
  `includes/Abilities/WordPressAbilities.php:197` (`search-plugin-directory`),
  `includes/Abilities/WordPressAbilities.php:1930` (`SearchPluginDirectoryAbility`).

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.4 plugin for [OpenCode](https://opencode.ai) v1.15.11 with claude-opus-4-7 spent 1h 50m and 53,932 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added expanded support for Claude Opus 4.8 models
  * Introduced BuddyPress to plugin recommendations
  * Added guidance on build vs. install workflows for plugin operations

* **Bug Fixes**
  * Improved clipboard copy reliability across message and code components
  * Enhanced connection resilience with automatic retry logic and user notifications for transient failures

* **Tests**
  * Expanded test coverage for model support and plugin discovery workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1908?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->