### PR TITLE
Fix WordPress abilities debug notices

### DIFF
--- a/includes/Bootstrap/WooCommerceIntegrationHandler.php
+++ b/includes/Bootstrap/WooCommerceIntegrationHandler.php
@@ -144,24 +144,28 @@ final class WooCommerceIntegrationHandler {
 			return;
 		}
 
+		if ( wp_get_ability_category( 'woocommerce-rest' ) ) {
+			return;
+		}
+
 		// Delegate to WooCommerce's own category registration when available so
 		// labels/descriptions stay in sync. Gracefully fall back to our own call
-		// if the class doesn't exist (older WooCommerce).
+		// if the class doesn't exist (older WooCommerce). Guard first because
+		// WooCommerce's category registrar emits a doing_it_wrong notice when the
+		// category has already been registered by another bootstrap path.
 		if ( class_exists( self::CATEGORY_CLASS ) ) {
 			( self::CATEGORY_CLASS )::register_categories();
 			return;
 		}
 
 		// Fallback for WooCommerce versions without AbilitiesCategories.
-		if ( ! wp_get_ability_category( 'woocommerce-rest' ) ) {
-			wp_register_ability_category(
-				'woocommerce-rest',
-				array(
-					'label'       => __( 'WooCommerce REST API', 'superdav-ai-agent' ),
-					'description' => __( 'REST API operations for WooCommerce resources including products, orders, and other store data.', 'superdav-ai-agent' ),
-				)
-			);
-		}
+		wp_register_ability_category(
+			'woocommerce-rest',
+			array(
+				'label'       => __( 'WooCommerce REST API', 'superdav-ai-agent' ),
+				'description' => __( 'REST API operations for WooCommerce resources including products, orders, and other store data.', 'superdav-ai-agent' ),
+			)
+		);
 	}
 
 	/**
@@ -205,7 +209,6 @@ final class WooCommerceIntegrationHandler {
 		try {
 			$ref    = new \ReflectionClass( $bridge_class );
 			$method = $ref->getMethod( 'get_configurations' );
-			$method->setAccessible( true );
 
 			/** @var array<int, array<string, mixed>> $configurations */
 			$configurations = $method->invoke( null );

--- a/includes/Bootstrap/WooCommerceIntegrationHandler.php
+++ b/includes/Bootstrap/WooCommerceIntegrationHandler.php
@@ -144,15 +144,27 @@ final class WooCommerceIntegrationHandler {
 			return;
 		}
 
-		if ( wp_get_ability_category( 'woocommerce-rest' ) ) {
+		if ( function_exists( 'wp_has_ability_category' ) && wp_has_ability_category( 'woocommerce-rest' ) ) {
+			if ( class_exists( self::CATEGORY_CLASS ) ) {
+				remove_action( 'wp_abilities_api_categories_init', array( self::CATEGORY_CLASS, 'register_categories' ) );
+			}
+			return;
+		}
+
+		// WooCommerce 10.8+ registers its categories on this same hook at the
+		// default priority. When that hook is present, let WooCommerce own the
+		// registration; calling its registrar early would make its later callback
+		// emit a duplicate-category doing_it_wrong notice.
+		if (
+			class_exists( self::CATEGORY_CLASS )
+			&& has_action( 'wp_abilities_api_categories_init', array( self::CATEGORY_CLASS, 'register_categories' ) )
+		) {
 			return;
 		}
 
 		// Delegate to WooCommerce's own category registration when available so
 		// labels/descriptions stay in sync. Gracefully fall back to our own call
-		// if the class doesn't exist (older WooCommerce). Guard first because
-		// WooCommerce's category registrar emits a doing_it_wrong notice when the
-		// category has already been registered by another bootstrap path.
+		// if the class doesn't exist or is not hooked (older WooCommerce).
 		if ( class_exists( self::CATEGORY_CLASS ) ) {
 			( self::CATEGORY_CLASS )::register_categories();
 			return;

--- a/includes/Bootstrap/WooCommerceIntegrationHandler.php
+++ b/includes/Bootstrap/WooCommerceIntegrationHandler.php
@@ -128,6 +128,40 @@ final class WooCommerceIntegrationHandler {
 	}
 
 	/**
+	 * Remove missing tools from WooCommerce's vendored MCP adapter default server.
+	 *
+	 * WooCommerce may load the MCP adapter default server before the adapter's own
+	 * introspection abilities are registered. Its component registry probes those
+	 * tool names with wp_get_ability(), which emits WordPress 6.9+ not-found
+	 * notices. Filter the default server config so only currently registered
+	 * abilities are handed to the adapter for validation.
+	 *
+	 * @param mixed $config MCP adapter default server configuration.
+	 * @return mixed Filtered configuration.
+	 */
+	#[Filter( tag: 'mcp_adapter_default_server_config', priority: 5 )]
+	public function remove_missing_mcp_adapter_default_tools( mixed $config ): mixed {
+		if ( ! is_array( $config ) || ! isset( $config['tools'] ) || ! is_array( $config['tools'] ) ) {
+			return $config;
+		}
+
+		if ( ! function_exists( 'wp_has_ability' ) ) {
+			return $config;
+		}
+
+		$config['tools'] = array_values(
+			array_filter(
+				$config['tools'],
+				static function ( mixed $tool ): bool {
+					return ! is_string( $tool ) || wp_has_ability( $tool );
+				}
+			)
+		);
+
+		return $config;
+	}
+
+	/**
 	 * Register the `woocommerce-rest` ability category for the WP Abilities API.
 	 *
 	 * WooCommerce normally registers this category only when its `AbilitiesRegistry`

--- a/includes/Compat/ai-client/class-wp-ai-client-ability-function-resolver.php
+++ b/includes/Compat/ai-client/class-wp-ai-client-ability-function-resolver.php
@@ -22,6 +22,7 @@ if ( class_exists( 'WP_AI_Client_Ability_Function_Resolver' ) ) {
 	return;
 }
 
+use SdAiAgent\Core\AbilityRegistry;
 use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\DTO\UserMessage;
@@ -144,7 +145,7 @@ class WP_AI_Client_Ability_Function_Resolver {
 			);
 		}
 
-		$ability = wp_get_ability( $ability_name );
+		$ability = AbilityRegistry::get( $ability_name );
 
 		if ( ! $ability instanceof WP_Ability ) {
 			return new FunctionResponse(

--- a/includes/Compat/ai-client/class-wp-ai-client-prompt-builder.php
+++ b/includes/Compat/ai-client/class-wp-ai-client-prompt-builder.php
@@ -22,6 +22,7 @@ if ( class_exists( 'WP_AI_Client_Prompt_Builder' ) ) {
 	return;
 }
 
+use SdAiAgent\Core\AbilityRegistry;
 use WordPress\AiClient\AiClient;
 use WordPress\AiClient\Builders\PromptBuilder;
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
@@ -240,7 +241,7 @@ class WP_AI_Client_Prompt_Builder {
 		foreach ( $abilities as $ability ) {
 			if ( is_string( $ability ) ) {
 				$ability_name = $ability;
-				$ability      = wp_get_ability( $ability );
+				$ability      = AbilityRegistry::get( $ability );
 				if ( ! $ability ) {
 					_doing_it_wrong(
 						__METHOD__,

--- a/includes/Core/AbilityFunctionResolver.php
+++ b/includes/Core/AbilityFunctionResolver.php
@@ -90,7 +90,7 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 			);
 		}
 
-		$ability = wp_get_ability( $ability_name );
+		$ability = AbilityRegistry::get( $ability_name );
 		if ( ! $ability instanceof \WP_Ability ) {
 			return new FunctionResponse(
 				$function_id,

--- a/includes/Core/AbilityRegistry.php
+++ b/includes/Core/AbilityRegistry.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Safe helpers for reading the WordPress Abilities registry.
+ *
+ * @package SdAiAgent\Core
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class AbilityRegistry {
+
+	/**
+	 * Return a registered ability without triggering WordPress 6.9+ not-found notices.
+	 *
+	 * WordPress 6.9 changed wp_get_ability() so missing names emit a
+	 * doing_it_wrong notice via WP_Abilities_Registry::get_registered(). Probe
+	 * with wp_has_ability() first when available, then fetch only known names.
+	 *
+	 * @param string $name Ability name.
+	 * @return \WP_Ability|null
+	 */
+	public static function get( string $name ): ?\WP_Ability {
+		if ( '' === $name || ! function_exists( 'wp_get_ability' ) ) {
+			return null;
+		}
+
+		if ( function_exists( 'wp_has_ability' ) && ! wp_has_ability( $name ) ) {
+			return null;
+		}
+
+		// @phpstan-ignore-next-line WordPress defines WP_Ability at runtime.
+		$ability = wp_get_ability( $name );
+
+		return $ability instanceof \WP_Ability ? $ability : null;
+	}
+}

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -2057,8 +2057,7 @@ class AgentLoop {
 		if ( ! empty( $this->abilities ) ) {
 			$resolved = array();
 			foreach ( $this->abilities as $name ) {
-				// @phpstan-ignore-next-line
-				$ability = wp_get_ability( $name );
+				$ability = AbilityRegistry::get( $name );
 				if ( $ability instanceof \WP_Ability ) {
 					$resolved[] = $ability;
 				}
@@ -2082,8 +2081,7 @@ class AgentLoop {
 			if ( 'disabled' === ( $perms[ $name ] ?? 'auto' ) ) {
 				continue;
 			}
-			// @phpstan-ignore-next-line
-			$ability = wp_get_ability( $name );
+			$ability = AbilityRegistry::get( $name );
 			if ( ! $ability instanceof \WP_Ability ) {
 				continue;
 			}

--- a/includes/Core/ClientAbilityRouter.php
+++ b/includes/Core/ClientAbilityRouter.php
@@ -101,8 +101,7 @@ final class ClientAbilityRouter {
 			}
 
 			// Check if already registered in the global registry.
-			// @phpstan-ignore-next-line
-			$existing = function_exists( 'wp_get_ability' ) ? wp_get_ability( $name ) : null;
+			$existing = AbilityRegistry::get( $name );
 			if ( $existing instanceof \WP_Ability ) {
 				$stubs[] = $existing;
 				continue;
@@ -131,8 +130,7 @@ final class ClientAbilityRouter {
 				)
 			);
 
-			// @phpstan-ignore-next-line
-			$stub = wp_get_ability( $name );
+			$stub = AbilityRegistry::get( $name );
 			if ( $stub instanceof \WP_Ability ) {
 				$stubs[] = $stub;
 			}

--- a/includes/REST/McpController.php
+++ b/includes/REST/McpController.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\REST;
 
+use SdAiAgent\Core\AbilityRegistry;
 use SdAiAgent\Core\AbilityVisibility;
 use SdAiAgent\Core\InstructionsAddendum;
 use SdAiAgent\Core\RevisionGuard;
@@ -233,7 +234,7 @@ final class McpController extends XWP_REST_Controller {
 		}
 
 		$ability_name = self::mcp_name_to_ability_name( $tool_name );
-		$ability      = wp_get_ability( $ability_name );
+		$ability      = AbilityRegistry::get( $ability_name );
 
 		if ( null === $ability ) {
 			return new WP_Error(

--- a/includes/REST/ProposalsController.php
+++ b/includes/REST/ProposalsController.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\REST;
 
+use SdAiAgent\Core\AbilityRegistry;
 use SdAiAgent\Core\ProposalRegistry;
 use WP_Error;
 use WP_REST_Request;
@@ -141,8 +142,7 @@ final class ProposalsController {
 			);
 		}
 
-		// @phpstan-ignore-next-line
-		$ability = wp_get_ability( $ability_name );
+		$ability = AbilityRegistry::get( $ability_name );
 		if ( ! $ability instanceof \WP_Ability ) {
 			return new WP_Error(
 				'ability_not_found',
@@ -215,8 +215,7 @@ final class ProposalsController {
 			);
 		}
 
-		// @phpstan-ignore-next-line
-		$ability = wp_get_ability( $ability_name );
+		$ability = AbilityRegistry::get( $ability_name );
 		if ( ! $ability instanceof \WP_Ability ) {
 			return new WP_Error(
 				'ability_not_found',

--- a/includes/Tools/ToolDiscovery.php
+++ b/includes/Tools/ToolDiscovery.php
@@ -34,6 +34,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Tools;
 
 use SdAiAgent\Abilities\Js\JsAbilityCatalog;
+use SdAiAgent\Core\AbilityRegistry;
 use SdAiAgent\Core\AbilityVisibility;
 use SdAiAgent\Core\Settings;
 use WP_Error;
@@ -826,8 +827,7 @@ class ToolDiscovery {
 
 		$ability_id = self::canonicalise_ability_id( $ability_id );
 
-		// @phpstan-ignore-next-line
-		$ability = wp_get_ability( $ability_id );
+		$ability = AbilityRegistry::get( $ability_id );
 		if ( ! $ability instanceof \WP_Ability ) {
 			return self::format_unknown_ability_response( $ability_id );
 		}
@@ -1009,8 +1009,7 @@ class ToolDiscovery {
 
 		$lines = array( '## Recently fetched ability schemas', 'These schemas have already been retrieved this session — call them via `ability-call` directly without searching again.', '' );
 		foreach ( array_keys( self::$schema_cache ) as $name ) {
-			// @phpstan-ignore-next-line
-			$ability = wp_get_ability( $name );
+			$ability = AbilityRegistry::get( $name );
 			if ( ! $ability instanceof \WP_Ability ) {
 				continue;
 			}
@@ -1055,8 +1054,7 @@ class ToolDiscovery {
 		// keep the rewrite when the canonical name actually resolves.
 		if ( str_starts_with( $ability_id, 'ai-agent/' ) ) {
 			$rewritten = 'sd-' . $ability_id;
-			// @phpstan-ignore-next-line
-			if ( wp_get_ability( $rewritten ) instanceof \WP_Ability ) {
+			if ( AbilityRegistry::get( $rewritten ) instanceof \WP_Ability ) {
 				return $rewritten;
 			}
 		}

--- a/tests/SdAiAgent/REST/McpControllerTest.php
+++ b/tests/SdAiAgent/REST/McpControllerTest.php
@@ -372,9 +372,6 @@ class McpControllerTest extends WP_UnitTestCase {
 			$this->markTestSkipped( 'WordPress Abilities API not available.' );
 		}
 
-		// wp_get_ability() triggers _doing_it_wrong when the ability is not found.
-		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::get_registered' );
-
 		$response = $this->dispatch_mcp(
 			[
 				'method' => 'call_tool',

--- a/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
+++ b/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
@@ -397,8 +397,6 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 	}
 
 	public function test_ability_call_returns_self_heal_payload_for_unknown_ability(): void {
-		$this->setExpectedIncorrectUsage( 'WP_Abilities_Registry::get_registered' );
-
 		$result = ToolDiscovery::handle_ability_call(
 			[ 'ability' => 'no-such/ability' ]
 		);


### PR DESCRIPTION
## Summary
- prevent duplicate WooCommerce `woocommerce-rest` ability category registration notices
- remove deprecated `ReflectionMethod::setAccessible()` usage for PHP 8.5
- add safe ability lookup helper to avoid missing-ability `WP_Abilities_Registry::get_registered` notices
- filter WooCommerce's vendored MCP adapter default tools when its introspection abilities are not registered

## Verification
- `php -l` on touched PHP files
- Targeted PHPCS/PHPStan were run on the source worktree before opening this follow-up branch
- Local admin page check: authenticated request to `http://superdave-main.localhost:18080/wp-admin/admin.php?page=sd-ai-agent` showed no matching `mcp-adapter`, `woocommerce-rest`, `setAccessible`, `Notice`, or `Deprecated` output in the response/debug log

## Worker self-verification
- PHPUnit: not run; local setup is blocked because `npm run test:php:setup` requires `svn`, which is not installed
- Lint:    PHP touched-file lint clean; full JS/CSS not run
- PHPStan: touched-file analysis clean on source worktree
- Build:   not run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Eliminated WordPress "not-found" notices when resolving abilities across the platform.
  * Fixed WooCommerce integration to prevent notices during ability introspection, including improved compatibility with WooCommerce 10.8+.

* **Improvements**
  * Enhanced ability resolution mechanism for improved stability and compatibility handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->