### PR TITLE
GH#2000: fix Superdav provider bootstrap timing

### DIFF
--- a/includes/Bootstrap/SuperdavAiProviderHandler.php
+++ b/includes/Bootstrap/SuperdavAiProviderHandler.php
@@ -24,8 +24,12 @@ final class SuperdavAiProviderHandler {
 
 	/**
 	 * Register the provider if the WordPress AI Client SDK is available.
+	 *
+	 * The SDK may be loaded by another plugin during `plugins_loaded`, so register
+	 * on early `init` after all `plugins_loaded` callbacks have had a chance to
+	 * expose their SDK classes and before the default connector registry runs.
 	 */
-	#[Action( tag: 'plugins_loaded', priority: 2 )]
+	#[Action( tag: 'init', priority: 5 )]
 	public function register_provider(): void {
 		if ( ! class_exists( '\WordPress\AiClient\AiClient' ) ) {
 			return;

--- a/superdav-ai-agent.php
+++ b/superdav-ai-agent.php
@@ -240,18 +240,28 @@ defined( 'SD_AI_AGENT_FEATURE_RUN_PHP' ) || define( 'SD_AI_AGENT_FEATURE_RUN_PHP
 
 // Load Jetpack Autoloader for PSR-4 autoloading with version conflict resolution.
 // Jetpack Autoloader ensures the newest version of shared packages (like php-ai-client) is used.
+// Composer source installs, such as Bedrock sites using a VCS repository, may
+// already expose the plugin and its dependencies through the root project
+// autoloader without copying a plugin-local vendor directory into wp-content.
+$sd_ai_agent_autoload_available = false;
 if ( file_exists( SD_AI_AGENT_DIR . '/vendor/autoload_packages.php' ) ) {
 	require_once SD_AI_AGENT_DIR . '/vendor/autoload_packages.php';
+	$sd_ai_agent_autoload_available = true;
 } elseif ( file_exists( SD_AI_AGENT_DIR . '/vendor/autoload.php' ) ) {
 	require_once SD_AI_AGENT_DIR . '/vendor/autoload.php';
+	$sd_ai_agent_autoload_available = true;
 } else {
+	$sd_ai_agent_autoload_available = class_exists( \SdAiAgent\Compat\SdkLoader::class ) && function_exists( 'xwp_load_app' );
+}
+
+if ( ! $sd_ai_agent_autoload_available ) {
 	add_action(
 		'admin_notices',
 		static function (): void {
 			printf(
 				'<div class="notice notice-error"><p>%s</p></div>',
 				esc_html__(
-					'Superdav AI Agent is missing its vendor dependencies. Please run "composer install" in the plugin directory.',
+					'Superdav AI Agent is missing its Composer dependencies. Please run "composer install" in the plugin directory or root Composer project.',
 					'superdav-ai-agent',
 				),
 			);

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
@@ -18,6 +18,7 @@ use WP_UnitTestCase;
 use WordPress\AiClient\AiClient;
 use WordPress\AiClient\Providers\Http\DTO\Response;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
+use XWP\DI\Decorators\Action;
 
 /**
  * Covers provider metadata, registration, and credential bridging.
@@ -52,6 +53,21 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 		( new SuperdavAiProviderHandler() )->register_provider();
 
 		$this->assertTrue( AiClient::defaultRegistry()->hasProvider( SuperdavAiProvider::PROVIDER_ID ) );
+	}
+
+	/**
+	 * Handler registration waits until early init so SDK classes loaded by later
+	 * plugins_loaded callbacks are available before default connectors register.
+	 */
+	public function test_handler_registers_provider_on_early_init(): void {
+		$method     = new \ReflectionMethod( SuperdavAiProviderHandler::class, 'register_provider' );
+		$attributes = $method->getAttributes( Action::class );
+
+		$this->assertCount( 1, $attributes );
+
+		$hook = $attributes[0]->newInstance();
+		$this->assertSame( 'init', $hook->tag );
+		$this->assertSame( 5, $hook->prio );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Allow Composer source installs to continue bootstrapping when dependencies are already available through the root Composer autoloader but the plugin directory has no local `vendor/` directory.
- Move first-party Superdav AI provider registration from `plugins_loaded:2` to `init:5`, after late SDK loaders and before default connector registration.
- Add a regression test that verifies the provider handler is wired to early `init`.

## Context

This supports Bedrock/VCS source installs where the plugin classes are autoloaded by the root project, while zip installs still require bundled plugin dependencies. It also fixes the provider registration race where the handler could run before `WordPress\AiClient\AiClient` was available.

For #2000.

## Verification

- `php -l superdav-ai-agent.php`
- `php -l includes/Bootstrap/SuperdavAiProviderHandler.php`
- `php -l tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php`
- Local WordPress AI Client smoke, with stored credentials redacted from output:
  - provider registered: true
  - auth present: true
  - models returned: `superdav-chat-fast`, `superdav-chat-pro`
  - `superdav-chat-fast` text generation returned one candidate with non-empty text

## Notes

- `composer test -- --filter=SuperdavAiProviderTest` could not run in the linked worktree because plugin-local `vendor/bin/phpunit` is absent.
- PHPCS could not run from the available site vendor because the required WPCS/PHPCompatibility sniffs were not installed in that vendor tree.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.13 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted AI provider initialization timing for improved stability.

* **Chores**
  * Enhanced plugin installation compatibility with improved dependency error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->