### PR TITLE
GH#2018: fix: avoid unavailable stock image providers

### DIFF
--- a/includes/Abilities/ImageAbilities/StockImageAbility.php
+++ b/includes/Abilities/ImageAbilities/StockImageAbility.php
@@ -69,6 +69,8 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 	 * {@inheritdoc}
 	 */
 	protected function input_schema(): array {
+		$available_providers = ImageSourceFactory::get_available_free_source_ids();
+
 		return [
 			'type'       => 'object',
 			'properties' => [
@@ -87,8 +89,8 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 				],
 				'provider'    => [
 					'type'        => 'string',
-					'enum'        => [ 'openverse', 'pixabay' ],
-					'description' => 'Restrict search or import to a specific provider. When action=import, this identifies which provider image_id belongs to.',
+					'enum'        => $available_providers,
+					'description' => 'Restrict search or import to a currently available free provider. Omit this value unless using a provider from this enum; unavailable providers such as unconfigured Pixabay are intentionally hidden so the ability can fall back to available free sources.',
 				],
 				'limit'       => [
 					'type'        => 'integer',

--- a/includes/Abilities/ImageSources/ImageSourceFactory.php
+++ b/includes/Abilities/ImageSources/ImageSourceFactory.php
@@ -107,6 +107,28 @@ class ImageSourceFactory {
 	}
 
 	/**
+	 * Get IDs for currently available free image sources.
+	 *
+	 * This powers the stock-image ability schema so provider enums do not advertise
+	 * sources that cannot be used in the current site configuration.
+	 *
+	 * @return list<string> Available free source IDs.
+	 */
+	public static function get_available_free_source_ids(): array {
+		$available = self::get_available();
+
+		return array_values(
+			array_map(
+				static fn( ImageSourceInterface $source ): string => $source->get_id(),
+				array_filter(
+					$available,
+					static fn( ImageSourceInterface $source ): bool => 'free' === $source->get_cost_type()
+				)
+			)
+		);
+	}
+
+	/**
 	 * Smart source selection for a keyword.
 	 *
 	 * Chooses the best available source based on preference hierarchy:
@@ -188,15 +210,23 @@ class ImageSourceFactory {
 			static fn( ImageSourceInterface $source ): bool => 'free' === $source->get_cost_type()
 		);
 
-		// If a specific provider is requested, restrict to that source only.
+		// If a specific provider is requested, prefer it only when it is currently
+		// available. Unavailable free providers (for example an unconfigured Pixabay
+		// API key) are omitted from the schema, but older/direct model calls may
+		// still send them. In that case, fall back to the available free-source chain
+		// rather than returning no imagery.
 		if ( '' !== $provider ) {
-			if ( ! isset( $free_sources[ $provider ] ) ) {
+			$known_source = self::get( $provider );
+			if ( ! $known_source || 'free' !== $known_source->get_cost_type() ) {
 				return new WP_Error(
 					'provider_unavailable',
 					sprintf( 'Provider "%s" is not available or is not a free source.', $provider )
 				);
 			}
-			$free_sources = [ $provider => $free_sources[ $provider ] ];
+
+			if ( isset( $free_sources[ $provider ] ) ) {
+				$free_sources = [ $provider => $free_sources[ $provider ] ];
+			}
 		}
 
 		if ( empty( $free_sources ) ) {

--- a/tests/SdAiAgent/Abilities/StockImageAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/StockImageAbilityTest.php
@@ -102,6 +102,29 @@ class StockImageAbilityTest extends WP_UnitTestCase {
 		$this->assertNotContains( 'keyword', $schema['required'] );
 	}
 
+	/**
+	 * The provider schema only advertises free sources that are currently usable,
+	 * so direct model calls are not guided toward an unconfigured Pixabay source.
+	 */
+	public function test_schema_provider_enum_excludes_unavailable_pixabay(): void {
+		$this->set_factory_sources(
+			[
+				'openverse' => new FakeStockImageSource( 'openverse', 'free', [], [], true ),
+				'pixabay'   => new FakeStockImageSource( 'pixabay', 'free', [], [], false ),
+				'generate'  => new FakeStockImageSource( 'generate', 'api', [], [], true ),
+			]
+		);
+
+		$method = new \ReflectionMethod( StockImageAbility::class, 'input_schema' );
+		$method->setAccessible( true );
+
+		/** @var array{properties: array{provider: array{enum: list<string>}}} $schema */
+		$schema = $method->invoke( $this->ability );
+
+		$this->assertSame( [ 'openverse' ], $schema['properties']['provider']['enum'] );
+		$this->assertNotContains( 'pixabay', $schema['properties']['provider']['enum'] );
+	}
+
 	// ─── search mode (action=search) ─────────────────────────────────────────
 
 	/**
@@ -226,6 +249,50 @@ class StockImageAbilityTest extends WP_UnitTestCase {
 		$this->assertSame( 'blue', $filters['colour'] ?? null );
 		$this->assertSame( 1600, $filters['min_width'] ?? 0 );
 		$this->assertSame( 900, $filters['min_height'] ?? 0 );
+	}
+
+	/**
+	 * Direct calls that still send an unavailable free provider fall back to the
+	 * available free-source chain instead of failing the stock-image search.
+	 */
+	public function test_search_mode_falls_back_from_unavailable_pixabay_to_available_provider(): void {
+		$openverse = new FakeStockImageSource(
+			'openverse',
+			'free',
+			[
+				[
+					'id'      => 'ov-ballet-1',
+					'preview' => 'https://openverse.example.com/thumb/ov-ballet-1.jpg',
+					'width'   => 1200,
+					'height'  => 800,
+					'title'   => 'Children ballet class',
+					'license' => 'CC0',
+					'source'  => 'openverse',
+				]
+			]
+		);
+
+		$this->set_factory_sources(
+			[
+				'openverse' => $openverse,
+				'pixabay'   => new FakeStockImageSource( 'pixabay', 'free', [], [], false ),
+				'generate'  => new FakeStockImageSource( 'generate', 'api', [] ),
+			]
+		);
+
+		$result = $this->invoke_execute(
+			[
+				'keyword'  => 'children ballet class',
+				'action'   => 'search',
+				'provider' => 'pixabay',
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertArrayNotHasKey( 'error', $result );
+		$this->assertCount( 1, $result['candidates'] );
+		$this->assertSame( 'openverse', $result['candidates'][0]['provider'] );
+		$this->assertCount( 1, $openverse->search_calls );
 	}
 
 	// ─── import mode (action=import with provider + image_id) ────────────────
@@ -631,7 +698,8 @@ class FakeStockImageSource implements ImageSourceInterface {
 		private string $id,
 		private string $cost_type,
 		private array $hits,
-		private array $images = []
+		private array $images = [],
+		private bool $available = true
 	) {}
 
 	/** {@inheritdoc} */
@@ -646,7 +714,7 @@ class FakeStockImageSource implements ImageSourceInterface {
 
 	/** {@inheritdoc} */
 	public function is_available(): bool {
-		return true;
+		return $this->available;
 	}
 
 	/** {@inheritdoc} */


### PR DESCRIPTION
## Summary

Updated stock-image provider metadata so the provider enum only advertises currently available free sources, and made search calls that still request an unavailable free provider fall back to available free sources instead of failing. Added PHPUnit coverage for schema output and unavailable Pixabay fallback.

## Files Changed

includes/Abilities/ImageAbilities/StockImageAbility.php,includes/Abilities/ImageSources/ImageSourceFactory.php,tests/SdAiAgent/Abilities/StockImageAbilityTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify (PHPUnit: Tests: 3536, Assertions: 14740, Errors: 0, Failures: 0, Skipped: 115, Incomplete: 4; lint PHP/JS/CSS clean; PHPStan 0 errors; build and bundle check succeeded). Targeted rerun after final commit: npm run test:php -- --filter='StockImageAbilityTest|ImageSourceFactoryTest' (18 tests, 85 assertions).

Resolves #2018


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.11 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 10m and 102,644 tokens on this as a headless worker.