### PR TITLE
GH#2050: docs: map issue 2050 contributor insights

### DIFF
--- a/.agents/scripts/commands/feedback-triage.md
+++ b/.agents/scripts/commands/feedback-triage.md
@@ -128,7 +128,8 @@ the only implementation guidance.
 
 For mixed contributor-insight issues, the body must also include a concise
 source map so the worker can start with implementation instead of rediscovering
-the lesson. For the recurring issue #2034 pattern, map the four notes as:
+the lesson. For the recurring mixed-report pattern seen in issues #2034 and
+#2050, map each note independently. For #2034-style reports, map the four notes as:
 `Block Themes` excerpts → `includes/Models/skills/wp-block-themes.md`; REST
 security shorthand → root `AGENTS.md`, `includes/REST/`, and
 `includes/Abilities/WpRestAbilities.php`; Google Search Console questions →
@@ -137,6 +138,11 @@ security shorthand → root `AGENTS.md`, `includes/REST/`, and
 `includes/Abilities/ToolCapabilities.php`; WordPress.org review-response prompts
 → root `AGENTS.md` "WordPress.org Review Responses". Require the PR body to cite
 the inspected guard or policy when no code change is needed.
+For #2050-style reports that include only block-theme excerpts, Google Search
+Console usage questions, and WordPress.org review-response prompts, update the
+block-theme skill, the GSC usage map, and the review-response policy only; do
+not add unrelated REST hardening work unless the report actually includes REST
+shorthand.
 
 Full payload schema (top-level keys):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,12 +157,15 @@ note to a committed, future-loaded source before editing:
   summarize each reviewer finding, cite the merged fix or evidence-backed
   rationale, include verification commands, and avoid blanket "all fixed" or
   "false positive" claims that are not tied to a specific finding.
-- For mixed reports like issue #2034, make the mapping explicit in the PR body:
-  block-theme excerpts map to `includes/Models/skills/wp-block-themes.md`; REST
-  hardening shorthand maps to this root REST policy plus `includes/REST/` and
+- For mixed reports like issues #2034 and #2050, make the mapping explicit in
+  the PR body: block-theme excerpts map to
+  `includes/Models/skills/wp-block-themes.md`; REST hardening shorthand maps to
+  this root REST policy plus `includes/REST/` and
   `includes/Abilities/WpRestAbilities.php`; Google Search Console questions map
   to the GSC surfaces listed below; WordPress.org reply prompts map to the
-  review-response policy above. State when the implementation is a guidance
+  review-response policy above. If a mixed report omits one of those categories,
+  do not invent work for it; state the inspected candidate list and the durable
+  source chosen for each note. State when the implementation is a guidance
   hardening only because the inspected code already has the required guard.
 - Verification for this class of guidance-only fix should include both:
   `rg -n "Contributor Insight|source mapping|local-path|sd-ai-agent/v1|file upload|WordPress.org Review|false positive" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md`

--- a/includes/Models/skills/wp-block-themes.md
+++ b/includes/Models/skills/wp-block-themes.md
@@ -25,10 +25,10 @@ When a contributor-insight issue contains a pasted local-path excerpt headed
 style variations, treat that excerpt as a source-mapping clue only. Update this
 committed skill file (and the root `AGENTS.md` summary when repo-wide guidance is
 needed); do not copy private local paths or duplicate the full excerpt into
-issues, PRs, templates, or generated theme files. In mixed reports like issue
-#2034, this file is only the block-theme target; REST, Google Search Console, and
-WordPress.org review-response notes must be mapped to their own committed source
-files instead of being folded into this skill.
+issues, PRs, templates, or generated theme files. In mixed reports like issues
+#2034 and #2050, this file is only the block-theme target; REST, Google Search
+Console, and WordPress.org review-response notes must be mapped to their own
+committed source files instead of being folded into this skill.
 
 ## Inputs required
 


### PR DESCRIPTION
## Summary

Mapped issue #2050's contributor-insight candidates to durable guidance: clarified mixed-report source mapping in AGENTS.md, updated feedback-triage instructions for #2050-style reports, and noted in the block-theme skill that non-block-theme notes belong in their own committed sources.

## Files Changed

.agents/scripts/commands/feedback-triage.md,AGENTS.md,includes/Models/skills/wp-block-themes.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** rg -n "Contributor Insight|source mapping|local-path|sd-ai-agent/v1|file upload|WordPress.org Review|false positive" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md; rg -n "wp-block-themes|Full Site Editing|theme.json|validate-block-content" AGENTS.md includes/Models/skills/wp-block-themes.md; rg -n "Google Search Console|GscAbilities|SettingsController|ToolCapabilities|gsc-credentials|searchAnalytics" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md includes/Abilities/GscAbilities.php includes/Core/Settings.php includes/REST/SettingsController.php includes/Abilities/ToolCapabilities.php

Resolves #2050


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.12 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 2m and 107,377 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced contributor-insight triage guidance for mixed reports containing multiple note categories
  * Updated source mapping instructions to prevent introducing unrelated work items
  * Clarified handling of block-theme-specific feedback when combined with other report types

<!-- end of auto-generated comment: release notes by coderabbit.ai -->