### PR TITLE
fix: allow stock image import by id without keyword

### DIFF
--- a/includes/Abilities/ImageAbilities/StockImageAbility.php
+++ b/includes/Abilities/ImageAbilities/StockImageAbility.php
@@ -74,7 +74,7 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 			'properties' => [
 				'keyword'     => [
 					'type'        => 'string',
-					'description' => 'Search term for finding a relevant stock photo (e.g. "mountain landscape", "coffee shop", "team meeting").',
+					'description' => 'Search term for finding a relevant stock photo (e.g. "mountain landscape", "coffee shop", "team meeting"). Required for search and auto-import; optional when importing a specific provider + image_id.',
 				],
 				'action'      => [
 					'type'        => 'string',
@@ -124,7 +124,7 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 					'description' => 'Subsite URL to import into on multisite (e.g. "https://example.com/mysite"). Omit for the main site.',
 				],
 			],
-			'required'   => [ 'keyword' ],
+			'required'   => [],
 		];
 	}
 
@@ -216,7 +216,9 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 		$height   = (int) ( $input['height'] ?? 800 );
 		$site_url = sanitize_text_field( $input['site_url'] ?? '' );
 
-		if ( empty( $keyword ) ) {
+		$is_specific_import = 'import' === $action && '' !== $image_id && '' !== $provider;
+
+		if ( empty( $keyword ) && ! $is_specific_import ) {
 			return new WP_Error( 'missing_keyword', 'keyword is required.' );
 		}
 
@@ -236,8 +238,9 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 		}
 
 		// ── action=import with specific provider + image_id ───────────────────
-		if ( 'import' === $action && '' !== $image_id && '' !== $provider ) {
-			return $this->handle_import_by_id( $keyword, $provider, $image_id, $width, $height, $site_url );
+		if ( $is_specific_import ) {
+			$import_keyword = '' !== $keyword ? $keyword : $image_id;
+			return $this->handle_import_by_id( $import_keyword, $provider, $image_id, $width, $height, $site_url );
 		}
 
 		// ── Default (auto) / action=import without image_id: original behavior ─

--- a/tests/SdAiAgent/Abilities/StockImageAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/StockImageAbilityTest.php
@@ -86,6 +86,22 @@ class StockImageAbilityTest extends WP_UnitTestCase {
 		$this->assertSame( 'missing_keyword', $result->get_error_code() );
 	}
 
+	/**
+	 * The schema keeps keyword optional so import-by-id calls from a previous
+	 * search result can pass provider + image_id without being rejected before
+	 * execute_callback() applies action-specific validation.
+	 */
+	public function test_schema_does_not_require_keyword_for_import_by_id(): void {
+		$method = new \ReflectionMethod( StockImageAbility::class, 'input_schema' );
+		$method->setAccessible( true );
+
+		/** @var array{required?: list<string>} $schema */
+		$schema = $method->invoke( $this->ability );
+
+		$this->assertArrayHasKey( 'required', $schema );
+		$this->assertNotContains( 'keyword', $schema['required'] );
+	}
+
 	// ─── search mode (action=search) ─────────────────────────────────────────
 
 	/**
@@ -279,6 +295,64 @@ class StockImageAbilityTest extends WP_UnitTestCase {
 		$this->assertSame( 'Photo by Test Author on openverse (CC0)', $stored );
 
 		// Clean up.
+		wp_delete_attachment( $result['attachment_id'], true );
+	}
+
+	/**
+	 * Importing a selected candidate by provider + image_id does not require the
+	 * model to repeat the original keyword; the image ID is used as the fallback
+	 * title/alt base when keyword is omitted.
+	 */
+	public function test_import_mode_with_provider_and_image_id_allows_missing_keyword(): void {
+		$fake_source = new FakeStockImageSource(
+			'openverse',
+			'free',
+			[],
+			[
+				'img-no-keyword' => [
+					'url'         => '',
+					'width'       => 800,
+					'height'      => 600,
+					'author'      => 'Test Author',
+					'author_url'  => 'https://example.com/author',
+					'license'     => 'CC0',
+					'source'      => 'openverse',
+					'attribution' => 'Photo by Test Author on openverse (CC0)',
+				],
+			]
+		);
+
+		$this->set_factory_sources(
+			[
+				'openverse' => $fake_source,
+				'generate'  => new FakeStockImageSource( 'generate', 'api', [] ),
+			]
+		);
+
+		$png_data = base64_decode( 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode -- test fixture
+		$tmp_file = get_temp_dir() . 'stock-test-' . uniqid() . '.png';
+		file_put_contents( $tmp_file, $png_data ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- test fixture
+
+		$fake_source->tmp_file = $tmp_file;
+
+		$result = $this->invoke_execute(
+			[
+				'action'   => 'import',
+				'provider' => 'openverse',
+				'image_id' => 'img-no-keyword',
+			]
+		);
+
+		if ( is_wp_error( $result ) ) {
+			$this->markTestSkipped( 'media_handle_sideload not available: ' . $result->get_error_message() );
+			return;
+		}
+
+		$this->assertIsArray( $result );
+		$this->assertGreaterThan( 0, $result['attachment_id'] );
+		$this->assertSame( 'Img No Keyword', $result['title'] );
+		$this->assertSame( [ 'img-no-keyword' ], $fake_source->downloaded_ids );
+
 		wp_delete_attachment( $result['attachment_id'], true );
 	}
 


### PR DESCRIPTION
## Summary
- Tested the stock-image flow against an existing local WordPress page and confirmed free stock images were imported into the media library, used as local image blocks, and applied as a featured image.
- Fixed the import-by-provider-id path so a selected search candidate can be imported with `provider` + `image_id` even when the model omits `keyword`.
- Added regression tests for the optional keyword schema and keyword-less import fallback title/alt handling.

## Manual test prompt
Ran `wp sd-ai-agent prompt` against local page `post_id=354` asking the agent to add an alpine lake hero image and a coffee cup inline image using free stock images only.

Evidence:
- Agent imported attachment IDs `355` and `356` from Openverse/Flickr.
- Agent updated page `354`, set featured image `355`, and produced valid block markup (`invalidBlocks: 0`).
- `wp post meta get 354 _thumbnail_id` returned `355`.
- Page content uses local media URLs under `/wp-content/uploads/`; no external Openverse thumbnail URLs are embedded.

Regression evidence:
- Before the fix, the prompt produced `ability_invalid_input` when the model called `stock-image` import with `provider` + `image_id` but no `keyword`.
- After the fix, direct runtime verification succeeded for `stock-image` import with no keyword: `attachment_id=358`, `source=flickr`, `has_url=true`.

## Worker self-verification
- PHPUnit: Tests: 3550, Assertions: 14793, Errors: 0, Failures: 0, Skipped: 114, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.8 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5
