### PR TITLE
GH#2028: docs: clarify contributor insight mapping

### DIFF
--- a/.agents/scripts/commands/feedback-triage.md
+++ b/.agents/scripts/commands/feedback-triage.md
@@ -189,6 +189,10 @@ Apply Step 3.6 validation from `/log-issue-aidevops` before classifying as `real
 For `contributor_insight` reports, convert shorthand into worker-ready actions
 before creating the issue:
 
+- For mixed reports with several candidates, create one issue whose `## Worker
+  Guidance` maps each candidate separately. Do not assume a pasted local-path
+  excerpt, REST shorthand, service-usage question, and review-response prompt all
+  belong in the same file; name the narrowest committed source for each note.
 - If the note asks whether instructions or scripts should change, direct the
   worker to change the narrowest durable source instead of replying in comments:
   root `AGENTS.md` for repo-wide plugin rules, `.agents/AGENTS.md` for
@@ -231,7 +235,9 @@ before creating the issue:
   explicit worker actions, and include the exact `rg -n` verification commands.
   Do not file a contributor-insight issue that only quotes the maintainer note;
   the issue body must be actionable without private paths, chat history, or
-  additional context.
+  additional context. When a candidate is a usage-mapping question rather than a
+  code defect, require the worker to document the committed integration surfaces
+  and related secrecy/capability checks instead of answering only in a comment.
 - If implementation hardening is broader than the instruction change, include a
   `## Follow-up issue briefs` section with one worker-ready brief per route,
   controller, helper, or skill family. Each brief names the missing guard or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,10 @@ when it includes all of the following:
 - Evidence in the PR body showing the instruction is now loaded by future
   workers, such as `rg -n "Contributor Insight|sd-ai-agent/v1|secret|current user|file upload" AGENTS.md .agents/AGENTS.md`
   plus any workflow-specific doc check.
+- If the repository already contains guidance for a reported candidate, tighten
+  the loaded source instead of closing the issue as "already documented". Add the
+  missing worker action, source map, or verification command that would have made
+  the original shorthand unambiguous to a fresh headless worker.
 
 #### Contributor Insight Source Mapping
 
@@ -132,7 +136,9 @@ note to a committed, future-loaded source before editing:
 - For block-theme snippets headed `Block Themes`, `Full Site Editing`,
   `theme.json`, templates, parts, patterns, or style variations, update
   `includes/Models/skills/wp-block-themes.md` and keep the root summary here in
-  sync.
+  sync. The skill itself should explain that pasted local-path excerpts are only
+  clues; future workers must edit the committed skill file and validate generated
+  block content before saving templates, parts, or patterns.
 - For REST security shorthand involving `sd-ai-agent/v1`, secret scrubbing,
   current-user execution, or file uploads, update this root guidance and inspect
   the concrete controller or ability family before deciding whether code or a

--- a/includes/Models/skills/wp-block-themes.md
+++ b/includes/Models/skills/wp-block-themes.md
@@ -20,6 +20,13 @@ Use this skill for block theme work such as:
 
 If the active theme is classic and the task is to modify that active theme, use `classic-themes` instead. If the task is to generate, convert to, or scaffold a block theme, use this skill even when the currently active theme is classic.
 
+When a contributor-insight issue contains a pasted local-path excerpt headed
+`Block Themes`, `Full Site Editing`, `theme.json`, templates, parts, patterns, or
+style variations, treat that excerpt as a source-mapping clue only. Update this
+committed skill file (and the root `AGENTS.md` summary when repo-wide guidance is
+needed); do not copy private local paths or duplicate the full excerpt into
+issues, PRs, templates, or generated theme files.
+
 ## Inputs required
 
 - Target theme directory or the slug/name for the new theme being generated.
@@ -36,6 +43,8 @@ If the active theme is classic and the task is to modify that active theme, use 
 5. Prefer filesystem-owned patterns under `patterns/*.php` when the theme should ship reusable layouts.
 6. Put style variations in `styles/*.json`; remember that once a user selects a style variation, that selection is stored in the database.
 7. Validate generated block markup before writing templates, parts, or patterns.
+8. For contributor-insight or maintenance changes to this skill, verify future
+   workers will load the guidance with `rg -n "wp-block-themes|Full Site Editing|theme.json|validate-block-content" AGENTS.md includes/Models/skills/wp-block-themes.md`.
 
 ## Absolute Rules
 


### PR DESCRIPTION
## Summary

Clarified contributor-insight handling so mixed reports map each candidate to the narrowest committed source, existing guidance is tightened instead of closed as already documented, block-theme local-path excerpts map back to the committed wp-block-themes skill, and usage-mapping questions require documenting integration surfaces and related secrecy/capability checks.

## Files Changed

.agents/scripts/commands/feedback-triage.md,AGENTS.md,includes/Models/skills/wp-block-themes.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** rg -n contributor insight/source mapping guidance checks passed; rg -n block-theme guidance check passed; rg -n GSC and REST security source-surface checks passed; npm run verify reached PHPStan but PHPStan parallel worker timed out after lint passed; vendor/bin/phpstan analyse --debug passed with 0 errors; npm run test:php passed: Tests: 3547, Assertions: 14776, Skipped: 116, Incomplete: 4; npm run build && npm run check:bundle passed

Resolves #2028


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.12 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 24m and 191,525 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated feedback triage procedures for processing mixed reports with multiple candidates, including clearer Worker Guidance mapping
  * Enhanced source-mapping rules and repository guidance documentation with improved verification procedures
  * Refined guidance for handling local-path excerpts in contributor-insight issues to ensure proper source attribution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->