### PR TITLE
GH#1925: docs: carve out dispatcher ability namespaces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,14 @@ between the user-facing plugin slug and the code-level prefixes/namespaces.
    - PR #1283 (auto-migration of legacy `ai-agent/` keys) — reverted
 6. Headless agents that propose these renames are operating outside scope. File
    an issue describing the rogue behaviour rather than merging the PR.
+7. **Do not canonicalise the deliberate dispatcher namespaces** `wp-rest/*` and
+   `wp-cli/*` to `sd-ai-agent/*`. These are the only ability namespaces
+   intentionally outside `sd-ai-agent/`: they mirror the underlying WordPress
+   REST API and `wp` CLI systems, act as generic dispatchers rather than
+   plugin-specific features, and would be both breaking and misleading if
+   renamed. PRs #1922 and #1923 hardened these paths with dual gates without
+   canonicalising their ability IDs; future "rename-to-canonical" PRs for
+   `wp-rest/` or `wp-cli/` should be closed and reverted.
 
 ### WordPress.org Review Responses
 


### PR DESCRIPTION
## Summary

Added an AGENTS.md canonical-naming rule documenting wp-rest/* and wp-cli/* as deliberate dispatcher namespace exceptions, including rationale and PR #1922/#1923 references.

## Files Changed

AGENTS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** rg -n "wp-rest|wp-cli" AGENTS.md

Resolves #1925


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 1m and 41,771 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guidelines to clarify namespace naming conventions and canonicalization rules for ability identifiers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1926?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->