### PR TITLE
GH#1952: feat: add fallback reload toast reflector

### DIFF
--- a/src/floating-widget/reflectors/__tests__/fallback-toast.test.js
+++ b/src/floating-widget/reflectors/__tests__/fallback-toast.test.js
@@ -1,0 +1,104 @@
+/**
+ * Unit tests for the fallback reload toast reflector.
+ */
+
+import {
+	showFallbackToast,
+	__resetFallbackToastForTests,
+	__setFallbackToastReloadForTests,
+} from '../fallback-toast';
+
+describe( 'fallback-toast', () => {
+	let reloadMock;
+
+	beforeEach( () => {
+		document.body.className = '';
+		__resetFallbackToastForTests();
+
+		reloadMock = jest.fn();
+		__setFallbackToastReloadForTests( reloadMock );
+	} );
+
+	afterEach( () => {
+		__resetFallbackToastForTests();
+		document.body.className = '';
+	} );
+
+	test( 'renders a toast with count 1 on first event', () => {
+		showFallbackToast( { affected: { kind: 'term' } } );
+
+		const toast = document.querySelector( '.sd-ai-agent-fallback-toast' );
+
+		expect( toast ).not.toBeNull();
+		expect(
+			toast.querySelector( '.sd-ai-agent-fallback-toast__msg' )
+		).toHaveProperty(
+			'textContent',
+			'Agent made 1 update. Reload to see changes.'
+		);
+	} );
+
+	test( 'increments count while keeping a single toast element', () => {
+		showFallbackToast( { affected: { kind: 'term' } } );
+		showFallbackToast( { affected: { kind: 'media' } } );
+
+		expect(
+			document.querySelectorAll( '.sd-ai-agent-fallback-toast' )
+		).toHaveLength( 1 );
+		expect(
+			document.querySelector( '.sd-ai-agent-fallback-toast__msg' )
+		).toHaveProperty(
+			'textContent',
+			'Agent made 2 updates. Reload to see changes.'
+		);
+	} );
+
+	test( 'dismiss removes the toast and resets the count', () => {
+		showFallbackToast( { affected: { kind: 'term' } } );
+		showFallbackToast( { affected: { kind: 'media' } } );
+
+		document
+			.querySelector( '.sd-ai-agent-fallback-toast__dismiss' )
+			.click();
+
+		expect(
+			document.querySelector( '.sd-ai-agent-fallback-toast' )
+		).toBeNull();
+
+		showFallbackToast( { affected: { kind: 'term' } } );
+
+		expect(
+			document.querySelector( '.sd-ai-agent-fallback-toast__msg' )
+		).toHaveProperty(
+			'textContent',
+			'Agent made 1 update. Reload to see changes.'
+		);
+	} );
+
+	test( 'reload button calls window.location.reload', () => {
+		showFallbackToast( { affected: { kind: 'term' } } );
+
+		document.querySelector( '.sd-ai-agent-fallback-toast__reload' ).click();
+
+		expect( reloadMock ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'sets polite status semantics', () => {
+		showFallbackToast( { affected: { kind: 'term' } } );
+
+		const toast = document.querySelector( '.sd-ai-agent-fallback-toast' );
+
+		expect( toast.getAttribute( 'role' ) ).toBe( 'status' );
+		expect( toast.getAttribute( 'aria-live' ) ).toBe( 'polite' );
+	} );
+
+	test( 'does not show on wp-admin screens', () => {
+		document.body.classList.add( 'wp-admin' );
+
+		showFallbackToast( { affected: { kind: 'term' } } );
+
+		expect(
+			document.querySelector( '.sd-ai-agent-fallback-toast' )
+		).toBeNull();
+	} );
+} );

--- a/src/floating-widget/reflectors/fallback-toast.css
+++ b/src/floating-widget/reflectors/fallback-toast.css
@@ -1,0 +1,56 @@
+.sd-ai-agent-fallback-toast {
+	align-items: center;
+	background: #1e1e1e;
+	border-radius: 8px;
+	bottom: 88px;
+	box-shadow: 0 8px 24px rgba(0, 0, 0, 0.24);
+	color: #fff;
+	display: flex;
+	font-size: 13px;
+	gap: 10px;
+	line-height: 1.4;
+	max-width: min(360px, calc(100vw - 48px));
+	padding: 12px 14px;
+	position: fixed;
+	right: 24px;
+	z-index: 999999;
+}
+
+.sd-ai-agent-fallback-toast__msg {
+	flex: 1 1 auto;
+}
+
+.sd-ai-agent-fallback-toast__reload,
+.sd-ai-agent-fallback-toast__dismiss {
+	appearance: none;
+	border: 0;
+	cursor: pointer;
+	font: inherit;
+}
+
+.sd-ai-agent-fallback-toast__reload {
+	background: #fff;
+	border-radius: 6px;
+	color: #1e1e1e;
+	font-weight: 600;
+	padding: 6px 10px;
+}
+
+.sd-ai-agent-fallback-toast__dismiss {
+	align-items: center;
+	background: transparent;
+	color: #fff;
+	display: inline-flex;
+	font-size: 20px;
+	height: 28px;
+	justify-content: center;
+	line-height: 1;
+	padding: 0;
+	width: 28px;
+}
+
+.sd-ai-agent-fallback-toast__reload:focus-visible,
+.sd-ai-agent-fallback-toast__dismiss:focus-visible {
+	outline: 2px solid #72aee6;
+	outline-offset: 2px;
+}

--- a/src/floating-widget/reflectors/fallback-toast.js
+++ b/src/floating-widget/reflectors/fallback-toast.js
@@ -1,0 +1,132 @@
+/**
+ * Fallback reload toast for affected kinds without a dedicated reflector.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf, _n } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './fallback-toast.css';
+
+let toastEl = null;
+let count = 0;
+let reloadPage = () => window.location.reload();
+
+/**
+ * Show or update the fallback reload toast for an unmapped reflection event.
+ *
+ * @param {Object} event Reflection event. Accepted for future strategy parity.
+ */
+export function showFallbackToast( event = {} ) {
+	void event;
+
+	if (
+		typeof document === 'undefined' ||
+		! document.body ||
+		document.body.classList.contains( 'wp-admin' )
+	) {
+		return;
+	}
+
+	count++;
+
+	if ( ! toastEl ) {
+		toastEl = createToast();
+		document.body.appendChild( toastEl );
+	}
+
+	updateToastText( toastEl, count );
+}
+
+/**
+ * Create the fallback toast DOM node.
+ *
+ * @return {HTMLDivElement} Toast root element.
+ */
+function createToast() {
+	const root = document.createElement( 'div' );
+	root.className = 'sd-ai-agent-fallback-toast';
+	root.setAttribute( 'role', 'status' );
+	root.setAttribute( 'aria-live', 'polite' );
+
+	const message = document.createElement( 'span' );
+	message.className = 'sd-ai-agent-fallback-toast__msg';
+
+	const reloadButton = document.createElement( 'button' );
+	reloadButton.type = 'button';
+	reloadButton.className = 'sd-ai-agent-fallback-toast__reload';
+	reloadButton.textContent = __( 'Reload', 'superdav-ai-agent' );
+	reloadButton.addEventListener( 'click', () => reloadPage() );
+
+	const dismissButton = document.createElement( 'button' );
+	dismissButton.type = 'button';
+	dismissButton.className = 'sd-ai-agent-fallback-toast__dismiss';
+	dismissButton.setAttribute(
+		'aria-label',
+		__( 'Dismiss', 'superdav-ai-agent' )
+	);
+	dismissButton.textContent = '×';
+	dismissButton.addEventListener( 'click', dismissToast );
+
+	root.append( message, reloadButton, dismissButton );
+
+	return root;
+}
+
+/**
+ * Update the toast message for the current pending update count.
+ *
+ * @param {HTMLElement} el Toast root element.
+ * @param {number}      n  Pending update count.
+ */
+function updateToastText( el, n ) {
+	const message = el.querySelector( '.sd-ai-agent-fallback-toast__msg' );
+
+	if ( ! message ) {
+		return;
+	}
+
+	message.textContent = sprintf(
+		/* translators: %d: number of pending site updates. */
+		_n(
+			'Agent made %d update. Reload to see changes.',
+			'Agent made %d updates. Reload to see changes.',
+			n,
+			'superdav-ai-agent'
+		),
+		n
+	);
+}
+
+/**
+ * Dismiss the toast and reset pending update count.
+ */
+function dismissToast() {
+	if ( toastEl ) {
+		toastEl.remove();
+		toastEl = null;
+	}
+
+	count = 0;
+}
+
+/**
+ * Reset module state for Jest tests.
+ */
+export function __resetFallbackToastForTests() {
+	dismissToast();
+	reloadPage = () => window.location.reload();
+}
+
+/**
+ * Override the reload callback for Jest tests.
+ *
+ * @param {Function} callback Reload callback.
+ */
+export function __setFallbackToastReloadForTests( callback ) {
+	reloadPage = callback;
+}

--- a/src/floating-widget/reflectors/index.js
+++ b/src/floating-widget/reflectors/index.js
@@ -1,12 +1,17 @@
 /**
  * Frontend live-preview reflector dispatcher.
+ *
+ * Subscribes to the reflection bus and sends each affected tool result to the
+ * best available DOM refresh strategy. Unknown kinds intentionally fall back to
+ * an honest reload prompt so the user is not left looking at stale content.
  */
 
 import bus from '../../store/reflection-bus';
+import { showFallbackToast } from './fallback-toast';
 import { reflectMenu } from './menu';
 
 bus.on( ( event ) => {
-	if ( event.type !== 'tool-applied' || ! event.affected ) {
+	if ( event.type !== 'tool-applied' || ! event.affected?.kind ) {
 		return;
 	}
 
@@ -15,7 +20,7 @@ bus.on( ( event ) => {
 			reflectMenu( event );
 			break;
 		default:
-			// Phase 2e fallback toast lands here.
+			showFallbackToast( event );
 			break;
 	}
 } );


### PR DESCRIPTION
## Summary

Added a fallback frontend reflection toast for unmapped affected kinds, wired the reflector dispatcher default path to it, and covered visible, counter, dismiss, reload, ARIA, and wp-admin guard behavior.

## Files Changed

src/floating-widget/reflectors/__tests__/fallback-toast.test.js,src/floating-widget/reflectors/fallback-toast.css,src/floating-widget/reflectors/fallback-toast.js,src/floating-widget/reflectors/index.js

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run test:js -- src/floating-widget/reflectors/__tests__/fallback-toast.test.js; npm run test:js -- src/floating-widget/reflectors/__tests__/fallback-toast.test.js src/floating-widget/reflectors/__tests__/menu.test.js; npm run lint:js; npm run lint:css; COMPOSER_PROCESS_TIMEOUT=1200 composer phpstan; npm run test:php (Tests: 3523, Assertions: 14673, Skipped: 114, Incomplete: 4); npm run build

Resolves #1952


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 57m and 102,555 tokens on this as a headless worker.