### PR TITLE
GH#2042: fix: protect block template hero edits

### DIFF
--- a/includes/Abilities/WpRestAbilities.php
+++ b/includes/Abilities/WpRestAbilities.php
@@ -64,6 +64,10 @@ class WpRestAbilities {
 	private const BLOCKED_ROUTES = array(
 		'DELETE /wp/v2/users',
 		'POST /wp/v2/users',
+		// Full-template REST writes can replace the entire block template body.
+		// Require the agent to use block-level mutators with a prior read instead
+		// of POSTing partial `content` payloads to wp_template endpoints.
+		'POST /wp/v2/templates',
 	);
 
 	/**

--- a/includes/Models/skills/wp-block-themes.md
+++ b/includes/Models/skills/wp-block-themes.md
@@ -150,6 +150,25 @@ For non-landing templates, create a reusable page-title part or pattern that use
 - `sd-ai-agent/create-block-content` / `sd-ai-agent/validate-block-content` — Build/check block markup before saving
 - `sd-ai-agent/update-global-styles` — Apply the selected design direction with a non-empty theme.json `styles` partial. Never call it with `styles: []`, `settings: []`, `{}`, or unchanged empty arguments; include concrete colors, typography, spacing, or element styles.
 
+### Safe existing-template edits
+
+When modifying an existing template such as `front-page`, preserve every block that
+the user did not ask to change:
+
+1. Inspect the current template first. Use `sd-ai-agent/list-block-templates` to
+   find the template, then fetch its current post/template content before writing.
+2. If a REST template response includes a `wp_id`, use `sd-ai-agent/get-page-blocks`
+   on that post ID and address the hero/section by `ref`, `path`, or `flat_index`.
+3. Use `sd-ai-agent/update-blocks` or `sd-ai-agent/edit-block-tree` for the target
+   hero background/image attributes only. Do not rebuild or replace the full
+   template unless the user explicitly requested a complete redesign.
+4. Validate the full resulting block markup with `sd-ai-agent/validate-block-content`
+   before saving. If validation fails, repair the proposed change and retry; do
+   not save a partial template body.
+5. Do not POST partial `content` payloads to `/wp/v2/templates/...` through
+   `wp-rest/execute`. That endpoint replaces the template body and can delete
+   sibling sections when the payload only contains the edited hero block.
+
 ## theme.json Overview
 
 `theme.json` controls global styles AND editor settings. Two top-level keys: `settings` (what users can do) and `styles` (default appearance). Always declare `$schema` and `version: 3`.

--- a/includes/Tools/ToolDiscovery.php
+++ b/includes/Tools/ToolDiscovery.php
@@ -67,6 +67,14 @@ class ToolDiscovery {
 		// falling back to WP-CLI or PHP snippets on fresh installs.
 		'sd-ai-agent/update-post',
 		'sd-ai-agent/update-global-styles',
+		// Block-theme editing safety cluster. These stay together so homepage/template
+		// visual edits can inspect the current structure, mutate only the target
+		// block, and validate the result instead of replacing a whole template body
+		// through generic REST/WP-CLI fallbacks.
+		'sd-ai-agent/list-block-templates',
+		'sd-ai-agent/get-page-blocks',
+		'sd-ai-agent/update-blocks',
+		'sd-ai-agent/validate-block-content',
 		// WP-CLI is the proper tool for admin commands like `wp site list`,
 		// `wp plugin list`, etc. Registered by the cli-abilities-bridge plugin.
 		'wp-cli/execute',

--- a/tests/SdAiAgent/Abilities/WpRestAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/WpRestAbilitiesTest.php
@@ -254,6 +254,26 @@ class WpRestAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test: execute blocks full-template REST writes so partial hero updates
+	 * cannot replace the rest of the front-page template body.
+	 */
+	public function test_execute_blocks_full_template_writes(): void {
+		$result = WpRestAbilities::handle_execute(
+			array(
+				'method' => 'POST',
+				'route'  => '/wp/v2/templates/example//front-page',
+				'params' => array(
+					'content' => '<!-- wp:group --><div class="wp-block-group"></div><!-- /wp:group -->',
+				),
+			)
+		);
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'wp_rest_route_blocked', $result->get_error_code() );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+	}
+
+	/**
 	 * Test: classification filter can downgrade a destructive call.
 	 */
 	public function test_execute_classification_via_filter(): void {

--- a/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
+++ b/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
@@ -172,6 +172,15 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 		$this->assertContains( 'sd-ai-agent/update-global-styles', $tier_1 );
 	}
 
+	public function test_tier_1_includes_block_theme_safe_editing_cluster(): void {
+		$tier_1 = ToolDiscovery::tier_1_for_run();
+
+		$this->assertContains( 'sd-ai-agent/list-block-templates', $tier_1 );
+		$this->assertContains( 'sd-ai-agent/get-page-blocks', $tier_1 );
+		$this->assertContains( 'sd-ai-agent/update-blocks', $tier_1 );
+		$this->assertContains( 'sd-ai-agent/validate-block-content', $tier_1 );
+	}
+
 	public function test_tier_1_omits_wp_cli_when_ability_is_not_registered(): void {
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Test isolates the Abilities API registry mutation.
 		global $_wp_ability_registry;


### PR DESCRIPTION
## Summary

Added a block-theme safe editing cluster to Tier 1, blocked destructive wp-rest template POST replacements, and documented the preserve/validate flow for existing template edits.

## Files Changed

includes/Abilities/WpRestAbilities.php,includes/Models/skills/wp-block-themes.md,includes/Tools/ToolDiscovery.php,tests/SdAiAgent/Abilities/WpRestAbilitiesTest.php,tests/SdAiAgent/Tools/ToolDiscoveryTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify (PHPUnit: Tests: 3551, Assertions: 14791, Errors: 0, Failures: 0, Skipped: 116, Incomplete: 4; lint/PHPStan/build/bundle checks clean)

Resolves #2042


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.12 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 11m and 118,488 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added four new tools for safe block theme template editing and validation.

* **Bug Fixes**
  * Blocked unsafe REST API template write operations to prevent unintended content loss.

* **Documentation**
  * Added step-by-step guidance for safely modifying existing block theme templates.

* **Tests**
  * Added verification tests for REST blocking and new template editing tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->