### PR TITLE
t235: mark ability discoverability complete

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -291,15 +291,16 @@ Format: `- [ ] tNNN Description @owner #tag ~estimate risk:level logged:date`
   - Source: Automattic wordpress-block-theming reference (29KB → ~280 lines added) at github.com/Automattic/wordpress-agent-skills/blob/trunk/claude-code/wp-site-creator/references/wordpress-block-theming.md
   - Verify: `wc -l includes/Models/skills/block-themes.md` is 350-450, and `grep -E "Editor Visibility|editor-styles-wrapper|prefers-reduced-motion" includes/Models/skills/block-themes.md` returns matches
 
-- [ ] t232 Ability discovery investigation: why agent misses registered abilities #investigation #parent #plan → [todo/PLANS.md#ability-discovery-investigation] ~5h logged:2026-04-26
+- [x] t232 Ability discovery investigation: why agent misses registered abilities #investigation #parent #plan → [todo/PLANS.md#ability-discovery-investigation] ~5h logged:2026-04-26 pr:#1204,#1228 completed:2026-04-27
 - [x] t234 Audit ability injection pipeline and tool catalog (Phase 1) #investigation #auto-dispatch ~3h For #t232 logged:2026-04-26 pr:#1204 completed:2026-04-27
   - Trace how abilities reach the model: ToolCapabilities.php → AgentLoop.php → wp_ai_client_prompt() injection
   - Check for count limits, filters, or namespace handling that could drop abilities
   - Check site-builder system prompt for tool enumeration gaps
   - Verify: document findings with specific file:line references
-- [ ] t235 Fix ability discoverability — descriptions, system prompt, namespace alignment (Phase 2) #enhancement #auto-dispatch ~2h For #t232 blocked-by:t234 logged:2026-04-26
+- [x] t235 Fix ability discoverability — descriptions, system prompt, namespace alignment (Phase 2) #enhancement #auto-dispatch ~2h For #t232 blocked-by:t234 logged:2026-04-26 pr:#1228 completed:2026-04-27
   - Apply fixes identified in t234: improve descriptions, align namespaces (ai-agent/ vs sd-ai-agent/), update system prompt
   - Verify: `composer phpstan && composer phpcs`
+  - Completion note: #1228 landed the discoverability fixes; current code uses the canonical `sd-ai-agent/` ability namespace and should not reopen legacy-prefix migration work.
 
 - [-] t233 Site builder ability improvements #parent #plan → [todo/PLANS.md#site-builder-ability-improvements] ~9h logged:2026-04-26 obsolete:2026-05-13 (Site Builder mode removed in beads sd-ai-dh0)
 - [ ] t236 Stock image fallback chain: retry all free sources on download failure (Phase 1) #bugfix #auto-dispatch ~1.5h For #t233 logged:2026-04-26

--- a/todo/PLANS.md
+++ b/todo/PLANS.md
@@ -1204,7 +1204,7 @@ WP 7.0 has been delayed again. The plugin currently hard-requires WP 7.0 for fou
 
 ### [2026-04-26] Ability Discovery Investigation — Why Agent Misses Registered Abilities {#ability-discovery-investigation}
 
-**Status:** Planning
+**Status:** Completed 2026-04-27 via #1204 and #1228
 **Estimate:** ~5h (ai:4h test:0.5h read:0.5h)
 **Tasks:** t232 (parent), t234 (phase 1), t235 (phase 2)
 
@@ -1214,8 +1214,8 @@ During a site builder session the agent reported that `update-post`, `manage-glo
 
 #### Progress
 
-- [ ] (2026-04-26) Phase 1: Audit ability injection pipeline and tool catalog ~3h — t234
-- [ ] (2026-04-26) Phase 2: Fix discoverability — descriptions, system prompt, namespace alignment ~2h — t235
+- [x] (2026-04-26) Phase 1: Audit ability injection pipeline and tool catalog ~3h — t234 (#1204)
+- [x] (2026-04-26) Phase 2: Fix discoverability — descriptions, system prompt, namespace alignment ~2h — t235 (#1228)
 
 #### Context from Discussion
 
@@ -1233,11 +1233,13 @@ During a site builder session the agent reported that `update-post`, `manage-glo
 
 #### Decision Log
 
-(To be populated during implementation)
+- 2026-04-27: Phase 1 documented the injection path and catalog gaps in #1204.
+- 2026-04-27: Phase 2 landed in #1228: fixed ability descriptions, system-prompt references, tool capability registration, and the missing post-listing discovery path.
+- 2026-06-04: Source-of-truth cleanup marked t232/t235 complete so the task sync does not keep redispatching already-merged work. Current code uses the canonical `sd-ai-agent/` ability namespace; do not restart this historical plan as legacy-prefix migration work.
 
 #### Surprises & Discoveries
 
-(To be populated during implementation)
+- The follow-up issue sync left t235 open even though #1228 had already merged the fix, causing repeated worker dispatch attempts against completed work.
 
 ---
 


### PR DESCRIPTION
## Summary

- Marked t232/t235 complete in `TODO.md` so issue sync stops redispatching already-merged ability discovery work.
- Updated the `todo/PLANS.md#ability-discovery-investigation` status, progress, decision log, and discovery notes with the #1204/#1228 completion evidence.
- Added a source-of-truth note that current code uses the canonical `sd-ai-agent/` namespace and should not restart this historical task as legacy-prefix migration work.

Resolves #2008

## Verification

- `git diff --check`
- `npm run verify`

## Worker self-verification
- PHPUnit: Tests: 3554, Assertions: 14794, Errors: 0, Failures: 0, Skipped: 118, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.12 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5
