### PR TITLE
fix: preserve DeepSeek tool-call reasoning history

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -784,7 +784,7 @@ class AgentLoop {
 			// "function_call + other part" shapes (see
 			// ConversationSerializer::append_assistant_message for the full
 			// rationale and provider-side validator reference).
-			ConversationSerializer::append_assistant_message( $this->history, $assistant_message );
+			$this->append_assistant_message_to_history( $assistant_message );
 
 			// Check if the model wants to call tools.
 			if ( ! $this->get_ability_resolver()->has_ability_calls( $assistant_message ) ) {
@@ -835,7 +835,7 @@ class AgentLoop {
 
 					if ( ! is_wp_error( $followup_result ) ) {
 						$followup_message = $followup_result->toMessage();
-						ConversationSerializer::append_assistant_message( $this->history, $followup_message );
+						$this->append_assistant_message_to_history( $followup_message );
 						$this->accumulate_tokens( $followup_result );
 
 						try {
@@ -1047,7 +1047,7 @@ class AgentLoop {
 
 			if ( ! is_wp_error( $fallback_result ) ) {
 				$fallback_message = $fallback_result->toMessage();
-				ConversationSerializer::append_assistant_message( $this->history, $fallback_message );
+				$this->append_assistant_message_to_history( $fallback_message );
 				$this->accumulate_tokens( $fallback_result );
 
 				$reply = '';
@@ -1651,6 +1651,70 @@ class AgentLoop {
 	 */
 	private function append_tool_response_to_history( Message $message ): void {
 		ConversationSerializer::append_tool_response( $this->history, $message );
+	}
+
+	/**
+	 * Append an assistant message to history using provider-aware preservation.
+	 *
+	 * DeepSeek thinking-mode chat completions require the assistant turn that
+	 * opened tool calls to round-trip with its original thought channel attached
+	 * as `reasoning_content` on that same wire message. The generic serializer
+	 * splits mixed thought+function_call messages so the OpenAI Responses API can
+	 * replay function calls as separate top-level input items, but that split
+	 * severs DeepSeek's reasoning/tool-call pairing. Keep DeepSeek tool-call
+	 * assistant messages intact so the DeepSeek provider can serialize them as a
+	 * single assistant entry with both `tool_calls` and `reasoning_content`.
+	 *
+	 * @param Message $message Assistant message returned by the model.
+	 */
+	private function append_assistant_message_to_history( Message $message ): void {
+		if ( $this->should_preserve_deepseek_tool_call_message( $message ) ) {
+			$this->history[] = $message;
+			return;
+		}
+
+		ConversationSerializer::append_assistant_message( $this->history, $message );
+	}
+
+	/**
+	 * Whether a model-role tool-call message should remain unsplit for DeepSeek.
+	 *
+	 * @param Message $message Assistant message returned by the model.
+	 */
+	private function should_preserve_deepseek_tool_call_message( Message $message ): bool {
+		if ( ! $this->is_deepseek_context() ) {
+			return false;
+		}
+
+		foreach ( $message->getParts() as $part ) {
+			$is_function_call = false;
+			if ( method_exists( $part, 'getType' ) ) {
+				$type = $part->getType();
+				if ( is_object( $type ) && is_callable( array( $type, 'isFunctionCall' ) ) ) {
+					$is_function_call = (bool) $type->isFunctionCall();
+				}
+			}
+
+			if ( ! $is_function_call && method_exists( $part, 'getFunctionCall' ) ) {
+				$is_function_call = null !== $part->getFunctionCall();
+			}
+
+			if ( $is_function_call ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Whether the active provider/model is DeepSeek or an OpenAI-compatible DeepSeek model.
+	 */
+	private function is_deepseek_context(): bool {
+		$provider_id = strtolower( trim( (string) $this->provider_id ) );
+		$model_id    = strtolower( trim( (string) $this->model_id ) );
+
+		return 'deepseek' === $provider_id || str_starts_with( $model_id, 'deepseek-' );
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -77,6 +77,99 @@ class AgentLoopTest extends WP_UnitTestCase {
 		remove_all_filters( 'pre_http_request' );
 	}
 
+	/**
+	 * DeepSeek tool-call messages must keep their thought channel attached.
+	 *
+	 * The DeepSeek provider serializes thought-channel text as the
+	 * `reasoning_content` sibling on the assistant wire message. Splitting a
+	 * thought+tool_calls assistant turn into separate ModelMessages severs that
+	 * pairing and can trigger DeepSeek's 400: "reasoning_content ... must be
+	 * passed back" on the next request.
+	 */
+	public function test_deepseek_tool_call_assistant_message_is_not_split(): void {
+		if ( ! class_exists( 'WordPress\AiClient\Messages\DTO\ModelMessage' ) ) {
+			$this->markTestSkipped( 'WP AI Client message classes are not available.' );
+		}
+
+		$loop = new AgentLoop(
+			'Test prompt',
+			[],
+			[],
+			[
+				'provider_id' => 'deepseek',
+				'model_id'    => 'deepseek-v4-flash',
+			]
+		);
+
+		$message = new \WordPress\AiClient\Messages\DTO\ModelMessage(
+			[
+				new \WordPress\AiClient\Messages\DTO\MessagePart(
+					'I need two tool calls.',
+					\WordPress\AiClient\Messages\Enums\MessagePartChannelEnum::thought()
+				),
+				new \WordPress\AiClient\Messages\DTO\MessagePart(
+					new \WordPress\AiClient\Tools\DTO\FunctionCall( 'call_1', 'wpab__sd-ai-agent__list-posts', [] )
+				),
+				new \WordPress\AiClient\Messages\DTO\MessagePart(
+					new \WordPress\AiClient\Tools\DTO\FunctionCall( 'call_2', 'wpab__sd-ai-agent__site-health-summary', [] )
+				),
+			]
+		);
+
+		$method = new \ReflectionMethod( AgentLoop::class, 'append_assistant_message_to_history' );
+		$method->setAccessible( true );
+		$method->invoke( $loop, $message );
+
+		$history_property = new \ReflectionProperty( AgentLoop::class, 'history' );
+		$history_property->setAccessible( true );
+		$history = $history_property->getValue( $loop );
+
+		$this->assertCount( 1, $history, 'DeepSeek tool-call assistant messages must remain one history message.' );
+		$this->assertSame( $message, $history[0] );
+		$this->assertCount( 3, $history[0]->getParts() );
+	}
+
+	/**
+	 * Non-DeepSeek providers still use the generic split needed by OpenAI Responses.
+	 */
+	public function test_non_deepseek_tool_call_assistant_message_still_splits(): void {
+		if ( ! class_exists( 'WordPress\AiClient\Messages\DTO\ModelMessage' ) ) {
+			$this->markTestSkipped( 'WP AI Client message classes are not available.' );
+		}
+
+		$loop = new AgentLoop(
+			'Test prompt',
+			[],
+			[],
+			[
+				'provider_id' => 'openai',
+				'model_id'    => 'gpt-5.5',
+			]
+		);
+
+		$message = new \WordPress\AiClient\Messages\DTO\ModelMessage(
+			[
+				new \WordPress\AiClient\Messages\DTO\MessagePart( 'Short answer.' ),
+				new \WordPress\AiClient\Messages\DTO\MessagePart(
+					new \WordPress\AiClient\Tools\DTO\FunctionCall( 'call_1', 'wpab__sd-ai-agent__list-posts', [] )
+				),
+				new \WordPress\AiClient\Messages\DTO\MessagePart(
+					new \WordPress\AiClient\Tools\DTO\FunctionCall( 'call_2', 'wpab__sd-ai-agent__site-health-summary', [] )
+				),
+			]
+		);
+
+		$method = new \ReflectionMethod( AgentLoop::class, 'append_assistant_message_to_history' );
+		$method->setAccessible( true );
+		$method->invoke( $loop, $message );
+
+		$history_property = new \ReflectionProperty( AgentLoop::class, 'history' );
+		$history_property->setAccessible( true );
+		$history = $history_property->getValue( $loop );
+
+		$this->assertCount( 3, $history, 'Non-DeepSeek providers should keep the generic split behavior.' );
+	}
+
 	// -------------------------------------------------------------------------
 	// Helpers
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Preserve DeepSeek assistant tool-call messages as a single history message so thought-channel reasoning remains attached to the tool call.
- Keep the generic split behavior for non-DeepSeek providers, including OpenAI Responses API compatibility.
- Add regression coverage for both DeepSeek preservation and non-DeepSeek splitting.

## Verification

- Reproduced the original DeepSeek 400 on the local WordPress test site using `DEEPSEEK_API_KEY` from the aidevops credential store.
- Verified the fix on the same site with `deepseek-v4-flash`: follow-up request succeeded and trace showed assistant messages with both `tool_calls` and `reasoning_content`.
- `npm run verify`

## Worker self-verification
- PHPUnit: Tests: 3542, Assertions: 14754, Errors: 0, Failures: 0, Skipped: 115, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.11 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5
