### PR TITLE
fix(db,readme): pre-submission wporg cleanup — %i identifier + reviewer note

### DIFF
--- a/includes/Abilities/SiteHealthAbilities.php
+++ b/includes/Abilities/SiteHealthAbilities.php
@@ -858,14 +858,16 @@ class SiteHealthAbilities {
 		global $wpdb;
 
 		$sessions_table = $wpdb->prefix . 'sd_ai_agent_sessions';
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
 		$table_name = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $sessions_table ) );
 		if ( $sessions_table !== $table_name ) {
 			return 0;
 		}
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		return (int) $wpdb->get_var( "SELECT COUNT(*) FROM `{$sessions_table}`" );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		return (int) $wpdb->get_var(
+			$wpdb->prepare( 'SELECT COUNT(*) FROM %i', $sessions_table )
+		);
 	}
 
 	/**

--- a/includes/Core/OnboardingManager.php
+++ b/includes/Core/OnboardingManager.php
@@ -116,8 +116,10 @@ class OnboardingManager {
 
 		global $wpdb;
 		$sessions_table = $wpdb->prefix . 'sd_ai_agent_sessions';
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		$session_count = (int) $wpdb->get_var( "SELECT COUNT(*) FROM `{$sessions_table}`" );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching
+		$session_count = (int) $wpdb->get_var(
+			$wpdb->prepare( 'SELECT COUNT(*) FROM %i', $sessions_table )
+		);
 		return $session_count > 0;
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "superdav-ai-agent",
-	"version": "1.16.1",
+	"version": "1.16.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "superdav-ai-agent",
-			"version": "1.16.1",
+			"version": "1.16.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@codemirror/commands": "^6.10.3",

--- a/readme.txt
+++ b/readme.txt
@@ -197,6 +197,12 @@ The agent has a built-in confirmation system. Potentially destructive tool calls
 
 Yes, the plugin works on both single-site and multisite WordPress installations. Each site has its own settings, sessions, memories, and automations.
 
+= Why does static analysis report `wp_function_not_compatible_with_requires_wp` for `wp_ai_client_prompt()`? =
+
+The plugin's `Requires at least` header is WordPress 6.9, but the agent core uses `wp_ai_client_prompt()`, which only ships natively in WordPress 7.0. The plugin bundles a compatibility shim at `includes/Compat/ai-client/` that defines `wp_ai_client_prompt()` and the supporting prompt-builder classes on WordPress 6.9 installs and yields to the native implementation on WordPress 7.0+.
+
+All call sites are either reached only after the shim has loaded the function, or are guarded by `function_exists( 'wp_ai_client_prompt' )` first. Static analyzers (including the WordPress.org Plugin Check tool's "compatibility with Requires at least" check) cannot follow the shim's load path and may flag these calls as version-incompatible. The bundled compat layer makes them safe on every supported WordPress version.
+
 == Screenshots ==
 
 1. Full-page chat interface with session sidebar and folder organization


### PR DESCRIPTION
## Summary

Two pre-submission wporg-readiness improvements identified by
`npm run wporg-review` (the AI-enabled local mirror of the WordPress.org
Internal Scanner — added in PR #1928, refined in PR #1930):

### 1. `DirectDB.UnescapedDBParameter` — 2 warnings fixed

Both `$wpdb->get_var( "SELECT COUNT(*) FROM \`{$sessions_table}\`" )`
call sites now use the modern WordPress 6.2+ `%i` (identifier) placeholder:

```php
$wpdb->get_var( $wpdb->prepare( 'SELECT COUNT(*) FROM %i', $sessions_table ) );
```

- `includes/Core/OnboardingManager.php:120`
- `includes/Abilities/SiteHealthAbilities.php:868`

Plugin requires WordPress 6.9, so `%i` is always available. This also lets
us drop the `WordPress.DB.PreparedSQL.InterpolatedNotPrepared` phpcs:ignore
from both call sites — only the `DirectQuery`/`NoCaching` ignores remain
(those are correct: we *are* doing a direct query against our own table).

### 2. `readme.txt` — FAQ entry for the WP 6.9 compatibility shim

The WordPress.org Internal Scanner reports 13
`wp_function_not_compatible_with_requires_wp` ERRORs against
`wp_ai_client_prompt()` calls because the function is WP 7.0+ and the
plugin's `Requires at least` is 6.9.

The plugin bundles a compatibility shim at `includes/Compat/ai-client/`
that defines the function on 6.9 and yields to the native implementation
on 7.0+. The Internal Scanner's own AI false-positive pass already
dismisses all 13 instances (see report from PR #1928), but the human
reviewer doesn't see that without opening the report. The new FAQ entry
makes the explanation visible directly in the directory listing.

## Verification

```text
WP_DIR=/home/dave/Git/wordpress npm run wporg-review
```

Expected deltas vs PR #1930's baseline (106 ERRORs, 167 WARNINGs):

- `DirectDB.UnescapedDBParameter`: 2 → 0
- `WordPress.DB.PreparedSQL.InterpolatedNotPrepared` ignores: 2 → 0
- All other findings: unchanged in this PR

The 13 `wp_function_not_compatible_with_requires_wp` ERRORs are not removed
by code changes (the AI already dismisses them); the readme FAQ is the
human-reviewer-facing mitigation.

## Worker self-verification

- PHPUnit: Tests: 3520, Assertions: 14634, Skipped: 114, Incomplete: 4
  (zero Failures, zero Errors — no `Failures:` / `Errors:` lines in
  PHPUnit summary when both are zero)
- Lint:    PHP / JS / CSS all clean (`composer phpcs` 8/8, eslint and
  stylelint silent)
- PHPStan: 0 errors (`277/277  [OK] No errors`)
- Build:   succeeded (`npm run build` → `Archive created: superdav-ai-agent.zip`)

For #1928

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 2d 6h and 111,419 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced database security by converting SQL queries to use prepared statements instead of direct string interpolation.

* **Documentation**
  * Added FAQ entry clarifying WordPress compatibility concerns and static-analysis warnings for sites on WordPress 6.9 or later.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1934?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->