### PR TITLE
t002: fix: harden TODO issue sync parsing

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -565,9 +565,10 @@ cmd_pull() {
 			local tid_ere
 			tid_ere=$(_escape_ere "$tid")
 
-			# Ref sync
-			if ! grep -qE "^\s*- \[.\] ${tid_ere} .*ref:GH#${num}" "$todo_file" 2>/dev/null; then
-				if ! grep -qE "^\s*- \[.\] ${tid_ere} " "$todo_file" 2>/dev/null; then
+			# Ref sync. Match against the stripped TODO stream so task-like examples
+			# inside HTML comments or code fences do not masquerade as real tasks.
+			if ! strip_code_fences <"$todo_file" | grep -qE "^\s*- \[.\] ${tid_ere} .*ref:GH#${num}"; then
+				if ! strip_code_fences <"$todo_file" | grep -qE "^\s*- \[.\] ${tid_ere} "; then
 					if [[ "$state" == "open" ]]; then
 						print_warning "ORPHAN: #$num ($tid: $title) — no TODO.md entry"
 						orphan_open=$((orphan_open + 1))
@@ -599,8 +600,21 @@ cmd_pull() {
 				continue
 			fi
 			local ln
-			# Use awk to get line number while skipping code-fenced blocks
-			ln=$(awk -v pat="^[[:space:]]*- \\[.\\] ${tid_ere} " '/^[[:space:]]*```/{f=!f; next} !f && $0 ~ pat {print NR; exit}' "$todo_file")
+			# Use awk to get line number while skipping code-fenced blocks and HTML
+			# comments, matching strip_code_fences semantics without losing line numbers.
+			ln=$(awk -v pat="^[[:space:]]*- \\[.\\] ${tid_ere} " '
+				/^[[:space:]]*```/ { in_fence = ! in_fence; next }
+				in_fence { next }
+				in_html_comment {
+					if ($0 ~ /-->/) { in_html_comment = 0 }
+					next
+				}
+				/<!--/ {
+					if ($0 !~ /-->/) { in_html_comment = 1 }
+					next
+				}
+				$0 ~ pat { print NR; exit }
+			' "$todo_file")
 			if [[ -n "$ln" ]]; then
 				local cl
 				cl=$(sed -n "${ln}p" "$todo_file")
@@ -722,7 +736,7 @@ cmd_status() {
 		[[ -z "$tid" ]] && continue
 		local tid_ere
 		tid_ere=$(_escape_ere "$tid")
-		grep -qE "^\s*- \[x\] ${tid_ere} " "$todo_file" 2>/dev/null && {
+		strip_code_fences <"$todo_file" | grep -qE "^\s*- \[x\] ${tid_ere} " && {
 			drift=$((drift + 1))
 			print_warning "DRIFT: #$(echo "$il" | jq -r '.number') ($tid) open but completed"
 		}

--- a/TODO.md
+++ b/TODO.md
@@ -883,7 +883,7 @@ Full plan: [todo/PLANS.md#complete-site-building-abilities](PLANS.md#2026-04-09-
   - Verify: `composer phpstan && composer phpcs`
 - [x] t000 Install dependencies and verify code quality baseline verified:2026-03-14 completed:2026-03-14
 - [x] t001 Set up dev environment: composer install, npm ci, wp-env config verified:2026-03-14 completed:2026-03-14
-- [x] t002 php-ai-client already at ^1.3 (latest) verified:2026-03-14 completed:2026-03-14
+- [x] t002 php-ai-client already at ^1.3 (latest) verified:2026-03-14 ref:GH#2005 completed:2026-03-14
 - [x] t003 .wp-env.json created with WP 6.9, PHP 8.2, multisite, debug config verified:2026-03-14 completed:2026-03-14
 - [x] t021 FileAbilities: 7 abilities (read/write/edit/delete/list/search-files/search-content) verified:2026-03-14 completed:2026-03-14
 - [x] t023 DatabaseAbilities: db_query with SELECT-only guard and {prefix} placeholder verified:2026-03-14 completed:2026-03-14


### PR DESCRIPTION
## Summary

Hardened TODO issue sync checks to ignore task-like lines inside HTML comments/code fences when syncing refs, assignees, and drift status; linked the completed t002 TODO entry to GH#2005 so the stale dependent-task issue can be reconciled.

## Files Changed

.agents/scripts/issue-sync-helper.sh,TODO.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run test:php:setup; npm run verify; bash -n .agents/scripts/issue-sync-helper.sh; .agents/scripts/issue-sync-helper.sh status Ultimate-Multisite/superdav-ai-agent

Resolves #2005


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.11 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 16m and 87,285 tokens on this as a headless worker.