### PR TITLE
GH#2026: feat: add safe crash resume checkpoints

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -78,6 +78,18 @@ class AgentLoop {
 	/** Default exponential backoff schedule in seconds, capped at 60 seconds. */
 	private const PROVIDER_RETRY_DELAYS = array( 1, 2, 4, 8, 16, 32, 60, 60, 60, 60 );
 
+	/** Durable checkpoint phase saved before a provider call is attempted. */
+	public const CHECKPOINT_BEFORE_PROVIDER_CALL = 'before_provider_call';
+
+	/** Durable checkpoint phase saved after an assistant/tool-call response is recorded. */
+	public const CHECKPOINT_PROVIDER_RESPONSE_RECORDED = 'provider_response_recorded';
+
+	/** Non-resumable phase set immediately before PHP abilities execute. */
+	public const CHECKPOINT_TOOL_EXECUTION_STARTED = 'tool_execution_started';
+
+	/** Durable checkpoint phase saved after tool responses are appended. */
+	public const CHECKPOINT_TOOL_RESPONSE_RECORDED = 'tool_response_recorded';
+
 	/**
 	 * Maximum consecutive preamble-only truncations before we abort the loop.
 	 *
@@ -657,6 +669,49 @@ class AgentLoop {
 	}
 
 	/**
+	 * Resume directly from a durable safe-boundary checkpoint.
+	 *
+	 * The checkpoint history already contains the user prompt and any durable
+	 * model/tool messages. Unlike run(), this method must not append a new user
+	 * message or blindly replay work that may have already executed.
+	 *
+	 * @param int $remaining_iterations Remaining loop iterations.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public function resume_from_checkpoint( int $remaining_iterations ) {
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			return new WP_Error(
+				'sd_ai_agent_missing_client',
+				__( 'wp_ai_client_prompt() is not available.', 'superdav-ai-agent' )
+			);
+		}
+
+		$budget_check = BudgetManager::check_budget();
+		if ( is_wp_error( $budget_check ) ) {
+			return $budget_check;
+		}
+
+		IdenticalFailureTracker::reset();
+		ModelHealthTracker::set_current_model( $this->model_id );
+		ProviderCredentialLoader::load();
+		AgentEventLog::set_session( $this->session_id );
+
+		if ( '' !== $this->active_job_id ) {
+			$this->active_job_started_at = microtime( true );
+			register_shutdown_function( array( $this, 'handle_active_job_shutdown' ) );
+		}
+
+		try {
+			$result = $this->run_loop( max( 1, $remaining_iterations ) );
+			$this->evaluate_skill_outcomes( $result );
+			return $result;
+		} finally {
+			$this->last_loop_phase = 'agent_loop_exiting';
+			AgentEventLog::clear_session();
+		}
+	}
+
+	/**
 	 * Resume the agent loop after the browser has executed client-side tool calls.
 	 *
 	 * Called by the /chat/tool-result REST endpoint. Reconstructs a tool-response
@@ -761,6 +816,35 @@ class AgentLoop {
 	}
 
 	/**
+	 * Persist the current loop state for safe automatic background-job resume.
+	 *
+	 * @param string $phase                Durable loop phase.
+	 * @param int    $iterations_remaining Remaining iterations for a resumed loop.
+	 * @return void
+	 */
+	private function save_active_job_checkpoint( string $phase, int $iterations_remaining ): void {
+		if ( '' === $this->active_job_id ) {
+			return;
+		}
+
+		ActiveJobRepository::save_checkpoint(
+			$this->active_job_id,
+			$phase,
+			array(
+				'history'              => $this->serialize_history(),
+				'tool_call_log'        => $this->tool_call_log,
+				'message_log'          => $this->message_log,
+				'token_usage'          => $this->token_usage,
+				'iterations_remaining' => max( 1, $iterations_remaining ),
+				'model_id'             => $this->model_id,
+				'provider_id'          => $this->provider_id,
+				'client_abilities'     => $this->client_abilities,
+				'page_context'         => $this->page_context,
+			)
+		);
+	}
+
+	/**
 	 * Inner loop: send prompts, handle tool calls, repeat.
 	 *
 	 * @param int $iterations Max iterations remaining.
@@ -835,6 +919,7 @@ class AgentLoop {
 			// corruption from session storage could leave orphaned tool
 			// calls that cause API 400 errors.
 			$this->history = ConversationTrimmer::validate_tool_pairs( $this->history );
+			$this->save_active_job_checkpoint( self::CHECKPOINT_BEFORE_PROVIDER_CALL, $iterations + 1 );
 
 			$this->last_loop_phase = 'provider_call';
 			$result                = $this->send_prompt();
@@ -904,6 +989,7 @@ class AgentLoop {
 			// ConversationSerializer::append_assistant_message for the full
 			// rationale and provider-side validator reference).
 			$this->append_assistant_message_to_history( $assistant_message );
+			$this->save_active_job_checkpoint( self::CHECKPOINT_PROVIDER_RESPONSE_RECORDED, $iterations );
 
 			// Check if the model wants to call tools.
 			if ( ! $this->message_has_function_calls( $assistant_message ) ) {
@@ -1074,6 +1160,7 @@ class AgentLoop {
 			}
 
 			// Execute the ability calls and get the function response message.
+			$this->save_active_job_checkpoint( self::CHECKPOINT_TOOL_EXECUTION_STARTED, $iterations );
 			$this->last_loop_phase = 'executing_abilities';
 			ChangeLogger::begin( $this->session_id );
 			try {
@@ -1123,6 +1210,7 @@ class AgentLoop {
 			$this->append_tool_response_to_history( $truncated_message );
 			$this->log_tool_responses( $truncated_message );
 			$this->last_loop_phase = 'tool_response_recorded';
+			$this->save_active_job_checkpoint( self::CHECKPOINT_TOOL_RESPONSE_RECORDED, $iterations );
 
 			// Reset the wall-clock deadline after each productive tool call.
 			// This allows genuinely long tasks (many sequential tool calls) to

--- a/includes/Core/Database.php
+++ b/includes/Core/Database.php
@@ -36,7 +36,7 @@ use SdAiAgent\Tools\CustomTools;
 class Database {
 
 	const DB_VERSION_OPTION = 'sd_ai_agent_db_version';
-	const DB_VERSION        = '19.5.2';
+	const DB_VERSION        = '19.5.3';
 
 	// ─── Table Name Registry ──────────────────────────────────────────────────
 
@@ -619,6 +619,9 @@ class Database {
 			status varchar(30) NOT NULL DEFAULT 'processing',
 			pending_tools longtext NOT NULL,
 			tool_calls longtext NOT NULL,
+			checkpoint longtext NULL,
+			checkpoint_phase varchar(60) NOT NULL DEFAULT '',
+			resume_attempts int(10) unsigned NOT NULL DEFAULT 0,
 			error text NULL,
 			interrupted_at datetime NULL,
 			created_at datetime NOT NULL,

--- a/includes/Models/ActiveJobRepository.php
+++ b/includes/Models/ActiveJobRepository.php
@@ -172,7 +172,7 @@ class ActiveJobRepository {
 			return false;
 		}
 
-		$allowed = [ 'pending_tools', 'tool_calls' ];
+		$allowed = [ 'pending_tools', 'tool_calls', 'checkpoint', 'checkpoint_phase', 'resume_attempts' ];
 		$data    = array_intersect_key( $extra, array_flip( $allowed ) );
 
 		$data['status']     = $status;
@@ -190,6 +190,65 @@ class ActiveJobRepository {
 		);
 
 		return $result !== false;
+	}
+
+	/**
+	 * Persist a durable agent-loop checkpoint for a processing job.
+	 *
+	 * @param string               $job_id     The job UUID.
+	 * @param string               $phase      Last durable loop phase.
+	 * @param array<string, mixed> $checkpoint Serializable checkpoint payload.
+	 * @return bool True on success, false on failure.
+	 */
+	public static function save_checkpoint( string $job_id, string $phase, array $checkpoint ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$encoded = wp_json_encode( $checkpoint );
+		if ( false === $encoded ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
+		$result = $wpdb->update(
+			self::table_name(),
+			[
+				'checkpoint'       => $encoded,
+				'checkpoint_phase' => $phase,
+				'updated_at'       => current_time( 'mysql', true ),
+			],
+			[ 'job_id' => $job_id ],
+			[ '%s', '%s', '%s' ],
+			[ '%s' ]
+		);
+
+		return $result !== false;
+	}
+
+	/**
+	 * Claim one automatic resume attempt by returning the row to processing.
+	 *
+	 * @param string $job_id       The job UUID.
+	 * @param int    $max_attempts Maximum permitted attempts.
+	 * @return bool True when an attempt was claimed.
+	 */
+	public static function claim_resume_attempt( string $job_id, int $max_attempts ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$now = current_time( 'mysql', true );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE %i SET status = 'processing', error = NULL, interrupted_at = NULL, resume_attempts = resume_attempts + 1, updated_at = %s WHERE job_id = %s AND status IN ('interrupted', 'abandoned') AND resume_attempts < %d",
+				self::table_name(),
+				$now,
+				$job_id,
+				$max_attempts
+			)
+		);
+
+		return $result !== false && $result > 0;
 	}
 
 	/**

--- a/includes/Models/DTO/ActiveJobRow.php
+++ b/includes/Models/DTO/ActiveJobRow.php
@@ -27,6 +27,9 @@ readonly class ActiveJobRow {
 	 * @param string      $status         Job status: processing|awaiting_confirmation|awaiting_client_tools|complete|error|interrupted|abandoned.
 	 * @param string      $pending_tools  JSON-encoded pending tool-call confirmations (default '[]').
 	 * @param string      $tool_calls     JSON-encoded tool-call log (default '[]').
+	 * @param string|null $checkpoint     JSON-encoded durable loop checkpoint, null when absent.
+	 * @param string      $checkpoint_phase Last durable checkpoint phase.
+	 * @param int         $resume_attempts Number of automatic resume attempts.
 	 * @param string|null $error          Error or interruption message, null when not set.
 	 * @param string|null $interrupted_at MySQL datetime string (UTC) when the shutdown handler fired, null if not interrupted.
 	 * @param string      $created_at     MySQL datetime string (UTC).
@@ -40,6 +43,9 @@ readonly class ActiveJobRow {
 		public string $status,
 		public string $pending_tools,
 		public string $tool_calls,
+		public ?string $checkpoint,
+		public string $checkpoint_phase,
+		public int $resume_attempts,
 		public ?string $error,
 		public ?string $interrupted_at,
 		public string $created_at,
@@ -61,6 +67,9 @@ readonly class ActiveJobRow {
 			status:         (string) ( $row->status ?? 'processing' ),
 			pending_tools:  (string) ( $row->pending_tools ?? '[]' ),
 			tool_calls:     (string) ( $row->tool_calls ?? '[]' ),
+			checkpoint:     isset( $row->checkpoint ) ? (string) $row->checkpoint : null,
+			checkpoint_phase: (string) ( $row->checkpoint_phase ?? '' ),
+			resume_attempts: (int) ( $row->resume_attempts ?? 0 ),
 			error:          isset( $row->error ) ? (string) $row->error : null,
 			interrupted_at: isset( $row->interrupted_at ) ? (string) $row->interrupted_at : null,
 			created_at:     (string) ( $row->created_at ?? '' ),

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -52,6 +52,9 @@ final class SessionController {
 	/** Maximum safe technical-detail length returned by job status polling. */
 	private const JOB_ERROR_DETAIL_MAX_LENGTH = 180;
 
+	/** Maximum automatic resume attempts for a crashed background job. */
+	private const JOB_AUTO_RESUME_MAX_ATTEMPTS = 2;
+
 	/** @var Database Injected database dependency. */
 	private Database $database;
 
@@ -1094,6 +1097,19 @@ final class SessionController {
 			'session_id' => $row->session_id,
 		];
 
+		if ( in_array( $status, array( 'interrupted', 'abandoned' ), true ) && $this->maybe_dispatch_checkpoint_resume( $job_id, $row ) ) {
+			return new WP_REST_Response(
+				array(
+					'status'          => 'processing',
+					'from_db'         => true,
+					'auto_resumed'    => true,
+					'original_status' => $status,
+					'session_id'      => $row->session_id,
+				),
+				202
+			);
+		}
+
 		// Include tool-call progress when present.
 		$tool_calls = json_decode( $row->tool_calls, true );
 		if ( is_array( $tool_calls ) && ! empty( $tool_calls ) ) {
@@ -1134,6 +1150,89 @@ final class SessionController {
 		}
 
 		return new WP_REST_Response( $response, 200 );
+	}
+
+	/**
+	 * Dispatch a crashed job from a safe durable checkpoint when retry budget remains.
+	 *
+	 * @param string       $job_id Job UUID.
+	 * @param ActiveJobRow $row    Active-job row.
+	 * @return bool True when a resume worker was dispatched.
+	 */
+	private function maybe_dispatch_checkpoint_resume( string $job_id, ActiveJobRow $row ): bool {
+		if ( $row->resume_attempts >= self::JOB_AUTO_RESUME_MAX_ATTEMPTS || ! $this->is_auto_resumable_checkpoint_phase( $row->checkpoint_phase ) ) {
+			return false;
+		}
+
+		$checkpoint = json_decode( (string) $row->checkpoint, true );
+		if ( ! is_array( $checkpoint ) || empty( $checkpoint['history'] ) || ! is_array( $checkpoint['history'] ) ) {
+			return false;
+		}
+
+		$token = wp_generate_password( 40, false );
+		$job   = array(
+			'status'            => 'processing',
+			'token'             => $token,
+			'user_id'           => $row->user_id,
+			'tool_calls'        => json_decode( $row->tool_calls, true ) ?: array(),
+			'messages'          => $checkpoint['message_log'] ?? array(),
+			'checkpoint_resume' => true,
+			'checkpoint_state'  => $checkpoint,
+			'params'            => array(
+				'message'            => '',
+				'history'            => array(),
+				'abilities'          => array(),
+				'system_instruction' => '',
+				'bootstrap_prompt'   => '',
+				'max_iterations'     => $checkpoint['iterations_remaining'] ?? null,
+				'session_id'         => $row->session_id,
+				'provider_id'        => $checkpoint['provider_id'] ?? '',
+				'model_id'           => $checkpoint['model_id'] ?? '',
+				'page_context'       => $checkpoint['page_context'] ?? array(),
+				'agent_id'           => 0,
+				'attachments'        => array(),
+				'client_abilities'   => $checkpoint['client_abilities'] ?? array(),
+			),
+		);
+
+		if ( ! ActiveJobRepository::claim_resume_attempt( $job_id, self::JOB_AUTO_RESUME_MAX_ATTEMPTS ) ) {
+			return false;
+		}
+
+		set_transient( RestController::JOB_PREFIX . $job_id, $job, RestController::JOB_TTL );
+		wp_remote_post(
+			rest_url( RestController::NAMESPACE . '/process' ),
+			array(
+				'timeout'  => 0.01,
+				'blocking' => false,
+				'body'     => (string) wp_json_encode(
+					array(
+						'job_id' => $job_id,
+						'token'  => $token,
+					)
+				),
+				'headers'  => array( 'Content-Type' => 'application/json' ),
+			)
+		);
+
+		return true;
+	}
+
+	/**
+	 * Determine whether a checkpoint phase can be resumed without replaying tools.
+	 *
+	 * @param string $phase Durable checkpoint phase.
+	 * @return bool True when automatic resume is safe.
+	 */
+	private function is_auto_resumable_checkpoint_phase( string $phase ): bool {
+		return in_array(
+			$phase,
+			array(
+				AgentLoop::CHECKPOINT_BEFORE_PROVIDER_CALL,
+				AgentLoop::CHECKPOINT_TOOL_RESPONSE_RECORDED,
+			),
+			true
+		);
 	}
 
 	/**
@@ -1608,15 +1707,39 @@ final class SessionController {
 		// Record start time for webhook duration tracking.
 		$start_ms = (int) round( microtime( true ) * 1000 );
 
-		// Check if this is a resume from a tool confirmation/rejection.
-		$is_resume = ! empty( $job['resume'] );
+		// Check if this is a resume from a tool confirmation/rejection or crash checkpoint.
+		$is_resume            = ! empty( $job['resume'] );
+		$is_checkpoint_resume = ! empty( $job['checkpoint_resume'] );
 
 		// Wrap the entire loop execution in a try/catch so that uncaught
 		// exceptions (e.g. from ability schema validation) are captured
 		// and written to the job transient instead of silently killing
 		// the background worker.
 		try {
-			if ( $is_resume ) {
+			if ( $is_checkpoint_resume ) {
+				$state = $job['checkpoint_state'] ?? array();
+
+				/** @var list<array<string, mixed>> $state_history */
+				$state_history  = is_array( $state ) ? ( $state['history'] ?? array() ) : array();
+				$resume_history = ConversationSerializer::deserialize( array_values( $state_history ) );
+
+				$resume_options = $options;
+				// @phpstan-ignore-next-line
+				$resume_options['tool_call_log'] = is_array( $state ) ? ( $state['tool_call_log'] ?? array() ) : array();
+				// @phpstan-ignore-next-line
+				$resume_options['message_log'] = is_array( $state ) ? ( $state['message_log'] ?? array() ) : array();
+				// @phpstan-ignore-next-line
+				$resume_options['token_usage'] = is_array( $state ) ? ( $state['token_usage'] ?? array(
+					'prompt'     => 0,
+					'completion' => 0,
+				) ) : array(
+					'prompt'     => 0,
+					'completion' => 0,
+				);
+
+				$loop   = new AgentLoop( '', array(), $resume_history, $resume_options );
+				$result = $loop->resume_from_checkpoint( (int) ( is_array( $state ) ? ( $state['iterations_remaining'] ?? 100 ) : 100 ) );
+			} elseif ( $is_resume ) {
 				$confirmed = 'confirm' === $job['resume'];
 				$state     = $job['confirmation_state'] ?? array();
 

--- a/tests/SdAiAgent/Core/ActiveJobsCleanupTest.php
+++ b/tests/SdAiAgent/Core/ActiveJobsCleanupTest.php
@@ -170,6 +170,46 @@ class ActiveJobsCleanupTest extends WP_UnitTestCase {
 		$this->assertSame( 'complete', $row->status, 'Complete row status must not be overwritten' );
 	}
 
+	/**
+	 * save_checkpoint() stores durable loop state for later crash resume.
+	 */
+	public function test_save_checkpoint_persists_phase_and_payload(): void {
+		$this->insert_job( 'test-checkpoint-1', 'processing' );
+
+		$result = ActiveJobRepository::save_checkpoint(
+			'test-checkpoint-1',
+			'before_provider_call',
+			array(
+				'history'              => array( array( 'role' => 'user', 'parts' => array() ) ),
+				'iterations_remaining' => 3,
+			)
+		);
+
+		$row = $this->fetch_row( 'test-checkpoint-1' );
+
+		$this->assertTrue( $result );
+		$this->assertNotNull( $row );
+		$this->assertSame( 'before_provider_call', $row->checkpoint_phase );
+		$this->assertIsArray( json_decode( (string) $row->checkpoint, true ) );
+	}
+
+	/**
+	 * claim_resume_attempt() returns interrupted rows to processing with a retry cap.
+	 */
+	public function test_claim_resume_attempt_caps_retries(): void {
+		$this->insert_job( 'test-resume-1', 'interrupted' );
+
+		$this->assertTrue( ActiveJobRepository::claim_resume_attempt( 'test-resume-1', 1 ) );
+		$row = $this->fetch_row( 'test-resume-1' );
+
+		$this->assertNotNull( $row );
+		$this->assertSame( 'processing', $row->status );
+		$this->assertSame( '1', (string) $row->resume_attempts );
+
+		ActiveJobRepository::mark_interrupted( 'test-resume-1', 'second crash' );
+		$this->assertFalse( ActiveJobRepository::claim_resume_attempt( 'test-resume-1', 1 ) );
+	}
+
 	// ── cleanup_stale() ──────────────────────────────────────────────────
 
 	/**

--- a/tests/SdAiAgent/Core/DatabaseSchemaTest.php
+++ b/tests/SdAiAgent/Core/DatabaseSchemaTest.php
@@ -348,11 +348,11 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 
 		$columns = $this->get_column_names( Database::active_jobs_table_name() );
 
-		foreach ( [ 'error', 'interrupted_at' ] as $col ) {
+		foreach ( [ 'checkpoint', 'checkpoint_phase', 'resume_attempts', 'error', 'interrupted_at' ] as $col ) {
 			$this->assertContains(
 				$col,
 				$columns,
-				"active_jobs table missing column '{$col}' — see GH#1510."
+				"active_jobs table missing column '{$col}' — see GH#2026."
 			);
 		}
 	}


### PR DESCRIPTION
## Summary

Implemented durable active-job checkpoints, safe checkpoint resume dispatch with retry caps, checkpoint-aware AgentLoop resume, schema/DTO/repository support, and regression coverage for checkpoint persistence and retry caps.

## Files Changed

includes/Core/AgentLoop.php,includes/Core/Database.php,includes/Models/ActiveJobRepository.php,includes/Models/DTO/ActiveJobRow.php,includes/REST/SessionController.php,tests/SdAiAgent/Core/ActiveJobsCleanupTest.php,tests/SdAiAgent/Core/DatabaseSchemaTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify (PHPUnit: Tests: 3556, Assertions: 14806, Skipped: 118, Incomplete: 4; Lint: PHP/JS/CSS all clean; PHPStan: 0 errors; Build: succeeded; bundle check succeeded)

Resolves #2026


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.12 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 14m and 142,523 tokens on this as a headless worker.