### PR TITLE
GH#2000: feat: add managed Superdav AI connector

### DIFF
--- a/includes/Compat/wp-connectors-polyfill.php
+++ b/includes/Compat/wp-connectors-polyfill.php
@@ -40,9 +40,10 @@ if ( ! function_exists( '_wp_connectors_get_provider_settings' ) ) {
 		// The setting name format is: connectors_ai_{sanitized_provider_id}_api_key
 		// This matches the WP 7.0 Connectors API exactly.
 		$providers = [
-			'anthropic' => 'anthropic',
-			'openai'    => 'openai',
-			'google'    => 'google',
+			'sd-ai-agent-cloud' => 'sd_ai_agent_cloud',
+			'anthropic'         => 'anthropic',
+			'openai'            => 'openai',
+			'google'            => 'google',
 		];
 
 		/**

--- a/includes/Core/SuperdavSiteConnectionService.php
+++ b/includes/Core/SuperdavSiteConnectionService.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Service-managed connection flow for the first-party Superdav AI provider.
+ *
+ * @package SdAiAgent\Core
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Core;
+
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Provisions and revokes site-scoped Superdav AI bearer tokens.
+ */
+final class SuperdavSiteConnectionService {
+
+	public const INSTALLATION_ID_OPTION = 'sd_ai_agent_site_installation_id';
+	public const TOKEN_METADATA_OPTION  = 'sd_ai_agent_cloud_connection_metadata';
+
+	/**
+	 * Build safe connector status metadata.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_status(): array {
+		$token    = $this->get_stored_token();
+		$metadata = $this->get_metadata();
+
+		return array(
+			'configured'                => '' !== $token,
+			'provider'                  => SuperdavAiProvider::PROVIDER_ID,
+			'connection_mode'           => $metadata['connection_mode'] ?? ( '' !== $token ? 'site' : 'none' ),
+			'installation_id'           => $this->get_installation_id(),
+			'site_url'                  => $this->get_verified_site_url(),
+			'connected_at'              => $metadata['connected_at'] ?? null,
+			'account_connect_available' => '' !== $this->get_account_connect_url(),
+			'account_connect_url'       => $this->get_account_connect_url(),
+		);
+	}
+
+	/**
+	 * Provision a site-scoped token for anonymous/free-tier installs.
+	 *
+	 * @return array<string, mixed>|WP_Error Safe status metadata or error.
+	 */
+	public function provision_site_token(): array|WP_Error {
+		$remote_token = $this->request_remote_site_token();
+		if ( $remote_token instanceof WP_Error ) {
+			return $remote_token;
+		}
+
+		$token = '' !== $remote_token ? $remote_token : $this->create_local_site_token();
+		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, $token, false );
+		update_option(
+			self::TOKEN_METADATA_OPTION,
+			array(
+				'connection_mode' => '' !== $remote_token ? 'site' : 'local-site',
+				'connected_at'    => gmdate( 'c' ),
+			),
+			false
+		);
+
+		return $this->get_status();
+	}
+
+	/**
+	 * Disconnect the first-party provider and revoke the token if configured.
+	 *
+	 * @return array<string, mixed>|WP_Error Safe status metadata or error.
+	 */
+	public function disconnect(): array|WP_Error {
+		$token = $this->get_stored_token();
+		if ( '' !== $token ) {
+			$revoked = $this->revoke_remote_token( $token );
+			if ( $revoked instanceof WP_Error ) {
+				return $revoked;
+			}
+		}
+
+		delete_option( SuperdavAiProvider::CREDENTIAL_OPTION );
+		delete_option( self::TOKEN_METADATA_OPTION );
+
+		return $this->get_status();
+	}
+
+	/**
+	 * Return the durable site-installation identity.
+	 */
+	private function get_installation_id(): string {
+		$installation_id = get_option( self::INSTALLATION_ID_OPTION, '' );
+		if ( is_string( $installation_id ) && '' !== $installation_id ) {
+			return $installation_id;
+		}
+
+		$installation_id = wp_generate_uuid4();
+		update_option( self::INSTALLATION_ID_OPTION, $installation_id, false );
+
+		return $installation_id;
+	}
+
+	/**
+	 * Return the verified site URL used for registration.
+	 */
+	private function get_verified_site_url(): string {
+		return (string) home_url( '/' );
+	}
+
+	/**
+	 * Return the account/OAuth connect URL when the service exposes one.
+	 */
+	private function get_account_connect_url(): string {
+		/**
+		 * Filters the Superdav account connection URL for future paid-account flows.
+		 *
+		 * The URL is safe UI metadata and must not include bearer tokens.
+		 *
+		 * @param string $url             Account connect URL.
+		 * @param string $installation_id Durable site-installation identity.
+		 * @param string $site_url        Verified site URL.
+		 */
+		$url = apply_filters( 'sd_ai_agent_cloud_account_connect_url', '', $this->get_installation_id(), $this->get_verified_site_url() );
+
+		return is_string( $url ) ? esc_url_raw( $url ) : '';
+	}
+
+	/**
+	 * Request a token from a configured cloud registration endpoint.
+	 *
+	 * @return string|WP_Error Token, empty string when no endpoint is configured, or error.
+	 */
+	private function request_remote_site_token(): string|WP_Error {
+		/**
+		 * Filters the Superdav site registration endpoint.
+		 *
+		 * Return an empty string to use local development provisioning.
+		 *
+		 * @param string $endpoint Registration endpoint URL.
+		 */
+		$endpoint = apply_filters( 'sd_ai_agent_cloud_registration_endpoint', '' );
+		$endpoint = is_string( $endpoint ) ? esc_url_raw( $endpoint ) : '';
+		if ( '' === $endpoint ) {
+			return '';
+		}
+
+		$response = wp_remote_post(
+			$endpoint,
+			array(
+				'timeout' => 15,
+				'headers' => array(
+					'Content-Type' => 'application/json',
+				),
+				'body'    => wp_json_encode(
+					array(
+						'installation_id' => $this->get_installation_id(),
+						'site_url'        => $this->get_verified_site_url(),
+					)
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( 'sd_ai_agent_cloud_registration_failed', __( 'Superdav AI connection failed.', 'superdav-ai-agent' ), array( 'status' => 502 ) );
+		}
+
+		$status = (int) wp_remote_retrieve_response_code( $response );
+		if ( $status < 200 || $status >= 300 ) {
+			return new WP_Error( 'sd_ai_agent_cloud_registration_failed', __( 'Superdav AI connection failed.', 'superdav-ai-agent' ), array( 'status' => 502 ) );
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( ! is_array( $body ) || empty( $body['access_token'] ) || ! is_string( $body['access_token'] ) ) {
+			return new WP_Error( 'sd_ai_agent_cloud_registration_invalid', __( 'Superdav AI connection response was invalid.', 'superdav-ai-agent' ), array( 'status' => 502 ) );
+		}
+
+		return $body['access_token'];
+	}
+
+	/**
+	 * Revoke a token against a configured endpoint when available.
+	 */
+	private function revoke_remote_token( string $token ): bool|WP_Error {
+		/**
+		 * Filters the Superdav token revocation endpoint.
+		 *
+		 * Return an empty string when revocation is unavailable.
+		 *
+		 * @param string $endpoint Revocation endpoint URL.
+		 */
+		$endpoint = apply_filters( 'sd_ai_agent_cloud_revocation_endpoint', '' );
+		$endpoint = is_string( $endpoint ) ? esc_url_raw( $endpoint ) : '';
+		if ( '' === $endpoint ) {
+			return true;
+		}
+
+		$response = wp_remote_post(
+			$endpoint,
+			array(
+				'timeout' => 15,
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $token,
+					'Content-Type'  => 'application/json',
+				),
+				'body'    => wp_json_encode(
+					array(
+						'installation_id' => $this->get_installation_id(),
+						'site_url'        => $this->get_verified_site_url(),
+					)
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( 'sd_ai_agent_cloud_revoke_failed', __( 'Superdav AI disconnection failed.', 'superdav-ai-agent' ), array( 'status' => 502 ) );
+		}
+
+		$status = (int) wp_remote_retrieve_response_code( $response );
+		if ( $status < 200 || $status >= 300 ) {
+			return new WP_Error( 'sd_ai_agent_cloud_revoke_failed', __( 'Superdav AI disconnection failed.', 'superdav-ai-agent' ), array( 'status' => 502 ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Create a local site-scoped bearer token for free-tier/local installs.
+	 */
+	private function create_local_site_token(): string {
+		$payload = implode( '|', array( $this->get_installation_id(), $this->get_verified_site_url(), wp_generate_password( 32, false, false ) ) );
+
+		return 'sdsite_' . hash_hmac( 'sha256', $payload, wp_salt( 'auth' ) );
+	}
+
+	/**
+	 * Return the stored site token without exposing it to callers.
+	 */
+	private function get_stored_token(): string {
+		$token = get_option( SuperdavAiProvider::CREDENTIAL_OPTION, '' );
+
+		return is_string( $token ) ? $token : '';
+	}
+
+	/**
+	 * Return safe connection metadata.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_metadata(): array {
+		$metadata = get_option( self::TOKEN_METADATA_OPTION, array() );
+		if ( ! is_array( $metadata ) ) {
+			return array();
+		}
+
+		$safe_metadata = array();
+		foreach ( $metadata as $key => $value ) {
+			if ( is_string( $key ) ) {
+				$safe_metadata[ $key ] = $value;
+			}
+		}
+
+		return $safe_metadata;
+	}
+}

--- a/includes/REST/ConnectorsController.php
+++ b/includes/REST/ConnectorsController.php
@@ -27,7 +27,9 @@ use WP_REST_Response;
 use WP_REST_Server;
 use XWP\DI\Decorators\Action;
 use XWP\DI\Decorators\Handler;
+use SdAiAgent\Core\SuperdavSiteConnectionService;
 use SdAiAgent\Admin\UnifiedAdminMenu;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -59,24 +61,32 @@ final class ConnectorsController {
 	 * Option_key mirrors WP 7.0's Connectors API naming convention
 	 * (connectors_ai_{provider}_api_key) for zero-migration on upgrade.
 	 *
-	 * @var array<string, array{name: string, plugin_file: string, plugin_slug: string, option_key: string, description: string}>
+	 * @var array<string, array{name: string, plugin_file: string, plugin_slug: string, option_key: string, description: string, managed?: bool}>
 	 */
 	const PROVIDERS = array(
-		'openai'    => array(
+		SuperdavAiProvider::PROVIDER_ID => array(
+			'name'        => 'Superdav AI',
+			'plugin_file' => '',
+			'plugin_slug' => '',
+			'option_key'  => SuperdavAiProvider::CREDENTIAL_OPTION,
+			'description' => 'Bundled first-party provider with service-managed site connection.',
+			'managed'     => true,
+		),
+		'openai'                        => array(
 			'name'        => 'OpenAI',
 			'plugin_file' => 'ai-provider-for-openai/ai-provider-for-openai.php',
 			'plugin_slug' => 'ai-provider-for-openai',
 			'option_key'  => 'connectors_ai_openai_api_key',
 			'description' => 'GPT-4.1, o3, o4-mini, and other OpenAI models.',
 		),
-		'anthropic' => array(
+		'anthropic'                     => array(
 			'name'        => 'Anthropic',
 			'plugin_file' => 'ai-provider-for-anthropic/ai-provider-for-anthropic.php',
 			'plugin_slug' => 'ai-provider-for-anthropic',
 			'option_key'  => 'connectors_ai_anthropic_api_key',
 			'description' => 'Claude Opus, Sonnet, and Haiku models.',
 		),
-		'google'    => array(
+		'google'                        => array(
 			'name'        => 'Google AI',
 			'plugin_file' => 'ai-provider-for-google/ai-provider-for-google.php',
 			'plugin_slug' => 'ai-provider-for-google',
@@ -137,6 +147,24 @@ final class ConnectorsController {
 				),
 			)
 		);
+
+		// Connect a service-managed provider without accepting raw credentials.
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/connectors/(?P<provider>[a-z0-9_-]+)/connect',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'handle_connect' ),
+				'permission_callback' => array( __CLASS__, 'check_admin_permission' ),
+				'args'                => array(
+					'provider' => array(
+						'required'          => true,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_key',
+					),
+				),
+			)
+		);
 	}
 
 	/**
@@ -185,6 +213,14 @@ final class ConnectorsController {
 			);
 		}
 
+		if ( $this->is_managed_provider( $provider_id ) ) {
+			return new WP_Error(
+				'managed_provider_key_rejected',
+				__( 'This provider uses service-managed connection. Use the connect action instead.', 'superdav-ai-agent' ),
+				array( 'status' => 400 )
+			);
+		}
+
 		if ( '' === $api_key ) {
 			return new WP_Error(
 				'empty_api_key',
@@ -225,6 +261,23 @@ final class ConnectorsController {
 			);
 		}
 
+		if ( $this->is_managed_provider( $provider_id ) ) {
+			$status = ( new SuperdavSiteConnectionService() )->disconnect();
+			if ( $status instanceof WP_Error ) {
+				return $status;
+			}
+
+			return new WP_REST_Response(
+				array(
+					'success'    => true,
+					'provider'   => $provider_id,
+					'configured' => false,
+					'status'     => $status,
+				),
+				200
+			);
+		}
+
 		$option_key = self::PROVIDERS[ $provider_id ]['option_key'];
 		delete_option( $option_key );
 
@@ -239,13 +292,73 @@ final class ConnectorsController {
 	}
 
 	/**
+	 * POST /sd-ai-agent/v1/connectors/{provider}/connect
+	 *
+	 * Provisions a service-managed first-party provider connection.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function handle_connect( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$provider_id = (string) $request->get_param( 'provider' );
+
+		if ( ! array_key_exists( $provider_id, self::PROVIDERS ) ) {
+			return new WP_Error(
+				'invalid_provider',
+				__( 'Unknown provider ID.', 'superdav-ai-agent' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( ! $this->is_managed_provider( $provider_id ) ) {
+			return new WP_Error(
+				'provider_not_managed',
+				__( 'This provider does not support managed connection.', 'superdav-ai-agent' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$status = ( new SuperdavSiteConnectionService() )->provision_site_token();
+		if ( $status instanceof WP_Error ) {
+			return $status;
+		}
+
+		return new WP_REST_Response(
+			array(
+				'success'    => true,
+				'provider'   => $provider_id,
+				'configured' => true,
+				'status'     => $status,
+			),
+			200
+		);
+	}
+
+	/**
 	 * Build the provider data array for the REST response.
 	 *
-	 * @param string                                                                                                 $provider_id Provider ID.
-	 * @param array{name: string, plugin_file: string, plugin_slug: string, option_key: string, description: string} $meta Provider metadata.
+	 * @param string                                                                                                                 $provider_id Provider ID.
+	 * @param array{name: string, plugin_file: string, plugin_slug: string, option_key: string, description: string, managed?: bool} $meta Provider metadata.
 	 * @return array<string, mixed>
 	 */
 	private function build_provider_data( string $provider_id, array $meta ): array {
+		if ( $this->is_managed_provider( $provider_id ) ) {
+			$status = ( new SuperdavSiteConnectionService() )->get_status();
+			return array(
+				'id'          => $provider_id,
+				'name'        => $meta['name'],
+				'description' => $meta['description'],
+				'plugin_file' => '',
+				'plugin_slug' => '',
+				'installed'   => true,
+				'active'      => true,
+				'configured'  => (bool) $status['configured'],
+				'masked_key'  => '',
+				'managed'     => true,
+				'status'      => $status,
+			);
+		}
+
 		$installed  = $this->is_plugin_installed( $meta['plugin_file'] );
 		$active     = $this->is_plugin_active( $meta['plugin_file'] );
 		$api_key    = (string) get_option( $meta['option_key'], '' );
@@ -269,6 +382,13 @@ final class ConnectorsController {
 			'configured'  => $configured,
 			'masked_key'  => $masked_key,
 		);
+	}
+
+	/**
+	 * Check whether a provider uses service-managed connection semantics.
+	 */
+	private function is_managed_provider( string $provider_id ): bool {
+		return ! empty( self::PROVIDERS[ $provider_id ]['managed'] );
 	}
 
 	/**

--- a/src/unified-admin/routes/connectors-style.css
+++ b/src/unified-admin/routes/connectors-style.css
@@ -134,6 +134,23 @@
 	padding-top: 16px;
 }
 
+.sd-ai-connectors__managed-section {
+	border-top: 1px solid #ddd;
+	padding-top: 16px;
+}
+
+.sd-ai-connectors__managed-status {
+	margin: 0 0 12px;
+	color: #50575e;
+	font-size: 0.9rem;
+}
+
+.sd-ai-connectors__managed-actions {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
 .sd-ai-connectors__api-key-label {
 	display: flex;
 	align-items: center;
@@ -190,6 +207,11 @@
 	}
 
 	.sd-ai-connectors__api-key-input {
+		flex-direction: column;
+		align-items: stretch;
+	}
+
+	.sd-ai-connectors__managed-actions {
 		flex-direction: column;
 		align-items: stretch;
 	}

--- a/src/unified-admin/routes/connectors.js
+++ b/src/unified-admin/routes/connectors.js
@@ -7,7 +7,7 @@
  * an equivalent UI for WordPress 6.9 installations without Gutenberg.
  *
  * Features:
- * - Lists AI provider connector plugins (Anthropic, OpenAI, Google AI)
+ * - Lists AI provider connector plugins and bundled Superdav AI
  * - Shows plugin install/activation status with action buttons
  * - Allows API key entry and storage (saved as connectors_ai_{id}_api_key)
  * - Detects WP 7.0+ and shows a redirect link to the native page
@@ -102,6 +102,7 @@ function ProviderCard( { provider, onRefresh } ) {
 	const [ apiKey, setApiKey ] = useState( '' );
 	const [ saving, setSaving ] = useState( false );
 	const [ clearing, setClearing ] = useState( false );
+	const [ connecting, setConnecting ] = useState( false );
 	const [ installing, setInstalling ] = useState( false );
 	const [ activating, setActivating ] = useState( false );
 	const [ cardNotice, setCardNotice ] = useState( null );
@@ -110,9 +111,9 @@ function ProviderCard( { provider, onRefresh } ) {
 
 	// Derive the plugin file identifier for the WP REST Plugins API.
 	// The API expects the plugin encoded as "folder%2Ffile" (folder/file without .php).
-	const pluginFileEncoded = encodeURIComponent(
-		provider.plugin_file.replace( /\.php$/, '' )
-	);
+	const pluginFileEncoded = provider.plugin_file
+		? encodeURIComponent( provider.plugin_file.replace( /\.php$/, '' ) )
+		: '';
 
 	const handleInstall = useCallback( async () => {
 		setInstalling( true );
@@ -200,10 +201,40 @@ function ProviderCard( { provider, onRefresh } ) {
 		}
 	}, [ apiKey, provider.id, onRefresh ] );
 
+	const handleManagedConnect = useCallback( async () => {
+		setConnecting( true );
+		setCardNotice( null );
+		try {
+			await apiFetch( {
+				path: `/sd-ai-agent/v1/connectors/${ provider.id }/connect`,
+				method: 'POST',
+			} );
+			setCardNotice( {
+				status: 'success',
+				message: __( 'Superdav AI connected.', 'sd-ai-agent' ),
+			} );
+			onRefresh();
+		} catch ( err ) {
+			setCardNotice( {
+				status: 'error',
+				message:
+					err?.message ||
+					__( 'Failed to connect Superdav AI.', 'sd-ai-agent' ),
+			} );
+		} finally {
+			setConnecting( false );
+		}
+	}, [ provider.id, onRefresh ] );
+
 	const handleClearKey = useCallback( async () => {
 		/* eslint-disable no-alert */
 		const confirmed = window.confirm(
-			__( 'Clear the saved API key for this provider?', 'sd-ai-agent' )
+			provider.managed
+				? __( 'Disconnect Superdav AI for this site?', 'sd-ai-agent' )
+				: __(
+						'Clear the saved API key for this provider?',
+						'sd-ai-agent'
+				  )
 		);
 		/* eslint-enable no-alert */
 		if ( ! confirmed ) {
@@ -218,7 +249,9 @@ function ProviderCard( { provider, onRefresh } ) {
 			} );
 			setCardNotice( {
 				status: 'success',
-				message: __( 'API key cleared.', 'sd-ai-agent' ),
+				message: provider.managed
+					? __( 'Superdav AI disconnected.', 'sd-ai-agent' )
+					: __( 'API key cleared.', 'sd-ai-agent' ),
 			} );
 			onRefresh();
 		} catch ( err ) {
@@ -231,9 +264,23 @@ function ProviderCard( { provider, onRefresh } ) {
 		} finally {
 			setClearing( false );
 		}
-	}, [ provider.id, onRefresh ] );
+	}, [ provider.id, provider.managed, onRefresh ] );
 
 	const statusBadge = () => {
+		if ( provider.managed && provider.configured ) {
+			return (
+				<span className="sd-ai-connectors__status sd-ai-connectors__status--active">
+					{ __( 'Connected', 'sd-ai-agent' ) }
+				</span>
+			);
+		}
+		if ( provider.managed ) {
+			return (
+				<span className="sd-ai-connectors__status sd-ai-connectors__status--inactive">
+					{ __( 'Available', 'sd-ai-agent' ) }
+				</span>
+			);
+		}
 		if ( provider.active ) {
 			return (
 				<span className="sd-ai-connectors__status sd-ai-connectors__status--active">
@@ -264,7 +311,7 @@ function ProviderCard( { provider, onRefresh } ) {
 						{ statusBadge() }
 					</div>
 					<div className="sd-ai-connectors__provider-actions">
-						{ ! provider.installed && (
+						{ ! provider.managed && ! provider.installed && (
 							<Button
 								variant="secondary"
 								onClick={ handleInstall }
@@ -276,18 +323,20 @@ function ProviderCard( { provider, onRefresh } ) {
 									: __( 'Install', 'sd-ai-agent' ) }
 							</Button>
 						) }
-						{ provider.installed && ! provider.active && (
-							<Button
-								variant="primary"
-								onClick={ handleActivate }
-								isBusy={ activating }
-								disabled={ activating }
-							>
-								{ activating
-									? __( 'Activating…', 'sd-ai-agent' )
-									: __( 'Activate', 'sd-ai-agent' ) }
-							</Button>
-						) }
+						{ ! provider.managed &&
+							provider.installed &&
+							! provider.active && (
+								<Button
+									variant="primary"
+									onClick={ handleActivate }
+									isBusy={ activating }
+									disabled={ activating }
+								>
+									{ activating
+										? __( 'Activating…', 'sd-ai-agent' )
+										: __( 'Activate', 'sd-ai-agent' ) }
+								</Button>
+							) }
 					</div>
 				</div>
 			</CardHeader>
@@ -307,65 +356,118 @@ function ProviderCard( { provider, onRefresh } ) {
 					{ provider.description }
 				</p>
 
-				<div className="sd-ai-connectors__api-key-section">
-					<div className="sd-ai-connectors__api-key-label">
-						<strong>{ __( 'API Key', 'sd-ai-agent' ) }</strong>
-						{ provider.configured && provider.masked_key && (
-							<span className="sd-ai-connectors__api-key-configured">
-								{ __( 'Configured:', 'sd-ai-agent' ) }{ ' ' }
-								<code>{ provider.masked_key }</code>
-								<Tooltip
-									text={ __(
-										'Clear this API key',
+				{ provider.managed ? (
+					<div className="sd-ai-connectors__managed-section">
+						<p className="sd-ai-connectors__managed-status">
+							{ provider.configured
+								? __(
+										'This site is connected with a service-managed site token. The token is stored securely and is never displayed.',
 										'sd-ai-agent'
-									) }
+								  )
+								: __(
+										'Connect this site to Superdav AI without pasting API keys or installing a separate provider plugin.',
+										'sd-ai-agent'
+								  ) }
+						</p>
+						<div className="sd-ai-connectors__managed-actions">
+							{ provider.configured ? (
+								<Button
+									variant="secondary"
+									isDestructive
+									onClick={ handleClearKey }
+									isBusy={ clearing }
+									disabled={ clearing }
 								>
-									<Button
-										variant="link"
-										isDestructive
-										onClick={ handleClearKey }
-										isBusy={ clearing }
-										disabled={ clearing }
-										className="sd-ai-connectors__clear-key-btn"
+									{ clearing
+										? __( 'Disconnecting…', 'sd-ai-agent' )
+										: __( 'Disconnect', 'sd-ai-agent' ) }
+								</Button>
+							) : (
+								<Button
+									variant="primary"
+									onClick={ handleManagedConnect }
+									isBusy={ connecting }
+									disabled={ connecting }
+								>
+									{ connecting
+										? __( 'Connecting…', 'sd-ai-agent' )
+										: __(
+												'Connect Superdav AI',
+												'sd-ai-agent'
+										  ) }
+								</Button>
+							) }
+							{ provider.status?.account_connect_url && (
+								<Button
+									variant="link"
+									href={ provider.status.account_connect_url }
+								>
+									{ __( 'Connect account', 'sd-ai-agent' ) }
+								</Button>
+							) }
+						</div>
+					</div>
+				) : (
+					<div className="sd-ai-connectors__api-key-section">
+						<div className="sd-ai-connectors__api-key-label">
+							<strong>{ __( 'API Key', 'sd-ai-agent' ) }</strong>
+							{ provider.configured && provider.masked_key && (
+								<span className="sd-ai-connectors__api-key-configured">
+									{ __( 'Configured:', 'sd-ai-agent' ) }{ ' ' }
+									<code>{ provider.masked_key }</code>
+									<Tooltip
+										text={ __(
+											'Clear this API key',
+											'sd-ai-agent'
+										) }
 									>
-										{ __( 'Clear', 'sd-ai-agent' ) }
-									</Button>
-								</Tooltip>
-							</span>
-						) }
+										<Button
+											variant="link"
+											isDestructive
+											onClick={ handleClearKey }
+											isBusy={ clearing }
+											disabled={ clearing }
+											className="sd-ai-connectors__clear-key-btn"
+										>
+											{ __( 'Clear', 'sd-ai-agent' ) }
+										</Button>
+									</Tooltip>
+								</span>
+							) }
+						</div>
+						<div className="sd-ai-connectors__api-key-input">
+							<TextControl
+								label={ __( 'Enter API Key', 'sd-ai-agent' ) }
+								hideLabelFromVision
+								value={ apiKey }
+								onChange={ setApiKey }
+								type="password"
+								placeholder={
+									provider.configured
+										? __(
+												'Enter new key to replace the existing one',
+												'sd-ai-agent'
+										  )
+										: __(
+												'Paste your API key here',
+												'sd-ai-agent'
+										  )
+								}
+								disabled={ saving }
+							/>
+							<Button
+								variant="primary"
+								onClick={ handleSaveKey }
+								isBusy={ saving }
+								disabled={ saving || ! apiKey.trim() }
+							>
+								{ saving
+									? __( 'Saving…', 'sd-ai-agent' )
+									: __( 'Save Key', 'sd-ai-agent' ) }
+							</Button>
+						</div>
 					</div>
-					<div className="sd-ai-connectors__api-key-input">
-						<TextControl
-							label={ __( 'Enter API Key', 'sd-ai-agent' ) }
-							hideLabelFromVision
-							value={ apiKey }
-							onChange={ setApiKey }
-							type="password"
-							placeholder={
-								provider.configured
-									? __(
-											'Enter new key to replace the existing one',
-											'sd-ai-agent'
-									  )
-									: __(
-											'Paste your API key here',
-											'sd-ai-agent'
-									  )
-							}
-							disabled={ saving }
-						/>
-						<Button
-							variant="primary"
-							onClick={ handleSaveKey }
-							isBusy={ saving }
-							disabled={ saving || ! apiKey.trim() }
-						>
-							{ saving
-								? __( 'Saving…', 'sd-ai-agent' )
-								: __( 'Save Key', 'sd-ai-agent' ) }
-						</Button>
-					</div>
-				</div>
+				) }
 			</CardBody>
 		</Card>
 	);

--- a/tests/SdAiAgent/REST/ConnectorsControllerTest.php
+++ b/tests/SdAiAgent/REST/ConnectorsControllerTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Tests for ConnectorsController.
+ *
+ * @package SdAiAgent\Tests\REST
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\REST;
+
+use SdAiAgent\Core\SuperdavSiteConnectionService;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
+use SdAiAgent\REST\ConnectorsController;
+use WP_REST_Request;
+use WP_UnitTestCase;
+
+/**
+ * Covers service-managed connector semantics for the first-party provider.
+ */
+final class ConnectorsControllerTest extends WP_UnitTestCase {
+
+	/**
+	 * Clean up connector options.
+	 */
+	public function tear_down(): void {
+		delete_option( SuperdavAiProvider::CREDENTIAL_OPTION );
+		delete_option( SuperdavSiteConnectionService::INSTALLATION_ID_OPTION );
+		delete_option( SuperdavSiteConnectionService::TOKEN_METADATA_OPTION );
+		parent::tear_down();
+	}
+
+	/**
+	 * The connector list includes bundled Superdav AI without exposing tokens.
+	 */
+	public function test_list_includes_bundled_managed_superdav_provider_without_token(): void {
+		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, 'secret-site-token', false );
+
+		$response  = ( new ConnectorsController() )->handle_list();
+		$data      = $response->get_data();
+		$providers = $data['providers'];
+		$superdav  = $this->find_provider( $providers, SuperdavAiProvider::PROVIDER_ID );
+
+		$this->assertNotNull( $superdav );
+		$this->assertTrue( $superdav['managed'] );
+		$this->assertTrue( $superdav['installed'] );
+		$this->assertTrue( $superdav['active'] );
+		$this->assertTrue( $superdav['configured'] );
+		$this->assertSame( '', $superdav['masked_key'] );
+		$this->assertStringNotContainsString( 'secret-site-token', wp_json_encode( $superdav ) ?: '' );
+	}
+
+	/**
+	 * Managed connection provisions a local site token and returns safe metadata.
+	 */
+	public function test_connect_provisions_site_token_without_returning_secret(): void {
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/connectors/' . SuperdavAiProvider::PROVIDER_ID . '/connect' );
+		$request->set_param( 'provider', SuperdavAiProvider::PROVIDER_ID );
+
+		$response = ( new ConnectorsController() )->handle_connect( $request );
+		$this->assertNotWPError( $response );
+
+		$token = get_option( SuperdavAiProvider::CREDENTIAL_OPTION, '' );
+		$this->assertIsString( $token );
+		$this->assertStringStartsWith( 'sdsite_', $token );
+
+		$data = $response->get_data();
+		$this->assertTrue( $data['configured'] );
+		$this->assertSame( SuperdavAiProvider::PROVIDER_ID, $data['provider'] );
+		$this->assertStringNotContainsString( $token, wp_json_encode( $data ) ?: '' );
+	}
+
+	/**
+	 * Managed providers reject manual raw API-key storage.
+	 */
+	public function test_managed_provider_rejects_manual_api_key(): void {
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/connectors/' . SuperdavAiProvider::PROVIDER_ID . '/key' );
+		$request->set_param( 'provider', SuperdavAiProvider::PROVIDER_ID );
+		$request->set_param( 'api_key', 'manual-secret' );
+
+		$result = ( new ConnectorsController() )->handle_set_key( $request );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'managed_provider_key_rejected', $result->get_error_code() );
+		$this->assertSame( '', get_option( SuperdavAiProvider::CREDENTIAL_OPTION, '' ) );
+	}
+
+	/**
+	 * Disconnect clears the local token and reports unconfigured state.
+	 */
+	public function test_disconnect_clears_managed_provider_token(): void {
+		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, 'secret-site-token', false );
+
+		$request = new WP_REST_Request( 'DELETE', '/sd-ai-agent/v1/connectors/' . SuperdavAiProvider::PROVIDER_ID . '/key' );
+		$request->set_param( 'provider', SuperdavAiProvider::PROVIDER_ID );
+
+		$response = ( new ConnectorsController() )->handle_clear_key( $request );
+		$this->assertNotWPError( $response );
+
+		$data = $response->get_data();
+		$this->assertFalse( $data['configured'] );
+		$this->assertSame( '', get_option( SuperdavAiProvider::CREDENTIAL_OPTION, '' ) );
+	}
+
+	/**
+	 * Find a provider entry by ID.
+	 *
+	 * @param array<int, array<string, mixed>> $providers Provider rows.
+	 * @param string                          $provider_id Provider ID.
+	 * @return array<string, mixed>|null
+	 */
+	private function find_provider( array $providers, string $provider_id ): ?array {
+		foreach ( $providers as $provider ) {
+			if ( $provider_id === $provider['id'] ) {
+				return $provider;
+			}
+		}
+
+		return null;
+	}
+}


### PR DESCRIPTION
## Summary

Implemented service-managed Superdav AI connector status/connect/disconnect flow, added a site-scoped token provisioning service, included the provider in the connectors polyfill, updated the connectors UI, and added REST coverage that verifies tokens are not returned.

## Files Changed

includes/Compat/wp-connectors-polyfill.php,includes/Core/SuperdavSiteConnectionService.php,includes/REST/ConnectorsController.php,src/unified-admin/routes/connectors-style.css,src/unified-admin/routes/connectors.js,tests/SdAiAgent/REST/ConnectorsControllerTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused PHP: npm run test:php -- --filter='SettingsController|ConnectorsController|SuperdavAiProviderTest|SettingsTest' passed (42 tests, 135 assertions). Lint: npm run lint:php and npm run lint:js passed. PHPStan: COMPOSER_PROCESS_TIMEOUT=1200 composer phpstan passed. Build: npm run build && npm run check:bundle passed. Full PHPUnit was attempted after test DB reset but failed on unrelated shared MySQL deadlocks in MenuAbilitiesTest/IfMatchTest and earlier DatabaseSchema/RevertToRevision tests; targeted connector suite passed.

Resolves #2000


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.13 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 20m and 261,588 tokens on this as a headless worker.