### PR TITLE
fix(admin): document core block enqueue hooks

### DIFF
--- a/includes/Admin/BlockValidatorPage.php
+++ b/includes/Admin/BlockValidatorPage.php
@@ -97,8 +97,10 @@ final class BlockValidatorPage {
 		wp_enqueue_style( 'wp-block-library' );
 		wp_enqueue_style( 'wp-block-library-theme' );
 
-		// Third-party block scripts hook these actions.
+		// Third-party block scripts hook these WordPress core actions.
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Intentionally fires the core block editor enqueue hook so third-party block scripts register for validation.
 		do_action( 'enqueue_block_editor_assets' );
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Intentionally fires the core block asset enqueue hook so third-party block scripts register for validation.
 		do_action( 'enqueue_block_assets' );
 
 		// Determine asset path. Built file lives at build/block-validator.js.


### PR DESCRIPTION
## Summary
- Adds scoped PHPCS ignores for the two intentional WordPress core block enqueue hooks in `BlockValidatorPage`.
- Documents why the hooks must remain `enqueue_block_editor_assets` and `enqueue_block_assets` for third-party block validation.

## Verification
- `npm run verify` started and completed JS/CSS/PHP lint, including PHPCS, but was aborted during PHPStan.
- Full verification intentionally skipped after maintainer instruction: "skip the verification, just commit".
- Pre-commit lint-staged hook passed PHPCBF/PHPCS for the changed PHP file.

## Worker self-verification
- PHPUnit: not run at maintainer request
- Lint:    PHP/JS/CSS lint completed during aborted `npm run verify`; staged PHP PHPCS passed in pre-commit
- PHPStan: not run at maintainer request
- Build:   not run at maintainer request

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 2d 9h and 111,419 tokens on this with the user in an interactive session.
