### PR TITLE
fix(security): default-deny option writes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -405,6 +405,17 @@ The single source of truth for the read blocklist lives in
 - `OptionsAbilities::secret_read_error( string $name ): WP_Error` — uniform
   `sd_ai_agent_option_secret_redacted` error code (HTTP 403).
 
+For option writes, the same file is the single source of truth for the
+default-deny write policy:
+
+- `OptionsAbilities::get_write_blocklist()` — protected names that always win.
+- `OptionsAbilities::get_write_allowlist()` — exact names site code explicitly
+  opts into AI write/delete access.
+- `OptionsAbilities::get_write_allowlist_prefixes()` — allowed prefixes; by
+  default only this plugin's `sd_ai_agent_` option namespace.
+- `OptionsAbilities::is_write_allowed_option( string $name ): bool` — predicate
+  every option write/delete surface must call after empty-name validation.
+
 **Rules for any new ability, REST controller, CLI command, or SQL helper that
 reads option data:**
 
@@ -419,19 +430,20 @@ reads option data:**
    implementation).
 4. For low-level function callers like `RunPhpAbility`, gate
    `get_option`/`get_site_option`/`get_network_option`/`get_transient`/
-   `get_site_transient` on the predicate and gate the matching write
-   functions on `OptionsAbilities::get_write_blocklist()`.
+   `get_site_transient` on the read predicate and gate the matching write
+   functions on `OptionsAbilities::is_write_allowed_option()`; the blocklist
+   still takes precedence and should keep the protected error path distinct.
 
-**Verification (must run for any PR that touches option reads):**
+**Verification (must run for any PR that touches option reads or writes):**
 
 ```bash
-rg -n "is_secret_option_name|SECRET_REDACTED_PLACEHOLDER|sd_ai_agent_option_secret_redacted|sd_ai_agent_options_read_blocklist" includes/ tests/
+rg -n "is_secret_option_name|is_write_allowed_option|SECRET_REDACTED_PLACEHOLDER|sd_ai_agent_option_secret_redacted|sd_ai_agent_options_write_allowlist|sd_ai_agent_options_read_blocklist" includes/ tests/
 npm run test:php -- --filter='OptionsAbilitiesTest|WordPressAbilitiesTest|DatabaseAbilitiesTest|WpCliAbilitiesTest'
 ```
 
-The first command must show coverage in every read surface (get-option,
-list-options, db-query, run-php, wp-cli). The second must report zero
-failures for the four ability suites.
+The first command must show coverage in every read/write surface (get-option,
+list-options, update-option, delete-option, db-query, run-php, wp-cli). The
+second must report zero failures for the four ability suites.
 
 ### REST API Security and Operational Guidelines
 - **Secret Scrubbing**: All REST endpoints must scrub sensitive data (API keys, tokens,

--- a/includes/Abilities/OptionsAbilities.php
+++ b/includes/Abilities/OptionsAbilities.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 /**
  * Options management abilities for the AI agent.
  *
- * Provides get, update, and delete operations for WordPress options with a
- * safety blocklist that prevents the AI from modifying critical site options
- * (e.g. siteurl, admin_email, active_plugins, db_version).
+ * Provides get, update, and delete operations for WordPress options. Writes
+ * are default-deny: only plugin-owned options and site-allowlisted option
+ * names can be modified, and critical core options remain blocklisted.
  *
  * @package SdAiAgent
  * @license GPL-2.0-or-later
@@ -111,6 +111,30 @@ class OptionsAbilities {
 	];
 
 	/**
+	 * Exact option names the AI agent may modify by default.
+	 *
+	 * The default list is intentionally empty. Site owners can opt specific
+	 * third-party options into AI write access with the
+	 * `sd_ai_agent_options_write_allowlist` filter.
+	 *
+	 * @var string[]
+	 */
+	private const WRITE_ALLOWLIST = [];
+
+	/**
+	 * Option-name prefixes the AI agent may modify by default.
+	 *
+	 * Limit default write/delete access to this plugin's own option namespace so
+	 * arbitrary WordPress core or third-party options cannot be changed merely
+	 * because they were missed by the finite blocklist above.
+	 *
+	 * @var string[]
+	 */
+	private const WRITE_ALLOWLIST_PREFIXES = [
+		'sd_ai_agent_',
+	];
+
+	/**
 	 * Register all options management abilities.
 	 */
 	public static function register_abilities(): void {
@@ -131,7 +155,7 @@ class OptionsAbilities {
 			'sd-ai-agent/update-option',
 			[
 				'label'         => __( 'Update Option', 'superdav-ai-agent' ),
-				'description'   => __( 'Create or update a WordPress option. Blocked for critical system options (siteurl, admin_email, active_plugins, etc.).', 'superdav-ai-agent' ),
+				'description'   => __( 'Create or update an allowed WordPress option. Default write access is limited to plugin-owned options; critical system options remain blocked.', 'superdav-ai-agent' ),
 				'ability_class' => UpdateOptionAbility::class,
 			]
 		);
@@ -140,7 +164,7 @@ class OptionsAbilities {
 			'sd-ai-agent/delete-option',
 			[
 				'label'         => __( 'Delete Option', 'superdav-ai-agent' ),
-				'description'   => __( 'Delete a WordPress option by name. Blocked for critical system options.', 'superdav-ai-agent' ),
+				'description'   => __( 'Delete an allowed WordPress option by name. Default delete access is limited to plugin-owned options; critical system options remain blocked.', 'superdav-ai-agent' ),
 				'ability_class' => DeleteOptionAbility::class,
 			]
 		);
@@ -171,6 +195,79 @@ class OptionsAbilities {
 		$blocklist = apply_filters( 'sd_ai_agent_options_blocklist', self::WRITE_BLOCKLIST );
 
 		return array_values( array_filter( (array) $blocklist, 'is_string' ) );
+	}
+
+	/**
+	 * Get exact option names the AI agent may modify.
+	 *
+	 * @return string[]
+	 */
+	public static function get_write_allowlist(): array {
+		/**
+		 * Filters the exact WordPress option names the AI agent may write/delete.
+		 *
+		 * Use this only for options that are safe for an AI-assisted administrator
+		 * to manage. The write blocklist still takes precedence.
+		 *
+		 * @since 1.3.0
+		 *
+		 * @param string[] $allowlist List of allowed option names.
+		 */
+		$allowlist = apply_filters( 'sd_ai_agent_options_write_allowlist', self::WRITE_ALLOWLIST );
+
+		return array_values( array_filter( (array) $allowlist, 'is_string' ) );
+	}
+
+	/**
+	 * Get option-name prefixes the AI agent may modify.
+	 *
+	 * @return string[]
+	 */
+	public static function get_write_allowlist_prefixes(): array {
+		/**
+		 * Filters option-name prefixes the AI agent may write/delete.
+		 *
+		 * The default allows only this plugin's `sd_ai_agent_` options. The write
+		 * blocklist still takes precedence over every prefix.
+		 *
+		 * @since 1.3.0
+		 *
+		 * @param string[] $prefixes List of allowed option-name prefixes.
+		 */
+		$prefixes = apply_filters( 'sd_ai_agent_options_write_allowlist_prefixes', self::WRITE_ALLOWLIST_PREFIXES );
+
+		return array_values( array_filter( (array) $prefixes, 'is_string' ) );
+	}
+
+	/**
+	 * Predicate: may the AI agent modify or delete the given option name?
+	 *
+	 * The write policy is default-deny. Exact allowlist entries and allowed
+	 * prefixes grant access, but the blocklist always takes precedence.
+	 *
+	 * @param string $option_name Option name to test.
+	 * @return bool True if the option is safe for write/delete access.
+	 */
+	public static function is_write_allowed_option( string $option_name ): bool {
+		if ( '' === $option_name ) {
+			return false;
+		}
+
+		if ( in_array( $option_name, self::get_write_blocklist(), true ) ) {
+			return false;
+		}
+
+		if ( in_array( $option_name, self::get_write_allowlist(), true ) ) {
+			return true;
+		}
+
+		foreach ( self::get_write_allowlist_prefixes() as $prefix ) {
+			if ( '' !== $prefix && str_starts_with( $option_name, $prefix ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**
@@ -335,7 +432,7 @@ class GetOptionAbility extends AbstractAbility {
 /**
  * Update Option ability.
  *
- * Creates or updates a WordPress option with blocklist enforcement.
+ * Creates or updates an allowed WordPress option.
  *
  * @since 1.2.0
  */
@@ -346,7 +443,7 @@ class UpdateOptionAbility extends AbstractAbility {
 	}
 
 	protected function description(): string {
-		return __( 'Create or update a WordPress option. Blocked for critical system options (siteurl, admin_email, active_plugins, etc.).', 'superdav-ai-agent' );
+		return __( 'Create or update an allowed WordPress option. Default write access is limited to plugin-owned options; critical system options remain blocked.', 'superdav-ai-agent' );
 	}
 
 	protected function input_schema(): array {
@@ -355,7 +452,7 @@ class UpdateOptionAbility extends AbstractAbility {
 			'properties' => [
 				'option_name'  => [
 					'type'        => 'string',
-					'description' => 'The option name to create or update.',
+					'description' => 'The allowed option name to create or update. By default, write access is limited to sd_ai_agent_ options unless site code extends the allowlist.',
 				],
 				'option_value' => [
 					'type'        => array( 'string', 'number', 'integer', 'boolean', 'array', 'object', 'null' ),
@@ -404,6 +501,18 @@ class UpdateOptionAbility extends AbstractAbility {
 					__( 'The option "%s" is protected and cannot be modified by the AI agent.', 'superdav-ai-agent' ),
 					$option_name
 				)
+			);
+		}
+
+		if ( ! OptionsAbilities::is_write_allowed_option( $option_name ) ) {
+			return new WP_Error(
+				'sd_ai_agent_option_not_allowed',
+				sprintf(
+					/* translators: %s: option name */
+					__( 'The option "%s" is not in the AI agent write allowlist. Only plugin-owned options and options explicitly allowed by site code can be modified by this ability.', 'superdav-ai-agent' ),
+					$option_name
+				),
+				array( 'status' => 403 )
 			);
 		}
 
@@ -490,7 +599,7 @@ class UpdateOptionAbility extends AbstractAbility {
 /**
  * Delete Option ability.
  *
- * Removes a WordPress option with blocklist enforcement.
+ * Removes an allowed WordPress option.
  *
  * @since 1.2.0
  */
@@ -501,7 +610,7 @@ class DeleteOptionAbility extends AbstractAbility {
 	}
 
 	protected function description(): string {
-		return __( 'Delete a WordPress option by name. Blocked for critical system options.', 'superdav-ai-agent' );
+		return __( 'Delete an allowed WordPress option by name. Default delete access is limited to plugin-owned options; critical system options remain blocked.', 'superdav-ai-agent' );
 	}
 
 	protected function input_schema(): array {
@@ -510,7 +619,7 @@ class DeleteOptionAbility extends AbstractAbility {
 			'properties' => [
 				'option_name' => [
 					'type'        => 'string',
-					'description' => 'The option name to delete.',
+					'description' => 'The allowed option name to delete. By default, delete access is limited to sd_ai_agent_ options unless site code extends the allowlist.',
 				],
 			],
 			'required'   => [ 'option_name' ],
@@ -549,6 +658,18 @@ class DeleteOptionAbility extends AbstractAbility {
 					__( 'The option "%s" is protected and cannot be deleted by the AI agent.', 'superdav-ai-agent' ),
 					$option_name
 				)
+			);
+		}
+
+		if ( ! OptionsAbilities::is_write_allowed_option( $option_name ) ) {
+			return new WP_Error(
+				'sd_ai_agent_option_not_allowed',
+				sprintf(
+					/* translators: %s: option name */
+					__( 'The option "%s" is not in the AI agent write allowlist. Only plugin-owned options and options explicitly allowed by site code can be deleted by this ability.', 'superdav-ai-agent' ),
+					$option_name
+				),
+				array( 'status' => 403 )
 			);
 		}
 

--- a/includes/Abilities/RunPhpAbility.php
+++ b/includes/Abilities/RunPhpAbility.php
@@ -67,9 +67,9 @@ class RunPhpAbility extends AbstractAbility {
 
 	/**
 	 * Option-mutating functions whose first argument is an option name.
-	 * Calls are gated against {@see OptionsAbilities::get_write_blocklist()}
-	 * so the agent cannot regenerate auth keys/salts (which would log out
-	 * every user) by routing around {@see UpdateOptionAbility}.
+	 * Calls are gated against {@see OptionsAbilities::is_write_allowed_option()}
+	 * so the agent cannot mutate arbitrary core or third-party options by
+	 * routing around {@see UpdateOptionAbility}.
 	 *
 	 * @var string[]
 	 */
@@ -233,8 +233,9 @@ class RunPhpAbility extends AbstractAbility {
 			);
 		}
 
-		// Secret-aware gating: option reads/writes against the auth-key
-		// blocklist. Applied AFTER the function allowlist check so any
+		// Secret-aware gating: option reads against the auth-key blocklist and
+		// option writes against the default-deny write policy. Applied AFTER the
+		// function allowlist check so any
 		// extension via `sd_ai_agent_allowed_wp_functions` is still
 		// constrained. Network/site variants of get_option take the option
 		// name in arg position 1 (network ID is arg 0); standard variants
@@ -301,7 +302,7 @@ class RunPhpAbility extends AbstractAbility {
 
 	/**
 	 * Gate option-reading / option-writing function calls against the
-	 * secret read blocklist and the existing write blocklist.
+	 * secret read blocklist and the default-deny write policy.
 	 *
 	 * Without this check, the AI could bypass {@see GetOptionAbility}'s
 	 * secret-read gate (and {@see UpdateOptionAbility}'s write gate) by
@@ -335,18 +336,32 @@ class RunPhpAbility extends AbstractAbility {
 			return OptionsAbilities::secret_read_error( $option_name );
 		}
 
-		if ( in_array( $function_name, self::OPTION_WRITE_FUNCTIONS, true )
-			&& in_array( $option_name, OptionsAbilities::get_write_blocklist(), true ) ) {
-			return new \WP_Error(
-				'sd_ai_agent_option_blocked',
-				sprintf(
-					/* translators: 1: function name, 2: option name */
-					__( 'The function "%1$s" cannot be used to modify the protected option "%2$s".', 'superdav-ai-agent' ),
-					$function_name,
-					$option_name
-				),
-				[ 'status' => 403 ]
-			);
+		if ( in_array( $function_name, self::OPTION_WRITE_FUNCTIONS, true ) ) {
+			if ( in_array( $option_name, OptionsAbilities::get_write_blocklist(), true ) ) {
+				return new \WP_Error(
+					'sd_ai_agent_option_blocked',
+					sprintf(
+						/* translators: 1: function name, 2: option name */
+						__( 'The function "%1$s" cannot be used to modify the protected option "%2$s".', 'superdav-ai-agent' ),
+						$function_name,
+						$option_name
+					),
+					[ 'status' => 403 ]
+				);
+			}
+
+			if ( ! OptionsAbilities::is_write_allowed_option( $option_name ) ) {
+				return new \WP_Error(
+					'sd_ai_agent_option_not_allowed',
+					sprintf(
+						/* translators: 1: function name, 2: option name */
+						__( 'The function "%1$s" cannot be used to modify the unallowlisted option "%2$s".', 'superdav-ai-agent' ),
+						$function_name,
+						$option_name
+					),
+					[ 'status' => 403 ]
+				);
+			}
 		}
 
 		return null;

--- a/includes/Abilities/WpCliAbilities.php
+++ b/includes/Abilities/WpCliAbilities.php
@@ -1098,7 +1098,7 @@ class WpCliAbilities {
 	 *
 	 * Index value is a classification used by {@see check_secret_option_subcommand()}:
 	 *   - 'read'  → name must not be on the secret read blocklist.
-	 *   - 'write' → name must not be on the existing write blocklist.
+	 *   - 'write' → name must pass the default-deny write allowlist policy.
 	 *
 	 * @var array<string,string>
 	 */
@@ -1114,7 +1114,7 @@ class WpCliAbilities {
 	);
 
 	/**
-	 * Reject `wp option get/pluck/update/delete <secret>` before execution.
+	 * Reject `wp option get/pluck/update/delete <secret-or-unallowlisted>` before execution.
 	 *
 	 * {@see extract_command_path()} stops at the first flag but consumes the
 	 * option name into the positional path (so `option get auth_key` becomes
@@ -1170,18 +1170,32 @@ class WpCliAbilities {
 			);
 		}
 
-		if ( 'write' === $mode
-			&& in_array( $option_name, OptionsAbilities::get_write_blocklist(), true ) ) {
-			return new WP_Error(
-				'wp_cli_option_protected',
-				sprintf(
-					/* translators: 1: WP-CLI subcommand, 2: option name */
-					__( 'The WP-CLI command "wp %1$s %2$s" targets a protected option and is blocked.', 'superdav-ai-agent' ),
-					$prefix,
-					$option_name
-				),
-				array( 'status' => 403 )
-			);
+		if ( 'write' === $mode ) {
+			if ( in_array( $option_name, OptionsAbilities::get_write_blocklist(), true ) ) {
+				return new WP_Error(
+					'wp_cli_option_protected',
+					sprintf(
+						/* translators: 1: WP-CLI subcommand, 2: option name */
+						__( 'The WP-CLI command "wp %1$s %2$s" targets a protected option and is blocked.', 'superdav-ai-agent' ),
+						$prefix,
+						$option_name
+					),
+					array( 'status' => 403 )
+				);
+			}
+
+			if ( ! OptionsAbilities::is_write_allowed_option( $option_name ) ) {
+				return new WP_Error(
+					'wp_cli_option_not_allowed',
+					sprintf(
+						/* translators: 1: WP-CLI subcommand, 2: option name */
+						__( 'The WP-CLI command "wp %1$s %2$s" targets an unallowlisted option and is blocked.', 'superdav-ai-agent' ),
+						$prefix,
+						$option_name
+					),
+					array( 'status' => 403 )
+				);
+			}
 		}
 
 		return null;

--- a/tests/SdAiAgent/Abilities/OptionsAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/OptionsAbilitiesTest.php
@@ -15,9 +15,11 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Tests\Abilities;
 
+use SdAiAgent\Abilities\DeleteOptionAbility;
 use SdAiAgent\Abilities\GetOptionAbility;
 use SdAiAgent\Abilities\ListOptionsAbility;
 use SdAiAgent\Abilities\OptionsAbilities;
+use SdAiAgent\Abilities\UpdateOptionAbility;
 use WP_UnitTestCase;
 
 /**
@@ -42,7 +44,12 @@ class OptionsAbilitiesTest extends WP_UnitTestCase {
 			delete_option( $name );
 		}
 		delete_option( 'sd_ai_agent_test_visible_option' );
+		delete_option( 'sd_ai_agent_test_write_option' );
+		delete_option( 'third_party_test_option' );
 		remove_all_filters( 'sd_ai_agent_options_read_blocklist' );
+		remove_all_filters( 'sd_ai_agent_options_blocklist' );
+		remove_all_filters( 'sd_ai_agent_options_write_allowlist' );
+		remove_all_filters( 'sd_ai_agent_options_write_allowlist_prefixes' );
 
 		parent::tear_down();
 	}
@@ -100,6 +107,129 @@ class OptionsAbilitiesTest extends WP_UnitTestCase {
 
 		$this->assertTrue( OptionsAbilities::is_secret_option_name( 'my_third_party_api_token' ) );
 		$this->assertContains( 'my_third_party_api_token', OptionsAbilities::get_secret_read_blocklist() );
+	}
+
+	/**
+	 * The write policy is default-deny except for plugin-owned options.
+	 */
+	public function test_write_allowlist_defaults_to_plugin_owned_options(): void {
+		$this->assertTrue( OptionsAbilities::is_write_allowed_option( 'sd_ai_agent_test_write_option' ) );
+		$this->assertFalse( OptionsAbilities::is_write_allowed_option( 'third_party_test_option' ) );
+		$this->assertFalse( OptionsAbilities::is_write_allowed_option( 'siteurl' ) );
+		$this->assertFalse( OptionsAbilities::is_write_allowed_option( '' ) );
+	}
+
+	/**
+	 * Exact and prefix write allowlists can be extended by trusted site code.
+	 */
+	public function test_write_allowlist_filters_can_extend_safe_names(): void {
+		add_filter(
+			'sd_ai_agent_options_write_allowlist',
+			static function ( array $list ): array {
+				$list[] = 'third_party_test_option';
+				return $list;
+			}
+		);
+
+		$this->assertTrue( OptionsAbilities::is_write_allowed_option( 'third_party_test_option' ) );
+
+		add_filter(
+			'sd_ai_agent_options_write_allowlist_prefixes',
+			static function ( array $prefixes ): array {
+				$prefixes[] = 'trusted_prefix_';
+				return $prefixes;
+			}
+		);
+
+		$this->assertTrue( OptionsAbilities::is_write_allowed_option( 'trusted_prefix_setting' ) );
+	}
+
+	/**
+	 * Blocklisted options stay blocked even if a filter tries to allow them.
+	 */
+	public function test_write_blocklist_takes_precedence_over_allowlist(): void {
+		add_filter(
+			'sd_ai_agent_options_write_allowlist',
+			static function ( array $list ): array {
+				$list[] = 'siteurl';
+				return $list;
+			}
+		);
+
+		$this->assertFalse( OptionsAbilities::is_write_allowed_option( 'siteurl' ) );
+	}
+
+	/**
+	 * UpdateOptionAbility rejects arbitrary unallowlisted option names.
+	 */
+	public function test_update_option_ability_blocks_unallowlisted_option(): void {
+		$ability = new UpdateOptionAbility( 'sd-ai-agent/update-option' );
+		$result  = $ability->run(
+			array(
+				'option_name'  => 'third_party_test_option',
+				'option_value' => 'unsafe-write',
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_option_not_allowed', $result->get_error_code() );
+		$this->assertFalse( get_option( 'third_party_test_option', false ) );
+	}
+
+	/**
+	 * UpdateOptionAbility still permits plugin-owned options.
+	 */
+	public function test_update_option_ability_allows_plugin_owned_option(): void {
+		$ability = new UpdateOptionAbility( 'sd-ai-agent/update-option' );
+		$result  = $ability->run(
+			array(
+				'option_name'  => 'sd_ai_agent_test_write_option',
+				'option_value' => 'safe-write',
+				'autoload'     => 'no',
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'updated', $result['status'] );
+		$this->assertSame( 'safe-write', get_option( 'sd_ai_agent_test_write_option' ) );
+	}
+
+	/**
+	 * DeleteOptionAbility rejects arbitrary unallowlisted option names.
+	 */
+	public function test_delete_option_ability_blocks_unallowlisted_option(): void {
+		update_option( 'third_party_test_option', 'must-remain' );
+
+		$ability = new DeleteOptionAbility( 'sd-ai-agent/delete-option' );
+		$result  = $ability->run( array( 'option_name' => 'third_party_test_option' ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_option_not_allowed', $result->get_error_code() );
+		$this->assertSame( 'must-remain', get_option( 'third_party_test_option' ) );
+	}
+
+	/**
+	 * UpdateOptionAbility rejects blocklisted options before allowlist checks.
+	 */
+	public function test_update_option_ability_blocks_protected_option_even_when_allowlisted(): void {
+		add_filter(
+			'sd_ai_agent_options_write_allowlist',
+			static function ( array $list ): array {
+				$list[] = 'siteurl';
+				return $list;
+			}
+		);
+
+		$ability = new UpdateOptionAbility( 'sd-ai-agent/update-option' );
+		$result  = $ability->run(
+			array(
+				'option_name'  => 'siteurl',
+				'option_value' => 'https://example.invalid',
+			)
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_option_blocked', $result->get_error_code() );
 	}
 
 	/**

--- a/tests/SdAiAgent/Abilities/WordPressAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/WordPressAbilitiesTest.php
@@ -376,6 +376,36 @@ class WordPressAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * RunPhpAbility must refuse arbitrary unallowlisted option writes.
+	 */
+	public function test_handle_run_php_blocks_update_option_for_unallowlisted_name() {
+		$result = WordPressAbilities::handle_run_php( [
+			'function' => 'update_option',
+			'args'     => [ 'third_party_test_option', 'blocked-by-policy' ],
+		] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_option_not_allowed', $result->get_error_code() );
+		$this->assertFalse( get_option( 'third_party_test_option', false ) );
+	}
+
+	/**
+	 * RunPhpAbility may still update plugin-owned options.
+	 */
+	public function test_handle_run_php_allows_update_option_for_plugin_owned_name() {
+		$result = WordPressAbilities::handle_run_php( [
+			'function' => 'update_option',
+			'args'     => [ 'sd_ai_agent_test_runphp_write_option', 'allowed-by-policy' ],
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['result'] );
+		$this->assertSame( 'allowed-by-policy', get_option( 'sd_ai_agent_test_runphp_write_option' ) );
+
+		delete_option( 'sd_ai_agent_test_runphp_write_option' );
+	}
+
+	/**
 	 * RunPhpAbility must refuse delete_option('auth_key').
 	 */
 	public function test_handle_run_php_blocks_delete_option_for_write_blocklist() {

--- a/tests/SdAiAgent/Abilities/WpCliAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/WpCliAbilitiesTest.php
@@ -55,6 +55,7 @@ class WpCliAbilitiesTest extends WP_UnitTestCase {
 		remove_all_filters( 'sd_ai_agent_wp_cli_binary' );
 		remove_all_filters( 'sd_ai_agent_wp_cli_candidates' );
 		remove_all_filters( 'sd_ai_agent_wp_cli_scan_path' );
+		delete_option( 'sd_ai_agent_test_cli_write_option' );
 
 		if ( '' !== $this->temp_dir && is_dir( $this->temp_dir ) ) {
 			$this->rrmdir( $this->temp_dir );
@@ -544,6 +545,30 @@ class WpCliAbilitiesTest extends WP_UnitTestCase {
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'wp_cli_option_protected', $result->get_error_code() );
+	}
+
+	/**
+	 * `wp option update third_party_test_option value` must be refused unless
+	 * trusted site code explicitly allowlists that option name.
+	 */
+	public function test_execute_blocks_option_update_for_unallowlisted_name(): void {
+		$result = WpCliAbilities::execute( 'option update third_party_test_option value' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'wp_cli_option_not_allowed', $result->get_error_code() );
+	}
+
+	/**
+	 * `wp option update sd_ai_agent_* value` remains allowed by the option-write
+	 * policy and may proceed to the subprocess layer.
+	 */
+	public function test_execute_allows_option_update_for_plugin_owned_name(): void {
+		$result = WpCliAbilities::execute( 'option update sd_ai_agent_test_cli_write_option value' );
+
+		if ( is_wp_error( $result ) ) {
+			$this->assertNotSame( 'wp_cli_option_not_allowed', $result->get_error_code() );
+			$this->assertNotSame( 'wp_cli_option_protected', $result->get_error_code() );
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Tightens option mutation surfaces from finite blocklist-only checks to a default-deny write policy:

- allows plugin-owned `sd_ai_agent_` options by default
- adds filterable exact-name and prefix allowlists for site-owned opt-ins
- keeps the critical option write blocklist as an override
- routes `update-option`, `delete-option`, `run-php` option writes, and `wp option` write commands through the shared predicate
- documents the new single source of truth in `AGENTS.md`

## Duplicate check

No exact recent PR already covers this write policy. Related merged PRs were reviewed:

- #1921 redacts auth keys/salts from option-read surfaces and mentions the prior finite write blocklist, but does not make option writes default-deny.
- #859 introduced the original options ability safety blocklist, but leaves non-blocklisted core/third-party options writable.

## Files changed

- `AGENTS.md`
- `includes/Abilities/OptionsAbilities.php`
- `includes/Abilities/RunPhpAbility.php`
- `includes/Abilities/WpCliAbilities.php`
- `tests/SdAiAgent/Abilities/OptionsAbilitiesTest.php`
- `tests/SdAiAgent/Abilities/WordPressAbilitiesTest.php`
- `tests/SdAiAgent/Abilities/WpCliAbilitiesTest.php`

## Worker self-verification

- PHPUnit: Tests: 3559, Assertions: 14815, Errors: 0, Failures: 0, Skipped: 114, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Follow-up to #1921.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.8 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened WordPress option write authorization by implementing a default-deny policy; only plugin-owned options and allowlisted names are permitted to be written or deleted.

* **Tests**
  * Added comprehensive test coverage for option write authorization enforcement across update, delete, PHP execution, and WP-CLI operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->