### PR TITLE
GH#2044: fix: guard empty global styles updates

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -990,6 +990,15 @@ class AgentLoop {
 			// Log tool calls and check for confirmation requirement.
 			$this->log_tool_calls( $assistant_message );
 
+			$empty_global_styles_guard = $this->build_empty_global_styles_guard_response( $assistant_message );
+			if ( null !== $empty_global_styles_guard ) {
+				$this->append_tool_response_to_history( $empty_global_styles_guard );
+				$this->log_tool_responses( $empty_global_styles_guard );
+				$this->inject_empty_global_styles_update_guidance();
+				$this->last_loop_phase = 'empty_global_styles_update_guarded';
+				continue;
+			}
+
 			// ── Client-side ability routing ───────────────────────────────
 			// Partition tool calls into PHP-executable and JS-pending sets.
 			// PHP calls execute inline; JS calls are returned as pending so
@@ -2205,6 +2214,141 @@ class AgentLoop {
 		);
 
 		return new ModelMessage( $deduped );
+	}
+
+	/**
+	 * Build a synthetic tool response for empty update-global-styles calls.
+	 *
+	 * The global-styles ability cannot infer a design direction from
+	 * `styles: []` / `settings: []`. Returning a guard response here prevents
+	 * dispatching a known-empty mutation and gives the model a concrete recovery
+	 * instruction instead of letting it repeat the same validation failure.
+	 *
+	 * @param Message $message Assistant message to inspect.
+	 * @return Message|null Synthetic response when every tool call was guarded; null otherwise.
+	 */
+	private function build_empty_global_styles_guard_response( Message $message ): ?Message {
+		$parts             = array();
+		$function_calls    = 0;
+		$guarded_responses = 0;
+
+		foreach ( $message->getParts() as $part ) {
+			$call = $part->getFunctionCall();
+			if ( ! $call ) {
+				continue;
+			}
+
+			++$function_calls;
+
+			$name = (string) $call->getName();
+			if ( 'sd-ai-agent/update-global-styles' !== self::normalize_logged_tool_name( $name ) ) {
+				continue;
+			}
+
+			$args = self::normalize_function_call_args( $call->getArgs() );
+			if ( ! self::is_empty_global_styles_update_args( $args ) ) {
+				continue;
+			}
+
+			++$guarded_responses;
+			$payload = array(
+				'success'           => false,
+				'code'              => 'sd_ai_agent_empty_global_styles_update_guarded',
+				'error'             => __( 'Empty global styles updates are not dispatched. Provide a non-empty theme.json styles or settings partial.', 'superdav-ai-agent' ),
+				'example_arguments' => array(
+					'styles' => array(
+						'color'      => array(
+							'background' => '<background hex or preset var>',
+							'text'       => '<text hex or preset var>',
+						),
+						'typography' => array(
+							'fontFamily' => '<system or bundled font stack>',
+							'lineHeight' => '<line height>',
+						),
+						'elements'   => array(
+							'button' => array(
+								'color' => array(
+									'background' => '<button background>',
+									'text'       => '<button text>',
+								),
+							),
+						),
+					),
+				),
+				'nudge'             => 'Do not retry update-global-styles with empty or unchanged arguments. Build a concrete design partial from the chosen palette/typography, call get-theme-json first if needed, or skip the style update and report the blocker to the user.',
+			);
+
+			$encoded_payload = wp_json_encode( $payload );
+			$parts[]         = new MessagePart(
+				new FunctionResponse(
+					(string) $call->getId(),
+					$name,
+					is_string( $encoded_payload ) ? $encoded_payload : '{}'
+				)
+			);
+		}
+
+		if ( 0 === $function_calls || $function_calls !== $guarded_responses ) {
+			return null;
+		}
+
+		$this->message_log[] = array(
+			'type'     => 'guardrail',
+			'reason'   => 'empty_global_styles_update_guarded',
+			'count'    => $guarded_responses,
+			'sequence' => $this->next_activity_sequence(),
+		);
+
+		return new UserMessage( $parts );
+	}
+
+	/**
+	 * Normalize function-call args to an array.
+	 *
+	 * @param mixed $args Raw function-call arguments.
+	 * @return array<string,mixed>
+	 */
+	private static function normalize_function_call_args( $args ): array {
+		if ( is_string( $args ) && '' !== $args ) {
+			$decoded = json_decode( $args, true );
+			return is_array( $decoded ) ? $decoded : array();
+		}
+
+		if ( is_array( $args ) ) {
+			return $args;
+		}
+
+		return array();
+	}
+
+	/**
+	 * Whether update-global-styles received no meaningful style/settings data.
+	 *
+	 * @param array<string,mixed> $args Normalized function-call args.
+	 */
+	private static function is_empty_global_styles_update_args( array $args ): bool {
+		$styles   = $args['styles'] ?? array();
+		$settings = $args['settings'] ?? array();
+
+		return empty( $styles ) && empty( $settings );
+	}
+
+	/**
+	 * Inject recovery guidance after the empty global-styles guard fires.
+	 */
+	private function inject_empty_global_styles_update_guidance(): void {
+		$this->history[] = new UserMessage(
+			array(
+				new MessagePart(
+					__(
+						'The previous update-global-styles call was blocked because both styles and settings were empty. Do not retry that call unchanged. Build a concrete non-empty theme.json styles partial from the selected design direction, call get-theme-json if you need existing presets, or skip the style update and tell the user exactly what blocked it before giving a final response.',
+						'superdav-ai-agent'
+					)
+				),
+			)
+		);
+
+		$this->fire_progress();
 	}
 
 	/**

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -2311,14 +2311,31 @@ class AgentLoop {
 	private static function normalize_function_call_args( $args ): array {
 		if ( is_string( $args ) && '' !== $args ) {
 			$decoded = json_decode( $args, true );
-			return is_array( $decoded ) ? $decoded : array();
+			return is_array( $decoded ) ? self::string_keyed_array( $decoded ) : array();
 		}
 
 		if ( is_array( $args ) ) {
-			return $args;
+			return self::string_keyed_array( $args );
 		}
 
 		return array();
+	}
+
+	/**
+	 * Keep only string-keyed values from a decoded JSON object.
+	 *
+	 * @param array<mixed> $value Decoded function-call args.
+	 * @return array<string,mixed>
+	 */
+	private static function string_keyed_array( array $value ): array {
+		$result = array();
+		foreach ( $value as $key => $item ) {
+			if ( is_string( $key ) ) {
+				$result[ $key ] = $item;
+			}
+		}
+
+		return $result;
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -2112,6 +2112,102 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertLessThanOrEqual( AgentLoop::MAX_IDLE_ROUNDS + 1, $result['iterations_used'] );
 	}
 
+	/**
+	 * Empty update-global-styles calls must be blocked before ability dispatch.
+	 */
+	public function test_run_guards_empty_global_styles_update_and_recovers(): void {
+		$this->skip_if_sdk_unavailable();
+
+		$call_count           = 0;
+		$second_request_body  = '';
+		$empty_tool_call_body = static function ( string $call_id ): string {
+			return (string) wp_json_encode(
+				[
+					'id'      => 'chatcmpl-empty-global-styles-' . $call_id,
+					'object'  => 'chat.completion',
+					'choices' => [
+						[
+							'index'         => 0,
+							'message'       => [
+								'role'       => 'assistant',
+								'content'    => null,
+								'tool_calls' => [
+									[
+										'id'       => $call_id,
+										'type'     => 'function',
+										'function' => [
+											'name'      => 'wpab__sd-ai-agent__update-global-styles',
+											'arguments' => '{"styles":[],"settings":[],"site_url":""}',
+										],
+									],
+								],
+							],
+							'finish_reason' => 'tool_calls',
+						],
+					],
+					'usage'   => [ 'prompt_tokens' => 10, 'completion_tokens' => 5, 'total_tokens' => 15 ],
+				]
+			);
+		};
+
+		$final_body = wp_json_encode(
+			[
+				'id'      => 'chatcmpl-empty-global-styles-recovered',
+				'object'  => 'chat.completion',
+				'choices' => [
+					[
+						'index'         => 0,
+						'message'       => [ 'role' => 'assistant', 'content' => 'I could not apply global styles because no concrete style partial was available, so I stopped that step and kept the homepage build moving.' ],
+						'finish_reason' => 'stop',
+					],
+				],
+				'usage'   => [ 'prompt_tokens' => 20, 'completion_tokens' => 12, 'total_tokens' => 32 ],
+			]
+		);
+
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $args, $url ) use ( &$call_count, &$second_request_body, $empty_tool_call_body, $final_body ) {
+				if ( false !== strpos( $url, 'fake-ai-proxy.test' ) ) {
+					++$call_count;
+					if ( 2 === $call_count ) {
+						$second_request_body = is_string( $args['body'] ?? null ) ? $args['body'] : (string) wp_json_encode( $args['body'] ?? [] );
+					}
+
+					return [
+						'headers'  => [ 'content-type' => 'application/json' ],
+						'body'     => $call_count < 3 ? $empty_tool_call_body( 'call_empty_' . $call_count ) : $final_body,
+						'response' => [ 'code' => 200, 'message' => 'OK' ],
+						'cookies'  => [],
+						'filename' => '',
+					];
+				}
+
+				return $preempt;
+			},
+			10,
+			3
+		);
+
+		$loop   = new AgentLoop( 'Build a homepage', [], [], [ 'max_iterations' => 4 ] );
+		$result = $loop->run();
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'I could not apply global styles because no concrete style partial was available, so I stopped that step and kept the homepage build moving.', $result['reply'] );
+		$this->assertStringContainsString( 'Empty global styles updates are not dispatched', $second_request_body );
+		$this->assertStringContainsString( 'Do not retry that call unchanged', $second_request_body );
+
+		$responses = array_filter(
+			$result['tool_calls'],
+			static fn( $entry ) => 'response' === ( $entry['type'] ?? '' )
+		);
+		$this->assertCount( 2, $responses, 'The empty global-styles calls should receive synthetic guard responses.' );
+		foreach ( $responses as $response ) {
+			$this->assertStringContainsString( 'sd_ai_agent_empty_global_styles_update_guarded', (string) $response['response'] );
+			$this->assertStringNotContainsString( 'Either styles or settings is required.', (string) $response['response'] );
+		}
+	}
+
 	// -------------------------------------------------------------------------
 	// Production hardening: wall-clock timeout
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Added an AgentLoop guard that intercepts empty direct update-global-styles tool calls before ability dispatch, returns a synthetic recovery response with concrete example arguments, injects follow-up guidance, and added a regression test for repeated empty calls recovering to a final response.

## Files Changed

includes/Core/AgentLoop.php,tests/SdAiAgent/Core/AgentLoopTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify (PHPUnit: Tests: 3550, Assertions: 14784, Errors: 0, Failures: 0, Skipped: 117, Incomplete: 4; Lint PHP/JS/CSS clean; PHPStan 0 errors; Build succeeded with existing webpack size warnings; bundle check passed)

Resolves #2044


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.12 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 13m and 149,278 tokens on this as a headless worker.