### PR TITLE
GH#1939: fix(cli): align skills sync help count

### DIFF
--- a/includes/CLI/SkillsCommand.php
+++ b/includes/CLI/SkillsCommand.php
@@ -112,7 +112,7 @@ class SkillsCommand extends WP_CLI_Command {
 	}
 
 	/**
-	 * Sync the four curated WordPress/agent-skills into includes/Models/skills/.
+	 * Sync the five curated WordPress/agent-skills into includes/Models/skills/.
 	 *
 	 * Fetches each SKILL.md from WordPress/agent-skills, applies sanitisation
 	 * (removes Studio-specific `studio wp ` CLI prefix, replaces wp-project-triage


### PR DESCRIPTION
## Summary

Updated the WP-CLI skills sync command help text to say it syncs five curated WordPress/agent-skills, matching SkillsCommand::SYNC_SLUGS.

## Files Changed

includes/CLI/SkillsCommand.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify (lint clean; PHPStan 0 errors; PHPUnit: Tests: 3520, Assertions: 14649, Skipped: 114, Incomplete: 4; build succeeded with webpack size warnings)

Resolves #1939


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 6m and 41,000 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect that five curated WordPress/agent-skills are now synced (previously four).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1941?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->