### PR TITLE
fix: strip database ability from wporg build

### DIFF
--- a/.distignore-wporg
+++ b/.distignore-wporg
@@ -14,6 +14,7 @@
 #  - SD_AI_AGENT_FEATURE_BENCHMARK               (WP-CLI benchmark with arbitrary --log-dir)
 #  - SD_AI_AGENT_FEATURE_USER_MANAGEMENT         (custom user create / role change)
 #  - SD_AI_AGENT_FEATURE_FILE_WRITE              (git-tracking source package snapshots)
+#  - DatabaseAbilities.php                       (dynamic SQL read ability)
 #  - WP 6.9 compatibility shims                 (WP.org build requires WP 7.0)
 #
 # Note: the PLUGIN_STATE_CHANGES and PLUGIN_INSTALL_FROM_URL gates only
@@ -71,6 +72,15 @@ includes/Abilities/UserManagementAbilities.php
 # `unzip -l | grep RunPhpAbility` check that the dispatcher cannot be
 # reintroduced by re-defining the feature flag.
 includes/Abilities/RunPhpAbility.php
+
+# ── Dynamic SQL read ability ─────────────────────────────────────────────────
+# The full release keeps sd-ai-agent/db-query for self-hosted administrator
+# diagnostics, with SELECT-only validation and prepared placeholder support.
+# WordPress.org Plugin Check still flags the final validated get_results() call
+# as a direct unescaped DB parameter, so the WP.org package strips this ability
+# entirely rather than shipping a surface that will keep recurring in automated
+# review output.
+includes/Abilities/DatabaseAbilities.php
 
 # Persistence layer used only by the plugin builder.
 includes/Repositories/GeneratedPluginsRepository.php

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -19,10 +19,11 @@
 #            the WP 6.9 compatibility shims. Also strips source files for the AI
 #            plugin builder (generate / sandbox / activate / update), for
 #            WP-CLI custom tools, the block-theme scaffolder ability that
-#            writes executable theme code, and the git-tracking source-package
-#            snapshot layer. It forces the matching feature flags to false in
-#            the main plugin file so the runtime gates cannot be re-enabled by
-#            re-adding the source files. Output:
+#            writes executable theme code, the git-tracking source-package
+#            snapshot layer, and the dynamic SQL database-query ability. It
+#            forces the matching feature flags to false in the main plugin file
+#            so the runtime gates cannot be re-enabled by re-adding the source
+#            files. Output:
 #               superdav-ai-agent-{version}-wporg.zip
 #
 # Why two targets?  WP.org Plugin Review Guideline 4 prohibits plugins
@@ -277,6 +278,22 @@ EXTRA
 			return 1
 		fi
 
+		# Keep readme.txt metadata in lockstep with the WP.org-only plugin header
+		# rewrite above. Plugin Check treats a header/readme mismatch as a hard
+		# submission error even when the runtime code has already been rewritten.
+		local readme_file="${dest}/readme.txt"
+		if [ -f "$readme_file" ]; then
+			sed -i.bak \
+				-e 's/^Requires at least:.*/Requires at least: 7.0/' \
+				"$readme_file"
+			rm -f "${readme_file}.bak"
+
+			if ! grep -q '^Requires at least: 7.0$' "$readme_file"; then
+				echo "ERROR: failed to force readme.txt Requires at least: 7.0 in wporg build." >&2
+				return 1
+			fi
+		fi
+
 		# The GitTrackingHandler class is stripped below. Remove it from the
 		# bundled module handler list so the DI bootstrap never attempts to reflect
 		# a class that is intentionally absent from the WP.org package.
@@ -332,6 +349,7 @@ PYADMIN
 			"${dest}/includes/CLI/BenchmarkCommand.php"
 			"${dest}/includes/Abilities/UserManagementAbilities.php"
 			"${dest}/includes/Abilities/RunPhpAbility.php"
+			"${dest}/includes/Abilities/DatabaseAbilities.php"
 			"${dest}/includes/Abilities/GitAbilities.php"
 			"${dest}/includes/Abilities/GitSnapshotAbility.php"
 			"${dest}/includes/Abilities/GitDiffAbility.php"
@@ -352,7 +370,7 @@ PYADMIN
 				return 1
 			fi
 		done
-		echo "    Stripped WP 6.9 compatibility shims, plugin-builder + theme-scaffolder + git-tracking source files, forced feature flags to false, and set Requires at least to 7.0."
+		echo "    Stripped WP 6.9 compatibility shims, plugin-builder + theme-scaffolder + git-tracking + dynamic-SQL source files, forced feature flags to false, and set Requires at least to 7.0."
 
 		# ── Neutralise forbidden move_uploaded_file() in bundled PSR-7 ───────
 		# WP.org's plugin-check tool hard-fails on any literal occurrence of

--- a/includes/Bootstrap/AbilitiesHandler.php
+++ b/includes/Bootstrap/AbilitiesHandler.php
@@ -170,7 +170,13 @@ final class AbilitiesHandler {
 		) {
 			PluginBuilderAbilities::register_abilities();
 		}
-		DatabaseAbilities::register_abilities();
+		// The WP.org build strips DatabaseAbilities.php to avoid recurring
+		// Plugin Check direct-SQL findings on the dynamic SELECT diagnostics
+		// ability. Keep the full release behaviour unchanged while avoiding a
+		// fatal when the source file is absent from the submitted zip.
+		if ( class_exists( DatabaseAbilities::class ) ) {
+			DatabaseAbilities::register_abilities();
+		}
 		WordPressAbilities::register_abilities();
 		// WP-CLI dispatcher: gated by SD_AI_AGENT_FEATURE_WP_CLI_DISPATCHER
 		// and class_exists() guarded so the WordPress.org build (which


### PR DESCRIPTION
## Summary

- Updates the WP.org build rewrite so `readme.txt` and the main plugin header both declare `Requires at least: 7.0`.
- Strips `includes/Abilities/DatabaseAbilities.php` from the WP.org package so Plugin Check no longer reports the dynamic SQL diagnostics ability.
- Guards `DatabaseAbilities::register_abilities()` with `class_exists()` so the full release keeps the ability while the stripped WP.org package cannot fatal.

## Verification

- `bin/build.sh --target=wporg`
- `wp plugin check <extracted-wporg-build> --slug=superdav-ai-agent --mode=new --include-experimental --format=strict-json` → `Success: Checks complete. No errors found.`
- `wp plugin check <extracted-wporg-build> --slug=superdav-ai-agent --mode=new --include-experimental --format=json --ai` → `Success: Checks complete. No errors found.`
- Confirmed the WP.org zip contains `readme.txt` and `superdav-ai-agent.php`, both with `Requires at least: 7.0`, and no `DatabaseAbilities.php` entry.

## Worker self-verification
- PHPUnit: Tests: 3548, Assertions: 14758, Errors: 0, Failures: 0, Skipped: 115, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.10 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 1h 16m and 384,803 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated WordPress.org distribution builds to require WordPress 7.0 or later.
  * Enhanced build process reliability for distribution packaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->