### PR TITLE
fix(frontend): enable frontend widget by default

### DIFF
--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -379,7 +379,7 @@ class Settings {
 			'max_history_turns'               => 20,
 			'suggestion_count'                => 3,
 			'yolo_mode'                       => false,
-			'show_on_frontend'                => false,
+			'show_on_frontend'                => true,
 			'keyboard_shortcut'               => 'alt+a',
 			'image_generation_size'           => '1024x1024',
 			'image_generation_quality'        => 'standard',

--- a/tests/SdAiAgent/Admin/FloatingWidgetTest.php
+++ b/tests/SdAiAgent/Admin/FloatingWidgetTest.php
@@ -139,7 +139,7 @@ class FloatingWidgetTest extends WP_UnitTestCase {
 	public function test_enqueue_assets_frontend_skips_when_disabled(): void {
 		wp_set_current_user( $this->admin_id );
 
-		// Default settings have show_on_frontend disabled.
+		// Explicitly disabled sites should still skip the frontend widget.
 		Settings::instance()->update( [ 'show_on_frontend' => false ] );
 
 		FloatingWidget::enqueue_assets_frontend();

--- a/tests/SdAiAgent/Core/SettingsTest.php
+++ b/tests/SdAiAgent/Core/SettingsTest.php
@@ -66,6 +66,7 @@ class SettingsTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'temperature', $defaults );
 		$this->assertArrayHasKey( 'max_output_tokens', $defaults );
 		$this->assertArrayHasKey( 'max_history_turns', $defaults );
+		$this->assertArrayHasKey( 'show_on_frontend', $defaults );
 	}
 
 	/**
@@ -81,6 +82,7 @@ class SettingsTest extends WP_UnitTestCase {
 		// and Settings::get_max_output_tokens_for_model(). Was 4096 until sd-ai-7rl.
 		$this->assertSame( 0, $defaults['max_output_tokens'] );
 		$this->assertSame( 20, $defaults['max_history_turns'] );
+		$this->assertTrue( $defaults['show_on_frontend'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Completes the frontend live-preview parent task by flipping the frontend floating widget default on after the reflector pipeline and delivery hardening landed.

- changes `Settings::defaults()` so `show_on_frontend` defaults to `true`
- updates floating widget expectations for the default-on behavior
- adds a settings default regression assertion

## Duplicate check

No exact recent PR already flips `show_on_frontend` to `true`. Related merged PRs were reviewed:

- #1946 explicitly kept `show_on_frontend` unchanged and deferred the default flip.
- #1957, #1958, #1959, #1960, and #1961 shipped the reflector/fallback/hardening phases needed before enabling the widget by default.

## Files changed

- `includes/Core/Settings.php`
- `tests/SdAiAgent/Admin/FloatingWidgetTest.php`
- `tests/SdAiAgent/Core/SettingsTest.php`

## Worker self-verification

- PHPUnit: Tests: 3548, Assertions: 14789, Errors: 0, Failures: 0, Skipped: 114, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Resolves #1947.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.8 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5
