### PR TITLE
fix: retire separate Theme Builder agent

### DIFF
--- a/includes/Core/Database.php
+++ b/includes/Core/Database.php
@@ -36,7 +36,7 @@ use SdAiAgent\Tools\CustomTools;
 class Database {
 
 	const DB_VERSION_OPTION = 'sd_ai_agent_db_version';
-	const DB_VERSION        = '19.5.1';
+	const DB_VERSION        = '19.5.2';
 
 	// ─── Table Name Registry ──────────────────────────────────────────────────
 

--- a/includes/Core/OnboardingManager.php
+++ b/includes/Core/OnboardingManager.php
@@ -15,6 +15,9 @@ declare(strict_types=1);
  *   POST /sd-ai-agent/v1/onboarding/rescan          — reset and schedule a new scan
  *   POST /sd-ai-agent/v1/onboarding/bootstrap-start — create the bootstrap discovery session
  *                                                     (attaches the Setup Assistant agent)
+ *   POST /sd-ai-agent/v1/onboarding/theme-builder-start — legacy empty-install
+ *                                                         setup route (also
+ *                                                         attaches Setup Assistant)
  *
  * @package SdAiAgent
  * @license GPL-2.0-or-later
@@ -51,14 +54,14 @@ class OnboardingManager {
 	const BOOTSTRAP_SESSION_OPTION = 'sd_ai_agent_bootstrap_session_id';
 
 	/**
-	 * Option key that persists the theme-builder session ID.
+	 * Option key that persists the legacy empty-install onboarding session ID.
 	 * Stored on first call to rest_theme_builder_start; reused on subsequent calls
 	 * to make the endpoint idempotent — repeat calls return the same session.
 	 */
 	const THEME_BUILDER_SESSION_OPTION = 'sd_ai_agent_theme_builder_session_id';
 
 	/**
-	 * Option key that records whether the theme-builder session has been started.
+	 * Option key that records whether the legacy empty-install session has been started.
 	 * Set to true on first call to rest_theme_builder_start to prevent the React
 	 * component from re-firing the kickoff message on reload.
 	 */
@@ -167,7 +170,7 @@ class OnboardingManager {
 	 * Reset onboarding state (allows re-running the scan and bootstrap session).
 	 *
 	 * Clears the triggered flag, the completion flag, the persisted bootstrap
-	 * and theme-builder session IDs, the theme-builder started flag, and the
+	 * and legacy empty-install session IDs, the empty-install started flag, and the
 	 * SiteScanner status so the next admin_init re-evaluates from scratch.
 	 * Also unschedules any pending scan cron event. The Settings store flag
 	 * `onboarding_complete` is NOT modified here — callers that need to re-open
@@ -458,24 +461,28 @@ class OnboardingManager {
 	/**
 	 * POST /sd-ai-agent/v1/onboarding/theme-builder-start
 	 *
-	 * Called by the frontend when a user chooses the theme-builder onboarding
-	 * path. This handler mirrors rest_bootstrap_start but:
+	 * Legacy empty-install onboarding route. The public route name is retained
+	 * for compatibility with the React bootstrapper, but the old Theme Builder
+	 * agent row has been retired: every first-run branch now attaches the single
+	 * Setup Assistant agent.
 	 *
-	 *  1. Resolves the theme-builder agent instead of the onboarding agent.
-	 *  2. Does NOT mark onboarding complete (the user may still want the
-	 *     bootstrap discovery flow after building the theme).
-	 *  3. Does NOT auto-detect WooCommerce.
-	 *  4. Persists the session ID under THEME_BUILDER_SESSION_OPTION so
+	 * This handler mirrors rest_bootstrap_start but:
+	 *
+	 *  1. Sends an empty-install kickoff suited to the Setup Assistant's fast
+	 *     build branch.
+	 *  2. Persists the session ID under THEME_BUILDER_SESSION_OPTION so
 	 *     repeat calls return the same session.
-	 *  5. Sets THEME_BUILDER_STARTED_OPTION on first call to prevent the React
+	 *  3. Sets THEME_BUILDER_STARTED_OPTION on first call to prevent the React
 	 *     component from re-firing the kickoff message on reload.
-	 *  6. Returns an explicit `is_fresh_start` boolean so the React component
+	 *  4. Marks onboarding complete because there is no second setup flow after
+	 *     the unified Setup Assistant session starts.
+	 *  5. Returns an explicit `is_fresh_start` boolean so the React component
 	 *     can distinguish a fresh-create request (kickoff SHOULD fire) from a
 	 *     resume request (kickoff MUST NOT fire). The boolean is the
 	 *     authoritative signal — `started_at` is also returned for
 	 *     observability/back-compat but MUST NOT be used to drive kickoff
 	 *     behaviour because both branches return a truthy timestamp.
-	 *  7. Returns the same JSON shape as bootstrap-start so the React entry
+	 *  6. Returns the same JSON shape as bootstrap-start so the React entry
 	 *     component can use a single helper.
 	 *
 	 * Idempotent: repeat calls return the originally-created session ID
@@ -487,19 +494,11 @@ class OnboardingManager {
 		$settings = Settings::instance();
 		$all      = $settings->get();
 
-		// As of t276 the empty-install onboarding branch uses the unified
-		// Setup Assistant agent (which runs the same fast-build path as the
-		// legacy Theme Builder, plus content-aware branching on resume).
-		// Falling back to the Theme Builder agent if the Setup Assistant
-		// row is missing preserves back-compat on installs that explicitly
-		// deleted the onboarding agent.
-		$onboarding_agent       = Agent::get_by_slug( Agent::ONBOARDING_AGENT_SLUG );
-		$theme_builder_agent_id = $onboarding_agent ? (int) $onboarding_agent->id : 0;
-
-		if ( 0 === $theme_builder_agent_id ) {
-			$theme_builder_agent    = Agent::get_by_slug( Agent::THEME_BUILDER_AGENT_SLUG );
-			$theme_builder_agent_id = $theme_builder_agent ? (int) $theme_builder_agent->id : 0;
-		}
+		// The empty-install onboarding branch always uses the unified Setup
+		// Assistant. The legacy Theme Builder built-in is removed during agent
+		// seeding/reset so it no longer appears as a second setup agent.
+		$onboarding_agent    = Agent::get_by_slug( Agent::ONBOARDING_AGENT_SLUG );
+		$onboarding_agent_id = $onboarding_agent ? (int) $onboarding_agent->id : 0;
 
 		// Empty-install kickoff. Matches the Setup Assistant's Phase 1
 		// "Capture (one warm turn)" expectation — the agent's stored
@@ -509,17 +508,17 @@ class OnboardingManager {
 			'superdav-ai-agent'
 		);
 
-		// Early-return if a theme-builder session was already created. Reuse the
-		// persisted session ID so the frontend can resume the same conversation
-		// without re-firing the kickoff message. `is_fresh_start` is false on
-		// this branch so the React component skips the kickoff send.
+		// Early-return if an empty-install onboarding session was already created.
+		// Reuse the persisted session ID so the frontend can resume the same
+		// conversation without re-firing the kickoff message. `is_fresh_start` is
+		// false on this branch so the React component skips the kickoff send.
 		$existing_session_id = get_option( self::THEME_BUILDER_SESSION_OPTION );
 		if ( ! empty( $existing_session_id ) ) {
 			return new \WP_REST_Response(
 				[
 					'success'         => true,
 					'session_id'      => $existing_session_id,
-					'agent_id'        => $theme_builder_agent_id,
+					'agent_id'        => $onboarding_agent_id,
 					'kickoff_message' => $kickoff_message,
 					'started_at'      => get_option( self::THEME_BUILDER_STARTED_OPTION ),
 					'is_fresh_start'  => false,
@@ -528,18 +527,18 @@ class OnboardingManager {
 			);
 		}
 
-		// Create the theme-builder session, applying the theme-builder agent's
-		// provider/model overrides if present so the session starts with the
-		// right model for the first turn.
+		// Create the empty-install setup session, applying the Setup Assistant
+		// agent's provider/model overrides if present so the session starts with
+		// the right model for the first turn.
 		$session_data = [
 			'user_id'     => get_current_user_id(),
-			'title'       => __( 'Theme Builder', 'superdav-ai-agent' ),
+			'title'       => __( 'Getting started', 'superdav-ai-agent' ),
 			'provider_id' => $all['default_provider'] ?? '',
 			'model_id'    => $all['default_model'] ?? '',
 		];
 
-		if ( $theme_builder_agent_id > 0 ) {
-			$agent_options = Agent::get_loop_options( $theme_builder_agent_id );
+		if ( $onboarding_agent_id > 0 ) {
+			$agent_options = Agent::get_loop_options( $onboarding_agent_id );
 			if ( ! empty( $agent_options['provider_id'] ) ) {
 				$session_data['provider_id'] = $agent_options['provider_id'];
 			}
@@ -564,15 +563,13 @@ class OnboardingManager {
 		if ( ! $session_id ) {
 			return new \WP_Error(
 				'theme_builder_session_failed',
-				__( 'Failed to create theme-builder session.', 'superdav-ai-agent' ),
+				__( 'Failed to create onboarding session.', 'superdav-ai-agent' ),
 				[ 'status' => 500 ]
 			);
 		}
 
 		// Persist the session ID and the started timestamp so repeat calls return
 		// the same session and the React component knows not to re-fire the kickoff.
-		// Note: we do NOT mark onboarding complete — the user may still want
-		// the bootstrap discovery flow after building the theme.
 		$started_at = time();
 		update_option( self::THEME_BUILDER_SESSION_OPTION, $session_id, false );
 		update_option( self::THEME_BUILDER_STARTED_OPTION, $started_at, false );
@@ -585,7 +582,7 @@ class OnboardingManager {
 			[
 				'success'         => true,
 				'session_id'      => $session_id,
-				'agent_id'        => $theme_builder_agent_id,
+				'agent_id'        => $onboarding_agent_id,
 				'kickoff_message' => $kickoff_message,
 				'started_at'      => $started_at,
 				'is_fresh_start'  => true,
@@ -605,9 +602,8 @@ class OnboardingManager {
 	 *
 	 * Unlike the legacy v1 flow, this endpoint does NOT re-launch a wizard.
 	 * The v2 gate probes `/wp/v2/posts` once per mount and drops the user
-	 * into either:
-	 *  - OnboardingBootstrap (Setup Assistant agent) — sites with content
-	 *  - OnboardingThemeBuilder (Theme Builder agent) — empty installs
+	 * into the unified Setup Assistant with either an established-site kickoff
+	 * or an empty-install fast-build kickoff.
 	 *
 	 * Resets, in order:
 	 *  1. {@see OnboardingManager::reset()} — clears TRIGGERED_OPTION,

--- a/includes/Models/Agent.php
+++ b/includes/Models/Agent.php
@@ -12,8 +12,8 @@ declare(strict_types=1);
  * - tool_profile: legacy, no longer applied — kept on the row for backward compatibility
  * - temperature / max_iterations: per-agent inference settings
  *
- * Six built-in agents are seeded on first install (is_builtin=1):
- * onboarding, general, content-creator, seo, ecommerce, theme-builder.
+ * Five built-in agents are seeded on first install (is_builtin=1):
+ * onboarding, general, content-creator, seo, ecommerce.
  * The "general" agent cannot be deleted. All built-in agents can be reset
  * to factory defaults via reset_defaults().
  *
@@ -39,7 +39,10 @@ class Agent {
 	public const ONBOARDING_AGENT_SLUG = 'onboarding';
 
 	/**
-	 * Slug of the theme-builder agent (4-phase guided block theme creation).
+	 * Slug of the retired Theme Builder built-in agent.
+	 *
+	 * Kept only so upgrades can remove the old built-in row and the legacy
+	 * /onboarding/theme-builder-start endpoint can keep its historic route name.
 	 */
 	public const THEME_BUILDER_AGENT_SLUG = 'theme-builder';
 
@@ -413,6 +416,8 @@ class Agent {
 	 * Database::install() on every schema upgrade.
 	 */
 	public static function seed_defaults(): void {
+		self::remove_retired_theme_builder_builtin();
+
 		$defaults = self::get_builtin_definitions();
 
 		foreach ( $defaults as $def ) {
@@ -433,6 +438,8 @@ class Agent {
 	 * customized those). Missing built-in agents are re-created.
 	 */
 	public static function reset_defaults(): void {
+		self::remove_retired_theme_builder_builtin();
+
 		$defaults = self::get_builtin_definitions();
 
 		foreach ( $defaults as $def ) {
@@ -455,6 +462,29 @@ class Agent {
 				self::create( $def );
 			}
 		}
+	}
+
+	/**
+	 * Remove the retired Theme Builder built-in agent row from upgraded installs.
+	 *
+	 * The Setup Assistant is now the single onboarding/setup agent. Keeping the
+	 * old built-in row enabled made the chat agent picker show two setup agents.
+	 * Only the built-in row is removed; a user-created non-built-in row with the
+	 * same slug would be left alone.
+	 */
+	private static function remove_retired_theme_builder_builtin(): void {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Built-in agent upgrade cleanup; caching not applicable.
+		$wpdb->delete(
+			self::table_name(),
+			[
+				'slug'       => self::THEME_BUILDER_AGENT_SLUG,
+				'is_builtin' => 1,
+			],
+			[ '%s', '%d' ]
+		);
 	}
 
 	/**
@@ -503,7 +533,6 @@ class Agent {
 			self::get_content_creator_definition( $general_tools ),
 			self::get_seo_definition( $general_tools ),
 			self::get_ecommerce_definition( $general_tools ),
-			self::get_theme_builder_definition( $general_tools ),
 		];
 	}
 
@@ -542,7 +571,7 @@ class Agent {
 			'slug'          => 'onboarding',
 			'name'          => __( 'Setup Assistant', 'superdav-ai-agent' ),
 			'description'   => __( 'Discovers your site, builds your homepage, and helps with everything after. The all-in-one first-run agent.', 'superdav-ai-agent' ),
-			'system_prompt' => self::build_setup_assistant_prompt( $site_title, $site_url, false ),
+			'system_prompt' => self::build_setup_assistant_prompt( $site_title, $site_url ),
 			'greeting'      => __( "Hi! Give me a moment to look around, then I'll show you what I can do.", 'superdav-ai-agent' ),
 			'avatar_icon'   => 'dashicons-welcome-learn-more',
 			'tier_1_tools'  => self::get_unified_onboarding_tier_1_tools( $base_tools ),
@@ -574,9 +603,7 @@ class Agent {
 	}
 
 	/**
-	 * Tier-1 tools for the unified Setup Assistant (and the legacy Theme
-	 * Builder agent, which now mirrors the same fast-build behaviour for
-	 * users who select it explicitly).
+	 * Tier-1 tools for the unified Setup Assistant.
 	 *
 	 * Merges the discovery toolset (list-options, list-posts, get-plugins,
 	 * get-themes) with the full theme/page/image build suite so the single
@@ -618,34 +645,21 @@ class Agent {
 	/**
 	 * Build the unified Setup Assistant system prompt.
 	 *
-	 * Shared by the Setup Assistant agent (`onboarding` slug) and the
-	 * legacy Theme Builder agent (`theme-builder` slug). The `$force_build`
-	 * flag flips the agent into "always run the fast-build path, even on
-	 * established sites" mode — used by Theme Builder so users who select
-	 * it explicitly always get a theme rebuild.
-	 *
 	 * @param string $site_title  Current site title for context.
 	 * @param string $site_url    Current site URL for context.
-	 * @param bool   $force_build When true, skip the content-aware branch
-	 *                            and always run the fast-build path.
 	 */
-	private static function build_setup_assistant_prompt( string $site_title, string $site_url, bool $force_build ): string {
-		$intro = $force_build
-			? "You are a WordPress Theme Builder for the site \"{$site_title}\" ({$site_url}). The user has explicitly asked you to design or rebuild their theme — always run the fast-build path (Phase 2) regardless of whether the site already has content.\n\n"
-			: "You are the Setup Assistant for the WordPress site \"{$site_title}\" ({$site_url}). You are warm, curious, and genuinely interested in helping. You move fast and show results — never quiz the user when you can infer or just do.\n\n";
-
-		$branch_rule = $force_build
-			? "## You are in the fast-build branch by default\n\nSkip the content-aware decision. Run Phase 0 (silent discovery) to gather context, then go straight to Phase 1 capture and Phase 2 build.\n\n"
-			: "## Phase 0: Silent discovery (always, before your first reply)\n\n"
-				. "Before saying anything to the user, silently use your read-only tools to learn the site:\n"
-				. "1. `sd-ai-agent/list-options` — site title, tagline, language, timezone, show_on_front, page_on_front.\n"
-				. "2. `sd-ai-agent/list-posts` — recent posts AND pages (look at post_type, status, title, snippet).\n"
-				. "3. `sd-ai-agent/get-plugins` — what's active (notably WooCommerce).\n"
-				. "4. `sd-ai-agent/get-themes` — the active theme.\n\n"
-				. "Decide which branch you are in. The user never sees this decision:\n\n"
-				. "- **Empty install** = the active theme is a WordPress default (twenty-twentyfive, twenty-twentyfour, twenty-twentythree, etc.) AND there are 0–1 real published posts/pages. The seed \"Hello world!\" post and the seed \"Sample Page\" do NOT count as real content.\n"
-				. "- **Established site** = anything else (a non-default theme, or 2+ real published items).\n\n"
-				. "Do NOT mention these probes to the user. They are how you arrive at the first message already understanding their site.\n\n";
+	private static function build_setup_assistant_prompt( string $site_title, string $site_url ): string {
+		$intro       = "You are the Setup Assistant for the WordPress site \"{$site_title}\" ({$site_url}). You are warm, curious, and genuinely interested in helping. You move fast and show results — never quiz the user when you can infer or just do.\n\n";
+		$branch_rule = "## Phase 0: Silent discovery (always, before your first reply)\n\n"
+			. "Before saying anything to the user, silently use your read-only tools to learn the site:\n"
+			. "1. `sd-ai-agent/list-options` — site title, tagline, language, timezone, show_on_front, page_on_front.\n"
+			. "2. `sd-ai-agent/list-posts` — recent posts AND pages (look at post_type, status, title, snippet).\n"
+			. "3. `sd-ai-agent/get-plugins` — what's active (notably WooCommerce).\n"
+			. "4. `sd-ai-agent/get-themes` — the active theme.\n\n"
+			. "Decide which branch you are in. The user never sees this decision:\n\n"
+			. "- **Empty install** = the active theme is a WordPress default (twenty-twentyfive, twenty-twentyfour, twenty-twentythree, etc.) AND there are 0–1 real published posts/pages. The seed \"Hello world!\" post and the seed \"Sample Page\" do NOT count as real content.\n"
+			. "- **Established site** = anything else (a non-default theme, or 2+ real published items).\n\n"
+			. "Do NOT mention these probes to the user. They are how you arrive at the first message already understanding their site.\n\n";
 
 		$phase_1_empty = "### Empty-install branch — Phase 1: Capture (one warm turn)\n\n"
 			. "Reply with ONE short, warm message that invites a one-line description. Suggested phrasing (adapt to the site context, do not paste verbatim):\n\n"
@@ -727,9 +741,7 @@ class Agent {
 			. "- Do not use placeholder text or robotic templates.\n"
 			. '- Be yourself — curious, helpful, genuinely interested in this site.';
 
-		$phase_1 = $force_build
-			? $phase_1_empty
-			: $phase_1_empty . $phase_1_established;
+		$phase_1 = $phase_1_empty . $phase_1_established;
 
 		return $intro
 			. $branch_rule
@@ -741,57 +753,6 @@ class Agent {
 			. $hard_rules
 			. $memory
 			. $important;
-	}
-
-	/**
-	 * Theme Builder agent definition.
-	 *
-	 * As of t276 this agent shares the unified Setup Assistant prompt with
-	 * `$force_build = true`, so direct selection always runs the fast-build
-	 * path regardless of whether the site already has content. This makes it
-	 * a "redesign my theme right now" specialisation of the Setup Assistant,
-	 * rather than a separate 4-phase interview agent.
-	 *
-	 * Kept as a built-in for back-compat with users who explicitly selected
-	 * the Theme Builder from the agent picker and for the legacy
-	 * `/onboarding/theme-builder-start` REST endpoint (which now resolves to
-	 * the Setup Assistant agent on fresh installs — see OnboardingManager).
-	 *
-	 * @param list<string> $base_tools Base tier 1 tools.
-	 * @return array<string, mixed>
-	 */
-	private static function get_theme_builder_definition( array $base_tools ): array { // phpcs:ignore Squiz.Commenting.FunctionComment.IncorrectTypeHint -- list<string> is valid PHPStan but not a native PHP type.
-		$site_title = function_exists( 'get_bloginfo' ) ? get_bloginfo( 'name' ) : '';
-		$site_url   = function_exists( 'get_site_url' ) ? get_site_url() : '';
-
-		return [
-			'slug'          => self::THEME_BUILDER_AGENT_SLUG,
-			'name'          => __( 'Theme Builder', 'superdav-ai-agent' ),
-			'description'   => __( 'Designs and builds a custom block theme. Runs the fast-build path on every conversation — useful for redesigning an existing site.', 'superdav-ai-agent' ),
-			'system_prompt' => self::build_setup_assistant_prompt( $site_title, $site_url, true ),
-			'greeting'      => __( "I'll design and build a custom block theme for you. Tell me what your site is — a name + one line is enough — and I'll get the homepage live in a couple of minutes.", 'superdav-ai-agent' ),
-			'avatar_icon'   => 'dashicons-art',
-			'tier_1_tools'  => self::get_unified_onboarding_tier_1_tools( $base_tools ),
-			'suggestions'   => [
-				[
-					'title'       => __( 'Design a theme for a craft brewery', 'superdav-ai-agent' ),
-					'description' => __( 'Custom block theme with rustic, bold aesthetics', 'superdav-ai-agent' ),
-					'prompt'      => __( 'Design a theme for a craft brewery website.', 'superdav-ai-agent' ),
-				],
-				[
-					'title'       => __( 'Design a theme for a SaaS startup', 'superdav-ai-agent' ),
-					'description' => __( 'Clean, modern block theme for a software product', 'superdav-ai-agent' ),
-					'prompt'      => __( 'Design a theme for a SaaS startup website.', 'superdav-ai-agent' ),
-				],
-				[
-					'title'       => __( 'Design a theme for a personal portfolio', 'superdav-ai-agent' ),
-					'description' => __( 'Minimal, elegant block theme to showcase your work', 'superdav-ai-agent' ),
-					'prompt'      => __( 'Design a theme for my personal portfolio website.', 'superdav-ai-agent' ),
-				],
-			],
-			'is_builtin'    => true,
-			'enabled'       => true,
-		];
 	}
 
 	/**

--- a/includes/Services/PreviewRenderer.php
+++ b/includes/Services/PreviewRenderer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
  * Preview Renderer service.
  *
  * Generates desktop (1280×800) and mobile (375×812) screenshots of HTML
- * preview files written by the Theme Builder agent during design-direction
+ * preview files written by the Setup Assistant during design-direction
  * selection. Falls back to client-side iframe display when server-side
  * headless rendering is not available (no Chromium binary, exec() disabled,
  * or Node.js / Playwright not installed).

--- a/src/admin-page/index.js
+++ b/src/admin-page/index.js
@@ -79,8 +79,9 @@ const ShortcutsHelp = lazy( () =>
  *    not yet completed. A single heuristic picks the right bootstrapper:
  *      - site has published content  → OnboardingBootstrap (Setup Assistant
  *        agent: explores the existing site and introduces itself).
- *      - site has no content yet     → OnboardingThemeBuilder (Theme Builder
- *        agent: helps design and scaffold a custom block theme).
+ *      - site has no content yet     → OnboardingThemeBuilder (Setup
+ *        Assistant empty-install kickoff: helps design and scaffold a custom
+ *        block theme).
  *    Both bootstrappers POST to their server endpoint, which flips
  *    `onboarding_complete` to true and opens an agent session.
  *
@@ -91,9 +92,9 @@ const ShortcutsHelp = lazy( () =>
 function AdminPageApp() {
 	/**
 	 * Tracks whether the site has any "real" published content yet. Used to
-	 * pick the default first-run agent: empty install → Theme Builder;
-	 * otherwise → Setup Assistant. `null` means the heuristic probe is still
-	 * in flight.
+	 * pick the default first-run kickoff for the unified Setup Assistant: empty
+	 * install → fast-build kickoff; otherwise → discovery kickoff. `null` means
+	 * the heuristic probe is still in flight.
 	 *
 	 * Probe target: GET /wp/v2/posts?per_page=2&status=publish. The probe
 	 * returns true when at least TWO published posts exist, so the WordPress
@@ -177,13 +178,12 @@ function AdminPageApp() {
 	//
 	// Threshold is `> 1`, not `> 0`, because every fresh WordPress install
 	// ships with one seeded "Hello world!" post. A `> 0` check would always
-	// be true on a default install and the Theme Builder branch would be
+	// be true on a default install and the empty-install branch would be
 	// unreachable. `> 1` treats the seed post as "no real content yet" and
 	// only flips to Setup Assistant once the user has at least two
 	// published posts. Edge case: a user who deletes the seed post and
-	// writes exactly one real post will still be routed to Theme Builder
-	// (they can switch agents from the chat picker if they prefer the
-	// Setup Assistant). Tracked in the v1.16.1 follow-up issue alongside
+	// writes exactly one real post will still be routed to the empty-install
+	// kickoff. Tracked in the v1.16.1 follow-up issue alongside
 	// the broader probe (it currently only counts `post`-type entries and
 	// misses page-only / CPT-only / WooCommerce-only installs).
 	const onboardingComplete = settings?.onboarding_complete !== false;
@@ -260,9 +260,9 @@ function AdminPageApp() {
 	// Onboarding v2 — no wizard, no mode picker. We pick a bootstrapper
 	// based on whether the site has any published content yet:
 	//   - empty install → OnboardingThemeBuilder (empty-install kickoff)
-	//   - has content   → OnboardingBootstrap    (discover kickoff)
-	// As of t276 both bootstrappers resolve to the unified Setup Assistant
-	// agent server-side and POST to a `*-start` endpoint that flips
+	//   - has content   → OnboardingBootstrap    (discovery kickoff)
+	// Both bootstrappers resolve to the unified Setup Assistant agent
+	// server-side and POST to a `*-start` endpoint that flips
 	// `onboarding_complete` to true and opens an agent session. The agent's
 	// own Phase 0 silent discovery then decides which branch to run.
 	if ( ! onboardingComplete ) {

--- a/src/components/__tests__/OnboardingThemeBuilder.test.js
+++ b/src/components/__tests__/OnboardingThemeBuilder.test.js
@@ -3,7 +3,7 @@
  *
  * Tests cover:
  * - Calls theme-builder-start endpoint on mount
- * - Selects the Theme Builder agent returned by theme-builder-start
+ * - Selects the Setup Assistant agent returned by theme-builder-start
  * - Opens the session returned by theme-builder-start
  * - Sends the kickoff message returned by theme-builder-start
  * - Falls back gracefully when theme-builder-start fails
@@ -106,7 +106,7 @@ describe( 'OnboardingThemeBuilder', () => {
 		} );
 	} );
 
-	test( 'selects the Theme Builder agent returned by theme-builder-start', async () => {
+	test( 'selects the Setup Assistant agent returned by theme-builder-start', async () => {
 		apiFetch.mockResolvedValue( {
 			session_id: 42,
 			agent_id: 7,
@@ -130,12 +130,12 @@ describe( 'OnboardingThemeBuilder', () => {
 		apiFetch.mockResolvedValue( {
 			session_id: 42,
 			agent_id: 7,
-			kickoff_message: 'Hello from theme-builder kickoff',
+			kickoff_message: 'Hello from setup kickoff',
 			is_fresh_start: true,
 		} );
 		await renderThemeBuilder();
 		expect( sendMessageMock ).toHaveBeenCalledWith(
-			'Hello from theme-builder kickoff'
+			'Hello from setup kickoff'
 		);
 	} );
 

--- a/src/components/design-preview-gallery.js
+++ b/src/components/design-preview-gallery.js
@@ -1,5 +1,5 @@
 /**
- * DesignPreviewGallery — renders desktop + mobile previews for Theme Builder
+ * DesignPreviewGallery — renders desktop + mobile previews for Setup Assistant
  * design-direction selection (issue #1532).
  *
  * Rendered inside a ToolCard when the `sd-ai-agent/render-design-previews`

--- a/src/components/onboarding-theme-builder.js
+++ b/src/components/onboarding-theme-builder.js
@@ -21,10 +21,8 @@ import './onboarding-theme-builder.css';
  *
  * Calls POST /onboarding/theme-builder-start to:
  *  1. Create a new session and resolve the unified Setup Assistant agent_id
- *     (as of t276 the endpoint routes to the Setup Assistant agent, which
- *     mirrors the legacy Theme Builder's fast-build behaviour. The legacy
- *     Theme Builder agent row is kept as a back-compat fallback for installs
- *     that explicitly deleted the onboarding agent).
+ *     (the route name is retained for compatibility, but the separate legacy
+ *     Theme Builder agent row has been retired).
  *  2. Return an `is_fresh_start` boolean indicating whether the server just
  *     created the session (true) or returned an existing one for resume
  *     (false). This is the authoritative signal — the `started_at`
@@ -65,14 +63,14 @@ export default function OnboardingThemeBuilder() {
 					return;
 				}
 
-				// Select the Theme Builder agent so streamMessage attaches
+				// Select the Setup Assistant agent so streamMessage attaches
 				// agent_id to the /run call and AgentLoop applies the agent's
 				// system prompt + tool tier overrides for this session.
 				if ( data.agent_id ) {
 					setSelectedAgentId( data.agent_id );
 				}
 
-				// Activate the theme-builder session in the store.
+				// Activate the empty-install onboarding session in the store.
 				openSession( data.session_id )
 					.then( () => {
 						// Only send the kickoff message on a genuine fresh start.

--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -340,9 +340,8 @@ export default function SettingsApp() {
 
 	const handleOnboardingReset = useCallback( async () => {
 		// Confirm before discarding onboarding state. The v2 gate will re-fire
-		// on the next chat-page mount and drop the user into either the Setup
-		// Assistant (site with content) or Theme Builder (empty install)
-		// agent — saved settings, memories, and chat history are kept.
+		// on the next chat-page mount and drop the user into the unified Setup
+		// Assistant. Saved settings, memories, and chat history are kept.
 		const confirmMessage = __(
 			'Restart the Setup Assistant? Your existing settings, memories, and chat sessions are kept — the agent will simply reintroduce itself the next time you open the AI Agent chat page.',
 			'superdav-ai-agent'
@@ -2295,7 +2294,7 @@ export default function SettingsApp() {
 										</h3>
 										<p className="description">
 											{ __(
-												'Clears onboarding state. The next time you open the AI Agent chat page, the Setup Assistant will reintroduce itself (or the Theme Builder agent will run on an empty install). Your existing memories, chat sessions, and saved settings are kept.',
+												'Clears onboarding state. The next time you open the AI Agent chat page, the Setup Assistant will reintroduce itself and choose the right setup path for the site. Your existing memories, chat sessions, and saved settings are kept.',
 												'superdav-ai-agent'
 											) }
 										</p>

--- a/tests/SdAiAgent/Abilities/StockImageAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/StockImageAbilityTest.php
@@ -486,17 +486,17 @@ class StockImageAbilityTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'pixabay', strtolower( $attribution ) );
 	}
 
-	// ─── Theme Builder tool list ──────────────────────────────────────────────
+	// ─── Setup Assistant tool list ────────────────────────────────────────────
 
 	/**
-	 * The theme-builder built-in agent includes stock-image and generate-image
-	 * in its tier_1_tools so the imagery guidance in Phase 4 can be executed.
+	 * The unified Setup Assistant includes stock-image and generate-image in its
+	 * tier_1_tools so the imagery guidance can be executed.
 	 */
-	public function test_theme_builder_tier_1_tools_include_imagery_abilities(): void {
+	public function test_setup_assistant_tier_1_tools_include_imagery_abilities(): void {
 		\SdAiAgent\Models\Agent::reset_defaults();
 
-		$agent = \SdAiAgent\Models\Agent::get_by_slug( 'theme-builder' );
-		$this->assertNotNull( $agent, 'theme-builder agent must exist after seed_defaults()' );
+		$agent = \SdAiAgent\Models\Agent::get_by_slug( \SdAiAgent\Models\Agent::ONBOARDING_AGENT_SLUG );
+		$this->assertNotNull( $agent, 'Setup Assistant agent must exist after seed_defaults()' );
 
 		$tools = $agent->tier_1_tools;
 		$this->assertIsArray( $tools );
@@ -504,7 +504,7 @@ class StockImageAbilityTest extends WP_UnitTestCase {
 		$this->assertContains(
 			'sd-ai-agent/stock-image',
 			$tools,
-			'tier_1_tools must include sd-ai-agent/stock-image for Phase 4 imagery'
+			'tier_1_tools must include sd-ai-agent/stock-image for setup imagery'
 		);
 
 		$this->assertContains(
@@ -513,20 +513,15 @@ class StockImageAbilityTest extends WP_UnitTestCase {
 			'tier_1_tools must include sd-ai-agent/generate-image as AI imagery fallback'
 		);
 
-		// Clean up.
-		global $wpdb;
-		/** @var \wpdb $wpdb */
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test cleanup; caching not applicable.
-		$wpdb->delete( \SdAiAgent\Models\Agent::table_name(), [ 'slug' => 'theme-builder' ], [ '%s' ] );
 	}
 
 	/**
-	 * The theme-builder system prompt references the stock-image imagery workflow.
+	 * The Setup Assistant system prompt references the stock-image imagery workflow.
 	 */
-	public function test_theme_builder_system_prompt_references_imagery_workflow(): void {
+	public function test_setup_assistant_system_prompt_references_imagery_workflow(): void {
 		\SdAiAgent\Models\Agent::reset_defaults();
 
-		$agent = \SdAiAgent\Models\Agent::get_by_slug( 'theme-builder' );
+		$agent = \SdAiAgent\Models\Agent::get_by_slug( \SdAiAgent\Models\Agent::ONBOARDING_AGENT_SLUG );
 		$this->assertNotNull( $agent );
 
 		$prompt_lower = strtolower( $agent->system_prompt );
@@ -547,11 +542,6 @@ class StockImageAbilityTest extends WP_UnitTestCase {
 			'system_prompt must reference attachment_id for use in create-post'
 		);
 
-		// Clean up.
-		global $wpdb;
-		/** @var \wpdb $wpdb */
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test cleanup; caching not applicable.
-		$wpdb->delete( \SdAiAgent\Models\Agent::table_name(), [ 'slug' => 'theme-builder' ], [ '%s' ] );
 	}
 
 	// ─── Helpers ─────────────────────────────────────────────────────────────

--- a/tests/SdAiAgent/Core/OnboardingManagerTest.php
+++ b/tests/SdAiAgent/Core/OnboardingManagerTest.php
@@ -383,7 +383,7 @@ class OnboardingManagerTest extends WP_UnitTestCase {
 	// ── reset() — v2 cleanup ──────────────────────────────────────────────
 
 	/**
-	 * reset() clears the persisted bootstrap and theme-builder session IDs so
+	 * reset() clears the persisted bootstrap and empty-install session IDs so
 	 * the v2 direct-routing gate creates fresh sessions on the next mount.
 	 */
 	public function test_reset_clears_persisted_session_options(): void {
@@ -436,7 +436,7 @@ class OnboardingManagerTest extends WP_UnitTestCase {
 	// ── rest_theme_builder_start ──────────────────────────────────────────
 
 	/**
-	 * register_rest_routes() registers the onboarding/theme-builder-start route.
+	 * register_rest_routes() registers the legacy empty-install onboarding route.
 	 */
 	public function test_register_rest_routes_registers_theme_builder_start_route(): void {
 		do_action( 'rest_api_init' );
@@ -476,7 +476,7 @@ class OnboardingManagerTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * rest_theme_builder_start() sets the theme-builder started option on first call.
+	 * rest_theme_builder_start() sets the empty-install started option on first call.
 	 */
 	public function test_rest_theme_builder_start_sets_started_option(): void {
 		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
@@ -588,7 +588,7 @@ class OnboardingManagerTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * reset() clears the theme-builder started option so the next call to
+	 * reset() clears the empty-install started option so the next call to
 	 * rest_theme_builder_start() will be treated as a fresh start.
 	 */
 	public function test_reset_clears_theme_builder_started_option(): void {

--- a/tests/SdAiAgent/Core/OnboardingManagerThemeBuilderTest.php
+++ b/tests/SdAiAgent/Core/OnboardingManagerThemeBuilderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 /**
- * Test case for OnboardingManager theme-builder REST endpoint.
+	 * Test case for the legacy empty-install onboarding REST endpoint.
  *
  * @package SdAiAgent
  * @subpackage Tests
@@ -17,7 +17,10 @@ use SdAiAgent\Models\Agent;
 use WP_UnitTestCase;
 
 /**
- * Test OnboardingManager::rest_theme_builder_start() functionality.
+	 * Test OnboardingManager::rest_theme_builder_start() functionality.
+	 *
+	 * The route name is retained for compatibility, but it now resolves the
+	 * unified Setup Assistant agent instead of a separate Theme Builder agent.
  */
 class OnboardingManagerThemeBuilderTest extends WP_UnitTestCase {
 
@@ -90,18 +93,26 @@ class OnboardingManagerThemeBuilderTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * rest_theme_builder_start() returns the theme-builder agent ID.
+	 * rest_theme_builder_start() returns the Setup Assistant agent ID.
 	 */
-	public function test_rest_theme_builder_start_returns_agent_id(): void {
+	public function test_rest_theme_builder_start_returns_setup_assistant_agent_id(): void {
+		Agent::reset_defaults();
+		$agent = Agent::get_by_slug( Agent::ONBOARDING_AGENT_SLUG );
+		$this->assertNotNull( $agent );
+
 		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
 		wp_set_current_user( $admin_id );
 
 		$response = OnboardingManager::rest_theme_builder_start();
 		$data     = $response->get_data();
 
-		// The agent ID should be present (may be 0 if the agent doesn't exist yet).
 		$this->assertArrayHasKey( 'agent_id', $data );
 		$this->assertIsInt( $data['agent_id'] );
+		$this->assertSame( (int) $agent->id, $data['agent_id'] );
+		$this->assertNull(
+			Agent::get_by_slug( Agent::THEME_BUILDER_AGENT_SLUG ),
+			'the retired Theme Builder agent must not be recreated for the legacy route'
+		);
 	}
 
 	/**
@@ -137,9 +148,9 @@ class OnboardingManagerThemeBuilderTest extends WP_UnitTestCase {
 	/**
 	 * rest_theme_builder_start() marks onboarding complete (t276 change).
 	 *
-	 * In the unified-agent world there is no separate "bootstrap discovery"
-	 * flow that runs after theme-builder. Once the user has been through
-	 * the fast-build path they are done with onboarding and the React
+	 * In the unified-agent world there is no separate setup flow after the
+	 * empty-install kickoff. Once the user has been through the fast-build path
+	 * they are done with onboarding and the React
 	 * admin-page must stop re-mounting the onboarding bootstrappers.
 	 *
 	 * Previously this test asserted the opposite (the legacy contract
@@ -280,7 +291,7 @@ class OnboardingManagerThemeBuilderTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * rest_theme_builder_start() creates a session with the correct title.
+	 * rest_theme_builder_start() creates a session with the unified onboarding title.
 	 */
 	public function test_rest_theme_builder_start_creates_session_with_correct_title(): void {
 		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
@@ -300,6 +311,6 @@ class OnboardingManagerThemeBuilderTest extends WP_UnitTestCase {
 		);
 
 		$this->assertNotNull( $session_row );
-		$this->assertStringContainsString( 'Theme Builder', $session_row->title );
+		$this->assertStringContainsString( 'Getting started', $session_row->title );
 	}
 }

--- a/tests/SdAiAgent/Models/AgentTest.php
+++ b/tests/SdAiAgent/Models/AgentTest.php
@@ -490,16 +490,16 @@ class AgentTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Theme Builder system prompt must contain the no-external-web-fonts rule.
+	 * Setup Assistant system prompt must contain the no-external-web-fonts rule.
 	 *
-	 * Regression test for #1512: Theme Builder agent's system prompt must
-	 * explicitly forbid external web fonts (Google Fonts, Bunny Fonts, etc.)
-	 * in addition to external image URLs, to ensure generated themes are
-	 * GDPR-compliant and self-contained.
+	 * Regression test for #1512: the unified setup/onboarding agent's system
+	 * prompt must explicitly forbid external web fonts (Google Fonts, Bunny
+	 * Fonts, etc.) in addition to external image URLs, to ensure generated
+	 * themes are GDPR-compliant and self-contained.
 	 */
-	public function test_theme_builder_system_prompt_forbids_external_web_fonts(): void {
+	public function test_setup_assistant_system_prompt_forbids_external_web_fonts(): void {
 		$reflection = new \ReflectionClass( Agent::class );
-		$method     = $reflection->getMethod( 'get_theme_builder_definition' );
+		$method     = $reflection->getMethod( 'get_onboarding_definition' );
 		$method->setAccessible( true );
 
 		// Get the base tools (empty array is fine for this test).
@@ -511,25 +511,25 @@ class AgentTest extends WP_UnitTestCase {
 		$this->assertStringContainsString(
 			'fonts.googleapis.com',
 			$prompt,
-			'Theme Builder system prompt must mention fonts.googleapis.com as a forbidden external font CDN.'
+			'Setup Assistant system prompt must mention fonts.googleapis.com as a forbidden external font CDN.'
 		);
 
 		$this->assertStringContainsString(
 			'Web fonts from external CDNs',
 			$prompt,
-			'Theme Builder system prompt must explicitly forbid web fonts from external CDNs.'
+			'Setup Assistant system prompt must explicitly forbid web fonts from external CDNs.'
 		);
 
 		$this->assertStringContainsString(
 			'system font stacks',
 			$prompt,
-			'Theme Builder system prompt must recommend system font stacks for previews.'
+			'Setup Assistant system prompt must recommend system font stacks for previews.'
 		);
 
 		$this->assertStringContainsString(
 			'fontFace',
 			$prompt,
-			'Theme Builder system prompt must mention fontFace entries for bundled fonts in theme.json.'
+			'Setup Assistant system prompt must mention fontFace entries for bundled fonts in theme.json.'
 		);
 	}
 }

--- a/tests/SdAiAgent/Models/AgentThemeBuilderTest.php
+++ b/tests/SdAiAgent/Models/AgentThemeBuilderTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 /**
- * Tests for the theme-builder built-in agent seeding.
+ * Tests for the retired theme-builder built-in agent and the unified Setup Assistant.
  *
- * Covers: seed_defaults() creates the agent on fresh install; seed_defaults()
- * is idempotent; reset_defaults() restores canonical fields after edits;
- * tier_1_tools contains the required theme-builder abilities.
+ * Covers: seed_defaults() no longer creates the theme-builder agent;
+ * seed_defaults()/reset_defaults() remove the retired built-in row on upgrade;
+ * the unified onboarding agent keeps the former Theme Builder capabilities.
  *
  * @package SdAiAgent
  * @subpackage Tests
@@ -19,661 +19,219 @@ use SdAiAgent\Models\Agent;
 use WP_UnitTestCase;
 
 /**
- * Tests for the theme-builder built-in agent.
+ * Tests for the retired theme-builder built-in agent.
  *
  * @since 1.6.0
  */
 class AgentThemeBuilderTest extends WP_UnitTestCase {
 
 	/**
-	 * Slug constant under test.
+	 * Retired theme-builder slug constant under test.
 	 */
-	private const SLUG = 'theme-builder';
+	private const RETIRED_SLUG = 'theme-builder';
 
 	/**
-	 * Remove the theme-builder agent row from the database (helper).
+	 * Remove theme-builder rows that individual tests may create.
 	 */
-	private function delete_theme_builder_agent(): void {
+	public function tear_down(): void {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test cleanup; caching not applicable.
-		$wpdb->delete( Agent::table_name(), [ 'slug' => self::SLUG ], [ '%s' ] );
-	}
-
-	/**
-	 * Set up: ensure no stale theme-builder row from a previous run.
-	 */
-	public function set_up(): void {
-		parent::set_up();
-		$this->delete_theme_builder_agent();
-	}
-
-	/**
-	 * Tear down: remove any theme-builder agent rows created during the test
-	 * so they don't bleed into subsequent tests.
-	 */
-	public function tear_down(): void {
-		$this->delete_theme_builder_agent();
+		$wpdb->delete( Agent::table_name(), [ 'slug' => self::RETIRED_SLUG ], [ '%s' ] );
 		parent::tear_down();
 	}
 
-	// ─── THEME_BUILDER_AGENT_SLUG constant ───────────────────────────────────
-
 	/**
-	 * THEME_BUILDER_AGENT_SLUG constant has the expected value.
+	 * THEME_BUILDER_AGENT_SLUG constant is retained for upgrade cleanup and the
+	 * legacy /onboarding/theme-builder-start route name.
 	 */
-	public function test_theme_builder_agent_slug_constant(): void {
-		$this->assertSame( self::SLUG, Agent::THEME_BUILDER_AGENT_SLUG );
-	}
-
-	// ─── seed_defaults() ─────────────────────────────────────────────────────
-
-	/**
-	 * seed_defaults() creates the theme-builder agent when it does not exist.
-	 */
-	public function test_seed_defaults_creates_theme_builder_agent(): void {
-		// Ensure no pre-existing row.
-		$this->assertNull( Agent::get_by_slug( self::SLUG ) );
-
-		Agent::seed_defaults();
-
-		$agent = Agent::get_by_slug( self::SLUG );
-		$this->assertNotNull( $agent, 'theme-builder agent must exist after seed_defaults()' );
-		$this->assertSame( self::SLUG, $agent->slug );
+	public function test_theme_builder_agent_slug_constant_is_retained_for_legacy_cleanup(): void {
+		$this->assertSame( self::RETIRED_SLUG, Agent::THEME_BUILDER_AGENT_SLUG );
 	}
 
 	/**
-	 * seed_defaults() is idempotent — running it twice does not create a duplicate.
+	 * seed_defaults() no longer creates the retired theme-builder agent.
 	 */
-	public function test_seed_defaults_is_idempotent(): void {
-		Agent::seed_defaults();
+	public function test_seed_defaults_does_not_create_theme_builder_agent(): void {
+		$this->delete_theme_builder_rows();
+
 		Agent::seed_defaults();
 
-		global $wpdb;
-		/** @var \wpdb $wpdb */
+		$this->assertNull(
+			Agent::get_by_slug( self::RETIRED_SLUG ),
+			'theme-builder must not be seeded as a visible built-in agent'
+		);
+		$this->assertNotNull(
+			Agent::get_by_slug( Agent::ONBOARDING_AGENT_SLUG ),
+			'onboarding Setup Assistant must remain the single setup/onboarding agent'
+		);
+	}
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test assertion; caching not applicable.
-		$count = (int) $wpdb->get_var(
-			$wpdb->prepare(
-				'SELECT COUNT(*) FROM %i WHERE slug = %s',
-				Agent::table_name(),
-				self::SLUG
-			)
+	/**
+	 * seed_defaults() removes an existing retired built-in theme-builder row on
+	 * upgrade so the agent picker no longer shows two setup agents.
+	 */
+	public function test_seed_defaults_removes_existing_builtin_theme_builder_agent(): void {
+		$this->delete_theme_builder_rows();
+
+		$legacy_id = Agent::create(
+			[
+				'slug'          => self::RETIRED_SLUG,
+				'name'          => 'Theme Builder',
+				'description'   => 'Legacy built-in row',
+				'system_prompt' => 'Legacy prompt',
+				'is_builtin'    => true,
+				'enabled'       => true,
+			]
 		);
 
-		$this->assertSame( 1, $count, 'seed_defaults() must not create duplicate theme-builder rows' );
-	}
-
-	// ─── reset_defaults() ────────────────────────────────────────────────────
-
-	/**
-	 * reset_defaults() restores the canonical system_prompt after it has been edited.
-	 */
-	public function test_reset_defaults_restores_system_prompt(): void {
+		$this->assertIsInt( $legacy_id );
 		Agent::seed_defaults();
 
-		$agent = Agent::get_by_slug( self::SLUG );
+		$this->assertNull(
+			Agent::get_by_slug( self::RETIRED_SLUG ),
+			'upgrade seeding must remove the retired built-in theme-builder row'
+		);
+	}
+
+	/**
+	 * reset_defaults() also removes the retired built-in row so the Settings →
+	 * Agents reset action cannot bring Theme Builder back.
+	 */
+	public function test_reset_defaults_removes_existing_builtin_theme_builder_agent(): void {
+		$this->delete_theme_builder_rows();
+
+		$legacy_id = Agent::create(
+			[
+				'slug'          => self::RETIRED_SLUG,
+				'name'          => 'Theme Builder',
+				'description'   => 'Legacy built-in row',
+				'system_prompt' => 'Legacy prompt',
+				'is_builtin'    => true,
+				'enabled'       => true,
+			]
+		);
+
+		$this->assertIsInt( $legacy_id );
+		Agent::reset_defaults();
+
+		$this->assertNull(
+			Agent::get_by_slug( self::RETIRED_SLUG ),
+			'reset_defaults() must not recreate or retain the retired theme-builder built-in'
+		);
+	}
+
+	/**
+	 * reset_defaults() preserves the unified Setup Assistant prompt contract.
+	 */
+	public function test_reset_defaults_restores_unified_setup_assistant_prompt(): void {
+		Agent::reset_defaults();
+
+		$agent = Agent::get_by_slug( Agent::ONBOARDING_AGENT_SLUG );
 		$this->assertNotNull( $agent );
 
-		// Corrupt the system_prompt.
 		Agent::update( $agent->id, [ 'system_prompt' => 'CORRUPTED' ] );
-		$corrupted = Agent::get_by_slug( self::SLUG );
-		$this->assertNotNull( $corrupted );
-		$this->assertSame( 'CORRUPTED', $corrupted->system_prompt );
-
 		Agent::reset_defaults();
 
-		$restored = Agent::get_by_slug( self::SLUG );
+		$restored = Agent::get_by_slug( Agent::ONBOARDING_AGENT_SLUG );
 		$this->assertNotNull( $restored );
-		$this->assertNotSame(
-			'CORRUPTED',
-			$restored->system_prompt,
-			'reset_defaults() must restore the canonical system_prompt'
-		);
-		$this->assertStringContainsString(
-			'site-specification',
-			$restored->system_prompt,
-			'Restored system_prompt must reference the site-specification skill'
-		);
+		$this->assertNotSame( 'CORRUPTED', $restored->system_prompt );
+		$this->assertStringContainsString( 'site-specification', $restored->system_prompt );
+		$this->assertStringContainsString( 'wp-block-themes', $restored->system_prompt );
+		$this->assertStringContainsString( 'Phase 1', $restored->system_prompt );
+		$this->assertStringContainsString( 'Phase 2', $restored->system_prompt );
+		$this->assertStringContainsString( 'Phase 3', $restored->system_prompt );
 	}
 
 	/**
-	 * reset_defaults() restores the canonical greeting after it has been edited.
+	 * The unified Setup Assistant includes the former Theme Builder tier-1 tools.
 	 */
-	public function test_reset_defaults_restores_greeting(): void {
-		Agent::seed_defaults();
-
-		$agent = Agent::get_by_slug( self::SLUG );
-		$this->assertNotNull( $agent );
-
-		Agent::update( $agent->id, [ 'greeting' => 'CORRUPTED GREETING' ] );
-
+	public function test_setup_assistant_tier_1_tools_contains_theme_build_abilities(): void {
 		Agent::reset_defaults();
 
-		$restored = Agent::get_by_slug( self::SLUG );
-		$this->assertNotNull( $restored );
-		$this->assertNotSame(
-			'CORRUPTED GREETING',
-			$restored->greeting,
-			'reset_defaults() must restore the canonical greeting'
-		);
-	}
-
-	/**
-	 * reset_defaults() restores the canonical tier_1_tools after they have been edited.
-	 */
-	public function test_reset_defaults_restores_tier_1_tools(): void {
-		Agent::seed_defaults();
-
-		$agent = Agent::get_by_slug( self::SLUG );
+		$agent = Agent::get_by_slug( Agent::ONBOARDING_AGENT_SLUG );
 		$this->assertNotNull( $agent );
-
-		Agent::update( $agent->id, [ 'tier_1_tools' => [] ] );
-
-		Agent::reset_defaults();
-
-		$restored = Agent::get_by_slug( self::SLUG );
-		$this->assertNotNull( $restored );
-
-		$tools = $restored->tier_1_tools;
-		$this->assertNotEmpty( $tools, 'reset_defaults() must restore tier_1_tools' );
-	}
-
-	// ─── tier_1_tools content ────────────────────────────────────────────────
-
-	/**
-	 * The seeded theme-builder agent includes all four core theme abilities
-	 * plus the required support tools in tier_1_tools.
-	 */
-	public function test_tier_1_tools_contains_required_theme_abilities(): void {
-		Agent::seed_defaults();
-
-		$agent = Agent::get_by_slug( self::SLUG );
-		$this->assertNotNull( $agent );
-
-		$tools = $agent->tier_1_tools;
-		$this->assertIsArray( $tools, 'tier_1_tools must be an array' );
+		$this->assertIsArray( $agent->tier_1_tools );
 
 		$required = [
 			'sd-ai-agent/scaffold-block-theme',
 			'sd-ai-agent/activate-theme',
 			'sd-ai-agent/file-write',
 			'sd-ai-agent/validate-block-content',
-			'sd-ai-agent/memory-save',
-			'sd-ai-agent/skill-load',
 			'sd-ai-agent/get-theme-json',
 			'sd-ai-agent/update-global-styles',
+			'sd-ai-agent/render-design-previews',
+			'sd-ai-agent/generate-menu-page',
+			'sd-ai-agent/validate-palette-contrast',
+			'sd-ai-agent/site-scrape',
+			'sd-ai-agent/stock-image',
+			'sd-ai-agent/generate-image',
+			'sd-ai-agent/generate-logo-svg',
 		];
 
 		foreach ( $required as $ability ) {
 			$this->assertContains(
 				$ability,
-				$tools,
-				sprintf( 'tier_1_tools must contain %s', $ability )
-			);
-		}
-	}
-
-	// ─── builtin definition fields ───────────────────────────────────────────
-
-	/**
-	 * The theme-builder definition in get_builtin_definitions() contains all
-	 * 8 required fields.
-	 */
-	public function test_builtin_definition_has_all_required_fields(): void {
-		$reflection = new \ReflectionClass( Agent::class );
-		$method     = $reflection->getMethod( 'get_builtin_definitions' );
-		$method->setAccessible( true );
-		/** @var list<array<string, mixed>> $definitions */
-		$definitions = $method->invoke( null );
-
-		$theme_builder_def = null;
-		foreach ( $definitions as $def ) {
-			if ( isset( $def['slug'] ) && $def['slug'] === self::SLUG ) {
-				$theme_builder_def = $def;
-				break;
-			}
-		}
-
-		$this->assertNotNull( $theme_builder_def, 'get_builtin_definitions() must include a theme-builder entry' );
-
-		$required_fields = [ 'slug', 'name', 'description', 'system_prompt', 'greeting', 'tier_1_tools', 'suggestions', 'avatar_icon' ];
-		foreach ( $required_fields as $field ) {
-			$this->assertArrayHasKey( $field, $theme_builder_def, sprintf( 'theme-builder definition must have field: %s', $field ) );
-			$this->assertNotEmpty( $theme_builder_def[ $field ], sprintf( 'theme-builder definition field must not be empty: %s', $field ) );
-		}
-	}
-
-	/**
-	 * The system_prompt references the skills and the unified-agent phase
-	 * contract introduced in t276 (Phase 1 Capture / Phase 2 Build /
-	 * Phase 3 Follow-up — the legacy Phase 4 was merged into Phase 2).
-	 */
-	public function test_system_prompt_references_required_skills_and_contract(): void {
-		Agent::seed_defaults();
-
-		$agent = Agent::get_by_slug( self::SLUG );
-		$this->assertNotNull( $agent );
-
-		$prompt = $agent->system_prompt;
-
-		$this->assertStringContainsString(
-			'site-specification',
-			$prompt,
-			'system_prompt must reference the site-specification skill'
-		);
-		$this->assertStringContainsString(
-			'wp-block-themes',
-			$prompt,
-			'system_prompt must reference the wp-block-themes skill'
-		);
-		// The unified 3-phase contract (t276): Phase 1 (Capture), Phase 2
-		// (Build the homepage), Phase 3 (Follow-up loop). Legacy Phase 4
-		// was merged into Phase 2.
-		$this->assertStringContainsString( 'Phase 1', $prompt, 'system_prompt must define Phase 1 (Capture)' );
-		$this->assertStringContainsString( 'Phase 2', $prompt, 'system_prompt must define Phase 2 (Build the homepage)' );
-		$this->assertStringContainsString( 'Phase 3', $prompt, 'system_prompt must define Phase 3 (Follow-up loop)' );
-		// Stock-imagery flow must be referenced (use sd-ai-agent/stock-image
-		// with action: import — never an external URL in a theme file).
-		$this->assertStringContainsString(
-			'stock-image',
-			strtolower( $prompt ),
-			'system_prompt must reference the stock-image flow'
-		);
-	}
-
-	// ─── Real-content principle (issue #1526) ────────────────────────────────
-
-	/**
-	 * The system_prompt encodes the "real content or no content" principle
-	 * required by issue #1526.
-	 */
-	public function test_system_prompt_encodes_real_content_principle(): void {
-		Agent::seed_defaults();
-
-		$agent = Agent::get_by_slug( self::SLUG );
-		$this->assertNotNull( $agent );
-
-		$prompt_lower = strtolower( $agent->system_prompt );
-
-		// The top-level principle heading must be present.
-		$this->assertStringContainsString(
-			'real content or no content',
-			$prompt_lower,
-			'system_prompt must encode the "real content or no content" principle'
-		);
-		// The stub-prevention rule must be explicit.
-		$this->assertStringContainsString(
-			'never publish a stub',
-			$prompt_lower,
-			'system_prompt must include the "never publish a stub" rule'
-		);
-	}
-
-	/**
-	 * The system_prompt explicitly bans placeholder strings that must never
-	 * appear in generated pages (issue #1526 acceptance criterion).
-	 */
-	public function test_system_prompt_bans_placeholder_strings(): void {
-		Agent::seed_defaults();
-
-		$agent = Agent::get_by_slug( self::SLUG );
-		$this->assertNotNull( $agent );
-
-		$prompt = $agent->system_prompt;
-
-		// The Rules section must name the banned strings so the model
-		// knows exactly what NOT to output.
-		$banned_phrases = [
-			'Lorem ipsum',
-			'Replace this',
-			'Edit this',
-			'Add your',
-		];
-
-		foreach ( $banned_phrases as $phrase ) {
-			$this->assertStringContainsString(
-				$phrase,
-				$prompt,
-				sprintf(
-					'system_prompt must explicitly ban the placeholder string "%s"',
-					$phrase
-				)
+				$agent->tier_1_tools,
+				sprintf( 'Setup Assistant tier_1_tools must contain %s', $ability )
 			);
 		}
 	}
 
 	/**
-	 * The system_prompt includes the page-creation prerequisite self-check
-	 * required by issue #1526 section 2. Updated for t276: the unified
-	 * prompt enforces the prerequisite check on every create-post call
-	 * EXCEPT the initial empty-install homepage (which is allowed to ship
-	 * with safe inferred copy because the user opted into the fast-build
-	 * path and refines it through Phase 3 follow-up chips).
+	 * The unified Setup Assistant prompt keeps the real-content principle.
 	 */
-	public function test_system_prompt_encodes_page_creation_prerequisite_check(): void {
-		Agent::seed_defaults();
+	public function test_setup_assistant_system_prompt_encodes_real_content_principle(): void {
+		Agent::reset_defaults();
 
-		$agent = Agent::get_by_slug( self::SLUG );
+		$agent = Agent::get_by_slug( Agent::ONBOARDING_AGENT_SLUG );
 		$this->assertNotNull( $agent );
 
 		$prompt_lower = strtolower( $agent->system_prompt );
-
-		// The prerequisite check section must be present.
-		$this->assertStringContainsString(
-			'prerequisite check',
-			$prompt_lower,
-			'system_prompt must include a page-creation prerequisite check section'
-		);
-		// The check must be linked to create-post calls.
-		$this->assertStringContainsString(
-			'create-post',
-			$agent->system_prompt,
-			'page-creation prerequisite check must reference create-post'
-		);
-		// No draft stubs.
-		$this->assertStringContainsString(
-			'draft stubs',
-			$prompt_lower,
-			'system_prompt must forbid draft stubs'
-		);
+		$this->assertStringContainsString( 'real content or no content', $prompt_lower );
+		$this->assertStringContainsString( 'never publish a stub', $prompt_lower );
+		$this->assertStringContainsString( 'prerequisite check', $prompt_lower );
 	}
 
 	/**
-	 * The system_prompt is vertical-aware: it lists the supported verticals
-	 * so the model can pick sensible defaults during Phase 1 inference.
-	 * As of t276 per-vertical question packs are deferred to Phase 3
-	 * follow-up chips — the prompt itself enumerates the verticals and
-	 * delegates depth to the `site-specification` skill.
+	 * The unified Setup Assistant prompt keeps the placeholder bans.
 	 */
-	public function test_system_prompt_is_vertical_aware(): void {
-		Agent::seed_defaults();
+	public function test_setup_assistant_system_prompt_bans_placeholder_strings(): void {
+		Agent::reset_defaults();
 
-		$agent = Agent::get_by_slug( self::SLUG );
+		$agent = Agent::get_by_slug( Agent::ONBOARDING_AGENT_SLUG );
 		$this->assertNotNull( $agent );
 
-		$prompt_lower = strtolower( $agent->system_prompt );
-
-		// Each key vertical type must appear in the supported-verticals list.
-		$verticals = [
-			'café',
-			'restaurant',
-			'retail',
-			'service business',
-			'portfolio',
-			'blog',
-			'event venue',
-		];
-
-		foreach ( $verticals as $vertical ) {
-			$this->assertStringContainsString(
-				$vertical,
-				$prompt_lower,
-				sprintf(
-					'system_prompt must list "%s" in the supported verticals',
-					$vertical
-				)
-			);
+		foreach ( [ 'Lorem ipsum', 'Replace this', 'Edit this', 'Add your' ] as $phrase ) {
+			$this->assertStringContainsString( $phrase, $agent->system_prompt );
 		}
-
-		// The unified prompt must describe itself as vertical-aware.
-		$this->assertStringContainsString(
-			'vertical-aware',
-			$prompt_lower,
-			'system_prompt must describe itself as vertical-aware'
-		);
-	}
-
-	// ─── Menu page generation tools (issue #1531) ────────────────────────────
-
-	/**
-	 * The seeded theme-builder agent includes the generate-menu-page ability
-	 * in tier_1_tools (issue #1531).
-	 */
-	public function test_tier_1_tools_contains_generate_menu_page(): void {
-		Agent::seed_defaults();
-
-		$agent = Agent::get_by_slug( self::SLUG );
-		$this->assertNotNull( $agent );
-
-		$this->assertContains(
-			'sd-ai-agent/generate-menu-page',
-			$agent->tier_1_tools,
-			'tier_1_tools must contain sd-ai-agent/generate-menu-page for hospitality menu pages'
-		);
 	}
 
 	/**
-	 * The system_prompt instructs the agent to run a structured menu
-	 * interview for hospitality verticals (issue #1531 acceptance
-	 * criterion). As of t276 the literal interview script is delegated to
-	 * the Phase 3 "Add menu page" follow-up chip, but the prompt must
-	 * still describe the structured shape (categories → items + prices →
-	 * optional descriptions / dietary tags / PDF URL) and forbid prose
-	 * menus.
+	 * The unified Setup Assistant prompt is vertical-aware.
 	 */
-	public function test_system_prompt_contains_structured_menu_interview_questions(): void {
-		Agent::seed_defaults();
+	public function test_setup_assistant_system_prompt_is_vertical_aware(): void {
+		Agent::reset_defaults();
 
-		$agent = Agent::get_by_slug( self::SLUG );
+		$agent = Agent::get_by_slug( Agent::ONBOARDING_AGENT_SLUG );
 		$this->assertNotNull( $agent );
 
 		$prompt_lower = strtolower( $agent->system_prompt );
-
-		// Phase 3 chip must describe the structured menu interview shape.
-		$this->assertStringContainsString(
-			'categories',
-			$prompt_lower,
-			'system_prompt must reference menu categories in the Phase 3 menu chip'
-		);
-		$this->assertStringContainsString(
-			'prices',
-			$prompt_lower,
-			'system_prompt must reference per-item prices in the Phase 3 menu chip'
-		);
-		// Dietary tags remain part of the structured menu interview.
-		$this->assertStringContainsString(
-			'dietary',
-			$prompt_lower,
-			'system_prompt must reference dietary tags in the Phase 3 menu chip'
-		);
-		// Menu prose is explicitly banned in the hard rules.
-		$this->assertStringContainsString(
-			'never write the menu as prose',
-			$prompt_lower,
-			'system_prompt must ban writing the menu as prose'
-		);
+		foreach ( [ 'café', 'restaurant', 'retail', 'service business', 'portfolio', 'blog', 'event venue' ] as $vertical ) {
+			$this->assertStringContainsString( $vertical, $prompt_lower );
+		}
+		$this->assertStringContainsString( 'vertical-aware', $prompt_lower );
 	}
 
 	/**
-	 * The system_prompt instructs the agent to use sd-ai-agent/generate-menu-page
-	 * for hospitality verticals — not prose (issue #1531 acceptance criterion).
+	 * Delete theme-builder rows regardless of built-in status for test setup.
 	 */
-	public function test_system_prompt_instructs_generate_menu_page_ability(): void {
-		Agent::seed_defaults();
+	private function delete_theme_builder_rows(): void {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
 
-		$agent = Agent::get_by_slug( self::SLUG );
-		$this->assertNotNull( $agent );
-
-		$this->assertStringContainsString(
-			'sd-ai-agent/generate-menu-page',
-			$agent->system_prompt,
-			'system_prompt must reference sd-ai-agent/generate-menu-page ability'
-		);
-	}
-
-	/**
-	 * The system_prompt explicitly bans prose menu pages
-	 * ("Our menu changes seasonally" placeholder style is banned).
-	 */
-	public function test_system_prompt_bans_prose_menu_pages(): void {
-		Agent::seed_defaults();
-
-		$agent = Agent::get_by_slug( self::SLUG );
-		$this->assertNotNull( $agent );
-
-		$prompt_lower = strtolower( $agent->system_prompt );
-
-		// The prompt must forbid writing the menu as prose.
-		$this->assertStringContainsString(
-			'as prose',
-			$prompt_lower,
-			'system_prompt must ban writing the menu as prose'
-		);
-	}
-
-	/**
-	 * The system_prompt includes the PDF menu preference question
-	 * (issue #1531 Caveats section). As of t276 it lives in the Phase 3
-	 * "Add menu page" chip description rather than the Phase 1 interview.
-	 */
-	public function test_system_prompt_asks_about_pdf_menu_preference(): void {
-		Agent::seed_defaults();
-
-		$agent = Agent::get_by_slug( self::SLUG );
-		$this->assertNotNull( $agent );
-
-		$prompt_lower = strtolower( $agent->system_prompt );
-
-		$this->assertStringContainsString(
-			'pdf',
-			$prompt_lower,
-			'system_prompt must mention downloadable PDF menu support'
-		);
-	}
-
-	/**
-	 * The system_prompt includes the hospitality verticals expanded list
-	 * (issue #1531 adds bar and food truck alongside café/restaurant).
-	 */
-	public function test_system_prompt_includes_expanded_hospitality_verticals(): void {
-		Agent::seed_defaults();
-
-		$agent = Agent::get_by_slug( self::SLUG );
-		$this->assertNotNull( $agent );
-
-		$prompt_lower = strtolower( $agent->system_prompt );
-
-		$this->assertStringContainsString(
-			'bar',
-			$prompt_lower,
-			'system_prompt must include "bar" in the hospitality verticals list'
-		);
-
-		$this->assertStringContainsString(
-			'food truck',
-			$prompt_lower,
-			'system_prompt must include "food truck" in the hospitality verticals list'
-		);
-	}
-
-	// ─── Site scrape tool (issue #1548) ─────────────────────────────────────
-
-	/**
-	 * The seeded theme-builder agent includes sd-ai-agent/site-scrape in
-	 * tier_1_tools so the model can pre-fill interview answers without
-	 * extra ability-search + ability-call round-trips (issue #1548).
-	 */
-	public function test_tier_1_tools_contains_site_scrape(): void {
-		Agent::seed_defaults();
-
-		$agent = Agent::get_by_slug( self::SLUG );
-		$this->assertNotNull( $agent );
-
-		$this->assertContains(
-			'sd-ai-agent/site-scrape',
-			$agent->tier_1_tools,
-			'tier_1_tools must contain sd-ai-agent/site-scrape for site pre-fill (issue #1548)'
-		);
-	}
-
-	// ─── Image generation tools (issue #1529) ────────────────────────────────
-
-	/**
-	 * The theme-builder's tier_1_tools includes both image tools required for
-	 * brand-specific imagery and generic photography (issue #1529).
-	 */
-	public function test_tier_1_tools_contains_image_tools(): void {
-		Agent::seed_defaults();
-
-		$agent = Agent::get_by_slug( self::SLUG );
-		$this->assertNotNull( $agent );
-
-		$tools = $agent->tier_1_tools;
-		$this->assertIsArray( $tools );
-
-		$this->assertContains(
-			'sd-ai-agent/generate-image',
-			$tools,
-			'tier_1_tools must contain sd-ai-agent/generate-image for brand-specific imagery'
-		);
-
-		$this->assertContains(
-			'sd-ai-agent/stock-image',
-			$tools,
-			'tier_1_tools must contain sd-ai-agent/stock-image for generic photography'
-		);
-	}
-
-	/**
-	 * The system_prompt teaches the model when to use stock-image vs generate-image.
-	 *
-	 * Generic photography uses stock-image; brand-specific / illustration /
-	 * pattern backgrounds use generate-image (issue #1529 acceptance criterion).
-	 */
-	public function test_system_prompt_contains_image_selection_guidance(): void {
-		Agent::seed_defaults();
-
-		$agent = Agent::get_by_slug( self::SLUG );
-		$this->assertNotNull( $agent );
-
-		$prompt = $agent->system_prompt;
-
-		$this->assertStringContainsString(
-			'sd-ai-agent/stock-image',
-			$prompt,
-			'system_prompt must reference sd-ai-agent/stock-image'
-		);
-
-		$this->assertStringContainsString(
-			'sd-ai-agent/generate-image',
-			$prompt,
-			'system_prompt must reference sd-ai-agent/generate-image'
-		);
-
-		// The prompt must explain when to choose each tool.
-		$prompt_lower = strtolower( $prompt );
-
-		$this->assertStringContainsString(
-			'stock',
-			$prompt_lower,
-			'system_prompt must mention stock imagery guidance'
-		);
-
-		$this->assertStringContainsString(
-			'brand',
-			$prompt_lower,
-			'system_prompt must mention brand-specific imagery as a generate-image use-case'
-		);
-	}
-
-	/**
-	 * The system_prompt includes the "no external image URLs in theme files" rule,
-	 * which is enforced by the image-selection guidance (issue #1529).
-	 */
-	public function test_system_prompt_bans_external_image_urls_in_theme_files(): void {
-		Agent::seed_defaults();
-
-		$agent = Agent::get_by_slug( self::SLUG );
-		$this->assertNotNull( $agent );
-
-		$prompt_lower = strtolower( $agent->system_prompt );
-
-		$this->assertStringContainsString(
-			'attachment_id',
-			$agent->system_prompt,
-			'system_prompt must instruct use of attachment_id (not external URLs) in theme files'
-		);
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test setup; caching not applicable.
+		$wpdb->delete( Agent::table_name(), [ 'slug' => self::RETIRED_SLUG ], [ '%s' ] );
 	}
 }


### PR DESCRIPTION
## Summary

Follow-up to #1932.

- Retire the separate built-in `theme-builder` agent so Setup Assistant is the single visible setup/onboarding agent.
- Remove the retired built-in row during agent seeding/reset and bump the DB version so upgraded sites clean it up.
- Keep `/onboarding/theme-builder-start` as a legacy empty-install route, but attach the `onboarding` Setup Assistant agent and use the unified session title.
- Update Settings → Advanced onboarding reset copy and the affected PHP/JS tests.

## Worker self-verification

- PHPUnit: Tests: 3547, Assertions: 14758, Errors: 0, Failures: 0, Skipped: 114, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Targeted JS check also passed: `OnboardingThemeBuilder.test.js` — 13 tests.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.10 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5
