### PR TITLE
GH#1943: docs: add file read recovery guidance

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -68,6 +68,12 @@ working here in OpenCode headless mode:
 - If the signature helper is unavailable, use the helper fallback path rather
   than retrying the same raw `gh` command; repeated unsigned writes are blocked
   by the framework guard.
+- Treat `read:file_not_found` as a recoverable path mismatch unless bounded
+  evidence proves the artifact is gone. Compare the requested basename with the
+  prior tool output, check for nearby variants such as `reply3` vs `r3`, verify
+  tracked paths with `git ls-files '<pattern>'`, and retry `Read` with the
+  corrected path before continuing. Do not stop a headless run solely because one
+  optional screenshot, prompt, or generated artifact path was stale.
 
 ## Contributor Insight Follow-through
 

--- a/.agents/scripts/commands/feedback-triage.md
+++ b/.agents/scripts/commands/feedback-triage.md
@@ -223,6 +223,15 @@ output and visible to claim routines:
   --label "bug,origin:worker,status:available"
 ```
 
+If any referenced screenshot, prompt, or generated artifact returns
+`read:file_not_found`, do a bounded recovery pass before filing or abandoning the
+triage issue: compare the requested basename with the tool output that introduced
+it, verify tracked repository paths with `git ls-files '<pattern>'`, inspect the
+known parent directory for nearby runtime-artifact names, and retry `Read` with
+the corrected path. If the artifact still cannot be found, include the attempted
+paths in the issue body and continue with the available session evidence instead
+of treating the missing read as the whole outcome.
+
 Capture the issue URL from output. Then update the report (the helper
 routes the third argument to `github_issue_url` for the `issue_created`
 status):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,25 @@ whenever creating issues, PR comments, or other GitHub write bodies:
   command form.
 - Verification for guidance-only fixes: run `rg -n "signature gate|body-file|heredoc|process substitution|gh issue create" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md` and ensure the policy is present in the root `AGENTS.md` loaded by future workers.
 
+#### Headless File Read Recovery
+
+Recurring contributor-insight reports also show workers stopping after a single
+`read:file_not_found` result when the path was merely misspelled or produced by a
+tool with a nearby filename. Treat missing-file reads as a recovery prompt, not a
+completion state:
+
+- Re-check the exact path and basename against the previous tool output before
+  assuming the artifact is unavailable; common failures include `reply3` vs
+  `r3`, omitted extensions, and stale `/tmp/opencode/` filenames.
+- For tracked repository files, verify the path with `git ls-files '<pattern>'`
+  before retrying `Read`; for untracked/runtime artifacts, inspect the known
+  parent directory or rerun the command that generated the artifact.
+- If the corrected path is found, retry `Read` with that path and continue the
+  task. If no plausible path exists after bounded recovery, record what was
+  checked and continue with the next safe implementation step rather than ending
+  the session solely because one optional artifact is missing.
+- Verification for guidance-only fixes: run `rg -n "read:file_not_found|missing-file reads|git ls-files|signature gate|body-file" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md` and ensure both file-read recovery and GitHub write-body policies are present in files loaded by future workers.
+
 ## Build Commands
 - **Build**: `npm run build` or `npx wp-scripts build` (production)
 - **Dev**: `npm start` or `npx wp-scripts start` (watch mode)


### PR DESCRIPTION
## Summary

Added durable headless recovery guidance for read:file_not_found artifacts in root AGENTS.md, .agents/AGENTS.md, and feedback-triage workflow docs while preserving existing GitHub signature-gate guidance.

## Files Changed

.agents/AGENTS.md,.agents/scripts/commands/feedback-triage.md,AGENTS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** rg -n "read:file_not_found|missing-file reads|git ls-files|signature gate|body-file" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md

Resolves #1943


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 1m and 68,340 tokens on this as a headless worker.