### PR TITLE
security(abilities): gate + strip + tighten caps for wp-rest/wp-cli dispatchers

### DIFF
--- a/.distignore-wporg
+++ b/.distignore-wporg
@@ -9,6 +9,8 @@
 #  - SD_AI_AGENT_FEATURE_PLUGIN_STATE_CHANGES    (autonomous activate/deactivate)
 #  - SD_AI_AGENT_FEATURE_PLUGIN_INSTALL_FROM_URL (install from arbitrary ZIP URL)
 #  - SD_AI_AGENT_FEATURE_SCAFFOLD_BLOCK_THEME    (executable theme code writes)
+#  - SD_AI_AGENT_FEATURE_WP_REST_DISPATCHER      (low-level REST dispatcher)
+#  - SD_AI_AGENT_FEATURE_WP_CLI_DISPATCHER       (shell-exec wp-cli dispatcher)
 #
 # Note: the PLUGIN_STATE_CHANGES and PLUGIN_INSTALL_FROM_URL gates only
 # remove individual `wp_register_ability()` calls inside
@@ -66,3 +68,24 @@ includes/Models/DTO/GeneratedPluginRow.php
 # source file gives the WP.org review team a single grep target to
 # confirm the scaffolder cannot be re-enabled by toggling the flag.
 includes/Abilities/ScaffoldBlockThemeAbility.php
+
+# ── WP REST dispatcher source file ───────────────────────────────────────────
+# Registers the wp-rest/discover, wp-rest/inspect, and wp-rest/execute
+# abilities, which let the agent enumerate and invoke any registered
+# WordPress REST endpoint via the internal in-process dispatcher. Even
+# though every dispatched call still goes through the target endpoint's
+# own permission_callback, this is a generic low-level dispatch surface
+# in the same risk class as run-php. Runtime is also gated off via
+# SD_AI_AGENT_FEATURE_WP_REST_DISPATCHER = false (forced in the bundled
+# main plugin file by bin/build.sh below). Stripping the source file
+# gives the WP.org review team a single grep target.
+includes/Abilities/WpRestAbilities.php
+
+# ── WP-CLI dispatcher source file ────────────────────────────────────────────
+# Registers the wp-cli/execute ability, which shells out to the `wp`
+# binary via PHP exec() to run arbitrary WP-CLI subcommands. Same
+# arbitrary-command-execution risk class as PLUGIN_BUILDER and
+# CUSTOM_TOOLS_CLI. Runtime is also gated off via
+# SD_AI_AGENT_FEATURE_WP_CLI_DISPATCHER = false (forced in the bundled
+# main plugin file by bin/build.sh below).
+includes/Abilities/WpCliAbilities.php

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -202,10 +202,10 @@ EXTRA
 	# prevents trivial bypass and gives the WP.org review team a single
 	# grep target to verify compliance.
 	if [ "$variant" = "wporg" ]; then
-		echo "==> [${variant}] Forcing plugin-builder + CLI + plugin-state + URL-install + file-write + scaffold-block-theme feature flags to false..."
+		echo "==> [${variant}] Forcing plugin-builder + CLI + plugin-state + URL-install + file-write + scaffold-block-theme + wp-rest + wp-cli dispatcher feature flags to false..."
 		local main_file="${dest}/superdav-ai-agent.php"
 
-		# The six feature flags this build target forces off, paired with a
+		# The feature flags this build target forces off, paired with a
 		# short rationale that ends up as an inline comment in the bundled
 		# main plugin file (a grep target the WP.org review team can use).
 		local -a flags=(
@@ -215,6 +215,8 @@ EXTRA
 			"SD_AI_AGENT_FEATURE_PLUGIN_INSTALL_FROM_URL:install-from-arbitrary-ZIP disabled per WP.org Changing Active Plugins guideline"
 			"SD_AI_AGENT_FEATURE_FILE_WRITE:arbitrary wp-content writes disabled per WP.org Changing Active Plugins guideline"
 			"SD_AI_AGENT_FEATURE_SCAFFOLD_BLOCK_THEME:executable theme code writes disabled per WP.org Changing Active Plugins guideline"
+			"SD_AI_AGENT_FEATURE_WP_REST_DISPATCHER:low-level REST dispatcher disabled per WP.org Guideline 4"
+			"SD_AI_AGENT_FEATURE_WP_CLI_DISPATCHER:shell-exec wp-cli dispatcher disabled per WP.org Guideline 4"
 		)
 
 		# Replace each `defined() || define( 'NAME', true )` line with a
@@ -250,6 +252,8 @@ EXTRA
 			"${dest}/includes/Abilities/PluginBuilderAbilities.php"
 			"${dest}/includes/Abilities/PluginDownloadAbilities.php"
 			"${dest}/includes/Abilities/ScaffoldBlockThemeAbility.php"
+			"${dest}/includes/Abilities/WpRestAbilities.php"
+			"${dest}/includes/Abilities/WpCliAbilities.php"
 		)
 		local p
 		for p in "${stripped_paths[@]}"; do

--- a/includes/Abilities/WpCliAbilities.php
+++ b/includes/Abilities/WpCliAbilities.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Abilities;
 
 use SdAiAgent\Core\ChangeLogger;
+use SdAiAgent\Core\Features;
 use SdAiAgent\Models\ChangesLog;
 use WP_Error;
 
@@ -169,6 +170,15 @@ class WpCliAbilities {
 	 * @return void
 	 */
 	public static function register_category(): void {
+		// Feature-gated: the wp-cli/execute ability is force-disabled in
+		// the WordPress.org distribution build and may be disabled
+		// per-site via SD_AI_AGENT_FEATURE_WP_CLI_DISPATCHER. Skipping
+		// the category registration here means the ability cannot
+		// register against a valid category later in the boot sequence.
+		if ( ! Features::is_enabled( Features::WP_CLI_DISPATCHER ) ) {
+			return;
+		}
+
 		if ( ! function_exists( 'wp_register_ability_category' ) || ! function_exists( 'wp_has_ability_category' ) ) {
 			return;
 		}
@@ -196,6 +206,11 @@ class WpCliAbilities {
 	 * @return void
 	 */
 	public static function register_ability(): void {
+		// Feature-gated: see register_category() for the rationale.
+		if ( ! Features::is_enabled( Features::WP_CLI_DISPATCHER ) ) {
+			return;
+		}
+
 		if ( ! function_exists( 'wp_register_ability' ) || ! function_exists( 'wp_has_ability_category' ) ) {
 			return;
 		}
@@ -238,17 +253,11 @@ class WpCliAbilities {
 				'description'         => $description,
 				'category'            => self::CATEGORY,
 				'permission_callback' => static function () {
-					if ( current_user_can( 'manage_network' ) ) {
-						return true;
-					}
-					if ( current_user_can( 'manage_options' ) ) {
-						return true;
-					}
-					return new WP_Error(
-						'wp_cli_forbidden',
-						__( 'You do not have permission to execute WP-CLI commands. Required capability: manage_options.', 'superdav-ai-agent' ),
-						array( 'status' => 403 )
-					);
+					// Strictest cap set: same as run-php. wp-cli/execute
+					// shells out to the wp binary via PHP exec(); any
+					// administrator who lacks any of these three caps
+					// is correctly excluded.
+					return self::check_permission_level( 'execute' );
 				},
 				'execute_callback'    => array( __CLASS__, 'handle_execute' ),
 				'input_schema'        => array(
@@ -577,38 +586,45 @@ class WpCliAbilities {
 	}
 
 	/**
-	 * Check if the current user has permission for a given access level.
+	 * Check if the current user has the strictest cap set required to
+	 * use the wp-cli/execute dispatcher.
 	 *
-	 * @param string $level 'read', 'write', or 'destructive'.
+	 * The dispatcher shells out to the `wp` binary via PHP `exec()` and
+	 * can run arbitrary WP-CLI subcommands (subject to the
+	 * BLOCKED_COMMANDS / BLOCKED_SUBCOMMANDS allowlist). We therefore
+	 * enforce the same cap set as `sd-ai-agent/run-php`:
+	 * `manage_options` AND `update_core` AND `unfiltered_html`. These
+	 * three caps are individually revocable via role-management
+	 * plugins, and an administrator who loses any one of them
+	 * (typical for managed-hosting customer admins) is correctly
+	 * excluded from the dispatcher.
+	 *
+	 * The `$level` parameter is retained for backward-compatible error
+	 * messages; the underlying cap requirement is the same for every
+	 * level because the dispatcher itself is the risk surface.
+	 *
+	 * @param string $level 'read', 'write', or 'destructive' (used in error message only).
 	 * @return true|WP_Error
 	 */
 	private static function check_permission_level( string $level ) {
-		if ( current_user_can( 'manage_network' ) ) {
-			return true;
+		$required = array( 'manage_options', 'update_core', 'unfiltered_html' );
+
+		foreach ( $required as $cap ) {
+			if ( ! current_user_can( $cap ) ) {
+				return new WP_Error(
+					'wp_cli_forbidden',
+					sprintf(
+						/* translators: 1: access level, 2: list of required capability names */
+						__( 'You do not have permission to execute this %1$s command. Required capabilities (all): %2$s.', 'superdav-ai-agent' ),
+						$level,
+						implode( ', ', $required )
+					),
+					array( 'status' => 403 )
+				);
+			}
 		}
 
-		$capability_map = array(
-			'read'        => 'manage_options',
-			'write'       => 'manage_options',
-			'destructive' => 'manage_network',
-		);
-
-		$required_cap = $capability_map[ $level ] ?? 'manage_network';
-
-		if ( current_user_can( $required_cap ) ) {
-			return true;
-		}
-
-		return new WP_Error(
-			'wp_cli_forbidden',
-			sprintf(
-				/* translators: 1: access level, 2: capability name */
-				__( 'You do not have permission to execute this %1$s command. Required capability: %2$s.', 'superdav-ai-agent' ),
-				$level,
-				$required_cap
-			),
-			array( 'status' => 403 )
-		);
+		return true;
 	}
 
 	// ─── Process execution ──────────────────────────────────────────────

--- a/includes/Abilities/WpRestAbilities.php
+++ b/includes/Abilities/WpRestAbilities.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Abilities;
 
 use SdAiAgent\Core\ChangeLogger;
+use SdAiAgent\Core\Features;
 use SdAiAgent\Models\ChangesLog;
 use WP_Error;
 use WP_REST_Request;
@@ -78,6 +79,16 @@ class WpRestAbilities {
 	 * @return void
 	 */
 	public static function register_category(): void {
+		// Feature-gated: the dispatcher surface is force-disabled in the
+		// WordPress.org distribution build and may be disabled per-site
+		// via SD_AI_AGENT_FEATURE_WP_REST_DISPATCHER in wp-config.php.
+		// Skipping the category registration here means none of the
+		// dispatcher abilities can later attach to a valid category, so
+		// even a manual `wp_register_ability` call would fail.
+		if ( ! Features::is_enabled( Features::WP_REST_DISPATCHER ) ) {
+			return;
+		}
+
 		if ( ! function_exists( 'wp_register_ability_category' ) || ! function_exists( 'wp_has_ability_category' ) ) {
 			return;
 		}
@@ -103,6 +114,11 @@ class WpRestAbilities {
 	 * @return void
 	 */
 	public static function register_abilities(): void {
+		// Feature-gated: see register_category() for the rationale.
+		if ( ! Features::is_enabled( Features::WP_REST_DISPATCHER ) ) {
+			return;
+		}
+
 		self::register_discover();
 		self::register_inspect();
 		self::register_execute();
@@ -267,17 +283,12 @@ class WpRestAbilities {
 				),
 				'category'            => self::CATEGORY,
 				'permission_callback' => static function () {
-					if ( current_user_can( 'manage_network' ) ) {
-						return true;
-					}
-					if ( current_user_can( 'manage_options' ) ) {
-						return true;
-					}
-					return new WP_Error(
-						'wp_rest_forbidden',
-						__( 'You do not have permission to execute REST requests. Required capability: manage_options.', 'superdav-ai-agent' ),
-						array( 'status' => 403 )
-					);
+					// Strictest cap set: same as run-php. The dispatcher is
+					// a generic low-level surface and shares run-php's
+					// arbitrary-script-dispatch risk class. Implemented in
+					// check_permission_level() so discover/inspect/execute
+					// share a single source of truth.
+					return self::check_permission_level( 'execute' );
 				},
 				'execute_callback'    => array( __CLASS__, 'handle_execute' ),
 				'input_schema'        => array(
@@ -773,47 +784,45 @@ class WpRestAbilities {
 	}
 
 	/**
-	 * Check if the current user has permission for a given access level.
+	 * Check if the current user has the strictest cap set required to
+	 * use any wp-rest dispatcher ability.
 	 *
-	 * Mirrors WpCliAbilities::check_permission_level() semantics exactly.
+	 * The wp-rest dispatcher is a generic low-level surface that can
+	 * invoke any registered WordPress REST endpoint, including endpoints
+	 * registered by other plugins. We therefore enforce the same cap
+	 * set as `sd-ai-agent/run-php`: `manage_options` AND `update_core`
+	 * AND `unfiltered_html`. These three caps are individually revocable
+	 * via role-management plugins, and an administrator who loses any
+	 * one of them (typical for managed-hosting customer admins) is
+	 * correctly excluded from the dispatcher.
 	 *
-	 * @param string $level 'read', 'write', or 'destructive'.
+	 * The `$level` parameter is retained for backward-compatible error
+	 * messages; the underlying cap requirement is the same for every
+	 * level because the dispatcher itself is the risk surface, not the
+	 * individual request.
+	 *
+	 * @param string $level 'read', 'write', or 'destructive' (used in error message only).
 	 * @return true|WP_Error
 	 */
 	private static function check_permission_level( string $level ) {
-		if ( current_user_can( 'manage_network' ) ) {
-			return true;
+		$required = array( 'manage_options', 'update_core', 'unfiltered_html' );
+
+		foreach ( $required as $cap ) {
+			if ( ! current_user_can( $cap ) ) {
+				return new WP_Error(
+					'wp_rest_forbidden',
+					sprintf(
+						/* translators: 1: access level, 2: list of required capability names */
+						__( 'You do not have permission to execute this %1$s REST request. Required capabilities (all): %2$s.', 'superdav-ai-agent' ),
+						$level,
+						implode( ', ', $required )
+					),
+					array( 'status' => 403 )
+				);
+			}
 		}
 
-		$capability_map = array(
-			'read'        => 'manage_options',
-			'write'       => 'manage_options',
-			'destructive' => 'manage_network',
-		);
-
-		$required_cap = $capability_map[ $level ] ?? 'manage_network';
-
-		// On single-site installs, manage_network is never granted.
-		// Fall back to manage_options so destructive calls remain accessible
-		// to administrators on non-multisite WordPress installations.
-		if ( 'manage_network' === $required_cap && ! is_multisite() ) {
-			$required_cap = 'manage_options';
-		}
-
-		if ( current_user_can( $required_cap ) ) {
-			return true;
-		}
-
-		return new WP_Error(
-			'wp_rest_forbidden',
-			sprintf(
-				/* translators: 1: access level, 2: capability name */
-				__( 'You do not have permission to execute this %1$s REST request. Required capability: %2$s.', 'superdav-ai-agent' ),
-				$level,
-				$required_cap
-			),
-			array( 'status' => 403 )
-		);
+		return true;
 	}
 
 	/**

--- a/includes/Bootstrap/AbilitiesHandler.php
+++ b/includes/Bootstrap/AbilitiesHandler.php
@@ -162,8 +162,25 @@ final class AbilitiesHandler {
 		}
 		DatabaseAbilities::register_abilities();
 		WordPressAbilities::register_abilities();
-		WpCliAbilities::register_ability();
-		WpRestAbilities::register_abilities();
+		// WP-CLI dispatcher: gated by SD_AI_AGENT_FEATURE_WP_CLI_DISPATCHER
+		// and class_exists() guarded so the WordPress.org build (which
+		// strips includes/Abilities/WpCliAbilities.php via
+		// .distignore-wporg + bin/build.sh stripped_paths) does not
+		// fatal here.
+		if (
+			Features::is_enabled( Features::WP_CLI_DISPATCHER )
+			&& class_exists( WpCliAbilities::class )
+		) {
+			WpCliAbilities::register_ability();
+		}
+		// WP REST dispatcher: gated by SD_AI_AGENT_FEATURE_WP_REST_DISPATCHER
+		// and class_exists() guarded for the same wp.org-strip reason.
+		if (
+			Features::is_enabled( Features::WP_REST_DISPATCHER )
+			&& class_exists( WpRestAbilities::class )
+		) {
+			WpRestAbilities::register_abilities();
+		}
 		OptionsAbilities::register_abilities();
 		// WooCommerce abilities are now registered by WooCommerceIntegrationHandler
 		// via WooCommerce's own AbilitiesRestBridge, making WooCommerce's native
@@ -193,8 +210,21 @@ final class AbilitiesHandler {
 	 */
 	#[Action( tag: 'wp_abilities_api_categories_init', priority: 10 )]
 	public function register_wpcli_category(): void {
-		WpCliAbilities::register_category();
-		WpRestAbilities::register_category();
+		// Both categories are feature-gated AND class_exists() guarded
+		// so the WordPress.org build (which strips the source files)
+		// does not fatal here.
+		if (
+			Features::is_enabled( Features::WP_CLI_DISPATCHER )
+			&& class_exists( WpCliAbilities::class )
+		) {
+			WpCliAbilities::register_category();
+		}
+		if (
+			Features::is_enabled( Features::WP_REST_DISPATCHER )
+			&& class_exists( WpRestAbilities::class )
+		) {
+			WpRestAbilities::register_category();
+		}
 	}
 
 	/**

--- a/includes/Core/Features.php
+++ b/includes/Core/Features.php
@@ -54,6 +54,23 @@ declare(strict_types=1);
  *    remaining Theme Builder abilities (activate-theme,
  *    render-design-previews, generate-menu-page,
  *    validate-palette-contrast, generate-logo-svg) stay registered.
+ *  - SD_AI_AGENT_FEATURE_WP_REST_DISPATCHER — The `wp-rest/discover`,
+ *    `wp-rest/inspect`, and `wp-rest/execute` abilities, which let the
+ *    agent enumerate and invoke arbitrary WordPress REST endpoints via
+ *    the internal dispatcher. Even though every dispatched call still
+ *    goes through the target endpoint's own `permission_callback`, the
+ *    enumeration + execute surface is a generic low-level dispatcher
+ *    and the same class of arbitrary-script-dispatch risk as run-php.
+ *    Disabled in the WordPress.org distribution build and the
+ *    `includes/Abilities/WpRestAbilities.php` source file is physically
+ *    stripped from the shipped zip.
+ *  - SD_AI_AGENT_FEATURE_WP_CLI_DISPATCHER — The `wp-cli/execute`
+ *    ability, which shells out to the `wp` binary via PHP `exec()` to
+ *    run arbitrary WP-CLI commands. Same class of arbitrary-command
+ *    risk as run-php and CUSTOM_TOOLS_CLI. Disabled in the
+ *    WordPress.org distribution build and the
+ *    `includes/Abilities/WpCliAbilities.php` source file is physically
+ *    stripped from the shipped zip.
  *
  * Usage example (wp-config.php):
  *   define( 'SD_AI_AGENT_FEATURE_BRANDING', false );
@@ -193,6 +210,45 @@ final class Features {
 	const SCAFFOLD_BLOCK_THEME = 'scaffold_block_theme';
 
 	/**
+	 * Feature: WP REST dispatcher abilities.
+	 *
+	 * Gates registration of the `wp-rest/discover`, `wp-rest/inspect`,
+	 * and `wp-rest/execute` abilities, plus their shared `wp-rest`
+	 * ability category. With this disabled the agent cannot enumerate
+	 * or invoke arbitrary WordPress REST endpoints through the
+	 * internal dispatcher.
+	 *
+	 * Disabled in the WordPress.org distribution build because the
+	 * dispatcher is a generic low-level surface that, once enabled,
+	 * exposes every registered REST endpoint to whatever caller has
+	 * the agent's permission set — the same class of low-level
+	 * dispatch risk as `run-php`. The
+	 * `includes/Abilities/WpRestAbilities.php` source file is
+	 * physically stripped from the shipped zip.
+	 *
+	 * Constant: SD_AI_AGENT_FEATURE_WP_REST_DISPATCHER
+	 */
+	const WP_REST_DISPATCHER = 'wp_rest_dispatcher';
+
+	/**
+	 * Feature: WP-CLI dispatcher ability.
+	 *
+	 * Gates registration of the `wp-cli/execute` ability and its
+	 * shared `wp-cli` ability category. The ability shells out to the
+	 * `wp` binary via PHP `exec()` and runs arbitrary WP-CLI
+	 * subcommands.
+	 *
+	 * Disabled in the WordPress.org distribution build for the same
+	 * arbitrary-command-execution reason as PLUGIN_BUILDER and
+	 * CUSTOM_TOOLS_CLI. The
+	 * `includes/Abilities/WpCliAbilities.php` source file is
+	 * physically stripped from the shipped zip.
+	 *
+	 * Constant: SD_AI_AGENT_FEATURE_WP_CLI_DISPATCHER
+	 */
+	const WP_CLI_DISPATCHER = 'wp_cli_dispatcher';
+
+	/**
 	 * Map of feature name → backing constant name.
 	 *
 	 * @var array<string, string>
@@ -206,6 +262,8 @@ final class Features {
 		self::PLUGIN_INSTALL_FROM_URL => 'SD_AI_AGENT_FEATURE_PLUGIN_INSTALL_FROM_URL',
 		self::FILE_WRITE              => 'SD_AI_AGENT_FEATURE_FILE_WRITE',
 		self::SCAFFOLD_BLOCK_THEME    => 'SD_AI_AGENT_FEATURE_SCAFFOLD_BLOCK_THEME',
+		self::WP_REST_DISPATCHER      => 'SD_AI_AGENT_FEATURE_WP_REST_DISPATCHER',
+		self::WP_CLI_DISPATCHER       => 'SD_AI_AGENT_FEATURE_WP_CLI_DISPATCHER',
 	);
 
 	/**

--- a/superdav-ai-agent.php
+++ b/superdav-ai-agent.php
@@ -162,6 +162,38 @@ defined( 'SD_AI_AGENT_FEATURE_FILE_WRITE' ) || define( 'SD_AI_AGENT_FEATURE_FILE
  */
 defined( 'SD_AI_AGENT_FEATURE_SCAFFOLD_BLOCK_THEME' ) || define( 'SD_AI_AGENT_FEATURE_SCAFFOLD_BLOCK_THEME', true );
 
+/**
+ * Feature: WP REST dispatcher abilities (`wp-rest/discover`,
+ * `wp-rest/inspect`, `wp-rest/execute`).
+ *
+ * The dispatcher lets the agent enumerate and invoke any registered
+ * WordPress REST endpoint via the internal in-process dispatcher. When
+ * false the three abilities and their shared `wp-rest` category are
+ * not registered.
+ *
+ * Forced to `false` in the WordPress.org distribution build because the
+ * dispatcher is a generic low-level surface that exposes every
+ * registered REST endpoint to whatever caller has the agent's
+ * permission set — the same arbitrary-script-dispatch risk class as
+ * `run-php`. Self-hosted users running the GitHub release retain the
+ * dispatcher.
+ */
+defined( 'SD_AI_AGENT_FEATURE_WP_REST_DISPATCHER' ) || define( 'SD_AI_AGENT_FEATURE_WP_REST_DISPATCHER', true );
+
+/**
+ * Feature: WP-CLI dispatcher ability (`wp-cli/execute`).
+ *
+ * Shells out to the `wp` binary via PHP `exec()` to run arbitrary
+ * WP-CLI subcommands. When false the ability and its shared `wp-cli`
+ * category are not registered.
+ *
+ * Forced to `false` in the WordPress.org distribution build for the
+ * same arbitrary-command-execution reason as `PLUGIN_BUILDER` and
+ * `CUSTOM_TOOLS_CLI`. Self-hosted users running the GitHub release
+ * retain the dispatcher.
+ */
+defined( 'SD_AI_AGENT_FEATURE_WP_CLI_DISPATCHER' ) || define( 'SD_AI_AGENT_FEATURE_WP_CLI_DISPATCHER', true );
+
 // Load Jetpack Autoloader for PSR-4 autoloading with version conflict resolution.
 // Jetpack Autoloader ensures the newest version of shared packages (like php-ai-client) is used.
 if ( file_exists( SD_AI_AGENT_DIR . '/vendor/autoload_packages.php' ) ) {


### PR DESCRIPTION
## Summary

Follow-up to #1922. The `wp-rest/discover`, `wp-rest/inspect`,
`wp-rest/execute`, and `wp-cli/execute` abilities are generic
low-level dispatchers that expose, respectively, every registered
WordPress REST endpoint and the entire `wp` CLI binary to the agent.
Even though every dispatched call still goes through the target
endpoint's own `permission_callback` (or, for wp-cli, the existing
top-level + sub-command blocklists), these surfaces are the same
arbitrary-script-dispatch risk class as `sd-ai-agent/run-php` and
should not ship in the WordPress.org distribution.

## Four-layer defence-in-depth (mirrors `run-php`)

1. **Feature flags** — `SD_AI_AGENT_FEATURE_WP_REST_DISPATCHER` and
   `SD_AI_AGENT_FEATURE_WP_CLI_DISPATCHER` in
   `includes/Core/Features.php` + `superdav-ai-agent.php`. Default
   `true`; forced `false` in the wp.org build.

2. **Runtime gates** — `WpRestAbilities::register_category()`,
   `WpRestAbilities::register_abilities()`,
   `WpCliAbilities::register_category()`, and
   `WpCliAbilities::register_ability()` early-return when the
   flag is off, even if the file is on disk.

3. **Bootstrap gates** — `AbilitiesHandler.php` wraps both classes'
   `register_*` calls in `Features::is_enabled()` AND
   `class_exists()` guards so the wp.org build (which strips the
   files) does not fatal.

4. **Physical strip** — `.distignore-wporg` lists both files;
   `bin/build.sh` adds them to `stripped_paths` verification (build
   fails loudly if they ever leak into the zip) and to the `flags`
   array that hard-defines the constants to `false` in the bundled
   main plugin file.

## Tightened permissions (also applies in the full build)

Both dispatcher classes' `check_permission_level()` previously
mapped levels to single caps (`read`/`write` → `manage_options`,
`destructive` → `manage_network`). The dispatcher *itself* is the
risk surface — not the individual request — so the helper now
requires the same three-cap set as `sd-ai-agent/run-php`:

```text
manage_options AND update_core AND unfiltered_html
```

These three caps are individually revocable via role-management
plugins, so a managed-hosting customer admin who has had any one
cap revoked is correctly excluded from the dispatcher. The `$level`
parameter is retained for backward-compatible error messages.

The inline `wp-rest/execute` `permission_callback` (which previously
used `manage_network` OR `manage_options`) is folded into the
helper so all three wp-rest abilities share a single source of
truth.

## Verification — wp.org zip

```bash
./bin/build.sh --target=wporg
unzip -l superdav-ai-agent-1.16.1-wporg.zip | grep -E "WpRest|WpCli"
# → no matches under includes/Abilities/

unzip -p ...zip superdav-ai-agent/superdav-ai-agent.php \
    | grep "SD_AI_AGENT_FEATURE_WP_(REST|CLI)_DISPATCHER"
# define( 'SD_AI_AGENT_FEATURE_WP_REST_DISPATCHER', false ); // wporg-build: low-level REST dispatcher disabled per WP.org Guideline 4.
# define( 'SD_AI_AGENT_FEATURE_WP_CLI_DISPATCHER', false ); // wporg-build: shell-exec wp-cli dispatcher disabled per WP.org Guideline 4.
```

Both confirmed locally before opening this PR.

## Worker self-verification

```text
- PHPUnit: Tests: 3468, Assertions: 13951, Errors: 0, Failures: 0, Skipped: 114
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded (wp-scripts + archive + bin/build.sh --target=wporg)
```

No new tests in this PR — the existing `WpRestAbilitiesTest` /
`WpCliAbilitiesTest` suites still pass because the admin user in
their setUp holds `manage_options`, `update_core`, and
`unfiltered_html` by default. The feature-flag gating is verified
by the wp.org build script itself, which fails the build if the
source files are not stripped.

## Files touched

- `includes/Core/Features.php` — two new constants + CONSTANT_MAP entries
- `superdav-ai-agent.php` — two new `defined() || define()` lines
- `includes/Abilities/WpRestAbilities.php` — Features import + gate +
  strict cap helper + inline-callback consolidation
- `includes/Abilities/WpCliAbilities.php` — same pattern
- `includes/Bootstrap/AbilitiesHandler.php` — feature-flag +
  class_exists guards around both classes' registration calls
- `.distignore-wporg` — two new strip entries + header comment update
- `bin/build.sh` — two flags + two stripped_paths entries

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 2d and 111,419 tokens on this with the user in an interactive session.
