### PR TITLE
security(abilities): enforce WP core caps on all ability permission_callbacks via dual-gate

### DIFF
--- a/.distignore-wporg
+++ b/.distignore-wporg
@@ -63,6 +63,13 @@ includes/Abilities/PluginDownloadAbilities.php
 # unaffected — that file is NOT stripped.
 includes/Abilities/UserManagementAbilities.php
 
+# ── Low-level whitelisted-PHP dispatcher (sd-ai-agent/run-php) ───────────────
+# Disabled by SD_AI_AGENT_FEATURE_RUN_PHP=false at build time and the source
+# file is physically stripped here so WP.org review can verify with a single
+# `unzip -l | grep RunPhpAbility` check that the dispatcher cannot be
+# reintroduced by re-defining the feature flag.
+includes/Abilities/RunPhpAbility.php
+
 # Persistence layer used only by the plugin builder.
 includes/Repositories/GeneratedPluginsRepository.php
 includes/Models/DTO/GeneratedPluginRow.php

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -202,7 +202,7 @@ EXTRA
 	# prevents trivial bypass and gives the WP.org review team a single
 	# grep target to verify compliance.
 	if [ "$variant" = "wporg" ]; then
-		echo "==> [${variant}] Forcing plugin-builder + CLI + plugin-state + URL-install + file-write + scaffold-block-theme + wp-rest + wp-cli dispatcher + benchmark + user-management feature flags to false..."
+		echo "==> [${variant}] Forcing plugin-builder + CLI + plugin-state + URL-install + file-write + scaffold-block-theme + wp-rest + wp-cli dispatcher + benchmark + user-management + run-php feature flags to false..."
 		local main_file="${dest}/superdav-ai-agent.php"
 
 		# The feature flags this build target forces off are:
@@ -214,8 +214,9 @@ EXTRA
 		# SD_AI_AGENT_FEATURE_SCAFFOLD_BLOCK_THEME,
 		# SD_AI_AGENT_FEATURE_WP_REST_DISPATCHER,
 		# SD_AI_AGENT_FEATURE_WP_CLI_DISPATCHER,
-		# SD_AI_AGENT_FEATURE_BENCHMARK, and
-		# SD_AI_AGENT_FEATURE_USER_MANAGEMENT. Each entry is paired with a
+		# SD_AI_AGENT_FEATURE_BENCHMARK,
+		# SD_AI_AGENT_FEATURE_USER_MANAGEMENT, and
+		# SD_AI_AGENT_FEATURE_RUN_PHP. Each entry is paired with a
 		# short rationale that ends up as an inline comment in the bundled
 		# main plugin file (a grep target the WP.org review team can use).
 		local -a flags=(
@@ -229,6 +230,7 @@ EXTRA
 			"SD_AI_AGENT_FEATURE_WP_CLI_DISPATCHER:shell-exec wp-cli dispatcher disabled per WP.org Guideline 4"
 			"SD_AI_AGENT_FEATURE_BENCHMARK:wp-cli benchmark suite with arbitrary --log-dir disabled per WP.org reviewer feedback"
 			"SD_AI_AGENT_FEATURE_USER_MANAGEMENT:custom user creation\/role-change disabled per WP.org plugin review feedback - bypasses security plugins on native register\/login flow"
+			"SD_AI_AGENT_FEATURE_RUN_PHP:low-level whitelisted-PHP dispatcher disabled per WP.org Guideline 4"
 		)
 
 		# Replace each `defined() || define( 'NAME', true )` line with a
@@ -269,6 +271,7 @@ EXTRA
 			"${dest}/includes/Benchmark"
 			"${dest}/includes/CLI/BenchmarkCommand.php"
 			"${dest}/includes/Abilities/UserManagementAbilities.php"
+			"${dest}/includes/Abilities/RunPhpAbility.php"
 		)
 		local p
 		for p in "${stripped_paths[@]}"; do

--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -98,7 +98,8 @@ class BlockAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_markdown_to_blocks' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/markdown-to-blocks' );
 				},
 				'meta'                => [
 					'mcp'         => [ 'public' => true ],
@@ -179,7 +180,8 @@ class BlockAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_list_block_types' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/list-block-types' );
 				},
 			]
 		);
@@ -224,7 +226,8 @@ class BlockAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_get_block_type' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/get-block-type' );
 				},
 			]
 		);
@@ -275,7 +278,8 @@ class BlockAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_list_block_patterns' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/list-block-patterns' );
 				},
 			]
 		);
@@ -313,7 +317,8 @@ class BlockAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_list_block_templates' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/list-block-templates' );
 				},
 			]
 		);
@@ -344,7 +349,8 @@ class BlockAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_create_block_content' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/create-block-content' );
 				},
 				'meta'                => [
 					'mcp'         => [ 'public' => true ],
@@ -399,7 +405,8 @@ class BlockAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_parse_block_content' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/parse-block-content' );
 				},
 			]
 		);
@@ -488,7 +495,8 @@ class BlockAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_validate_block_content' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/validate-block-content' );
 				},
 			]
 		);
@@ -566,7 +574,8 @@ class BlockAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_get_page_blocks' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/get-page-blocks' );
 				},
 				'meta'                => [
 					'mcp'         => [ 'public' => true ],
@@ -635,7 +644,8 @@ class BlockAbilities {
 			],
 			'execute_callback'    => [ __CLASS__, 'handle_get_site_block_usage' ],
 			'permission_callback' => function () {
-				return current_user_can( 'edit_posts' );
+				// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+				return ToolCapabilities::current_user_can( 'sd-ai-agent/get-site-block-usage' );
 			},
 		]
 		);
@@ -752,7 +762,8 @@ class BlockAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_edit_block_tree' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/edit-block-tree' );
 				},
 				'meta'                => [
 					'mcp'         => [ 'public' => true ],
@@ -857,7 +868,8 @@ class BlockAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_update_blocks' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/update-blocks' );
 				},
 				'meta'                => [
 					'mcp'         => [ 'public' => true ],
@@ -926,7 +938,8 @@ class BlockAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_rewrite_post_blocks' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/rewrite-post-blocks' );
 				},
 				'meta'                => [
 					'mcp'         => [ 'public' => true ],
@@ -1013,7 +1026,8 @@ class BlockAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_insert_pattern' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/insert-pattern' );
 				},
 				'meta'                => [
 					'mcp'         => [ 'public' => true ],
@@ -1075,7 +1089,8 @@ class BlockAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_revert_to_revision' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/revert-to-revision' );
 				},
 				'meta'                => [
 					'mcp'         => [ 'public' => true ],
@@ -1167,7 +1182,8 @@ class BlockAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_replace_block_range' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/replace-block-range' );
 				},
 				'meta'                => [
 					'mcp'         => [ 'public' => true ],
@@ -1257,7 +1273,8 @@ class BlockAbilities {
 			],
 			'execute_callback'    => [ __CLASS__, 'handle_scan_storage_modes' ],
 			'permission_callback' => function () {
-				return current_user_can( 'edit_posts' );
+				// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+				return ToolCapabilities::current_user_can( 'sd-ai-agent/scan-storage-modes' );
 			},
 			'meta'                => [
 				'mcp'         => [ 'public' => true ],

--- a/includes/Abilities/ContentAbilities.php
+++ b/includes/Abilities/ContentAbilities.php
@@ -74,7 +74,8 @@ class ContentAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_content_analyze' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/content-analyze' );
 				},
 			]
 		);
@@ -123,7 +124,8 @@ class ContentAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_performance_report' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/content-performance-report' );
 				},
 			]
 		);
@@ -176,7 +178,8 @@ class ContentAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_create_contact_form' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/create-contact-form' );
 				},
 			]
 		);

--- a/includes/Abilities/CustomPostTypeAbilities.php
+++ b/includes/Abilities/CustomPostTypeAbilities.php
@@ -141,7 +141,8 @@ class CustomPostTypeAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_register_post_type' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'manage_options' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/register-post-type' );
 				},
 			]
 		);
@@ -178,7 +179,8 @@ class CustomPostTypeAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_list_post_types' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/list-post-types' );
 				},
 			]
 		);
@@ -216,7 +218,8 @@ class CustomPostTypeAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_delete_post_type' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'manage_options' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/delete-post-type' );
 				},
 			]
 		);

--- a/includes/Abilities/CustomTaxonomyAbilities.php
+++ b/includes/Abilities/CustomTaxonomyAbilities.php
@@ -141,7 +141,8 @@ class CustomTaxonomyAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_register_taxonomy' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'manage_options' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/register-taxonomy' );
 				},
 			]
 		);
@@ -178,7 +179,8 @@ class CustomTaxonomyAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_list_taxonomies' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/list-taxonomies' );
 				},
 			]
 		);
@@ -216,7 +218,8 @@ class CustomTaxonomyAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_delete_taxonomy' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'manage_options' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/delete-taxonomy' );
 				},
 			]
 		);

--- a/includes/Abilities/DesignSystemAbilities.php
+++ b/includes/Abilities/DesignSystemAbilities.php
@@ -67,7 +67,8 @@ class DesignSystemAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_inject_custom_css' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_theme_options' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/inject-custom-css' );
 				},
 				'meta'                => [
 					'mcp'         => [ 'public' => true ],
@@ -132,7 +133,8 @@ class DesignSystemAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_curated_block_patterns' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/curated-block-patterns' );
 				},
 				'meta'                => [
 					'mcp'         => [ 'public' => true ],
@@ -181,7 +183,8 @@ class DesignSystemAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_set_site_logo' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/set-site-logo' );
 				},
 				'meta'                => [
 					'mcp'         => [ 'public' => true ],
@@ -228,7 +231,8 @@ class DesignSystemAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_theme_json_presets' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_theme_options' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/theme-json-presets' );
 				},
 				'meta'                => [
 					'mcp'         => [ 'public' => true ],

--- a/includes/Abilities/EditorialAbilities.php
+++ b/includes/Abilities/EditorialAbilities.php
@@ -94,7 +94,10 @@ class EditorialAbilities {
 					],
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_generate_title' ],
-				'permission_callback' => [ __CLASS__, 'permission_edit_posts' ],
+				'permission_callback' => static function (): bool {
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/generate-title' );
+				},
 				'meta'                => [
 					'mcp'          => [ 'public' => true ],
 					'annotations'  => [
@@ -211,7 +214,10 @@ INSTRUCTION;
 					'description' => __( 'Generated excerpt (plain text, ~55 words).', 'superdav-ai-agent' ),
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_generate_excerpt' ],
-				'permission_callback' => [ __CLASS__, 'permission_edit_posts' ],
+				'permission_callback' => static function (): bool {
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/generate-excerpt' );
+				},
 				'meta'                => [
 					'mcp'          => [ 'public' => true ],
 					'annotations'  => [
@@ -329,7 +335,10 @@ INSTRUCTION;
 					'description' => __( 'Generated summary (plain text).', 'superdav-ai-agent' ),
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_summarize_content' ],
-				'permission_callback' => [ __CLASS__, 'permission_edit_posts' ],
+				'permission_callback' => static function (): bool {
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/summarize-content' );
+				},
 				'meta'                => [
 					'mcp'          => [ 'public' => true ],
 					'annotations'  => [
@@ -472,7 +481,10 @@ INSTRUCTION;
 					],
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_review_block' ],
-				'permission_callback' => [ __CLASS__, 'permission_edit_posts' ],
+				'permission_callback' => static function (): bool {
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/review-block' );
+				},
 				'meta'                => [
 					'mcp'          => [ 'public' => true ],
 					'annotations'  => [

--- a/includes/Abilities/FeedbackAbilities.php
+++ b/includes/Abilities/FeedbackAbilities.php
@@ -76,7 +76,8 @@ class FeedbackAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_report_inability' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/report-inability' );
 				},
 			]
 		);

--- a/includes/Abilities/GenerateLogoSvgAbility.php
+++ b/includes/Abilities/GenerateLogoSvgAbility.php
@@ -176,7 +176,9 @@ class GenerateLogoSvgAbility extends AbstractAbility {
 	 * {@inheritdoc}
 	 */
 	protected function permission_callback( mixed $input = null ): bool {
-		return current_user_can( 'upload_files' );
+		// Dual gate: per-tool cap AND core cap (`upload_files`) from
+		// CORE_CAP_MAP. Both must pass.
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	/**

--- a/includes/Abilities/GenerateMenuPageAbility.php
+++ b/includes/Abilities/GenerateMenuPageAbility.php
@@ -224,7 +224,11 @@ class GenerateMenuPageAbility extends AbstractAbility {
 	 * @return bool True if the current user can publish_pages.
 	 */
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'publish_pages' );
+		// Dual gate: per-tool cap AND the core cap from CORE_CAP_MAP
+		// (`edit_theme_options`). Adds defence-in-depth so a misconfigured
+		// role-management plugin granting `sd_ai_agent_tool_generate_menu_page`
+		// cannot bypass the theme-options gate.
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {

--- a/includes/Abilities/GlobalStylesAbilities.php
+++ b/includes/Abilities/GlobalStylesAbilities.php
@@ -66,7 +66,8 @@ class GlobalStylesAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_get_global_styles' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_theme_options' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/get-global-styles' );
 				},
 			]
 		);
@@ -114,7 +115,8 @@ class GlobalStylesAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_update_global_styles' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_theme_options' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/update-global-styles' );
 				},
 			]
 		);
@@ -153,7 +155,8 @@ class GlobalStylesAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_get_theme_json' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_theme_options' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/get-theme-json' );
 				},
 			]
 		);
@@ -192,7 +195,8 @@ class GlobalStylesAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_reset_global_styles' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_theme_options' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/reset-global-styles' );
 				},
 			]
 		);

--- a/includes/Abilities/GscAbilities.php
+++ b/includes/Abilities/GscAbilities.php
@@ -99,7 +99,8 @@ class GscAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_top_queries' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/gsc-top-queries' );
 				},
 			]
 		);
@@ -155,7 +156,8 @@ class GscAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_page_performance' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/gsc-page-performance' );
 				},
 			]
 		);
@@ -199,7 +201,8 @@ class GscAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_query_details' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/gsc-query-details' );
 				},
 			]
 		);
@@ -243,7 +246,8 @@ class GscAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_site_summary' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/gsc-site-summary' );
 				},
 			]
 		);

--- a/includes/Abilities/ImageAbilities.php
+++ b/includes/Abilities/ImageAbilities.php
@@ -98,7 +98,10 @@ class ImageAbilities {
 					],
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_generate_alt_text' ],
-				'permission_callback' => [ __CLASS__, 'permission_upload_files' ],
+				'permission_callback' => static function (): bool {
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/generate-alt-text' );
+				},
 				'meta'                => [
 					'mcp'          => [ 'public' => true ],
 					'annotations'  => [
@@ -226,7 +229,10 @@ INSTRUCTION;
 					'description' => __( 'The image generation prompt.', 'superdav-ai-agent' ),
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_generate_image_prompt' ],
-				'permission_callback' => [ __CLASS__, 'permission_edit_posts' ],
+				'permission_callback' => static function (): bool {
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/generate-image-prompt' );
+				},
 				'meta'                => [
 					'mcp'          => [ 'public' => true ],
 					'annotations'  => [
@@ -422,7 +428,10 @@ INSTRUCTION;
 					],
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_import_base64_image' ],
-				'permission_callback' => [ __CLASS__, 'permission_upload_files' ],
+				'permission_callback' => static function (): bool {
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/import-base64-image' );
+				},
 				'meta'                => [
 					'mcp'          => [ 'public' => true ],
 					'annotations'  => [

--- a/includes/Abilities/ImageAbilities/GenerateImageAbility.php
+++ b/includes/Abilities/ImageAbilities/GenerateImageAbility.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Abilities\ImageAbilities;
 
+use SdAiAgent\Abilities\ToolCapabilities;
 use SdAiAgent\Core\Net\SafeHttpClient;
 use WP_Error;
 
@@ -160,12 +161,19 @@ class GenerateImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 
 	/**
 	 * {@inheritdoc}
+	 *
+	 * Dual gate: routed through {@see ToolCapabilities::current_user_can()},
+	 * which checks the per-tool capability (`sd_ai_agent_tool_generate_image`)
+	 * AND the core capability (`upload_files`) listed in
+	 * `ToolCapabilities::CORE_CAP_MAP`. On multisite with an explicit
+	 * `site_url`, the check is performed in the context of the target blog
+	 * so the same dual-gate applies to subsite uploads.
 	 */
 	protected function permission_callback( mixed $input = null ): bool {
 		$site_url = is_array( $input ) ? (string) ( $input['site_url'] ?? '' ) : '';
 
 		if ( '' === $site_url || ! is_multisite() ) {
-			return current_user_can( 'upload_files' );
+			return ToolCapabilities::current_user_can( 'sd-ai-agent/generate-image' );
 		}
 
 		$blog_id = get_blog_id_from_url(
@@ -178,11 +186,11 @@ class GenerateImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 		}
 
 		if ( (int) $blog_id === get_current_blog_id() ) {
-			return current_user_can( 'upload_files' );
+			return ToolCapabilities::current_user_can( 'sd-ai-agent/generate-image' );
 		}
 
 		switch_to_blog( $blog_id );
-		$allowed = current_user_can( 'upload_files' );
+		$allowed = ToolCapabilities::current_user_can( 'sd-ai-agent/generate-image' );
 		restore_current_blog();
 
 		return $allowed;

--- a/includes/Abilities/ImageAbilities/StockImageAbility.php
+++ b/includes/Abilities/ImageAbilities/StockImageAbility.php
@@ -19,6 +19,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Abilities\ImageAbilities;
 
 use SdAiAgent\Abilities\ImageSources\ImageSourceFactory;
+use SdAiAgent\Abilities\ToolCapabilities;
 use WP_Error;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -171,10 +172,14 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 	 * {@inheritdoc}
 	 */
 	protected function permission_callback( mixed $input = null ): bool {
+		// Dual gate: per-tool cap (sd_ai_agent_tool_stock_image) AND core cap
+		// (`upload_files`) from CORE_CAP_MAP. On multisite with an explicit
+		// `site_url`, the check is performed in the target blog's context so
+		// the dual-gate applies to subsite uploads too.
 		$site_url = is_array( $input ) ? (string) ( $input['site_url'] ?? '' ) : '';
 
 		if ( '' === $site_url || ! is_multisite() ) {
-			return current_user_can( 'upload_files' );
+			return ToolCapabilities::current_user_can( 'sd-ai-agent/stock-image' );
 		}
 
 		$blog_id = get_blog_id_from_url(
@@ -187,11 +192,11 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 		}
 
 		if ( (int) $blog_id === get_current_blog_id() ) {
-			return current_user_can( 'upload_files' );
+			return ToolCapabilities::current_user_can( 'sd-ai-agent/stock-image' );
 		}
 
 		switch_to_blog( $blog_id );
-		$allowed = current_user_can( 'upload_files' );
+		$allowed = ToolCapabilities::current_user_can( 'sd-ai-agent/stock-image' );
 		restore_current_blog();
 
 		return $allowed;

--- a/includes/Abilities/InternetSearchAbilities.php
+++ b/includes/Abilities/InternetSearchAbilities.php
@@ -150,7 +150,10 @@ class InternetSearchAbilities {
 					],
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_search' ],
-				'permission_callback' => [ __CLASS__, 'check_permission' ],
+				'permission_callback' => static function (): bool {
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/internet-search' );
+				},
 			]
 		);
 
@@ -209,7 +212,10 @@ class InternetSearchAbilities {
 					],
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_configure_provider' ],
-				'permission_callback' => [ __CLASS__, 'check_admin_permission' ],
+				'permission_callback' => static function (): bool {
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/configure-search-provider' );
+				},
 			]
 		);
 	}

--- a/includes/Abilities/KnowledgeAbilities.php
+++ b/includes/Abilities/KnowledgeAbilities.php
@@ -65,7 +65,9 @@ class KnowledgeAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_knowledge_search' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' ); },
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/knowledge-search' );
+				},
 			]
 		);
 	}

--- a/includes/Abilities/MarketingAbilities.php
+++ b/includes/Abilities/MarketingAbilities.php
@@ -65,7 +65,8 @@ class MarketingAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_fetch_url' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/fetch-url' );
 				},
 			]
 		);
@@ -107,7 +108,8 @@ class MarketingAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_analyze_headers' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/analyze-headers' );
 				},
 			]
 		);

--- a/includes/Abilities/MediaAbilities.php
+++ b/includes/Abilities/MediaAbilities.php
@@ -78,7 +78,8 @@ class MediaAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_list_media' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'upload_files' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/list-media' );
 				},
 			]
 		);
@@ -143,7 +144,8 @@ class MediaAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_upload_media_from_url' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'upload_files' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/upload-media-from-url' );
 				},
 			]
 		);
@@ -186,7 +188,8 @@ class MediaAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_delete_media' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'delete_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/delete-media' );
 				},
 			]
 		);

--- a/includes/Abilities/MemoryAbilities.php
+++ b/includes/Abilities/MemoryAbilities.php
@@ -66,7 +66,9 @@ class MemoryAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_memory_save' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' ); },
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/memory-save' );
+				},
 			]
 		);
 
@@ -97,7 +99,9 @@ class MemoryAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_memory_list' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' ); },
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/memory-list' );
+				},
 			]
 		);
 
@@ -135,7 +139,9 @@ class MemoryAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_memory_delete' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' ); },
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/memory-delete' );
+				},
 			]
 		);
 	}

--- a/includes/Abilities/MenuAbilities.php
+++ b/includes/Abilities/MenuAbilities.php
@@ -56,7 +56,8 @@ class MenuAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_list_menus' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'edit_theme_options' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/list-menus' );
 				},
 			]
 		);
@@ -101,7 +102,8 @@ class MenuAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_get_menu' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'edit_theme_options' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/get-menu' );
 				},
 			]
 		);
@@ -170,7 +172,8 @@ class MenuAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_create_menu' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'edit_theme_options' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/create-menu' );
 				},
 			]
 		);
@@ -213,7 +216,8 @@ class MenuAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_delete_menu' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'edit_theme_options' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/delete-menu' );
 				},
 			]
 		);
@@ -298,7 +302,8 @@ class MenuAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_add_menu_item' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'edit_theme_options' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/add-menu-item' );
 				},
 			]
 		);
@@ -337,7 +342,8 @@ class MenuAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_remove_menu_item' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'edit_theme_options' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/remove-menu-item' );
 				},
 			]
 		);
@@ -385,7 +391,8 @@ class MenuAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_assign_menu_location' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'edit_theme_options' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/assign-menu-location' );
 				},
 			]
 		);

--- a/includes/Abilities/PluginDownloadAbilities.php
+++ b/includes/Abilities/PluginDownloadAbilities.php
@@ -162,7 +162,8 @@ class ListModifiedPluginsAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'manage_options' );
+		// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {
@@ -275,7 +276,8 @@ class GetPluginDownloadUrlAbility extends AbstractAbility {
 	}
 
 	protected function permission_callback( $input ): bool {
-		return current_user_can( 'manage_options' );
+		// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+		return ToolCapabilities::current_user_can( $this->name );
 	}
 
 	protected function meta(): array {

--- a/includes/Abilities/PostAbilities.php
+++ b/includes/Abilities/PostAbilities.php
@@ -102,7 +102,8 @@ class PostAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_get_post' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/get-post' );
 				},
 			]
 		);
@@ -187,7 +188,8 @@ class PostAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_create_post' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/create-post' );
 				},
 			]
 		);
@@ -280,7 +282,8 @@ class PostAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_update_post' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/update-post' );
 				},
 			]
 		);
@@ -336,7 +339,8 @@ class PostAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_append_post_content' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/append-post-content' );
 				},
 			]
 		);
@@ -500,7 +504,8 @@ class PostAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_list_posts' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/list-posts' );
 				},
 			]
 		);
@@ -606,7 +611,8 @@ class PostAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_batch_create_posts' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/batch-create-posts' );
 				},
 			]
 		);
@@ -654,7 +660,8 @@ class PostAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_delete_post' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'delete_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/delete-post' );
 				},
 			]
 		);
@@ -701,7 +708,8 @@ class PostAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_set_featured_image' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/set-featured-image' );
 				},
 			]
 		);

--- a/includes/Abilities/RunPhpAbility.php
+++ b/includes/Abilities/RunPhpAbility.php
@@ -1,0 +1,370 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Low-level whitelisted WordPress-function dispatcher.
+ *
+ * This file is physically removed from the WordPress.org distribution build
+ * (`bin/build.sh --target=wporg`) and the corresponding
+ * `SD_AI_AGENT_FEATURE_RUN_PHP` constant is forced to `false` so the gated
+ * registration in `WordPressAbilities::register_abilities()` becomes a no-op
+ * and the class is never autoloaded. Both belt-and-braces guards exist
+ * because WP.org Guideline 4 prohibits plugins that allow arbitrary script
+ * insertion or low-level PHP dispatch — even when guarded by an allowlist.
+ *
+ * The full-feature GitHub release build retains this file because it is the
+ * documented low-level fallback for self-hosted users when no purpose-built
+ * ability matches a task.
+ *
+ * @package SdAiAgent
+ * @since 1.1.0
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Abilities;
+
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Call a whitelisted WordPress function by name with arguments.
+ *
+ * Replaces the former eval-based dispatcher with a safe, whitelisted
+ * approach that only allows calling pre-approved WordPress functions via
+ * `call_user_func_array()`. Execution is gated by
+ * `ToolCapabilities::current_user_can()`, which enforces both the
+ * per-tool capability (`sd_ai_agent_tool_run_php`) and the
+ * `CORE_CAP_MAP` entry for `sd-ai-agent/run-php` — the strictest gate
+ * in the plugin (`manage_options` + `update_core` + `unfiltered_html`)
+ * so even a misconfigured role-management plugin cannot lower the bar.
+ *
+ * @since 1.1.0
+ */
+class RunPhpAbility extends AbstractAbility {
+
+	/**
+	 * Option-reading functions whose first argument is an option/transient
+	 * name. Any call into these functions is gated against the secret
+	 * read blocklist defined in {@see OptionsAbilities::get_secret_read_blocklist()}
+	 * so a caller cannot bypass {@see GetOptionAbility} via this low-level
+	 * function caller.
+	 *
+	 * Transient names share the auth-key/salt naming space when stored as
+	 * options ({@see WP_Object_Cache}); gating them here is defence-in-depth.
+	 *
+	 * @var string[]
+	 */
+	private const OPTION_READ_FUNCTIONS = [
+		'get_option',
+		'get_site_option',
+		'get_network_option',
+		'get_transient',
+		'get_site_transient',
+	];
+
+	/**
+	 * Option-mutating functions whose first argument is an option name.
+	 * Calls are gated against {@see OptionsAbilities::get_write_blocklist()}
+	 * so the agent cannot regenerate auth keys/salts (which would log out
+	 * every user) by routing around {@see UpdateOptionAbility}.
+	 *
+	 * @var string[]
+	 */
+	private const OPTION_WRITE_FUNCTIONS = [
+		'update_option',
+		'delete_option',
+		'update_site_option',
+		'delete_site_option',
+		'update_network_option',
+		'delete_network_option',
+	];
+
+	/**
+	 * Allowed WordPress functions that the AI agent may call.
+	 *
+	 * Only side-effect-free read functions and common write functions with
+	 * well-understood behaviour are included. Extend via the
+	 * `sd_ai_agent_allowed_wp_functions` filter.
+	 *
+	 * @var string[]
+	 */
+	private const ALLOWED_FUNCTIONS = [
+		// Options.
+		'get_option',
+		'update_option',
+		'delete_option',
+		// Posts / Pages.
+		'get_post',
+		'get_posts',
+		'wp_insert_post',
+		'wp_update_post',
+		'wp_delete_post',
+		'get_post_meta',
+		'update_post_meta',
+		'delete_post_meta',
+		// Terms / Taxonomies.
+		'get_terms',
+		'get_term',
+		'wp_insert_term',
+		'wp_update_term',
+		'wp_delete_term',
+		'wp_set_post_terms',
+		'wp_get_post_terms',
+		// Users.
+		'get_user_by',
+		'get_users',
+		'get_current_user_id',
+		'get_user_meta',
+		'update_user_meta',
+		// Comments.
+		'get_comments',
+		'get_comment',
+		'wp_insert_comment',
+		'wp_update_comment',
+		'wp_delete_comment',
+		// Queries.
+		'wp_count_posts',
+		'wp_count_terms',
+		'count_users',
+		// Transients.
+		'get_transient',
+		'set_transient',
+		'delete_transient',
+		// Site info.
+		'get_bloginfo',
+		'home_url',
+		'site_url',
+		'admin_url',
+		'wp_upload_dir',
+		'is_multisite',
+		// Plugins / Themes.
+		'get_plugins',
+		'is_plugin_active',
+		'wp_get_theme',
+		'wp_get_themes',
+		// Shortcodes.
+		'do_shortcode',
+		'shortcode_exists',
+		// Menus.
+		'wp_get_nav_menus',
+		'wp_get_nav_menu_items',
+		// Misc.
+		'wp_remote_get',
+		'wp_remote_post',
+		'current_time',
+		'wp_date',
+		'wp_create_nonce',
+	];
+
+	protected function label(): string {
+		return __( 'Call WordPress Function', 'superdav-ai-agent' );
+	}
+
+	protected function description(): string {
+		return __( 'Low-level fallback: call a whitelisted WordPress function directly. Use ONLY when no dedicated ability exists for the task. For posts (use `sd-ai-agent/create-post`), users, options, plugins, themes, and other common operations, call `sd-ai-agent/ability-search` first to find a purpose-built tool — dedicated abilities have typed schemas and better error recovery than guessing positional args here. When you do use this, pass the function name via `function` and an ordered array via `args`.', 'superdav-ai-agent' );
+	}
+
+	protected function input_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'function' => [
+					'type'        => 'string',
+					'description' => 'The WordPress function name to call, e.g. "get_option", "wp_insert_post".',
+				],
+				'args'     => [
+					'type'        => 'array',
+					'description' => 'Ordered array of arguments to pass to the function. Defaults to an empty array.',
+					'items'       => array(
+						'type' => array( 'string', 'number', 'integer', 'boolean', 'array', 'object', 'null' ),
+					),
+				],
+			],
+			'required'   => [ 'function' ],
+		];
+	}
+
+	protected function output_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'result' => [
+					'type'        => [ 'string', 'number', 'integer', 'boolean', 'array', 'object', 'null' ],
+					'description' => 'The function return value. Type varies by function.',
+				],
+				'output' => [ 'type' => 'string' ],
+			],
+		];
+	}
+
+	protected function execute_callback( $input ) {
+		/** @var array<string, mixed> $input */
+		$function = $input['function'] ?? '';
+		$args     = $input['args'] ?? [];
+
+		if ( empty( $function ) || ! is_string( $function ) ) {
+			return new WP_Error(
+				'sd_ai_agent_empty_function',
+				__( 'A function name is required.', 'superdav-ai-agent' )
+			);
+		}
+
+		if ( ! is_array( $args ) ) {
+			return new WP_Error(
+				'sd_ai_agent_invalid_args',
+				__( 'The "args" parameter must be an array.', 'superdav-ai-agent' )
+			);
+		}
+
+		// Build the runtime allowlist (static defaults + user extensions).
+		$allowed = self::get_allowed_functions();
+
+		if ( ! in_array( $function, $allowed, true ) ) {
+			return new WP_Error(
+				'sd_ai_agent_disallowed_function',
+				sprintf(
+					/* translators: %s: function name */
+					__( 'The function "%s" is not in the allowed list. Use the sd_ai_agent_allowed_wp_functions filter to extend it.', 'superdav-ai-agent' ),
+					$function
+				)
+			);
+		}
+
+		// Secret-aware gating: option reads/writes against the auth-key
+		// blocklist. Applied AFTER the function allowlist check so any
+		// extension via `sd_ai_agent_allowed_wp_functions` is still
+		// constrained. Network/site variants of get_option take the option
+		// name in arg position 1 (network ID is arg 0); standard variants
+		// take it in arg 0. Both shapes are covered below.
+		$secret_check = self::check_secret_option_call( $function, $args );
+		if ( is_wp_error( $secret_check ) ) {
+			return $secret_check;
+		}
+
+		if ( ! function_exists( $function ) ) {
+			return new WP_Error(
+				'sd_ai_agent_undefined_function',
+				sprintf(
+					/* translators: %s: function name */
+					__( 'The function "%s" does not exist in this WordPress environment.', 'superdav-ai-agent' ),
+					$function
+				)
+			);
+		}
+
+		ob_start();
+		$error  = null;
+		$result = null;
+
+		try {
+			$result = call_user_func_array( $function, array_values( $args ) );
+		} catch ( \Throwable $e ) {
+			$error = $e->getMessage();
+		}
+
+		$output = ob_get_clean();
+
+		if ( null !== $error ) {
+			return new WP_Error(
+				'sd_ai_agent_php_error',
+				sprintf( 'PHP error: %s', $error )
+			);
+		}
+
+		return [
+			'result' => $result,
+			'output' => $output,
+		];
+	}
+
+	/**
+	 * Get the full list of allowed functions (built-in + filtered).
+	 *
+	 * @return string[]
+	 */
+	private static function get_allowed_functions(): array {
+		/**
+		 * Filters the list of WordPress functions the AI agent is allowed to call.
+		 *
+		 * @since 1.1.0
+		 *
+		 * @param string[] $functions List of allowed function names.
+		 */
+		$functions = apply_filters( 'sd_ai_agent_allowed_wp_functions', self::ALLOWED_FUNCTIONS );
+
+		// Ensure the list is a flat array of strings (defensive).
+		return array_values( array_filter( (array) $functions, 'is_string' ) );
+	}
+
+	/**
+	 * Gate option-reading / option-writing function calls against the
+	 * secret read blocklist and the existing write blocklist.
+	 *
+	 * Without this check, the AI could bypass {@see GetOptionAbility}'s
+	 * secret-read gate (and {@see UpdateOptionAbility}'s write gate) by
+	 * calling `get_option('auth_key')` (or `update_option('auth_key', ...)`)
+	 * through this low-level function caller.
+	 *
+	 * Returns null when the call is allowed, a WP_Error when blocked.
+	 *
+	 * @param string       $function_name The PHP function name about to be called.
+	 * @param array<mixed> $args          Positional arguments that will be passed.
+	 * @return \WP_Error|null
+	 */
+	private static function check_secret_option_call( string $function_name, array $args ): ?\WP_Error {
+		// Network/site option variants accept (int $network_id, string $option, ...);
+		// standard variants accept (string $option, ...). Pick the right arg index.
+		$is_network_variant = in_array(
+			$function_name,
+			[ 'get_network_option', 'update_network_option', 'delete_network_option' ],
+			true
+		);
+		$name_index         = $is_network_variant ? 1 : 0;
+
+		if ( ! isset( $args[ $name_index ] ) || ! is_string( $args[ $name_index ] ) ) {
+			return null;
+		}
+
+		$option_name = $args[ $name_index ];
+
+		if ( in_array( $function_name, self::OPTION_READ_FUNCTIONS, true )
+			&& OptionsAbilities::is_secret_option_name( $option_name ) ) {
+			return OptionsAbilities::secret_read_error( $option_name );
+		}
+
+		if ( in_array( $function_name, self::OPTION_WRITE_FUNCTIONS, true )
+			&& in_array( $option_name, OptionsAbilities::get_write_blocklist(), true ) ) {
+			return new \WP_Error(
+				'sd_ai_agent_option_blocked',
+				sprintf(
+					/* translators: 1: function name, 2: option name */
+					__( 'The function "%1$s" cannot be used to modify the protected option "%2$s".', 'superdav-ai-agent' ),
+					$function_name,
+					$option_name
+				),
+				[ 'status' => 403 ]
+			);
+		}
+
+		return null;
+	}
+
+	protected function permission_callback( $input ): bool {
+		return ToolCapabilities::current_user_can( $this->name );
+	}
+
+	protected function meta(): array {
+		return [
+			'mcp'          => [ 'public' => true ],
+			'annotations'  => [
+				'readonly'    => false,
+				'destructive' => true,
+				'idempotent'  => false,
+			],
+			'show_in_rest' => true,
+		];
+	}
+}

--- a/includes/Abilities/SeoAbilities.php
+++ b/includes/Abilities/SeoAbilities.php
@@ -79,7 +79,8 @@ class SeoAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_audit_url' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/seo-audit-url' );
 				},
 			]
 		);
@@ -143,7 +144,8 @@ class SeoAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_analyze_content' ],
 				'permission_callback' => function () {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/seo-analyze-content' );
 				},
 			]
 		);

--- a/includes/Abilities/SkillAbilities.php
+++ b/includes/Abilities/SkillAbilities.php
@@ -63,7 +63,9 @@ class SkillAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_skill_load' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' ); },
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/skill-load' );
+				},
 			]
 		);
 
@@ -94,7 +96,9 @@ class SkillAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_skill_list' ],
 				'permission_callback' => function () {
-					return current_user_can( 'manage_options' ); },
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/skill-list' );
+				},
 			]
 		);
 	}

--- a/includes/Abilities/TaxonomyAbilities.php
+++ b/includes/Abilities/TaxonomyAbilities.php
@@ -127,7 +127,8 @@ class TaxonomyAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_list_terms' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/list-terms' );
 				},
 			]
 		);

--- a/includes/Abilities/ToolCapabilities.php
+++ b/includes/Abilities/ToolCapabilities.php
@@ -4,17 +4,34 @@ declare(strict_types=1);
 /**
  * Per-tool WordPress capability checks for Superdav AI Agent abilities.
  *
- * Provides granular capability checks so each ability can be granted
- * independently via user roles. Capability names follow the pattern
- * `sd_ai_agent_tool_{name}` where `{name}` is derived from the ability ID
- * (e.g. `sd-ai-agent/memory-save` → `sd_ai_agent_tool_memory_save`).
+ * Provides a dual-gate capability check so each ability can be granted
+ * independently via user roles AND is always anchored to a matching
+ * WordPress core capability. Without the core-cap anchor, a misconfigured
+ * role-management plugin (Members, User Role Editor, etc.) that grants the
+ * per-tool capability to a low-privilege role could otherwise bypass the
+ * underlying core gate (`delete_plugins`, `promote_users`, `upload_files`,
+ * etc.).
  *
- * Fallback: if the capability has not been granted to any role, the check
- * falls back to `manage_options` (admin only) so the default behaviour is
- * unchanged until an administrator explicitly delegates a capability.
+ * Resolution order in `current_user_can()`:
  *
- * Filter: `sd_ai_agent_tool_capability` allows overriding the resolved
- * capability name per tool.
+ *   1. Per-tool capability layer.
+ *      Capability names follow the pattern `sd_ai_agent_tool_{name}` where
+ *      `{name}` is derived from the ability ID
+ *      (`sd-ai-agent/memory-save` → `sd_ai_agent_tool_memory_save`).
+ *      If the resolved cap is granted to any role, the current user must
+ *      have it. If it is not granted to any role, the check falls back to
+ *      `manage_options` so the default is admin-only.
+ *
+ *   2. Core-cap layer.
+ *      The {@see CORE_CAP_MAP} entry for the ability ID lists one or more
+ *      WordPress core capabilities the current user MUST also hold. The
+ *      list is filterable via `sd_ai_agent_tool_required_core_cap`.
+ *      Abilities listed in {@see CORE_CAP_OPTOUT} explicitly opt out (used
+ *      for low-risk read-only public-data abilities such as the
+ *      `report-inability` feedback channel).
+ *
+ * Final result is the AND of both layers. Either layer denying access is
+ * sufficient to deny the ability execution.
  *
  * @package SdAiAgent
  * @license GPL-2.0-or-later
@@ -29,7 +46,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * ToolCapabilities
  *
- * Static helper that resolves and checks per-tool WordPress capabilities.
+ * Static helper that resolves and checks per-tool WordPress capabilities,
+ * anchored to matching WordPress core capabilities for defence-in-depth.
  */
 class ToolCapabilities {
 
@@ -38,6 +56,234 @@ class ToolCapabilities {
 	 * granted to any role.
 	 */
 	public const FALLBACK_CAP = 'manage_options';
+
+	/**
+	 * Map of ability ID → required WordPress core capability (or list of
+	 * capabilities — all must be held).
+	 *
+	 * Every privileged ability MUST appear here so that even if the
+	 * per-tool capability layer is misconfigured by a role-management
+	 * plugin, the underlying core gate still applies. Abilities that are
+	 * intentionally public-data / low-risk read-only MUST appear in
+	 * {@see CORE_CAP_OPTOUT} instead — silence is not opt-out.
+	 *
+	 * The list is filterable per-ability via the
+	 * `sd_ai_agent_tool_required_core_cap` filter.
+	 *
+	 * @var array<string, string|string[]>
+	 */
+	public const CORE_CAP_MAP = [
+		// ─── Options (admin-only) ───────────────────────────────────────────
+		'sd-ai-agent/get-option'                 => 'manage_options',
+		'sd-ai-agent/update-option'              => 'manage_options',
+		'sd-ai-agent/delete-option'              => 'manage_options',
+		'sd-ai-agent/list-options'               => 'manage_options',
+
+		// ─── Users ──────────────────────────────────────────────────────────
+		'sd-ai-agent/list-users'                 => 'list_users',
+		// Both caps required: create_users gates user creation; promote_users
+		// gates the role assignment that always accompanies a create-user call.
+		// Mirrors the explicit pair enforced inside
+		// UserManagementAbilities::can_create_user().
+		'sd-ai-agent/create-user'                => [ 'create_users', 'promote_users' ],
+		// Both caps required: promote_users is core's role-change gate;
+		// edit_users gates modifying another user. Mirrors the explicit pair
+		// enforced inside UserManagementAbilities::can_update_user_role().
+		'sd-ai-agent/update-user-role'           => [ 'promote_users', 'edit_users' ],
+
+		// ─── Plugins ────────────────────────────────────────────────────────
+		'sd-ai-agent/get-plugins'                => 'activate_plugins',
+		'sd-ai-agent/recommend-plugin'           => 'activate_plugins',
+		'sd-ai-agent/search-plugin-directory'    => 'install_plugins',
+		'sd-ai-agent/list-plugin-updates'        => 'update_plugins',
+		'sd-ai-agent/install-plugin'             => 'install_plugins',
+		'sd-ai-agent/install-plugin-from-url'    => 'install_plugins',
+		'sd-ai-agent/update-plugin'              => 'update_plugins',
+		'sd-ai-agent/activate-plugin'            => 'activate_plugins',
+		'sd-ai-agent/deactivate-plugin'          => 'activate_plugins',
+		'sd-ai-agent/switch-plugin'              => 'activate_plugins',
+		'sd-ai-agent/delete-plugin'              => 'delete_plugins',
+		'sd-ai-agent/list-modified-plugins'      => 'activate_plugins',
+		'sd-ai-agent/get-plugin-download-url'    => 'activate_plugins',
+		'sd-ai-agent/generate-plugin'            => 'install_plugins',
+		'sd-ai-agent/sandbox-test-plugin'        => 'install_plugins',
+		'sd-ai-agent/sandbox-activate-plugin'    => 'install_plugins',
+		'sd-ai-agent/update-plugin-sandboxed'    => 'update_plugins',
+		'sd-ai-agent/scan-plugin-hooks'          => 'install_plugins',
+		'sd-ai-agent/scan-theme-hooks'           => 'install_plugins',
+
+		// ─── Themes / Global styles / Design ────────────────────────────────
+		'sd-ai-agent/get-themes'                 => 'edit_theme_options',
+		'sd-ai-agent/activate-theme'             => 'switch_themes',
+		'sd-ai-agent/get-global-styles'          => 'edit_theme_options',
+		'sd-ai-agent/update-global-styles'       => 'edit_theme_options',
+		'sd-ai-agent/get-theme-json'             => 'edit_theme_options',
+		'sd-ai-agent/reset-global-styles'        => 'edit_theme_options',
+		'sd-ai-agent/inject-custom-css'          => 'edit_theme_options',
+		'sd-ai-agent/curated-block-patterns'     => 'edit_theme_options',
+		'sd-ai-agent/theme-json-presets'         => 'edit_theme_options',
+		'sd-ai-agent/set-site-logo'              => 'edit_theme_options',
+		'sd-ai-agent/scaffold-block-theme'       => 'edit_themes',
+		'sd-ai-agent/render-design-previews'     => 'edit_theme_options',
+		'sd-ai-agent/validate-palette-contrast'  => 'edit_theme_options',
+		'sd-ai-agent/generate-logo-svg'          => 'upload_files',
+
+		// ─── Menus ──────────────────────────────────────────────────────────
+		'sd-ai-agent/list-menus'                 => 'edit_theme_options',
+		'sd-ai-agent/get-menu'                   => 'edit_theme_options',
+		'sd-ai-agent/create-menu'                => 'edit_theme_options',
+		'sd-ai-agent/delete-menu'                => 'edit_theme_options',
+		'sd-ai-agent/add-menu-item'              => 'edit_theme_options',
+		'sd-ai-agent/remove-menu-item'           => 'edit_theme_options',
+		'sd-ai-agent/assign-menu-location'       => 'edit_theme_options',
+		'sd-ai-agent/generate-menu-page'         => 'edit_theme_options',
+
+		// ─── Posts ──────────────────────────────────────────────────────────
+		'sd-ai-agent/get-post'                   => 'edit_posts',
+		'sd-ai-agent/list-posts'                 => 'edit_posts',
+		'sd-ai-agent/create-post'                => 'edit_posts',
+		'sd-ai-agent/update-post'                => 'edit_posts',
+		'sd-ai-agent/append-post-content'        => 'edit_posts',
+		'sd-ai-agent/batch-create-posts'         => 'edit_posts',
+		'sd-ai-agent/delete-post'                => 'delete_posts',
+		'sd-ai-agent/set-featured-image'         => 'edit_posts',
+		'sd-ai-agent/revert-to-revision'         => 'edit_posts',
+		'sd-ai-agent/generate-title'             => 'edit_posts',
+		'sd-ai-agent/generate-excerpt'           => 'edit_posts',
+		'sd-ai-agent/summarize-content'          => 'edit_posts',
+		'sd-ai-agent/review-block'               => 'edit_posts',
+		'sd-ai-agent/generate-alt-text'          => 'edit_posts',
+		'sd-ai-agent/generate-image-prompt'      => 'edit_posts',
+		'sd-ai-agent/create-contact-form'        => 'edit_posts',
+
+		// ─── Blocks ─────────────────────────────────────────────────────────
+		'sd-ai-agent/markdown-to-blocks'         => 'edit_posts',
+		'sd-ai-agent/parse-block-content'        => 'edit_posts',
+		'sd-ai-agent/validate-block-content'     => 'edit_posts',
+		'sd-ai-agent/list-block-types'           => 'edit_posts',
+		'sd-ai-agent/get-block-type'             => 'edit_posts',
+		'sd-ai-agent/list-block-patterns'        => 'edit_posts',
+		'sd-ai-agent/list-block-templates'       => 'edit_posts',
+		'sd-ai-agent/create-block-content'       => 'edit_posts',
+		'sd-ai-agent/get-page-blocks'            => 'edit_posts',
+		'sd-ai-agent/get-site-block-usage'       => 'edit_posts',
+		'sd-ai-agent/edit-block-tree'            => 'edit_posts',
+		'sd-ai-agent/update-blocks'              => 'edit_posts',
+		'sd-ai-agent/rewrite-post-blocks'        => 'edit_posts',
+		'sd-ai-agent/insert-pattern'             => 'edit_posts',
+		'sd-ai-agent/replace-block-range'        => 'edit_posts',
+		'sd-ai-agent/scan-storage-modes'         => 'edit_posts',
+
+		// ─── Media / Image generation ───────────────────────────────────────
+		'sd-ai-agent/list-media'                 => 'upload_files',
+		'sd-ai-agent/upload-media'               => 'upload_files',
+		'sd-ai-agent/upload-media-from-url'      => 'upload_files',
+		'sd-ai-agent/delete-media'               => 'upload_files',
+		'sd-ai-agent/import-base64-image'        => 'upload_files',
+		'sd-ai-agent/generate-image'             => 'upload_files',
+		'sd-ai-agent/stock-image'                => 'upload_files',
+
+		// ─── Taxonomies / Custom types ──────────────────────────────────────
+		'sd-ai-agent/list-terms'                 => 'manage_categories',
+		'sd-ai-agent/list-taxonomies'            => 'manage_options',
+		'sd-ai-agent/register-taxonomy'          => 'manage_options',
+		'sd-ai-agent/delete-taxonomy'            => 'manage_options',
+		'sd-ai-agent/list-post-types'            => 'manage_options',
+		'sd-ai-agent/register-post-type'         => 'manage_options',
+		'sd-ai-agent/delete-post-type'           => 'manage_options',
+
+		// ─── Files (read = admin; write gated separately by FILE_WRITE) ─────
+		'sd-ai-agent/file-read'                  => 'manage_options',
+		'sd-ai-agent/file-list'                  => 'manage_options',
+		'sd-ai-agent/file-search'                => 'manage_options',
+		'sd-ai-agent/content-search'             => 'manage_options',
+		'sd-ai-agent/file-write'                 => [ 'manage_options', 'edit_files' ],
+		'sd-ai-agent/file-edit'                  => [ 'manage_options', 'edit_files' ],
+		'sd-ai-agent/file-delete'                => [ 'manage_options', 'edit_files' ],
+
+		// ─── Git (snapshot/diff = admin; restore = admin + edit_files) ──────
+		'sd-ai-agent/git-list'                   => 'manage_options',
+		'sd-ai-agent/git-diff'                   => 'manage_options',
+		'sd-ai-agent/git-package-summary'        => 'manage_options',
+		'sd-ai-agent/git-snapshot'               => 'manage_options',
+		'sd-ai-agent/git-restore'                => [ 'manage_options', 'edit_files' ],
+		'sd-ai-agent/git-revert-package'         => [ 'manage_options', 'edit_files' ],
+
+		// ─── Site health ────────────────────────────────────────────────────
+		'sd-ai-agent/check-disk-space'           => 'manage_options',
+		'sd-ai-agent/check-performance'          => 'manage_options',
+		'sd-ai-agent/check-security'             => 'manage_options',
+		'sd-ai-agent/check-plugin-updates'       => 'update_plugins',
+		'sd-ai-agent/scan-php-error-log'         => 'manage_options',
+		'sd-ai-agent/site-health-summary'        => 'manage_options',
+		'sd-ai-agent/detect-fresh-install'       => 'manage_options',
+		'sd-ai-agent/site-loopback-check'        => 'manage_options',
+
+		// ─── SEO / Content marketing ────────────────────────────────────────
+		'sd-ai-agent/seo-audit-url'              => 'edit_posts',
+		'sd-ai-agent/seo-analyze-content'        => 'edit_posts',
+		'sd-ai-agent/content-analyze'            => 'edit_posts',
+		'sd-ai-agent/content-performance-report' => 'edit_posts',
+		'sd-ai-agent/fetch-url'                  => 'manage_options',
+		'sd-ai-agent/analyze-headers'            => 'manage_options',
+
+		// ─── Knowledge / Memory / Skills ────────────────────────────────────
+		'sd-ai-agent/knowledge-search'           => 'manage_options',
+		'sd-ai-agent/memory-save'                => 'manage_options',
+		'sd-ai-agent/memory-list'                => 'manage_options',
+		'sd-ai-agent/memory-delete'              => 'manage_options',
+		'sd-ai-agent/skill-load'                 => 'manage_options',
+		'sd-ai-agent/skill-list'                 => 'manage_options',
+
+		// ─── Analytics / Search Console ─────────────────────────────────────
+		'sd-ai-agent/ga-traffic-summary'         => 'manage_options',
+		'sd-ai-agent/ga-top-pages'               => 'manage_options',
+		'sd-ai-agent/ga-realtime'                => 'manage_options',
+		'sd-ai-agent/gsc-site-summary'           => 'manage_options',
+		'sd-ai-agent/gsc-top-queries'            => 'manage_options',
+		'sd-ai-agent/gsc-query-details'          => 'manage_options',
+		'sd-ai-agent/gsc-page-performance'       => 'manage_options',
+
+		// ─── Internet / URL utilities ───────────────────────────────────────
+		'sd-ai-agent/internet-search'            => 'manage_options',
+		'sd-ai-agent/resolve-url'                => 'manage_options',
+		'sd-ai-agent/configure-search-provider'  => 'manage_options',
+
+		// ─── Navigation / Browsing ──────────────────────────────────────────
+		'sd-ai-agent/navigate'                   => 'manage_options',
+		'sd-ai-agent/get-page-html'              => 'manage_options',
+
+		// ─── Database ───────────────────────────────────────────────────────
+		'sd-ai-agent/db-query'                   => [ 'manage_options', 'unfiltered_html' ],
+
+		// ─── Strictest: low-level whitelisted-PHP dispatcher ────────────────
+		// run-php is also feature-flag-gated (SD_AI_AGENT_FEATURE_RUN_PHP)
+		// AND has its source file stripped from the wp.org build. Even when
+		// the feature flag is on, this dual-cap requirement gives a final
+		// belt-and-braces gate so a misconfigured role-management plugin
+		// cannot expose the dispatcher to a non-admin role.
+		'sd-ai-agent/run-php'                    => [ 'manage_options', 'update_core', 'unfiltered_html' ],
+	];
+
+	/**
+	 * Ability IDs that intentionally opt out of the core-cap layer.
+	 *
+	 * These abilities are gated only by the per-tool layer; the dual-gate
+	 * core-cap check is skipped. Reserved for genuinely public-data /
+	 * low-risk read-only abilities (e.g. anonymous feedback ingestion).
+	 *
+	 * Adding to this list requires an explicit security review comment in
+	 * the PR — silence is not opt-out, missing entries fall through to
+	 * {@see resolve_core_caps()} which returns `manage_options` by default.
+	 *
+	 * @var string[]
+	 */
+	public const CORE_CAP_OPTOUT = [
+		// Feedback channel — any logged-in user may report an AI failure
+		// so the data the agent collects covers all roles. Per-tool layer
+		// still applies (so admins can revoke via role plugins).
+		'sd-ai-agent/report-inability',
+	];
 
 	/**
 	 * Derive the tool-specific capability name from an ability ID.
@@ -61,17 +307,70 @@ class ToolCapabilities {
 	}
 
 	/**
+	 * Resolve the required WordPress core capabilities for an ability.
+	 *
+	 * Returns an empty array when the ability is in {@see CORE_CAP_OPTOUT}.
+	 * Returns the {@see CORE_CAP_MAP} entry (normalised to an array of
+	 * strings) when one exists. Falls back to `[FALLBACK_CAP]` so an
+	 * unmapped privileged ability fails closed (admin-only) rather than
+	 * silently downgrading to the per-tool layer alone.
+	 *
+	 * The result is passed through the `sd_ai_agent_tool_required_core_cap`
+	 * filter so admins / extension code can override per-ability.
+	 *
+	 * @param string $ability_id The ability ID.
+	 * @return string[] Zero or more core capability names; all must be held.
+	 */
+	public static function resolve_core_caps( string $ability_id ): array {
+		if ( in_array( $ability_id, self::CORE_CAP_OPTOUT, true ) ) {
+			$caps = [];
+		} elseif ( isset( self::CORE_CAP_MAP[ $ability_id ] ) ) {
+			$raw  = self::CORE_CAP_MAP[ $ability_id ];
+			$caps = is_array( $raw ) ? $raw : [ $raw ];
+		} else {
+			// Unmapped privileged ability: fail closed at admin-only.
+			$caps = [ self::FALLBACK_CAP ];
+		}
+
+		/**
+		 * Filter the WordPress core capabilities required to execute a
+		 * Superdav AI Agent ability.
+		 *
+		 * Return an empty array to opt out of the core-cap layer entirely
+		 * (per-tool layer still applies). Return a non-empty array to
+		 * require all listed capabilities.
+		 *
+		 * @since 1.7.0
+		 *
+		 * @param string[] $caps       Default core capabilities for the ability.
+		 * @param string   $ability_id The full ability ID (e.g. "sd-ai-agent/delete-plugin").
+		 */
+		$caps = apply_filters( 'sd_ai_agent_tool_required_core_cap', $caps, $ability_id );
+
+		return array_values( array_filter( (array) $caps, 'is_string' ) );
+	}
+
+	/**
 	 * Check whether the current user can execute a given ability.
 	 *
-	 * Resolution order:
-	 * 1. Apply the `sd_ai_agent_tool_capability` filter to allow overrides.
-	 * 2. If the resolved capability exists in any role, use it.
-	 * 3. Otherwise fall back to `manage_options`.
+	 * Dual-gate resolution:
+	 *
+	 *   1. Apply the `sd_ai_agent_tool_capability` filter to resolve the
+	 *      per-tool capability name. If the cap exists in any role, the
+	 *      current user must hold it. Otherwise fall back to
+	 *      `manage_options` so the default is admin-only.
+	 *
+	 *   2. Resolve required core capabilities via
+	 *      {@see resolve_core_caps()}. The current user must hold ALL of
+	 *      them (or the ability must be in {@see CORE_CAP_OPTOUT}).
+	 *
+	 * Both layers must pass.
 	 *
 	 * @param string $ability_id The ability ID (e.g. "sd-ai-agent/memory-save").
 	 * @return bool True if the current user has permission.
 	 */
 	public static function current_user_can( string $ability_id ): bool {
+		// ── Layer 1: per-tool capability ────────────────────────────────
 		$tool_cap = self::cap_name( $ability_id );
 
 		/**
@@ -82,13 +381,22 @@ class ToolCapabilities {
 		 */
 		$resolved_cap = (string) apply_filters( 'sd_ai_agent_tool_capability', $tool_cap, $ability_id );
 
-		// If the capability has been granted to at least one role, use it.
-		// Otherwise fall back to manage_options so the default is admin-only.
-		if ( self::capability_exists( $resolved_cap ) ) {
-			return current_user_can( $resolved_cap );
+		$tool_ok = self::capability_exists( $resolved_cap )
+			? current_user_can( $resolved_cap )
+			: current_user_can( self::FALLBACK_CAP );
+
+		if ( ! $tool_ok ) {
+			return false;
 		}
 
-		return current_user_can( self::FALLBACK_CAP );
+		// ── Layer 2: required WordPress core capabilities ───────────────
+		foreach ( self::resolve_core_caps( $ability_id ) as $core_cap ) {
+			if ( ! current_user_can( $core_cap ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**
@@ -158,101 +466,16 @@ class ToolCapabilities {
 	 * Return the list of all Superdav AI Agent ability IDs that have tool capabilities.
 	 *
 	 * This list is used both for capability registration and for documentation.
+	 * It is intentionally the union of {@see CORE_CAP_MAP} keys and
+	 * {@see CORE_CAP_OPTOUT} entries plus any historically-registered
+	 * abilities — kept in sync via `tests/SdAiAgent/Abilities/ToolCapabilitiesDualGateTest.php`,
+	 * which fails when a new ability is registered without an entry.
 	 *
 	 * @return string[]
 	 */
 	public static function all_ability_ids(): array {
-		return [
-			// Posts (registered under the WP core "sd-ai-agent/" prefix).
-			'sd-ai-agent/list-posts',
-			'sd-ai-agent/get-post',
-			'sd-ai-agent/create-post',
-			'sd-ai-agent/update-post',
-			'sd-ai-agent/delete-post',
-			// Global styles (registered under the WP core "sd-ai-agent/" prefix).
-			'sd-ai-agent/get-global-styles',
-			'sd-ai-agent/update-global-styles',
-			'sd-ai-agent/get-theme-json',
-			'sd-ai-agent/reset-global-styles',
-			// Memory (registered under the WP core "sd-ai-agent/" prefix).
-			'sd-ai-agent/memory-save',
-			'sd-ai-agent/memory-list',
-			'sd-ai-agent/memory-delete',
-			// Skills (registered under the WP core "sd-ai-agent/" prefix).
-			'sd-ai-agent/skill-load',
-			'sd-ai-agent/skill-list',
-			// Knowledge (registered under the WP core "sd-ai-agent/" prefix).
-			'sd-ai-agent/knowledge-search',
-			// Nav menus (registered under the WP core "sd-ai-agent/" prefix).
-			'sd-ai-agent/list-menus',
-			'sd-ai-agent/get-menu',
-			'sd-ai-agent/create-menu',
-			'sd-ai-agent/delete-menu',
-			'sd-ai-agent/add-menu-item',
-			'sd-ai-agent/remove-menu-item',
-			'sd-ai-agent/assign-menu-location',
-			// Images.
-			'sd-ai-agent/stock-image',
-			'sd-ai-agent/generate-image',
-			// SEO (registered under the WP core "sd-ai-agent/" prefix).
-			'sd-ai-agent/seo-audit-url',
-			'sd-ai-agent/seo-analyze-content',
-			// Content (registered under the WP core "sd-ai-agent/" prefix).
-			'sd-ai-agent/content-analyze',
-			'sd-ai-agent/content-performance-report',
-			// Marketing (registered under the WP core "sd-ai-agent/" prefix).
-			'sd-ai-agent/fetch-url',
-			'sd-ai-agent/analyze-headers',
-			// Blocks (registered under the WP core "sd-ai-agent/" prefix).
-			'sd-ai-agent/markdown-to-blocks',
-			'sd-ai-agent/list-block-types',
-			'sd-ai-agent/get-block-type',
-			'sd-ai-agent/list-block-patterns',
-			'sd-ai-agent/list-block-templates',
-			'sd-ai-agent/create-block-content',
-			'sd-ai-agent/parse-block-content',
-			// Files.
-			'sd-ai-agent/file-read',
-			'sd-ai-agent/file-write',
-			'sd-ai-agent/file-edit',
-			'sd-ai-agent/file-delete',
-			'sd-ai-agent/file-list',
-			'sd-ai-agent/file-search',
-			'sd-ai-agent/content-search',
-			// Database.
-			'sd-ai-agent/db-query',
-			// WordPress management.
-			'sd-ai-agent/get-plugins',
-			'sd-ai-agent/get-themes',
-			'sd-ai-agent/install-plugin',
-			'sd-ai-agent/run-php',
-			// Options management.
-			'sd-ai-agent/get-option',
-			'sd-ai-agent/update-option',
-			'sd-ai-agent/delete-option',
-			'sd-ai-agent/list-options',
-			// Navigation.
-			'sd-ai-agent/navigate',
-			'sd-ai-agent/get-page-html',
-			// Git.
-			'sd-ai-agent/git-list',
-			'sd-ai-agent/git-diff',
-			'sd-ai-agent/git-snapshot',
-			'sd-ai-agent/git-restore',
-			'sd-ai-agent/git-revert-package',
-			'sd-ai-agent/git-package-summary',
-			// Site health.
-			'sd-ai-agent/site-health-summary',
-			'sd-ai-agent/check-plugin-updates',
-			'sd-ai-agent/check-security',
-			'sd-ai-agent/check-performance',
-			'sd-ai-agent/check-disk-space',
-			'sd-ai-agent/detect-fresh-install',
-			'sd-ai-agent/scan-php-error-log',
-			// Google Analytics.
-			'sd-ai-agent/ga-traffic-summary',
-			'sd-ai-agent/ga-top-pages',
-			'sd-ai-agent/ga-realtime',
-		];
+		$ids = array_merge( array_keys( self::CORE_CAP_MAP ), self::CORE_CAP_OPTOUT );
+		sort( $ids );
+		return array_values( array_unique( $ids ) );
 	}
 }

--- a/includes/Abilities/UploadMediaAbility.php
+++ b/includes/Abilities/UploadMediaAbility.php
@@ -144,7 +144,8 @@ class UploadMediaAbility {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_upload_media' ],
 				'permission_callback' => function (): bool {
-					return current_user_can( 'upload_files' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/upload-media' );
 				},
 			]
 		);

--- a/includes/Abilities/UrlResolverAbilities.php
+++ b/includes/Abilities/UrlResolverAbilities.php
@@ -74,7 +74,8 @@ class UrlResolverAbilities {
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_resolve_url' ],
 				'permission_callback' => static function (): bool {
-					return (bool) current_user_can( 'edit_posts' );
+					// Dual gate: per-tool cap AND core cap from CORE_CAP_MAP.
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/resolve-url' );
 				},
 				'meta'                => [
 					'mcp'         => [ 'public' => true ],

--- a/includes/Abilities/UserAbilities.php
+++ b/includes/Abilities/UserAbilities.php
@@ -80,8 +80,12 @@ class UserAbilities {
 					'show_in_rest' => true,
 				],
 				'execute_callback'    => [ __CLASS__, 'handle_list_users' ],
-				'permission_callback' => function (): bool {
-					return current_user_can( 'list_users' );
+				// Dual gate: per-tool cap (sd_ai_agent_tool_list_users) AND
+				// core cap (list_users) per CORE_CAP_MAP. See
+				// includes/Abilities/ToolCapabilities.php for the layered
+				// resolution order.
+				'permission_callback' => static function (): bool {
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/list-users' );
 				},
 			]
 		);

--- a/includes/Abilities/WordPressAbilities.php
+++ b/includes/Abilities/WordPressAbilities.php
@@ -243,10 +243,22 @@ class WordPressAbilities {
 	/**
 	 * Call a whitelisted WordPress function by name with arguments.
 	 *
+	 * Returns a WP_Error when the `SD_AI_AGENT_FEATURE_RUN_PHP` feature is
+	 * disabled (e.g. in the WordPress.org distribution build) or when the
+	 * `RunPhpAbility` class is not present because its source file has
+	 * been physically stripped from the shipped zip.
+	 *
 	 * @param array<string,mixed> $input Input args (function, args).
 	 * @return array<string,mixed>|\WP_Error
 	 */
 	public static function handle_run_php( array $input = [] ) {
+		if ( ! Features::is_enabled( Features::RUN_PHP ) || ! class_exists( RunPhpAbility::class ) ) {
+			return new WP_Error(
+				'sd_ai_agent_run_php_disabled',
+				__( 'The low-level run-php dispatcher is disabled in this build. Use a purpose-built ability instead (see `sd-ai-agent/ability-search`).', 'superdav-ai-agent' )
+			);
+		}
+
 		$ability = new RunPhpAbility(
 			'sd-ai-agent/run-php',
 			[
@@ -338,14 +350,25 @@ class WordPressAbilities {
 			]
 		);
 
-		wp_register_ability(
-			'sd-ai-agent/run-php',
-			[
-				'label'         => __( 'Call WordPress Function', 'superdav-ai-agent' ),
-				'description'   => __( 'Low-level fallback: call a whitelisted WordPress function directly. Use ONLY when no dedicated ability exists for the task. For posts (use `sd-ai-agent/create-post`), users, options, plugins, themes, and other common operations, call `sd-ai-agent/ability-search` first to find a purpose-built tool — dedicated abilities have typed schemas and better error recovery than passing positional args through `run-php`.', 'superdav-ai-agent' ),
-				'ability_class' => RunPhpAbility::class,
-			]
-		);
+		// ─── Gated: low-level whitelisted PHP dispatcher ──────────────────────
+		//
+		// `sd-ai-agent/run-php` is gated by SD_AI_AGENT_FEATURE_RUN_PHP, which is
+		// forced to false in the WordPress.org build. The matching source file
+		// (`includes/Abilities/RunPhpAbility.php`) is also physically removed
+		// from the wp.org zip via `.distignore-wporg`, so the `RunPhpAbility`
+		// class-name string below is never resolved by the autoloader in that
+		// build. Both defences are required by WP.org Guideline 4.
+
+		if ( Features::is_enabled( Features::RUN_PHP ) ) {
+			wp_register_ability(
+				'sd-ai-agent/run-php',
+				[
+					'label'         => __( 'Call WordPress Function', 'superdav-ai-agent' ),
+					'description'   => __( 'Low-level fallback: call a whitelisted WordPress function directly. Use ONLY when no dedicated ability exists for the task. For posts (use `sd-ai-agent/create-post`), users, options, plugins, themes, and other common operations, call `sd-ai-agent/ability-search` first to find a purpose-built tool — dedicated abilities have typed schemas and better error recovery than passing positional args through `run-php`.', 'superdav-ai-agent' ),
+					'ability_class' => RunPhpAbility::class,
+				]
+			);
+		}
 
 		// ─── Gated: changes the active plugin set ──────────────────────────────
 
@@ -893,341 +916,6 @@ class UpdatePluginAbility extends AbstractAbility {
 				'readonly'    => false,
 				'destructive' => false,
 				'idempotent'  => true,
-			],
-			'show_in_rest' => true,
-		];
-	}
-}
-
-/**
- * Call a whitelisted WordPress function by name with arguments.
- *
- * Replaces the former RunPhpAbility (eval-based) with a safe, whitelisted
- * approach that only allows calling pre-approved WordPress functions via
- * call_user_func_array().
- *
- * @since 1.1.0
- */
-class RunPhpAbility extends AbstractAbility {
-
-	/**
-	 * Option-reading functions whose first argument is an option/transient
-	 * name. Any call into these functions is gated against the secret
-	 * read blocklist defined in {@see OptionsAbilities::get_secret_read_blocklist()}
-	 * so a caller cannot bypass {@see GetOptionAbility} via this low-level
-	 * function caller.
-	 *
-	 * Transient names share the auth-key/salt naming space when stored as
-	 * options ({@see WP_Object_Cache}); gating them here is defence-in-depth.
-	 *
-	 * @var string[]
-	 */
-	private const OPTION_READ_FUNCTIONS = [
-		'get_option',
-		'get_site_option',
-		'get_network_option',
-		'get_transient',
-		'get_site_transient',
-	];
-
-	/**
-	 * Option-mutating functions whose first argument is an option name.
-	 * Calls are gated against {@see OptionsAbilities::get_write_blocklist()}
-	 * so the agent cannot regenerate auth keys/salts (which would log out
-	 * every user) by routing around {@see UpdateOptionAbility}.
-	 *
-	 * @var string[]
-	 */
-	private const OPTION_WRITE_FUNCTIONS = [
-		'update_option',
-		'delete_option',
-		'update_site_option',
-		'delete_site_option',
-		'update_network_option',
-		'delete_network_option',
-	];
-
-	/**
-	 * Allowed WordPress functions that the AI agent may call.
-	 *
-	 * Only side-effect-free read functions and common write functions with
-	 * well-understood behaviour are included.  Extend via the
-	 * `sd_ai_agent_allowed_wp_functions` filter.
-	 *
-	 * @var string[]
-	 */
-	private const ALLOWED_FUNCTIONS = [
-		// Options.
-		'get_option',
-		'update_option',
-		'delete_option',
-		// Posts / Pages.
-		'get_post',
-		'get_posts',
-		'wp_insert_post',
-		'wp_update_post',
-		'wp_delete_post',
-		'get_post_meta',
-		'update_post_meta',
-		'delete_post_meta',
-		// Terms / Taxonomies.
-		'get_terms',
-		'get_term',
-		'wp_insert_term',
-		'wp_update_term',
-		'wp_delete_term',
-		'wp_set_post_terms',
-		'wp_get_post_terms',
-		// Users.
-		'get_user_by',
-		'get_users',
-		'get_current_user_id',
-		'get_user_meta',
-		'update_user_meta',
-		// Comments.
-		'get_comments',
-		'get_comment',
-		'wp_insert_comment',
-		'wp_update_comment',
-		'wp_delete_comment',
-		// Queries.
-		'wp_count_posts',
-		'wp_count_terms',
-		'count_users',
-		// Transients.
-		'get_transient',
-		'set_transient',
-		'delete_transient',
-		// Site info.
-		'get_bloginfo',
-		'home_url',
-		'site_url',
-		'admin_url',
-		'wp_upload_dir',
-		'is_multisite',
-		// Plugins / Themes.
-		'get_plugins',
-		'is_plugin_active',
-		'wp_get_theme',
-		'wp_get_themes',
-		// Shortcodes.
-		'do_shortcode',
-		'shortcode_exists',
-		// Menus.
-		'wp_get_nav_menus',
-		'wp_get_nav_menu_items',
-		// Misc.
-		'wp_remote_get',
-		'wp_remote_post',
-		'current_time',
-		'wp_date',
-		'wp_create_nonce',
-	];
-
-	protected function label(): string {
-		return __( 'Call WordPress Function', 'superdav-ai-agent' );
-	}
-
-	protected function description(): string {
-		return __( 'Low-level fallback: call a whitelisted WordPress function directly. Use ONLY when no dedicated ability exists for the task. For posts (use `sd-ai-agent/create-post`), users, options, plugins, themes, and other common operations, call `sd-ai-agent/ability-search` first to find a purpose-built tool — dedicated abilities have typed schemas and better error recovery than guessing positional args here. When you do use this, pass the function name via `function` and an ordered array via `args`.', 'superdav-ai-agent' );
-	}
-
-	protected function input_schema(): array {
-		return [
-			'type'       => 'object',
-			'properties' => [
-				'function' => [
-					'type'        => 'string',
-					'description' => 'The WordPress function name to call, e.g. "get_option", "wp_insert_post".',
-				],
-				'args'     => [
-					'type'        => 'array',
-					'description' => 'Ordered array of arguments to pass to the function. Defaults to an empty array.',
-					'items'       => array(
-						'type' => array( 'string', 'number', 'integer', 'boolean', 'array', 'object', 'null' ),
-					),
-				],
-			],
-			'required'   => [ 'function' ],
-		];
-	}
-
-	protected function output_schema(): array {
-		return [
-			'type'       => 'object',
-			'properties' => [
-				'result' => [
-					'type'        => [ 'string', 'number', 'integer', 'boolean', 'array', 'object', 'null' ],
-					'description' => 'The function return value. Type varies by function.',
-				],
-				'output' => [ 'type' => 'string' ],
-			],
-		];
-	}
-
-	protected function execute_callback( $input ) {
-		/** @var array<string, mixed> $input */
-		$function = $input['function'] ?? '';
-		$args     = $input['args'] ?? [];
-
-		if ( empty( $function ) || ! is_string( $function ) ) {
-			return new WP_Error(
-				'sd_ai_agent_empty_function',
-				__( 'A function name is required.', 'superdav-ai-agent' )
-			);
-		}
-
-		if ( ! is_array( $args ) ) {
-			return new WP_Error(
-				'sd_ai_agent_invalid_args',
-				__( 'The "args" parameter must be an array.', 'superdav-ai-agent' )
-			);
-		}
-
-		// Build the runtime allowlist (static defaults + user extensions).
-		$allowed = self::get_allowed_functions();
-
-		if ( ! in_array( $function, $allowed, true ) ) {
-			return new WP_Error(
-				'sd_ai_agent_disallowed_function',
-				sprintf(
-					/* translators: %s: function name */
-					__( 'The function "%s" is not in the allowed list. Use the sd_ai_agent_allowed_wp_functions filter to extend it.', 'superdav-ai-agent' ),
-					$function
-				)
-			);
-		}
-
-		// Secret-aware gating: option reads/writes against the auth-key
-		// blocklist. Applied AFTER the function allowlist check so any
-		// extension via `sd_ai_agent_allowed_wp_functions` is still
-		// constrained. Network/site variants of get_option take the option
-		// name in arg position 1 (network ID is arg 0); standard variants
-		// take it in arg 0. Both shapes are covered below.
-		$secret_check = self::check_secret_option_call( $function, $args );
-		if ( is_wp_error( $secret_check ) ) {
-			return $secret_check;
-		}
-
-		if ( ! function_exists( $function ) ) {
-			return new WP_Error(
-				'sd_ai_agent_undefined_function',
-				sprintf(
-					/* translators: %s: function name */
-					__( 'The function "%s" does not exist in this WordPress environment.', 'superdav-ai-agent' ),
-					$function
-				)
-			);
-		}
-
-		ob_start();
-		$error  = null;
-		$result = null;
-
-		try {
-			$result = call_user_func_array( $function, array_values( $args ) );
-		} catch ( \Throwable $e ) {
-			$error = $e->getMessage();
-		}
-
-		$output = ob_get_clean();
-
-		if ( null !== $error ) {
-			return new WP_Error(
-				'sd_ai_agent_php_error',
-				sprintf( 'PHP error: %s', $error )
-			);
-		}
-
-		return [
-			'result' => $result,
-			'output' => $output,
-		];
-	}
-
-	/**
-	 * Get the full list of allowed functions (built-in + filtered).
-	 *
-	 * @return string[]
-	 */
-	private static function get_allowed_functions(): array {
-		/**
-		 * Filters the list of WordPress functions the AI agent is allowed to call.
-		 *
-		 * @since 1.1.0
-		 *
-		 * @param string[] $functions List of allowed function names.
-		 */
-		$functions = apply_filters( 'sd_ai_agent_allowed_wp_functions', self::ALLOWED_FUNCTIONS );
-
-		// Ensure the list is a flat array of strings (defensive).
-		return array_values( array_filter( (array) $functions, 'is_string' ) );
-	}
-
-	/**
-	 * Gate option-reading / option-writing function calls against the
-	 * secret read blocklist and the existing write blocklist.
-	 *
-	 * Without this check, the AI could bypass {@see GetOptionAbility}'s
-	 * secret-read gate (and {@see UpdateOptionAbility}'s write gate) by
-	 * calling `get_option('auth_key')` (or `update_option('auth_key', ...)`)
-	 * through this low-level function caller.
-	 *
-	 * Returns null when the call is allowed, a WP_Error when blocked.
-	 *
-	 * @param string       $function_name The PHP function name about to be called.
-	 * @param array<mixed> $args          Positional arguments that will be passed.
-	 * @return \WP_Error|null
-	 */
-	private static function check_secret_option_call( string $function_name, array $args ): ?\WP_Error {
-		// Network/site option variants accept (int $network_id, string $option, ...);
-		// standard variants accept (string $option, ...). Pick the right arg index.
-		$is_network_variant = in_array(
-			$function_name,
-			[ 'get_network_option', 'update_network_option', 'delete_network_option' ],
-			true
-		);
-		$name_index         = $is_network_variant ? 1 : 0;
-
-		if ( ! isset( $args[ $name_index ] ) || ! is_string( $args[ $name_index ] ) ) {
-			return null;
-		}
-
-		$option_name = $args[ $name_index ];
-
-		if ( in_array( $function_name, self::OPTION_READ_FUNCTIONS, true )
-			&& OptionsAbilities::is_secret_option_name( $option_name ) ) {
-			return OptionsAbilities::secret_read_error( $option_name );
-		}
-
-		if ( in_array( $function_name, self::OPTION_WRITE_FUNCTIONS, true )
-			&& in_array( $option_name, OptionsAbilities::get_write_blocklist(), true ) ) {
-			return new \WP_Error(
-				'sd_ai_agent_option_blocked',
-				sprintf(
-					/* translators: 1: function name, 2: option name */
-					__( 'The function "%1$s" cannot be used to modify the protected option "%2$s".', 'superdav-ai-agent' ),
-					$function_name,
-					$option_name
-				),
-				[ 'status' => 403 ]
-			);
-		}
-
-		return null;
-	}
-
-	protected function permission_callback( $input ): bool {
-		return ToolCapabilities::current_user_can( $this->name );
-	}
-
-	protected function meta(): array {
-		return [
-			'mcp'          => [ 'public' => true ],
-			'annotations'  => [
-				'readonly'    => false,
-				'destructive' => true,
-				'idempotent'  => false,
 			],
 			'show_in_rest' => true,
 		];

--- a/includes/Core/Features.php
+++ b/includes/Core/Features.php
@@ -85,6 +85,16 @@ declare(strict_types=1);
  *    password-policy enforcers, etc.) that hook the native register/login
  *    flow — per WP.org reviewer feedback. Read-only `sd-ai-agent/list-users`
  *    is unaffected and remains available in all builds.
+ *  - SD_AI_AGENT_FEATURE_RUN_PHP — The `sd-ai-agent/run-php` ability,
+ *    which dispatches calls to a whitelisted set of WordPress
+ *    functions via `call_user_func_array()`. Even with a static
+ *    allowlist this surface is a low-level fallback dispatcher and
+ *    WP.org Guideline 4 prohibits plugins that allow arbitrary
+ *    script insertion or low-level PHP dispatch. Disabled in the
+ *    WordPress.org distribution build and the
+ *    `includes/Abilities/RunPhpAbility.php` source file is physically
+ *    stripped from the shipped zip so the review team can verify
+ *    compliance with a single `unzip -l | grep RunPhpAbility` check.
  *
  * Usage example (wp-config.php):
  *   define( 'SD_AI_AGENT_FEATURE_BRANDING', false );
@@ -303,6 +313,23 @@ final class Features {
 	const USER_MANAGEMENT = 'user_management';
 
 	/**
+	 * Feature: low-level whitelisted-PHP dispatcher (`sd-ai-agent/run-php`).
+	 *
+	 * Gates registration of the `sd-ai-agent/run-php` ability, which calls
+	 * functions from a static whitelist via `call_user_func_array()`. With
+	 * this disabled the dispatcher is not registered, the underlying
+	 * `RunPhpAbility` class is not loaded, and (in the wp.org build) the
+	 * source file is physically removed from the shipped zip.
+	 *
+	 * Disabled in the WordPress.org distribution build because WP.org
+	 * Guideline 4 prohibits plugins that allow low-level script insertion
+	 * or arbitrary PHP dispatch — even with an allowlist.
+	 *
+	 * Constant: SD_AI_AGENT_FEATURE_RUN_PHP
+	 */
+	const RUN_PHP = 'run_php';
+
+	/**
 	 * Map of feature name → backing constant name.
 	 *
 	 * @var array<string, string>
@@ -320,6 +347,7 @@ final class Features {
 		self::WP_CLI_DISPATCHER       => 'SD_AI_AGENT_FEATURE_WP_CLI_DISPATCHER',
 		self::BENCHMARK               => 'SD_AI_AGENT_FEATURE_BENCHMARK',
 		self::USER_MANAGEMENT         => 'SD_AI_AGENT_FEATURE_USER_MANAGEMENT',
+		self::RUN_PHP                 => 'SD_AI_AGENT_FEATURE_RUN_PHP',
 	);
 
 	/**

--- a/superdav-ai-agent.php
+++ b/superdav-ai-agent.php
@@ -227,6 +227,16 @@ defined( 'SD_AI_AGENT_FEATURE_BENCHMARK' ) || define( 'SD_AI_AGENT_FEATURE_BENCH
  */
 defined( 'SD_AI_AGENT_FEATURE_USER_MANAGEMENT' ) || define( 'SD_AI_AGENT_FEATURE_USER_MANAGEMENT', true );
 
+/**
+ * Feature: low-level whitelisted-PHP dispatcher (`sd-ai-agent/run-php`).
+ * When false, the run-php ability is not registered and the underlying
+ * `RunPhpAbility` class is not loaded. Forced to `false` in the
+ * WordPress.org distribution build and the `RunPhpAbility.php` source
+ * file is physically stripped from the shipped zip, per WP.org Guideline
+ * 4 (no arbitrary script insertion or low-level PHP dispatch surfaces).
+ */
+defined( 'SD_AI_AGENT_FEATURE_RUN_PHP' ) || define( 'SD_AI_AGENT_FEATURE_RUN_PHP', true );
+
 // Load Jetpack Autoloader for PSR-4 autoloading with version conflict resolution.
 // Jetpack Autoloader ensures the newest version of shared packages (like php-ai-client) is used.
 if ( file_exists( SD_AI_AGENT_DIR . '/vendor/autoload_packages.php' ) ) {

--- a/tests/SdAiAgent/Abilities/ToolCapabilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/ToolCapabilitiesTest.php
@@ -100,32 +100,50 @@ class ToolCapabilitiesTest extends WP_UnitTestCase {
 
 	/**
 	 * Test current_user_can uses the specific capability when it exists.
+	 *
+	 * Dual-gate semantics: per-tool cap AND core cap (from CORE_CAP_MAP, or
+	 * `manage_options` fallback for unmapped ad-hoc IDs) must both be held.
 	 */
 	public function test_current_user_can_uses_specific_cap_when_registered(): void {
 		$ability_id = 'sd-ai-agent/test-specific-tool-' . uniqid();
 		$cap        = ToolCapabilities::cap_name( $ability_id );
 
-		// Grant the capability to the editor role.
+		// Grant the per-tool cap to the editor role.
 		$editor_role = get_role( 'editor' );
 		$this->assertNotNull( $editor_role );
 		$editor_role->add_cap( $cap, true );
 
-		// Editor should now have access.
+		// Override CORE_CAP_MAP for this ad-hoc ID so the core-cap layer
+		// is satisfied by a cap the editor role holds by default.
+		$core_filter = static function ( array $caps, string $id ) use ( $ability_id ): array {
+			if ( $id === $ability_id ) {
+				return [ 'edit_posts' ];
+			}
+			return $caps;
+		};
+		add_filter( 'sd_ai_agent_tool_required_core_cap', $core_filter, 10, 2 );
+
+		// Editor should now have access (per-tool granted, edit_posts held).
 		$editor_id = $this->factory->user->create( [ 'role' => 'editor' ] );
 		wp_set_current_user( $editor_id );
 		$this->assertTrue( ToolCapabilities::current_user_can( $ability_id ) );
 
-		// Subscriber should not have access.
+		// Subscriber lacks both per-tool and edit_posts → false.
 		$subscriber_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
 		wp_set_current_user( $subscriber_id );
 		$this->assertFalse( ToolCapabilities::current_user_can( $ability_id ) );
 
 		// Clean up.
+		remove_filter( 'sd_ai_agent_tool_required_core_cap', $core_filter, 10 );
 		$editor_role->remove_cap( $cap );
 	}
 
 	/**
 	 * Test the sd_ai_agent_tool_capability filter overrides the capability name.
+	 *
+	 * Dual-gate: the per-tool filter changes layer 1, but layer 2 still
+	 * requires the CORE_CAP_MAP-resolved core cap. memory-save maps to
+	 * manage_options, so we also override the core-cap layer for the test.
 	 */
 	public function test_filter_overrides_capability_name(): void {
 		$ability_id   = 'sd-ai-agent/memory-save';
@@ -133,7 +151,7 @@ class ToolCapabilitiesTest extends WP_UnitTestCase {
 
 		add_filter(
 			'sd_ai_agent_tool_capability',
-			function ( string $cap, string $id ) use ( $ability_id, $override_cap ): string {
+			static function ( string $cap, string $id ) use ( $ability_id, $override_cap ): string {
 				if ( $id === $ability_id ) {
 					return $override_cap;
 				}
@@ -143,14 +161,117 @@ class ToolCapabilitiesTest extends WP_UnitTestCase {
 			2
 		);
 
+		// Lower the required core cap to one editor holds.
+		$core_filter = static function ( array $caps, string $id ) use ( $ability_id ): array {
+			if ( $id === $ability_id ) {
+				return [ 'edit_posts' ];
+			}
+			return $caps;
+		};
+		add_filter( 'sd_ai_agent_tool_required_core_cap', $core_filter, 10, 2 );
+
 		// Grant edit_posts to editor role (it already has it by default).
 		$editor_id = $this->factory->user->create( [ 'role' => 'editor' ] );
 		wp_set_current_user( $editor_id );
 
-		// The capability 'edit_posts' exists in roles, so it should be used directly.
+		// Both gates satisfied → true.
 		$this->assertTrue( ToolCapabilities::current_user_can( $ability_id ) );
 
+		remove_filter( 'sd_ai_agent_tool_required_core_cap', $core_filter, 10 );
 		remove_all_filters( 'sd_ai_agent_tool_capability' );
+	}
+
+	/**
+	 * Dual-gate: core cap held but per-tool cap missing → false.
+	 *
+	 * Proves the per-tool layer is enforced even when the user holds the
+	 * mapped WordPress core cap. The site administrator who manages role
+	 * caps via a plugin must explicitly grant the per-tool cap.
+	 */
+	public function test_dual_gate_core_cap_alone_is_not_sufficient(): void {
+		// list-posts is mapped to edit_posts in CORE_CAP_MAP. Editor has
+		// edit_posts by default but no plugin-specific per-tool cap, and
+		// the per-tool cap is not registered (so falls back to
+		// manage_options, which editor lacks).
+		$editor_id = $this->factory->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $editor_id );
+
+		$this->assertFalse( ToolCapabilities::current_user_can( 'sd-ai-agent/list-posts' ) );
+	}
+
+	/**
+	 * Dual-gate: per-tool cap held but core cap missing → false.
+	 *
+	 * Proves the core-cap layer is enforced even when a role plugin
+	 * grants the per-tool cap to a low-privilege role.
+	 */
+	public function test_dual_gate_per_tool_cap_alone_is_not_sufficient(): void {
+		$ability_id = 'sd-ai-agent/delete-plugin'; // CORE_CAP_MAP → delete_plugins.
+		$tool_cap   = ToolCapabilities::cap_name( $ability_id );
+
+		// Pretend a role plugin granted the per-tool cap to subscribers.
+		$role = get_role( 'subscriber' );
+		$this->assertNotNull( $role );
+		$role->add_cap( $tool_cap, true );
+
+		$subscriber_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+
+		// Subscribers have neither delete_plugins nor manage_options →
+		// the core-cap layer must reject regardless of the per-tool cap.
+		$this->assertFalse( ToolCapabilities::current_user_can( $ability_id ) );
+
+		// Clean up.
+		$role->remove_cap( $tool_cap );
+	}
+
+	/**
+	 * Dual-gate: administrator holds both per-tool and core caps → true.
+	 */
+	public function test_dual_gate_administrator_passes_for_mapped_ability(): void {
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$this->assertTrue( ToolCapabilities::current_user_can( 'sd-ai-agent/delete-plugin' ) );
+		$this->assertTrue( ToolCapabilities::current_user_can( 'sd-ai-agent/list-posts' ) );
+		$this->assertTrue( ToolCapabilities::current_user_can( 'sd-ai-agent/run-php' ) );
+	}
+
+	/**
+	 * CORE_CAP_OPTOUT abilities skip the core-cap layer entirely.
+	 *
+	 * `sd-ai-agent/report-inability` is the only opted-out ability — any
+	 * logged-in user may report an AI failure. Per-tool layer still applies.
+	 */
+	public function test_core_cap_optout_skips_core_layer(): void {
+		$tool_cap = ToolCapabilities::cap_name( 'sd-ai-agent/report-inability' );
+		$role     = get_role( 'subscriber' );
+		$this->assertNotNull( $role );
+		// Add the per-tool cap to the role BEFORE creating the user so the
+		// user's allcaps cache picks it up.
+		$role->add_cap( $tool_cap, true );
+
+		$subscriber_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+
+		// Per-tool granted, core-cap layer skipped → true.
+		$this->assertTrue( ToolCapabilities::current_user_can( 'sd-ai-agent/report-inability' ) );
+
+		$role->remove_cap( $tool_cap );
+	}
+
+	/**
+	 * run-php requires the strictest cap set: manage_options, update_core,
+	 * unfiltered_html — even though SD_AI_AGENT_FEATURE_RUN_PHP also gates
+	 * registration. This is the in-code belt for the belt-and-braces
+	 * defence-in-depth: a misconfigured role plugin must not expose run-php.
+	 */
+	public function test_run_php_requires_strictest_cap_set(): void {
+		$caps = ToolCapabilities::resolve_core_caps( 'sd-ai-agent/run-php' );
+
+		$this->assertContains( 'manage_options', $caps );
+		$this->assertContains( 'update_core', $caps );
+		$this->assertContains( 'unfiltered_html', $caps );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Resolves WordPress.org reviewer finding: 33 abilities registered via
`wp_register_ability()` whose `permission_callback` did not enforce a
WordPress core capability. Several were administrator-level operations
(delete-option, activate-plugin, delete-plugin, update-user-role,
run-php, generate-image, list-options, git-revert-package) gated only by
a plugin-specific tool cap, which a misconfigured role-management plugin
could grant to a non-admin role.

This PR introduces a single chokepoint — `ToolCapabilities::current_user_can()` —
and routes every ability `permission_callback` through it. The chokepoint
enforces a two-layer (dual-gate) authorisation model.

## Dual-gate model

| Layer | Source | Purpose |
| --- | --- | --- |
| 1. Per-tool cap (existing) | `sd_ai_agent_tool_<name>` derived from ability ID; `sd_ai_agent_tool_capability` filter | Lets site admins revoke individual tools via role-management plugins |
| 2. WordPress core cap (NEW) | `ToolCapabilities::CORE_CAP_MAP` + `sd_ai_agent_tool_required_core_cap` filter | Pins each ability to the matching WP core capability |

Both layers must pass. Unmapped privileged abilities fail closed to
`manage_options` — silence is **not** opt-out. `CORE_CAP_OPTOUT`
explicitly lists abilities that skip layer 2 (currently only
`report-inability`); adding to that list requires a security-review
comment.

## Defence-in-depth for `sd-ai-agent/run-php`

Four independent guards:

1. **Physical strip**: extracted to its own file
   `includes/Abilities/RunPhpAbility.php`; `.distignore-wporg` and
   `bin/build.sh` `stripped_paths` remove it from the wp.org zip.
2. **Feature flag**: new `Features::RUN_PHP` constant
   (`SD_AI_AGENT_FEATURE_RUN_PHP`, default true; build forces off for
   wp.org).
3. **Runtime guard**: `handle_run_php()` returns `WP_Error` if the flag
   is off, even if the registration somehow leaked.
4. **Strictest cap set**: CORE_CAP_MAP requires `manage_options` AND
   `update_core` AND `unfiltered_html` — three independently-revocable
   admin-level caps.

## Other notable corrections

- `update-user-role`: previously checked `edit_users`; corrected to the
  semantically correct `promote_users` via CORE_CAP_MAP.
- `generate-image`: now requires `upload_files` (Author+) on single-site
  and the per-blog cap on multisite (`switch_to_blog` path preserved).
- `StockImageAbility`: same dual-gate as `GenerateImageAbility`.

## Scope note

`wp-rest/*` and `wp-cli/*` abilities use a different ID namespace
(`wp-rest/discover` etc., not the canonical `sd-ai-agent/` prefix) and
have their own multi-layered permission logic (`check_permission_level`).
They are not among the reviewer-cited abilities and are out of scope
here — to be hardened in a follow-up.

## Test coverage

- 5 new `ToolCapabilitiesTest` cases prove dual-gate semantics:
  - core cap alone insufficient (editor on list-posts without per-tool cap)
  - per-tool cap alone insufficient (subscriber granted delete-plugin)
  - administrator passes for mapped abilities
  - `CORE_CAP_OPTOUT` skips layer 2
  - run-php requires the strictest 3-cap set
- 2 existing tests updated to reflect the new dual-gate semantics.

## Worker self-verification

```text
- PHPUnit: Tests: 3473, Assertions: 14104, Errors: 0, Failures: 0, Skipped: 114
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded (wp-scripts + archive)
```

Baseline on `origin/main`: Tests: 3468, Errors: 1, Failures: 2.
This branch: Tests: 3473 (+5 new), Errors: 0, Failures: 0.
Net: +5 new tests, all green; pre-existing baseline failures also resolved.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 1d 23h and 111,419 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a whitelisted PHP function dispatcher capability with configurable access controls.

* **Improvements**
  * Enhanced permission system with granular, per-ability authorization checks across all agent capabilities.
  * Introduced dual-layer permission validation combining tool-specific and core WordPress capability checks.

* **Distribution Notes**
  * PHP function dispatcher is disabled in WordPress.org distributions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1922?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->