### PR TITLE
fix: refresh wporg autoload after stripping

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -372,6 +372,14 @@ PYADMIN
 		done
 		echo "    Stripped WP 6.9 compatibility shims, plugin-builder + theme-scaffolder + git-tracking + dynamic-SQL source files, forced feature flags to false, and set Requires at least to 7.0."
 
+		# Composer's optimized autoloader is generated before the WP.org-only
+		# strip list is applied. Regenerate it inside the bundled tree so Jetpack
+		# Autoloader cannot retain classmap entries for source files that were
+		# intentionally removed from the submitted zip.
+		echo "==> [${variant}] Regenerating Composer autoloader after WP.org source stripping..."
+		composer --working-dir="$dest" dump-autoload --no-dev --optimize --quiet
+		echo "    Composer autoloader regenerated for stripped WP.org tree."
+
 		# ── Neutralise forbidden move_uploaded_file() in bundled PSR-7 ───────
 		# WP.org's plugin-check tool hard-fails on any literal occurrence of
 		# move_uploaded_file() (Generic.PHP.ForbiddenFunctions.Found). The

--- a/includes/Bootstrap/AbilitiesHandler.php
+++ b/includes/Bootstrap/AbilitiesHandler.php
@@ -172,9 +172,11 @@ final class AbilitiesHandler {
 		}
 		// The WP.org build strips DatabaseAbilities.php to avoid recurring
 		// Plugin Check direct-SQL findings on the dynamic SELECT diagnostics
-		// ability. Keep the full release behaviour unchanged while avoiding a
-		// fatal when the source file is absent from the submitted zip.
-		if ( class_exists( DatabaseAbilities::class ) ) {
+		// ability. Check the physical source path before class_exists() because
+		// Jetpack Autoloader can hard-require optimized classmap paths for files
+		// that existed before the WP.org strip step.
+		$database_abilities_file = dirname( __DIR__ ) . '/Abilities/DatabaseAbilities.php';
+		if ( file_exists( $database_abilities_file ) && class_exists( DatabaseAbilities::class ) ) {
 			DatabaseAbilities::register_abilities();
 		}
 		WordPressAbilities::register_abilities();


### PR DESCRIPTION
## Summary
- Regenerate Composer/Jetpack autoload metadata inside the already-stripped WP.org build tree before zipping.
- Guard `DatabaseAbilities::class` behind a physical source-file check so the WP.org package does not trigger an autoload require for a deliberately stripped file.

## Verification
- `npm run lint`
- `composer phpstan`
- `npm run test:php`
- `bash bin/build.sh --target=wporg`
- WP.org zip inspection confirmed:
  - no `DatabaseAbilities.php` entry is present
  - `vendor/composer/jetpack_autoload_filemap.php` no longer references `DatabaseAbilities.php`
  - bundled `includes/Bootstrap/AbilitiesHandler.php` contains the physical-file guard

## Worker self-verification
- PHPUnit: Tests: 3540, Assertions: 14750, Errors: 0, Failures: 0, Skipped: 115, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   `bash bin/build.sh --target=wporg` succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.11 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5
