### PR TITLE
test: cover stock image fallback after requested source failure

### DIFF
--- a/tests/SdAiAgent/Abilities/ImageSourceFactoryTest.php
+++ b/tests/SdAiAgent/Abilities/ImageSourceFactoryTest.php
@@ -92,6 +92,52 @@ class ImageSourceFactoryTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * An explicitly requested free source is tried first, but its download failure
+	 * does not stop the fallback chain from trying the remaining free providers.
+	 */
+	public function test_import_image_retries_remaining_free_sources_after_requested_source_failure(): void {
+		$openverse = new FakeImageSource(
+			'openverse',
+			'free',
+			[
+				[ 'id' => 'openverse-1', 'source' => 'openverse' ],
+			]
+		);
+		$pixabay   = new FakeImageSource(
+			'pixabay',
+			'free',
+			[
+				[ 'id' => 'pixabay-1', 'source' => 'pixabay' ],
+			]
+		);
+		$generate  = new FakeImageSource( 'generate', 'api', [] );
+
+		$this->set_sources(
+			[
+				'openverse' => $openverse,
+				'pixabay'   => $pixabay,
+				'generate'  => $generate,
+			]
+		);
+
+		$result = ImageSourceFactory::import_image(
+			'test query',
+			'pixabay',
+			1200,
+			800,
+			[ 'no_generate_fallback' => true ]
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'all_sources_failed', $result->get_error_code() );
+		$this->assertSame( [ 'pixabay-1' ], $pixabay->downloaded_ids );
+		$this->assertSame( [ 'openverse-1' ], $openverse->downloaded_ids );
+		$this->assertSame( [], $generate->downloaded_ids );
+		$this->assertStringContainsString( 'pixabay', $result->get_error_message() );
+		$this->assertStringContainsString( 'openverse', $result->get_error_message() );
+	}
+
+	/**
 	 * Get the private source registry.
 	 *
 	 * @return array<string, ImageSourceInterface>


### PR DESCRIPTION
## Summary
- Adds regression coverage for the stock image import fallback chain.
- Verifies a requested free source is attempted first and download failures continue to the remaining free providers.
- Verifies AI generation is not used when `no_generate_fallback` is set.

Resolves #2009

## Worker self-verification
- PHPUnit: Tests: 3531, Assertions: 14725, Errors: 0, Failures: 0, Skipped: 115, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  check:bundle succeeded

## Notes
- `npm run verify` timed out during PHPStan at the default 1200s Composer timeout. The gates were rerun individually: lint passed via `npm run verify` before timeout, PHPStan passed with `COMPOSER_PROCESS_TIMEOUT=2400`, PHPUnit passed after restoring dev dependencies, build passed, and bundle check passed.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.11 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test validating that image import continues retrying remaining available sources when a requested source fails, ensuring robust fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->