### PR TITLE
GH#1942: docs: clarify contributor insight follow-through

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -80,6 +80,10 @@ to change, do not answer only in the issue thread. Make the durable repo change:
   routes in the private `sd-ai-agent/v1` namespace. Convert shorthand feedback
   into explicit checks for capability gates, real current-user context, secret
   scrubbing, and hidden or restricted file-upload endpoints.
+- For pasted local-path skill excerpts, first map the excerpt to the committed
+  in-plugin source. Block theme or Full Site Editing excerpts belong in
+  `includes/Models/skills/wp-block-themes.md`; update that skill or the root
+  `AGENTS.md` summary instead of copying private local paths into GitHub.
 - Do not mark contributor-insight issues complete after documentation reading
   alone. A valid fix changes a durable instruction, workflow doc, or helper, then
   verifies the changed guidance with an exact `rg -n` check that future workers

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,11 @@ turn it into durable, worker-ready guidance instead of relying on chat history:
   the verification command that should prove the change.
 - Keep instruction changes concrete and actionable; avoid copying vague feedback
   without translating it into a rule, reference pattern, or testable outcome.
+- When a contributor insight contains a pasted local-path skill or prompt excerpt,
+  identify the committed source file it came from before editing. For block-theme
+  or Full Site Editing excerpts, use `includes/Models/skills/wp-block-themes.md`
+  as the durable target; do not paste private local paths or duplicate the whole
+  skill into GitHub comments.
 
 #### Contributor Insight Completion Checklist
 
@@ -112,6 +117,23 @@ when it includes all of the following:
 - Evidence in the PR body showing the instruction is now loaded by future
   workers, such as `rg -n "Contributor Insight|sd-ai-agent/v1|secret|current user|file upload" AGENTS.md .agents/AGENTS.md`
   plus any workflow-specific doc check.
+
+### Block Theme Automation Guidance
+
+When work touches WordPress block themes, Full Site Editing, `theme.json`,
+`templates/*.html`, `parts/*.html`, `patterns/*.php`, or style variations:
+
+- Treat `includes/Models/skills/wp-block-themes.md` as the canonical in-plugin
+  guidance for generated block-theme work. Update that skill when maintainers
+  report recurring block-theme automation failures.
+- Keep block-theme guidance agent-safe and actionable: require core block markup,
+  avoid `core/html` escape hatches, avoid decorative non-block comments, avoid
+  unprovided stock image URLs, and validate generated block content before saving.
+- For active-site diagnosis, confirm whether the theme is a block theme with
+  `sd-ai-agent/site-info`, `wp option get template` / `stylesheet`, or
+  `wp_is_block_theme()` before applying Full Site Editing assumptions.
+- Verification for guidance-only block-theme fixes should include
+  `rg -n "wp-block-themes|Full Site Editing|theme.json|validate-block-content" AGENTS.md includes/Models/skills/wp-block-themes.md`.
 
 #### Headless GitHub Write Guardrails
 


### PR DESCRIPTION
## Summary

Added durable contributor-insight guidance that maps pasted local-path block theme skill excerpts to includes/Models/skills/wp-block-themes.md, added block-theme automation guidance to root AGENTS.md, and mirrored runtime follow-through guidance in .agents/AGENTS.md.

## Files Changed

.agents/AGENTS.md,AGENTS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** rg -n "Contributor Insight|sd-ai-agent/v1|secret|current user|file upload" AGENTS.md .agents/AGENTS.md; rg -n "wp-block-themes|Full Site Editing|theme.json|validate-block-content" AGENTS.md includes/Models/skills/wp-block-themes.md; npm run verify (PHPUnit: Tests: 3520, Assertions: 14649, Errors: 0, Failures: 0, Skipped: 114, Incomplete: 4; Lint: PHP/JS/CSS all clean; PHPStan: 0 errors; Build: succeeded with existing webpack size warnings)

Resolves #1942


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 8m and 136,637 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance for handling local-path skill excerpts, directing them to committed in-repo sources instead of private local paths.
  * Introduced block theme automation guidance, including a canonical skill reference and constraints for generated block-theme content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1944?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->