### PR TITLE
Fix generated logo SVG upload directory

### DIFF
--- a/includes/Abilities/GenerateLogoSvgAbility.php
+++ b/includes/Abilities/GenerateLogoSvgAbility.php
@@ -40,6 +40,11 @@ class GenerateLogoSvgAbility extends AbstractAbility {
 	private const MAX_SVG_BYTES = 512000;
 
 	/**
+	 * Uploads subdirectory for generated logo SVG attachments.
+	 */
+	private const UPLOAD_SUBDIR = 'superdav-ai-agent';
+
+	/**
 	 * Elements that must never appear in a sanitised SVG.
 	 *
 	 * @var list<string>
@@ -708,9 +713,10 @@ INSTRUCTION;
 	/**
 	 * Save SVG content directly to the WordPress media library.
 	 *
-	 * Writes the SVG to the current upload directory and creates an attachment
-	 * post with MIME type `image/svg+xml`. Bypasses `media_handle_sideload()`
-	 * because WordPress's MIME check blocks SVG uploads by default.
+	 * Writes the SVG to a plugin-specific uploads subdirectory and creates an
+	 * attachment post with MIME type `image/svg+xml`. Bypasses
+	 * `media_handle_sideload()` because WordPress's MIME check blocks SVG uploads
+	 * by default.
 	 *
 	 * @param string $svg  Sanitised SVG markup.
 	 * @param string $slug Filename slug (will be sanitised and made unique).
@@ -729,9 +735,21 @@ INSTRUCTION;
 			return new WP_Error( 'upload_dir_error', (string) $upload_dir['error'] );
 		}
 
+		$upload_basedir = trailingslashit( (string) $upload_dir['basedir'] );
+		$upload_baseurl = trailingslashit( (string) $upload_dir['baseurl'] );
+		$target_dir     = $upload_basedir . self::UPLOAD_SUBDIR;
+		$target_url     = $upload_baseurl . self::UPLOAD_SUBDIR;
+
+		if ( ! wp_mkdir_p( $target_dir ) ) {
+			return new WP_Error(
+				'svg_upload_dir_create_failed',
+				__( 'Failed to create the Superdav AI Agent uploads directory.', 'superdav-ai-agent' )
+			);
+		}
+
 		$filename = sanitize_file_name( $slug ) . '-' . substr( uniqid( '', false ), -6 ) . '.svg';
-		$filepath = trailingslashit( (string) $upload_dir['path'] ) . $filename;
-		$url      = trailingslashit( (string) $upload_dir['url'] ) . $filename;
+		$filepath = trailingslashit( $target_dir ) . $filename;
+		$url      = trailingslashit( $target_url ) . $filename;
 
 		// Write SVG to disk.
 		$written = file_put_contents( $filepath, $svg ); // phpcs:ignore WordPress.WP.AlternativeFunctions

--- a/tests/SdAiAgent/Abilities/GenerateLogoSvgAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/GenerateLogoSvgAbilityTest.php
@@ -466,6 +466,25 @@ class GenerateLogoSvgAbilityTest extends WP_UnitTestCase {
 		$this->assertStringStartsWith( 'data:image/svg+xml;base64,', $data_uri );
 	}
 
+	/**
+	 * save_svg_to_media_library writes generated files to the plugin uploads folder.
+	 */
+	public function test_save_svg_uses_plugin_uploads_subdirectory(): void {
+		$svg           = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 50" width="100" height="50"><rect x="0" y="0" width="100" height="50" fill="#abc"/></svg>';
+		$attachment_id = $this->call_protected( 'save_svg_to_media_library', $svg, 'test-logo-subdir' );
+
+		if ( is_wp_error( $attachment_id ) ) {
+			$this->fail( 'save_svg_to_media_library returned WP_Error: ' . $attachment_id->get_error_message() );
+		}
+
+		$this->created_attachments[] = $attachment_id;
+
+		$file = get_attached_file( $attachment_id );
+
+		$this->assertIsString( $file );
+		$this->assertStringContainsString( '/superdav-ai-agent/', str_replace( '\\', '/', $file ) );
+	}
+
 	// ─── end-to-end via run() when AI is unavailable ──────────────────────────
 
 	/**


### PR DESCRIPTION
## Summary

- Store generated logo SVG attachments under `wp-content/uploads/superdav-ai-agent/` instead of the generic current uploads path.
- Create the plugin-specific uploads directory with `wp_mkdir_p()` before writing SVG files.
- Add PHPUnit coverage proving `GenerateLogoSvgAbility` saves generated SVG files in the plugin uploads subdirectory.

## WordPress.org review item

Addresses the reviewer finding for `includes/Abilities/GenerateLogoSvgAbility.php:737`: generated SVG files are now written outside the plugin folder and inside a plugin-specific uploads subdirectory based on `wp_upload_dir()['basedir']`, with attachment URLs based on `wp_upload_dir()['baseurl']`.

## Worker self-verification

- PHPUnit: Tests: 3539, Assertions: 14773, Errors: 0, Failures: 0, Skipped: 114, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Additional bundle check: `npm run check:bundle` passed as part of `npm run verify`.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.8 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 5d 1h and 111,419 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Generated logo SVG files are now saved to a dedicated plugin subdirectory instead of the general uploads folder.

* **Tests**
  * Added test to verify SVG files are saved to the plugin subdirectory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->