### PR TITLE
GH#1966: fix: publish reflection bus documented global

### DIFF
--- a/src/store/__tests__/reflection-bus.test.js
+++ b/src/store/__tests__/reflection-bus.test.js
@@ -8,6 +8,7 @@
  * - listener errors are swallowed (one bad listener does not break others)
  * - clear() drops all listeners
  * - cross-bundle singleton on `window`
+ * - documented `window.sdAiAgentReflection` global points at the singleton
  * - __resetReflectionBusForTests() returns a fresh bus
  * - non-function listener is a no-op
  */
@@ -135,6 +136,23 @@ describe( 'reflection-bus', () => {
 		expect( reimported ).toBe( sharedBus );
 		reimported.emit( { type: 'tool-applied' } );
 		expect( listener ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'publishes the documented window.sdAiAgentReflection global', () => {
+		expect( window.sdAiAgentReflection ).toBe( sharedBus );
+	} );
+
+	test( 'keeps the documented global aligned with the internal singleton', () => {
+		window.sdAiAgentReflection = createReflectionBus();
+
+		let reimported;
+		jest.isolateModules( () => {
+			// eslint-disable-next-line global-require
+			reimported = require( '../reflection-bus' ).default;
+		} );
+
+		expect( reimported ).toBe( sharedBus );
+		expect( window.sdAiAgentReflection ).toBe( sharedBus );
 	} );
 
 	test( '__resetReflectionBusForTests() clears listeners in-place on the shared bus', () => {

--- a/src/store/reflection-bus.js
+++ b/src/store/reflection-bus.js
@@ -153,6 +153,9 @@ function resolveBus() {
 	if ( ! window[ WIN_KEY ] ) {
 		window[ WIN_KEY ] = createReflectionBus();
 	}
+	if ( window.sdAiAgentReflection !== window[ WIN_KEY ] ) {
+		window.sdAiAgentReflection = window[ WIN_KEY ];
+	}
 	return window[ WIN_KEY ];
 }
 


### PR DESCRIPTION
## Summary

Published the reflection bus singleton on window.sdAiAgentReflection and added Jest coverage to ensure the documented global stays aligned with the internal singleton.

## Files Changed

src/store/__tests__/reflection-bus.test.js,src/store/reflection-bus.js

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify; npm run test:js -- reflection-bus.test.js

Resolves #1966


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 7m and 44,614 tokens on this as a headless worker.