### PR TITLE
GH#1987: docs: include option prefix allowlist verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -467,7 +467,7 @@ reads option data:**
 **Verification (must run for any PR that touches option reads or writes):**
 
 ```bash
-rg -n "is_secret_option_name|is_write_allowed_option|SECRET_REDACTED_PLACEHOLDER|sd_ai_agent_option_secret_redacted|sd_ai_agent_options_write_allowlist|sd_ai_agent_options_read_blocklist" includes/ tests/
+rg -n "is_secret_option_name|is_write_allowed_option|get_write_allowlist_prefixes|SECRET_REDACTED_PLACEHOLDER|sd_ai_agent_option_secret_redacted|sd_ai_agent_options_write_allowlist|sd_ai_agent_options_write_allowlist_prefixes|sd_ai_agent_options_read_blocklist" includes/ tests/
 npm run test:php -- --filter='OptionsAbilitiesTest|WordPressAbilitiesTest|DatabaseAbilitiesTest|WpCliAbilitiesTest'
 ```
 


### PR DESCRIPTION
## Summary

Updated the Secret-Option Read Blocklist verification grep in AGENTS.md to include get_write_allowlist_prefixes and sd_ai_agent_options_write_allowlist_prefixes.

## Files Changed

AGENTS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** rg -n "is_secret_option_name|is_write_allowed_option|get_write_allowlist_prefixes|SECRET_REDACTED_PLACEHOLDER|sd_ai_agent_option_secret_redacted|sd_ai_agent_options_write_allowlist|sd_ai_agent_options_write_allowlist_prefixes|sd_ai_agent_options_read_blocklist" includes/ tests/

Resolves #1987


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.8 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 1m and 58,593 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development verification guidance documentation with expanded configuration option coverage validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->