### PR TITLE
GH#2060: docs: map issue 2060 contributor insight

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -125,15 +125,19 @@ to change, do not answer only in the issue thread. Make the durable repo change:
   finding, includes verification commands, and avoids broad "everything is fixed"
   or "remaining issues are false positives" claims unless each claim is tied to
   exact file or pattern evidence.
-- For mixed reports like issue #2034, include the source map in the PR body:
-  block-theme excerpts → `includes/Models/skills/wp-block-themes.md`; REST
+- For mixed reports like issues #2034, #2050, and #2060, include the source map
+  in the PR body: block-theme excerpts →
+  `includes/Models/skills/wp-block-themes.md`; REST
   hardening → root `AGENTS.md`, `includes/REST/`, and
   `includes/Abilities/WpRestAbilities.php`; Google Search Console →
   `includes/Abilities/GscAbilities.php`, `includes/Core/Settings.php`,
   `includes/REST/SettingsController.php`, and
   `includes/Abilities/ToolCapabilities.php`; WordPress.org review responses →
-  root `AGENTS.md` review-response policy. If code already has the requested
-  guard, cite the exact inspected guard instead of claiming "already documented".
+  root `AGENTS.md` review-response policy. For #2060-style reports with only
+  block-theme, Google Search Console, and WordPress.org review-response notes,
+  do not invent REST work; cite the three inspected durable sources instead. If
+  code already has the requested guard, cite the exact inspected guard instead of
+  claiming "already documented".
 - Do not mark contributor-insight issues complete after documentation reading
   alone. A valid fix changes a durable instruction, workflow doc, or helper, then
   verifies the changed guidance with an exact `rg -n` check that future workers

--- a/.agents/scripts/commands/feedback-triage.md
+++ b/.agents/scripts/commands/feedback-triage.md
@@ -128,8 +128,9 @@ the only implementation guidance.
 
 For mixed contributor-insight issues, the body must also include a concise
 source map so the worker can start with implementation instead of rediscovering
-the lesson. For the recurring mixed-report pattern seen in issues #2034 and
-#2050, map each note independently. For #2034-style reports, map the four notes as:
+the lesson. For the recurring mixed-report pattern seen in issues #2034, #2050,
+and #2060, map each note independently. For #2034-style reports, map the four
+notes as:
 `Block Themes` excerpts → `includes/Models/skills/wp-block-themes.md`; REST
 security shorthand → root `AGENTS.md`, `includes/REST/`, and
 `includes/Abilities/WpRestAbilities.php`; Google Search Console questions →
@@ -138,11 +139,14 @@ security shorthand → root `AGENTS.md`, `includes/REST/`, and
 `includes/Abilities/ToolCapabilities.php`; WordPress.org review-response prompts
 → root `AGENTS.md` "WordPress.org Review Responses". Require the PR body to cite
 the inspected guard or policy when no code change is needed.
-For #2050-style reports that include only block-theme excerpts, Google Search
-Console usage questions, and WordPress.org review-response prompts, update the
-block-theme skill, the GSC usage map, and the review-response policy only; do
-not add unrelated REST hardening work unless the report actually includes REST
-shorthand.
+For #2050/#2060-style reports that include only block-theme excerpts, Google
+Search Console usage questions, and WordPress.org review-response prompts,
+update the block-theme skill, the GSC usage map, and the review-response policy
+only; do not add unrelated REST hardening work unless the report actually
+includes REST shorthand. When filing the issue, include Worker Guidance that maps
+the exact three candidates to `includes/Models/skills/wp-block-themes.md`,
+`AGENTS.md` Google Search Console API Usage Mapping, and `AGENTS.md`
+WordPress.org Review Responses.
 
 Full payload schema (top-level keys):
 
@@ -250,6 +254,13 @@ before creating the issue:
   each reviewer finding separately, cite the merged fix or evidence-backed
   rationale, include commands/manual checks run, and avoid "all fixed" or
   "false positive" language unless tied to exact file/pattern evidence.
+- If the report matches the #2060 three-candidate pattern (`Block Themes` local
+  excerpt, "where do we use Google Search Console API?", and WordPress.org
+  review-response prompt), file Worker Guidance that explicitly says the durable
+  fix is guidance-only unless inspection finds a missing committed source: update
+  `includes/Models/skills/wp-block-themes.md` for the block-theme excerpt, root
+  `AGENTS.md` for GSC usage mapping and WordPress.org response policy, and this
+  feedback-triage SOP if the issue lacked actionable worker guidance.
 - Include verification in the issue body, for example
   `rg -n "Contributor Insight|sd-ai-agent/v1|secret|current user|file upload|WordPress.org Review|false positive" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md`
   or `rg -n "read:file_not_found|missing-file reads|git ls-files|debug.log|canonical plugin|signature gate|body-file|gh-signature-helper" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md includes/Models/skills/site-troubleshooting.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,8 +157,8 @@ note to a committed, future-loaded source before editing:
   summarize each reviewer finding, cite the merged fix or evidence-backed
   rationale, include verification commands, and avoid blanket "all fixed" or
   "false positive" claims that are not tied to a specific finding.
-- For mixed reports like issues #2034 and #2050, make the mapping explicit in
-  the PR body: block-theme excerpts map to
+- For mixed reports like issues #2034, #2050, and #2060, make the mapping
+  explicit in the PR body: block-theme excerpts map to
   `includes/Models/skills/wp-block-themes.md`; REST hardening shorthand maps to
   this root REST policy plus `includes/REST/` and
   `includes/Abilities/WpRestAbilities.php`; Google Search Console questions map
@@ -167,6 +167,12 @@ note to a committed, future-loaded source before editing:
   do not invent work for it; state the inspected candidate list and the durable
   source chosen for each note. State when the implementation is a guidance
   hardening only because the inspected code already has the required guard.
+- For #2060-style reports that include the three candidates `Block Themes`,
+  "where do we use Google Search Console API?", and a WordPress.org
+  review-response prompt, update or verify only those three durable sources:
+  `includes/Models/skills/wp-block-themes.md`, the Google Search Console usage
+  map below, and the WordPress.org review-response policy above. Do not add REST
+  hardening work unless the issue body also includes REST shorthand.
 - Verification for this class of guidance-only fix should include both:
   `rg -n "Contributor Insight|source mapping|local-path|sd-ai-agent/v1|file upload|WordPress.org Review|false positive" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md`
   and `rg -n "wp-block-themes|Full Site Editing|theme.json|validate-block-content" AGENTS.md includes/Models/skills/wp-block-themes.md`.

--- a/includes/Models/skills/wp-block-themes.md
+++ b/includes/Models/skills/wp-block-themes.md
@@ -26,9 +26,9 @@ style variations, treat that excerpt as a source-mapping clue only. Update this
 committed skill file (and the root `AGENTS.md` summary when repo-wide guidance is
 needed); do not copy private local paths or duplicate the full excerpt into
 issues, PRs, templates, or generated theme files. In mixed reports like issues
-#2034 and #2050, this file is only the block-theme target; REST, Google Search
-Console, and WordPress.org review-response notes must be mapped to their own
-committed source files instead of being folded into this skill.
+#2034, #2050, and #2060, this file is only the block-theme target; REST, Google
+Search Console, and WordPress.org review-response notes must be mapped to their
+own committed source files instead of being folded into this skill.
 
 ## Inputs required
 


### PR DESCRIPTION
## Summary

Mapped issue #2060's three contributor-insight candidates to durable loaded guidance: block theme excerpts now explicitly include #2060 in the wp-block-themes source map, GSC and WordPress.org response prompts stay mapped to root AGENTS.md, and feedback-triage now files Worker Guidance for the exact three-candidate pattern.

## Files Changed

.agents/AGENTS.md,.agents/scripts/commands/feedback-triage.md,AGENTS.md,includes/Models/skills/wp-block-themes.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** rg -n 'Contributor Insight|source mapping|local-path|sd-ai-agent/v1|file upload|WordPress.org Review|false positive' AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md; rg -n 'wp-block-themes|Full Site Editing|theme.json|validate-block-content' AGENTS.md includes/Models/skills/wp-block-themes.md; docs-only change, PHP/JS/CSS/build not run

Resolves #2060


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.13 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 2m and 159,864 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal contributor guidance documentation to clarify source-mapping instructions and expand reference patterns for specific issue workflows.
  * Enhanced feedback-triage procedures and skill-mapping guidelines to improve consistency across contributor-insight report types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->