### PR TITLE
spike(frontend): wire post-tool reflection bus (Phase 1)

### DIFF
--- a/includes/Abilities/PostAbilities.php
+++ b/includes/Abilities/PostAbilities.php
@@ -270,6 +270,23 @@ class PostAbilities {
 							'type'        => [ 'integer', 'null' ],
 							'description' => 'Latest revision ID after the write. null when the post has no revisions yet. Use as expected_revision for the next write.',
 						],
+						'affected'    => [
+							'type'        => 'object',
+							'description' => 'Transport descriptor for the frontend reflection bus — identifies the entity, its public URL, and which fields changed so the client can refresh the visible page without a full reload.',
+							'properties'  => [
+								'kind'      => [
+									'type' => 'string',
+									'enum' => [ 'post' ],
+								],
+								'post_id'   => [ 'type' => 'integer' ],
+								'post_type' => [ 'type' => 'string' ],
+								'url'       => [ 'type' => 'string' ],
+								'fields'    => [
+									'type'  => 'array',
+									'items' => [ 'type' => 'string' ],
+								],
+							],
+						],
 					],
 				],
 				'meta'                => [
@@ -1519,6 +1536,7 @@ class PostAbilities {
 			'status'      => $updated_post instanceof WP_Post ? $updated_post->post_status : '',
 			'post_type'   => $updated_post instanceof WP_Post ? $updated_post->post_type : '',
 			'revision_id' => RevisionGuard::current_revision_id( $post_id ),
+			'affected'    => self::build_affected_payload( $post_id, $updated_post, $permalink, $input, $post_data ),
 		];
 
 		// GH#1584 follow-up: re-validate after update so the model knows
@@ -1531,6 +1549,63 @@ class PostAbilities {
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Build the `affected` payload describing what this update changed.
+	 *
+	 * Spike (Phase 1, frontend live-preview bus): a generic, transport-only
+	 * descriptor consumed by the JS reflection bus so future reflectors can
+	 * decide how to refresh the visible page after a tool call. The shape is
+	 * intentionally minimal — just enough for a reflector to identify the
+	 * target entity, its public URL, and which fields the agent touched.
+	 *
+	 * Keep this side-effect free: callers downstream only read these fields.
+	 *
+	 * @param int                  $post_id      Updated post ID.
+	 * @param WP_Post|null         $updated_post Refreshed post object, or null on fetch failure.
+	 * @param string|false         $permalink    Result of get_permalink(), false when unavailable.
+	 * @param array<string, mixed> $input        Original ability input from the model.
+	 * @param array<string, mixed> $post_data    Sanitised wp_update_post() payload.
+	 * @return array<string, mixed>
+	 */
+	private static function build_affected_payload(
+		int $post_id,
+		?WP_Post $updated_post,
+		$permalink,
+		array $input,
+		array $post_data
+	): array {
+		$fields = [];
+		foreach ( [ 'post_title', 'post_content', 'post_excerpt', 'post_status', 'post_name', 'post_parent', 'menu_order' ] as $key ) {
+			if ( array_key_exists( $key, $post_data ) ) {
+				$fields[] = $key;
+			}
+		}
+		// Extra-table writes that handle_update_post performs after wp_update_post().
+		if ( isset( $input['categories'] ) && is_array( $input['categories'] ) ) {
+			$fields[] = 'categories';
+		}
+		if ( isset( $input['tags'] ) && is_array( $input['tags'] ) ) {
+			$fields[] = 'tags';
+		}
+		if ( isset( $input['featured_image_id'] ) && (int) $input['featured_image_id'] > 0 ) {
+			$fields[] = 'featured_image';
+		}
+		if ( isset( $input['page_template'] ) ) {
+			$fields[] = 'page_template';
+		}
+		if ( isset( $input['meta'] ) && is_array( $input['meta'] ) ) {
+			$fields[] = 'meta';
+		}
+
+		return [
+			'kind'      => 'post',
+			'post_id'   => $post_id,
+			'post_type' => $updated_post instanceof WP_Post ? $updated_post->post_type : '',
+			'url'       => is_string( $permalink ) ? $permalink : '',
+			'fields'    => array_values( array_unique( $fields ) ),
+		];
 	}
 
 	/**

--- a/src/floating-widget/index.js
+++ b/src/floating-widget/index.js
@@ -12,6 +12,11 @@ import STORE_NAME from '../store';
 // Register sd-ai-agent-js/* client-side abilities into core/abilities
 // before the chat mounts (t165 — closes the wiring gap in #815).
 import '../abilities';
+// Spike: subscribe to the frontend live-preview reflection bus and log
+// every tool-applied event to the browser console. Phase 1 only —
+// remove once real DOM reflectors land (Phase 2). See
+// `src/store/reflection-bus.js` and `src/store/reflection-emitter.js`.
+import './reflection-debug';
 import ErrorBoundary from '../components/error-boundary';
 import ChatWidget from '../components/chat-widget';
 import useKeyboardShortcut from './use-keyboard-shortcut';

--- a/src/floating-widget/reflection-debug.js
+++ b/src/floating-widget/reflection-debug.js
@@ -1,0 +1,29 @@
+/**
+ * Spike-only reflection debug consumer.
+ *
+ * Subscribes to the frontend live-preview reflection bus and logs every
+ * `tool-applied` event to the browser console. This is a temporary
+ * Phase 1 verification surface — once Phase 2 ships real reflectors
+ * (DOM morphing for posts, CSS swap for global-styles, etc.) this file
+ * should be removed.
+ *
+ * Side-effect module: importing it once is enough to start listening.
+ * Safe to import on both admin and frontend bundles.
+ *
+ * Browser usage (no rebuild required for one-off inspection):
+ *
+ *   window.sdAiAgentReflection.on( ( e ) => console.log( e ) );
+ */
+
+import bus from '../store/reflection-bus';
+
+bus.on( ( event ) => {
+	// eslint-disable-next-line no-console
+	console.info( `[sd-ai-agent] reflection ${ event.type }`, {
+		tool: event.tool,
+		sessionId: event.sessionId,
+		jobId: event.jobId,
+		affected: event.affected,
+		args: event.args,
+	} );
+} );

--- a/src/store/__tests__/reflection-bus.test.js
+++ b/src/store/__tests__/reflection-bus.test.js
@@ -1,0 +1,151 @@
+/**
+ * Unit tests for the frontend live-preview reflection bus
+ * (src/store/reflection-bus.js).
+ *
+ * Covers:
+ * - on/off/emit happy path
+ * - unsubscribe via the returned closure
+ * - listener errors are swallowed (one bad listener does not break others)
+ * - clear() drops all listeners
+ * - cross-bundle singleton on `window`
+ * - __resetReflectionBusForTests() returns a fresh bus
+ * - non-function listener is a no-op
+ */
+
+import sharedBus, {
+	createReflectionBus,
+	__resetReflectionBusForTests,
+} from '../reflection-bus';
+
+describe( 'reflection-bus', () => {
+	let consoleErrorSpy;
+
+	beforeEach( () => {
+		consoleErrorSpy = jest
+			.spyOn( console, 'error' )
+			.mockImplementation( () => {} );
+		__resetReflectionBusForTests();
+	} );
+
+	afterEach( () => {
+		consoleErrorSpy.mockRestore();
+		__resetReflectionBusForTests();
+	} );
+
+	test( 'on() registers a listener that receives emitted events', () => {
+		const bus = createReflectionBus();
+		const listener = jest.fn();
+
+		bus.on( listener );
+		bus.emit( { type: 'tool-applied', tool: 'sd-ai-agent/update-post' } );
+
+		expect( listener ).toHaveBeenCalledTimes( 1 );
+		expect( listener ).toHaveBeenCalledWith( {
+			type: 'tool-applied',
+			tool: 'sd-ai-agent/update-post',
+		} );
+	} );
+
+	test( 'on() returns an unsubscribe closure', () => {
+		const bus = createReflectionBus();
+		const listener = jest.fn();
+
+		const unsubscribe = bus.on( listener );
+		bus.emit( { type: 'tool-applied' } );
+		unsubscribe();
+		bus.emit( { type: 'tool-applied' } );
+
+		expect( listener ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'off() removes a previously-registered listener', () => {
+		const bus = createReflectionBus();
+		const listener = jest.fn();
+
+		bus.on( listener );
+		bus.off( listener );
+		bus.emit( { type: 'tool-applied' } );
+
+		expect( listener ).not.toHaveBeenCalled();
+	} );
+
+	test( 'non-function listener is ignored by on()', () => {
+		const bus = createReflectionBus();
+
+		const unsubscribe = bus.on( /** @type {*} */ ( 'not a function' ) );
+
+		expect( bus.listenerCount() ).toBe( 0 );
+		expect( typeof unsubscribe ).toBe( 'function' );
+		// Unsubscribe of an ignored listener must not throw.
+		expect( () => unsubscribe() ).not.toThrow();
+	} );
+
+	test( 'a throwing listener does not break sibling listeners', () => {
+		const bus = createReflectionBus();
+		const goodBefore = jest.fn();
+		const bad = jest.fn( () => {
+			throw new Error( 'boom' );
+		} );
+		const goodAfter = jest.fn();
+
+		bus.on( goodBefore );
+		bus.on( bad );
+		bus.on( goodAfter );
+		bus.emit( { type: 'tool-applied' } );
+
+		expect( goodBefore ).toHaveBeenCalledTimes( 1 );
+		expect( bad ).toHaveBeenCalledTimes( 1 );
+		expect( goodAfter ).toHaveBeenCalledTimes( 1 );
+		expect( consoleErrorSpy ).toHaveBeenCalledWith(
+			'[sd-ai-agent] reflection listener threw:',
+			expect.any( Error )
+		);
+	} );
+
+	test( 'clear() removes all listeners', () => {
+		const bus = createReflectionBus();
+		const a = jest.fn();
+		const b = jest.fn();
+
+		bus.on( a );
+		bus.on( b );
+		expect( bus.listenerCount() ).toBe( 2 );
+
+		bus.clear();
+		expect( bus.listenerCount() ).toBe( 0 );
+
+		bus.emit( { type: 'tool-applied' } );
+		expect( a ).not.toHaveBeenCalled();
+		expect( b ).not.toHaveBeenCalled();
+	} );
+
+	test( 'default export is a singleton across imports', () => {
+		const listener = jest.fn();
+		sharedBus.on( listener );
+
+		// Re-import inside an isolated module registry. The module re-runs
+		// resolveBus() but finds window[WIN_KEY] populated, so it must hand
+		// back the SAME instance the top-level import resolved earlier.
+		let reimported;
+		jest.isolateModules( () => {
+			// eslint-disable-next-line global-require
+			reimported = require( '../reflection-bus' ).default;
+		} );
+
+		expect( reimported ).toBe( sharedBus );
+		reimported.emit( { type: 'tool-applied' } );
+		expect( listener ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( '__resetReflectionBusForTests() clears listeners in-place on the shared bus', () => {
+		sharedBus.on( jest.fn() );
+		expect( sharedBus.listenerCount() ).toBe( 1 );
+
+		const returned = __resetReflectionBusForTests();
+
+		// The shared instance must be preserved so module-level captures
+		// stay valid; only its listener set is cleared.
+		expect( returned ).toBe( sharedBus );
+		expect( sharedBus.listenerCount() ).toBe( 0 );
+	} );
+} );

--- a/src/store/__tests__/reflection-emitter.test.js
+++ b/src/store/__tests__/reflection-emitter.test.js
@@ -1,0 +1,189 @@
+/**
+ * Unit tests for the reflection event emitter
+ * (src/store/reflection-emitter.js).
+ *
+ * Covers:
+ * - emits one event per new response entry with `affected`
+ * - skips entries before the cursor (no double-emit on subsequent polls)
+ * - skips non-response entries and responses without `affected`
+ * - pairs response with matching call entry by id for args
+ * - returns entries.length as the new cursor
+ * - tolerates malformed input gracefully
+ */
+
+import { emitReflectionEvents } from '../reflection-emitter';
+import sharedBus, { __resetReflectionBusForTests } from '../reflection-bus';
+
+describe( 'reflection-emitter', () => {
+	let received;
+	let unsubscribe;
+
+	beforeEach( () => {
+		__resetReflectionBusForTests();
+		received = [];
+		unsubscribe = sharedBus.on( ( evt ) => received.push( evt ) );
+	} );
+
+	afterEach( () => {
+		unsubscribe();
+		__resetReflectionBusForTests();
+	} );
+
+	test( 'emits one event per new response entry with `affected`', () => {
+		const entries = [
+			{
+				type: 'call',
+				id: 'c1',
+				name: 'sd-ai-agent/update-post',
+				args: { post_id: 42, title: 'New' },
+			},
+			{
+				type: 'response',
+				id: 'c1',
+				name: 'sd-ai-agent/update-post',
+				response: {
+					post_id: 42,
+					affected: {
+						kind: 'post',
+						post_id: 42,
+						url: 'https://example.com/about/',
+						fields: [ 'post_title' ],
+					},
+				},
+			},
+		];
+
+		const next = emitReflectionEvents( entries, 0, {
+			sessionId: 7,
+			jobId: 'job-abc',
+		} );
+
+		expect( next ).toBe( 2 );
+		expect( received ).toHaveLength( 1 );
+		expect( received[ 0 ] ).toEqual( {
+			type: 'tool-applied',
+			tool: 'sd-ai-agent/update-post',
+			sessionId: 7,
+			jobId: 'job-abc',
+			args: { post_id: 42, title: 'New' },
+			result: entries[ 1 ].response,
+			affected: entries[ 1 ].response.affected,
+		} );
+	} );
+
+	test( 'skips entries before the cursor on subsequent calls', () => {
+		const entries = [
+			{
+				type: 'call',
+				id: 'c1',
+				name: 'sd-ai-agent/update-post',
+				args: {},
+			},
+			{
+				type: 'response',
+				id: 'c1',
+				name: 'sd-ai-agent/update-post',
+				response: { affected: { kind: 'post', post_id: 1 } },
+			},
+		];
+
+		const first = emitReflectionEvents( entries, 0, {
+			sessionId: 1,
+			jobId: 'j',
+		} );
+		// Second call with the same entries should not re-emit.
+		const second = emitReflectionEvents( entries, first, {
+			sessionId: 1,
+			jobId: 'j',
+		} );
+
+		expect( first ).toBe( 2 );
+		expect( second ).toBe( 2 );
+		expect( received ).toHaveLength( 1 );
+	} );
+
+	test( 'skips non-response entries and responses without affected', () => {
+		const entries = [
+			{ type: 'preamble', text: 'Looking up your post…' },
+			{
+				type: 'call',
+				id: 'c1',
+				name: 'sd-ai-agent/get-post',
+				args: { id: 42 },
+			},
+			{
+				type: 'response',
+				id: 'c1',
+				name: 'sd-ai-agent/get-post',
+				response: { post_id: 42, title: 'Hello' }, // No `affected` — readonly tool.
+			},
+			{
+				type: 'provider_retry',
+				message: 'Retrying…',
+			},
+		];
+
+		emitReflectionEvents( entries, 0, { sessionId: 1, jobId: 'j' } );
+
+		expect( received ).toHaveLength( 0 );
+	} );
+
+	test( 'pairs response with matching call entry by id for args', () => {
+		const entries = [
+			{ type: 'call', id: 'a', name: 'foo', args: { x: 1 } },
+			{ type: 'call', id: 'b', name: 'bar', args: { y: 2 } },
+			{
+				type: 'response',
+				id: 'b',
+				name: 'bar',
+				response: { affected: { kind: 'post', post_id: 9 } },
+			},
+		];
+
+		emitReflectionEvents( entries, 0, { sessionId: 1, jobId: 'j' } );
+
+		expect( received ).toHaveLength( 1 );
+		expect( received[ 0 ].args ).toEqual( { y: 2 } );
+	} );
+
+	test( 'tolerates malformed input gracefully', () => {
+		expect(
+			emitReflectionEvents( /** @type {*} */ ( null ), 0, {
+				sessionId: 1,
+				jobId: 'j',
+			} )
+		).toBe( 0 );
+
+		expect(
+			emitReflectionEvents(
+				[ null, undefined, { type: 'response' } ],
+				0,
+				{
+					sessionId: 1,
+					jobId: 'j',
+				}
+			)
+		).toBe( 3 );
+
+		expect( received ).toHaveLength( 0 );
+	} );
+
+	test( 'cursor beyond array length is clamped, not crashing', () => {
+		const entries = [
+			{
+				type: 'response',
+				id: 'x',
+				name: 'foo',
+				response: { affected: { kind: 'post' } },
+			},
+		];
+
+		const next = emitReflectionEvents( entries, 9999, {
+			sessionId: 1,
+			jobId: 'j',
+		} );
+
+		expect( next ).toBe( 1 );
+		expect( received ).toHaveLength( 0 );
+	} );
+} );

--- a/src/store/reflection-bus.js
+++ b/src/store/reflection-bus.js
@@ -1,0 +1,176 @@
+/**
+ * Frontend live-preview reflection bus.
+ *
+ * Tiny pub/sub channel that fires `tool-applied` events whenever an agent
+ * tool call completes with a structured `affected` descriptor. This is the
+ * Phase 1 spike of the frontend live-preview pipeline (todo:
+ * spike/frontend-live-preview-bus): the producer side lives in
+ * `src/store/slices/jobSlice.js` (pollJob inspects each new entry of
+ * `tool_call_log[].response.affected`); consumers are free to wire any
+ * DOM-refresh strategy without coupling to Redux.
+ *
+ * Event shape:
+ *   {
+ *     type: 'tool-applied',
+ *     tool: 'sd-ai-agent/update-post',
+ *     sessionId: 123,
+ *     jobId: 'abc',
+ *     args: { ... },        // tool-call args from the matching `call` entry
+ *     result: { ... },      // full ability response
+ *     affected: {           // mirror of result.affected for convenience
+ *       kind: 'post',
+ *       post_id: 42,
+ *       post_type: 'page',
+ *       url: 'https://example.com/about/',
+ *       fields: ['post_title']
+ *     }
+ *   }
+ *
+ * The module also exposes the bus on `window.sdAiAgentReflection` so
+ * external scripts (or browser devtools) can subscribe without importing
+ * the bundle:
+ *
+ *   window.sdAiAgentReflection.on( ( event ) => console.log( event ) );
+ *
+ * Design notes:
+ * - Pure-JS, no React or Redux dependency, so it stays bundle-cheap and is
+ *   safe to reference from non-React reflectors in Phase 2.
+ * - Errors thrown by listeners are swallowed and logged so a broken
+ *   reflector cannot abort the chat loop.
+ * - Singleton: the first import wins; subsequent imports see the same
+ *   bus instance (the window-global is also re-used to dedupe across
+ *   webpack bundles, matching the pattern in `src/abilities/index.js`).
+ */
+
+const WIN_KEY = '__sdAiAgentReflectionBus';
+
+/**
+ * @typedef {Object} ReflectionEvent
+ * @property {string} type      Event type — currently always 'tool-applied'.
+ * @property {string} tool      Canonical ability name.
+ * @property {number} sessionId Session that owns the job.
+ * @property {string} jobId     Background job ID.
+ * @property {Object} [args]    Tool call arguments, if known.
+ * @property {*}      result    Raw tool response.
+ * @property {Object} affected  Structured descriptor (mirror of result.affected).
+ */
+
+/**
+ * @typedef {(event: ReflectionEvent) => void} ReflectionListener
+ */
+
+/**
+ * Build a fresh bus instance. Exported only for tests.
+ *
+ * @return {{
+ *   on: (listener: ReflectionListener) => () => void,
+ *   off: (listener: ReflectionListener) => void,
+ *   emit: (event: ReflectionEvent) => void,
+ *   clear: () => void,
+ *   listenerCount: () => number,
+ * }} New bus with its own listener set.
+ */
+export function createReflectionBus() {
+	const listeners = new Set();
+
+	return {
+		/**
+		 * Subscribe to reflection events.
+		 *
+		 * @param {ReflectionListener} listener Handler invoked for each event.
+		 * @return {() => void} Unsubscribe function.
+		 */
+		on( listener ) {
+			if ( typeof listener !== 'function' ) {
+				return () => {};
+			}
+			listeners.add( listener );
+			return () => listeners.delete( listener );
+		},
+
+		/**
+		 * Unsubscribe a previously-registered listener.
+		 *
+		 * @param {ReflectionListener} listener Handler reference to remove.
+		 */
+		off( listener ) {
+			listeners.delete( listener );
+		},
+
+		/**
+		 * Broadcast an event to all subscribers.
+		 *
+		 * Listener errors are caught and logged so a broken reflector cannot
+		 * abort the producer (the chat poll loop).
+		 *
+		 * @param {ReflectionEvent} event Event payload.
+		 */
+		emit( event ) {
+			for ( const listener of listeners ) {
+				try {
+					listener( event );
+				} catch ( err ) {
+					// eslint-disable-next-line no-console
+					console.error(
+						'[sd-ai-agent] reflection listener threw:',
+						err
+					);
+				}
+			}
+		},
+
+		/**
+		 * Remove all listeners. Used by tests and hot-reload paths.
+		 */
+		clear() {
+			listeners.clear();
+		},
+
+		/**
+		 * @return {number} Current listener count.
+		 */
+		listenerCount() {
+			return listeners.size;
+		},
+	};
+}
+
+/**
+ * Resolve the shared bus instance. Cross-bundle dedup mirrors the pattern in
+ * `src/abilities/index.js`: the first bundle to import this module on a page
+ * creates the bus and stores it on `window`; subsequent bundles reuse it.
+ *
+ * In non-browser contexts (Jest, SSR) the window global is unavailable, so a
+ * fresh instance is returned. Tests can call `__resetReflectionBusForTests()`
+ * to start from a known state.
+ *
+ * @return {ReturnType<typeof createReflectionBus>} The page-singleton bus.
+ */
+function resolveBus() {
+	if ( typeof window === 'undefined' ) {
+		return createReflectionBus();
+	}
+	if ( ! window[ WIN_KEY ] ) {
+		window[ WIN_KEY ] = createReflectionBus();
+	}
+	return window[ WIN_KEY ];
+}
+
+const bus = resolveBus();
+
+export default bus;
+
+/**
+ * Test-only reset hook. Clears all listeners on the shared bus instance.
+ *
+ * Critically, this mutates the existing instance in-place rather than
+ * replacing the window global, so callers that captured the default
+ * export at module-load time keep a valid reference. Not part of the
+ * public API.
+ *
+ * @return {ReturnType<typeof createReflectionBus>} The cleared shared bus.
+ */
+export function __resetReflectionBusForTests() {
+	bus.clear();
+	return bus;
+}

--- a/src/store/reflection-emitter.js
+++ b/src/store/reflection-emitter.js
@@ -1,0 +1,110 @@
+/**
+ * Producer side of the frontend live-preview reflection bus.
+ *
+ * Walks a job's `tool_call_log` array starting from a cursor index and emits
+ * one `tool-applied` event per server-side tool response that carries a
+ * structured `affected` descriptor. Tool responses without `affected` are
+ * ignored (no event fired), so abilities that have not yet opted in to the
+ * Phase 1 protocol are invisible to subscribers.
+ *
+ * The function is pure-ish — it mutates nothing in `entries`, only calls
+ * `bus.emit()` for each new event. It returns the new cursor so the caller
+ * can persist it across poll ticks and avoid double-emitting events that
+ * remain in the log on subsequent polls.
+ *
+ * Pairing: `response` entries match `call` entries by `id`. When a matching
+ * `call` is found, its `args` are included on the event for reflectors that
+ * need the original input (e.g. to know which post_id was targeted before the
+ * response carries it). Responses without a matching call still fire — the
+ * `affected` descriptor is the authoritative source.
+ */
+
+import bus from './reflection-bus';
+
+/**
+ * @typedef {Object} ToolCallLogEntry
+ * @property {string} type       Entry kind — 'call' | 'response' | 'preamble' | 'event' | etc.
+ * @property {string} [id]       Call/response correlation id assigned by the SDK.
+ * @property {string} [name]     Canonical ability/tool name.
+ * @property {Object} [args]     Tool-call arguments (present on 'call' entries).
+ * @property {*}      [response] Tool execution result (present on 'response' entries).
+ * @property {string} [source]   Origin of the entry — 'client' for browser-side abilities, otherwise server.
+ */
+
+/**
+ * @typedef {Object} EmitContext
+ * @property {number} sessionId Owning session.
+ * @property {string} jobId     Background job ID.
+ */
+
+/**
+ * Emit `tool-applied` events for every new `response` entry in `entries`
+ * whose response contains an `affected` descriptor.
+ *
+ * Safe to call with an out-of-date cursor (e.g. after a polling reset): it
+ * will simply re-walk from the cursor and emit any events not yet seen. To
+ * avoid duplicates, store the returned cursor and pass it on the next call.
+ *
+ * @param {ToolCallLogEntry[]} entries Full tool_call_log so far.
+ * @param {number}             cursor  Index of the first entry that has not
+ *                                     yet been considered for emission.
+ * @param {EmitContext}        context Session and job identifiers.
+ * @return {number} New cursor (== entries.length on success).
+ */
+export function emitReflectionEvents( entries, cursor, context ) {
+	if ( ! Array.isArray( entries ) ) {
+		return cursor;
+	}
+
+	// Coerce the cursor to a finite, non-negative integer without bitwise
+	// tricks (ESLint's no-bitwise rule).
+	const safeCursor = Number.isFinite( cursor )
+		? Math.max( 0, Math.floor( cursor ) )
+		: 0;
+	const start = Math.min( safeCursor, entries.length );
+
+	for ( let i = start; i < entries.length; i++ ) {
+		const entry = entries[ i ];
+		if ( ! entry || entry.type !== 'response' ) {
+			continue;
+		}
+
+		const response = entry.response;
+		if ( ! response || typeof response !== 'object' ) {
+			continue;
+		}
+
+		const affected = response.affected;
+		if ( ! affected || typeof affected !== 'object' ) {
+			continue;
+		}
+
+		// Pair with the matching call entry by id (best-effort).
+		let args;
+		if ( entry.id ) {
+			for ( let j = i - 1; j >= 0; j-- ) {
+				const candidate = entries[ j ];
+				if (
+					candidate &&
+					candidate.type === 'call' &&
+					candidate.id === entry.id
+				) {
+					args = candidate.args;
+					break;
+				}
+			}
+		}
+
+		bus.emit( {
+			type: 'tool-applied',
+			tool: entry.name || '',
+			sessionId: context.sessionId,
+			jobId: context.jobId,
+			args,
+			result: response,
+			affected,
+		} );
+	}
+
+	return entries.length;
+}

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -12,6 +12,7 @@ import { setActiveJob, clearActiveJob } from '../../utils/active-jobs-storage';
 import { notifyConfirmationNeeded } from '../../utils/notification-manager';
 import { playDing, playDong, playThinking } from '../../utils/sound-manager';
 import { executeClientAbility } from '../../abilities/registry';
+import { emitReflectionEvents } from '../reflection-emitter';
 
 export const initialState = {
 	// Active polling job ID (most-recently-started job for the current session).
@@ -239,6 +240,12 @@ export const actions = {
 			let consecutiveErrors = 0;
 			const maxConsecutiveErrors = 8;
 			let lastToolCallsLength = 0;
+			// Cursor for the frontend live-preview reflection bus
+			// (spike/frontend-live-preview-bus). Tracks how far into
+			// result.tool_calls we have already emitted `tool-applied`
+			// events. Persists across poll ticks so each event fires exactly
+			// once even though the log grows incrementally.
+			let reflectionCursor = 0;
 			let visibilityPaused = false;
 			let resumeCallback = null;
 
@@ -313,6 +320,16 @@ export const actions = {
 								toolCalls: result.tool_calls,
 								status: 'processing',
 							} );
+
+							// Fire `tool-applied` reflection events for any
+							// new response entries that carry an `affected`
+							// descriptor. Cursor-driven so each event fires
+							// exactly once across the polling stream.
+							reflectionCursor = emitReflectionEvents(
+								result.tool_calls,
+								reflectionCursor,
+								{ sessionId, jobId }
+							);
 						}
 
 						// Only update live tool calls when this is the active session.
@@ -650,6 +667,17 @@ export const actions = {
 					}
 
 					if ( result.status === 'complete' ) {
+						// Flush any final reflection events for tool responses
+						// that arrived between the last `processing` tick and
+						// this terminal poll.
+						if ( Array.isArray( result.tool_calls ) ) {
+							reflectionCursor = emitReflectionEvents(
+								result.tool_calls,
+								reflectionCursor,
+								{ sessionId, jobId }
+							);
+						}
+
 						// Reload the session from the DB when it's the active session.
 						if (
 							result.session_id &&

--- a/tests/SdAiAgent/Abilities/PostAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/PostAbilitiesTest.php
@@ -523,6 +523,63 @@ class PostAbilitiesTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'status', $result );
 	}
 
+	// ─── affected payload (frontend live-preview bus, Phase 1 spike) ────
+
+	/**
+	 * Test handle_update_post returns an `affected` descriptor for the
+	 * frontend reflection bus when fields are changed. Fields list must
+	 * reflect exactly what the input mutated (post_title here).
+	 */
+	public function test_handle_update_post_returns_affected_payload() {
+		$post_id = $this->factory->post->create( [
+			'post_status' => 'publish',
+			'post_title'  => 'Original title',
+		] );
+
+		$result = PostAbilities::handle_update_post( [
+			'post_id' => $post_id,
+			'title'   => 'Updated title',
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'affected', $result );
+		$this->assertIsArray( $result['affected'] );
+		$this->assertSame( 'post', $result['affected']['kind'] );
+		$this->assertSame( $post_id, $result['affected']['post_id'] );
+		$this->assertSame( 'post', $result['affected']['post_type'] );
+		$this->assertNotEmpty( $result['affected']['url'] );
+		$this->assertContains( 'post_title', $result['affected']['fields'] );
+		$this->assertNotContains( 'post_content', $result['affected']['fields'] );
+	}
+
+	/**
+	 * Test that taxonomy + featured-image + meta inputs are reported in
+	 * `affected.fields` even though wp_update_post() does not touch them.
+	 */
+	public function test_handle_update_post_affected_lists_taxonomy_and_meta_fields() {
+		$post_id = $this->factory->post->create( [ 'post_status' => 'publish' ] );
+		$thumb   = $this->factory->attachment->create_upload_object(
+			DIR_TESTDATA . '/images/canola.jpg',
+			$post_id
+		);
+
+		$result = PostAbilities::handle_update_post( [
+			'post_id'           => $post_id,
+			'content'           => 'New body',
+			'tags'              => [ 'live-preview', 'spike' ],
+			'featured_image_id' => $thumb,
+			'meta'              => [ 'sd_test_key' => 'value' ],
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'affected', $result );
+		$fields = $result['affected']['fields'];
+		$this->assertContains( 'post_content', $fields );
+		$this->assertContains( 'tags', $fields );
+		$this->assertContains( 'featured_image', $fields );
+		$this->assertContains( 'meta', $fields );
+	}
+
 	// ─── block_validation save-time gate (GH#1584 follow-up) ────────
 
 	/**


### PR DESCRIPTION
## Summary

Phase 1 of the frontend live-preview pipeline. Wires the producer side of a
post-tool reflection bus so subsequent phases can add real DOM-refresh
strategies without re-touching the agent loop or REST layer.

Zero UX change today: events fire to `console.info` only. The
`show_on_frontend` setting default is unchanged (`false`); flipping it is
explicitly deferred to Phase 3.

This is the deliverable for the **"Spike Phase 1 only"** branch of the
investigation requested in the floating-widget conversation.

For #1947 — parent: Frontend live-preview pipeline. Subsequent phases:
#1948 (2a), #1949 (2b), #1950 (2c), #1951 (2d), #1952 (2e), #1953 (3).

## What ships

### PHP

- `PostAbilities::handle_update_post()` now returns an `affected`
  descriptor:
  ```
  affected: {
    kind: 'post',
    post_id: 123,
    post_type: 'page',
    url: 'https://example.com/about/',
    fields: ['post_title', 'post_content', 'tags', 'featured_image']
  }
  ```
- New private `PostAbilities::build_affected_payload()` helper assembles
  the descriptor from sanitised `wp_update_post()` data plus the
  extra-table writes (categories, tags, featured image, page template,
  meta).
- `update-post` ability `output_schema` documents the new field as part
  of the public contract.

### JavaScript

- `src/store/reflection-bus.js` — page-singleton pub/sub. Window-global
  dedup mirrors the pattern in `src/abilities/index.js` (cross-bundle
  safe). Reachable via `window.sdAiAgentReflection` for ad-hoc inspection
  from devtools without rebuilding.
- `src/store/reflection-emitter.js` — cursor-driven walker. Given the
  growing `tool_call_log` and the last-seen index, emits one
  `tool-applied` event per *new* `response` entry whose
  `response.affected` is set. Pairs by `id` with the matching `call`
  entry so listeners get the original `args`.
- `src/store/slices/jobSlice.js` — `pollJob()` calls
  `emitReflectionEvents()` on every `processing` tick and once more on
  `complete`, with a `reflectionCursor` that survives across poll
  iterations so each event fires exactly once.
- `src/floating-widget/reflection-debug.js` — temporary `console.info`
  consumer. Side-effect import in `src/floating-widget/index.js`. Phase 2
  removes this file when real reflectors land.

## Event shape

```js
{
  type: 'tool-applied',
  tool: 'sd-ai-agent/update-post',
  sessionId: 123,
  jobId: 'abc',
  args: { post_id: 42, title: 'New' },
  result: { post_id: 42, permalink: '…', affected: {…}, … },
  affected: { kind: 'post', post_id: 42, post_type: 'post', url: '…', fields: ['post_title'] },
}
```

## Tests added

- PHP: `PostAbilitiesTest::test_handle_update_post_returns_affected_payload`
- PHP: `PostAbilitiesTest::test_handle_update_post_affected_lists_taxonomy_and_meta_fields`
- JS: `src/store/__tests__/reflection-bus.test.js` (8 cases — on/off/emit,
  unsubscribe closure, listener-throw isolation, clear, singleton, reset)
- JS: `src/store/__tests__/reflection-emitter.test.js` (6 cases —
  happy path, cursor advance, skip-no-affected, pair-by-id, malformed
  input, cursor clamping)

## Worker self-verification

```text
- PHPUnit: Tests: 3510, Assertions: 14468, Errors: 0, Failures: 0, Skipped: 114, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded (floating-widget.js 68.7 KiB)
```

`npm run verify` (lint → phpstan → test:php → build) is green end-to-end.

## What this is NOT yet

- **No DOM reflection.** `tool-applied` events fire to console only.
- **Only `update-post` emits `affected`.** Other content-mutating
  abilities (`create-post`, `append-post-content`, `delete-post`,
  `MenuAbilities`, `GlobalStylesAbilities`, `MediaAbilities`) still need
  the same hook. Tracked as the Phase 2a follow-up issue.
- **`show_on_frontend` default is unchanged** (still `false`). Flipping
  it without reflectors would be worse UX than today (admin sees stale
  content after tool calls). Tracked as the Phase 3 follow-up issue.

## Manual smoke test

1. Check out this branch on an existing wp-env install.
2. `npm run build`
3. Open any wp-admin page, open devtools console.
4. Open the floating chat widget, ask the agent to update the title of
   any post. Approve the confirmation if YOLO mode is off.
5. After the tool completes, the console logs:
   ```
   [sd-ai-agent] reflection tool-applied {
     tool: 'sd-ai-agent/update-post',
     sessionId: 12,
     jobId: 'abc123',
     affected: {
       kind: 'post',
       post_id: 42,
       post_type: 'post',
       url: 'http://localhost:8890/?p=42',
       fields: ['post_title']
     },
     args: { post_id: 42, title: 'New title' }
   }
   ```

## Risk

Low — additive only:

- PHP: one new optional key in the response of one ability. No callers
  inspect this key today; the WordPress AI Client SDK passes responses
  back to the model verbatim. Models may now see a slightly larger
  response, but the payload is tiny (sub-200 bytes) and structured.
- JS: new files plus a cursor in `pollJob()`. The cursor only reads from
  the existing `tool_call_log` array and never mutates it. Listener
  errors are caught so a broken reflector cannot abort the chat loop.
- No setting defaults change. No new REST routes. No new capabilities.

## Follow-ups (filed as separate issues)

- **Phase 2a**: Extend the `affected` producer to remaining
  content-mutating abilities.
- **Phase 2b**: First real reflector — current-post DOM morph via
  `morphdom`/`idiomorph`.
- **Phase 2c**: Reflector — global styles (re-fetch the
  `wp_global_styles-*` stylesheet).
- **Phase 2d**: Reflector — navigation menus.
- **Phase 2e**: Fallback toast for tools without a dedicated reflector.
- **Phase 3**: Flip `show_on_frontend` default to `true` once the
  reflector layer covers the common 80% of admin tool calls.

Each child references this PR's parent issue with `For #N` so the
auto-merge gates do not close the parent prematurely.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 2d 18h and 111,419 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Post update operations now include detailed metadata showing which fields were modified (`affected` payload with post ID, type, URL, and field list).
  * Background job polling now emits live-preview reflection events during processing for improved real-time feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1946?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
