### PR TITLE
chore: bump automattic/jetpack-autoloader 5.0.17 -> 5.0.18

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "v5.0.17",
+            "version": "v5.0.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "6933cc3d91d155ed6935d9c189077e7e1a8845bd"
+                "reference": "be5ea0f2109f3300a22a05727721587c9116ffe8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/6933cc3d91d155ed6935d9c189077e7e1a8845bd",
-                "reference": "6933cc3d91d155ed6935d9c189077e7e1a8845bd",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/be5ea0f2109f3300a22a05727721587c9116ffe8",
+                "reference": "be5ea0f2109f3300a22a05727721587c9116ffe8",
                 "shasum": ""
             },
             "require": {
@@ -25,7 +25,7 @@
                 "php": ">=7.2"
             },
             "require-dev": {
-                "automattic/phpunit-select-config": "^1.0.5",
+                "automattic/phpunit-select-config": "^1.0.6",
                 "composer/composer": "^2.2",
                 "yoast/phpunit-polyfills": "^4.0.0"
             },
@@ -66,9 +66,9 @@
                 "wordpress"
             ],
             "support": {
-                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v5.0.17"
+                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v5.0.18"
             },
-            "time": "2026-05-04T16:17:55+00:00"
+            "time": "2026-05-19T09:17:26+00:00"
         },
         {
             "name": "automattic/jetpack-constants",


### PR DESCRIPTION
## Summary

Bumps `automattic/jetpack-autoloader` from **v5.0.17 → v5.0.18** (released 2026-05-19) as flagged by the aidevops update check toast.

Only `composer.lock` changes — `composer.json` already permitted `^5.0`. The upstream patch release only bumps a dev-only dependency (`automattic/phpunit-select-config: ^1.0.5 → ^1.0.6`) and produces no runtime API changes; jetpack autoloader file generation succeeds with the new version (see verification below — generated files all match the expected list, namespaced under `al5_0_18`).

Composer security advisory check: `No security vulnerability advisories found.`

## Worker self-verification

- PHPUnit: Tests: 3468, Assertions: 13951, Errors: 0, Failures: 0, Skipped: 114, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded (archive `superdav-ai-agent.zip` produced)

### Notes on PHPUnit run

The first verify run surfaced 12 transient `Deadlock found when trying to get lock; try restarting transaction` errors from `wp_insert_post()` in `BlockAbilitiesTest`, `IfMatchTest`, `InsertPatternTest`, `PostAbilitiesTest`. Re-running the same filter (`--filter 'BlockAbilitiesTest|IfMatchTest|InsertPatternTest|PostAbilitiesTest'`) returned `OK (169 tests, 660 assertions)`, and re-running the full suite (`npm run test:php`) returned the clean summary above. The failures are pre-existing MySQL deadlock flake in the local test DB and are not caused by this change (a `composer.lock`-only autoloader patch bump cannot affect `wp_insert_post` DB transaction behaviour).

## Verification commands run

```bash
composer update automattic/jetpack-autoloader --with-dependencies
composer show automattic/jetpack-autoloader      # -> versions: * v5.0.18
npm run verify                                   # lint -> phpstan -> test:php -> build all reached
npm run test:php                                 # clean rerun, summary above
```

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 1d 23h and 111,419 tokens on this with the user in an interactive session.
