### PR TITLE
GH#1967: fix: flush reflection events on terminal errors

### DIFF
--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -666,18 +666,22 @@ export const actions = {
 						}
 					}
 
-					if ( result.status === 'complete' ) {
+					if (
+						( result.status === 'complete' ||
+							result.status === 'error' ) &&
+						Array.isArray( result.tool_calls )
+					) {
 						// Flush any final reflection events for tool responses
 						// that arrived between the last `processing` tick and
 						// this terminal poll.
-						if ( Array.isArray( result.tool_calls ) ) {
-							reflectionCursor = emitReflectionEvents(
-								result.tool_calls,
-								reflectionCursor,
-								{ sessionId, jobId }
-							);
-						}
+						reflectionCursor = emitReflectionEvents(
+							result.tool_calls,
+							reflectionCursor,
+							{ sessionId, jobId }
+						);
+					}
 
+					if ( result.status === 'complete' ) {
 						// Reload the session from the DB when it's the active session.
 						if (
 							result.session_id &&


### PR DESCRIPTION
## Summary

Updated src/store/slices/jobSlice.js so terminal error poll responses with tool_calls also flush pending reflection events before the error handling completes.

## Files Changed

src/store/slices/jobSlice.js

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify — lint, PHPStan, PHPUnit (Tests: 3538, Assertions: 14771, Skipped: 114, Incomplete: 4), build, and bundle size check passed

Resolves #1967


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.5 plugin for [OpenCode](https://opencode.ai) v1.15.12 with gpt-5.5 spent 8m and 75,238 tokens on this as a headless worker.