### PR TITLE
fix: harden REST permission callbacks

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,9 +45,9 @@ jobs:
           - wp: 'trunk'
             wp_env_port: '8890'
             wp_env_override: '{"core":"WordPress/WordPress#master"}'
-            # 2 workers: 3 workers cause resource contention that manifests
-            # as login and SPA-render timeouts on CI runners.
-            playwright_workers: '2'
+            # 1 worker: shard 1 still showed login and SPA-render timeouts
+            # with 2 workers on GitHub-hosted runners under WP trunk load.
+            playwright_workers: '1'
 
     steps:
       - name: Checkout code
@@ -118,6 +118,10 @@ jobs:
       - name: Install Playwright browser dependencies
         run: |
           npx playwright install-deps chromium
+          # Retries record traces/video; install Playwright's ffmpeg binary even
+          # though the tests launch system Chrome. Without this, any retry can
+          # fail before the page opens with "ffmpeg-linux" missing.
+          npx playwright install ffmpeg
           google-chrome --version
 
       - name: Build plugin assets
@@ -165,7 +169,7 @@ jobs:
           npx wp-env run cli wp plugin list --format=table
           echo ""
           echo "=== Verify plugin is active ==="
-          npx wp-env run cli wp plugin is-active sd-ai-agent && echo "Plugin is active" || echo "ERROR: Plugin is NOT active"
+          npx wp-env run cli wp plugin is-active superdav-ai-agent && echo "Plugin is active" || echo "ERROR: Plugin is NOT active"
           echo ""
           echo "=== Check admin page loads (HTTP status) ==="
           # Log in and fetch the admin page to verify the SPA renders.

--- a/includes/Core/Health/HealthEndpoint.php
+++ b/includes/Core/Health/HealthEndpoint.php
@@ -54,22 +54,43 @@ class HealthEndpoint {
 	 * @return bool|WP_Error True if allowed, WP_Error otherwise.
 	 */
 	public static function check_loopback_permission( WP_REST_Request $request ): bool|WP_Error {
-		$remote_addr = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : '';
+		$remote_addr = isset( $_SERVER['REMOTE_ADDR'] ) ? trim( sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) ) : '';
 
-		// Allow loopback and private-network addresses used by local Docker/dev proxies.
-		if (
-			'127.0.0.1' === $remote_addr
-			|| '::1' === $remote_addr
-			|| (bool) filter_var( $remote_addr, FILTER_VALIDATE_IP, FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE ) === false
-		) {
+		if ( self::is_loopback_address( $remote_addr ) ) {
 			return true;
 		}
 
 		return new WP_Error(
 			'sd_ai_agent_health_forbidden',
-			'Health endpoint is only accessible from loopback or private-network addresses.',
+			'Health endpoint is only accessible from loopback addresses.',
 			[ 'status' => 403 ]
 		);
+	}
+
+	/**
+	 * Check whether an IP address is a true loopback address.
+	 *
+	 * Accepts the full IPv4 127.0.0.0/8 loopback range and IPv6 ::1. Private,
+	 * reserved, empty, or invalid REMOTE_ADDR values are not loopback requests.
+	 *
+	 * @param string $address IP address to check.
+	 * @return bool True when the address is loopback.
+	 */
+	private static function is_loopback_address( string $address ): bool {
+		if ( false === filter_var( $address, FILTER_VALIDATE_IP ) ) {
+			return false;
+		}
+
+		$packed = inet_pton( $address );
+		if ( false === $packed ) {
+			return false;
+		}
+
+		if ( 4 === strlen( $packed ) ) {
+			return 127 === ord( $packed[0] );
+		}
+
+		return inet_pton( '::1' ) === $packed;
 	}
 
 	/**

--- a/includes/REST/PermissionTrait.php
+++ b/includes/REST/PermissionTrait.php
@@ -60,6 +60,56 @@ trait PermissionTrait {
 	}
 
 	/**
+	 * Permission check for the browser tool-result callback endpoint.
+	 *
+	 * The endpoint mutates session state by consuming paused_state and appending
+	 * resumed loop output, so the current user must both have chat access and be
+	 * allowed to continue the supplied session before paused_state is loaded.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return bool|WP_Error
+	 */
+	public function check_tool_result_permission( WP_REST_Request $request ) {
+		$chat_permission = $this->check_chat_permission();
+		if ( true !== $chat_permission ) {
+			return $chat_permission;
+		}
+
+		$session_id = self::get_int_param( $request, 'session_id' );
+		if ( ! $session_id ) {
+			return new WP_Error(
+				'sd_ai_agent_missing_session',
+				__( 'session_id is required.', 'superdav-ai-agent' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$session = Database::get_session( $session_id );
+		if ( ! $session ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to access this chat session.', 'superdav-ai-agent' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$is_owner = (int) $session->user_id === get_current_user_id();
+		if ( $is_owner ) {
+			return true;
+		}
+
+		if ( Database::get_shared_session( $session_id ) ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'rest_forbidden',
+			__( 'You do not have permission to access this chat session.', 'superdav-ai-agent' ),
+			array( 'status' => 403 )
+		);
+	}
+
+	/**
 	 * Permission check for session-specific endpoints.
 	 *
 	 * Verifies chat access + (session ownership OR session is shared with all admins).

--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -175,7 +175,7 @@ final class RestController {
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( __CLASS__, 'handle_tool_result' ),
-				'permission_callback' => array( $this, 'check_chat_permission' ),
+				'permission_callback' => array( $this, 'check_tool_result_permission' ),
 				'args'                => array(
 					'session_id'   => array(
 						'required'          => true,

--- a/tests/SdAiAgent/Core/Health/PostMutationHealthCheckTest.php
+++ b/tests/SdAiAgent/Core/Health/PostMutationHealthCheckTest.php
@@ -438,12 +438,21 @@ class PostMutationHealthCheckTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test private-network loopback proxies can access the health endpoint.
+	 * Test loopback addresses can access the health endpoint.
 	 */
-	public function test_health_endpoint_allows_private_network_loopback_proxy(): void {
-		$_SERVER['REMOTE_ADDR'] = '172.18.0.1';
+	public function test_health_endpoint_allows_loopback_address(): void {
+		$_SERVER['REMOTE_ADDR'] = '127.0.0.2';
 
 		$this->assertTrue( HealthEndpoint::check_loopback_permission( new WP_REST_Request( 'GET', '/sd-ai-agent/v1/_health' ) ) );
+	}
+
+	/**
+	 * Test private-network proxy addresses are rejected by the loopback endpoint.
+	 */
+	public function test_health_endpoint_rejects_private_network_address(): void {
+		$_SERVER['REMOTE_ADDR'] = '172.18.0.1';
+
+		$this->assertInstanceOf( WP_Error::class, HealthEndpoint::check_loopback_permission( new WP_REST_Request( 'GET', '/sd-ai-agent/v1/_health' ) ) );
 	}
 
 	/**
@@ -451,6 +460,15 @@ class PostMutationHealthCheckTest extends WP_UnitTestCase {
 	 */
 	public function test_health_endpoint_rejects_public_remote_address(): void {
 		$_SERVER['REMOTE_ADDR'] = '8.8.8.8';
+
+		$this->assertInstanceOf( WP_Error::class, HealthEndpoint::check_loopback_permission( new WP_REST_Request( 'GET', '/sd-ai-agent/v1/_health' ) ) );
+	}
+
+	/**
+	 * Test invalid REMOTE_ADDR values are rejected by the health endpoint.
+	 */
+	public function test_health_endpoint_rejects_invalid_remote_address(): void {
+		$_SERVER['REMOTE_ADDR'] = 'not-an-ip-address';
 
 		$this->assertInstanceOf( WP_Error::class, HealthEndpoint::check_loopback_permission( new WP_REST_Request( 'GET', '/sd-ai-agent/v1/_health' ) ) );
 	}

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -1422,6 +1422,55 @@ class RestControllerTest extends WP_UnitTestCase {
 	// ─── /chat/tool-result regression: 409 loop fix (sd-ai-9ip) ──────────────
 
 	/**
+	 * Test POST /chat/tool-result cannot consume another user's paused state.
+	 *
+	 * The permission callback must verify access to the supplied session_id before
+	 * the handler calls Database::load_and_clear_paused_state().
+	 */
+	public function test_tool_result_rejects_other_users_session_before_clearing_paused_state(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$session_id = Database::create_session( [
+			'user_id' => $this->admin_id,
+			'title'   => 'Paused state owner session',
+		] );
+		Database::save_paused_state(
+			$session_id,
+			[
+				'history'               => [],
+				'iterations_remaining'  => 3,
+				'pending_tool_call_ids' => [ 'call_x' ],
+			]
+		);
+
+		$other_admin = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $other_admin );
+
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/chat/tool-result' );
+		$request->set_body( wp_json_encode( [
+			'session_id'   => $session_id,
+			'tool_results' => [
+				[
+					'id'     => 'call_x',
+					'name'   => 'sd-ai-agent-js/screenshot-url',
+					'result' => [ 'success' => true ],
+				],
+			],
+		] ) );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertStatus( 403, $response );
+
+		$session_after = Database::get_session( $session_id );
+		$this->assertNotNull( $session_after );
+		$this->assertNotEmpty(
+			$session_after->paused_state,
+			'Unauthorized tool-result requests must not clear another user\'s paused state.'
+		);
+	}
+
+	/**
 	 * Test POST /chat/tool-result returns 409 when no paused_state exists AND
 	 * downgrades a stale 'awaiting_client_tools' job transient/DB row to
 	 * 'error'.

--- a/tests/SdAiAgent/Security/PermissionCallbackAuditTest.php
+++ b/tests/SdAiAgent/Security/PermissionCallbackAuditTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Static source audit for REST route and ability permission callbacks.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests\Security
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Security;
+
+use WP_UnitTestCase;
+
+/**
+ * Verifies executable route/ability registrations declare permission gates.
+ */
+class PermissionCallbackAuditTest extends WP_UnitTestCase {
+
+	/**
+	 * register_rest_route() calls must explicitly declare permission_callback.
+	 */
+	public function test_register_rest_route_calls_define_permission_callback(): void {
+		$missing = [];
+
+		foreach ( $this->get_php_files( 'includes' ) as $file ) {
+			$source = $this->strip_comments( (string) file_get_contents( $file ) );
+			foreach ( $this->extract_calls( $source, 'register_rest_route' ) as $call ) {
+				if ( ! str_contains( $call['body'], 'permission_callback' ) ) {
+					$missing[] = $this->relative_path( $file ) . ':' . $call['line'];
+				}
+			}
+		}
+
+		$this->assertSame( [], $missing, 'Every register_rest_route() call must define permission_callback.' );
+	}
+
+	/**
+	 * wp_register_ability() calls must declare a direct permission callback or an ability_class.
+	 */
+	public function test_wp_register_ability_calls_define_permission_callback_or_ability_class(): void {
+		$missing = [];
+
+		foreach ( $this->get_php_files( 'includes' ) as $file ) {
+			$source = $this->strip_comments( (string) file_get_contents( $file ) );
+			foreach ( $this->extract_calls( $source, 'wp_register_ability' ) as $call ) {
+				$body = $call['body'];
+				if ( ! str_contains( $body, 'permission_callback' ) && ! str_contains( $body, 'ability_class' ) ) {
+					$missing[] = $this->relative_path( $file ) . ':' . $call['line'];
+				}
+			}
+		}
+
+		$this->assertSame(
+			[],
+			$missing,
+			'Every wp_register_ability() call must define permission_callback or use AbstractAbility via ability_class.'
+		);
+	}
+
+	/**
+	 * x-wp/di REST_Route attributes must define a guard callback.
+	 */
+	public function test_rest_route_attributes_define_guard(): void {
+		$missing = [];
+
+		foreach ( $this->get_php_files( 'includes/REST' ) as $file ) {
+			$source = $this->strip_comments( (string) file_get_contents( $file ) );
+			foreach ( $this->extract_calls( $source, 'REST_Route' ) as $call ) {
+				if ( ! str_contains( $call['body'], 'guard:' ) ) {
+					$missing[] = $this->relative_path( $file ) . ':' . $call['line'];
+				}
+			}
+		}
+
+		$this->assertSame( [], $missing, 'Every REST_Route attribute must define a guard callback.' );
+	}
+
+	/**
+	 * Return PHP files under a repository-relative directory.
+	 *
+	 * @param string $relative_dir Directory relative to the repository root.
+	 * @return list<string> Absolute file paths.
+	 */
+	private function get_php_files( string $relative_dir ): array {
+		$dir   = $this->repo_root() . '/' . $relative_dir;
+		$files = [];
+
+		$iterator = new \RecursiveIteratorIterator( new \RecursiveDirectoryIterator( $dir ) );
+		foreach ( $iterator as $file ) {
+			if ( ! $file instanceof \SplFileInfo || ! $file->isFile() || 'php' !== $file->getExtension() ) {
+				continue;
+			}
+
+			$files[] = $file->getPathname();
+		}
+
+		sort( $files );
+
+		return $files;
+	}
+
+	/**
+	 * Strip PHP comments while preserving executable attributes and line numbers.
+	 *
+	 * @param string $source PHP source.
+	 * @return string Source without comments.
+	 */
+	private function strip_comments( string $source ): string {
+		$output = '';
+
+		foreach ( token_get_all( $source ) as $token ) {
+			if ( ! is_array( $token ) ) {
+				$output .= $token;
+				continue;
+			}
+
+			if ( T_COMMENT === $token[0] || T_DOC_COMMENT === $token[0] ) {
+				$output .= str_repeat( "\n", substr_count( $token[1], "\n" ) );
+				continue;
+			}
+
+			$output .= $token[1];
+		}
+
+		return $output;
+	}
+
+	/**
+	 * Extract top-level function/attribute calls by balanced parentheses.
+	 *
+	 * @param string $source Source code.
+	 * @param string $name   Function or attribute class basename.
+	 * @return list<array{line:int, body:string}> Call locations and source bodies.
+	 */
+	private function extract_calls( string $source, string $name ): array {
+		$calls  = [];
+		$offset = 0;
+		$needle = $name . '(';
+
+		while ( false !== ( $start = strpos( $source, $needle, $offset ) ) ) {
+			if ( $start > 0 && preg_match( '/[A-Za-z0-9_]/', $source[ $start - 1 ] ) ) {
+				$offset = $start + 1;
+				continue;
+			}
+
+			$body = $this->read_balanced_call( $source, $start + strlen( $needle ) - 1 );
+			if ( null !== $body ) {
+				$calls[] = [
+					'line' => substr_count( substr( $source, 0, $start ), "\n" ) + 1,
+					'body' => substr( $source, $start, strlen( $needle ) - 1 ) . $body,
+				];
+				$offset  = $start + strlen( $body );
+				continue;
+			}
+
+			$offset = $start + 1;
+		}
+
+		return $calls;
+	}
+
+	/**
+	 * Read a balanced parenthesized call body from an opening parenthesis offset.
+	 *
+	 * @param string $source Source code.
+	 * @param int    $start  Offset of the opening parenthesis.
+	 * @return string|null Balanced body, or null when no complete call is found.
+	 */
+	private function read_balanced_call( string $source, int $start ): ?string {
+		$length = strlen( $source );
+		$depth  = 0;
+		$quote  = null;
+		$escape = false;
+
+		for ( $i = $start; $i < $length; $i++ ) {
+			$char = $source[ $i ];
+
+			if ( null !== $quote ) {
+				if ( $escape ) {
+					$escape = false;
+				} elseif ( '\\' === $char ) {
+					$escape = true;
+				} elseif ( $quote === $char ) {
+					$quote = null;
+				}
+				continue;
+			}
+
+			if ( '"' === $char || "'" === $char ) {
+				$quote = $char;
+				continue;
+			}
+
+			if ( '(' === $char ) {
+				$depth++;
+				continue;
+			}
+
+			if ( ')' === $char ) {
+				$depth--;
+				if ( 0 === $depth ) {
+					return substr( $source, $start, $i - $start + 1 );
+				}
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Return a repository-relative path.
+	 *
+	 * @param string $file Absolute file path.
+	 * @return string Repository-relative path.
+	 */
+	private function relative_path( string $file ): string {
+		return ltrim( str_replace( $this->repo_root(), '', $file ), '/' );
+	}
+
+	/**
+	 * Return the repository root.
+	 *
+	 * @return string Absolute repository root.
+	 */
+	private function repo_root(): string {
+		return dirname( __DIR__, 3 );
+	}
+}


### PR DESCRIPTION
## Summary
- Harden `/chat/tool-result` so the permission callback checks chat access plus session ownership/shared access before paused state can be loaded and cleared.
- Restrict the `_health` endpoint permission callback to true loopback addresses only, rejecting private-network, public, empty, and invalid `REMOTE_ADDR` values.
- Add a static security audit test that fails if future `register_rest_route()`, `REST_Route`, or `wp_register_ability()` registrations omit their permission gate.

## Worker self-verification
- PHPUnit: Tests: 3544, Assertions: 14779, Errors: 0, Failures: 0, Skipped: 114, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Additional checks:
- `npm run test:php -- --filter='PermissionCallbackAuditTest|RestControllerTest|PostMutationHealthCheckTest'` — 107 tests, 231 assertions
- `npm run check:bundle` — passed

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.8 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 5d 3h and 111,419 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened health check endpoint validation to accept only true loopback addresses
  * Added session ownership verification for tool result submissions to prevent unauthorized access to other users' sessions

* **Tests**
  * Added security audit test to validate REST API permission callback enforcement
  * Extended health endpoint and session access control test coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->