### PR TITLE
GH#1996: docs: clarify contributor insight review responses

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -113,6 +113,11 @@ to change, do not answer only in the issue thread. Make the durable repo change:
   `includes/REST/SettingsController.php`, and
   `includes/Abilities/ToolCapabilities.php` so the response names API calls,
   credential storage, REST routes, and capability gates.
+- For WordPress.org review-response prompts, require an issue-by-issue reply
+  that cites the merged fix or evidence-backed rationale for each reviewer
+  finding, includes verification commands, and avoids broad "everything is fixed"
+  or "remaining issues are false positives" claims unless each claim is tied to
+  exact file or pattern evidence.
 - Do not mark contributor-insight issues complete after documentation reading
   alone. A valid fix changes a durable instruction, workflow doc, or helper, then
   verifies the changed guidance with an exact `rg -n` check that future workers

--- a/.agents/scripts/commands/feedback-triage.md
+++ b/.agents/scripts/commands/feedback-triage.md
@@ -117,6 +117,10 @@ issue. Examples:
   map to `includes/Abilities/GscAbilities.php`, `includes/Core/Settings.php`,
   `includes/REST/SettingsController.php`, and
   `includes/Abilities/ToolCapabilities.php`.
+- WordPress.org review-response notes map to the root `AGENTS.md`
+  "WordPress.org Review Responses" policy. The issue body should require a
+  concise issue-by-issue response, concrete fix/rationale references, verification
+  evidence, and no broad "false positive" claims without finding-specific proof.
 
 The resulting issue body must name the target files, expected behaviour, and at
 least one verification command; do not leave private local paths or shorthand as
@@ -212,8 +216,13 @@ before creating the issue:
   avoid heredocs/process substitution/command substitution/inline markdown, pass
   that file via `--body-file`, and switch to the signed helper path instead of
   retrying the same raw unsigned `gh` command.
+- If the note asks for a WordPress.org plugin-review email response, require the
+  worker to draft against the root `AGENTS.md` review-response rules: address
+  each reviewer finding separately, cite the merged fix or evidence-backed
+  rationale, include commands/manual checks run, and avoid "all fixed" or
+  "false positive" language unless tied to exact file/pattern evidence.
 - Include verification in the issue body, for example
-  `rg -n "Contributor Insight|sd-ai-agent/v1|secret|current user|file upload" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md`
+  `rg -n "Contributor Insight|sd-ai-agent/v1|secret|current user|file upload|WordPress.org Review|false positive" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md`
   or `rg -n "read:file_not_found|missing-file reads|git ls-files|signature gate|body-file|gh-signature-helper" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md`
   plus `rg -n "wp-block-themes|Full Site Editing|theme.json|validate-block-content" AGENTS.md includes/Models/skills/wp-block-themes.md`
   when block-theme guidance is involved.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,9 @@ professional, issue-by-issue format:
   or manual review commands that were run.
 - Avoid defensive language, marketing copy, emojis, and broad claims that are not
   backed by a concrete change or test.
+- Do not say remaining reviewer findings are "false positives" unless a specific
+  finding was reproduced, traced to a scanner limitation, and documented with the
+  exact file/pattern evidence that proves the submitted code is safe.
 - Close with the resubmission status and any specific reviewer action requested.
 
 ### Contributor Insight Triage
@@ -144,8 +147,12 @@ note to a committed, future-loaded source before editing:
   for API calls and ability IDs, `includes/Core/Settings.php` for credential
   storage, `includes/REST/SettingsController.php` for credential REST routes,
   and `includes/Abilities/ToolCapabilities.php` for capability gating.
+- For WordPress.org review-response prompts, use the review response rules above:
+  summarize each reviewer finding, cite the merged fix or evidence-backed
+  rationale, include verification commands, and avoid blanket "all fixed" or
+  "false positive" claims that are not tied to a specific finding.
 - Verification for this class of guidance-only fix should include both:
-  `rg -n "Contributor Insight|source mapping|local-path|sd-ai-agent/v1|file upload" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md`
+  `rg -n "Contributor Insight|source mapping|local-path|sd-ai-agent/v1|file upload|WordPress.org Review|false positive" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md`
   and `rg -n "wp-block-themes|Full Site Editing|theme.json|validate-block-content" AGENTS.md includes/Models/skills/wp-block-themes.md`.
 
 ### Google Search Console API Usage Mapping


### PR DESCRIPTION
## Summary

Updated contributor-insight guidance so WordPress.org review-response prompts map to durable instructions in AGENTS.md, .agents/AGENTS.md, and feedback-triage workflow docs; reinforced evidence-backed false-positive language.

## Files Changed

.agents/AGENTS.md,.agents/scripts/commands/feedback-triage.md,AGENTS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** rg -n "Contributor Insight|source mapping|local-path|sd-ai-agent/v1|file upload|WordPress.org Review|false positive" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md; rg -n "wp-block-themes|Full Site Editing|theme.json|validate-block-content" AGENTS.md includes/Models/skills/wp-block-themes.md

Resolves #1996


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.11 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 2m and 72,736 tokens on this as a headless worker.