### PR TITLE
Fix AgentLoop tool call activity logs

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -119,7 +119,13 @@ class AgentLoop {
 	private $model_id;
 
 	/** @var list<array<string, mixed>> Logged tool call activity. */
-	private $tool_call_log = array();
+	private array $tool_call_log = array();
+
+	/** @var list<array<string, mixed>> Assistant channel messages separate from real tool calls. */
+	private array $message_log = array();
+
+	/** @var int Monotonic sequence for merging tool calls and channel messages in UI order. */
+	private int $activity_sequence = 0;
 
 	/** @var array<int, array<string, mixed>> Posts that still require block-validation repair. */
 	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase -- Project property naming guidance requires camelCase.
@@ -196,9 +202,9 @@ class AgentLoop {
 	/**
 	 * Optional callback invoked after each tool call/response pair.
 	 *
-	 * Signature: function( list<array<string, mixed>> $tool_call_log ): void
+	 * Signature: function( list<array<string, mixed>> $tool_call_log, list<array<string, mixed>> $message_log ): void
 	 * Used by the job system to write live progress to the transient so the
-	 * polling frontend can show tool activity before the loop completes.
+	 * polling frontend can show tool activity and channel messages before the loop completes.
 	 *
 	 * @var callable|null
 	 */
@@ -326,9 +332,10 @@ class AgentLoop {
 		$raw_perms              = $options['tool_permissions'] ?? ( $settings['tool_permissions'] ?? null );
 		$this->tool_permissions = is_array( $raw_perms ) ? $raw_perms : array();
 		// @phpstan-ignore-next-line
-		$this->yolo_mode = (bool) ( $options['yolo_mode'] ?? ( $settings['yolo_mode'] ?? false ) );
-		// @phpstan-ignore-next-line
-		$this->tool_call_log = $options['tool_call_log'] ?? array();
+		$this->yolo_mode         = (bool) ( $options['yolo_mode'] ?? ( $settings['yolo_mode'] ?? false ) );
+		$this->tool_call_log     = self::normalize_activity_log( $options['tool_call_log'] ?? array() );
+		$this->message_log       = self::normalize_activity_log( $options['message_log'] ?? array() );
+		$this->activity_sequence = $this->get_max_activity_sequence( $this->tool_call_log, $this->message_log );
 		// @phpstan-ignore-next-line
 		$this->session_id = (int) ( $options['session_id'] ?? 0 );
 		// Active job UUID for heartbeat and shutdown-handler updates.
@@ -586,12 +593,19 @@ class AgentLoop {
 
 			// Log the client tool responses for transparency.
 			foreach ( $results as $result ) {
+				$id   = (string) ( $result['id'] ?? '' );
+				$name = (string) ( $result['name'] ?? '' );
+				if ( '' === $id || '' === $name ) {
+					continue;
+				}
+
 				$this->tool_call_log[] = array(
 					'type'     => 'response',
-					'id'       => (string) ( $result['id'] ?? '' ),
-					'name'     => (string) ( $result['name'] ?? '' ),
+					'id'       => $id,
+					'name'     => $name,
 					'response' => $result['result'] ?? $result['error'] ?? null,
 					'source'   => 'client',
+					'sequence' => $this->next_activity_sequence(),
 				);
 			}
 
@@ -605,6 +619,29 @@ class AgentLoop {
 		} finally {
 			AgentEventLog::clear_session();
 		}
+	}
+
+	/**
+	 * Attach channel/message logs to a terminal loop payload.
+	 *
+	 * @param array<string, mixed> $payload Base result payload.
+	 * @return array<string, mixed>
+	 */
+	private function with_result_logs( array $payload ): array {
+		$payload['messages'] = $this->message_log;
+		return $payload;
+	}
+
+	/**
+	 * Attach resumable channel/message logs to a paused loop payload.
+	 *
+	 * @param array<string, mixed> $payload Base pause payload.
+	 * @return array<string, mixed>
+	 */
+	private function with_paused_logs( array $payload ): array {
+		$payload['message_log'] = $this->message_log;
+		$payload['messages']    = $this->message_log;
+		return $payload;
 	}
 
 	/**
@@ -648,17 +685,19 @@ class AgentLoop {
 					)
 				);
 
-				return array(
-					'reply'           => __(
-						'This request took longer than expected and was stopped to protect your usage budget. You can continue the conversation to pick up where it left off.',
-						'superdav-ai-agent'
-					),
-					'history'         => $this->serialize_history(),
-					'tool_calls'      => $this->tool_call_log,
-					'token_usage'     => $this->token_usage,
-					'iterations_used' => $this->iterations_used,
-					'model_id'        => $this->model_id,
-					'exit_reason'     => 'timeout',
+				return $this->with_result_logs(
+					array(
+						'reply'           => __(
+							'This request took longer than expected and was stopped to protect your usage budget. You can continue the conversation to pick up where it left off.',
+							'superdav-ai-agent'
+						),
+						'history'         => $this->serialize_history(),
+						'tool_calls'      => $this->tool_call_log,
+						'token_usage'     => $this->token_usage,
+						'iterations_used' => $this->iterations_used,
+						'model_id'        => $this->model_id,
+						'exit_reason'     => 'timeout',
+					)
 				);
 			}
 
@@ -734,6 +773,12 @@ class AgentLoop {
 			// so an unrelated later truncation doesn't inherit prior state.
 			$this->preamble_truncation_retries = 0;
 
+			// Some providers/models emit the same function call more than once in
+			// a single assistant response when they are hedging. Unless there is an
+			// explicit parallel identifier, execute only the first identical
+			// name+arguments pair so metrics and provider time reflect real work.
+			$assistant_message = $this->deduplicate_tool_calls( $assistant_message );
+
 			// Split multi-part assistant messages so each function_call lives
 			// in its own ModelMessage. The OpenAI Responses API rejects
 			// "function_call + other part" shapes (see
@@ -805,14 +850,16 @@ class AgentLoop {
 				$reply = $this->inject_real_permalinks( $reply );
 
 				return $this->inject_inability_data(
-				array(
-					'reply'           => $reply,
-					'history'         => $this->serialize_history(),
-					'tool_calls'      => $this->tool_call_log,
-					'token_usage'     => $this->token_usage,
-					'iterations_used' => $this->iterations_used,
-					'model_id'        => $this->model_id,
-				)
+					$this->with_result_logs(
+						array(
+							'reply'           => $reply,
+							'history'         => $this->serialize_history(),
+							'tool_calls'      => $this->tool_call_log,
+							'token_usage'     => $this->token_usage,
+							'iterations_used' => $this->iterations_used,
+							'model_id'        => $this->model_id,
+						)
+					)
 				);
 			}
 
@@ -850,6 +897,7 @@ class AgentLoop {
 						$paused_state = array(
 							'history'              => $this->serialize_history(),
 							'tool_call_log'        => $this->tool_call_log,
+							'message_log'          => $this->message_log,
 							'token_usage'          => $this->token_usage,
 							'iterations_remaining' => $iterations,
 							'model_id'             => $this->model_id,
@@ -860,14 +908,16 @@ class AgentLoop {
 					}
 
 					// Return pending client tool calls to the browser.
-					return array(
-						'pending_client_tool_calls' => $partition['client'],
-						'history'                   => $this->serialize_history(),
-						'tool_call_log'             => $this->tool_call_log,
-						'token_usage'               => $this->token_usage,
-						'iterations_remaining'      => $iterations,
-						'iterations_used'           => $this->iterations_used,
-						'model_id'                  => $this->model_id,
+					return $this->with_paused_logs(
+						array(
+							'pending_client_tool_calls' => $partition['client'],
+							'history'                   => $this->serialize_history(),
+							'tool_call_log'             => $this->tool_call_log,
+							'token_usage'               => $this->token_usage,
+							'iterations_remaining'      => $iterations,
+							'iterations_used'           => $this->iterations_used,
+							'model_id'                  => $this->model_id,
+						)
 					);
 				}
 			}
@@ -876,15 +926,17 @@ class AgentLoop {
 			$confirm_needed = $this->permission_resolver->get_tools_needing_confirmation( $assistant_message );
 
 			if ( ! empty( $confirm_needed ) ) {
-				return array(
-					'awaiting_confirmation' => true,
-					'pending_tools'         => $confirm_needed,
-					'history'               => $this->serialize_history(),
-					'tool_call_log'         => $this->tool_call_log,
-					'token_usage'           => $this->token_usage,
-					'iterations_remaining'  => $iterations,
-					'iterations_used'       => $this->iterations_used,
-					'model_id'              => $this->model_id,
+				return $this->with_paused_logs(
+					array(
+						'awaiting_confirmation' => true,
+						'pending_tools'         => $confirm_needed,
+						'history'               => $this->serialize_history(),
+						'tool_call_log'         => $this->tool_call_log,
+						'token_usage'           => $this->token_usage,
+						'iterations_remaining'  => $iterations,
+						'iterations_used'       => $this->iterations_used,
+						'model_id'              => $this->model_id,
+					)
 				);
 			}
 
@@ -906,6 +958,7 @@ class AgentLoop {
 					$paused_state = array(
 						'history'              => $this->serialize_history(),
 						'tool_call_log'        => $this->tool_call_log,
+						'message_log'          => $this->message_log,
 						'token_usage'          => $this->token_usage,
 						'iterations_remaining' => $iterations,
 						'model_id'             => $this->model_id,
@@ -915,14 +968,16 @@ class AgentLoop {
 					Database::save_paused_state( $this->session_id, $paused_state );
 				}
 
-				return array(
-					'pending_proposal'     => $pending_proposal,
-					'history'              => $this->serialize_history(),
-					'tool_call_log'        => $this->tool_call_log,
-					'token_usage'          => $this->token_usage,
-					'iterations_remaining' => $iterations,
-					'iterations_used'      => $this->iterations_used,
-					'model_id'             => $this->model_id,
+				return $this->with_paused_logs(
+					array(
+						'pending_proposal'     => $pending_proposal,
+						'history'              => $this->serialize_history(),
+						'tool_call_log'        => $this->tool_call_log,
+						'token_usage'          => $this->token_usage,
+						'iterations_remaining' => $iterations,
+						'iterations_used'      => $this->iterations_used,
+						'model_id'             => $this->model_id,
+					)
 				);
 			}
 
@@ -955,17 +1010,19 @@ class AgentLoop {
 					)
 				);
 
-				return array(
-					'reply'           => __(
-						'I\'ve been repeating the same operations without making progress. Here\'s what I found so far. Try rephrasing your request or providing more specifics.',
-						'superdav-ai-agent'
-					),
-					'history'         => $this->serialize_history(),
-					'tool_calls'      => $this->tool_call_log,
-					'token_usage'     => $this->token_usage,
-					'iterations_used' => $this->iterations_used,
-					'model_id'        => $this->model_id,
-					'exit_reason'     => 'spin_detected',
+				return $this->with_result_logs(
+					array(
+						'reply'           => __(
+							'I\'ve been repeating the same operations without making progress. Here\'s what I found so far. Try rephrasing your request or providing more specifics.',
+							'superdav-ai-agent'
+						),
+						'history'         => $this->serialize_history(),
+						'tool_calls'      => $this->tool_call_log,
+						'token_usage'     => $this->token_usage,
+						'iterations_used' => $this->iterations_used,
+						'model_id'        => $this->model_id,
+						'exit_reason'     => 'spin_detected',
+					)
 				);
 			}
 		}
@@ -1004,14 +1061,16 @@ class AgentLoop {
 				$reply = $this->inject_real_permalinks( $reply );
 
 				return $this->inject_inability_data(
-				[
-					'reply'           => $reply,
-					'history'         => $this->serialize_history(),
-					'tool_calls'      => $this->tool_call_log,
-					'token_usage'     => $this->token_usage,
-					'iterations_used' => $this->iterations_used,
-					'model_id'        => $this->model_id,
-				]
+					$this->with_result_logs(
+						array(
+							'reply'           => $reply,
+							'history'         => $this->serialize_history(),
+							'tool_calls'      => $this->tool_call_log,
+							'token_usage'     => $this->token_usage,
+							'iterations_used' => $this->iterations_used,
+							'model_id'        => $this->model_id,
+						)
+					)
 				);
 			}
 		}
@@ -1036,12 +1095,14 @@ class AgentLoop {
 				__( 'Agent reached the maximum of %d iterations without completing.', 'superdav-ai-agent' ),
 				$this->max_iterations
 			),
-			array(
-				'tool_calls'      => $this->tool_call_log,
-				'token_usage'     => $this->token_usage,
-				'iterations_used' => $this->iterations_used,
-				'model_id'        => $this->model_id,
-				'history'         => $this->serialize_history(),
+			$this->with_result_logs(
+				array(
+					'tool_calls'      => $this->tool_call_log,
+					'token_usage'     => $this->token_usage,
+					'iterations_used' => $this->iterations_used,
+					'model_id'        => $this->model_id,
+					'history'         => $this->serialize_history(),
+				)
 			)
 		);
 	}
@@ -1387,13 +1448,14 @@ class AgentLoop {
 			$this->provider_retry_max_attempts
 		);
 
-		$this->tool_call_log[] = [
+		$this->message_log[] = [
 			'type'         => 'provider_retry',
 			'message'      => $message,
 			'status_code'  => $status_code,
 			'attempt'      => $next_attempt,
 			'max_attempts' => $this->provider_retry_max_attempts,
 			'delay'        => $delay,
+			'sequence'     => $this->next_activity_sequence(),
 		];
 		$this->fire_progress();
 	}
@@ -1444,6 +1506,7 @@ class AgentLoop {
 				[
 					'history'          => $this->serialize_history(),
 					'tool_call_log'    => $this->tool_call_log,
+					'message_log'      => $this->message_log,
 					'token_usage'      => $this->token_usage,
 					'model_id'         => $this->model_id,
 					'provider_id'      => $this->provider_id,
@@ -1456,14 +1519,16 @@ class AgentLoop {
 		return new WP_Error(
 			'sd_ai_agent_provider_retry_failed',
 			$message,
-			[
-				'tool_calls'      => $this->tool_call_log,
-				'token_usage'     => $this->token_usage,
-				'iterations_used' => $this->iterations_used,
-				'model_id'        => $this->model_id,
-				'history'         => $this->serialize_history(),
-				'elapsed_seconds' => $elapsed_seconds,
-			]
+			$this->with_result_logs(
+				[
+					'tool_calls'      => $this->tool_call_log,
+					'token_usage'     => $this->token_usage,
+					'iterations_used' => $this->iterations_used,
+					'model_id'        => $this->model_id,
+					'history'         => $this->serialize_history(),
+					'elapsed_seconds' => $elapsed_seconds,
+				]
+			)
 		);
 	}
 
@@ -1810,45 +1875,235 @@ class AgentLoop {
 
 	// ── Tool call logging ─────────────────────────────────────────────────
 
+	// Tool-call entries and assistant channel messages share a monotonic
+	// sequence so the live UI can merge them without polluting tool_calls.
 	/**
-	 * Log tool calls (and any preceding/interleaved assistant text) from an
-	 * assistant message for transparency.
+	 * Return the next chronological activity sequence number.
 	 *
-	 * Some models — Claude in particular, but also many OpenAI- and
-	 * Anthropic-derived chat-completion responses — emit a short "preamble"
-	 * text part in the same message as their tool calls (for example
-	 * "Looking up your recent posts first…" immediately followed by a
-	 * function call for list-posts). Without surfacing this text in the live
-	 * progress stream the chat UI shows the tool card with no human-readable
-	 * context for why the model is making that call. Logging text parts here
-	 * — interleaved with call parts in original order — lets the polling
-	 * frontend render the assistant's running commentary above each tool
-	 * card while the loop is still executing.
+	 * @return int Next sequence number.
+	 */
+	private function next_activity_sequence(): int {
+		++$this->activity_sequence;
+		return $this->activity_sequence;
+	}
+
+	/**
+	 * Normalise a persisted activity log into string-keyed entries.
 	 *
-	 * The text part also remains in `$this->history` via the assistant
-	 * message that is appended in the main run loop, so the final persisted
-	 * assistant message still owns the canonical text content. The frontend
-	 * filters preamble entries out of finalised messages via the function-
-	 * call id pairing in {@see associateToolCallsWithMessages}, so there is
-	 * no double-rendering on reload.
+	 * @param mixed $raw Raw option/state value.
+	 * @return list<array<string, mixed>> Normalised activity entries.
+	 */
+	private static function normalize_activity_log( $raw ): array {
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+
+		$normalized = array();
+		foreach ( $raw as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$normalized_entry = array();
+			foreach ( $entry as $key => $value ) {
+				if ( is_string( $key ) ) {
+					$normalized_entry[ $key ] = $value;
+				}
+			}
+
+			if ( ! empty( $normalized_entry ) ) {
+				$normalized[] = $normalized_entry;
+			}
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Find the highest existing activity sequence across resumable logs.
+	 *
+	 * @param array<int, array<string, mixed>> ...$logs Existing activity logs.
+	 * @return int Highest sequence found, or 0.
+	 */
+	private function get_max_activity_sequence( array ...$logs ): int {
+		$max = 0;
+		foreach ( $logs as $log ) {
+			foreach ( $log as $entry ) {
+				$sequence = $entry['sequence'] ?? null;
+				if ( is_numeric( $sequence ) ) {
+					$max = max( $max, (int) $sequence );
+				}
+			}
+		}
+
+		return $max;
+	}
+
+	/**
+	 * Remove identical tool calls from one assistant turn before dispatch.
+	 *
+	 * @param Message $message Assistant message returned by the provider.
+	 * @return Message Message with duplicate function calls removed.
+	 */
+	private function deduplicate_tool_calls( Message $message ): Message {
+		$parts       = $message->getParts();
+		$seen        = array();
+		$deduped     = array();
+		$removed     = 0;
+		$has_changes = false;
+
+		foreach ( $parts as $part ) {
+			$call = $part->getFunctionCall();
+			if ( ! $call ) {
+				$deduped[] = $part;
+				continue;
+			}
+
+			$key = $this->build_tool_call_dedupe_key( $call );
+			if ( '' !== $key && ! $this->tool_call_has_parallel_intent( $call ) ) {
+				if ( isset( $seen[ $key ] ) ) {
+					++$removed;
+					$has_changes = true;
+					continue;
+				}
+				$seen[ $key ] = true;
+			}
+
+			$deduped[] = $part;
+		}
+
+		if ( ! $has_changes ) {
+			return $message;
+		}
+
+		$this->message_log[] = array(
+			'type'     => 'event',
+			'reason'   => 'tool_call_deduplicated',
+			'count'    => $removed,
+			'sequence' => $this->next_activity_sequence(),
+		);
+
+		// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Required operational observability line for duplicate tool-call suppression.
+		error_log( '[Superdav AI Agent] event=tool_call_deduplicated count=' . $removed );
+
+		AgentEventLog::log(
+			'tool_call_deduplicated',
+			AgentEventLog::SEVERITY_INFO,
+			array(
+				'session_id'  => $this->session_id,
+				'model_id'    => (string) $this->model_id,
+				'provider_id' => (string) $this->provider_id,
+			)
+		);
+
+		return new ModelMessage( $deduped );
+	}
+
+	/**
+	 * Build the per-iteration duplicate key for a function call.
+	 *
+	 * @param FunctionCall $call Function call DTO.
+	 * @return string Stable duplicate key, or empty string when not comparable.
+	 */
+	private function build_tool_call_dedupe_key( FunctionCall $call ): string {
+		$name = (string) $call->getName();
+		if ( '' === $name ) {
+			return '';
+		}
+
+		$args_json = wp_json_encode( self::canonicalize_tool_call_args( $call->getArgs() ) );
+		if ( ! is_string( $args_json ) ) {
+			$args_json = '';
+		}
+
+		return $name . "\n" . $args_json;
+	}
+
+	/**
+	 * Canonicalise arrays so semantically identical argument objects hash equally.
+	 *
+	 * @param mixed $value Raw function-call arguments.
+	 * @return mixed Canonicalised value.
+	 */
+	private static function canonicalize_tool_call_args( $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		if ( ! array_is_list( $value ) ) {
+			ksort( $value );
+		}
+
+		foreach ( $value as $key => $item ) {
+			$value[ $key ] = self::canonicalize_tool_call_args( $item );
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Whether a call carries an explicit provider/model signal to keep duplicates parallel.
+	 *
+	 * @param FunctionCall $call Function call DTO.
+	 * @return bool True when the call should not be deduped.
+	 */
+	private function tool_call_has_parallel_intent( FunctionCall $call ): bool {
+		$args = $call->getArgs();
+		if ( ! is_array( $args ) ) {
+			return false;
+		}
+
+		foreach ( array( 'parallel_id', 'parallelId', 'parallel_group', 'parallelGroup' ) as $key ) {
+			if ( ! array_key_exists( $key, $args ) ) {
+				continue;
+			}
+
+			$value = $args[ $key ];
+			if ( is_scalar( $value ) && '' !== (string) $value ) {
+				return true;
+			}
+			if ( null !== $value && ! is_scalar( $value ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Log real tool calls and separate any assistant preamble text.
+	 *
+	 * Some models emit short narration in the same assistant message as a tool
+	 * call. The narration belongs in the message log, not `tool_calls`, so
+	 * usage dashboards and run summaries can count only real tool activity while
+	 * the live UI can still merge both streams by sequence.
+	 *
+	 * @param Message $message Assistant message to inspect.
 	 */
 	private function log_tool_calls( Message $message ): void {
 		foreach ( $message->getParts() as $part ) {
 			$text = $part->getText();
 			if ( is_string( $text ) && '' !== trim( $text ) ) {
-				$this->tool_call_log[] = array(
-					'type' => 'preamble',
-					'text' => $text,
+				$this->message_log[] = array(
+					'type'     => 'preamble',
+					'text'     => $text,
+					'sequence' => $this->next_activity_sequence(),
 				);
 			}
 
 			$call = $part->getFunctionCall();
 			if ( $call ) {
+				$name = (string) $call->getName();
+				if ( '' === $name ) {
+					continue;
+				}
+
 				$this->tool_call_log[] = array(
-					'type' => 'call',
-					'id'   => $call->getId(),
-					'name' => $call->getName(),
-					'args' => $call->getArgs(),
+					'type'     => 'call',
+					'id'       => $call->getId(),
+					'name'     => $name,
+					'args'     => $call->getArgs(),
+					'sequence' => $this->next_activity_sequence(),
 				);
 			}
 		}
@@ -1972,12 +2227,13 @@ class AgentLoop {
 			$tool_name
 		);
 
-		$this->tool_call_log[] = array(
+		$this->message_log[] = array(
 			'type'       => 'event',
 			'reason'     => 'truncated_tool_call',
 			'name'       => $tool_name,
 			'max_tokens' => $cap,
 			'message'    => $guidance,
+			'sequence'   => $this->next_activity_sequence(),
 		);
 
 		AgentEventLog::log(
@@ -2015,11 +2271,12 @@ class AgentLoop {
 			$cap
 		);
 
-		$this->tool_call_log[] = array(
+		$this->message_log[] = array(
 			'type'       => 'event',
 			'reason'     => 'truncated_before_tool_call',
 			'max_tokens' => $cap,
 			'message'    => $guidance,
+			'sequence'   => $this->next_activity_sequence(),
 		);
 
 		AgentEventLog::log(
@@ -2071,8 +2328,10 @@ class AgentLoop {
 				$cap
 			),
 			array(
-				'cap'     => $cap,
-				'retries' => $this->preamble_truncation_retries,
+				'cap'        => $cap,
+				'retries'    => $this->preamble_truncation_retries,
+				'tool_calls' => $this->tool_call_log,
+				'messages'   => $this->message_log,
 			)
 		);
 	}
@@ -2134,13 +2393,19 @@ class AgentLoop {
 		foreach ( $message->getParts() as $part ) {
 			$response = $part->getFunctionResponse();
 			if ( $response ) {
-				$this->track_block_validation_response( $response->getName(), $response->getResponse() );
+				$name = (string) $response->getName();
+				if ( '' === $name ) {
+					continue;
+				}
+
+				$this->track_block_validation_response( $name, $response->getResponse() );
 
 				$this->tool_call_log[] = array(
 					'type'     => 'response',
 					'id'       => $response->getId(),
-					'name'     => $response->getName(),
+					'name'     => $name,
 					'response' => $response->getResponse(),
+					'sequence' => $this->next_activity_sequence(),
 				);
 			}
 		}
@@ -2218,10 +2483,11 @@ class AgentLoop {
 
 		$this->history[] = new UserMessage( array( new MessagePart( implode( "\n", $lines ) ) ) );
 
-		$this->tool_call_log[] = array(
-			'type'    => 'guardrail',
-			'reason'  => 'block_validation_repair_required',
-			'pending' => $pending,
+		$this->message_log[] = array(
+			'type'     => 'guardrail',
+			'reason'   => 'block_validation_repair_required',
+			'pending'  => $pending,
+			'sequence' => $this->next_activity_sequence(),
 		);
 
 		$this->fire_progress();
@@ -2263,7 +2529,7 @@ class AgentLoop {
 	}
 
 	/**
-	 * Fire the progress callback with the current tool call log.
+	 * Fire the progress callback with the current tool-call and message logs.
 	 *
 	 * Progress reporting is best-effort: if the callback throws, the exception
 	 * is swallowed so a broken progress handler cannot abort the agent loop.
@@ -2274,7 +2540,7 @@ class AgentLoop {
 		}
 
 		try {
-			call_user_func( $this->progress_callback, $this->tool_call_log );
+			call_user_func( $this->progress_callback, $this->tool_call_log, $this->message_log );
 		} catch ( \Throwable $e ) {
 			// Progress reporting is best-effort and must not interrupt the agent loop.
 		}
@@ -2319,9 +2585,10 @@ class AgentLoop {
 			);
 
 			// Log the interrupt for transparency.
-			$this->tool_call_log[] = array(
-				'type'    => 'interrupt',
-				'message' => $message_text,
+			$this->message_log[] = array(
+				'type'     => 'interrupt',
+				'message'  => $message_text,
+				'sequence' => $this->next_activity_sequence(),
 			);
 
 			$this->fire_progress();

--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -527,6 +527,7 @@ Assistant: %s',
 			'provider_id'      => (string) ( $paused_state['provider_id'] ?? '' ),
 			'model_id'         => (string) ( $paused_state['model_id'] ?? '' ),
 			'tool_call_log'    => $paused_state['tool_call_log'] ?? array(),
+			'message_log'      => $paused_state['message_log'] ?? array(),
 			'token_usage'      => $paused_state['token_usage'] ?? array(
 				'prompt'     => 0,
 				'completion' => 0,
@@ -569,6 +570,7 @@ Assistant: %s',
 						'prompt'     => 0,
 						'completion' => 0,
 					),
+					'messages'                  => $result['messages'] ?? array(),
 					'iterations_used'           => $result['iterations_used'] ?? 0,
 					'model_id'                  => $result['model_id'] ?? '',
 				),
@@ -617,6 +619,7 @@ Assistant: %s',
 			'reply'           => $result['reply'] ?? '',
 			'history'         => $result['history'] ?? array(),
 			'tool_calls'      => $result['tool_calls'] ?? array(),
+			'messages'        => $result['messages'] ?? array(),
 			'token_usage'     => $token_usage,
 			'iterations_used' => $result['iterations_used'] ?? 0,
 			'model_id'        => $model_id,
@@ -675,12 +678,15 @@ Assistant: %s',
 			$pending_calls = (array) ( $result['pending_client_tool_calls'] ?? array() );
 			/** @var list<array<string, mixed>> $tool_calls */
 			$tool_calls = (array) ( $result['tool_call_log'] ?? array() );
+			/** @var list<array<string, mixed>> $messages */
+			$messages = (array) ( $result['message_log'] ?? array() );
 
 			if ( is_array( $job ) ) {
 				unset( $job['token'] );
 				$job['status']                    = 'awaiting_client_tools';
 				$job['pending_client_tool_calls'] = $pending_calls;
 				$job['tool_calls']                = $tool_calls;
+				$job['messages']                  = $messages;
 				set_transient( $transient_key, $job, self::JOB_TTL );
 			}
 
@@ -702,6 +708,7 @@ Assistant: %s',
 			'reply'           => $result['reply'] ?? '',
 			'history'         => $result['history'] ?? array(),
 			'tool_calls'      => $result['tool_calls'] ?? array(),
+			'messages'        => $result['messages'] ?? array(),
 			'session_id'      => $session_id,
 			'token_usage'     => $result['token_usage'] ?? array(
 				'prompt'     => 0,

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -959,6 +959,9 @@ final class SessionController {
 		if ( ! empty( $job['tool_calls'] ) ) {
 			$response['tool_calls'] = $job['tool_calls'];
 		}
+		if ( ! empty( $job['messages'] ) ) {
+			$response['messages'] = $job['messages'];
+		}
 
 		if ( 'awaiting_confirmation' === $job['status'] && isset( $job['pending_tools'] ) ) {
 			$response['pending_tools'] = $job['pending_tools'];
@@ -979,6 +982,8 @@ final class SessionController {
 			$response['history'] = $job['result']['history'] ?? array();
 			// @phpstan-ignore-next-line
 			$response['tool_calls'] = $job['result']['tool_calls'] ?? array();
+			// @phpstan-ignore-next-line
+			$response['messages'] = $job['result']['messages'] ?? array();
 			// @phpstan-ignore-next-line
 			$response['session_id'] = $job['result']['session_id'] ?? null;
 			// @phpstan-ignore-next-line
@@ -1294,6 +1299,7 @@ final class SessionController {
 			'token'      => $token,
 			'user_id'    => get_current_user_id(),
 			'tool_calls' => array(),
+			'messages'   => array(),
 			'params'     => array(
 				'message'            => $request->get_param( 'message' ),
 				'history'            => $request->get_param( 'history' ),
@@ -1493,13 +1499,14 @@ final class SessionController {
 		 */
 		$options['active_job_id'] = $job_id;
 
-		// Progress callback: write live tool-call activity to the job
-		// transient so the polling frontend can display it incrementally.
+		// Progress callback: write live tool-call activity and channel messages
+		// to the job transient so the polling frontend can display them incrementally.
 		$progress_job_id              = $job_id;
-		$options['progress_callback'] = static function ( array $tool_call_log ) use ( $progress_job_id ) {
+		$options['progress_callback'] = static function ( array $tool_call_log, array $message_log = array() ) use ( $progress_job_id ) {
 			$current = get_transient( RestController::JOB_PREFIX . $progress_job_id );
 			if ( is_array( $current ) && 'processing' === ( $current['status'] ?? '' ) ) {
 				$current['tool_calls'] = $tool_call_log;
+				$current['messages']   = $message_log;
 				// Refresh TTL on each update to prevent mid-execution expiration.
 				// Adding 60s buffer ensures the transient outlasts the execution
 				// limit even when the callback fires near the end of the job.
@@ -1515,6 +1522,7 @@ final class SessionController {
 					array(
 						'status'     => 'processing',
 						'tool_calls' => $tool_call_log,
+						'messages'   => $message_log,
 					),
 					RestController::JOB_TTL + 60
 				);
@@ -1543,6 +1551,8 @@ final class SessionController {
 				$resume_options = $options;
 				// @phpstan-ignore-next-line
 				$resume_options['tool_call_log'] = $state['tool_call_log'] ?? array();
+				// @phpstan-ignore-next-line
+				$resume_options['message_log'] = $state['message_log'] ?? array();
 				// @phpstan-ignore-next-line
 				$resume_options['token_usage'] = $state['token_usage'] ?? array(
 					'prompt'     => 0,
@@ -1599,6 +1609,11 @@ final class SessionController {
 		if ( is_wp_error( $result ) ) {
 			$job['status'] = 'error';
 			$job['error']  = $result->get_error_message();
+			$error_data    = $result->get_error_data();
+			if ( is_array( $error_data ) ) {
+				$job['tool_calls'] = $error_data['tool_calls'] ?? ( $job['tool_calls'] ?? array() );
+				$job['messages']   = $error_data['messages'] ?? ( $job['messages'] ?? array() );
+			}
 
 			// Log webhook execution failure.
 			if ( ! empty( $job['webhook_id'] ) ) {
@@ -1619,9 +1634,11 @@ final class SessionController {
 			/** @var array<string, mixed> $result */
 			$job['status']             = 'awaiting_confirmation';
 			$job['pending_tools']      = $result['pending_tools'] ?? array();
+			$job['messages']           = $result['message_log'] ?? array();
 			$job['confirmation_state'] = array(
 				'history'              => $result['history'] ?? array(),
 				'tool_call_log'        => $result['tool_call_log'] ?? array(),
+				'message_log'          => $result['message_log'] ?? array(),
 				'token_usage'          => $result['token_usage'] ?? array(
 					'prompt'     => 0,
 					'completion' => 0,
@@ -1658,6 +1675,7 @@ final class SessionController {
 			$job['pending_client_tool_calls'] = $result['pending_client_tool_calls'];
 			// Preserve live tool-call progress so the UI stays current.
 			$job['tool_calls'] = $result['tool_call_log'] ?? array();
+			$job['messages']   = $result['message_log'] ?? array();
 
 			unset( $job['token'] );
 			set_transient( RestController::JOB_PREFIX . $job_id, $job, RestController::JOB_TTL );

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -14,6 +14,52 @@ import { playDing, playDong, playThinking } from '../../utils/sound-manager';
 import { executeClientAbility } from '../../abilities/registry';
 import { emitReflectionEvents } from '../reflection-emitter';
 
+/**
+ * Merge real tool calls with assistant channel messages for live rendering.
+ *
+ * Backend `tool_calls` now contains only real tool invocations/results. Text
+ * preambles, retry notices, and guardrail messages arrive separately in
+ * `messages`; the live running UI still needs both streams interleaved by the
+ * monotonic `sequence` field.
+ *
+ * @param {Array} toolCalls Tool call/result entries.
+ * @param {Array} messages  Assistant channel or event entries.
+ * @return {Array} Combined activity entries for display only.
+ */
+function mergeActivityForDisplay( toolCalls, messages ) {
+	const callEntries = Array.isArray( toolCalls ) ? toolCalls : [];
+	const messageEntries = Array.isArray( messages ) ? messages : [];
+
+	if ( ! messageEntries.length ) {
+		return callEntries;
+	}
+
+	return [ ...callEntries, ...messageEntries ]
+		.map( ( entry, index ) => ( { ...entry, activityIndex: index } ) )
+		.sort( ( a, b ) => {
+			const aSeq = Number.isFinite( a.sequence ) ? a.sequence : null;
+			const bSeq = Number.isFinite( b.sequence ) ? b.sequence : null;
+
+			if ( aSeq !== null && bSeq !== null && aSeq !== bSeq ) {
+				return aSeq - bSeq;
+			}
+
+			if ( aSeq !== null && bSeq === null ) {
+				return -1;
+			}
+
+			if ( aSeq === null && bSeq !== null ) {
+				return 1;
+			}
+
+			return a.activityIndex - b.activityIndex;
+		} )
+		.map( ( entry ) => {
+			const { activityIndex, ...clean } = entry;
+			return clean;
+		} );
+}
+
 export const initialState = {
 	// Active polling job ID (most-recently-started job for the current session).
 	currentJobId: null,
@@ -311,13 +357,20 @@ export const actions = {
 					// Successful poll — reset the transient-error counter so
 					// only *consecutive* failures count toward the cap.
 					consecutiveErrors = 0;
+					const resultToolCalls = Array.isArray( result.tool_calls )
+						? result.tool_calls
+						: [];
+					const liveActivity = mergeActivityForDisplay(
+						resultToolCalls,
+						result.messages
+					);
 
 					if ( result.status === 'processing' ) {
 						// Update per-session job state for ALL sessions.
-						if ( result.tool_calls?.length ) {
+						if ( liveActivity.length ) {
 							dispatch.setSessionJob( sessionId, {
 								jobId,
-								toolCalls: result.tool_calls,
+								toolCalls: liveActivity,
 								status: 'processing',
 							} );
 
@@ -326,7 +379,7 @@ export const actions = {
 							// descriptor. Cursor-driven so each event fires
 							// exactly once across the polling stream.
 							reflectionCursor = emitReflectionEvents(
-								result.tool_calls,
+								resultToolCalls,
 								reflectionCursor,
 								{ sessionId, jobId }
 							);
@@ -334,14 +387,14 @@ export const actions = {
 
 						// Only update live tool calls when this is the active session.
 						if (
-							result.tool_calls?.length &&
+							liveActivity.length &&
 							select.getCurrentSessionId() === sessionId
 						) {
-							dispatch.setLiveToolCalls( result.tool_calls );
+							dispatch.setLiveToolCalls( liveActivity );
 						}
 
 						// Detect progress: reset backoff when tool_calls length increases.
-						const newLen = result.tool_calls?.length || 0;
+						const newLen = liveActivity.length;
 						if ( newLen > lastToolCallsLength ) {
 							lastToolCallsLength = newLen;
 							attempts = 0; // Reset backoff on progress.
@@ -388,7 +441,7 @@ export const actions = {
 					if ( result.status === 'awaiting_confirmation' ) {
 						dispatch.setSessionJob( sessionId, {
 							jobId,
-							toolCalls: result.tool_calls || [],
+							toolCalls: liveActivity,
 							status: 'awaiting_confirmation',
 						} );
 
@@ -427,7 +480,7 @@ export const actions = {
 						// Show the proposal panel to the user.
 						dispatch.setSessionJob( sessionId, {
 							jobId,
-							toolCalls: result.tool_calls || [],
+							toolCalls: liveActivity,
 							status: 'pending_proposal',
 						} );
 
@@ -675,7 +728,7 @@ export const actions = {
 						// that arrived between the last `processing` tick and
 						// this terminal poll.
 						reflectionCursor = emitReflectionEvents(
-							result.tool_calls,
+							resultToolCalls,
 							reflectionCursor,
 							{ sessionId, jobId }
 						);
@@ -708,7 +761,7 @@ export const actions = {
 									dispatch.appendMessage( {
 										role: 'model',
 										parts: [ { text: result.reply } ],
-										toolCalls: result.tool_calls,
+										toolCalls: resultToolCalls,
 									} );
 								}
 							}
@@ -719,7 +772,7 @@ export const actions = {
 							dispatch.appendMessage( {
 								role: 'model',
 								parts: [ { text: result.reply } ],
-								toolCalls: result.tool_calls,
+								toolCalls: resultToolCalls,
 							} );
 						}
 

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -369,6 +369,7 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'reply', $result );
 		$this->assertArrayHasKey( 'history', $result );
 		$this->assertArrayHasKey( 'tool_calls', $result );
+		$this->assertArrayHasKey( 'messages', $result );
 		$this->assertArrayHasKey( 'token_usage', $result );
 		$this->assertArrayHasKey( 'iterations_used', $result );
 		$this->assertArrayHasKey( 'model_id', $result );
@@ -553,7 +554,7 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result );
 		$this->assertSame( 'Recovered after retry', $result['reply'] );
 		$this->assertSame( 4, $call_count );
-		$retry_entries = array_filter( $result['tool_calls'], static fn( $entry ) => 'provider_retry' === ( $entry['type'] ?? '' ) );
+		$retry_entries = array_filter( $result['messages'], static fn( $entry ) => 'provider_retry' === ( $entry['type'] ?? '' ) );
 		$this->assertCount( 3, $retry_entries );
 		$this->assertCount( 3, $progress );
 	}
@@ -589,7 +590,7 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertSame( 3, $call_count );
 		$data = $result->get_error_data();
 		$this->assertIsArray( $data );
-		$retry_entries = array_filter( $data['tool_calls'], static fn( $entry ) => 'provider_retry' === ( $entry['type'] ?? '' ) );
+		$retry_entries = array_filter( $data['messages'], static fn( $entry ) => 'provider_retry' === ( $entry['type'] ?? '' ) );
 		$this->assertCount( 2, $retry_entries );
 	}
 
@@ -860,8 +861,8 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$calls = array_filter( $result['tool_calls'], fn( $entry ) => 'call' === $entry['type'] );
 		$this->assertEmpty( $calls, 'The truncated tool call must not be dispatched or logged as a call.' );
 
-		$events = array_filter( $result['tool_calls'], fn( $entry ) => 'truncated_tool_call' === ( $entry['reason'] ?? '' ) );
-		$this->assertNotEmpty( $events, 'The truncation should be visible in the tool-call log.' );
+		$events = array_filter( $result['messages'], fn( $entry ) => 'truncated_tool_call' === ( $entry['reason'] ?? '' ) );
+		$this->assertNotEmpty( $events, 'The truncation should be visible in the message log.' );
 	}
 
 	/**
@@ -958,12 +959,12 @@ class AgentLoopTest extends WP_UnitTestCase {
 			'The truncated preamble must not leak through as the final reply.'
 		);
 
-		// And the event should be visible in the tool-call log.
+		// And the event should be visible in the message log.
 		$events = array_filter(
-			$result['tool_calls'],
+			$result['messages'],
 			static fn( $entry ) => 'truncated_before_tool_call' === ( $entry['reason'] ?? '' )
 		);
-		$this->assertNotEmpty( $events, 'The preamble truncation should be visible in the tool-call log.' );
+		$this->assertNotEmpty( $events, 'The preamble truncation should be visible in the message log.' );
 	}
 
 	/**
@@ -2346,8 +2347,103 @@ class AgentLoopTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Identical function calls in one model response should be dispatched once.
+	 */
+	public function test_run_deduplicates_identical_tool_calls_within_iteration(): void {
+		$this->skip_if_sdk_unavailable();
+		if ( ! class_exists( 'WP_AI_Client_Ability_Function_Resolver' ) ) {
+			$this->markTestSkipped( 'WP_AI_Client_Ability_Function_Resolver not available.' );
+		}
+
+		$call_count      = 0;
+		$duplicate_calls = wp_json_encode(
+			[
+				'id'      => 'chatcmpl-duplicate-tools',
+				'object'  => 'chat.completion',
+				'choices' => [
+					[
+						'index'         => 0,
+						'message'       => [
+							'role'       => 'assistant',
+							'content'    => null,
+							'tool_calls' => [
+								[
+									'id'       => 'call_dup_1',
+									'type'     => 'function',
+									'function' => [
+										'name'      => 'wpab__sd-ai-agent__memory-list',
+										'arguments' => '{"query":"same"}',
+									],
+								],
+								[
+									'id'       => 'call_dup_2',
+									'type'     => 'function',
+									'function' => [
+										'name'      => 'wpab__sd-ai-agent__memory-list',
+										'arguments' => '{"query":"same"}',
+									],
+								],
+							],
+						],
+						'finish_reason' => 'tool_calls',
+					],
+				],
+				'usage'   => [ 'prompt_tokens' => 10, 'completion_tokens' => 5, 'total_tokens' => 15 ],
+			]
+		);
+		$final_reply     = wp_json_encode(
+			[
+				'id'      => 'chatcmpl-deduped-final',
+				'object'  => 'chat.completion',
+				'choices' => [
+					[
+						'index'         => 0,
+						'message'       => [ 'role' => 'assistant', 'content' => 'Done.' ],
+						'finish_reason' => 'stop',
+					],
+				],
+				'usage'   => [ 'prompt_tokens' => 20, 'completion_tokens' => 5, 'total_tokens' => 25 ],
+			]
+		);
+
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( &$call_count, $duplicate_calls, $final_reply ) {
+				if ( false !== strpos( $url, 'fake-ai-proxy.test' ) ) {
+					++$call_count;
+					return [
+						'headers'  => [ 'content-type' => 'application/json' ],
+						'body'     => ( 1 === $call_count ) ? $duplicate_calls : $final_reply,
+						'response' => [ 'code' => 200, 'message' => 'OK' ],
+						'cookies'  => [],
+						'filename' => '',
+					];
+				}
+				return $preempt;
+			},
+			10,
+			3
+		);
+
+		$loop   = new AgentLoop( 'List memories once' );
+		$result = $loop->run();
+
+		$this->assertIsArray( $result );
+		$calls = array_values( array_filter( $result['tool_calls'], static fn( $entry ) => 'call' === ( $entry['type'] ?? '' ) ) );
+		$this->assertCount( 1, $calls, 'Duplicate identical calls in one iteration must be dispatched once.' );
+		$this->assertSame( 'call_dup_1', $calls[0]['id'] );
+
+		$responses = array_values( array_filter( $result['tool_calls'], static fn( $entry ) => 'response' === ( $entry['type'] ?? '' ) ) );
+		$this->assertCount( 1, $responses, 'Only one response should be logged for the deduped call.' );
+
+		$events = array_values( array_filter( $result['messages'], static fn( $entry ) => 'tool_call_deduplicated' === ( $entry['reason'] ?? '' ) ) );
+		$this->assertCount( 1, $events );
+		$this->assertSame( 1, $events[0]['count'] );
+	}
+
+	/**
 	 * Regression test: preamble text emitted alongside a tool call must appear
-	 * in the live tool_call_log so the polling frontend can render it above
+	 * in the live message log so the polling frontend can render it above
 	 * the tool card while the loop is still running.
 	 *
 	 * The mock turn returns an assistant message that contains both a text
@@ -2429,8 +2525,11 @@ class AgentLoopTest extends WP_UnitTestCase {
 		);
 
 		$options                      = [];
-		$options['progress_callback'] = static function ( array $log ) use ( &$progress_snapshots ): void {
-			$progress_snapshots[] = $log;
+		$options['progress_callback'] = static function ( array $log, array $messages = array() ) use ( &$progress_snapshots ): void {
+			$progress_snapshots[] = array(
+				'tool_calls' => $log,
+				'messages'   => $messages,
+			);
 		};
 
 		$loop   = new AgentLoop( 'Find my notes', [], [], $options );
@@ -2439,28 +2538,29 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'tool_calls', $result );
 
-		// The preamble entry must precede the call entry in original order.
-		$preamble_index = null;
-		$call_index     = null;
-		foreach ( $result['tool_calls'] as $i => $entry ) {
-			if ( null === $preamble_index && 'preamble' === ( $entry['type'] ?? '' ) ) {
-				$preamble_index = $i;
-			}
-			if ( null === $call_index && 'call' === ( $entry['type'] ?? '' ) ) {
-				$call_index = $i;
-			}
-		}
+		$preamble_entries = array_values(
+			array_filter(
+				$result['messages'],
+				static fn( $entry ) => 'preamble' === ( $entry['type'] ?? '' )
+			)
+		);
+		$call_entries     = array_values(
+			array_filter(
+				$result['tool_calls'],
+				static fn( $entry ) => 'call' === ( $entry['type'] ?? '' )
+			)
+		);
 
-		$this->assertNotNull( $preamble_index, 'A preamble entry must be present in tool_call_log when the model emits text alongside a tool call.' );
-		$this->assertNotNull( $call_index, 'The tool call entry must still be present.' );
-		$this->assertLessThan( $call_index, $preamble_index, 'Preamble must be logged before the tool call to match emission order.' );
-		$this->assertSame( $preamble_text, $result['tool_calls'][ $preamble_index ]['text'] );
+		$this->assertNotEmpty( $preamble_entries, 'A preamble entry must be present in messages when the model emits text alongside a tool call.' );
+		$this->assertNotEmpty( $call_entries, 'The tool call entry must still be present.' );
+		$this->assertSame( $preamble_text, $preamble_entries[0]['text'] );
+		$this->assertLessThan( $call_entries[0]['sequence'], $preamble_entries[0]['sequence'], 'Preamble must be sequenced before the tool call to match emission order.' );
 
 		// The progress callback must have observed the preamble in at least
 		// one snapshot so the polling frontend can render it incrementally.
 		$saw_preamble_in_progress = false;
 		foreach ( $progress_snapshots as $snapshot ) {
-			foreach ( $snapshot as $entry ) {
+			foreach ( $snapshot['messages'] as $entry ) {
 				if ( 'preamble' === ( $entry['type'] ?? '' ) && ( $entry['text'] ?? '' ) === $preamble_text ) {
 					$saw_preamble_in_progress = true;
 					break 2;
@@ -2550,7 +2650,7 @@ class AgentLoopTest extends WP_UnitTestCase {
 
 		$this->assertIsArray( $result );
 		$preamble_entries = array_filter(
-			$result['tool_calls'],
+			$result['messages'],
 			static fn( $entry ) => 'preamble' === ( $entry['type'] ?? '' )
 		);
 		$this->assertEmpty( $preamble_entries, 'Whitespace-only assistant text must not be logged as a preamble entry.' );


### PR DESCRIPTION
## Summary
- Keep `tool_calls` limited to real tool call/response entries with non-empty names.
- Move assistant channel activity such as preambles, retries, truncation notices, guardrails, and interrupts into a separate `messages`/`message_log` stream with monotonic `sequence` ordering.
- Merge `tool_calls` and `messages` only for live UI display while keeping reflection events and persisted model messages tied to real tool calls.
- Suppress duplicate identical same-turn tool calls unless the call arguments include explicit parallel intent.

Closes #1903.

## Worker self-verification
- PHPUnit: Tests: 3562, Assertions: 14823, Errors: 0, Failures: 0, Skipped: 115, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.10 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced activity logging with dual-channel tracking: assistant messages now logged alongside tool calls with unified sequencing
  * Message logs now included in API responses and job-status polling endpoints
  * Automatic deduplication of identical tool calls within a single model response

* **Tests**
  * Added validation for tool call deduplication behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->