### PR TITLE
GH#1970: docs: improve contributor insight guidance

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -99,6 +99,11 @@ to change, do not answer only in the issue thread. Make the durable repo change:
   in-plugin source. Block theme or Full Site Editing excerpts belong in
   `includes/Models/skills/wp-block-themes.md`; update that skill or the root
   `AGENTS.md` summary instead of copying private local paths into GitHub.
+- For mixed shorthand reports, map each note before editing: automation/process
+  feedback belongs in `.agents/AGENTS.md`, `.agents/scripts/commands/feedback-triage.md`,
+  or the relevant helper; REST security feedback belongs in root `AGENTS.md`
+  plus the concrete controller or ability family; block-theme excerpts belong in
+  `includes/Models/skills/wp-block-themes.md`.
 - Do not mark contributor-insight issues complete after documentation reading
   alone. A valid fix changes a durable instruction, workflow doc, or helper, then
   verifies the changed guidance with an exact `rg -n` check that future workers

--- a/.agents/scripts/commands/feedback-triage.md
+++ b/.agents/scripts/commands/feedback-triage.md
@@ -196,6 +196,17 @@ before creating the issue:
   or `rg -n "read:file_not_found|missing-file reads|git ls-files|signature gate|body-file|gh-signature-helper" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md`
   plus `rg -n "wp-block-themes|Full Site Editing|theme.json|validate-block-content" AGENTS.md includes/Models/skills/wp-block-themes.md`
   when block-theme guidance is involved.
+- Add a `## Worker Guidance` section to the created GitHub issue. It must name
+  each durable target file to inspect or edit, translate shorthand notes into
+  explicit worker actions, and include the exact `rg -n` verification commands.
+  Do not file a contributor-insight issue that only quotes the maintainer note;
+  the issue body must be actionable without private paths, chat history, or
+  additional context.
+- If implementation hardening is broader than the instruction change, include a
+  `## Follow-up issue briefs` section with one worker-ready brief per route,
+  controller, helper, or skill family. Each brief names the missing guard or
+  guidance, expected safe behaviour, and one concrete verification command or
+  REST request.
 
 #### 4d: Dedup check (for real_bug and missing_ability)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,30 @@ when it includes all of the following:
   workers, such as `rg -n "Contributor Insight|sd-ai-agent/v1|secret|current user|file upload" AGENTS.md .agents/AGENTS.md`
   plus any workflow-specific doc check.
 
+#### Contributor Insight Source Mapping
+
+When a contributor-insight issue combines multiple shorthand notes, resolve each
+note to a committed, future-loaded source before editing:
+
+- Treat local-path snippets as evidence only. Identify the matching committed
+  file by title, heading, or distinctive phrases, then edit that file instead of
+  reproducing the private path or pasted excerpt.
+- For block-theme snippets headed `Block Themes`, `Full Site Editing`,
+  `theme.json`, templates, parts, patterns, or style variations, update
+  `includes/Models/skills/wp-block-themes.md` and keep the root summary here in
+  sync.
+- For REST security shorthand involving `sd-ai-agent/v1`, secret scrubbing,
+  current-user execution, or file uploads, update this root guidance and inspect
+  the concrete controller or ability family before deciding whether code or a
+  follow-up issue brief is required.
+- For automation/process shorthand such as "do we need instructions or script",
+  update `.agents/AGENTS.md`, `.agents/scripts/commands/feedback-triage.md`, or
+  the relevant helper so future triage issues include worker-ready files,
+  expectations, and verification commands.
+- Verification for this class of guidance-only fix should include both:
+  `rg -n "Contributor Insight|source mapping|local-path|sd-ai-agent/v1|file upload" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md`
+  and `rg -n "wp-block-themes|Full Site Editing|theme.json|validate-block-content" AGENTS.md includes/Models/skills/wp-block-themes.md`.
+
 ### Block Theme Automation Guidance
 
 When work touches WordPress block themes, Full Site Editing, `theme.json`,


### PR DESCRIPTION
## Summary

Added contributor-insight source mapping guidance in AGENTS.md, reinforced headless follow-through mapping in .agents/AGENTS.md, and updated feedback-triage SOP to require Worker Guidance and follow-up issue brief sections for contributor insight issues.

## Files Changed

.agents/AGENTS.md,.agents/scripts/commands/feedback-triage.md,AGENTS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify; rg -n 'Contributor Insight|source mapping|local-path|sd-ai-agent/v1|file upload' AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md; rg -n 'wp-block-themes|Full Site Editing|theme.json|validate-block-content' AGENTS.md includes/Models/skills/wp-block-themes.md

Resolves #1970


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.7 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 7m and 104,182 tokens on this as a headless worker.