### PR TITLE
GH#1951: feat: add navigation menu reflector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
 				"@wordpress/notices": "^5.35.0",
 				"chart.js": "^4.5.1",
 				"html2canvas": "^1.4.1",
+				"morphdom": "^2.7.8",
 				"react": "^18.3.1",
 				"react-markdown": "^10.1.0",
 				"remark-gfm": "^4.0.1"
@@ -19967,6 +19968,12 @@
 			"engines": {
 				"node": "*"
 			}
+		},
+		"node_modules/morphdom": {
+			"version": "2.7.8",
+			"resolved": "https://registry.npmjs.org/morphdom/-/morphdom-2.7.8.tgz",
+			"integrity": "sha512-D/fR4xgGUyVRbdMGU6Nejea1RFzYxYtyurG4Fbv2Fi/daKlWKuXGLOdXtl+3eIwL110cI2hz1ZojGICjjFLgTg==",
+			"license": "MIT"
 		},
 		"node_modules/motion-dom": {
 			"version": "11.18.1",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
 		"@wordpress/notices": "^5.35.0",
 		"chart.js": "^4.5.1",
 		"html2canvas": "^1.4.1",
+		"morphdom": "^2.7.8",
 		"react": "^18.3.1",
 		"react-markdown": "^10.1.0",
 		"remark-gfm": "^4.0.1"

--- a/src/floating-widget/index.js
+++ b/src/floating-widget/index.js
@@ -12,11 +12,8 @@ import STORE_NAME from '../store';
 // Register sd-ai-agent-js/* client-side abilities into core/abilities
 // before the chat mounts (t165 — closes the wiring gap in #815).
 import '../abilities';
-// Spike: subscribe to the frontend live-preview reflection bus and log
-// every tool-applied event to the browser console. Phase 1 only —
-// remove once real DOM reflectors land (Phase 2). See
-// `src/store/reflection-bus.js` and `src/store/reflection-emitter.js`.
-import './reflection-debug';
+// Subscribe real DOM reflectors to frontend live-preview events.
+import './reflectors';
 import ErrorBoundary from '../components/error-boundary';
 import ChatWidget from '../components/chat-widget';
 import useKeyboardShortcut from './use-keyboard-shortcut';

--- a/src/floating-widget/reflectors/__tests__/menu.test.js
+++ b/src/floating-widget/reflectors/__tests__/menu.test.js
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for the navigation menu reflector.
+ */
+
+import { reflectMenu } from '../menu';
+
+/**
+ * Get menu item text for a selected menu.
+ *
+ * @param {string} selector Menu selector.
+ * @return {string[]} Menu item labels.
+ */
+function menuItems( selector ) {
+	return Array.from(
+		document.querySelector( selector ).querySelectorAll( 'li' )
+	).map( ( item ) => item.textContent.trim() );
+}
+
+/**
+ * Build a mocked Fetch API response.
+ *
+ * @param {string}  html   Response body.
+ * @param {boolean} ok     Whether the response is successful.
+ * @param {number}  status HTTP response status.
+ * @return {Promise<Object>} Mock fetch response.
+ */
+function responseWithHtml( html, ok = true, status = 200 ) {
+	return Promise.resolve( {
+		ok,
+		status,
+		text: () => Promise.resolve( html ),
+	} );
+}
+
+describe( 'reflectMenu', () => {
+	let warnSpy;
+
+	beforeEach( () => {
+		warnSpy = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+		global.fetch = jest.fn();
+	} );
+
+	afterEach( () => {
+		warnSpy.mockRestore();
+		delete global.fetch;
+		document.body.innerHTML = '';
+		document.head.innerHTML = '';
+	} );
+
+	test( 'morphs multiple block navigation menus in document order', async () => {
+		document.body.innerHTML = `
+			<nav class="wp-block-navigation" aria-label="Header">
+				<ul><li>Home</li><li>Blog</li><li>About</li></ul>
+			</nav>
+			<nav class="wp-block-navigation" aria-label="Footer">
+				<ul><li>Home</li><li>Privacy</li><li>Terms</li></ul>
+			</nav>
+		`;
+
+		global.fetch.mockReturnValue(
+			responseWithHtml( `
+				<html><body>
+					<nav class="wp-block-navigation" aria-label="Header">
+						<ul><li>Home</li><li>Blog</li><li>About</li><li>Contact</li></ul>
+					</nav>
+					<nav class="wp-block-navigation" aria-label="Footer">
+						<ul><li>Home</li><li>Privacy</li><li>Terms</li><li>Contact</li></ul>
+					</nav>
+				</body></html>
+			` )
+		);
+
+		await reflectMenu( { affected: { kind: 'menu', url: '/' } } );
+
+		expect( menuItems( 'nav[aria-label="Header"]' ) ).toEqual( [
+			'Home',
+			'Blog',
+			'About',
+			'Contact',
+		] );
+		expect( menuItems( 'nav[aria-label="Footer"]' ) ).toEqual( [
+			'Home',
+			'Privacy',
+			'Terms',
+			'Contact',
+		] );
+	} );
+
+	test( 'keeps extra current menus when the fresh page has fewer matches', async () => {
+		document.body.innerHTML = `
+			<nav class="wp-block-navigation" aria-label="Header"><ul><li>Old</li></ul></nav>
+			<nav class="wp-block-navigation" aria-label="Mobile"><ul><li>Keep</li></ul></nav>
+		`;
+
+		global.fetch.mockReturnValue(
+			responseWithHtml( `
+				<html><body>
+					<nav class="wp-block-navigation" aria-label="Header"><ul><li>New</li><li>Contact</li></ul></nav>
+				</body></html>
+			` )
+		);
+
+		await reflectMenu( { affected: { kind: 'menu', url: '/' } } );
+
+		expect( menuItems( 'nav[aria-label="Header"]' ) ).toEqual( [
+			'New',
+			'Contact',
+		] );
+		expect( menuItems( 'nav[aria-label="Mobile"]' ) ).toEqual( [ 'Keep' ] );
+	} );
+
+	test( 'silently no-ops when no current menus match', async () => {
+		document.body.innerHTML = '<main>No menus here</main>';
+		global.fetch.mockReturnValue(
+			responseWithHtml(
+				'<html><body><nav class="wp-block-navigation"><ul><li>Fresh</li></ul></nav></body></html>'
+			)
+		);
+
+		await reflectMenu( { affected: { kind: 'menu', url: '/' } } );
+
+		expect( document.body.textContent ).toContain( 'No menus here' );
+		expect( warnSpy ).not.toHaveBeenCalled();
+	} );
+
+	test( 'catches and logs fetch failures', async () => {
+		document.body.innerHTML =
+			'<nav class="wp-block-navigation"><ul><li>Home</li></ul></nav>';
+		global.fetch.mockReturnValue( responseWithHtml( '', false, 500 ) );
+
+		await reflectMenu( { affected: { kind: 'menu', url: '/' } } );
+
+		expect( warnSpy ).toHaveBeenCalledWith(
+			'[sd-ai-agent] menu reflector failed',
+			expect.any( Error )
+		);
+	} );
+} );

--- a/src/floating-widget/reflectors/dom-morph.js
+++ b/src/floating-widget/reflectors/dom-morph.js
@@ -1,0 +1,72 @@
+/**
+ * DOM morphing helpers for frontend live-preview reflectors.
+ */
+
+import morphdom from 'morphdom';
+
+/**
+ * Fetch a fresh copy of a frontend page as a parsed document.
+ *
+ * @param {string} url Page URL to fetch.
+ * @return {Promise<Document>} Parsed fresh document.
+ */
+export async function fetchFreshPage( url ) {
+	const target = url || window.location.href;
+	const bust =
+		target + ( target.includes( '?' ) ? '&' : '?' ) + '_=' + Date.now();
+	const res = await fetch( bust, {
+		credentials: 'same-origin',
+		cache: 'no-store',
+		headers: { Accept: 'text/html' },
+	} );
+
+	if ( ! res.ok ) {
+		throw new Error( `HTTP ${ res.status }` );
+	}
+
+	return new DOMParser().parseFromString( await res.text(), 'text/html' );
+}
+
+/**
+ * Morph the first matching selector from a fresh document into the current one.
+ *
+ * @param {Document|Element} currentDoc Current document or root element.
+ * @param {Document|Element} freshDoc   Fresh document or root element.
+ * @param {string}           selector   CSS selector to morph.
+ */
+export function morphTargetFromFresh( currentDoc, freshDoc, selector ) {
+	const current = currentDoc.querySelector( selector );
+	const fresh = freshDoc.querySelector( selector );
+
+	if ( ! current || ! fresh ) {
+		return;
+	}
+
+	morphTargetByElement( current, fresh );
+}
+
+/**
+ * Morph a specific current element to match a fresh element.
+ *
+ * @param {Element} currentEl Current DOM element.
+ * @param {Element} freshEl   Fresh DOM element.
+ */
+export function morphTargetByElement( currentEl, freshEl ) {
+	if ( ! currentEl || ! freshEl ) {
+		return;
+	}
+
+	morphdom( currentEl, freshEl.cloneNode( true ), {
+		onBeforeElUpdated( fromEl, toEl ) {
+			if ( fromEl === fromEl.ownerDocument.activeElement ) {
+				return false;
+			}
+
+			if ( fromEl.closest && fromEl.closest( '#sdaa-floating-root' ) ) {
+				return false;
+			}
+
+			return ! fromEl.isEqualNode( toEl );
+		},
+	} );
+}

--- a/src/floating-widget/reflectors/index.js
+++ b/src/floating-widget/reflectors/index.js
@@ -1,0 +1,21 @@
+/**
+ * Frontend live-preview reflector dispatcher.
+ */
+
+import bus from '../../store/reflection-bus';
+import { reflectMenu } from './menu';
+
+bus.on( ( event ) => {
+	if ( event.type !== 'tool-applied' || ! event.affected ) {
+		return;
+	}
+
+	switch ( event.affected.kind ) {
+		case 'menu':
+			reflectMenu( event );
+			break;
+		default:
+			// Phase 2e fallback toast lands here.
+			break;
+	}
+} );

--- a/src/floating-widget/reflectors/menu.js
+++ b/src/floating-widget/reflectors/menu.js
@@ -1,0 +1,39 @@
+/**
+ * Navigation menu reflector.
+ */
+
+import { fetchFreshPage, morphTargetByElement } from './dom-morph';
+
+const MENU_SELECTORS = [
+	'nav.wp-block-navigation',
+	'.wp-block-navigation',
+	'.menu',
+	'.nav-menu',
+	'ul.wp-block-navigation__container',
+];
+
+/**
+ * Refresh visible frontend navigation menus after an agent menu update.
+ *
+ * @param {Object} event Reflection event.
+ */
+export async function reflectMenu( event ) {
+	try {
+		const fresh = await fetchFreshPage(
+			event?.affected?.url || window.location.href
+		);
+
+		for ( const selector of MENU_SELECTORS ) {
+			const currents = document.querySelectorAll( selector );
+			const freshes = fresh.querySelectorAll( selector );
+			const pairs = Math.min( currents.length, freshes.length );
+
+			for ( let i = 0; i < pairs; i++ ) {
+				morphTargetByElement( currents[ i ], freshes[ i ] );
+			}
+		}
+	} catch ( err ) {
+		// eslint-disable-next-line no-console
+		console.warn( '[sd-ai-agent] menu reflector failed', err );
+	}
+}


### PR DESCRIPTION
## Summary

Added a frontend menu reflector wired through the reflection dispatcher, with shared dom-morph helpers and jsdom coverage for multiple menus, missing fresh pairs, no-op selectors, and fetch failures.

## Files Changed

package-lock.json,package.json,src/floating-widget/index.js,src/floating-widget/reflectors/__tests__/menu.test.js,src/floating-widget/reflectors/dom-morph.js,src/floating-widget/reflectors/index.js,src/floating-widget/reflectors/menu.js

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run lint:js; npm run test:js -- src/floating-widget/reflectors/__tests__/menu.test.js; npm run build

Resolves #1951


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 16m and 74,983 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Navigation menus now automatically update in real-time when changes are applied through the floating widget.

* **Tests**
  * Added test coverage for menu reflection functionality.

* **Chores**
  * Added morphdom dependency to project.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/superdav-ai-agent/pull/1956?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->