### PR TITLE
fix: guide global styles tool arguments

### DIFF
--- a/includes/Abilities/GlobalStylesAbilities.php
+++ b/includes/Abilities/GlobalStylesAbilities.php
@@ -76,25 +76,75 @@ class GlobalStylesAbilities {
 			'sd-ai-agent/update-global-styles',
 			[
 				'label'               => __( 'Update Global Styles', 'superdav-ai-agent' ),
-				'description'         => __( 'Update WordPress global styles (theme.json customizations). Merges the provided styles into the existing user customizations. Supports color palette, typography, spacing, and layout settings.', 'superdav-ai-agent' ),
+				'description'         => __( 'Update WordPress global styles (theme.json customizations). Pass a non-empty theme.json partial in styles (and optionally settings); never call this with empty styles/settings. Merges the provided colors, typography, spacing, elements, and layout into existing user customizations.', 'superdav-ai-agent' ),
 				'category'            => 'sd-ai-agent',
 				'input_schema'        => [
 					'type'       => 'object',
 					'properties' => [
 						'styles'   => [
-							'type'        => 'object',
-							'description' => 'Styles object to merge. Supports nested keys: color (palette, background, text, link), typography (fontFamily, fontSize, fontWeight, lineHeight), spacing (padding, margin, blockGap), layout (contentSize, wideSize).',
+							'type'          => 'object',
+							'minProperties' => 1,
+							'description'   => 'Required non-empty theme.json styles object to merge. Example: {"color":{"background":"#fffaf3","text":"#20120d"},"typography":{"fontFamily":"system-ui, sans-serif","lineHeight":"1.6"},"elements":{"button":{"color":{"background":"#d97706","text":"#ffffff"},"border":{"radius":"0.75rem"}}}}.',
+							'properties'    => [
+								'color'      => [
+									'type'        => 'object',
+									'description' => 'Global color styles.',
+									'properties'  => [
+										'background' => [
+											'type'        => 'string',
+											'description' => 'Page background hex or preset var.',
+										],
+										'text'       => [
+											'type'        => 'string',
+											'description' => 'Body text hex or preset var.',
+										],
+									],
+								],
+								'typography' => [
+									'type'        => 'object',
+									'description' => 'Global typography styles.',
+									'properties'  => [
+										'fontFamily' => [
+											'type'        => 'string',
+											'description' => 'System or bundled font stack.',
+										],
+										'fontSize'   => [
+											'type'        => 'string',
+											'description' => 'Base font size.',
+										],
+										'lineHeight' => [
+											'type'        => 'string',
+											'description' => 'Base line height.',
+										],
+									],
+								],
+								'spacing'    => [
+									'type'        => 'object',
+									'description' => 'Global spacing styles.',
+									'properties'  => [
+										'blockGap' => [
+											'type'        => 'string',
+											'description' => 'Default block gap.',
+										],
+									],
+								],
+								'elements'   => [
+									'type'        => 'object',
+									'description' => 'Element styles such as links, headings, and buttons.',
+								],
+							],
 						],
 						'settings' => [
-							'type'        => 'object',
-							'description' => 'Settings object to merge (e.g. color.palette, typography.fontSizes, spacing.spacingSizes).',
+							'type'          => 'object',
+							'minProperties' => 1,
+							'description'   => 'Optional non-empty theme.json settings object to merge when presets changed (e.g. color.palette, typography.fontSizes, spacing.spacingSizes).',
 						],
 						'site_url' => [
 							'type'        => 'string',
 							'description' => 'Subsite URL for multisite (e.g. "https://example.com/mysite").',
 						],
 					],
-					'required'   => [],
+					'required'   => [ 'styles' ],
 				],
 				'output_schema'       => [
 					'type'       => 'object',
@@ -108,6 +158,9 @@ class GlobalStylesAbilities {
 				],
 				'meta'                => [
 					'mcp'         => [ 'public' => true ],
+					'ai'          => [
+						'usage_instructions' => 'For homepage/theme builds, call update-global-styles exactly once with a real, non-empty theme.json partial. Do not pass [] or {} for styles/settings; include at least styles.color plus typography or element styles from the chosen design direction.',
+					],
 					'annotations' => [
 						'readonly'    => false,
 						'destructive' => false,

--- a/includes/Models/Agent.php
+++ b/includes/Models/Agent.php
@@ -681,7 +681,7 @@ class Agent {
 			. "5. Call `sd-ai-agent/validate-palette-contrast` on the chosen palette and auto-apply the suggested adjustments so the scaffold ships WCAG-AA compliant.\n"
 			. "6. Call `sd-ai-agent/scaffold-block-theme` with the inferred metadata and a `theme.json` using schema **version 3** (never v2) with `\"\$schema\": \"https://schemas.wp.org/trunk/theme.json\"` and `\"version\": 3`.\n"
 			. "7. Write `parts/header.html`, `parts/footer.html`, `templates/index.html`, `templates/page.html`, and `templates/front-page.html` via `sd-ai-agent/file-write`. Validate each one with `sd-ai-agent/validate-block-content`.\n"
-			. "8. Apply the chosen design system (colors, typography, spacing) via `sd-ai-agent/update-global-styles`.\n"
+			. "8. Apply the chosen design system (colors, typography, spacing) via `sd-ai-agent/update-global-styles` with a real, non-empty theme.json partial. The call must include `styles` (for example `styles.color.background`, `styles.color.text`, `styles.typography`, and `styles.elements.button`) and may also include `settings`; never pass empty arrays/objects.\n"
 			. "9. Publish the homepage as a real page via `sd-ai-agent/create-post` (post_type: page, status: publish). Compose hero + about + primary CTA using:\n"
 			. "   - real user-supplied facts (name, location, vertical, photos) FIRST\n"
 			. "   - safe inferred copy where the user gave nothing (e.g. \"Welcome to {name}\", a 2-sentence about paragraph derived from vertical + name, a vertical-appropriate CTA label).\n"

--- a/includes/Models/skills/wp-block-themes.md
+++ b/includes/Models/skills/wp-block-themes.md
@@ -136,6 +136,7 @@ For non-landing templates, create a reusable page-title part or pattern that use
 - `sd-ai-agent/list-block-patterns` — Browse patterns for page creation and templates
 - `sd-ai-agent/parse-block-content` — Inspect template structure
 - `sd-ai-agent/create-block-content` / `sd-ai-agent/validate-block-content` — Build/check block markup before saving
+- `sd-ai-agent/update-global-styles` — Apply the selected design direction with a non-empty theme.json `styles` partial. Never call it with `styles: []`, `settings: []`, `{}`, or unchanged empty arguments; include concrete colors, typography, spacing, or element styles.
 
 ## theme.json Overview
 
@@ -182,6 +183,8 @@ Recommended palette: 5–7 entries (`primary`, `secondary`, `accent`, `backgroun
 ```
 
 ### Styles
+
+When calling `sd-ai-agent/update-global-styles`, pass only the inner `styles` and optional `settings` objects — not the full theme.json wrapper. The `styles` argument is required and must be non-empty.
 
 ```json
 {

--- a/includes/Tools/SchemaExampleBuilder.php
+++ b/includes/Tools/SchemaExampleBuilder.php
@@ -36,13 +36,16 @@ class SchemaExampleBuilder {
 	/**
 	 * Walk an input_schema and produce a stub arguments object containing
 	 * every required field with a placeholder value of the form
-	 * `<{type} — {description}>`. Optional fields are omitted.
+	 * `<{type} — {description}>`. Nested required object/array fields are
+	 * expanded so nudges for complex tools show a usable argument shape instead
+	 * of a top-level `<object>` placeholder. Optional top-level fields are
+	 * omitted.
 	 *
 	 * Returns an empty array when the schema has no required fields, no
 	 * properties, or is malformed.
 	 *
 	 * @param mixed $schema The ability input_schema (assoc array).
-	 * @return array<string, string>
+	 * @return array<string, mixed>
 	 */
 	public static function build_example( $schema ): array {
 		if ( ! is_array( $schema ) ) {
@@ -61,33 +64,74 @@ class SchemaExampleBuilder {
 			if ( ! is_string( $field ) || '' === $field ) {
 				continue;
 			}
-			$prop = isset( $properties[ $field ] ) && is_array( $properties[ $field ] ) ? $properties[ $field ] : array();
-
-			$type = isset( $prop['type'] ) ? $prop['type'] : 'value';
-			if ( is_array( $type ) ) {
-				$type = implode( '|', $type );
-			} else {
-				$type = (string) $type;
-			}
-
-			$desc = isset( $prop['description'] ) ? trim( (string) $prop['description'] ) : '';
-			if ( strlen( $desc ) > 80 ) {
-				$desc = substr( $desc, 0, 77 ) . '...';
-			}
-
-			// If the schema lists an enum, hint with the allowed values
-			// instead of the description — much more actionable.
-			if ( isset( $prop['enum'] ) && is_array( $prop['enum'] ) && ! empty( $prop['enum'] ) ) {
-				$enum_summary = implode( '|', array_map( static fn( $v ) => (string) $v, array_slice( $prop['enum'], 0, 5 ) ) );
-				$desc         = "one of: {$enum_summary}";
-			}
-
-			$example[ $field ] = '' !== $desc
-				? "<{$type} — {$desc}>"
-				: "<{$type}>";
+			$prop              = isset( $properties[ $field ] ) && is_array( $properties[ $field ] ) ? $properties[ $field ] : array();
+			$example[ $field ] = self::build_value( $prop );
 		}
 
 		return $example;
+	}
+
+	/**
+	 * Build an example value for a single schema property.
+	 *
+	 * @param array<string, mixed> $prop  Property schema.
+	 * @param int                  $depth Current recursion depth.
+	 * @return mixed Example value.
+	 */
+	private static function build_value( array $prop, int $depth = 0 ): mixed {
+		$type_raw = isset( $prop['type'] ) ? $prop['type'] : 'value';
+		$type     = is_array( $type_raw )
+			? implode( '|', array_map( static fn( $value ): string => is_scalar( $value ) || null === $value ? (string) $value : gettype( $value ), $type_raw ) )
+			: (string) $type_raw;
+
+		if ( $depth < 4 && str_contains( $type, 'object' ) && isset( $prop['properties'] ) && is_array( $prop['properties'] ) && ! empty( $prop['properties'] ) ) {
+			$fields = isset( $prop['required'] ) && is_array( $prop['required'] ) && ! empty( $prop['required'] )
+				? array_values( array_filter( $prop['required'], 'is_string' ) )
+				: array_keys( $prop['properties'] );
+
+			$value = array();
+			foreach ( $fields as $field ) {
+				if ( ! is_string( $field ) || ! isset( $prop['properties'][ $field ] ) || ! is_array( $prop['properties'][ $field ] ) ) {
+					continue;
+				}
+				$value[ $field ] = self::build_value( $prop['properties'][ $field ], $depth + 1 );
+			}
+
+			if ( ! empty( $value ) ) {
+				return $value;
+			}
+		}
+
+		if ( $depth < 4 && str_contains( $type, 'array' ) && isset( $prop['items'] ) && is_array( $prop['items'] ) && ! empty( $prop['items'] ) ) {
+			return array( self::build_value( $prop['items'], $depth + 1 ) );
+		}
+
+		return self::placeholder( $type, $prop );
+	}
+
+	/**
+	 * Build a scalar placeholder for a schema property.
+	 *
+	 * @param string               $type Property type label.
+	 * @param array<string, mixed> $prop Property schema.
+	 * @return string Placeholder string.
+	 */
+	private static function placeholder( string $type, array $prop ): string {
+		$desc = isset( $prop['description'] ) ? trim( (string) $prop['description'] ) : '';
+		if ( strlen( $desc ) > 80 ) {
+			$desc = substr( $desc, 0, 77 ) . '...';
+		}
+
+		// If the schema lists an enum, hint with the allowed values
+		// instead of the description — much more actionable.
+		if ( isset( $prop['enum'] ) && is_array( $prop['enum'] ) && ! empty( $prop['enum'] ) ) {
+			$enum_summary = implode( '|', array_map( static fn( $v ) => (string) $v, array_slice( $prop['enum'], 0, 5 ) ) );
+			$desc         = "one of: {$enum_summary}";
+		}
+
+		return '' !== $desc
+			? "<{$type} — {$desc}>"
+			: "<{$type}>";
 	}
 
 	/**

--- a/tests/SdAiAgent/Abilities/GlobalStylesAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/GlobalStylesAbilitiesTest.php
@@ -18,6 +18,22 @@ use WP_UnitTestCase;
 class GlobalStylesAbilitiesTest extends WP_UnitTestCase {
 
 	/**
+	 * Test update-global-styles schema nudges agents toward non-empty styles.
+	 */
+	public function test_update_global_styles_schema_requires_styles_argument(): void {
+		$this->ensure_global_styles_ability_registered();
+
+		$ability = wp_get_ability( 'sd-ai-agent/update-global-styles' );
+		$this->assertInstanceOf( \WP_Ability::class, $ability );
+
+		$schema = $ability->get_input_schema();
+
+		$this->assertSame( [ 'styles' ], $schema['required'] );
+		$this->assertSame( 1, $schema['properties']['styles']['minProperties'] );
+		$this->assertStringContainsString( 'never call this with empty styles/settings', $ability->get_description() );
+	}
+
+	/**
 	 * Test update-global-styles returns an affected descriptor.
 	 */
 	public function test_handle_update_global_styles_returns_affected_payload(): void {
@@ -60,5 +76,19 @@ class GlobalStylesAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 'global_styles', $result['affected']['kind'] );
 		$this->assertNotEmpty( $result['affected']['url'] );
 		$this->assertContains( 'reset', $result['affected']['fields'] );
+	}
+
+	/**
+	 * Register the global styles ability when the full bootstrap has not already done it.
+	 */
+	private function ensure_global_styles_ability_registered(): void {
+		if ( null !== wp_get_ability( 'sd-ai-agent/update-global-styles' ) ) {
+			return;
+		}
+
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_init';
+		GlobalStylesAbilities::register_abilities();
+		array_pop( $wp_current_filter );
 	}
 }

--- a/tests/SdAiAgent/Tools/SchemaExampleBuilderTest.php
+++ b/tests/SdAiAgent/Tools/SchemaExampleBuilderTest.php
@@ -97,6 +97,40 @@ class SchemaExampleBuilderTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'value', $example['phantom'] );
 	}
 
+	public function test_build_example_expands_nested_required_object_shape(): void {
+		$schema = array(
+			'type'       => 'object',
+			'properties' => array(
+				'styles' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'color'      => array(
+							'type'       => 'object',
+							'properties' => array(
+								'background' => array( 'type' => 'string', 'description' => 'Background colour.' ),
+								'text'       => array( 'type' => 'string', 'description' => 'Text colour.' ),
+							),
+						),
+						'typography' => array(
+							'type'       => 'object',
+							'properties' => array(
+								'fontFamily' => array( 'type' => 'string', 'description' => 'Font stack.' ),
+							),
+						),
+					),
+				),
+			),
+			'required'   => array( 'styles' ),
+		);
+
+		$example = SchemaExampleBuilder::build_example( $schema );
+
+		$this->assertIsArray( $example['styles'] );
+		$this->assertArrayHasKey( 'color', $example['styles'] );
+		$this->assertArrayHasKey( 'background', $example['styles']['color'] );
+		$this->assertStringContainsString( 'Background colour', $example['styles']['color']['background'] );
+	}
+
 	// ─── extract_missing_required ────────────────────────────────────
 
 	public function test_extract_missing_required_handles_standard_phrasing(): void {


### PR DESCRIPTION
## Summary

- Require a non-empty `styles` payload for `sd-ai-agent/update-global-styles` and add nested schema hints for color, typography, spacing, and element styles.
- Expand `SchemaExampleBuilder` nested object/array examples so retry nudges no longer emit `{}` for complex required objects.
- Update Setup Assistant and `wp-block-themes` guidance to tell agents not to call global styles with empty arrays/objects.
- Add regression coverage for the stricter global styles schema and nested schema examples.

## Live tool-use test

- Ran a similar Setup Assistant prompt for “a single product ecommerce store selling a dog training kit”.
- The agent called `wpab__sd-ai-agent__update-global-styles` once with non-empty `styles.color`, `styles.typography`, `styles.spacing`, and `styles.elements`.
- Tool result: `success: true`, `post_id: 365`, `message: Global styles updated successfully.`

## Worker self-verification

- PHPUnit: Tests: 3542, Assertions: 14758, Errors: 0, Failures: 0, Skipped: 115, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Additional checks:
- `php bin/run-wp-phpunit.php "--filter=SchemaExampleBuilderTest|GlobalStylesAbilitiesTest"` — OK (14 tests, 34 assertions)
- `npm run verify` — passed, including bundle size check

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.11 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5
