### PR TITLE
fix: detach process requests on LiteSpeed

### DIFF
--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -1443,13 +1443,20 @@ final class SessionController {
 
 		// Send the HTTP response immediately so the calling process (the
 		// non-blocking loopback from /run or /confirm) can close its
-		// connection. PHP-FPM continues executing after this call.
-		// Without this, FPM kills the process when the client disconnects.
-		if ( function_exists( 'fastcgi_finish_request' ) ) {
+		// connection while PHP continues the job. PHP-FPM exposes
+		// fastcgi_finish_request(); LiteSpeed exposes litespeed_finish_request().
+		// Without a SAPI-specific detach call, some hosts terminate the worker
+		// when the non-blocking client disconnects.
+		if ( function_exists( 'fastcgi_finish_request' ) || function_exists( 'litespeed_finish_request' ) ) {
 			// Send a minimal JSON response before detaching.
 			header( 'Content-Type: application/json' );
 			echo '{"ok":true}';
-			fastcgi_finish_request();
+
+			if ( function_exists( 'fastcgi_finish_request' ) ) {
+				fastcgi_finish_request();
+			} else {
+				litespeed_finish_request();
+			}
 		}
 
 		/** @var array<string, mixed> $job */


### PR DESCRIPTION
## Summary
- Add LiteSpeed-compatible request detachment to the internal `/process` background worker.
- Keep existing PHP-FPM `fastcgi_finish_request()` behavior and fall back to `litespeed_finish_request()` when FastCGI is unavailable.
- This reduces early web-worker termination on LiteSpeed/cPanel hosts when non-blocking loopback requests disconnect.

## Evidence
- Live server identifies as `server: LiteSpeed`.
- A live interruption reported `phase=provider_call`, `iteration=2/100`, `elapsed_s=9`, `connection_status=normal`, `fatal=none`.
- Matching traces showed a successful first DeepSeek call followed by SDK `no_result_event` on the next provider call, with no PHP fatal/debug-log exception.
- The change was deployed to the live plugin after backup and syntax-checked there.

## Verification
- `php -l includes/REST/SessionController.php`
- `git diff --check origin/main...HEAD`
- Live syntax check: `php -l wp-content/plugins/superdav-ai-agent/includes/REST/SessionController.php`
- Live homepage remained HTTP 200 after deployment.

## Note
This is a hosting compatibility hardening fix, not a replacement for a durable queue/worker architecture for very long agent jobs.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.12 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for LiteSpeed servers in background task handling, alongside existing PHP-FPM compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->