### PR TITLE
GH#2034: docs: clarify contributor insight source mapping

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -124,6 +124,15 @@ to change, do not answer only in the issue thread. Make the durable repo change:
   finding, includes verification commands, and avoids broad "everything is fixed"
   or "remaining issues are false positives" claims unless each claim is tied to
   exact file or pattern evidence.
+- For mixed reports like issue #2034, include the source map in the PR body:
+  block-theme excerpts → `includes/Models/skills/wp-block-themes.md`; REST
+  hardening → root `AGENTS.md`, `includes/REST/`, and
+  `includes/Abilities/WpRestAbilities.php`; Google Search Console →
+  `includes/Abilities/GscAbilities.php`, `includes/Core/Settings.php`,
+  `includes/REST/SettingsController.php`, and
+  `includes/Abilities/ToolCapabilities.php`; WordPress.org review responses →
+  root `AGENTS.md` review-response policy. If code already has the requested
+  guard, cite the exact inspected guard instead of claiming "already documented".
 - Do not mark contributor-insight issues complete after documentation reading
   alone. A valid fix changes a durable instruction, workflow doc, or helper, then
   verifies the changed guidance with an exact `rg -n` check that future workers

--- a/.agents/scripts/commands/feedback-triage.md
+++ b/.agents/scripts/commands/feedback-triage.md
@@ -126,6 +126,18 @@ The resulting issue body must name the target files, expected behaviour, and at
 least one verification command; do not leave private local paths or shorthand as
 the only implementation guidance.
 
+For mixed contributor-insight issues, the body must also include a concise
+source map so the worker can start with implementation instead of rediscovering
+the lesson. For the recurring issue #2034 pattern, map the four notes as:
+`Block Themes` excerpts → `includes/Models/skills/wp-block-themes.md`; REST
+security shorthand → root `AGENTS.md`, `includes/REST/`, and
+`includes/Abilities/WpRestAbilities.php`; Google Search Console questions →
+`includes/Abilities/GscAbilities.php`, `includes/Core/Settings.php`,
+`includes/REST/SettingsController.php`, and
+`includes/Abilities/ToolCapabilities.php`; WordPress.org review-response prompts
+→ root `AGENTS.md` "WordPress.org Review Responses". Require the PR body to cite
+the inspected guard or policy when no code change is needed.
+
 Full payload schema (top-level keys):
 
 - `id`, `created_at`, `reviewed_at`, `status`, `report_type`, `api_key_id`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,13 @@ note to a committed, future-loaded source before editing:
   summarize each reviewer finding, cite the merged fix or evidence-backed
   rationale, include verification commands, and avoid blanket "all fixed" or
   "false positive" claims that are not tied to a specific finding.
+- For mixed reports like issue #2034, make the mapping explicit in the PR body:
+  block-theme excerpts map to `includes/Models/skills/wp-block-themes.md`; REST
+  hardening shorthand maps to this root REST policy plus `includes/REST/` and
+  `includes/Abilities/WpRestAbilities.php`; Google Search Console questions map
+  to the GSC surfaces listed below; WordPress.org reply prompts map to the
+  review-response policy above. State when the implementation is a guidance
+  hardening only because the inspected code already has the required guard.
 - Verification for this class of guidance-only fix should include both:
   `rg -n "Contributor Insight|source mapping|local-path|sd-ai-agent/v1|file upload|WordPress.org Review|false positive" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md`
   and `rg -n "wp-block-themes|Full Site Editing|theme.json|validate-block-content" AGENTS.md includes/Models/skills/wp-block-themes.md`.
@@ -520,6 +527,14 @@ second must report zero failures for the four ability suites.
   verify the controller uses the real current user context, has a capability
   gate, avoids public file-upload exposure, and returns scrubbed responses before
   calling the route WordPress.org-ready.
+- **Evidence checklist for contributor-insight REST hardening**: cite the exact
+  inspected guard before deciding guidance-only is enough. Reference
+  `includes/Abilities/WpRestAbilities.php` for the `sd-ai-agent/v1` execute
+  block, file-upload hiding, current-user dispatcher behaviour, and audit-log
+  secret scrubbing; reference `includes/REST/PermissionTrait.php` or the concrete
+  controller for the route capability check; reference the upload controller
+  method (for example `includes/REST/KnowledgeController.php`) when the note says
+  to hide or restrict uploads.
 - **Follow-up issue briefs**: If a REST hardening pass finds remaining exposure,
   file worker-ready GitHub issue briefs that name the route/controller, the missing
   guard or scrubber, the expected safe behaviour, and the exact verification command

--- a/includes/Models/skills/wp-block-themes.md
+++ b/includes/Models/skills/wp-block-themes.md
@@ -25,7 +25,10 @@ When a contributor-insight issue contains a pasted local-path excerpt headed
 style variations, treat that excerpt as a source-mapping clue only. Update this
 committed skill file (and the root `AGENTS.md` summary when repo-wide guidance is
 needed); do not copy private local paths or duplicate the full excerpt into
-issues, PRs, templates, or generated theme files.
+issues, PRs, templates, or generated theme files. In mixed reports like issue
+#2034, this file is only the block-theme target; REST, Google Search Console, and
+WordPress.org review-response notes must be mapped to their own committed source
+files instead of being folded into this skill.
 
 ## Inputs required
 


### PR DESCRIPTION
## Summary

Updated durable contributor-insight guidance so mixed reports map block-theme excerpts, REST security shorthand, Google Search Console usage questions, and WordPress.org review-response prompts to committed source files. Added REST evidence guidance requiring workers to cite inspected guards when no code change is needed.

## Files Changed

.agents/AGENTS.md,.agents/scripts/commands/feedback-triage.md,AGENTS.md,includes/Models/skills/wp-block-themes.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** rg -n 'Contributor Insight|source mapping|local-path|sd-ai-agent/v1|file upload|WordPress.org Review|false positive' AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md; rg -n 'wp-block-themes|Full Site Editing|theme.json|validate-block-content' AGENTS.md includes/Models/skills/wp-block-themes.md; npm run verify (PHPUnit: Tests: 3549, Assertions: 14784, Errors: 0, Failures: 0, Skipped: 116, Incomplete: 4; lint/PHPStan/build/check: passed)

## Worker self-verification
- PHPUnit: Tests: 3549, Assertions: 14784, Errors: 0, Failures: 0, Skipped: 116, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Resolves #2034


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.12 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 8m and 158,095 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor instructions and agent guidance for improved issue reporting processes.
  * Enhanced source mapping requirements for mixed reports to improve clarity and verification accuracy.
  * Added evidence checklists and mapping procedures for security verification scenarios.
  * Refined guidance for handling contributor insights and component-specific excerpts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->