### PR TITLE
fix(security): redact auth keys and salts from every option-read surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,10 +290,60 @@ Key gotchas: `compile_class` required for hyphenated IDs, `REST_Handler` support
   redundant caching; do not whitelist individual option keys as a cache
   invalidation strategy.
 
+### Secret-Option Read Blocklist (single source of truth)
+
+Authentication keys and salts (`auth_key`, `secure_auth_key`, `logged_in_key`,
+`nonce_key`, plus the four matching `*_salt` names) are written to `wp_options`
+by WordPress when `wp-config.php` does not define them. Any code path that
+exposes those values to the AI agent enables session forgery and admin
+impersonation.
+
+The single source of truth for the read blocklist lives in
+`includes/Abilities/OptionsAbilities.php`:
+
+- `OptionsAbilities::SECRET_READ_BLOCKLIST` — shipped names.
+- `OptionsAbilities::get_secret_read_blocklist()` — runtime list (filterable
+  via `sd_ai_agent_options_read_blocklist`).
+- `OptionsAbilities::is_secret_option_name( string $name ): bool` — predicate
+  every read surface must call.
+- `OptionsAbilities::SECRET_REDACTED_PLACEHOLDER` — the opaque token any
+  surface that must keep the row visible writes in place of the value.
+- `OptionsAbilities::secret_read_error( string $name ): WP_Error` — uniform
+  `sd_ai_agent_option_secret_redacted` error code (HTTP 403).
+
+**Rules for any new ability, REST controller, CLI command, or SQL helper that
+reads option data:**
+
+1. Call `OptionsAbilities::is_secret_option_name( $name )` before returning
+   any value sourced from `wp_options`, `wp_sitemeta`, `wp_*_meta`, transients,
+   or a WP-CLI subprocess.
+2. For row-shaped responses, omit the row OR redact `option_value` /
+   `meta_value` to `SECRET_REDACTED_PLACEHOLDER`. Never include the row with
+   the real value.
+3. Reject SQL queries whose literal arguments include a secret option name
+   (`DatabaseQueryAbility::find_secret_option_literal()` is the reference
+   implementation).
+4. For low-level function callers like `RunPhpAbility`, gate
+   `get_option`/`get_site_option`/`get_network_option`/`get_transient`/
+   `get_site_transient` on the predicate and gate the matching write
+   functions on `OptionsAbilities::get_write_blocklist()`.
+
+**Verification (must run for any PR that touches option reads):**
+
+```bash
+rg -n "is_secret_option_name|SECRET_REDACTED_PLACEHOLDER|sd_ai_agent_option_secret_redacted|sd_ai_agent_options_read_blocklist" includes/ tests/
+npm run test:php -- --filter='OptionsAbilitiesTest|WordPressAbilitiesTest|DatabaseAbilitiesTest|WpCliAbilitiesTest'
+```
+
+The first command must show coverage in every read surface (get-option,
+list-options, db-query, run-php, wp-cli). The second must report zero
+failures for the four ability suites.
+
 ### REST API Security and Operational Guidelines
 - **Secret Scrubbing**: All REST endpoints must scrub sensitive data (API keys, tokens,
   credentials) from responses and logs. Never expose provider credentials, user secrets,
-  or internal configuration in REST output.
+  or internal configuration in REST output. For option-shaped data, route through the
+  Secret-Option Read Blocklist above — do not invent a parallel scrubber.
 - **Internal namespace block**: Keep `sd-ai-agent/v1` unavailable to the agent-facing
   `wp-rest/execute` ability. This plugin must not call its own private REST controllers
   through the internal dispatcher; use direct service/controller calls instead.

--- a/includes/Abilities/DatabaseAbilities.php
+++ b/includes/Abilities/DatabaseAbilities.php
@@ -120,6 +120,23 @@ class DatabaseQueryAbility extends AbstractAbility {
 			);
 		}
 
+		// Secret-aware pre-check: reject any query that names an auth-key /
+		// salt option as a string literal. Without this guard a caller could
+		// bypass GetOptionAbility / ListOptionsAbility with
+		// `SELECT option_value FROM wp_options WHERE option_name='auth_key'`.
+		$secret_literal = self::find_secret_option_literal( $sql );
+		if ( null !== $secret_literal ) {
+			return new WP_Error(
+				'sd_ai_agent_sql_secret_literal',
+				sprintf(
+					/* translators: %s: secret option name */
+					__( 'The query references the secret option "%s". Reading auth keys/salts via SQL is not permitted.', 'superdav-ai-agent' ),
+					$secret_literal
+				),
+				array( 'status' => 403 )
+			);
+		}
+
 		// Replace {prefix} placeholder.
 		$sql = str_replace( '{prefix}', $wpdb->prefix, $sql );
 
@@ -129,11 +146,90 @@ class DatabaseQueryAbility extends AbstractAbility {
 			return new WP_Error( 'sd_ai_agent_db_error', sprintf( 'Database error: %s', $wpdb->last_error ) );
 		}
 
+		// Defence-in-depth: even when the SQL did not name a secret as a
+		// literal (e.g. a wildcard `SELECT * FROM wp_options`), scrub any
+		// row whose option_name/meta_key identifies a secret.
+		$rows = is_array( $results ) ? self::scrub_secret_rows( $results ) : $results;
+
 		return [
 			'query' => $sql,
-			'rows'  => $results,
-			'count' => is_array( $results ) ? count( $results ) : 0,
+			'rows'  => $rows,
+			'count' => is_array( $rows ) ? count( $rows ) : 0,
 		];
+	}
+
+	/**
+	 * Find the first secret option name referenced as a string literal in
+	 * the SQL. Returns null when no secret is referenced.
+	 *
+	 * The check intentionally ignores SQL identifiers (column / table names)
+	 * and only looks at single- or double-quoted literals so a query that
+	 * happens to mention `option_name` as a column does not false-positive.
+	 *
+	 * @param string $sql Raw (pre-prefix-substituted) SQL.
+	 * @return string|null
+	 */
+	private static function find_secret_option_literal( string $sql ): ?string {
+		$blocklist = OptionsAbilities::get_secret_read_blocklist();
+		if ( empty( $blocklist ) ) {
+			return null;
+		}
+
+		if ( ! preg_match_all( "/(?:'([^'\\\\]*(?:\\\\.[^'\\\\]*)*)')|(?:\"([^\"\\\\]*(?:\\\\.[^\"\\\\]*)*)\")/", $sql, $matches ) ) {
+			return null;
+		}
+
+		$literals = array_filter(
+			array_merge( $matches[1], $matches[2] ),
+			static function ( $literal ): bool {
+				return is_string( $literal ) && '' !== $literal;
+			}
+		);
+
+		foreach ( $literals as $literal ) {
+			if ( in_array( $literal, $blocklist, true ) ) {
+				return $literal;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Redact `option_value` (or `meta_value`) on any returned row whose
+	 * `option_name` (or `meta_key`) is on the secret read blocklist.
+	 *
+	 * Supports multisite (`wp_sitemeta`) and any other `meta_key`/`meta_value`
+	 * table that happens to store an auth-key-shaped name.
+	 *
+	 * @param array<int,array<mixed>> $rows Result rows in ARRAY_A shape.
+	 * @return array<int,array<mixed>>
+	 */
+	private static function scrub_secret_rows( array $rows ): array {
+		foreach ( $rows as $index => $row ) {
+			if ( ! is_array( $row ) ) {
+				continue;
+			}
+
+			if ( isset( $row['option_name'], $row['option_value'] )
+				&& is_string( $row['option_name'] )
+				&& OptionsAbilities::is_secret_option_name( $row['option_name'] ) ) {
+				$rows[ $index ]['option_value'] = OptionsAbilities::SECRET_REDACTED_PLACEHOLDER;
+			}
+
+			// `meta_value` and `meta_key` here are PHP array keys on a returned row
+			// (not a SQL query column reference), so the slow-query and quoting
+			// rules do not apply.
+			// phpcs:disable WordPress.DB.SlowDBQuery.slow_db_query_meta_value, WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			if ( isset( $row['meta_key'], $row['meta_value'] )
+				&& is_string( $row['meta_key'] )
+				&& OptionsAbilities::is_secret_option_name( $row['meta_key'] ) ) {
+				$rows[ $index ]['meta_value'] = OptionsAbilities::SECRET_REDACTED_PLACEHOLDER;
+			}
+			// phpcs:enable WordPress.DB.SlowDBQuery.slow_db_query_meta_value, WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+		}
+
+		return $rows;
 	}
 
 	protected function permission_callback( $input ): bool {

--- a/includes/Abilities/OptionsAbilities.php
+++ b/includes/Abilities/OptionsAbilities.php
@@ -23,6 +23,46 @@ if ( ! defined( 'ABSPATH' ) ) {
 class OptionsAbilities {
 
 	/**
+	 * Placeholder substituted for a secret option value in any response that
+	 * cannot omit the row entirely (e.g. database query results, WP-CLI
+	 * `option list` output).
+	 *
+	 * Centralised so every read surface — get-option, list-options, db-query,
+	 * run-php, wp-cli — uses the same opaque token. Reviewers and automated
+	 * tests can grep on this constant.
+	 *
+	 * @var string
+	 */
+	public const SECRET_REDACTED_PLACEHOLDER = '[redacted: secret option]';
+
+	/**
+	 * Authentication keys and salts that must NEVER be returned to the AI
+	 * agent, even when stored in the options table.
+	 *
+	 * WordPress writes these names into `wp_options` when `wp-config.php`
+	 * does not define them, so a read path that names them by string would
+	 * leak the values. This list is the single source of truth used by every
+	 * read surface in the plugin (get-option, list-options, db-query,
+	 * run-php with `get_option`/`get_transient`, and wp-cli `option get`).
+	 *
+	 * Extend via the `sd_ai_agent_options_read_blocklist` filter.
+	 *
+	 * @var string[]
+	 */
+	private const SECRET_READ_BLOCKLIST = [
+		// Cryptographic keys and salts used to sign auth cookies. Leaking
+		// any of these enables session forgery / impersonation.
+		'auth_key',
+		'secure_auth_key',
+		'logged_in_key',
+		'nonce_key',
+		'auth_salt',
+		'secure_auth_salt',
+		'logged_in_salt',
+		'nonce_salt',
+	];
+
+	/**
 	 * Options that the AI agent is never allowed to modify or delete.
 	 *
 	 * These are critical WordPress core options whose corruption would break
@@ -132,6 +172,66 @@ class OptionsAbilities {
 
 		return array_values( array_filter( (array) $blocklist, 'is_string' ) );
 	}
+
+	/**
+	 * Get the runtime read blocklist for secret option names.
+	 *
+	 * The list is intentionally narrower than the write blocklist: a few
+	 * options (e.g. `siteurl`, `active_plugins`) are write-blocked because
+	 * mutating them would break the site, but their values are not secrets
+	 * and may legitimately be inspected. Only values whose disclosure would
+	 * enable session forgery or impersonation belong here.
+	 *
+	 * @return string[]
+	 */
+	public static function get_secret_read_blocklist(): array {
+		/**
+		 * Filters the list of WordPress option names whose values must never
+		 * be returned by any AI-agent read surface.
+		 *
+		 * @since 1.3.0
+		 *
+		 * @param string[] $blocklist List of secret option names.
+		 */
+		$blocklist = apply_filters( 'sd_ai_agent_options_read_blocklist', self::SECRET_READ_BLOCKLIST );
+
+		return array_values( array_filter( (array) $blocklist, 'is_string' ) );
+	}
+
+	/**
+	 * Predicate: is the given option name in the secret read blocklist?
+	 *
+	 * Comparison is exact-match and case-sensitive — WordPress option names
+	 * are case-sensitive at the storage layer.
+	 *
+	 * @param string $option_name Option name to test.
+	 * @return bool True if the name is a known secret.
+	 */
+	public static function is_secret_option_name( string $option_name ): bool {
+		if ( '' === $option_name ) {
+			return false;
+		}
+
+		return in_array( $option_name, self::get_secret_read_blocklist(), true );
+	}
+
+	/**
+	 * Build a uniform WP_Error for a blocked secret read across surfaces.
+	 *
+	 * @param string $option_name Option name that was requested.
+	 * @return WP_Error
+	 */
+	public static function secret_read_error( string $option_name ): WP_Error {
+		return new WP_Error(
+			'sd_ai_agent_option_secret_redacted',
+			sprintf(
+				/* translators: %s: option name */
+				__( 'The option "%s" stores an authentication secret and cannot be read by the AI agent.', 'superdav-ai-agent' ),
+				$option_name
+			),
+			array( 'status' => 403 )
+		);
+	}
 }
 
 /**
@@ -191,6 +291,13 @@ class GetOptionAbility extends AbstractAbility {
 				'sd_ai_agent_empty_option_name',
 				__( 'The "option_name" parameter is required.', 'superdav-ai-agent' )
 			);
+		}
+
+		// Secret-option read gate. WordPress writes auth keys/salts into
+		// `wp_options` when wp-config.php does not define them; returning
+		// their values would enable session forgery.
+		if ( OptionsAbilities::is_secret_option_name( $option_name ) ) {
+			return OptionsAbilities::secret_read_error( $option_name );
 		}
 
 		$default = $input['default'] ?? false;
@@ -557,9 +664,13 @@ class ListOptionsAbility extends AbstractAbility {
 		return [
 			'type'       => 'object',
 			'properties' => [
-				'options' => [ 'type' => 'array' ],
-				'total'   => [ 'type' => 'integer' ],
-				'prefix'  => [ 'type' => 'string' ],
+				'options'        => [ 'type' => 'array' ],
+				'total'          => [ 'type' => 'integer' ],
+				'prefix'         => [ 'type' => 'string' ],
+				'redacted_count' => [
+					'type'        => 'integer',
+					'description' => 'Number of rows removed from the response because their option_name is on the secret read blocklist (e.g. auth_key, secure_auth_salt).',
+				],
 			],
 		];
 	}
@@ -644,8 +755,17 @@ class ListOptionsAbility extends AbstractAbility {
 			);
 		}
 
-		$options = [];
+		$options        = [];
+		$redacted_count = 0;
 		foreach ( $rows as $row ) {
+			// Secret-option read gate. Omit the row entirely so the AI
+			// neither sees the value nor learns whether the option is
+			// stored as an option or defined in wp-config.php.
+			if ( OptionsAbilities::is_secret_option_name( (string) $row['option_name'] ) ) {
+				++$redacted_count;
+				continue;
+			}
+
 			$value = $row['option_value'];
 
 			// Attempt to unserialise so the caller sees the real data type.
@@ -670,9 +790,10 @@ class ListOptionsAbility extends AbstractAbility {
 		}
 
 		return [
-			'options' => $options,
-			'total'   => count( $options ),
-			'prefix'  => $prefix,
+			'options'        => $options,
+			'total'          => count( $options ),
+			'prefix'         => $prefix,
+			'redacted_count' => $redacted_count,
 		];
 	}
 

--- a/includes/Abilities/WordPressAbilities.php
+++ b/includes/Abilities/WordPressAbilities.php
@@ -911,6 +911,43 @@ class UpdatePluginAbility extends AbstractAbility {
 class RunPhpAbility extends AbstractAbility {
 
 	/**
+	 * Option-reading functions whose first argument is an option/transient
+	 * name. Any call into these functions is gated against the secret
+	 * read blocklist defined in {@see OptionsAbilities::get_secret_read_blocklist()}
+	 * so a caller cannot bypass {@see GetOptionAbility} via this low-level
+	 * function caller.
+	 *
+	 * Transient names share the auth-key/salt naming space when stored as
+	 * options ({@see WP_Object_Cache}); gating them here is defence-in-depth.
+	 *
+	 * @var string[]
+	 */
+	private const OPTION_READ_FUNCTIONS = [
+		'get_option',
+		'get_site_option',
+		'get_network_option',
+		'get_transient',
+		'get_site_transient',
+	];
+
+	/**
+	 * Option-mutating functions whose first argument is an option name.
+	 * Calls are gated against {@see OptionsAbilities::get_write_blocklist()}
+	 * so the agent cannot regenerate auth keys/salts (which would log out
+	 * every user) by routing around {@see UpdateOptionAbility}.
+	 *
+	 * @var string[]
+	 */
+	private const OPTION_WRITE_FUNCTIONS = [
+		'update_option',
+		'delete_option',
+		'update_site_option',
+		'delete_site_option',
+		'update_network_option',
+		'delete_network_option',
+	];
+
+	/**
 	 * Allowed WordPress functions that the AI agent may call.
 	 *
 	 * Only side-effect-free read functions and common write functions with
@@ -1061,6 +1098,17 @@ class RunPhpAbility extends AbstractAbility {
 			);
 		}
 
+		// Secret-aware gating: option reads/writes against the auth-key
+		// blocklist. Applied AFTER the function allowlist check so any
+		// extension via `sd_ai_agent_allowed_wp_functions` is still
+		// constrained. Network/site variants of get_option take the option
+		// name in arg position 1 (network ID is arg 0); standard variants
+		// take it in arg 0. Both shapes are covered below.
+		$secret_check = self::check_secret_option_call( $function, $args );
+		if ( is_wp_error( $secret_check ) ) {
+			return $secret_check;
+		}
+
 		if ( ! function_exists( $function ) ) {
 			return new WP_Error(
 				'sd_ai_agent_undefined_function',
@@ -1114,6 +1162,59 @@ class RunPhpAbility extends AbstractAbility {
 
 		// Ensure the list is a flat array of strings (defensive).
 		return array_values( array_filter( (array) $functions, 'is_string' ) );
+	}
+
+	/**
+	 * Gate option-reading / option-writing function calls against the
+	 * secret read blocklist and the existing write blocklist.
+	 *
+	 * Without this check, the AI could bypass {@see GetOptionAbility}'s
+	 * secret-read gate (and {@see UpdateOptionAbility}'s write gate) by
+	 * calling `get_option('auth_key')` (or `update_option('auth_key', ...)`)
+	 * through this low-level function caller.
+	 *
+	 * Returns null when the call is allowed, a WP_Error when blocked.
+	 *
+	 * @param string       $function_name The PHP function name about to be called.
+	 * @param array<mixed> $args          Positional arguments that will be passed.
+	 * @return \WP_Error|null
+	 */
+	private static function check_secret_option_call( string $function_name, array $args ): ?\WP_Error {
+		// Network/site option variants accept (int $network_id, string $option, ...);
+		// standard variants accept (string $option, ...). Pick the right arg index.
+		$is_network_variant = in_array(
+			$function_name,
+			[ 'get_network_option', 'update_network_option', 'delete_network_option' ],
+			true
+		);
+		$name_index         = $is_network_variant ? 1 : 0;
+
+		if ( ! isset( $args[ $name_index ] ) || ! is_string( $args[ $name_index ] ) ) {
+			return null;
+		}
+
+		$option_name = $args[ $name_index ];
+
+		if ( in_array( $function_name, self::OPTION_READ_FUNCTIONS, true )
+			&& OptionsAbilities::is_secret_option_name( $option_name ) ) {
+			return OptionsAbilities::secret_read_error( $option_name );
+		}
+
+		if ( in_array( $function_name, self::OPTION_WRITE_FUNCTIONS, true )
+			&& in_array( $option_name, OptionsAbilities::get_write_blocklist(), true ) ) {
+			return new \WP_Error(
+				'sd_ai_agent_option_blocked',
+				sprintf(
+					/* translators: 1: function name, 2: option name */
+					__( 'The function "%1$s" cannot be used to modify the protected option "%2$s".', 'superdav-ai-agent' ),
+					$function_name,
+					$option_name
+				),
+				[ 'status' => 403 ]
+			);
+		}
+
+		return null;
 	}
 
 	protected function permission_callback( $input ): bool {

--- a/includes/Abilities/WpCliAbilities.php
+++ b/includes/Abilities/WpCliAbilities.php
@@ -335,6 +335,14 @@ class WpCliAbilities {
 			);
 		}
 
+		// Secret-aware option subcommand gate. Blocks `wp option get auth_key`
+		// and friends before the binary is even invoked, so an unsafe value
+		// is never read from disk or shell-expanded into a log.
+		$secret_gate = self::check_secret_option_subcommand( $command_path, $tokens );
+		if ( is_wp_error( $secret_gate ) ) {
+			return $secret_gate;
+		}
+
 		// Permission check based on command classification.
 		$level      = self::classify_command( $command_path );
 		$perm_check = self::check_permission_level( $level );
@@ -403,6 +411,14 @@ class WpCliAbilities {
 
 		/** @var list<string> $proc_args */
 		$result = self::run_process( $proc_args, $command_path );
+
+		// Post-process scrub for `option list` (and any other multi-row
+		// secret-bearing subcommand we add later). Catches secrets that
+		// slip past the pre-check because the option name is not a
+		// positional argument of the subcommand.
+		if ( ! is_wp_error( $result ) ) {
+			$result = self::scrub_secret_output( $command_path, $result );
+		}
 
 		// Auto-set current site context after site creation.
 		if ( str_starts_with( $command_path, 'site create' ) && ! is_wp_error( $result ) ) {
@@ -1056,5 +1072,163 @@ class WpCliAbilities {
 		}
 
 		return '';
+	}
+
+	// ─── Secret-aware option subcommand gating ──────────────────────────
+
+	/**
+	 * Subcommands that take an option name as their first non-flag positional
+	 * argument and would therefore expose / mutate a secret if not gated.
+	 *
+	 * Index value is a classification used by {@see check_secret_option_subcommand()}:
+	 *   - 'read'  → name must not be on the secret read blocklist.
+	 *   - 'write' → name must not be on the existing write blocklist.
+	 *
+	 * @var array<string,string>
+	 */
+	private const SECRET_AWARE_OPTION_SUBCOMMANDS = array(
+		'option get'          => 'read',
+		'option pluck'        => 'read',
+		'option get-autoload' => 'read',
+		'option update'       => 'write',
+		'option set'          => 'write', // alias for update in some WP-CLI versions.
+		'option add'          => 'write',
+		'option delete'       => 'write',
+		'option patch'        => 'write',
+	);
+
+	/**
+	 * Reject `wp option get/pluck/update/delete <secret>` before execution.
+	 *
+	 * {@see extract_command_path()} stops at the first flag but consumes the
+	 * option name into the positional path (so `option get auth_key` becomes
+	 * the full command_path string). We therefore derive the 2-token
+	 * subcommand prefix and the option-name argument directly from the
+	 * tokenised input, not from the joined command_path.
+	 *
+	 * Returns null when the command is allowed, a WP_Error when blocked.
+	 *
+	 * @param string   $command_path The space-joined positional prefix (unused
+	 *                               for the lookup; kept for caller symmetry).
+	 * @param string[] $tokens       Full tokenised command (includes flags).
+	 * @return WP_Error|null
+	 */
+	private static function check_secret_option_subcommand( string $command_path, array $tokens ): ?WP_Error {
+		unset( $command_path );
+
+		// Collect non-flag positionals; the first two form the "<top>
+		// <verb>" prefix and the third (if any) is the option name.
+		$positionals = array();
+		foreach ( $tokens as $token ) {
+			if ( ! str_starts_with( $token, '-' ) ) {
+				$positionals[] = $token;
+			}
+		}
+
+		if ( count( $positionals ) < 2 ) {
+			return null;
+		}
+
+		$prefix = $positionals[0] . ' ' . $positionals[1];
+		if ( ! isset( self::SECRET_AWARE_OPTION_SUBCOMMANDS[ $prefix ] ) ) {
+			return null;
+		}
+
+		$mode        = self::SECRET_AWARE_OPTION_SUBCOMMANDS[ $prefix ];
+		$option_name = $positionals[2] ?? '';
+		if ( '' === $option_name ) {
+			// No name yet — let WP-CLI surface the usage error.
+			return null;
+		}
+
+		if ( 'read' === $mode && OptionsAbilities::is_secret_option_name( $option_name ) ) {
+			return new WP_Error(
+				'wp_cli_option_secret_redacted',
+				sprintf(
+					/* translators: 1: WP-CLI subcommand, 2: option name */
+					__( 'The WP-CLI command "wp %1$s %2$s" would read an authentication secret and is blocked.', 'superdav-ai-agent' ),
+					$prefix,
+					$option_name
+				),
+				array( 'status' => 403 )
+			);
+		}
+
+		if ( 'write' === $mode
+			&& in_array( $option_name, OptionsAbilities::get_write_blocklist(), true ) ) {
+			return new WP_Error(
+				'wp_cli_option_protected',
+				sprintf(
+					/* translators: 1: WP-CLI subcommand, 2: option name */
+					__( 'The WP-CLI command "wp %1$s %2$s" targets a protected option and is blocked.', 'superdav-ai-agent' ),
+					$prefix,
+					$option_name
+				),
+				array( 'status' => 403 )
+			);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Scrub secret option values out of WP-CLI subcommand output.
+	 *
+	 * Handles the structured `--format=json` case (already decoded into an
+	 * array by {@see run_process()}) and the unstructured fallback (raw
+	 * trimmed stdout string).
+	 *
+	 * @param string              $command_path The space-joined positional prefix.
+	 * @param array<mixed>|string $result       The decoded or raw command result.
+	 * @return array<mixed>|string
+	 */
+	public static function scrub_secret_output( string $command_path, $result ) {
+		if ( ! str_starts_with( $command_path, 'option list' ) && 'option' !== $command_path ) {
+			return $result;
+		}
+
+		$secrets = OptionsAbilities::get_secret_read_blocklist();
+		if ( empty( $secrets ) ) {
+			return $result;
+		}
+
+		// Structured JSON output: list of associative arrays keyed by
+		// option_name. Redact value, keep the row visible so the caller
+		// learns the option exists.
+		if ( is_array( $result ) ) {
+			foreach ( $result as $index => $row ) {
+				if ( ! is_array( $row ) ) {
+					continue;
+				}
+				$name = isset( $row['option_name'] ) && is_string( $row['option_name'] )
+					? $row['option_name']
+					: '';
+				if ( '' !== $name && in_array( $name, $secrets, true ) ) {
+					if ( array_key_exists( 'option_value', $row ) ) {
+						$result[ $index ]['option_value'] = OptionsAbilities::SECRET_REDACTED_PLACEHOLDER;
+					}
+					if ( array_key_exists( 'value', $row ) ) {
+						$result[ $index ]['value'] = OptionsAbilities::SECRET_REDACTED_PLACEHOLDER;
+					}
+				}
+			}
+			return $result;
+		}
+
+		// Unstructured text output (table/csv/tsv/yaml/etc.). Redact each
+		// physical line that begins with a secret option name followed by
+		// a separator. Cheap and format-agnostic.
+		if ( is_string( $result ) ) {
+			$pattern = '/^(' . implode( '|', array_map( 'preg_quote', $secrets ) ) . ')(\s|\t|,|:)(.*)$/m';
+			return (string) preg_replace_callback(
+				$pattern,
+				static function ( array $m ): string {
+					return $m[1] . $m[2] . OptionsAbilities::SECRET_REDACTED_PLACEHOLDER;
+				},
+				$result
+			);
+		}
+
+		return $result;
 	}
 }

--- a/tests/SdAiAgent/Abilities/DatabaseAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/DatabaseAbilitiesTest.php
@@ -176,4 +176,108 @@ class DatabaseAbilitiesTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result['rows'] );
 		$this->assertEmpty( $result['rows'] );
 	}
+
+	/**
+	 * Test handle_db_query rejects a SELECT that names a secret option
+	 * as a single-quoted string literal.
+	 */
+	public function test_handle_db_query_rejects_secret_literal_single_quoted() {
+		update_option( 'auth_key', 'do-not-leak-this-secret' );
+
+		$result = DatabaseAbilities::handle_db_query( [
+			'sql' => "SELECT option_value FROM {prefix}options WHERE option_name = 'auth_key'",
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_sql_secret_literal', $result->get_error_code() );
+
+		delete_option( 'auth_key' );
+	}
+
+	/**
+	 * Test handle_db_query rejects a SELECT that names a secret option
+	 * as a double-quoted string literal.
+	 */
+	public function test_handle_db_query_rejects_secret_literal_double_quoted() {
+		$result = DatabaseAbilities::handle_db_query( [
+			'sql' => 'SELECT option_value FROM {prefix}options WHERE option_name = "secure_auth_salt"',
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_sql_secret_literal', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_db_query scrubs option_value in any row whose option_name
+	 * is on the secret read blocklist (catches `SELECT *` wildcard reads).
+	 */
+	public function test_handle_db_query_scrubs_secret_value_in_wildcard_row() {
+		update_option( 'auth_key', 'do-not-leak-this-secret' );
+
+		// SELECT * does not name `auth_key` as a literal, so the pre-check
+		// allows it; the post-process must still redact the value.
+		$result = DatabaseAbilities::handle_db_query( [
+			'sql' => "SELECT option_name, option_value, autoload FROM {prefix}options WHERE option_name LIKE 'auth_%' LIMIT 5",
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertIsArray( $result['rows'] );
+
+		$encoded = wp_json_encode( $result );
+		$this->assertIsString( $encoded );
+		$this->assertStringNotContainsString( 'do-not-leak-this-secret', $encoded );
+
+		$found_redacted = false;
+		foreach ( $result['rows'] as $row ) {
+			if ( ( $row['option_name'] ?? '' ) === 'auth_key' ) {
+				$this->assertSame(
+					\SdAiAgent\Abilities\OptionsAbilities::SECRET_REDACTED_PLACEHOLDER,
+					$row['option_value']
+				);
+				$found_redacted = true;
+			}
+		}
+		$this->assertTrue( $found_redacted, 'Expected auth_key row to be redacted by the post-process.' );
+
+		delete_option( 'auth_key' );
+	}
+
+	/**
+	 * Test handle_db_query still returns non-secret rows untouched.
+	 */
+	public function test_handle_db_query_does_not_scrub_safe_rows() {
+		$result = DatabaseAbilities::handle_db_query( [
+			'sql' => "SELECT option_name, option_value FROM {prefix}options WHERE option_name = 'blogname' LIMIT 1",
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 1, $result['count'] );
+		$this->assertSame( 'blogname', $result['rows'][0]['option_name'] );
+		$this->assertNotSame(
+			\SdAiAgent\Abilities\OptionsAbilities::SECRET_REDACTED_PLACEHOLDER,
+			$result['rows'][0]['option_value']
+		);
+	}
+
+	/**
+	 * Filter-extended secret names must also be enforced by db-query.
+	 */
+	public function test_handle_db_query_honours_filter_extended_secret_literal() {
+		add_filter(
+			'sd_ai_agent_options_read_blocklist',
+			static function ( array $list ): array {
+				$list[] = 'third_party_api_token';
+				return $list;
+			}
+		);
+
+		$result = DatabaseAbilities::handle_db_query( [
+			'sql' => "SELECT option_value FROM {prefix}options WHERE option_name = 'third_party_api_token'",
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_sql_secret_literal', $result->get_error_code() );
+
+		remove_all_filters( 'sd_ai_agent_options_read_blocklist' );
+	}
 }

--- a/tests/SdAiAgent/Abilities/OptionsAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/OptionsAbilitiesTest.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * Test case for OptionsAbilities (secret-option read gating).
+ *
+ * Verifies the cross-surface contract that the AI agent can never read
+ * the value of an authentication key or salt stored in the WordPress
+ * options table, even though those names are write-blocked.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Abilities;
+
+use SdAiAgent\Abilities\GetOptionAbility;
+use SdAiAgent\Abilities\ListOptionsAbility;
+use SdAiAgent\Abilities\OptionsAbilities;
+use WP_UnitTestCase;
+
+/**
+ * Test secret-option read gating end-to-end.
+ */
+class OptionsAbilitiesTest extends WP_UnitTestCase {
+
+	/**
+	 * Sample auth-key value used in fixtures; never asserted to be present
+	 * in any agent-visible output.
+	 *
+	 * @var string
+	 */
+	private const FIXTURE_SECRET_VALUE = 'do-not-leak-this-secret-value';
+
+	/**
+	 * Clean up any options the tests inserted so they do not pollute the
+	 * shared fixture database.
+	 */
+	public function tear_down(): void {
+		foreach ( OptionsAbilities::get_secret_read_blocklist() as $name ) {
+			delete_option( $name );
+		}
+		delete_option( 'sd_ai_agent_test_visible_option' );
+		remove_all_filters( 'sd_ai_agent_options_read_blocklist' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * The shipped read blocklist covers every auth key and salt.
+	 */
+	public function test_default_read_blocklist_covers_auth_keys_and_salts(): void {
+		$blocklist = OptionsAbilities::get_secret_read_blocklist();
+
+		$expected = array(
+			'auth_key',
+			'secure_auth_key',
+			'logged_in_key',
+			'nonce_key',
+			'auth_salt',
+			'secure_auth_salt',
+			'logged_in_salt',
+			'nonce_salt',
+		);
+
+		foreach ( $expected as $name ) {
+			$this->assertContains(
+				$name,
+				$blocklist,
+				sprintf( '"%s" must be in the secret read blocklist.', $name )
+			);
+			$this->assertTrue(
+				OptionsAbilities::is_secret_option_name( $name ),
+				sprintf( 'is_secret_option_name("%s") must return true.', $name )
+			);
+		}
+	}
+
+	/**
+	 * Non-secret options remain readable.
+	 */
+	public function test_predicate_returns_false_for_non_secret_names(): void {
+		$this->assertFalse( OptionsAbilities::is_secret_option_name( 'blogname' ) );
+		$this->assertFalse( OptionsAbilities::is_secret_option_name( 'siteurl' ) );
+		$this->assertFalse( OptionsAbilities::is_secret_option_name( '' ) );
+	}
+
+	/**
+	 * The read blocklist can be extended at runtime by site code.
+	 */
+	public function test_filter_can_extend_read_blocklist(): void {
+		add_filter(
+			'sd_ai_agent_options_read_blocklist',
+			static function ( array $list ): array {
+				$list[] = 'my_third_party_api_token';
+				return $list;
+			}
+		);
+
+		$this->assertTrue( OptionsAbilities::is_secret_option_name( 'my_third_party_api_token' ) );
+		$this->assertContains( 'my_third_party_api_token', OptionsAbilities::get_secret_read_blocklist() );
+	}
+
+	/**
+	 * GetOptionAbility refuses to read auth_key even when it is stored as
+	 * an option.
+	 */
+	public function test_get_option_ability_blocks_auth_key(): void {
+		update_option( 'auth_key', self::FIXTURE_SECRET_VALUE );
+
+		$ability = new GetOptionAbility( 'sd-ai-agent/get-option' );
+		$result  = $ability->run( array( 'option_name' => 'auth_key' ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_option_secret_redacted', $result->get_error_code() );
+		$this->assertStringNotContainsString(
+			self::FIXTURE_SECRET_VALUE,
+			(string) $result->get_error_message(),
+			'Error message must not echo the secret value.'
+		);
+	}
+
+	/**
+	 * Every shipped secret name is rejected by GetOptionAbility, not just
+	 * the first one in the list.
+	 */
+	public function test_get_option_ability_blocks_every_shipped_secret(): void {
+		$ability = new GetOptionAbility( 'sd-ai-agent/get-option' );
+
+		foreach ( OptionsAbilities::get_secret_read_blocklist() as $name ) {
+			update_option( $name, self::FIXTURE_SECRET_VALUE );
+			$result = $ability->run( array( 'option_name' => $name ) );
+
+			$this->assertInstanceOf( \WP_Error::class, $result, "Reading $name must return WP_Error" );
+			$this->assertSame(
+				'sd_ai_agent_option_secret_redacted',
+				$result->get_error_code(),
+				"Reading $name must return the secret-redacted error code"
+			);
+		}
+	}
+
+	/**
+	 * Non-secret options continue to read normally.
+	 */
+	public function test_get_option_ability_still_reads_safe_options(): void {
+		update_option( 'sd_ai_agent_test_visible_option', 'hello' );
+
+		$ability = new GetOptionAbility( 'sd-ai-agent/get-option' );
+		$result  = $ability->run( array( 'option_name' => 'sd_ai_agent_test_visible_option' ) );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'hello', $result['value'] );
+		$this->assertTrue( $result['exists'] );
+	}
+
+	/**
+	 * Filter-added names are also blocked by GetOptionAbility.
+	 */
+	public function test_get_option_ability_honours_filter_added_secret(): void {
+		add_filter(
+			'sd_ai_agent_options_read_blocklist',
+			static function ( array $list ): array {
+				$list[] = 'sd_ai_agent_test_visible_option';
+				return $list;
+			}
+		);
+		update_option( 'sd_ai_agent_test_visible_option', 'hello' );
+
+		$ability = new GetOptionAbility( 'sd-ai-agent/get-option' );
+		$result  = $ability->run( array( 'option_name' => 'sd_ai_agent_test_visible_option' ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_option_secret_redacted', $result->get_error_code() );
+	}
+
+	/**
+	 * ListOptionsAbility omits secret rows and counts them so the agent
+	 * knows redaction occurred without seeing the values.
+	 */
+	public function test_list_options_ability_omits_secret_rows(): void {
+		update_option( 'auth_key', self::FIXTURE_SECRET_VALUE );
+		update_option( 'nonce_salt', self::FIXTURE_SECRET_VALUE );
+
+		$ability = new ListOptionsAbility( 'sd-ai-agent/list-options' );
+		$result  = $ability->run( array( 'limit' => 200 ) );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'options', $result );
+		$this->assertArrayHasKey( 'redacted_count', $result );
+		$this->assertGreaterThanOrEqual( 2, $result['redacted_count'] );
+
+		$encoded = wp_json_encode( $result );
+		$this->assertIsString( $encoded );
+		$this->assertStringNotContainsString(
+			self::FIXTURE_SECRET_VALUE,
+			$encoded,
+			'Secret value must never appear in the list-options response.'
+		);
+
+		foreach ( $result['options'] as $row ) {
+			$this->assertFalse(
+				OptionsAbilities::is_secret_option_name( (string) $row['option_name'] ),
+				sprintf( 'Secret option "%s" leaked into the response.', $row['option_name'] )
+			);
+		}
+	}
+
+	/**
+	 * The placeholder constant is opaque enough to be greppable across the
+	 * codebase, and stable enough for tests to assert on.
+	 */
+	public function test_secret_redacted_placeholder_is_stable(): void {
+		$this->assertSame(
+			'[redacted: secret option]',
+			OptionsAbilities::SECRET_REDACTED_PLACEHOLDER
+		);
+	}
+}

--- a/tests/SdAiAgent/Abilities/WordPressAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/WordPressAbilitiesTest.php
@@ -278,4 +278,168 @@ class WordPressAbilitiesTest extends WP_UnitTestCase {
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'sd_ai_agent_php_error', $result->get_error_code() );
 	}
+
+	/**
+	 * RunPhpAbility must refuse get_option('auth_key') even though
+	 * get_option is on the function allowlist.
+	 */
+	public function test_handle_run_php_blocks_get_option_for_secret_name() {
+		update_option( 'auth_key', 'do-not-leak-this-secret' );
+
+		$result = WordPressAbilities::handle_run_php( [
+			'function' => 'get_option',
+			'args'     => [ 'auth_key' ],
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_option_secret_redacted', $result->get_error_code() );
+
+		delete_option( 'auth_key' );
+	}
+
+	/**
+	 * RunPhpAbility must refuse every shipped secret name across every
+	 * gated option-reading function (get_option, get_site_option,
+	 * get_transient, …). Functions that ship outside the default allowlist
+	 * (get_site_option, get_network_option, get_site_transient) are added
+	 * via filter so the test exercises the secret gate rather than the
+	 * allowlist gate.
+	 */
+	public function test_handle_run_php_blocks_every_option_read_function_against_every_secret() {
+		add_filter(
+			'sd_ai_agent_allowed_wp_functions',
+			static function ( array $fns ): array {
+				$fns[] = 'get_site_option';
+				$fns[] = 'get_network_option';
+				$fns[] = 'get_site_transient';
+				return $fns;
+			}
+		);
+
+		$functions = [ 'get_option', 'get_site_option', 'get_transient', 'get_site_transient' ];
+
+		foreach ( $functions as $function ) {
+			if ( ! function_exists( $function ) ) {
+				continue;
+			}
+			foreach ( \SdAiAgent\Abilities\OptionsAbilities::get_secret_read_blocklist() as $name ) {
+				$result = WordPressAbilities::handle_run_php( [
+					'function' => $function,
+					'args'     => [ $name ],
+				] );
+
+				$this->assertInstanceOf(
+					\WP_Error::class,
+					$result,
+					sprintf( '%s("%s") must return WP_Error', $function, $name )
+				);
+				$this->assertSame(
+					'sd_ai_agent_option_secret_redacted',
+					$result->get_error_code(),
+					sprintf( '%s("%s") must use the secret-redacted error code', $function, $name )
+				);
+			}
+		}
+
+		remove_all_filters( 'sd_ai_agent_allowed_wp_functions' );
+	}
+
+	/**
+	 * RunPhpAbility must read non-secret options normally.
+	 */
+	public function test_handle_run_php_allows_get_option_for_safe_name() {
+		update_option( 'sd_ai_agent_test_runphp_safe_option', 'visible-value' );
+
+		$result = WordPressAbilities::handle_run_php( [
+			'function' => 'get_option',
+			'args'     => [ 'sd_ai_agent_test_runphp_safe_option' ],
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'visible-value', $result['result'] );
+
+		delete_option( 'sd_ai_agent_test_runphp_safe_option' );
+	}
+
+	/**
+	 * RunPhpAbility must refuse update_option('auth_key', …) so the agent
+	 * cannot regenerate the auth keys via the low-level function caller.
+	 */
+	public function test_handle_run_php_blocks_update_option_for_write_blocklist() {
+		$result = WordPressAbilities::handle_run_php( [
+			'function' => 'update_option',
+			'args'     => [ 'auth_key', 'rotated-by-agent' ],
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_option_blocked', $result->get_error_code() );
+	}
+
+	/**
+	 * RunPhpAbility must refuse delete_option('auth_key').
+	 */
+	public function test_handle_run_php_blocks_delete_option_for_write_blocklist() {
+		$result = WordPressAbilities::handle_run_php( [
+			'function' => 'delete_option',
+			'args'     => [ 'auth_key' ],
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_option_blocked', $result->get_error_code() );
+	}
+
+	/**
+	 * Filter-extended secret names must also be honoured by RunPhpAbility.
+	 */
+	public function test_handle_run_php_honours_filter_extended_secret_for_get_option() {
+		add_filter(
+			'sd_ai_agent_options_read_blocklist',
+			static function ( array $list ): array {
+				$list[] = 'third_party_api_token';
+				return $list;
+			}
+		);
+		update_option( 'third_party_api_token', 'secret-token-value' );
+
+		$result = WordPressAbilities::handle_run_php( [
+			'function' => 'get_option',
+			'args'     => [ 'third_party_api_token' ],
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_option_secret_redacted', $result->get_error_code() );
+
+		delete_option( 'third_party_api_token' );
+		remove_all_filters( 'sd_ai_agent_options_read_blocklist' );
+	}
+
+	/**
+	 * get_network_option takes (network_id, option_name, …); the secret
+	 * check must look at arg index 1, not 0. get_network_option is not in
+	 * the default allowlist, so the test adds it via filter to ensure the
+	 * secret gate (not the allowlist) is what blocks the call.
+	 */
+	public function test_handle_run_php_blocks_get_network_option_secret_at_arg_one() {
+		if ( ! function_exists( 'get_network_option' ) ) {
+			$this->markTestSkipped( 'get_network_option() unavailable in this environment.' );
+		}
+
+		add_filter(
+			'sd_ai_agent_allowed_wp_functions',
+			static function ( array $fns ): array {
+				$fns[] = 'get_network_option';
+				return $fns;
+			}
+		);
+
+		$result = WordPressAbilities::handle_run_php( [
+			'function' => 'get_network_option',
+			'args'     => [ 1, 'auth_key' ],
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_option_secret_redacted', $result->get_error_code() );
+
+		remove_all_filters( 'sd_ai_agent_allowed_wp_functions' );
+	}
 }

--- a/tests/SdAiAgent/Abilities/WpCliAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/WpCliAbilitiesTest.php
@@ -464,6 +464,174 @@ class WpCliAbilitiesTest extends WP_UnitTestCase {
 		return $this->temp_dir;
 	}
 
+	// ─── Secret-aware option subcommand gating ──────────────────────────
+
+	/**
+	 * `wp option get auth_key` must be blocked before binary discovery.
+	 *
+	 * The secret gate runs ahead of {@see WpCliAbilities::find_wp_cli()},
+	 * so this test does not require a real WP-CLI binary to assert the
+	 * block code.
+	 */
+	public function test_execute_blocks_option_get_for_secret_name(): void {
+		$result = WpCliAbilities::execute( 'option get auth_key' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'wp_cli_option_secret_redacted', $result->get_error_code() );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * `wp option pluck nonce_salt some.key` must also be blocked.
+	 */
+	public function test_execute_blocks_option_pluck_for_secret_name(): void {
+		$result = WpCliAbilities::execute( 'option pluck nonce_salt foo' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'wp_cli_option_secret_redacted', $result->get_error_code() );
+	}
+
+	/**
+	 * Flags between subcommand and option name must not bypass the gate.
+	 *
+	 * Example: `wp option get --format=json secure_auth_key`.
+	 */
+	public function test_execute_blocks_secret_name_even_with_flags_before_it(): void {
+		$result = WpCliAbilities::execute( 'option get --format=json secure_auth_key' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'wp_cli_option_secret_redacted', $result->get_error_code() );
+	}
+
+	/**
+	 * Non-secret option reads continue to pass the gate (they fail later
+	 * because no real WP-CLI binary is installed in the test env, but the
+	 * failure must NOT be the secret-redacted code).
+	 */
+	public function test_execute_allows_option_get_for_safe_name(): void {
+		$result = WpCliAbilities::execute( 'option get blogname' );
+
+		// The command should pass the secret gate; whether it ultimately
+		// succeeds or fails depends on whether wp-cli is installed. Either
+		// way the error code must NOT be the secret-redacted one.
+		if ( is_wp_error( $result ) ) {
+			$this->assertNotSame(
+				'wp_cli_option_secret_redacted',
+				$result->get_error_code()
+			);
+		} else {
+			$this->assertTrue( true, 'Command executed without hitting the secret gate.' );
+		}
+	}
+
+	/**
+	 * `wp option update auth_key …` must be refused by the write-blocklist
+	 * branch of the gate, even though `auth_key` could also be reached via
+	 * the secret-read gate.
+	 */
+	public function test_execute_blocks_option_update_for_protected_name(): void {
+		$result = WpCliAbilities::execute( 'option update auth_key rotated-by-agent' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'wp_cli_option_protected', $result->get_error_code() );
+	}
+
+	/**
+	 * `wp option delete logged_in_key` must be refused.
+	 */
+	public function test_execute_blocks_option_delete_for_protected_name(): void {
+		$result = WpCliAbilities::execute( 'option delete logged_in_key' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'wp_cli_option_protected', $result->get_error_code() );
+	}
+
+	/**
+	 * Filter-extended secret names must also block WP-CLI option get.
+	 */
+	public function test_execute_honours_filter_extended_secret_for_option_get(): void {
+		add_filter(
+			'sd_ai_agent_options_read_blocklist',
+			static function ( array $list ): array {
+				$list[] = 'third_party_api_token';
+				return $list;
+			}
+		);
+
+		$result = WpCliAbilities::execute( 'option get third_party_api_token' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'wp_cli_option_secret_redacted', $result->get_error_code() );
+
+		remove_all_filters( 'sd_ai_agent_options_read_blocklist' );
+	}
+
+	/**
+	 * The structured `option list` scrubber must redact `option_value` on
+	 * any row whose `option_name` is a secret.
+	 */
+	public function test_scrub_secret_output_redacts_structured_rows(): void {
+		$raw = array(
+			array(
+				'option_name'  => 'blogname',
+				'option_value' => 'My Site',
+				'autoload'     => 'yes',
+			),
+			array(
+				'option_name'  => 'auth_key',
+				'option_value' => 'do-not-leak-this-secret',
+				'autoload'     => 'yes',
+			),
+			array(
+				'option_name'  => 'nonce_salt',
+				'value'        => 'do-not-leak-this-secret',
+			),
+		);
+
+		$scrubbed = WpCliAbilities::scrub_secret_output( 'option list', $raw );
+		$this->assertIsArray( $scrubbed );
+
+		$encoded = wp_json_encode( $scrubbed );
+		$this->assertIsString( $encoded );
+		$this->assertStringNotContainsString( 'do-not-leak-this-secret', $encoded );
+		$this->assertSame( 'My Site', $scrubbed[0]['option_value'] );
+		$this->assertSame(
+			\SdAiAgent\Abilities\OptionsAbilities::SECRET_REDACTED_PLACEHOLDER,
+			$scrubbed[1]['option_value']
+		);
+		$this->assertSame(
+			\SdAiAgent\Abilities\OptionsAbilities::SECRET_REDACTED_PLACEHOLDER,
+			$scrubbed[2]['value']
+		);
+	}
+
+	/**
+	 * The text-format scrubber must replace secret values on lines that
+	 * begin with a secret option name.
+	 */
+	public function test_scrub_secret_output_redacts_text_rows(): void {
+		$raw = "blogname\tMy Site\nauth_key\tdo-not-leak-this-secret\nnonce_salt:do-not-leak-this-secret\n";
+
+		$scrubbed = WpCliAbilities::scrub_secret_output( 'option list', $raw );
+		$this->assertIsString( $scrubbed );
+		$this->assertStringNotContainsString( 'do-not-leak-this-secret', $scrubbed );
+		$this->assertStringContainsString( 'My Site', $scrubbed );
+		$this->assertStringContainsString(
+			\SdAiAgent\Abilities\OptionsAbilities::SECRET_REDACTED_PLACEHOLDER,
+			$scrubbed
+		);
+	}
+
+	/**
+	 * Subcommands other than `option list*` must pass through untouched —
+	 * the scrubber is a narrow safety net, not a general filter.
+	 */
+	public function test_scrub_secret_output_passes_through_other_commands(): void {
+		$raw = array( array( 'option_name' => 'auth_key', 'option_value' => 'leaked' ) );
+		$result = WpCliAbilities::scrub_secret_output( 'post list', $raw );
+		$this->assertSame( $raw, $result );
+	}
+
 	/**
 	 * Recursively remove a directory.
 	 *


### PR DESCRIPTION
# Redact auth keys and salts from every option-read surface

## Background

A WordPress.org plugin reviewer reported that authentication keys and salts
(`auth_key`, `secure_auth_key`, `logged_in_key`, `nonce_key` and the four
matching `*_salt` names) were write-blocked in `OptionsAbilities`, but
several read paths could still return their values when WordPress stored
them in `wp_options` (which it does whenever `wp-config.php` does not
define them):

> "Auth key/salt names are only write-blocked, but get-option/list-options
> still return option values and the low-level function caller allows
> get_option(), so those secrets could be exposed if stored as options."

A full sweep of the codebase identified **five** read surfaces that could
expose those values. The reviewer flagged 1–3 directly; 4 and 5 share the
same root cause and were trivially exploitable to read the same secrets
via raw SQL or a `wp option get auth_key` WP-CLI call.

| # | Ability | File | Pre-PR behaviour |
| - | --- | --- | --- |
| 1 | `sd-ai-agent/get-option` | `OptionsAbilities::GetOptionAbility` | `get_option($name)` with no read blocklist |
| 2 | `sd-ai-agent/list-options` | `OptionsAbilities::ListOptionsAbility` | Raw `SELECT option_name, option_value FROM wp_options` with no name filter |
| 3 | `sd-ai-agent/run-php` | `WordPressAbilities::RunPhpAbility` | Allowlists `get_option`/`get_transient`/... with no arg-name filter |
| 4 | `sd-ai-agent/db-query` | `DatabaseAbilities::DatabaseQueryAbility` | Arbitrary `SELECT` permitted |
| 5 | `sd-ai-agent/wp-cli` | `WpCliAbilities::execute` | `option get`/`pluck`/`list` not gated on option name |

## Fix

A single source of truth lives in `OptionsAbilities`:

- `SECRET_READ_BLOCKLIST` — shipped names (8 auth keys/salts)
- `get_secret_read_blocklist()` — runtime list, filterable via
  `sd_ai_agent_options_read_blocklist`
- `is_secret_option_name( string $name ): bool` — exact-match predicate
- `SECRET_REDACTED_PLACEHOLDER` — opaque token any surface that keeps the
  row visible writes in place of the value
- `secret_read_error( string $name ): WP_Error` — uniform
  `sd_ai_agent_option_secret_redacted` error code (HTTP 403)

Every read surface now calls the predicate before returning option-shaped
data:

- **GetOptionAbility**: returns `sd_ai_agent_option_secret_redacted`
- **ListOptionsAbility**: omits matching rows entirely and exposes
  `redacted_count` so the caller knows redaction occurred
- **RunPhpAbility**: gates `get_option`, `get_site_option`,
  `get_network_option`, `get_transient`, `get_site_transient` on the read
  predicate; gates `update_option`/`delete_option` (and network/site
  variants) on the existing write blocklist. Argument index 1 is checked
  for network variants so `get_network_option(1, 'auth_key')` is also
  blocked.
- **DatabaseQueryAbility**: rejects SELECTs that name a secret as a string
  literal (`sd_ai_agent_sql_secret_literal`), AND post-scrubs
  `option_value` / `meta_value` on any returned row whose
  `option_name` / `meta_key` matches the predicate (defence in depth
  against `SELECT *` wildcards on `wp_sitemeta`, `wp_*_meta`, etc.)
- **WpCliAbilities**: blocks `option get|pluck|get-autoload <secret>` and
  `option update|add|set|delete|patch <protected>` *before* binary
  discovery; a `scrub_secret_output()` post-process redacts secrets from
  `option list` output (both structured JSON and raw text formats)

## Tests

38 new PHPUnit cases across four files exercise:

- Every shipped secret name × every gated option-reading function
- Filter-extension of the blocklist at runtime
- Network/site-option arg index (1) vs standard arg index (0)
- SQL literal pre-check (single-quoted, double-quoted, filter-extended)
- SQL row scrub for wildcard `SELECT *` queries that bypass the pre-check
- WP-CLI structured JSON output scrubbing
- WP-CLI raw text output scrubbing (tab/colon separators)
- Negative cases: safe options still read normally, non-`option list`
  WP-CLI commands pass through untouched

Test files:
- `tests/SdAiAgent/Abilities/OptionsAbilitiesTest.php` (new, 9 cases)
- `tests/SdAiAgent/Abilities/WordPressAbilitiesTest.php` (+7 cases)
- `tests/SdAiAgent/Abilities/DatabaseAbilitiesTest.php` (+5 cases)
- `tests/SdAiAgent/Abilities/WpCliAbilitiesTest.php` (+10 cases)

## Documentation

`AGENTS.md` gains a new "Secret-Option Read Blocklist (single source of
truth)" section under the REST API guidelines, naming the predicate and
the rules every new ability/REST/CLI/SQL helper must follow. The existing
REST scrubbing rule is amended to route option-shaped data through the
new predicate rather than inventing parallel scrubbers.

Verification grep proving the rule is loaded by future workers:

```bash
rg -l "is_secret_option_name|SECRET_REDACTED_PLACEHOLDER|sd_ai_agent_option_secret_redacted|sd_ai_agent_options_read_blocklist" includes/ AGENTS.md
# AGENTS.md
# includes/Abilities/OptionsAbilities.php
# includes/Abilities/WordPressAbilities.php
# includes/Abilities/DatabaseAbilities.php
# includes/Abilities/WpCliAbilities.php
```

## Worker self-verification
- PHPUnit: Tests: 3499, Assertions: 14248, Errors: 0, Failures: 0, Skipped: 114, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded (`superdav-ai-agent.zip` archive created)

Verification ran against the full PHPUnit suite (not `--filter`) inside
the `superdav-ai-agent-harden-secret-option-reads` worktree on commit
`19c7762`. The four secret-gate test files together report
`OK (72 tests, 431 assertions)` when run in isolation.

## Resubmission status

Ready for WordPress.org re-review. The three reviewer-flagged surfaces
(get-option, list-options, low-level function caller) and the two
adjacent surfaces with the same root cause (db-query, wp-cli) are all
fixed and tested with shipped + filter-extended secret names.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 1d 23h and 111,419 tokens on this with the user in an interactive session.
