### PR TITLE
GH#1982: docs: map contributor insight service surfaces

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -104,6 +104,12 @@ to change, do not answer only in the issue thread. Make the durable repo change:
   or the relevant helper; REST security feedback belongs in root `AGENTS.md`
   plus the concrete controller or ability family; block-theme excerpts belong in
   `includes/Models/skills/wp-block-themes.md`.
+- For service-usage questions, map the named service to the committed integration
+  surfaces before answering. For Google Search Console, inspect
+  `includes/Abilities/GscAbilities.php`, `includes/Core/Settings.php`,
+  `includes/REST/SettingsController.php`, and
+  `includes/Abilities/ToolCapabilities.php` so the response names API calls,
+  credential storage, REST routes, and capability gates.
 - Do not mark contributor-insight issues complete after documentation reading
   alone. A valid fix changes a durable instruction, workflow doc, or helper, then
   verifies the changed guidance with an exact `rg -n` check that future workers

--- a/.agents/scripts/commands/feedback-triage.md
+++ b/.agents/scripts/commands/feedback-triage.md
@@ -103,6 +103,25 @@ Use `get <report_id>` instead when you need the raw JSON payload (rare —
 mostly when crafting an issue body that needs verbatim quotes). The raw
 payload may contain user data; never echo it into chat or commit it.
 
+When a report is a contributor-insight shorthand rather than a direct bug,
+translate each note into committed source surfaces before filing or updating an
+issue. Examples:
+
+- Block-theme or Full Site Editing excerpts headed `Block Themes`, `theme.json`,
+  templates, parts, patterns, or style variations map to
+  `includes/Models/skills/wp-block-themes.md` plus the root `AGENTS.md` summary.
+- REST security shorthand mentioning `sd-ai-agent/v1`, secret scrubbing, current
+  users, file uploads, or WordPress.org readiness maps to root `AGENTS.md`,
+  `includes/REST/`, and the `wp-rest/execute` ability path.
+- Service-usage questions such as "where do we use Google Search Console API?"
+  map to `includes/Abilities/GscAbilities.php`, `includes/Core/Settings.php`,
+  `includes/REST/SettingsController.php`, and
+  `includes/Abilities/ToolCapabilities.php`.
+
+The resulting issue body must name the target files, expected behaviour, and at
+least one verification command; do not leave private local paths or shorthand as
+the only implementation guidance.
+
 Full payload schema (top-level keys):
 
 - `id`, `created_at`, `reviewed_at`, `status`, `report_type`, `api_key_id`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -138,9 +138,35 @@ note to a committed, future-loaded source before editing:
   update `.agents/AGENTS.md`, `.agents/scripts/commands/feedback-triage.md`, or
   the relevant helper so future triage issues include worker-ready files,
   expectations, and verification commands.
+- For service-usage questions such as "where do we use Google Search Console
+  API?", map the question to the concrete integration files before answering or
+  filing follow-up work. For GSC, inspect `includes/Abilities/GscAbilities.php`
+  for API calls and ability IDs, `includes/Core/Settings.php` for credential
+  storage, `includes/REST/SettingsController.php` for credential REST routes,
+  and `includes/Abilities/ToolCapabilities.php` for capability gating.
 - Verification for this class of guidance-only fix should include both:
   `rg -n "Contributor Insight|source mapping|local-path|sd-ai-agent/v1|file upload" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md`
   and `rg -n "wp-block-themes|Full Site Editing|theme.json|validate-block-content" AGENTS.md includes/Models/skills/wp-block-themes.md`.
+
+### Google Search Console API Usage Mapping
+
+The Google Search Console integration lives in these committed surfaces:
+
+- `includes/Abilities/GscAbilities.php` registers `sd-ai-agent/gsc-*` abilities
+  and calls the Search Analytics API endpoint
+  `searchconsole.googleapis.com/webmasters/v3/sites/{siteUrl}/searchAnalytics/query`.
+- `includes/Core/Settings.php` stores credentials in
+  `sd_ai_agent_gsc_credentials`, separate from general settings so the main
+  settings response does not leak secrets.
+- `includes/REST/SettingsController.php` exposes admin-only create/delete routes
+  for `/settings/gsc-credentials` and reports only configured/type/default-site
+  metadata in settings responses.
+- `includes/Abilities/ToolCapabilities.php` gates all `sd-ai-agent/gsc-*`
+  abilities behind `manage_options`.
+
+When changing or auditing this integration, verify both credential secrecy and
+capability gating with `npm run test:php -- --filter=GscAbilitiesTest` plus the
+relevant REST/settings test when a route or settings response changes.
 
 ### Block Theme Automation Guidance
 


### PR DESCRIPTION
## Summary

Updated durable contributor-insight guidance to map service-usage questions to committed integration files, including Google Search Console API surfaces; added matching runtime and feedback-triage guidance.

## Files Changed

.agents/AGENTS.md,.agents/scripts/commands/feedback-triage.md,AGENTS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** rg -n 'Contributor Insight|source mapping|local-path|sd-ai-agent/v1|file upload|Google Search Console' AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md; rg -n 'wp-block-themes|Full Site Editing|theme.json|validate-block-content' AGENTS.md includes/Models/skills/wp-block-themes.md; rg -n 'GscAbilities|gsc-credentials|sd_ai_agent_gsc_credentials|ToolCapabilities|searchconsole.googleapis.com' AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md

Resolves #1982


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.8 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 2m and 74,139 tokens on this as a headless worker.