### PR TITLE
GH#1931: test: isolate flaky PHPUnit ability fixtures

### DIFF
--- a/includes/Tools/CustomTools.php
+++ b/includes/Tools/CustomTools.php
@@ -420,6 +420,11 @@ class CustomTools {
 			if ( ! $cli_enabled && self::TYPE_CLI === $example['type'] ) {
 				continue;
 			}
+
+			if ( self::get_by_slug( (string) $example['slug'] ) ) {
+				continue;
+			}
+
 			self::create( $example );
 		}
 

--- a/tests/SdAiAgent/Abilities/InsertPatternTest.php
+++ b/tests/SdAiAgent/Abilities/InsertPatternTest.php
@@ -47,31 +47,44 @@ class InsertPatternTest extends WP_UnitTestCase {
 	public function set_up(): void {
 		parent::set_up();
 
+		$this->unregister_all_block_patterns();
+
 		// Create an admin user and set as current user for capability checks.
 		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
 		wp_set_current_user( $admin_id );
 
 		// Register a test pattern for all tests.
-		if ( ! \WP_Block_Patterns_Registry::get_instance()->is_registered( self::TEST_PATTERN ) ) {
-			register_block_pattern(
-				self::TEST_PATTERN,
-				[
-					'title'   => 'Insert Test Pattern',
-					'content' => '<!-- wp:quote --><blockquote class="wp-block-quote"><p>Test quote</p></blockquote><!-- /wp:quote -->',
-				]
-			);
-		}
+		register_block_pattern(
+			self::TEST_PATTERN,
+			[
+				'title'   => 'Insert Test Pattern',
+				'content' => '<!-- wp:quote --><blockquote class="wp-block-quote"><p>Test quote</p></blockquote><!-- /wp:quote -->',
+			]
+		);
 	}
 
 	/**
 	 * Clean up test fixtures.
 	 */
 	public function tear_down(): void {
-		if ( \WP_Block_Patterns_Registry::get_instance()->is_registered( self::TEST_PATTERN ) ) {
-			unregister_block_pattern( self::TEST_PATTERN );
-		}
+		$this->unregister_all_block_patterns();
 
 		parent::tear_down();
+	}
+
+	/**
+	 * Remove all process-global block patterns so each test starts isolated.
+	 */
+	private function unregister_all_block_patterns(): void {
+		$registry = \WP_Block_Patterns_Registry::get_instance();
+
+		foreach ( $registry->get_all_registered() as $pattern_name => $pattern ) {
+			if ( is_int( $pattern_name ) && is_array( $pattern ) && isset( $pattern['name'] ) ) {
+				$pattern_name = $pattern['name'];
+			}
+
+			unregister_block_pattern( $pattern_name );
+		}
 	}
 
 	// ── Helpers ────────────────────────────────────────────────────────────

--- a/tests/SdAiAgent/Abilities/RevertToRevisionTest.php
+++ b/tests/SdAiAgent/Abilities/RevertToRevisionTest.php
@@ -41,6 +41,13 @@ class RevertToRevisionTest extends WP_UnitTestCase {
 	private int $admin_id;
 
 	/**
+	 * Post IDs created during the current test.
+	 *
+	 * @var int[]
+	 */
+	private array $created_post_ids = [];
+
+	/**
 	 * Set up an administrator user context before each test.
 	 */
 	public function set_up(): void {
@@ -54,6 +61,11 @@ class RevertToRevisionTest extends WP_UnitTestCase {
 	 * Restore user context after each test.
 	 */
 	public function tear_down(): void {
+		foreach ( array_reverse( $this->created_post_ids ) as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+
+		$this->created_post_ids = [];
 		wp_set_current_user( 0 );
 		parent::tear_down();
 	}
@@ -84,6 +96,7 @@ class RevertToRevisionTest extends WP_UnitTestCase {
 
 		$this->assertIsInt( $post_id );
 		$this->assertGreaterThan( 0, $post_id );
+		$this->created_post_ids[] = $post_id;
 
 		return $post_id;
 	}


### PR DESCRIPTION
## Summary

Made CustomTools example seeding skip already-present slugs, reset process-global block-pattern registry around InsertPatternTest, and force-delete RevertToRevisionTest posts created during each test.

## Files Changed

includes/Tools/CustomTools.php,tests/SdAiAgent/Abilities/InsertPatternTest.php,tests/SdAiAgent/Abilities/RevertToRevisionTest.php

## Runtime Testing

- **Risk level:** Low (test-infrastructure and idempotent seeding guard)
- **Verification:** npm run verify; npm run test:php -- --filter='CustomToolsTest|InsertPatternTest|RevertToRevisionTest|RestControllerTest'; repeated full PHPUnit flake check five times: Tests: 3520, Assertions: 14634, Skipped: 114, Incomplete: 4 each run.

## Worker self-verification
- PHPUnit: Tests: 3520, Assertions: 14634, Errors: 0, Failures: 0, Skipped: 114, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Resolves #1931


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 13m and 95,988 tokens on this as a headless worker.
