### PR TITLE
GH#1983: docs: clarify missing read recovery

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -77,8 +77,11 @@ working here in OpenCode headless mode:
   evidence proves the artifact is gone. Compare the requested basename with the
   prior tool output, check for nearby variants such as `reply3` vs `r3`, verify
   tracked paths with `git ls-files '<pattern>'`, and retry `Read` with the
-  corrected path before continuing. Do not stop a headless run solely because one
-  optional screenshot, prompt, or generated artifact path was stale.
+  corrected path before continuing. If the tool error includes a "you mean one
+  of these?" suggestion, verify and read the suggested path first (for example,
+  a failed `phpcs.xml.dist` read that suggests `bootstrap.php`). Do not stop a
+  headless run solely because one optional screenshot, prompt, or generated
+  artifact path was stale.
 - Treat `bash:other` / `Tool execution aborted` as a recoverable command-shape or
   hook failure first. Inspect the preceding command, retry once with a narrower
   non-inline command and a clear `description`, avoid heredocs/process or command

--- a/.agents/scripts/commands/feedback-triage.md
+++ b/.agents/scripts/commands/feedback-triage.md
@@ -183,8 +183,10 @@ before creating the issue:
 - If recurring tool errors mention `read:file_not_found`, require durable worker
   guidance to treat the missing path as a recoverable mismatch: compare the
   requested basename with the previous tool output, check nearby names such as
-  `reply3` vs `r3`, use `git ls-files '<pattern>'` for tracked files, then retry
-  `Read` before continuing with the next safe implementation step.
+  `reply3` vs `r3`, follow any "you mean one of these?" suggested path (for
+  example `phpcs.xml.dist` → `bootstrap.php`), use `git ls-files '<pattern>'`
+  for tracked files, then retry `Read` before continuing with the next safe
+  implementation step.
 - If recurring tool errors mention `bash:file_not_found`, `gh-signature-helper.sh
   invocation failed`, `signature gate`, or blocked `gh` writes, require durable
   worker guidance to create the issue/PR/comment body as an existing stable file,
@@ -272,7 +274,8 @@ output and visible to claim routines:
 If any referenced screenshot, prompt, or generated artifact returns
 `read:file_not_found`, do a bounded recovery pass before filing or abandoning the
 triage issue: compare the requested basename with the tool output that introduced
-it, verify tracked repository paths with `git ls-files '<pattern>'`, inspect the
+it, follow any "you mean one of these?" nearby-path hint from the tool error,
+verify tracked repository paths with `git ls-files '<pattern>'`, inspect the
 known parent directory for nearby runtime-artifact names, and retry `Read` with
 the corrected path. If the artifact still cannot be found, include the attempted
 paths in the issue body and continue with the available session evidence instead

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,6 +196,10 @@ completion state:
 - Re-check the exact path and basename against the previous tool output before
   assuming the artifact is unavailable; common failures include `reply3` vs
   `r3`, omitted extensions, and stale `/tmp/opencode/` filenames.
+- When the read tool reports a nearby-path hint such as "you mean one of
+  these?", treat that hint as the next recovery target. For example, if reading
+  `phpcs.xml.dist` fails but the tool suggests `bootstrap.php`, verify and read
+  the suggested path before concluding the file is unavailable.
 - For tracked repository files, verify the path with `git ls-files '<pattern>'`
   before retrying `Read`; for untracked/runtime artifacts, inspect the known
   parent directory or rerun the command that generated the artifact.


### PR DESCRIPTION
## Summary

Clarified durable headless read:file_not_found recovery guidance in root AGENTS.md, .agents/AGENTS.md, and feedback-triage SOP so workers follow nearby "you mean one of these?" path hints such as phpcs.xml.dist to bootstrap.php before treating an artifact as unavailable.

## Files Changed

.agents/AGENTS.md,.agents/scripts/commands/feedback-triage.md,AGENTS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** rg -n "read:file_not_found|missing-file reads|git ls-files|you mean one of these|phpcs\.xml\.dist|bootstrap\.php|signature gate|body-file" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md

Resolves #1983


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.8 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 1m and 53,380 tokens on this as a headless worker.