### PR TITLE
GH#2037: fix: preserve cloud provider type in runtime stub

### DIFF
--- a/stubs/wordpress-7-runtime.php
+++ b/stubs/wordpress-7-runtime.php
@@ -483,7 +483,12 @@ namespace WordPress\AiClient\Providers\Enums {
 		}
 
 		/** @return self */
-		public static function cloud(): self { return new self(); }
+		public static function cloud(): self {
+			$enum        = new self();
+			$enum->value = 'cloud';
+
+			return $enum;
+		}
 
 		/** @return string */
 		public function __toString(): string { return $this->value; }


### PR DESCRIPTION
## Summary

Updated the WordPress 7 runtime ProviderTypeEnum stub so cloud() sets the backing value to 'cloud', matching php-ai-client behavior.

## Files Changed

stubs/wordpress-7-runtime.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify (lint JS/CSS/PHP, PHPStan 0 errors, PHPUnit Tests: 3549, Assertions: 14784, Skipped: 116, Incomplete: 4, build, bundle check)

## Worker self-verification

- PHPUnit: Tests: 3549, Assertions: 14784, Errors: 0, Failures: 0, Skipped: 116, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Resolves #2037

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.12 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 8m and 82,859 tokens on this as a headless worker.
