### PR TITLE
fix: prepare database ability queries

### DIFF
--- a/includes/Abilities/DatabaseAbilities.php
+++ b/includes/Abilities/DatabaseAbilities.php
@@ -79,9 +79,16 @@ class DatabaseQueryAbility extends AbstractAbility {
 		return [
 			'type'       => 'object',
 			'properties' => [
-				'sql' => [
+				'sql'    => [
 					'type'        => 'string',
-					'description' => 'The SELECT SQL query to execute. Use {prefix} as placeholder for table prefix.',
+					'description' => 'The SELECT SQL query to execute. Use {prefix} as placeholder for table prefix and wpdb::prepare placeholders (%s, %d, %f, %i) for dynamic values.',
+				],
+				'params' => [
+					'type'        => 'array',
+					'description' => 'Values for the wpdb::prepare placeholders in sql. Use one array item per placeholder.',
+					'items'       => [
+						'type' => [ 'string', 'number', 'integer', 'boolean', 'null' ],
+					],
 				],
 			],
 			'required'   => [ 'sql' ],
@@ -112,6 +119,17 @@ class DatabaseQueryAbility extends AbstractAbility {
 			return new WP_Error( 'sd_ai_agent_empty_sql', __( 'SQL query cannot be empty.', 'superdav-ai-agent' ) );
 		}
 
+		$params = $input['params'] ?? [];
+		if ( ! is_array( $params ) ) {
+			return new WP_Error( 'sd_ai_agent_sql_params_invalid', __( 'SQL params must be an array.', 'superdav-ai-agent' ) );
+		}
+
+		foreach ( $params as $param ) {
+			if ( is_array( $param ) || is_object( $param ) || is_resource( $param ) ) {
+				return new WP_Error( 'sd_ai_agent_sql_params_invalid', __( 'SQL params may only contain scalar values or null.', 'superdav-ai-agent' ) );
+			}
+		}
+
 		// Only allow SELECT queries.
 		if ( stripos( $sql, 'SELECT' ) !== 0 ) {
 			return new WP_Error(
@@ -137,10 +155,55 @@ class DatabaseQueryAbility extends AbstractAbility {
 			);
 		}
 
-		// Replace {prefix} placeholder.
-		$sql = str_replace( '{prefix}', $wpdb->prefix, $sql );
+		if ( self::has_unprepared_string_literal( $sql ) ) {
+			return new WP_Error(
+				'sd_ai_agent_sql_unprepared_literal',
+				__( 'SQL string literals must be passed with wpdb::prepare placeholders and the params array.', 'superdav-ai-agent' ),
+				array( 'status' => 400 )
+			);
+		}
 
-		$results = $wpdb->get_results( $sql, ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- AI agent database ability executes user-approved dynamic SELECT queries with capability checks; results are not cacheable.
+		// Replace {prefix} placeholder.
+		$sql               = str_replace( '{prefix}', $wpdb->prefix, $sql );
+		$placeholder_count = self::count_prepare_placeholders( $sql );
+
+		if ( $placeholder_count !== count( $params ) ) {
+			return new WP_Error(
+				'sd_ai_agent_sql_placeholder_mismatch',
+				sprintf(
+					/* translators: 1: placeholder count, 2: param count */
+					__( 'SQL placeholder count (%1$d) must match params count (%2$d).', 'superdav-ai-agent' ),
+					$placeholder_count,
+					count( $params )
+				),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( $placeholder_count > 0 ) {
+			// @phpstan-ignore-next-line wpdb::prepare accepts a variadic scalar list.
+			$prepared_sql = $wpdb->prepare( $sql, ...array_values( $params ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- The SQL template is validated above; raw string literals are rejected and params are counted before prepare.
+			if ( ! is_string( $prepared_sql ) ) {
+				return new WP_Error( 'sd_ai_agent_sql_prepare_failed', __( 'SQL query could not be prepared.', 'superdav-ai-agent' ), array( 'status' => 400 ) );
+			}
+
+			$sql = $prepared_sql;
+
+			$secret_literal = self::find_secret_option_literal( $sql );
+			if ( null !== $secret_literal ) {
+				return new WP_Error(
+					'sd_ai_agent_sql_secret_literal',
+					sprintf(
+						/* translators: %s: secret option name */
+						__( 'The query references the secret option "%s". Reading auth keys/salts via SQL is not permitted.', 'superdav-ai-agent' ),
+						$secret_literal
+					),
+					array( 'status' => 403 )
+				);
+			}
+		}
+
+		$results = $wpdb->get_results( $sql, ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- AI agent database ability executes validated SELECT queries; raw string literals are rejected and placeholder values are prepared above.
 
 		if ( $wpdb->last_error ) {
 			return new WP_Error( 'sd_ai_agent_db_error', sprintf( 'Database error: %s', $wpdb->last_error ) );
@@ -193,6 +256,31 @@ class DatabaseQueryAbility extends AbstractAbility {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Determine whether the SQL contains raw string literals instead of
+	 * wpdb::prepare placeholders.
+	 *
+	 * @param string $sql Raw SQL.
+	 * @return bool
+	 */
+	private static function has_unprepared_string_literal( string $sql ): bool {
+		return str_contains( $sql, "'" ) || str_contains( $sql, '"' );
+	}
+
+	/**
+	 * Count wpdb::prepare placeholders in a query.
+	 *
+	 * @param string $sql SQL with placeholders.
+	 * @return int
+	 */
+	private static function count_prepare_placeholders( string $sql ): int {
+		if ( ! preg_match_all( '/(?<!%)%(?:\d+\$)?[sdifi]/', $sql, $matches ) ) {
+			return 0;
+		}
+
+		return count( $matches[0] );
 	}
 
 	/**

--- a/includes/Repositories/SessionRepository.php
+++ b/includes/Repositories/SessionRepository.php
@@ -159,33 +159,56 @@ class SessionRepository {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 
+		$session_ids = array_values(
+			array_filter(
+				array_map(
+					static function ( $session_id ): int {
+						return absint( $session_id );
+					},
+					$session_ids
+				)
+			)
+		);
 		if ( empty( $session_ids ) || empty( $data ) ) {
 			return 0;
 		}
 
 		$table              = Database::table_name();
 		$data['updated_at'] = current_time( 'mysql', true );
+		$allowed_fields     = [ 'status', 'pinned', 'folder', 'updated_at' ];
 
 		$set_parts = [];
-		$values    = [];
 
 		foreach ( $data as $key => $value ) {
-			$set_parts[] = "{$key} = %s";
-			$values[]    = $value;
+			if ( ! in_array( $key, $allowed_fields, true ) ) {
+				continue;
+			}
+
+			if ( 'pinned' === $key ) {
+				$set_parts[] = $wpdb->prepare( '%i = %d', $key, $value );
+				continue;
+			}
+
+			$set_parts[] = $wpdb->prepare( '%i = %s', $key, $value );
+		}
+
+		if ( empty( $set_parts ) ) {
+			return 0;
 		}
 
 		$set_sql      = implode( ', ', $set_parts );
 		$placeholders = implode( ',', array_fill( 0, count( $session_ids ), '%d' ) );
-		$values       = array_merge( $values, $session_ids, [ $user_id ] );
+		$values       = array_merge( $session_ids, [ $user_id ] );
 
-		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Custom table query; dynamic columns from internal method, not user input.
+		// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Custom table query; SET fragments are prepared from allowlisted column names and values.
 		$result = $wpdb->query(
 			$wpdb->prepare(
-				"UPDATE {$table} SET {$set_sql} WHERE id IN ({$placeholders}) AND user_id = %d",
+				"UPDATE %i SET {$set_sql} WHERE id IN ({$placeholders}) AND user_id = %d",
+				$table,
 				...$values
 			)
 		);
-		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter
+		// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 
 		return $result !== false ? (int) $result : 0;
 	}

--- a/tests/SdAiAgent/Abilities/DatabaseAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/DatabaseAbilitiesTest.php
@@ -52,7 +52,8 @@ class DatabaseAbilitiesTest extends WP_UnitTestCase {
 		global $wpdb;
 
 		$result = DatabaseAbilities::handle_db_query( [
-			'sql' => 'SELECT option_name FROM {prefix}options WHERE option_name = "siteurl" LIMIT 1',
+			'sql'    => 'SELECT option_name FROM {prefix}options WHERE option_name = %s LIMIT 1',
+			'params' => [ 'siteurl' ],
 		] );
 
 		$this->assertIsArray( $result );
@@ -67,7 +68,8 @@ class DatabaseAbilitiesTest extends WP_UnitTestCase {
 	 */
 	public function test_handle_db_query_real_table() {
 		$result = DatabaseAbilities::handle_db_query( [
-			'sql' => 'SELECT option_name FROM {prefix}options WHERE option_name = "siteurl" LIMIT 1',
+			'sql'    => 'SELECT option_name FROM {prefix}options WHERE option_name = %s LIMIT 1',
+			'params' => [ 'siteurl' ],
 		] );
 
 		$this->assertSame( 1, $result['count'] );
@@ -168,7 +170,8 @@ class DatabaseAbilitiesTest extends WP_UnitTestCase {
 	 */
 	public function test_handle_db_query_empty_result() {
 		$result = DatabaseAbilities::handle_db_query( [
-			'sql' => "SELECT option_name FROM {prefix}options WHERE option_name = 'nonexistent_option_xyz_12345' LIMIT 1",
+			'sql'    => 'SELECT option_name FROM {prefix}options WHERE option_name = %s LIMIT 1',
+			'params' => [ 'nonexistent_option_xyz_12345' ],
 		] );
 
 		$this->assertIsArray( $result );
@@ -185,7 +188,8 @@ class DatabaseAbilitiesTest extends WP_UnitTestCase {
 		update_option( 'auth_key', 'do-not-leak-this-secret' );
 
 		$result = DatabaseAbilities::handle_db_query( [
-			'sql' => "SELECT option_value FROM {prefix}options WHERE option_name = 'auth_key'",
+			'sql'    => 'SELECT option_value FROM {prefix}options WHERE option_name = %s',
+			'params' => [ 'auth_key' ],
 		] );
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
@@ -200,7 +204,8 @@ class DatabaseAbilitiesTest extends WP_UnitTestCase {
 	 */
 	public function test_handle_db_query_rejects_secret_literal_double_quoted() {
 		$result = DatabaseAbilities::handle_db_query( [
-			'sql' => 'SELECT option_value FROM {prefix}options WHERE option_name = "secure_auth_salt"',
+			'sql'    => 'SELECT option_value FROM {prefix}options WHERE option_name = %s',
+			'params' => [ 'secure_auth_salt' ],
 		] );
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
@@ -217,7 +222,8 @@ class DatabaseAbilitiesTest extends WP_UnitTestCase {
 		// SELECT * does not name `auth_key` as a literal, so the pre-check
 		// allows it; the post-process must still redact the value.
 		$result = DatabaseAbilities::handle_db_query( [
-			'sql' => "SELECT option_name, option_value, autoload FROM {prefix}options WHERE option_name LIKE 'auth_%' LIMIT 5",
+			'sql'    => 'SELECT option_name, option_value, autoload FROM {prefix}options WHERE option_name LIKE %s LIMIT 5',
+			'params' => [ 'auth_%' ],
 		] );
 
 		$this->assertIsArray( $result );
@@ -247,7 +253,8 @@ class DatabaseAbilitiesTest extends WP_UnitTestCase {
 	 */
 	public function test_handle_db_query_does_not_scrub_safe_rows() {
 		$result = DatabaseAbilities::handle_db_query( [
-			'sql' => "SELECT option_name, option_value FROM {prefix}options WHERE option_name = 'blogname' LIMIT 1",
+			'sql'    => 'SELECT option_name, option_value FROM {prefix}options WHERE option_name = %s LIMIT 1',
+			'params' => [ 'blogname' ],
 		] );
 
 		$this->assertIsArray( $result );
@@ -272,12 +279,38 @@ class DatabaseAbilitiesTest extends WP_UnitTestCase {
 		);
 
 		$result = DatabaseAbilities::handle_db_query( [
-			'sql' => "SELECT option_value FROM {prefix}options WHERE option_name = 'third_party_api_token'",
+			'sql'    => 'SELECT option_value FROM {prefix}options WHERE option_name = %s',
+			'params' => [ 'third_party_api_token' ],
 		] );
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'sd_ai_agent_sql_secret_literal', $result->get_error_code() );
 
 		remove_all_filters( 'sd_ai_agent_options_read_blocklist' );
+	}
+
+	/**
+	 * Test handle_db_query rejects raw string literals that are not passed via params.
+	 */
+	public function test_handle_db_query_rejects_unprepared_string_literal() {
+		$result = DatabaseAbilities::handle_db_query( [
+			'sql' => "SELECT option_name FROM {prefix}options WHERE option_name = 'blogname' LIMIT 1",
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_sql_unprepared_literal', $result->get_error_code() );
+	}
+
+	/**
+	 * Test handle_db_query rejects mismatched placeholders and params.
+	 */
+	public function test_handle_db_query_rejects_placeholder_param_mismatch() {
+		$result = DatabaseAbilities::handle_db_query( [
+			'sql'    => 'SELECT option_name FROM {prefix}options WHERE option_name = %s AND autoload = %s',
+			'params' => [ 'blogname' ],
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_sql_placeholder_mismatch', $result->get_error_code() );
 	}
 }

--- a/tests/SdAiAgent/Core/DatabaseTest.php
+++ b/tests/SdAiAgent/Core/DatabaseTest.php
@@ -340,6 +340,23 @@ class DatabaseTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test bulk_update_sessions ignores fields outside the allowlist.
+	 */
+	public function test_bulk_update_sessions_ignores_unknown_fields() {
+		$user_id    = self::factory()->user->create();
+		$session_id = Database::create_session( [ 'user_id' => $user_id, 'title' => 'Bulk Unknown' ] );
+
+		$count = Database::bulk_update_sessions(
+			[ $session_id ],
+			$user_id,
+			[ 'title = %s WHERE 1=1 --' => 'Injected' ]
+		);
+
+		$this->assertSame( 0, $count );
+		$this->assertSame( 'Bulk Unknown', Database::get_session( $session_id )->title );
+	}
+
+	/**
 	 * Test empty_trash deletes trashed sessions.
 	 */
 	public function test_empty_trash() {


### PR DESCRIPTION
## Summary
- Add `params` support to `sd-ai-agent/db-query` so dynamic values are supplied through `wpdb::prepare()` placeholders instead of raw SQL string literals.
- Reject raw quoted string literals and placeholder/parameter mismatches before executing SELECT queries, while preserving the existing secret-option redaction checks.
- Harden `SessionRepository::bulk_update()` with sanitized IDs, allowlisted columns, prepared SET fragments, and a prepared table identifier.

## Testing
- `npm run lint:php`
- `composer phpstan -- --memory-limit=2G`
- `npm run test:php -- --filter='DatabaseAbilitiesTest|DatabaseTest|OptionsAbilitiesTest|WordPressAbilitiesTest|WpCliAbilitiesTest'`
- `npm run test:php`
- `npm run lint:js`
- `npm run lint:css`
- `npm run build` (succeeded with existing webpack asset-size warnings)

## Worker self-verification
- PHPUnit: Tests: 3548, Assertions: 14787, Errors: 0, Failures: 0, Skipped: 114, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.8 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 5d 4h and 111,419 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced database query validation with prepared statement enforcement and parameter type checking
  * Improved session bulk update operations with field allowlisting and prepared identifiers
  * Added stricter SQL placeholder count validation

* **Tests**
  * Extended test coverage for SQL injection prevention scenarios
  * Added test cases validating query parameter mismatches

<!-- end of auto-generated comment: release notes by coderabbit.ai -->