### PR TITLE
GH#2029: docs: guide missing-read fatal recovery

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -82,6 +82,12 @@ working here in OpenCode headless mode:
   a failed `phpcs.xml.dist` read that suggests `bootstrap.php`). Do not stop a
   headless run solely because one optional screenshot, prompt, or generated
   artifact path was stale.
+- When a missing-file read happens during WordPress fatal-error triage, switch to
+  the runtime evidence before more repo-path probing: inspect
+  `../wordpress/wp-content/debug.log` (enable `WP_DEBUG_LOG` and reproduce once if
+  absent), then verify the shared install's plugin symlinks point at each
+  worktree's canonical plugin directory name rather than a stale or basename-only
+  path.
 - Treat `bash:other` / `Tool execution aborted` as a recoverable command-shape or
   hook failure first. Inspect the preceding command, retry once with a narrower
   non-inline command and a clear `description`, avoid heredocs/process or command

--- a/.agents/scripts/commands/feedback-triage.md
+++ b/.agents/scripts/commands/feedback-triage.md
@@ -210,6 +210,11 @@ before creating the issue:
   example `phpcs.xml.dist` → `bootstrap.php`), use `git ls-files '<pattern>'`
   for tracked files, then retry `Read` before continuing with the next safe
   implementation step.
+- If the same note mentions a WordPress fatal error, plugin activation, or
+  canonical plugin symlinks, require the worker guidance to inspect
+  `../wordpress/wp-content/debug.log` before chasing unrelated missing repo paths,
+  and to verify the local WordPress install symlinks each plugin worktree into the
+  expected canonical plugin directory name.
 - If recurring tool errors mention `bash:file_not_found`, `gh-signature-helper.sh
   invocation failed`, `signature gate`, or blocked `gh` writes, require durable
   worker guidance to create the issue/PR/comment body as an existing stable file,
@@ -223,7 +228,7 @@ before creating the issue:
   "false positive" language unless tied to exact file/pattern evidence.
 - Include verification in the issue body, for example
   `rg -n "Contributor Insight|sd-ai-agent/v1|secret|current user|file upload|WordPress.org Review|false positive" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md`
-  or `rg -n "read:file_not_found|missing-file reads|git ls-files|signature gate|body-file|gh-signature-helper" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md`
+  or `rg -n "read:file_not_found|missing-file reads|git ls-files|debug.log|canonical plugin|signature gate|body-file|gh-signature-helper" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md includes/Models/skills/site-troubleshooting.md`
   plus `rg -n "wp-block-themes|Full Site Editing|theme.json|validate-block-content" AGENTS.md includes/Models/skills/wp-block-themes.md`
   when block-theme guidance is involved.
 - Add a `## Worker Guidance` section to the created GitHub issue. It must name
@@ -305,9 +310,12 @@ triage issue: compare the requested basename with the tool output that introduce
 it, follow any "you mean one of these?" nearby-path hint from the tool error,
 verify tracked repository paths with `git ls-files '<pattern>'`, inspect the
 known parent directory for nearby runtime-artifact names, and retry `Read` with
-the corrected path. If the artifact still cannot be found, include the attempted
-paths in the issue body and continue with the available session evidence instead
-of treating the missing read as the whole outcome.
+the corrected path. For WordPress fatal-error reports, make the known runtime
+artifact `../wordpress/wp-content/debug.log` the next read target and include a
+canonical plugin-symlink check in the worker guidance. If the artifact still
+cannot be found, include the attempted paths in the issue body and continue with
+the available session evidence instead of treating the missing read as the whole
+outcome.
 
 Capture the issue URL from output. Then update the report (the helper
 routes the third argument to `github_issue_url` for the `issue_created`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,11 +236,19 @@ completion state:
 - For tracked repository files, verify the path with `git ls-files '<pattern>'`
   before retrying `Read`; for untracked/runtime artifacts, inspect the known
   parent directory or rerun the command that generated the artifact.
+- For local WordPress fatal-error reports, do not keep retrying unrelated project
+  paths such as `vendor/` after a missing-file read. First inspect the runtime
+  artifact that contains the failure: `../wordpress/wp-content/debug.log`, or
+  enable `WP_DEBUG_LOG` and reproduce once if the log does not exist.
+- Before blaming plugin code for local activation fatals, verify the shared
+  WordPress install has symlinks for every checked-out plugin worktree under its
+  canonical plugin directory name. A missing or basename-only worktree symlink can
+  make WordPress load the wrong path and hide the real debug.log failure.
 - If the corrected path is found, retry `Read` with that path and continue the
   task. If no plausible path exists after bounded recovery, record what was
   checked and continue with the next safe implementation step rather than ending
   the session solely because one optional artifact is missing.
-- Verification for guidance-only fixes: run `rg -n "read:file_not_found|missing-file reads|git ls-files|signature gate|body-file" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md` and ensure both file-read recovery and GitHub write-body policies are present in files loaded by future workers.
+- Verification for guidance-only fixes: run `rg -n "read:file_not_found|missing-file reads|git ls-files|debug.log|canonical plugin" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md includes/Models/skills/site-troubleshooting.md` and ensure file-read recovery, debug-log triage, and canonical plugin-symlink policies are present in files loaded by future workers.
 
 #### Headless Tool-Abort Recovery
 
@@ -519,7 +527,7 @@ The shared WordPress dev install for testing this plugin is at `../wordpress` (r
 - **URL**: http://wordpress.local:8080
 - **Admin**: http://wordpress.local:8080/wp-admin — `admin` / `admin`
 - **WordPress version**: 7.0-RC2
-- **This plugin**: symlinked into `../wordpress/wp-content/plugins/$(basename $PWD)`
+- **This plugin**: symlinked into `../wordpress/wp-content/plugins/$(basename $PWD)` for the active worktree, and into the canonical WordPress plugin directory when testing slug-specific activation/loading behaviour.
 - **Reset to clean state**: `cd ../wordpress && ./reset.sh`
 
 WP-CLI is configured via `wp-cli.yml` in this repo root — run `wp` commands directly from here without specifying `--path`.

--- a/includes/Models/skills/site-troubleshooting.md
+++ b/includes/Models/skills/site-troubleshooting.md
@@ -10,6 +10,8 @@ Use this skill when the user reports errors, performance issues, white screens, 
 - `wp eval "error_reporting(E_ALL); ini_set('display_errors', 1);"` — Check PHP error reporting
 - `wp config get WP_DEBUG` — Check debug mode status
 - `wp config get WP_DEBUG_LOG` — Check if debug logging is on
+- `wp eval "echo file_exists(WP_CONTENT_DIR . '/debug.log') ? file_get_contents(WP_CONTENT_DIR . '/debug.log') : '';"` — Read the runtime debug log without assuming the file exists
+- `wp plugin path <plugin-slug>` — Confirm a plugin resolves through its expected canonical plugin directory or symlink before debugging activation fatals
 
 ### Plugin Conflicts
 - `wp plugin list --status=active --fields=name,version` — List active plugins
@@ -39,9 +41,19 @@ Use this skill when the user reports errors, performance issues, white screens, 
 
 ### White Screen of Death
 1. Enable WP_DEBUG: `wp config set WP_DEBUG true --raw`
-2. Check debug.log: `wp eval "echo file_get_contents(WP_CONTENT_DIR . '/debug.log');"`
+2. Check debug.log: `wp eval "echo file_exists(WP_CONTENT_DIR . '/debug.log') ? file_get_contents(WP_CONTENT_DIR . '/debug.log') : '';"`
 3. Deactivate plugins to find conflict
 4. Switch to default theme
+
+### Plugin Activation Fatal Error
+1. Verify `WP_DEBUG_LOG` is enabled and reproduce the activation once.
+2. Read `../wordpress/wp-content/debug.log` or use the guarded `wp eval` command
+   above; do not stop after a missing repository path such as `vendor/`.
+3. Confirm the shared WordPress install symlinks every checked-out plugin worktree
+   into the plugin's canonical directory name before treating the fatal as an
+   application-code regression.
+4. Activate the plugin by canonical slug, then re-check debug.log for the first
+   new fatal stack trace.
 
 ### 500 Internal Server Error
 1. Check PHP error logs


### PR DESCRIPTION
## Summary

Added durable guidance for read:file_not_found recovery during WordPress fatal-error triage, including debug.log as the next runtime evidence target, canonical plugin-symlink checks for shared local installs, feedback-triage issue guidance, and site-troubleshooting skill commands.

## Files Changed

.agents/AGENTS.md,.agents/scripts/commands/feedback-triage.md,AGENTS.md,includes/Models/skills/site-troubleshooting.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** rg -n "read:file_not_found|missing-file reads|git ls-files|debug.log|canonical plugin" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md includes/Models/skills/site-troubleshooting.md; npm run lint passed; vendor/bin/phpstan analyse --configuration=phpstan.neon --no-progress --memory-limit=3G --debug passed; npm run test:php passed: Tests: 3547, Assertions: 14777, Skipped: 116, Incomplete: 4; npm run build passed; npm run check:bundle passed

Resolves #2029


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.12 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 25m and 178,097 tokens on this as a headless worker.