### PR TITLE
GH#1950: feat: add global styles reflector

### DIFF
--- a/src/floating-widget/reflectors/__tests__/global-styles.test.js
+++ b/src/floating-widget/reflectors/__tests__/global-styles.test.js
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for the global-styles live-preview reflector.
+ */
+
+import { reflectGlobalStyles } from '../global-styles';
+
+/**
+ * Populate the current document head with global styles fixtures.
+ *
+ * @param {string} extra Additional HTML appended to the fixture.
+ */
+function setCurrentHead( extra = '' ) {
+	document.head.innerHTML = `
+		<style id="global-styles-inline-css">body{color:blue}</style>
+		<link rel="stylesheet" id="wp_global_styles-css" href="https://example.com/wp-global.css?ver=1" />
+		${ extra }
+	`;
+}
+
+/**
+ * Mock fetch with a fresh HTML document containing the supplied head markup.
+ *
+ * @param {string} head Fresh document head HTML.
+ */
+function mockFreshHtml( head ) {
+	global.fetch = jest.fn().mockResolvedValue( {
+		ok: true,
+		status: 200,
+		text: jest
+			.fn()
+			.mockResolvedValue( `<html><head>${ head }</head></html>` ),
+	} );
+}
+
+describe( 'reflectGlobalStyles', () => {
+	let consoleWarnSpy;
+	let dateNowSpy;
+
+	beforeEach( () => {
+		setCurrentHead();
+		consoleWarnSpy = jest
+			.spyOn( console, 'warn' )
+			.mockImplementation( () => {} );
+		dateNowSpy = jest.spyOn( Date, 'now' ).mockReturnValue( 1700000000000 );
+	} );
+
+	afterEach( () => {
+		consoleWarnSpy.mockRestore();
+		dateNowSpy.mockRestore();
+		delete global.fetch;
+		document.head.innerHTML = '';
+	} );
+
+	test( 'updates inline styles and changed global stylesheet hrefs', async () => {
+		mockFreshHtml( `
+			<style id="global-styles-inline-css">body{color:red}</style>
+			<link rel="stylesheet" id="wp_global_styles-css" href="/wp-global.css?ver=2" />
+		` );
+
+		await reflectGlobalStyles( {
+			affected: { kind: 'global_styles', url: '/' },
+		} );
+
+		expect( global.fetch ).toHaveBeenCalledWith(
+			'/?_=1700000000000',
+			expect.objectContaining( {
+				credentials: 'same-origin',
+				cache: 'no-store',
+				headers: { Accept: 'text/html' },
+			} )
+		);
+		expect(
+			document.getElementById( 'global-styles-inline-css' ).textContent
+		).toBe( 'body{color:red}' );
+
+		const href = document
+			.getElementById( 'wp_global_styles-css' )
+			.getAttribute( 'href' );
+		expect( href ).toBe(
+			'http://localhost/wp-global.css?ver=2&_=1700000000000'
+		);
+	} );
+
+	test( 'does not delete current inline style when fresh document omits it', async () => {
+		mockFreshHtml(
+			'<link rel="stylesheet" id="wp_global_styles-css" href="https://example.com/wp-global.css?ver=1" />'
+		);
+
+		await reflectGlobalStyles( {
+			affected: { kind: 'global_styles', url: '/' },
+		} );
+
+		expect(
+			document.getElementById( 'global-styles-inline-css' ).textContent
+		).toBe( 'body{color:blue}' );
+	} );
+
+	test( 'keeps stylesheet href unchanged when fresh href is identical', async () => {
+		mockFreshHtml( `
+			<style id="global-styles-inline-css">body{color:blue}</style>
+			<link rel="stylesheet" id="wp_global_styles-css" href="https://example.com/wp-global.css?ver=1" />
+		` );
+
+		await reflectGlobalStyles( {
+			affected: { kind: 'global_styles', url: '/' },
+		} );
+
+		expect(
+			document
+				.getElementById( 'wp_global_styles-css' )
+				.getAttribute( 'href' )
+		).toBe( 'https://example.com/wp-global.css?ver=1' );
+	} );
+
+	test( 'logs and leaves DOM unchanged when fetch fails', async () => {
+		global.fetch = jest.fn().mockResolvedValue( {
+			ok: false,
+			status: 500,
+			text: jest.fn(),
+		} );
+
+		await reflectGlobalStyles( {
+			affected: { kind: 'global_styles', url: '/' },
+		} );
+
+		expect( consoleWarnSpy ).toHaveBeenCalledWith(
+			'[sd-ai-agent] global-styles reflector failed',
+			expect.any( Error )
+		);
+		expect(
+			document.getElementById( 'global-styles-inline-css' ).textContent
+		).toBe( 'body{color:blue}' );
+		expect(
+			document
+				.getElementById( 'wp_global_styles-css' )
+				.getAttribute( 'href' )
+		).toBe( 'https://example.com/wp-global.css?ver=1' );
+	} );
+
+	test( 'also swaps the classic global-styles-css link id', async () => {
+		setCurrentHead(
+			'<link rel="stylesheet" id="global-styles-css" href="https://example.com/global.css?ver=1" />'
+		);
+		mockFreshHtml( `
+			<style id="global-styles-inline-css">body{color:blue}</style>
+			<link rel="stylesheet" id="wp_global_styles-css" href="https://example.com/wp-global.css?ver=1" />
+			<link rel="stylesheet" id="global-styles-css" href="/global.css?ver=2" />
+		` );
+
+		await reflectGlobalStyles( {
+			affected: { kind: 'global_styles', url: '/' },
+		} );
+
+		expect(
+			document
+				.getElementById( 'global-styles-css' )
+				.getAttribute( 'href' )
+		).toBe( 'http://localhost/global.css?ver=2&_=1700000000000' );
+	} );
+} );

--- a/src/floating-widget/reflectors/global-styles.js
+++ b/src/floating-widget/reflectors/global-styles.js
@@ -1,0 +1,102 @@
+/**
+ * Reflect WordPress global styles updates into the current page.
+ *
+ * WordPress may render global styles as an inline `<style>` block or as a
+ * stylesheet `<link>`, depending on theme support and persistence mode. This
+ * reflector fetches a fresh copy of the current/affected page head and swaps
+ * only the known global-styles nodes so unrelated theme/block CSS does not
+ * flicker.
+ */
+
+const GLOBAL_INLINE_STYLE_ID = 'global-styles-inline-css';
+const GLOBAL_STYLESHEET_IDS = [ 'wp_global_styles-css', 'global-styles-css' ];
+
+/**
+ * Re-fetch the page head and apply fresh global styles nodes when they change.
+ *
+ * @param {{ affected?: { url?: string } }} event Reflection event.
+ * @return {Promise<void>} Resolves once reflection has been attempted.
+ */
+export async function reflectGlobalStyles( event ) {
+	try {
+		const fresh = await fetchFreshHead( event?.affected?.url );
+
+		replaceInlineStyle( fresh, GLOBAL_INLINE_STYLE_ID );
+		for ( const id of GLOBAL_STYLESHEET_IDS ) {
+			replaceLinkStylesheet( fresh, id );
+		}
+	} catch ( err ) {
+		// Reflector failure is non-fatal; the agent/tool result already landed.
+		// eslint-disable-next-line no-console
+		console.warn( '[sd-ai-agent] global-styles reflector failed', err );
+	}
+}
+
+/**
+ * Fetch and parse a fresh page document for global-style extraction.
+ *
+ * @param {string|undefined} url Optional affected page URL.
+ * @return {Promise<Document>} Parsed fresh document.
+ */
+async function fetchFreshHead( url ) {
+	const target = url || window.location.href;
+	const bust = `${ target }${
+		target.includes( '?' ) ? '&' : '?'
+	}_=${ Date.now() }`;
+	const res = await fetch( bust, {
+		credentials: 'same-origin',
+		cache: 'no-store',
+		headers: { Accept: 'text/html' },
+	} );
+
+	if ( ! res.ok ) {
+		throw new Error( `HTTP ${ res.status }` );
+	}
+
+	return new DOMParser().parseFromString( await res.text(), 'text/html' );
+}
+
+/**
+ * Replace the current inline global styles text when the fresh page changed.
+ *
+ * @param {Document} freshDoc Freshly fetched document.
+ * @param {string}   id       Element ID to compare.
+ */
+function replaceInlineStyle( freshDoc, id ) {
+	const fresh = freshDoc.getElementById( id );
+	const current = document.getElementById( id );
+
+	if ( ! fresh || ! current || fresh.tagName !== 'STYLE' ) {
+		return;
+	}
+
+	if ( fresh.textContent === current.textContent ) {
+		return;
+	}
+
+	current.textContent = fresh.textContent;
+}
+
+/**
+ * Swap a known global-styles stylesheet href when the fresh page changed.
+ *
+ * @param {Document} freshDoc Freshly fetched document.
+ * @param {string}   id       Element ID to compare.
+ */
+function replaceLinkStylesheet( freshDoc, id ) {
+	const fresh = freshDoc.getElementById( id );
+	const current = document.getElementById( id );
+
+	if ( ! fresh || ! current || fresh.tagName !== 'LINK' ) {
+		return;
+	}
+
+	const freshHref = fresh.getAttribute( 'href' );
+	if ( ! freshHref || freshHref === current.getAttribute( 'href' ) ) {
+		return;
+	}
+
+	const url = new URL( freshHref, window.location.origin );
+	url.searchParams.set( '_', String( Date.now() ) );
+	current.setAttribute( 'href', url.toString() );
+}

--- a/src/floating-widget/reflectors/index.js
+++ b/src/floating-widget/reflectors/index.js
@@ -8,6 +8,7 @@
 
 import bus from '../../store/reflection-bus';
 import { showFallbackToast } from './fallback-toast';
+import { reflectGlobalStyles } from './global-styles';
 import { reflectMenu } from './menu';
 
 bus.on( ( event ) => {
@@ -16,6 +17,9 @@ bus.on( ( event ) => {
 	}
 
 	switch ( event.affected.kind ) {
+		case 'global_styles':
+			reflectGlobalStyles( event );
+			break;
 		case 'menu':
 			reflectMenu( event );
 			break;


### PR DESCRIPTION
## Summary

Adds a global-styles live-preview reflector that re-fetches the affected page head, updates inline global styles, cache-busts changed global stylesheet hrefs, and dispatches global_styles events alongside the existing menu and fallback reflectors.

## Files Changed

- `src/floating-widget/reflectors/__tests__/global-styles.test.js`
- `src/floating-widget/reflectors/global-styles.js`
- `src/floating-widget/reflectors/index.js`

## Worker self-verification
- PHPUnit: Tests: 3523, Assertions: 14673, Errors: 0, Failures: 0, Skipped: 114, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

## Additional verification

- `npm run lint`
- `vendor/bin/phpstan analyse --no-progress --memory-limit=2G`
- `npm run test:js -- src/floating-widget/reflectors/__tests__/global-styles.test.js src/floating-widget/reflectors/__tests__/menu.test.js src/floating-widget/reflectors/__tests__/fallback-toast.test.js`
- `npm run test:php`
- `npm run build` (succeeded with existing webpack size warnings)
- GitHub Actions: Code Quality, Tests, Canonical Naming Guard, Worker Model Allowlist, and E2E Tests passed for PR #1959; E2E reported one flaky retry annotation in `tests/e2e/shared-conversations.spec.js`, but the workflow completed successfully.

Resolves #1950


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 1h 8m and 155,524 tokens on this as a headless worker.