### PR TITLE
GH#1948: feat: add affected payloads to content mutators

### DIFF
--- a/includes/Abilities/ContentAbilities.php
+++ b/includes/Abilities/ContentAbilities.php
@@ -167,6 +167,7 @@ class ContentAbilities {
 						'block'     => [ 'type' => 'string' ],
 						'form_id'   => [ 'type' => 'integer' ],
 						'message'   => [ 'type' => 'string' ],
+						'affected'  => self::affected_output_schema(),
 					],
 				],
 				'meta'                => [
@@ -511,6 +512,51 @@ class ContentAbilities {
 			'block'     => '<!-- wp:shortcode -->' . "\n" . $shortcode . "\n" . '<!-- /wp:shortcode -->',
 			'form_id'   => $form_id,
 			'message'   => __( 'WPForms Lite form created; insert the shortcode block into page content and verify the frontend renders the form.', 'superdav-ai-agent' ),
+			'affected'  => self::build_affected_payload( $form_id, [ 'post_title', 'post_content', 'meta' ] ),
+		];
+	}
+
+	/**
+	 * Build affected descriptor schema for contact-form content mutations.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function affected_output_schema(): array {
+		return [
+			'type'        => 'object',
+			'description' => 'Transport descriptor for the frontend reflection bus identifying a created form post when the active form provider stores one.',
+			'properties'  => [
+				'kind'      => [
+					'type' => 'string',
+					'enum' => [ 'post' ],
+				],
+				'post_id'   => [ 'type' => 'integer' ],
+				'post_type' => [ 'type' => 'string' ],
+				'url'       => [ 'type' => 'string' ],
+				'fields'    => [
+					'type'  => 'array',
+					'items' => [ 'type' => 'string' ],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Build affected descriptor for created form posts.
+	 *
+	 * @param int      $post_id Created form post ID.
+	 * @param string[] $fields  Mutated fields.
+	 * @return array<string, mixed>
+	 */
+	private static function build_affected_payload( int $post_id, array $fields ): array {
+		$post = get_post( $post_id );
+
+		return [
+			'kind'      => 'post',
+			'post_id'   => $post_id,
+			'post_type' => $post instanceof \WP_Post ? $post->post_type : '',
+			'url'       => get_permalink( $post_id ) ?: home_url( '/' ),
+			'fields'    => array_values( array_unique( $fields ) ),
 		];
 	}
 

--- a/includes/Abilities/GlobalStylesAbilities.php
+++ b/includes/Abilities/GlobalStylesAbilities.php
@@ -99,10 +99,11 @@ class GlobalStylesAbilities {
 				'output_schema'       => [
 					'type'       => 'object',
 					'properties' => [
-						'success' => [ 'type' => 'boolean' ],
-						'post_id' => [ 'type' => 'integer' ],
-						'message' => [ 'type' => 'string' ],
-						'error'   => [ 'type' => 'string' ],
+						'success'  => [ 'type' => 'boolean' ],
+						'post_id'  => [ 'type' => 'integer' ],
+						'message'  => [ 'type' => 'string' ],
+						'error'    => [ 'type' => 'string' ],
+						'affected' => self::affected_output_schema(),
 					],
 				],
 				'meta'                => [
@@ -180,9 +181,10 @@ class GlobalStylesAbilities {
 				'output_schema'       => [
 					'type'       => 'object',
 					'properties' => [
-						'success' => [ 'type' => 'boolean' ],
-						'message' => [ 'type' => 'string' ],
-						'error'   => [ 'type' => 'string' ],
+						'success'  => [ 'type' => 'boolean' ],
+						'message'  => [ 'type' => 'string' ],
+						'error'    => [ 'type' => 'string' ],
+						'affected' => self::affected_output_schema(),
 					],
 				],
 				'meta'                => [
@@ -313,9 +315,10 @@ class GlobalStylesAbilities {
 		}
 
 		return [
-			'success' => true,
-			'post_id' => $post_id,
-			'message' => __( 'Global styles updated successfully.', 'superdav-ai-agent' ),
+			'success'  => true,
+			'post_id'  => $post_id,
+			'message'  => __( 'Global styles updated successfully.', 'superdav-ai-agent' ),
+			'affected' => self::build_affected_payload( [ 'styles', 'settings' ] ),
 		];
 	}
 
@@ -405,8 +408,46 @@ class GlobalStylesAbilities {
 		}
 
 		return [
-			'success' => true,
-			'message' => __( 'Global styles reset to theme defaults.', 'superdav-ai-agent' ),
+			'success'  => true,
+			'message'  => __( 'Global styles reset to theme defaults.', 'superdav-ai-agent' ),
+			'affected' => self::build_affected_payload( [ 'reset' ] ),
+		];
+	}
+
+	/**
+	 * Build affected descriptor schema for global-styles mutations.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function affected_output_schema(): array {
+		return [
+			'type'        => 'object',
+			'description' => 'Transport descriptor for the frontend reflection bus. Global styles affect the whole site, so the public URL is the site home URL.',
+			'properties'  => [
+				'kind'   => [
+					'type' => 'string',
+					'enum' => [ 'global_styles' ],
+				],
+				'url'    => [ 'type' => 'string' ],
+				'fields' => [
+					'type'  => 'array',
+					'items' => [ 'type' => 'string' ],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Build affected descriptor for global-styles mutations.
+	 *
+	 * @param string[] $fields Mutated fields.
+	 * @return array<string, mixed>
+	 */
+	private static function build_affected_payload( array $fields ): array {
+		return [
+			'kind'   => 'global_styles',
+			'url'    => home_url( '/' ),
+			'fields' => array_values( array_unique( $fields ) ),
 		];
 	}
 

--- a/includes/Abilities/MediaAbilities.php
+++ b/includes/Abilities/MediaAbilities.php
@@ -132,6 +132,7 @@ class MediaAbilities {
 						'title'         => [ 'type' => 'string' ],
 						'mime_type'     => [ 'type' => 'string' ],
 						'file_size'     => [ 'type' => 'integer' ],
+						'affected'      => self::affected_output_schema(),
 					],
 				],
 				'meta'                => [
@@ -176,6 +177,7 @@ class MediaAbilities {
 						'attachment_id' => [ 'type' => 'integer' ],
 						'title'         => [ 'type' => 'string' ],
 						'deleted'       => [ 'type' => 'boolean' ],
+						'affected'      => self::affected_output_schema(),
 					],
 				],
 				'meta'                => [
@@ -442,6 +444,7 @@ class MediaAbilities {
 			'title'         => $title,
 			'mime_type'     => $mime_type,
 			'file_size'     => $file_size,
+			'affected'      => self::build_affected_payload( $attachment_id, $attachment_url, [ 'attachment', 'post_title', 'post_excerpt', 'post_content', 'alt_text' ] ),
 		];
 	}
 
@@ -489,8 +492,9 @@ class MediaAbilities {
 			);
 		}
 
-		$title  = $attachment->post_title;
-		$result = wp_delete_attachment( $attachment_id, true );
+		$title          = $attachment->post_title;
+		$attachment_url = wp_get_attachment_url( $attachment_id ) ?: '';
+		$result         = wp_delete_attachment( $attachment_id, true );
 
 		if ( $switched ) {
 			restore_current_blog();
@@ -517,6 +521,48 @@ class MediaAbilities {
 			'attachment_id' => $attachment_id,
 			'title'         => $title,
 			'deleted'       => (bool) $result,
+			'affected'      => self::build_affected_payload( $attachment_id, $attachment_url, [ 'deleted' ] ),
+		];
+	}
+
+	/**
+	 * Build affected descriptor schema for media mutations.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function affected_output_schema(): array {
+		return [
+			'type'        => 'object',
+			'description' => 'Transport descriptor for the frontend reflection bus identifying the changed media attachment.',
+			'properties'  => [
+				'kind'    => [
+					'type' => 'string',
+					'enum' => [ 'media' ],
+				],
+				'post_id' => [ 'type' => 'integer' ],
+				'url'     => [ 'type' => 'string' ],
+				'fields'  => [
+					'type'  => 'array',
+					'items' => [ 'type' => 'string' ],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Build affected descriptor for media mutations.
+	 *
+	 * @param int      $attachment_id Attachment post ID.
+	 * @param string   $url           Attachment URL.
+	 * @param string[] $fields        Mutated fields.
+	 * @return array<string, mixed>
+	 */
+	public static function build_affected_payload( int $attachment_id, string $url, array $fields ): array {
+		return [
+			'kind'    => 'media',
+			'post_id' => $attachment_id,
+			'url'     => $url,
+			'fields'  => array_values( array_unique( $fields ) ),
 		];
 	}
 }

--- a/includes/Abilities/MenuAbilities.php
+++ b/includes/Abilities/MenuAbilities.php
@@ -160,6 +160,7 @@ class MenuAbilities {
 						'name'        => [ 'type' => 'string' ],
 						'slug'        => [ 'type' => 'string' ],
 						'items_added' => [ 'type' => 'integer' ],
+						'affected'    => self::affected_output_schema(),
 					],
 				],
 				'meta'                => [
@@ -201,9 +202,10 @@ class MenuAbilities {
 				'output_schema'       => [
 					'type'       => 'object',
 					'properties' => [
-						'menu_id' => [ 'type' => 'integer' ],
-						'name'    => [ 'type' => 'string' ],
-						'deleted' => [ 'type' => 'boolean' ],
+						'menu_id'  => [ 'type' => 'integer' ],
+						'name'     => [ 'type' => 'string' ],
+						'deleted'  => [ 'type' => 'boolean' ],
+						'affected' => self::affected_output_schema(),
 					],
 				],
 				'meta'                => [
@@ -286,10 +288,11 @@ class MenuAbilities {
 				'output_schema'       => [
 					'type'       => 'object',
 					'properties' => [
-						'item_id' => [ 'type' => 'integer' ],
-						'title'   => [ 'type' => 'string' ],
-						'url'     => [ 'type' => 'string' ],
-						'menu_id' => [ 'type' => 'integer' ],
+						'item_id'  => [ 'type' => 'integer' ],
+						'title'    => [ 'type' => 'string' ],
+						'url'      => [ 'type' => 'string' ],
+						'menu_id'  => [ 'type' => 'integer' ],
+						'affected' => self::affected_output_schema(),
 					],
 				],
 				'meta'                => [
@@ -327,9 +330,10 @@ class MenuAbilities {
 				'output_schema'       => [
 					'type'       => 'object',
 					'properties' => [
-						'item_id' => [ 'type' => 'integer' ],
-						'title'   => [ 'type' => 'string' ],
-						'deleted' => [ 'type' => 'boolean' ],
+						'item_id'  => [ 'type' => 'integer' ],
+						'title'    => [ 'type' => 'string' ],
+						'deleted'  => [ 'type' => 'boolean' ],
+						'affected' => self::affected_output_schema(),
 					],
 				],
 				'meta'                => [
@@ -379,6 +383,7 @@ class MenuAbilities {
 						'name'     => [ 'type' => 'string' ],
 						'location' => [ 'type' => 'string' ],
 						'assigned' => [ 'type' => 'boolean' ],
+						'affected' => self::affected_output_schema(),
 					],
 				],
 				'meta'                => [
@@ -575,6 +580,7 @@ class MenuAbilities {
 			'name'        => $menu ? $menu->name : $name,
 			'slug'        => $menu ? $menu->slug : sanitize_title( $name ),
 			'items_added' => $items_added,
+			'affected'    => self::build_affected_payload( (int) $menu_id, [ 'name', 'location', 'items' ] ),
 		];
 	}
 
@@ -601,9 +607,10 @@ class MenuAbilities {
 		}
 
 		return [
-			'menu_id' => $menu_id,
-			'name'    => $menu_name,
-			'deleted' => (bool) $result,
+			'menu_id'  => $menu_id,
+			'name'     => $menu_name,
+			'deleted'  => (bool) $result,
+			'affected' => self::build_affected_payload( (int) $menu_id, [ 'deleted' ] ),
 		];
 	}
 
@@ -679,10 +686,11 @@ class MenuAbilities {
 		}
 
 		return [
-			'item_id' => $item_id,
-			'title'   => $title,
-			'url'     => $url,
-			'menu_id' => $menu->term_id,
+			'item_id'  => $item_id,
+			'title'    => $title,
+			'url'      => $url,
+			'menu_id'  => $menu->term_id,
+			'affected' => self::build_affected_payload( (int) $menu->term_id, array_keys( $item_data ) ),
 		];
 	}
 
@@ -714,9 +722,10 @@ class MenuAbilities {
 		$result = wp_delete_post( $item_id, true );
 
 		return [
-			'item_id' => $item_id,
-			'title'   => $title,
-			'deleted' => (bool) $result,
+			'item_id'  => $item_id,
+			'title'    => $title,
+			'deleted'  => (bool) $result,
+			'affected' => self::build_affected_payload( 0, [ 'item_deleted' ] ),
 		];
 	}
 
@@ -749,6 +758,47 @@ class MenuAbilities {
 			'name'     => $menu->name,
 			'location' => $location,
 			'assigned' => true,
+			'affected' => self::build_affected_payload( (int) $menu->term_id, [ 'location' ] ),
+		];
+	}
+
+	/**
+	 * Build affected descriptor schema for menu-mutating abilities.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function affected_output_schema(): array {
+		return [
+			'type'        => 'object',
+			'description' => 'Transport descriptor for the frontend reflection bus — menus appear site-wide, so the public URL is the site home URL.',
+			'properties'  => [
+				'kind'    => [
+					'type' => 'string',
+					'enum' => [ 'menu' ],
+				],
+				'menu_id' => [ 'type' => 'integer' ],
+				'url'     => [ 'type' => 'string' ],
+				'fields'  => [
+					'type'  => 'array',
+					'items' => [ 'type' => 'string' ],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Build affected descriptor for menu-mutating abilities.
+	 *
+	 * @param int      $menu_id Menu term ID, or 0 when only a deleted item ID is available.
+	 * @param string[] $fields  Mutated fields.
+	 * @return array<string, mixed>
+	 */
+	private static function build_affected_payload( int $menu_id, array $fields ): array {
+		return [
+			'kind'    => 'menu',
+			'menu_id' => $menu_id,
+			'url'     => home_url( '/' ),
+			'fields'  => array_values( array_unique( $fields ) ),
 		];
 	}
 

--- a/includes/Abilities/PostAbilities.php
+++ b/includes/Abilities/PostAbilities.php
@@ -176,6 +176,7 @@ class PostAbilities {
 						'permalink' => [ 'type' => 'string' ],
 						'status'    => [ 'type' => 'string' ],
 						'post_type' => [ 'type' => 'string' ],
+						'affected'  => self::affected_output_schema( 'post' ),
 					],
 				],
 				'meta'                => [
@@ -344,6 +345,7 @@ class PostAbilities {
 							'type'        => [ 'integer', 'null' ],
 							'description' => 'Latest revision ID after the write. null when the post has no revisions yet. Use as expected_revision for the next write.',
 						],
+						'affected'       => self::affected_output_schema( 'post' ),
 					],
 				],
 				'meta'                => [
@@ -616,6 +618,10 @@ class PostAbilities {
 						],
 						'created_count' => [ 'type' => 'integer' ],
 						'error_count'   => [ 'type' => 'integer' ],
+						'affected'      => [
+							'type'  => 'array',
+							'items' => self::affected_output_schema( 'post' ),
+						],
 					],
 				],
 				'meta'                => [
@@ -665,6 +671,7 @@ class PostAbilities {
 						'title'        => [ 'type' => 'string' ],
 						'action'       => [ 'type' => 'string' ],
 						'force_delete' => [ 'type' => 'boolean' ],
+						'affected'     => self::affected_output_schema( 'post' ),
 					],
 				],
 				'meta'                => [
@@ -713,6 +720,7 @@ class PostAbilities {
 						'post_id'           => [ 'type' => 'integer' ],
 						'featured_image_id' => [ 'type' => 'integer' ],
 						'result'            => [ 'type' => 'string' ],
+						'affected'          => self::affected_output_schema( 'post' ),
 					],
 				],
 				'meta'                => [
@@ -1308,6 +1316,8 @@ class PostAbilities {
 			$response['block_validation'] = $validation;
 		}
 
+		$response['affected'] = self::build_affected_payload( $post_id, $created_post, $permalink, $input, $post_data );
+
 		return $response;
 	}
 
@@ -1333,6 +1343,7 @@ class PostAbilities {
 		}
 
 		$results       = [];
+		$affected      = [];
 		$created_count = 0;
 		$error_count   = 0;
 
@@ -1362,6 +1373,9 @@ class PostAbilities {
 				];
 			} else {
 				++$created_count;
+				if ( isset( $result['affected'] ) && is_array( $result['affected'] ) ) {
+					$affected[] = $result['affected'];
+				}
 				$results[] = [
 					'post_id'   => $result['post_id'],
 					'permalink' => $result['permalink'],
@@ -1376,6 +1390,7 @@ class PostAbilities {
 			'results'       => $results,
 			'created_count' => $created_count,
 			'error_count'   => $error_count,
+			'affected'      => $affected,
 		];
 	}
 
@@ -1536,7 +1551,6 @@ class PostAbilities {
 			'status'      => $updated_post instanceof WP_Post ? $updated_post->post_status : '',
 			'post_type'   => $updated_post instanceof WP_Post ? $updated_post->post_type : '',
 			'revision_id' => RevisionGuard::current_revision_id( $post_id ),
-			'affected'    => self::build_affected_payload( $post_id, $updated_post, $permalink, $input, $post_data ),
 		];
 
 		// GH#1584 follow-up: re-validate after update so the model knows
@@ -1547,6 +1561,8 @@ class PostAbilities {
 				$response['block_validation'] = $validation;
 			}
 		}
+
+		$response['affected'] = self::build_affected_payload( $post_id, $updated_post, $permalink, $input, $post_data );
 
 		return $response;
 	}
@@ -1589,7 +1605,7 @@ class PostAbilities {
 		if ( isset( $input['tags'] ) && is_array( $input['tags'] ) ) {
 			$fields[] = 'tags';
 		}
-		if ( isset( $input['featured_image_id'] ) && (int) $input['featured_image_id'] > 0 ) {
+		if ( isset( $input['featured_image_id'] ) ) {
 			$fields[] = 'featured_image';
 		}
 		if ( isset( $input['page_template'] ) ) {
@@ -1716,6 +1732,7 @@ class PostAbilities {
 			'appended_bytes' => $appended_bytes,
 			'total_bytes'    => $total_bytes,
 			'revision_id'    => RevisionGuard::current_revision_id( $post_id ),
+			'affected'       => self::build_affected_payload( $post_id, get_post( $post_id ), $permalink, $input, [ 'post_content' => $new_content ] ),
 		];
 	}
 
@@ -1775,8 +1792,9 @@ class PostAbilities {
 			);
 		}
 
-		$title  = $post->post_title;
-		$result = wp_delete_post( $post_id, $force_delete );
+		$title     = $post->post_title;
+		$permalink = get_permalink( $post_id );
+		$result    = wp_delete_post( $post_id, $force_delete );
 
 		if ( $switched ) {
 			restore_current_blog();
@@ -1795,6 +1813,7 @@ class PostAbilities {
 			'title'        => $title,
 			'action'       => $force_delete ? 'permanently_deleted' : 'trashed',
 			'force_delete' => $force_delete,
+			'affected'     => self::build_affected_payload( $post_id, $post, $permalink, $input, [ 'post_status' => $force_delete ? 'deleted' : 'trash' ] ),
 		];
 	}
 
@@ -1869,6 +1888,33 @@ class PostAbilities {
 			'post_id'           => $post_id,
 			'featured_image_id' => $featured_image_id,
 			'result'            => $action,
+			'affected'          => self::build_affected_payload( $post_id, $post, get_permalink( $post_id ), $input, [] ),
+		];
+	}
+
+	/**
+	 * Build the output-schema fragment for post affected descriptors.
+	 *
+	 * @param string $kind Affected entity kind.
+	 * @return array<string, mixed>
+	 */
+	private static function affected_output_schema( string $kind ): array {
+		return [
+			'type'        => 'object',
+			'description' => 'Transport descriptor for the frontend reflection bus — identifies the entity, its public URL, and which fields changed so the client can refresh the visible page without a full reload.',
+			'properties'  => [
+				'kind'      => [
+					'type' => 'string',
+					'enum' => [ $kind ],
+				],
+				'post_id'   => [ 'type' => 'integer' ],
+				'post_type' => [ 'type' => 'string' ],
+				'url'       => [ 'type' => 'string' ],
+				'fields'    => [
+					'type'  => 'array',
+					'items' => [ 'type' => 'string' ],
+				],
+			],
 		];
 	}
 

--- a/includes/Abilities/UploadMediaAbility.php
+++ b/includes/Abilities/UploadMediaAbility.php
@@ -132,6 +132,22 @@ class UploadMediaAbility {
 							'type'        => 'string',
 							'description' => __( 'Echoes the input source discriminator.', 'superdav-ai-agent' ),
 						],
+						'affected'       => [
+							'type'        => 'object',
+							'description' => __( 'Transport descriptor for the frontend reflection bus identifying the changed media attachment.', 'superdav-ai-agent' ),
+							'properties'  => [
+								'kind'    => [
+									'type' => 'string',
+									'enum' => [ 'media' ],
+								],
+								'post_id' => [ 'type' => 'integer' ],
+								'url'     => [ 'type' => 'string' ],
+								'fields'  => [
+									'type'  => 'array',
+									'items' => [ 'type' => 'string' ],
+								],
+							],
+						],
 					],
 				],
 				'meta'                => [
@@ -391,14 +407,17 @@ class UploadMediaAbility {
 		$file_path  = get_attached_file( $attachment_id );
 		$metadata   = wp_get_attachment_metadata( $attachment_id );
 
+		$url = wp_get_attachment_url( $attachment_id ) ?: '';
+
 		return [
 			'attachment_id'  => $attachment_id,
-			'url'            => wp_get_attachment_url( $attachment_id ) ?: '',
+			'url'            => $url,
 			'mime_type'      => $mime_type,
 			'filesize_bytes' => ( $file_path && file_exists( $file_path ) ) ? (int) filesize( $file_path ) : 0,
 			'width'          => is_array( $metadata ) ? (int) ( $metadata['width'] ?? 0 ) : 0,
 			'height'         => is_array( $metadata ) ? (int) ( $metadata['height'] ?? 0 ) : 0,
 			'source'         => $source,
+			'affected'       => MediaAbilities::build_affected_payload( $attachment_id, $url, [ 'attachment', 'post_title', 'post_excerpt', 'post_content', 'alt_text' ] ),
 		];
 	}
 }

--- a/tests/SdAiAgent/Abilities/ContentAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/ContentAbilitiesTest.php
@@ -277,6 +277,12 @@ class ContentAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 'Sales Inquiry', $form_data['settings']['form_title'] );
 		$this->assertSame( 'sales@example.test', $form_data['settings']['notifications']['1']['email'] );
 		$this->assertSame( 'Send Inquiry', $form_data['settings']['submit_text'] );
+		$this->assertArrayHasKey( 'affected', $result );
+		$this->assertSame( 'post', $result['affected']['kind'] );
+		$this->assertSame( $result['form_id'], $result['affected']['post_id'] );
+		$this->assertSame( 'wpforms', $result['affected']['post_type'] );
+		$this->assertNotEmpty( $result['affected']['url'] );
+		$this->assertContains( 'post_content', $result['affected']['fields'] );
 
 	}
 

--- a/tests/SdAiAgent/Abilities/GlobalStylesAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/GlobalStylesAbilitiesTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Test case for GlobalStylesAbilities class.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Abilities;
+
+use SdAiAgent\Abilities\GlobalStylesAbilities;
+use WP_UnitTestCase;
+
+/**
+ * Test GlobalStylesAbilities handler methods.
+ */
+class GlobalStylesAbilitiesTest extends WP_UnitTestCase {
+
+	/**
+	 * Test update-global-styles returns an affected descriptor.
+	 */
+	public function test_handle_update_global_styles_returns_affected_payload(): void {
+		$result = GlobalStylesAbilities::handle_update_global_styles(
+			[
+				'styles' => [
+					'color' => [
+						'text' => '#111111',
+					],
+				],
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'affected', $result );
+		$this->assertSame( 'global_styles', $result['affected']['kind'] );
+		$this->assertNotEmpty( $result['affected']['url'] );
+		$this->assertContains( 'styles', $result['affected']['fields'] );
+	}
+
+	/**
+	 * Test reset-global-styles returns an affected descriptor after deleting customizations.
+	 */
+	public function test_handle_reset_global_styles_returns_affected_payload(): void {
+		$update = GlobalStylesAbilities::handle_update_global_styles(
+			[
+				'settings' => [
+					'color' => [
+						'custom' => true,
+					],
+				],
+			]
+		);
+		$this->assertIsArray( $update );
+
+		$result = GlobalStylesAbilities::handle_reset_global_styles( [] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'affected', $result );
+		$this->assertSame( 'global_styles', $result['affected']['kind'] );
+		$this->assertNotEmpty( $result['affected']['url'] );
+		$this->assertContains( 'reset', $result['affected']['fields'] );
+	}
+}

--- a/tests/SdAiAgent/Abilities/MediaAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/MediaAbilitiesTest.php
@@ -209,4 +209,24 @@ class MediaAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( $attachment_id, $result['attachment_id'] );
 		$this->assertTrue( $result['deleted'] );
 	}
+
+	/**
+	 * Test handle_delete_media returns an affected descriptor.
+	 */
+	public function test_handle_delete_media_returns_affected_payload() {
+		$attachment_id = $this->factory->attachment->create( [
+			'post_title'     => 'Affected Deletable Image',
+			'post_mime_type' => 'image/jpeg',
+			'post_status'    => 'inherit',
+		] );
+
+		$result = MediaAbilities::handle_delete_media( [ 'attachment_id' => $attachment_id ] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'affected', $result );
+		$this->assertSame( 'media', $result['affected']['kind'] );
+		$this->assertSame( $attachment_id, $result['affected']['post_id'] );
+		$this->assertArrayHasKey( 'url', $result['affected'] );
+		$this->assertContains( 'deleted', $result['affected']['fields'] );
+	}
 }

--- a/tests/SdAiAgent/Abilities/MenuAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/MenuAbilitiesTest.php
@@ -154,6 +154,20 @@ class MenuAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 'Persisted Menu', $menu->name );
 	}
 
+	/**
+	 * Test handle_create_menu returns an affected descriptor.
+	 */
+	public function test_handle_create_menu_returns_affected_payload() {
+		$result = MenuAbilities::handle_create_menu( [ 'name' => 'Affected Menu' ] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'affected', $result );
+		$this->assertSame( 'menu', $result['affected']['kind'] );
+		$this->assertSame( $result['menu_id'], $result['affected']['menu_id'] );
+		$this->assertNotEmpty( $result['affected']['url'] );
+		$this->assertContains( 'name', $result['affected']['fields'] );
+	}
+
 	// ─── handle_delete_menu ───────────────────────────────────────
 
 	/**
@@ -182,6 +196,23 @@ class MenuAbilitiesTest extends WP_UnitTestCase {
 		// Verify it's gone.
 		$menu = wp_get_nav_menu_object( $menu_id );
 		$this->assertFalse( $menu );
+	}
+
+	/**
+	 * Test handle_delete_menu returns an affected descriptor.
+	 */
+	public function test_handle_delete_menu_returns_affected_payload() {
+		$menu_id = wp_create_nav_menu( 'Affected Delete Menu' );
+		$this->assertIsInt( $menu_id );
+
+		$result = MenuAbilities::handle_delete_menu( [ 'menu_id' => $menu_id ] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'affected', $result );
+		$this->assertSame( 'menu', $result['affected']['kind'] );
+		$this->assertSame( $menu_id, $result['affected']['menu_id'] );
+		$this->assertNotEmpty( $result['affected']['url'] );
+		$this->assertContains( 'deleted', $result['affected']['fields'] );
 	}
 
 	// ─── handle_add_menu_item ─────────────────────────────────────
@@ -228,6 +259,27 @@ class MenuAbilitiesTest extends WP_UnitTestCase {
 		$this->assertIsInt( $result['item_id'] );
 		$this->assertSame( 'Home', $result['title'] );
 		$this->assertSame( $menu_id, $result['menu_id'] );
+	}
+
+	/**
+	 * Test handle_add_menu_item returns an affected descriptor.
+	 */
+	public function test_handle_add_menu_item_returns_affected_payload() {
+		$menu_id = wp_create_nav_menu( 'Affected Add Item Menu' );
+		$this->assertIsInt( $menu_id );
+
+		$result = MenuAbilities::handle_add_menu_item( [
+			'menu_id' => $menu_id,
+			'title'   => 'Docs',
+			'url'     => 'https://example.com/docs',
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'affected', $result );
+		$this->assertSame( 'menu', $result['affected']['kind'] );
+		$this->assertSame( $menu_id, $result['affected']['menu_id'] );
+		$this->assertNotEmpty( $result['affected']['url'] );
+		$this->assertContains( 'menu-item-title', $result['affected']['fields'] );
 	}
 
 	/**
@@ -379,6 +431,33 @@ class MenuAbilitiesTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result );
 		$this->assertSame( $item_id, $result['item_id'] );
 		$this->assertTrue( $result['deleted'] );
+	}
+
+	/**
+	 * Test handle_remove_menu_item returns an affected descriptor.
+	 */
+	public function test_handle_remove_menu_item_returns_affected_payload() {
+		$menu_id = wp_create_nav_menu( 'Affected Remove Item Menu' );
+		$this->assertIsInt( $menu_id );
+		$item_id = wp_update_nav_menu_item(
+			$menu_id,
+			0,
+			[
+				'menu-item-title'  => 'Remove me',
+				'menu-item-url'    => 'https://example.com/remove-me',
+				'menu-item-type'   => 'custom',
+				'menu-item-status' => 'publish',
+			]
+		);
+		$this->assertIsInt( $item_id );
+
+		$result = MenuAbilities::handle_remove_menu_item( [ 'item_id' => $item_id ] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'affected', $result );
+		$this->assertSame( 'menu', $result['affected']['kind'] );
+		$this->assertNotEmpty( $result['affected']['url'] );
+		$this->assertContains( 'item_deleted', $result['affected']['fields'] );
 	}
 
 	// ─── handle_create_menu with items ───────────────────────────
@@ -645,5 +724,25 @@ class MenuAbilitiesTest extends WP_UnitTestCase {
 		$locations = get_nav_menu_locations();
 		$this->assertArrayHasKey( 'primary', $locations );
 		$this->assertSame( $menu_id, $locations['primary'] );
+	}
+
+	/**
+	 * Test handle_assign_menu_location returns an affected descriptor.
+	 */
+	public function test_handle_assign_menu_location_returns_affected_payload() {
+		$menu_id = wp_create_nav_menu( 'Affected Assign Location Menu' );
+		$this->assertIsInt( $menu_id );
+
+		$result = MenuAbilities::handle_assign_menu_location( [
+			'menu_id'  => $menu_id,
+			'location' => 'primary',
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'affected', $result );
+		$this->assertSame( 'menu', $result['affected']['kind'] );
+		$this->assertSame( $menu_id, $result['affected']['menu_id'] );
+		$this->assertNotEmpty( $result['affected']['url'] );
+		$this->assertContains( 'location', $result['affected']['fields'] );
 	}
 }

--- a/tests/SdAiAgent/Abilities/PostAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/PostAbilitiesTest.php
@@ -580,6 +580,97 @@ class PostAbilitiesTest extends WP_UnitTestCase {
 		$this->assertContains( 'meta', $fields );
 	}
 
+	/**
+	 * Test handle_create_post returns an affected descriptor.
+	 */
+	public function test_handle_create_post_returns_affected_payload() {
+		$result = PostAbilities::handle_create_post( [
+			'title'   => 'Affected create',
+			'content' => 'Created body',
+			'status'  => 'publish',
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'affected', $result );
+		$this->assertSame( 'post', $result['affected']['kind'] );
+		$this->assertSame( $result['post_id'], $result['affected']['post_id'] );
+		$this->assertNotEmpty( $result['affected']['url'] );
+		$this->assertContains( 'post_content', $result['affected']['fields'] );
+	}
+
+	/**
+	 * Test handle_append_post_content returns an affected descriptor.
+	 */
+	public function test_handle_append_post_content_returns_affected_payload() {
+		$post_id = $this->factory->post->create( [ 'post_status' => 'publish' ] );
+
+		$result = PostAbilities::handle_append_post_content( [
+			'post_id' => $post_id,
+			'content' => '<!-- wp:paragraph --><p>New section.</p><!-- /wp:paragraph -->',
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'affected', $result );
+		$this->assertSame( 'post', $result['affected']['kind'] );
+		$this->assertSame( $post_id, $result['affected']['post_id'] );
+		$this->assertNotEmpty( $result['affected']['url'] );
+		$this->assertContains( 'post_content', $result['affected']['fields'] );
+	}
+
+	/**
+	 * Test handle_batch_create_posts returns affected descriptors for successes.
+	 */
+	public function test_handle_batch_create_posts_returns_affected_payload() {
+		$result = PostAbilities::handle_batch_create_posts( [
+			'posts' => [
+				[ 'title' => 'Affected batch one' ],
+				[ 'title' => 'Affected batch two' ],
+			],
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'affected', $result );
+		$this->assertCount( 2, $result['affected'] );
+		$this->assertSame( 'post', $result['affected'][0]['kind'] );
+		$this->assertNotEmpty( $result['affected'][0]['url'] );
+		$this->assertContains( 'post_title', $result['affected'][0]['fields'] );
+	}
+
+	/**
+	 * Test handle_delete_post returns an affected descriptor.
+	 */
+	public function test_handle_delete_post_returns_affected_payload() {
+		$post_id = $this->factory->post->create( [ 'post_status' => 'publish' ] );
+
+		$result = PostAbilities::handle_delete_post( [ 'post_id' => $post_id ] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'affected', $result );
+		$this->assertSame( 'post', $result['affected']['kind'] );
+		$this->assertSame( $post_id, $result['affected']['post_id'] );
+		$this->assertNotEmpty( $result['affected']['url'] );
+		$this->assertContains( 'post_status', $result['affected']['fields'] );
+	}
+
+	/**
+	 * Test handle_set_featured_image returns an affected descriptor.
+	 */
+	public function test_handle_set_featured_image_returns_affected_payload() {
+		$post_id = $this->factory->post->create( [ 'post_status' => 'publish' ] );
+
+		$result = PostAbilities::handle_set_featured_image( [
+			'post_id'           => $post_id,
+			'featured_image_id' => 0,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'affected', $result );
+		$this->assertSame( 'post', $result['affected']['kind'] );
+		$this->assertSame( $post_id, $result['affected']['post_id'] );
+		$this->assertNotEmpty( $result['affected']['url'] );
+		$this->assertContains( 'featured_image', $result['affected']['fields'] );
+	}
+
 	// ─── block_validation save-time gate (GH#1584 follow-up) ────────
 
 	/**

--- a/tests/SdAiAgent/Abilities/UploadMediaAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/UploadMediaAbilityTest.php
@@ -518,7 +518,7 @@ class UploadMediaAbilityTest extends WP_UnitTestCase {
 			return;
 		}
 
-		$required_keys = [ 'attachment_id', 'url', 'mime_type', 'filesize_bytes', 'width', 'height', 'source' ];
+		$required_keys = [ 'attachment_id', 'url', 'mime_type', 'filesize_bytes', 'width', 'height', 'source', 'affected' ];
 		foreach ( $required_keys as $key ) {
 			$this->assertArrayHasKey( $key, $result, "Missing response key: {$key}" );
 		}
@@ -529,6 +529,10 @@ class UploadMediaAbilityTest extends WP_UnitTestCase {
 		$this->assertIsInt( $result['width'] );
 		$this->assertIsInt( $result['height'] );
 		$this->assertIsString( $result['source'] );
+		$this->assertSame( 'media', $result['affected']['kind'] );
+		$this->assertSame( $result['attachment_id'], $result['affected']['post_id'] );
+		$this->assertNotEmpty( $result['affected']['url'] );
+		$this->assertContains( 'attachment', $result['affected']['fields'] );
 
 		// Clean up.
 		wp_delete_attachment( $result['attachment_id'], true );


### PR DESCRIPTION
## Summary

Extended affected descriptors and output schemas across post, menu, global styles, media, upload-media, and contact-form content mutation handlers; added PHPUnit coverage for each modified handler.

## Files Changed

includes/Abilities/ContentAbilities.php,includes/Abilities/GlobalStylesAbilities.php,includes/Abilities/MediaAbilities.php,includes/Abilities/MenuAbilities.php,includes/Abilities/PostAbilities.php,includes/Abilities/UploadMediaAbility.php,tests/SdAiAgent/Abilities/ContentAbilitiesTest.php,tests/SdAiAgent/Abilities/GlobalStylesAbilitiesTest.php,tests/SdAiAgent/Abilities/MediaAbilitiesTest.php,tests/SdAiAgent/Abilities/MenuAbilitiesTest.php,tests/SdAiAgent/Abilities/PostAbilitiesTest.php,tests/SdAiAgent/Abilities/UploadMediaAbilityTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)

## Worker self-verification
- PHPUnit: Tests: 3536, Assertions: 14765, Errors: 0, Failures: 0, Skipped: 114, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors via vendor/bin/phpstan analyse --memory-limit=2G
- Build:   succeeded (webpack emitted existing asset-size warnings)

Resolves #1948


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 1h 2m and 168,312 tokens on this as a headless worker.
