### PR TITLE
fix(wporg): move direct access guards to file top

### DIFF
--- a/includes/Bootstrap/AbilitiesHandler.php
+++ b/includes/Bootstrap/AbilitiesHandler.php
@@ -1,4 +1,13 @@
 <?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Bootstrap;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * DI handler that registers all WordPress Abilities.
  *
@@ -17,10 +26,6 @@
  * @package SdAiAgent\Bootstrap
  * @license GPL-2.0-or-later
  */
-
-declare(strict_types=1);
-
-namespace SdAiAgent\Bootstrap;
 
 use SdAiAgent\Abilities\AiImageAbilities;
 use SdAiAgent\Abilities\BlockAbilities;
@@ -68,10 +73,6 @@ use SdAiAgent\Abilities\WpCliAbilities;
 use SdAiAgent\Abilities\WpRestAbilities;
 use XWP\DI\Decorators\Action;
 use XWP\DI\Decorators\Handler;
-
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 
 /**
  * Registers all ability groups on `wp_abilities_api_init` and wires

--- a/includes/Compat/GutenbergConnectorsBridge.php
+++ b/includes/Compat/GutenbergConnectorsBridge.php
@@ -1,4 +1,13 @@
 <?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Compat;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Bridge: restore Gutenberg's Connectors infrastructure on WP 6.9 installs.
  *
@@ -58,14 +67,6 @@
  * @license GPL-2.0-or-later
  * @since   1.11.1
  */
-
-declare(strict_types=1);
-
-namespace SdAiAgent\Compat;
-
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 
 /**
  * Restores Gutenberg's Connectors admin page on WP 6.9 when a plugin

--- a/includes/Core/AbilityHooks.php
+++ b/includes/Core/AbilityHooks.php
@@ -1,6 +1,13 @@
 <?php
 
 declare(strict_types=1);
+
+namespace SdAiAgent\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Ability execution hook system.
  *
@@ -63,13 +70,6 @@ declare(strict_types=1);
  * @package SdAiAgent
  * @license GPL-2.0-or-later
  */
-
-namespace SdAiAgent\Core;
-
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 class AbilityHooks {
 
 	/**

--- a/includes/Core/AbilityVisibility.php
+++ b/includes/Core/AbilityVisibility.php
@@ -1,6 +1,13 @@
 <?php
 
 declare(strict_types=1);
+
+namespace SdAiAgent\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Centralised visibility resolver for WordPress abilities.
  *
@@ -57,15 +64,9 @@ declare(strict_types=1);
  * @license GPL-2.0-or-later
  */
 
-namespace SdAiAgent\Core;
-
 use SdAiAgent\Abilities\ThirdParty\PartnerAllowlist;
 use SdAiAgent\Core\Settings;
 use WP_Ability;
-
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 
 /**
  * Classify abilities and resolve per-surface visibility.

--- a/includes/Core/Features.php
+++ b/includes/Core/Features.php
@@ -1,6 +1,13 @@
 <?php
 
 declare(strict_types=1);
+
+namespace SdAiAgent\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Feature-flag registry.
  *
@@ -102,13 +109,6 @@ declare(strict_types=1);
  * @package SdAiAgent
  * @license GPL-2.0-or-later
  */
-
-namespace SdAiAgent\Core;
-
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 final class Features {
 
 	/**

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -1,4 +1,13 @@
 <?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Plugin entry-point module for the Superdav AI Agent DI container.
  *
@@ -13,10 +22,6 @@
  * @package SdAiAgent
  * @license GPL-2.0-or-later
  */
-
-declare(strict_types=1);
-
-namespace SdAiAgent;
 
 use SdAiAgent\Bootstrap\AbilitiesHandler;
 use SdAiAgent\Bootstrap\AdminHandler;
@@ -66,10 +71,6 @@ use SdAiAgent\REST\ToolController;
 use SdAiAgent\REST\TraceController;
 use SdAiAgent\REST\WebhookController;
 use XWP\DI\Decorators\Module;
-
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 
 /**
  * Root application module for the DI container.

--- a/includes/REST/IfMatchHeader.php
+++ b/includes/REST/IfMatchHeader.php
@@ -1,6 +1,13 @@
 <?php
 
 declare(strict_types=1);
+
+namespace SdAiAgent\REST;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * HTTP If-Match / ETag header parser and formatter for optimistic concurrency.
  *
@@ -48,13 +55,7 @@ declare(strict_types=1);
  * @see     https://github.com/Ultimate-Multisite/superdav-ai-agent/issues/1785
  */
 
-namespace SdAiAgent\REST;
-
 use WP_Error;
-
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 
 /**
  * HTTP If-Match / ETag parser and formatter.

--- a/lib/php-ai-client/third-party/Nyholm/Psr7/Factory/HttplugFactory.php
+++ b/lib/php-ai-client/third-party/Nyholm/Psr7/Factory/HttplugFactory.php
@@ -3,6 +3,10 @@
 declare (strict_types=1);
 namespace WordPress\AiClientDependencies\Nyholm\Psr7\Factory;
 
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 use WordPress\AiClientDependencies\Http\Message\MessageFactory;
 use WordPress\AiClientDependencies\Http\Message\StreamFactory;
 use WordPress\AiClientDependencies\Http\Message\UriFactory;

--- a/lib/php-ai-client/third-party/Nyholm/Psr7/StreamTrait.php
+++ b/lib/php-ai-client/third-party/Nyholm/Psr7/StreamTrait.php
@@ -3,6 +3,10 @@
 declare (strict_types=1);
 namespace WordPress\AiClientDependencies\Nyholm\Psr7;
 
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 use WordPress\AiClientDependencies\Psr\Http\Message\StreamInterface;
 use WordPress\AiClientDependencies\Symfony\Component\Debug\ErrorHandler as SymfonyLegacyErrorHandler;
 use WordPress\AiClientDependencies\Symfony\Component\ErrorHandler\ErrorHandler as SymfonyErrorHandler;


### PR DESCRIPTION
## Summary
- Moves the `ABSPATH` direct-access guard to the top of the flagged namespaced PHP files.
- Adds the same guard to the two bundled Nyholm PSR-7 third-party files reported by plugin-check.
- Keeps existing namespaces and canonical `sd-ai-agent` identifiers unchanged.

## Worker self-verification
- PHPUnit: Tests: 3520, Assertions: 14649, Errors: 0, Failures: 0, Skipped: 114, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Note: `npm run verify` completed successfully before the branch was rebased on the latest `origin/main`; post-rebase rerun was skipped per maintainer request.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 2d 9h and 111,419 tokens on this with the user in an interactive session.
