### PR TITLE
t216: harden skill usage telemetry inserts

### DIFF
--- a/includes/Repositories/SkillUsageRepository.php
+++ b/includes/Repositories/SkillUsageRepository.php
@@ -40,6 +40,11 @@ class SkillUsageRepository {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 
+		$skill_id = (int) ( $data['skill_id'] ?? 0 );
+		if ( $skill_id <= 0 ) {
+			return false;
+		}
+
 		$trigger_type = $data['trigger_type'] ?? 'auto';
 		if ( ! in_array( $trigger_type, [ 'auto', 'manual', 'tool_call' ], true ) ) {
 			$trigger_type = 'auto';
@@ -54,7 +59,7 @@ class SkillUsageRepository {
 		$result = $wpdb->insert(
 			Database::skill_usage_table_name(),
 			[
-				'skill_id'        => (int) ( $data['skill_id'] ?? 0 ),
+				'skill_id'        => $skill_id,
 				'session_id'      => (int) ( $data['session_id'] ?? 0 ),
 				'trigger_type'    => $trigger_type,
 				'injected_tokens' => (int) ( $data['injected_tokens'] ?? 0 ),

--- a/tests/SdAiAgent/Repositories/SkillUsageRepositoryTest.php
+++ b/tests/SdAiAgent/Repositories/SkillUsageRepositoryTest.php
@@ -65,6 +65,15 @@ class SkillUsageRepositoryTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * create() rejects events that cannot be attributed to a real skill.
+	 */
+	public function test_create_rejects_missing_skill_id(): void {
+		$this->assertFalse( SkillUsageRepository::create( [] ) );
+		$this->assertFalse( SkillUsageRepository::create( [ 'skill_id' => 0 ] ) );
+		$this->assertFalse( SkillUsageRepository::create( [ 'skill_id' => -1 ] ) );
+	}
+
+	/**
 	 * Invalid enum-like values fall back to safe defaults.
 	 */
 	public function test_create_sanitizes_invalid_trigger_and_outcome(): void {


### PR DESCRIPTION
Resolves #2010

## Summary
- Reject skill usage telemetry inserts that do not reference a real positive skill ID
- Reuse the validated skill ID for persisted usage rows
- Add repository coverage for missing, zero, and negative skill IDs

## Worker self-verification
- PHPUnit: Tests: 3548, Assertions: 14779, Errors: 0, Failures: 0, Skipped: 116, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors (rerun with `composer phpstan -- --debug` after default parallel worker timeout)
- Build:   succeeded (`npm run build && npm run check:bundle`)

## Notes
- `npm run verify` reached PHPStan but the default parallel worker timed out after 600 seconds; rerunning PHPStan with `--debug` completed with 0 errors.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.12 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5
