### PR TITLE
chore(wporg-zip): drop dev-only files + let wporg-review run from worktrees

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -138,6 +138,22 @@
 /test-results
 /skills-lock.json
 
+# Temporary issue-specific dev notes (root *.md files). Listed individually
+# so future ISSUE_*.md scratch notes get added here, not silently shipped.
+/ISSUE_1497_FIX.md
+
+# Editor / agent runtime scratch directories — contain node_modules and
+# session state that must never reach the GitHub release or WP.org zip.
+/.opencode
+/.claude
+/.cursor
+
+# Repository-only dev tooling. The /tools tree holds one-off audit and
+# maintenance scripts (e.g. tools/audit/schema-type-audit.php) — none of it
+# is loaded by the plugin runtime. Distinct from the /sd-ai-agent/tools/
+# REST resource implemented by includes/REST/ToolController.php.
+/tools
+
 # Playwright artefacts (top-level only)
 /playwright-report
 /blob-report

--- a/bin/wporg-review.sh
+++ b/bin/wporg-review.sh
@@ -74,7 +74,13 @@ cd "$PLUGIN_DIR"
 : "${SKIP_PLUGINS:=multisite-ultimate-domain-seller}"
 : "${KEEP:=0}"
 
-WP_DIR="${PLUGIN_DIR}/../wordpress"
+# WP_DIR defaults to the sibling ../wordpress dev install per
+# AGENTS.md > Local Development Environment. Override it explicitly when
+# running this script from a git worktree under ~/Git/<repo>-worktrees/,
+# where ${PLUGIN_DIR}/../wordpress points at the wrong directory:
+#
+#   WP_DIR=/home/dave/Git/wordpress npm run wporg-review
+: "${WP_DIR:=${PLUGIN_DIR}/../wordpress}"
 PLUGINS_DIR="${WP_DIR}/wp-content/plugins"
 REPORT_DIR="${PLUGIN_DIR}/build/wporg-review"
 
@@ -197,12 +203,12 @@ echo "==> [3/5] Ensuring Plugin Check (PCP) is installed and recent..."
 # We need PCP ≥ 2.0.0 for the --ai / --ai-model flags.
 # `wp plugin install plugin-check --activate --force` always pulls the
 # latest, which is what we want for review parity with .org.
-wp plugin install plugin-check --activate --force \
+wp --path="$WP_DIR" plugin install plugin-check --activate --force \
 	--skip-plugins="$SKIP_PLUGINS" --skip-themes \
 	>/dev/null
 
 PCP_VERSION="$(
-	wp plugin get plugin-check --field=version \
+	wp --path="$WP_DIR" plugin get plugin-check --field=version \
 		--skip-plugins="$SKIP_PLUGINS" --skip-themes 2>/dev/null || true
 )"
 echo "    Plugin Check version: ${PCP_VERSION:-unknown}"
@@ -232,7 +238,7 @@ mkdir -p "$REPORT_DIR"
 	echo "Review dir     : ${TARGET_DIR}"
 	echo "Reported slug  : ${SUBMISSION_SLUG}"
 	echo "Skipped plugins: ${SKIP_PLUGINS}"
-	echo "Command        : wp plugin check ${REVIEW_SLUG} \\"
+	echo "Command        : wp --path=${WP_DIR} plugin check ${REVIEW_SLUG} \\"
 	echo "                     --slug=${SUBMISSION_SLUG} \\"
 	echo "                     --ai --ai-model=${MODEL} \\"
 	echo "                     --require=${PCP_CLI} \\"
@@ -244,7 +250,7 @@ mkdir -p "$REPORT_DIR"
 # PCP exits non-zero when issues are found — that's the whole point of
 # running it. Capture the exit code but don't abort the script on it.
 set +e
-wp plugin check "$REVIEW_SLUG" \
+wp --path="$WP_DIR" plugin check "$REVIEW_SLUG" \
 	--slug="$SUBMISSION_SLUG" \
 	--ai \
 	--ai-model="$MODEL" \

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "superdav-ai-agent",
-	"version": "1.16.1",
+	"version": "1.16.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "superdav-ai-agent",
-			"version": "1.16.1",
+			"version": "1.16.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@codemirror/commands": "^6.10.3",


### PR DESCRIPTION
## Summary

Two small follow-ups to PR #1928 (wporg-review pipeline):

1. **`chore(wporg-zip)`** — three dev-only paths were silently shipping in the
   wporg + GitHub build zips and showing up in the `wp plugin check --ai` AI
   review output:

   - `ISSUE_1497_FIX.md` — temp issue scratch note at repo root.
   - `.opencode/` — editor session dir (contains `node_modules/`).
   - `tools/` — repo-only audit/maintenance scripts. No runtime loader. Distinct
     from the `/sd-ai-agent/tools/` REST resource implemented by
     `includes/REST/ToolController.php`.

   All three go in main `.distignore`, not `.distignore-wporg`, per the
   "applies to both builds" rule documented in `.distignore-wporg`'s header
   (line 34).

   Also catches `package-lock.json` up from 1.16.1 → 1.16.2 to match
   `package.json` — pre-existing drift that `npm install` surfaced.

2. **`fix(wporg-review)`** — `bin/wporg-review.sh` hard-coded `$WP_DIR` to
   `$PLUGIN_DIR/../wordpress` and ran every `wp` call without `--path`, so it
   broke whenever invoked from a git worktree (i.e. the canonical interactive
   maintainer workflow per `.agents/AGENTS.md`). `$WP_DIR` is now overridable:

   ```bash
   WP_DIR=/home/dave/Git/wordpress npm run wporg-review
   ```

   All three `wp` invocations (`plugin install` / `plugin get` / `plugin check`)
   now pass `--path="$WP_DIR"` explicitly. Default behaviour (run from main
   checkout) is unchanged.

## Verification

End-to-end review run from the worktree:

```text
WP_DIR=/home/dave/Git/wordpress npm run wporg-review
→ build/wporg-review/1.16.2-20260530T024150Z.txt
→ PCP exit 0
```

Finding deltas vs the pre-fix baseline (PR #1928's first report):

| metric    | before | after | delta |
| --------- | -----: | ----: | ----: |
| ERRORs    |    126 |   106 |   −20 |
| WARNINGs  |    186 |   167 |   −19 |

Zip contents check:

```bash
unzip -l superdav-ai-agent-1.16.2-wporg.zip \
  | grep -E 'ISSUE_1497|\.opencode|tools/audit'
# → no matches
```

Script syntax:

```bash
bash -n bin/wporg-review.sh && shellcheck bin/wporg-review.sh
# → both clean
```

## Worker self-verification

This PR touches **no PHP, JS, or CSS** — only `.distignore`, a bash script,
and a lockfile version bump. The standard `npm run verify` gates
(PHPUnit / PHPStan / PHPCS / ESLint / Stylelint / webpack) are not exercised
by these changes, so the block below reflects what was actually run:

- PHPUnit: not run — no PHP touched
- Lint PHP/JS/CSS: not run — no PHP/JS/CSS touched
- PHPStan: not run — no PHP touched
- Build (`npm run build`): exercised indirectly via `npm run wporg-review`,
  which calls `bin/build.sh --target=wporg`, which runs `npx wp-scripts build`.
  Result: succeeded (`webpack 5.105.3 compiled with 2 warnings in 21289 ms`,
  matching pre-existing baseline).
- Bash syntax + shellcheck on `bin/wporg-review.sh`: clean.
- End-to-end `npm run wporg-review`: succeeded, report attached above.

CI is the second gate and will run the full matrix.

For #1928

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 2d 6h and 111,419 tokens on this with the user in an interactive session.
