### PR TITLE
GH#1954: fix: create verifiable WPForms contact forms

### DIFF
--- a/includes/Abilities/ContentAbilities.php
+++ b/includes/Abilities/ContentAbilities.php
@@ -134,7 +134,7 @@ class ContentAbilities {
 			'sd-ai-agent/create-contact-form',
 			[
 				'label'               => __( 'Create Contact Form', 'superdav-ai-agent' ),
-				'description'         => __( 'Create a simple contact form for a page. Uses Contact Form 7 when available and otherwise returns a Gutenberg HTML block with a dependency-free form.', 'superdav-ai-agent' ),
+				'description'         => __( 'Create a simple contact form for a page. Uses WPForms Lite or Contact Form 7 when available and otherwise returns a Gutenberg HTML block with a dependency-free mailto form.', 'superdav-ai-agent' ),
 				'category'            => 'sd-ai-agent',
 				'input_schema'        => [
 					'type'       => 'object',
@@ -438,6 +438,12 @@ class ContentAbilities {
 	 * @return array<string,mixed> Contact form result.
 	 */
 	private static function create_contact_form_result( string $title, string $recipient_email, string $submit_label ): array {
+		$wpforms_result = self::create_wpforms_form( $title, $recipient_email, $submit_label );
+
+		if ( ! empty( $wpforms_result ) ) {
+			return $wpforms_result;
+		}
+
 		$cf7_class = 'WPCF7_ContactForm';
 
 		if ( class_exists( $cf7_class ) ) {
@@ -457,6 +463,123 @@ class ContentAbilities {
 			'block'     => $block,
 			'form_id'   => 0,
 			'message'   => __( 'Contact Form 7 is not active; use the returned Gutenberg HTML block in the page content.', 'superdav-ai-agent' ),
+		];
+	}
+
+	/**
+	 * Create a WPForms Lite form when the plugin post type is available.
+	 *
+	 * WPForms Lite does not expose WordPress Abilities on every install. Creating
+	 * the form post directly gives the agent a verifiable shortcode instead of a
+	 * broken placeholder after installing WPForms Lite.
+	 *
+	 * @param string $title           Form title.
+	 * @param string $recipient_email Recipient email address.
+	 * @param string $submit_label    Submit button label.
+	 * @return array<string,mixed> WPForms result, or empty array when unavailable.
+	 */
+	private static function create_wpforms_form( string $title, string $recipient_email, string $submit_label ): array {
+		if ( ! post_type_exists( 'wpforms' ) ) {
+			return [];
+		}
+
+		$form_data = self::build_wpforms_form_data( $title, $recipient_email, $submit_label );
+		$form_id   = wp_insert_post(
+			[
+				'post_title'   => $title,
+				'post_type'    => 'wpforms',
+				'post_status'  => 'publish',
+				'post_content' => wp_slash( (string) wp_json_encode( $form_data ) ),
+			],
+			true
+		);
+
+		if ( is_wp_error( $form_id ) || (int) $form_id <= 0 ) {
+			return [];
+		}
+
+		$form_id = (int) $form_id;
+		update_post_meta( $form_id, '_wpforms_version', defined( 'WPFORMS_VERSION' ) ? (string) WPFORMS_VERSION : '' );
+		update_post_meta( $form_id, '_wpforms_author', get_current_user_id() );
+
+		$shortcode = sprintf( '[wpforms id="%d"]', $form_id );
+
+		return [
+			'provider'  => 'wpforms-lite',
+			'title'     => $title,
+			'shortcode' => $shortcode,
+			'block'     => '<!-- wp:shortcode -->' . "\n" . $shortcode . "\n" . '<!-- /wp:shortcode -->',
+			'form_id'   => $form_id,
+			'message'   => __( 'WPForms Lite form created; insert the shortcode block into page content and verify the frontend renders the form.', 'superdav-ai-agent' ),
+		];
+	}
+
+	/**
+	 * Build WPForms Lite form data for a basic contact form.
+	 *
+	 * @param string $title           Form title.
+	 * @param string $recipient_email Recipient email address.
+	 * @param string $submit_label    Submit button label.
+	 * @return array<string,mixed> WPForms form data.
+	 */
+	private static function build_wpforms_form_data( string $title, string $recipient_email, string $submit_label ): array {
+		return [
+			'field_id' => 4,
+			'fields'   => [
+				'0' => [
+					'id'       => '0',
+					'type'     => 'name',
+					'label'    => __( 'Name', 'superdav-ai-agent' ),
+					'format'   => 'simple',
+					'required' => '1',
+				],
+				'1' => [
+					'id'       => '1',
+					'type'     => 'email',
+					'label'    => __( 'Email', 'superdav-ai-agent' ),
+					'required' => '1',
+				],
+				'2' => [
+					'id'    => '2',
+					'type'  => 'text',
+					'label' => __( 'Subject', 'superdav-ai-agent' ),
+				],
+				'3' => [
+					'id'       => '3',
+					'type'     => 'textarea',
+					'label'    => __( 'Message', 'superdav-ai-agent' ),
+					'required' => '1',
+				],
+			],
+			'settings' => [
+				'form_title'             => $title,
+				'form_desc'              => '',
+				'submit_text'            => $submit_label,
+				'submit_text_processing' => __( 'Sending...', 'superdav-ai-agent' ),
+				'notification_enable'    => '1',
+				'notifications'          => [
+					'1' => [
+						'notification_name' => __( 'Default Notification', 'superdav-ai-agent' ),
+						'email'             => $recipient_email,
+						'subject'           => sprintf(
+							/* translators: %s: contact form title */
+							__( 'New entry: %s', 'superdav-ai-agent' ),
+							$title
+						),
+						'sender_name'       => '{field_id="0"}',
+						'sender_address'    => '{admin_email}',
+						'replyto'           => '{field_id="1"}',
+						'message'           => '{all_fields}',
+					],
+				],
+				'confirmations'          => [
+					'1' => [
+						'name'    => __( 'Default Confirmation', 'superdav-ai-agent' ),
+						'type'    => 'message',
+						'message' => __( 'Thanks for contacting us. We will be in touch soon.', 'superdav-ai-agent' ),
+					],
+				],
+			],
 		];
 	}
 

--- a/includes/Core/AbilityPluginRegistry.php
+++ b/includes/Core/AbilityPluginRegistry.php
@@ -73,12 +73,12 @@ class AbilityPluginRegistry {
 		[
 			'slug'            => 'wpforms-lite',
 			'name'            => 'WPForms Lite',
-			'ability_count'   => 5,
-			'has_abilities'   => true,
+			'ability_count'   => 0,
+			'has_abilities'   => false,
 			'has_blocks'      => true,
 			'categories'      => [ 'forms', 'contact', 'surveys', 'lead-capture' ],
 			'active_installs' => 6000000,
-			'description'     => 'Recommended form plugin. Registers native WordPress Abilities (v1.9.9.2+) for AI-assisted form creation. Drag-and-drop builder with spam protection and email notifications.',
+			'description'     => 'Recommended form plugin for plugin-backed submissions. WordPress Abilities availability varies by install; use sd-ai-agent/create-contact-form to create and verify forms.',
 		],
 		[
 			'slug'            => 'contact-form-7',

--- a/includes/Models/skills/contact-forms.md
+++ b/includes/Models/skills/contact-forms.md
@@ -7,13 +7,15 @@ Use this skill when the user asks to:
 - Manage form notifications or submission settings
 - Embed a form into an existing page or post
 
-## Recommended Plugin: WPForms Lite
+## Recommended Path: `sd-ai-agent/create-contact-form`
 
-**WPForms Lite** (`wpforms-lite`) is the recommended contact form plugin. It is the only major free form plugin with confirmed WordPress Abilities API integration (added in v1.9.9.2), making it natively AI-ready for form management.
+Use the `sd-ai-agent/create-contact-form` ability for new contact pages. It creates a WPForms Lite form when WPForms is active, creates a Contact Form 7 form when CF7 is active, and otherwise returns a dependency-free Gutenberg HTML fallback. Do not assume WPForms Lite registers WordPress Abilities on the target site.
+
+WPForms Lite (`wpforms-lite`) remains the recommended form plugin when a plugin-backed form is needed:
 
 - **Slug**: `wpforms-lite`
 - **Active installs**: 6 million+
-- **WP Abilities**: confirmed (v1.9.9.2+)
+- **WP Abilities**: not required; availability varies by install
 - **Gutenberg block**: yes
 - **Spam protection**: built-in, plus reCAPTCHA/hCaptcha/Turnstile
 - **Email notifications**: yes, with smart tags
@@ -27,11 +29,11 @@ Use `sd-ai-agent/get-plugins` to list installed plugins, then look for:
 
 | Plugin slug | Abilities API | Notes |
 |---|---|---|
-| `wpforms-lite` / `wpforms` | **Yes** | Preferred |
+| `wpforms-lite` / `wpforms` | Varies | Preferred; use `sd-ai-agent/create-contact-form` |
 | `contact-form-7` | No | 10M installs, common fallback |
 | `fluentform` | No | Developer-friendly, no Abilities yet |
 
-### Step 2 — Install WPForms if no supported plugin is active
+### Step 2 — Install WPForms if the user wants plugin-backed submissions
 
 Use `sd-ai-agent/install-plugin`:
 ```json
@@ -40,14 +42,18 @@ Use `sd-ai-agent/install-plugin`:
 
 This installs from wordpress.org and immediately activates the plugin.
 
-### Step 3 — Discover WPForms abilities
+### Step 3 — Create the form
 
-After WPForms Lite is active, use `sd-ai-agent/ability-search` to discover its registered abilities:
+Call `sd-ai-agent/create-contact-form` after activating WPForms Lite:
 ```json
-{ "query": "wpforms" }
+{
+  "title": "Contact Form",
+  "recipient_email": "owner@example.com",
+  "submit_label": "Send Message"
+}
 ```
 
-WPForms registers its own abilities under the `wpforms/*` namespace. Use those abilities for all form creation and management tasks — do not attempt to duplicate form creation in custom code.
+Use the returned `block` or `shortcode` exactly. If the result provider is `wpforms-lite`, the shortcode is `[wpforms id="FORM_ID"]`.
 
 ### Step 4 — Embed the form in a page
 
@@ -91,8 +97,9 @@ Note: Avoid installing CF7 on new sites. Prefer WPForms Lite for all new setups.
 ## Verification Steps
 
 After creating and embedding a form:
-1. Confirm WPForms is active: `sd-ai-agent/get-plugins`
-2. Confirm the form ID exists via WPForms abilities (list forms)
+1. Confirm WPForms is active when the provider is `wpforms-lite`: `sd-ai-agent/get-plugins`
+2. Confirm the returned form ID exists: `wp post get <FORM_ID> --post_type=wpforms --field=post_status`
 3. Confirm the page is published: `wp post get <PAGE_ID> --field=post_status`
 4. Confirm the shortcode is in the page content: `wp post get <PAGE_ID> --field=post_content`
 5. Confirm the admin notification email is set to the site owner's address
+6. Visit the frontend page or fetch it anonymously and confirm the form markup renders, not just the shortcode text

--- a/tests/SdAiAgent/Abilities/ContentAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/ContentAbilitiesTest.php
@@ -18,6 +18,17 @@ use WP_UnitTestCase;
 class ContentAbilitiesTest extends WP_UnitTestCase {
 
 	/**
+	 * Clean up registered post types between tests.
+	 */
+	public function tear_down(): void {
+		if ( post_type_exists( 'wpforms' ) ) {
+			unregister_post_type( 'wpforms' );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
 	 * Test handle_content_analyze with no posts returns empty message.
 	 */
 	public function test_handle_content_analyze_no_posts() {
@@ -234,6 +245,39 @@ class ContentAbilitiesTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '<!-- wp:html -->', $result['block'] );
 		$this->assertStringContainsString( 'sd-ai-agent-contact-form', $result['block'] );
 		$this->assertStringContainsString( 'Send Now', $result['block'] );
+	}
+
+	/**
+	 * Test handle_create_contact_form creates a WPForms form when the post type is registered.
+	 */
+	public function test_handle_create_contact_form_creates_wpforms_form_when_available() {
+		register_post_type(
+			'wpforms',
+			[
+				'public'   => false,
+				'supports' => [ 'title', 'editor' ],
+			]
+		);
+
+		$result = ContentAbilities::handle_create_contact_form( [
+			'title'           => 'Sales Inquiry',
+			'recipient_email' => 'sales@example.test',
+			'submit_label'    => 'Send Inquiry',
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'wpforms-lite', $result['provider'] );
+		$this->assertGreaterThan( 0, $result['form_id'] );
+		$this->assertSame( '[wpforms id="' . $result['form_id'] . '"]', $result['shortcode'] );
+		$this->assertStringContainsString( '<!-- wp:shortcode -->', $result['block'] );
+
+		$form_data = json_decode( (string) get_post_field( 'post_content', (int) $result['form_id'] ), true );
+
+		$this->assertIsArray( $form_data );
+		$this->assertSame( 'Sales Inquiry', $form_data['settings']['form_title'] );
+		$this->assertSame( 'sales@example.test', $form_data['settings']['notifications']['1']['email'] );
+		$this->assertSame( 'Send Inquiry', $form_data['settings']['submit_text'] );
+
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Created WPForms Lite form posts directly when the wpforms post type is available, updated the contact forms skill to use sd-ai-agent/create-contact-form instead of assuming WPForms abilities, and adjusted the plugin registry metadata to reflect variable WPForms ability support.

## Files Changed

includes/Abilities/ContentAbilities.php,includes/Core/AbilityPluginRegistry.php,includes/Models/skills/contact-forms.md,tests/SdAiAgent/Abilities/ContentAbilitiesTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify (PHPUnit: Tests: 3521, Assertions: 14658, Skipped: 114, Incomplete: 4; lint clean; PHPStan 0 errors; build succeeded with existing webpack size warnings)

Resolves #1954


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 10m and 124,602 tokens on this as a headless worker.