### PR TITLE
fix: strip wporg compatibility shims

### DIFF
--- a/.distignore-wporg
+++ b/.distignore-wporg
@@ -14,6 +14,7 @@
 #  - SD_AI_AGENT_FEATURE_BENCHMARK               (WP-CLI benchmark with arbitrary --log-dir)
 #  - SD_AI_AGENT_FEATURE_USER_MANAGEMENT         (custom user create / role change)
 #  - SD_AI_AGENT_FEATURE_FILE_WRITE              (git-tracking source package snapshots)
+#  - WP 6.9 compatibility shims                 (WP.org build requires WP 7.0)
 #
 # Note: the PLUGIN_STATE_CHANGES and PLUGIN_INSTALL_FROM_URL gates only
 # remove individual `wp_register_ability()` calls inside
@@ -148,3 +149,11 @@ includes/Benchmark
 # .distignore but listed here for documentation completeness.
 # tests/SdAiAgent/Benchmark
 # tests/benchmark
+
+# ── WordPress 6.9 compatibility shims ────────────────────────────────────────
+# The WP.org build requires WordPress 7.0+, where the AI Client SDK,
+# wp_ai_client_prompt(), and Connectors API are provided by core. Strip the
+# bundled WP 6.9 bridge/polyfill code from the submitted zip so automated
+# WordPress.org review sees only the native WP 7.0 integration path.
+includes/Compat
+lib/php-ai-client

--- a/.github/scripts/validate-wporg-build-flags.py
+++ b/.github/scripts/validate-wporg-build-flags.py
@@ -110,6 +110,23 @@ def main() -> int:
                 f"bin/build.sh stripped_paths entry {source_rel} is missing from .distignore-wporg."
             )
 
+    if "Requires at least: 7.0" not in script:
+        failures.append(
+            "bin/build.sh must force the WP.org package header to Requires at least: 7.0 "
+            "when stripping WP 6.9 compatibility shims."
+        )
+
+    for required_entry in ("includes/Compat", "lib/php-ai-client"):
+        if required_entry not in dist_entries:
+            failures.append(
+                f".distignore-wporg is missing {required_entry}; WP.org builds must strip WP 6.9 compatibility shims."
+            )
+        if f"${{dest}}/{required_entry}" not in stripped:
+            failures.append(
+                f"bin/build.sh stripped_paths is missing ${{dest}}/{required_entry}; "
+                "the build must fail if a compatibility shim leaks into the WP.org package."
+            )
+
     feature_constant = re.compile(r"SD_AI_AGENT_FEATURE_[A-Z0-9_]+")
     for entry in sorted(dist_entries):
         if not entry.startswith("includes/Abilities/"):

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -15,7 +15,8 @@
 #            Ultimate Multisite channel. Output:
 #               superdav-ai-agent-{version}.zip
 #
-#   wporg  — WordPress.org-compliant zip. Strips source files for the AI
+#   wporg  — WordPress.org-compliant zip. Requires WordPress 7.0+ and strips
+#            the WP 6.9 compatibility shims. Also strips source files for the AI
 #            plugin builder (generate / sandbox / activate / update), for
 #            WP-CLI custom tools, the block-theme scaffolder ability that
 #            writes executable theme code, and the git-tracking source-package
@@ -259,6 +260,23 @@ EXTRA
 			fi
 		done
 
+		# The WP.org package intentionally requires WordPress 7.0+. Native core
+		# provides the AI Client SDK, wp_ai_client_prompt(), and Connectors API, so
+		# the bundled WP 6.9 compatibility shims are stripped from this build.
+		sed -i.bak \
+			-e 's/^ \* Requires at least:.*/ * Requires at least: 7.0/' \
+			-e '/use SdAiAgent\\Compat\\AiBridgeLoader;/d' \
+			-e '/use SdAiAgent\\Compat\\GutenbergConnectorsBridge;/d' \
+			-e '/use SdAiAgent\\Compat\\SdkLoader;/d' \
+			-e '/^\/\/ Phase 1 (t227): Register the bundled wordpress\/php-ai-client SDK autoloader\./,/^add_action( '\''plugins_loaded'\'', \[ GutenbergConnectorsBridge::class, '\''force_load_connectors_subsystem'\'' \], 1 );/d' \
+			"$main_file"
+		rm -f "${main_file}.bak"
+
+		if ! grep -q '^ \* Requires at least: 7.0$' "$main_file"; then
+			echo "ERROR: failed to force Requires at least: 7.0 in wporg build." >&2
+			return 1
+		fi
+
 		# The GitTrackingHandler class is stripped below. Remove it from the
 		# bundled module handler list so the DI bootstrap never attempts to reflect
 		# a class that is intentionally absent from the WP.org package.
@@ -271,8 +289,37 @@ EXTRA
 			rm -f "${plugin_module}.bak"
 		fi
 
+		# The WP 6.9 Gutenberg Connectors bridge class is stripped below. Remove
+		# the admin-only fallback hook from the bundled handler so the DI bootstrap
+		# never references a compatibility class that is absent from the WP.org zip.
+		local admin_handler="${dest}/includes/Bootstrap/AdminHandler.php"
+		if [ -f "$admin_handler" ]; then
+			python3 - "$admin_handler" <<'PYADMIN'
+import pathlib
+import re
+import sys
+
+p = pathlib.Path(sys.argv[1])
+src = p.read_text()
+src = src.replace("use SdAiAgent\\Compat\\GutenbergConnectorsBridge;\n", "")
+pattern = re.compile(
+    r"\n\t/\*\*\n\t \* Belt-and-braces fallback for the Gutenberg Connectors page on WP 6\.9\..*?\n\t\}\n",
+    re.DOTALL,
+)
+new_src, count = pattern.subn("\n", src, count=1)
+if count != 1:
+    sys.stderr.write(
+        "ERROR: failed to remove Gutenberg Connectors bridge hook from AdminHandler.php.\n"
+    )
+    sys.exit(1)
+p.write_text(new_src)
+PYADMIN
+		fi
+
 		# Sanity-check that the gated source files were actually removed.
 		local stripped_paths=(
+			"${dest}/includes/Compat"
+			"${dest}/lib/php-ai-client"
 			"${dest}/includes/PluginBuilder"
 			"${dest}/includes/Abilities/GeneratePluginAbility.php"
 			"${dest}/includes/Abilities/SandboxActivatePluginAbility.php"
@@ -305,7 +352,7 @@ EXTRA
 				return 1
 			fi
 		done
-		echo "    Stripped plugin-builder + theme-scaffolder + git-tracking source files and forced feature flags to false."
+		echo "    Stripped WP 6.9 compatibility shims, plugin-builder + theme-scaffolder + git-tracking source files, forced feature flags to false, and set Requires at least to 7.0."
 
 		# ── Neutralise forbidden move_uploaded_file() in bundled PSR-7 ───────
 		# WP.org's plugin-check tool hard-fails on any literal occurrence of


### PR DESCRIPTION
## Summary

- Strip WP 6.9 compatibility shims from the WP.org package by excluding `includes/Compat` and `lib/php-ai-client`.
- Rewrite the bundled WP.org plugin header to `Requires at least: 7.0`.
- Remove copied compat imports/hooks from the WP.org build and add validator coverage so the shim exclusions stay enforced.

## Verification

- `bash -n bin/build.sh`
- `shellcheck bin/build.sh`
- `python3 .github/scripts/validate-wporg-build-flags.py`
- `bin/build.sh --target=wporg`
- Zip inspection confirmed `Requires at least: 7.0`, no `includes/Compat`, no `lib/php-ai-client`, and no bundled compat bridge references.
- `npm run verify`

## Worker self-verification

- PHPUnit: Tests: 3561, Assertions: 14823, Errors: 0, Failures: 0, Skipped: 114, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.8 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5
