### PR TITLE
GH#2036: fix: type Superdav request data

### DIFF
--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiTextGenerationModel.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiTextGenerationModel.php
@@ -26,7 +26,7 @@ final class SuperdavAiTextGenerationModel extends AbstractOpenAiCompatibleTextGe
 	 * @param string|array<string, mixed>|null   $data    Request body/query data.
 	 * @return Request
 	 */
-	protected function createRequest( HttpMethodEnum $method, string $path, array $headers = array(), $data = null ): Request {
+	protected function createRequest( HttpMethodEnum $method, string $path, array $headers = array(), mixed $data = null ): Request {
 		return new Request( $method, SuperdavAiProvider::url( $path ), $headers, $data );
 	}
 }


### PR DESCRIPTION
## Summary

Typed the Superdav AI text generation model createRequest data parameter as mixed while leaving the request construction unchanged.

## Files Changed

includes/Infrastructure/AiClient/Superdav/SuperdavAiTextGenerationModel.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify (lint clean; PHPStan 0 errors; PHPUnit Tests: 3549, Assertions: 14784, Skipped: 116, Incomplete: 4; build and bundle checks succeeded)

Resolves #2036


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.12 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 8m and 79,913 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code type safety and consistency to enhance code maintainability and reduce potential issues during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->