### PR TITLE
docs: clarify headless GitHub write guidance

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -57,9 +57,14 @@ working here in OpenCode headless mode:
   framework sync helpers that add the required aidevops signature footer, such as
   `.agents/scripts/issue-sync-helper.sh`, or write the body to a temporary file
   and pass it with `--body-file` after appending the signed footer.
-- Keep the signed body as a real file throughout the same command. Do not use
-  shell heredocs, process substitution, or command substitution to generate the
-  body inline for a `gh` write; the framework signature gate blocks those forms.
+- Keep the signed body as a real file that already exists before the `gh` write
+  command starts. Do not create the `--body-file` later in the same shell command
+  that invokes `gh`, because the signature gate may inspect the path before the
+  shell has produced it.
+- Do not use shell heredocs, process substitution, or command substitution to
+  generate the body inline for a `gh` write; the framework signature gate blocks
+  those forms. Create or update the markdown with the runtime file-writing tool,
+  then pass that stable file path to `gh --body-file` in a later command.
 - If the signature helper is unavailable, use the helper fallback path rather
   than retrying the same raw `gh` command; repeated unsigned writes are blocked
   by the framework guard.

--- a/.agents/scripts/commands/feedback-triage.md
+++ b/.agents/scripts/commands/feedback-triage.md
@@ -205,17 +205,19 @@ Report ID: {report_id} (submitted {created_at})
 
 Write the body to a temp file (avoids quoting hazards with backticks /
 unicode dashes). In headless runs, create the file with the runtime's
-file-writing tool or an existing generated file; do not use shell heredocs,
-process substitution, or command substitution to inline the body or signature.
-Those forms are rejected by the aidevops GitHub signature gate. Create the
-GitHub issue through the repo helper so the required aidevops signature footer
-is appended automatically and the fallback signature is used if the framework
-signature helper is unavailable. Apply `origin:worker` and `status:available`
-alongside `bug` so the issue is traceable as feedback-triage output and visible
-to claim routines:
+file-writing tool or an existing generated file before invoking `gh`; do not
+create the `--body-file` later in the same shell command that runs the GitHub
+write. The signature gate may inspect the path before the shell has produced it.
+Do not use shell heredocs, process substitution, or command substitution to
+inline the body or signature. Those forms are rejected by the aidevops GitHub
+signature gate. Create the GitHub issue through the repo helper so the required
+aidevops signature footer is appended automatically and the fallback signature is
+used if the framework signature helper is unavailable. Apply `origin:worker` and
+`status:available` alongside `bug` so the issue is traceable as feedback-triage
+output and visible to claim routines:
 
 ```bash
-.agents/scripts/issue-sync-helper.sh --repo Ultimate-Multisite/sd-ai-agent create-signed-issue \
+.agents/scripts/issue-sync-helper.sh --repo Ultimate-Multisite/superdav-ai-agent create-signed-issue \
   --title "<concise bug title>" \
   --body-file /tmp/opencode/r020-triage/issue-<id>-body.md \
   --label "bug,origin:worker,status:available"


### PR DESCRIPTION
## Summary

- Clarify OpenCode headless GitHub write guidance so workers create `--body-file` markdown before invoking `gh`.
- Explicitly warn against creating the body file later in the same shell command that performs the GitHub write.
- Correct the feedback-triage signed issue helper example to target `Ultimate-Multisite/superdav-ai-agent`.

Resolves #1911

## Worker self-verification
- PHPUnit: Tests: 3468, Assertions: 13940, Failures: 3, Skipped: 116, Incomplete: 4 — pre-existing on `origin/main`; tracked in #1913
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

## Verification details

- `rg -n "signature gate|body-file|heredoc|process substitution|gh issue create" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md`
- `npm run verify` reached PHPUnit after lint and PHPStan passed; PHPUnit failed in existing PluginBuilder sandbox tests.
- `git switch --detach origin/main && npm run test:php` reproduced the same 3 PHPUnit failures on `origin/main`.
- `npm run build` succeeded after the pre-existing PHPUnit failure was confirmed.

MERGE_SUMMARY: Clarified durable headless GitHub write guidance for issue #1911 and fixed the feedback-triage helper example repository slug. Verification: guidance grep passed; lint and PHPStan passed through `npm run verify`; PHPUnit has 3 pre-existing PluginBuilder sandbox failures reproduced on `origin/main` and tracked in #1913; build succeeded.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 8m and 61,939 tokens on this as a headless worker.
