### PR TITLE
fix: share onboarding sessions across admins

### DIFF
--- a/includes/Abilities/GenerateLogoSvgAbility.php
+++ b/includes/Abilities/GenerateLogoSvgAbility.php
@@ -31,8 +31,17 @@ class GenerateLogoSvgAbility extends AbstractAbility {
 
 	/**
 	 * Maximum number of AI generation attempts per candidate before falling back.
+	 *
+	 * Keep this deliberately low for shared-hosting/browser-triggered agent runs:
+	 * the deterministic wordmark fallback is preferable to letting logo generation
+	 * consume the full background request budget.
 	 */
-	private const MAX_RETRIES = 3;
+	private const MAX_RETRIES = 1;
+
+	/**
+	 * Per-request timeout for AI SVG generation attempts.
+	 */
+	private const AI_REQUEST_TIMEOUT_SECONDS = 8;
 
 	/**
 	 * Maximum allowed SVG byte size (500 KB).
@@ -413,9 +422,15 @@ INSTRUCTION;
 		$last_error = null;
 
 		for ( $attempt = 1; $attempt <= self::MAX_RETRIES; $attempt++ ) {
-			$raw = wp_ai_client_prompt( $prompt )
-				->using_system_instruction( $system_instruction )
-				->generate_text();
+			$timeout_filter = static fn (): int => self::AI_REQUEST_TIMEOUT_SECONDS;
+			add_filter( 'wp_ai_client_default_request_timeout', $timeout_filter, 999 );
+			try {
+				$raw = wp_ai_client_prompt( $prompt )
+					->using_system_instruction( $system_instruction )
+					->generate_text();
+			} finally {
+				remove_filter( 'wp_ai_client_default_request_timeout', $timeout_filter, 999 );
+			}
 
 			if ( is_wp_error( $raw ) ) {
 				$last_error = $raw;

--- a/includes/Core/OnboardingManager.php
+++ b/includes/Core/OnboardingManager.php
@@ -377,6 +377,10 @@ class OnboardingManager {
 				$settings->update( [ 'onboarding_complete' => true ] );
 			}
 
+			if ( ! empty( $existing_session_id ) ) {
+				self::share_bootstrap_session( (int) $existing_session_id );
+			}
+
 			return new \WP_REST_Response(
 				[
 					'success'             => true,
@@ -437,6 +441,7 @@ class OnboardingManager {
 		// Persist the session ID and mark onboarding complete atomically across
 		// both persistence layers so is_complete() and /onboarding/status agree.
 		update_option( self::BOOTSTRAP_SESSION_OPTION, $session_id, false );
+		self::share_bootstrap_session( (int) $session_id );
 		self::mark_complete();
 		$settings->update( [ 'onboarding_complete' => true ] );
 
@@ -451,6 +456,29 @@ class OnboardingManager {
 			],
 			200
 		);
+	}
+
+	/**
+	 * Share the site-wide onboarding session with admins.
+	 *
+	 * The persisted bootstrap session ID is site-scoped, not user-scoped. If one
+	 * administrator starts onboarding and another administrator later loads the
+	 * Setup Assistant, /onboarding/start returns the same session ID. Marking the
+	 * session as shared keeps that site-scoped behaviour while allowing normal
+	 * session permission checks to grant read/continue access.
+	 *
+	 * @param int $session_id Bootstrap session ID.
+	 */
+	private static function share_bootstrap_session( int $session_id ): void {
+		if ( $session_id <= 0 ) {
+			return;
+		}
+
+		if ( Database::get_shared_session( $session_id ) ) {
+			return;
+		}
+
+		Database::share_session( $session_id, get_current_user_id() );
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/OnboardingManagerTest.php
+++ b/tests/SdAiAgent/Core/OnboardingManagerTest.php
@@ -440,6 +440,7 @@ class OnboardingManagerTest extends WP_UnitTestCase {
 
 		$this->assertSame( $data['session_id'], get_option( OnboardingManager::BOOTSTRAP_SESSION_OPTION ) );
 		$this->assertTrue( (bool) get_option( OnboardingManager::COMPLETE_OPTION ) );
+		$this->assertNotNull( \SdAiAgent\Core\Database::get_shared_session( (int) $data['session_id'] ) );
 
 		$settings = \SdAiAgent\Core\Settings::instance()->get();
 		$this->assertTrue( (bool) ( $settings['onboarding_complete'] ?? false ) );
@@ -457,6 +458,30 @@ class OnboardingManagerTest extends WP_UnitTestCase {
 
 		$this->assertSame( $first['session_id'], $second['session_id'] );
 		$this->assertTrue( $second['already_complete'] );
+	}
+
+	/**
+	 * rest_start() shares the reused site-scoped onboarding session so a second
+	 * administrator can open the persisted Setup Assistant chat.
+	 */
+	public function test_rest_start_shares_reused_session_for_second_admin(): void {
+		$first_admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $first_admin_id );
+
+		$first      = OnboardingManager::rest_start()->get_data();
+		$session_id = (int) $first['session_id'];
+
+		\SdAiAgent\Core\Database::unshare_session( $session_id );
+		$this->assertNull( \SdAiAgent\Core\Database::get_shared_session( $session_id ) );
+
+		$second_admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $second_admin_id );
+
+		$second = OnboardingManager::rest_start()->get_data();
+
+		$this->assertSame( $session_id, (int) $second['session_id'] );
+		$this->assertTrue( $second['already_complete'] );
+		$this->assertNotNull( \SdAiAgent\Core\Database::get_shared_session( $session_id ) );
 	}
 
 	// ── rest_reset ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Share the site-scoped Setup Assistant onboarding session when it is created or reused so another admin can open the persisted chat instead of hitting `GET /sessions/{id}` 403.
- Bound AI-powered SVG logo generation to one short attempt and rely on the existing deterministic wordmark fallback when the AI call fails or times out.
- Add regression coverage for reused onboarding sessions being shared for a second admin.

## Why

Real browser testing on a LiteSpeed/cPanel WordPress install exposed two standard-hosting failures:

1. `/onboarding/start` returns a site-scoped persisted session ID, but normal session permissions are owner-scoped. A second admin received `403` when the frontend fetched the reused Setup Assistant session.
2. `sd-ai-agent/generate-logo-svg` could spend too much of the background request budget on AI retries. The deterministic fallback is safer than letting logo generation kill or stall the broader setup run.

## Verification

- `php -l includes/Core/OnboardingManager.php`
- `php -l includes/Abilities/GenerateLogoSvgAbility.php`
- `php -l tests/SdAiAgent/Core/OnboardingManagerTest.php`
- Attempted: `php bin/run-wp-phpunit.php tests/SdAiAgent/Core/OnboardingManagerTest.php`
  - Result: could not run in this local worktree because `phpunit` / `vendor/bin/phpunit` is unavailable.
- Live browser verification on the affected standard-hosting site:
  - temporary second admin could fetch the shared setup session after the fix (`GET /sessions/1` returned 200 instead of 403).
  - setup prompt job `31f30b9e-fc67-461b-a142-580339b32834` completed and persisted the session update.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.12 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5
