### PR TITLE
fix(block-policy): use literal filter hook names

### DIFF
--- a/includes/Core/BlockContentPolicy.php
+++ b/includes/Core/BlockContentPolicy.php
@@ -208,7 +208,7 @@ class BlockContentPolicy {
 		 *
 		 * @param array<string, int> $merged Merged scores (defaults + stored).
 		 */
-		return (array) apply_filters( self::OPTION_PREFERENCES, $merged );
+		return (array) apply_filters( 'sd_ai_agent_block_preferences', $merged );
 	}
 
 	/**
@@ -240,7 +240,7 @@ class BlockContentPolicy {
 		 *
 		 * @param array<string, string> $merged Merged replacement map.
 		 */
-		return (array) apply_filters( self::OPTION_REPLACEMENTS, $merged );
+		return (array) apply_filters( 'sd_ai_agent_block_replacements', $merged );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Replaces `self::OPTION_PREFERENCES` in `apply_filters()` with the literal `sd_ai_agent_block_preferences` hook name.
- Replaces `self::OPTION_REPLACEMENTS` in `apply_filters()` with the literal `sd_ai_agent_block_replacements` hook name.
- Keeps the option constants for option reads while avoiding automated WordPress.org reviewer confusion around dynamic hook names.

## Verification

- Skipped broader verification by maintainer request.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 2d 9h and 111,419 tokens on this with the user in an interactive session.
