### PR TITLE
GH#2051: docs: clarify fatal read recovery

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -85,9 +85,10 @@ working here in OpenCode headless mode:
 - When a missing-file read happens during WordPress fatal-error triage, switch to
   the runtime evidence before more repo-path probing: inspect
   `../wordpress/wp-content/debug.log` (enable `WP_DEBUG_LOG` and reproduce once if
-  absent), then verify the shared install's plugin symlinks point at each
-  worktree's canonical plugin directory name rather than a stale or basename-only
-  path.
+  absent), then verify the shared install's plugin symlinks point at every
+  checked-out plugin worktree's canonical plugin directory name, not just the
+  current basename. Use `wp plugin path <plugin-slug>` or inspect
+  `../wordpress/wp-content/plugins/` before retrying unrelated repository paths.
 - Treat `bash:other` / `Tool execution aborted` as a recoverable command-shape or
   hook failure first. Inspect the preceding command, retry once with a narrower
   non-inline command and a clear `description`, avoid heredocs/process or command

--- a/.agents/scripts/commands/feedback-triage.md
+++ b/.agents/scripts/commands/feedback-triage.md
@@ -235,8 +235,10 @@ before creating the issue:
 - If the same note mentions a WordPress fatal error, plugin activation, or
   canonical plugin symlinks, require the worker guidance to inspect
   `../wordpress/wp-content/debug.log` before chasing unrelated missing repo paths,
-  and to verify the local WordPress install symlinks each plugin worktree into the
-  expected canonical plugin directory name.
+  and to verify the local WordPress install symlinks every checked-out plugin
+  worktree into the expected canonical plugin directory name. Name
+  `wp plugin path <plugin-slug>` or `../wordpress/wp-content/plugins/` as the
+  concrete check so workers do not only verify the active worktree basename.
 - If recurring tool errors mention `bash:file_not_found`, `gh-signature-helper.sh
   invocation failed`, `signature gate`, or blocked `gh` writes, require durable
   worker guidance to create the issue/PR/comment body as an existing stable file,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,9 +257,12 @@ completion state:
   artifact that contains the failure: `../wordpress/wp-content/debug.log`, or
   enable `WP_DEBUG_LOG` and reproduce once if the log does not exist.
 - Before blaming plugin code for local activation fatals, verify the shared
-  WordPress install has symlinks for every checked-out plugin worktree under its
-  canonical plugin directory name. A missing or basename-only worktree symlink can
-  make WordPress load the wrong path and hide the real debug.log failure.
+  WordPress install has symlinks for every checked-out plugin worktree under each
+  plugin's canonical directory name, not only the active worktree basename. Use
+  `wp plugin path <plugin-slug>` or inspect `../wordpress/wp-content/plugins/`
+  so the failing plugin resolves to the intended checkout. A missing, stale, or
+  basename-only symlink can make WordPress load the wrong path and hide the real
+  debug.log failure.
 - If the corrected path is found, retry `Read` with that path and continue the
   task. If no plausible path exists after bounded recovery, record what was
   checked and continue with the next safe implementation step rather than ending

--- a/includes/Models/skills/site-troubleshooting.md
+++ b/includes/Models/skills/site-troubleshooting.md
@@ -11,7 +11,7 @@ Use this skill when the user reports errors, performance issues, white screens, 
 - `wp config get WP_DEBUG` — Check debug mode status
 - `wp config get WP_DEBUG_LOG` — Check if debug logging is on
 - `wp eval "echo file_exists(WP_CONTENT_DIR . '/debug.log') ? file_get_contents(WP_CONTENT_DIR . '/debug.log') : '';"` — Read the runtime debug log without assuming the file exists
-- `wp plugin path <plugin-slug>` — Confirm a plugin resolves through its expected canonical plugin directory or symlink before debugging activation fatals
+- `wp plugin path <plugin-slug>` — Confirm each checked-out plugin resolves through its expected canonical plugin directory or symlink before debugging activation fatals
 
 ### Plugin Conflicts
 - `wp plugin list --status=active --fields=name,version` — List active plugins
@@ -50,8 +50,10 @@ Use this skill when the user reports errors, performance issues, white screens, 
 2. Read `../wordpress/wp-content/debug.log` or use the guarded `wp eval` command
    above; do not stop after a missing repository path such as `vendor/`.
 3. Confirm the shared WordPress install symlinks every checked-out plugin worktree
-   into the plugin's canonical directory name before treating the fatal as an
-   application-code regression.
+   into each plugin's canonical directory name before treating the fatal as an
+   application-code regression. Use `wp plugin path <plugin-slug>` or inspect
+   `../wordpress/wp-content/plugins/`; do not only verify the active worktree
+   basename.
 4. Activate the plugin by canonical slug, then re-check debug.log for the first
    new fatal stack trace.
 


### PR DESCRIPTION
## Summary

Clarified headless missing-file recovery so WordPress activation fatals inspect debug.log first and verify every checked-out plugin worktree is symlinked through its canonical plugin directory, using wp plugin path or wp-content/plugins checks.

## Files Changed

.agents/AGENTS.md,.agents/scripts/commands/feedback-triage.md,AGENTS.md,includes/Models/skills/site-troubleshooting.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** rg -n 'read:file_not_found|missing-file reads|git ls-files|debug.log|canonical plugin|wp plugin path|wp-content/plugins' AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md includes/Models/skills/site-troubleshooting.md

Resolves #2051


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.12 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 1m and 103,338 tokens on this as a headless worker.