### PR TITLE
GH#2043: fix: allow multisite admin URL helpers

### DIFF
--- a/includes/Abilities/RunPhpAbility.php
+++ b/includes/Abilities/RunPhpAbility.php
@@ -138,6 +138,8 @@ class RunPhpAbility extends AbstractAbility {
 		'home_url',
 		'site_url',
 		'admin_url',
+		'get_admin_url',
+		'network_admin_url',
 		'wp_upload_dir',
 		'is_multisite',
 		// Plugins / Themes.

--- a/tests/SdAiAgent/Abilities/WordPressAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/WordPressAbilitiesTest.php
@@ -406,6 +406,44 @@ class WordPressAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * RunPhpAbility allows safe admin URL helpers so agents can derive the
+	 * correct dashboard context instead of hard-coding wp-admin paths.
+	 */
+	public function test_handle_run_php_allows_safe_admin_url_helpers() {
+		$result = WordPressAbilities::handle_run_php( [
+			'function' => 'get_admin_url',
+			'args'     => [ null, 'admin.php?page=sd-ai-agent' ],
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertIsString( $result['result'] );
+		$this->assertStringContainsString( '/wp-admin/admin.php?page=sd-ai-agent', $result['result'] );
+	}
+
+	/**
+	 * Network-admin-only plugin screens must be derivable via run-php on
+	 * multisite so agents avoid sending users to dead site-admin URLs.
+	 */
+	public function test_handle_run_php_derives_wordfence_network_admin_url() {
+		if ( ! function_exists( 'network_admin_url' ) ) {
+			$this->markTestSkipped( 'network_admin_url() unavailable in this environment.' );
+		}
+
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'network_admin_url() resolves to site admin outside multisite.' );
+		}
+
+		$result = WordPressAbilities::handle_run_php( [
+			'function' => 'network_admin_url',
+			'args'     => [ 'admin.php?page=Wordfence' ],
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertIsString( $result['result'] );
+		$this->assertStringContainsString( '/wp-admin/network/admin.php?page=Wordfence', $result['result'] );
+	}
+
+	/**
 	 * RunPhpAbility must refuse delete_option('auth_key').
 	 */
 	public function test_handle_run_php_blocks_delete_option_for_write_blocklist() {


### PR DESCRIPTION
## Summary

Allowed the safe WordPress admin URL helpers get_admin_url() and network_admin_url() through sd-ai-agent/run-php, and added coverage proving the agent can derive Wordfence network-admin URLs on multisite.

## Files Changed

includes/Abilities/RunPhpAbility.php,tests/SdAiAgent/Abilities/WordPressAbilitiesTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify; WP_MULTISITE=1 npm run test:php -- --filter=WordPressAbilitiesTest

Resolves #2043


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.12 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 8m and 73,843 tokens on this as a headless worker.