### PR TITLE
docs: shorten 1.16.2 upgrade notice

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -583,7 +583,7 @@ All call sites are either reached only after the shim has loaded the function, o
 == Upgrade Notice ==
 
 = 1.16.2 =
-Documentation and cleanup release addressing WordPress.org review feedback. Clarifies that third-party OpenAI-compatible providers are governed by their own connector plugins, removes hardcoded third-party provider hostnames that were not direct integrations, and adds two filter extension points (`sd_ai_agent_models_endpoint_hosts`, `sd_ai_agent_resolve_cache_strategy`) for connector plugins.
+Documentation and cleanup release for WordPress.org review feedback. Clarifies third-party connector responsibility, removes hardcoded provider hostnames that were not direct integrations, and documents the models endpoint and cache-strategy filters.
 
 = 1.12.0 =
 Documentation and dependency-maintenance release addressing WordPress.org review feedback. Discloses the opt-in feedback service, fixes the Openverse Terms link, removes placeholder URLs, moves the WP-CLI benchmark log directory out of the plugin folder, and updates bundled libraries.


### PR DESCRIPTION
## Summary
- Shortens the `readme.txt` 1.16.2 upgrade notice to satisfy the WordPress.org 300-character limit.
- Keeps the notice focused on the WordPress.org review cleanup, provider-hostname removal, and documented filter extension points.

## Verification
- `python3` readme parser: `1.16.2 upgrade notice length: 250` / `PASS`
- `npm run verify`

## Worker self-verification
- PHPUnit: Tests: 3520, Assertions: 14649, Errors: 0, Failures: 0, Skipped: 114, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 2d 9h and 111,419 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated upgrade notice to clarify third-party connector responsibilities and document the models ingestion allow-list feature
  * Enhanced documentation of cache strategy options for better transparency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1935?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->