### PR TITLE
GH#2061: docs: clarify fatal-error symlink triage

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -88,7 +88,9 @@ working here in OpenCode headless mode:
   absent), then verify the shared install's plugin symlinks point at every
   checked-out plugin worktree's canonical plugin directory name, not just the
   current basename. Use `wp plugin path <plugin-slug>` or inspect
-  `../wordpress/wp-content/plugins/` before retrying unrelated repository paths.
+  `../wordpress/wp-content/plugins/` before retrying unrelated repository paths;
+  enumerate all involved plugin slugs when multiple local plugins or worktrees
+  participate in the failing activation path.
 - Treat `bash:other` / `Tool execution aborted` as a recoverable command-shape or
   hook failure first. Inspect the preceding command, retry once with a narrower
   non-inline command and a clear `description`, avoid heredocs/process or command

--- a/.agents/scripts/commands/feedback-triage.md
+++ b/.agents/scripts/commands/feedback-triage.md
@@ -242,7 +242,9 @@ before creating the issue:
   and to verify the local WordPress install symlinks every checked-out plugin
   worktree into the expected canonical plugin directory name. Name
   `wp plugin path <plugin-slug>` or `../wordpress/wp-content/plugins/` as the
-  concrete check so workers do not only verify the active worktree basename.
+  concrete check so workers do not only verify the active worktree basename;
+  when multiple plugins or worktrees are mentioned, require guidance to enumerate
+  each canonical plugin slug and confirm all resolve to the intended checkout.
 - If recurring tool errors mention `bash:file_not_found`, `gh-signature-helper.sh
   invocation failed`, `signature gate`, or blocked `gh` writes, require durable
   worker guidance to create the issue/PR/comment body as an existing stable file,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -269,6 +269,10 @@ completion state:
   so the failing plugin resolves to the intended checkout. A missing, stale, or
   basename-only symlink can make WordPress load the wrong path and hide the real
   debug.log failure.
+- When several local plugins or worktrees are involved, enumerate each expected
+  canonical plugin slug and confirm all of them resolve to their current checkout
+  before retrying activation; a single correct symlink does not prove the shared
+  install is safe.
 - If the corrected path is found, retry `Read` with that path and continue the
   task. If no plausible path exists after bounded recovery, record what was
   checked and continue with the next safe implementation step rather than ending

--- a/includes/Models/skills/site-troubleshooting.md
+++ b/includes/Models/skills/site-troubleshooting.md
@@ -53,7 +53,8 @@ Use this skill when the user reports errors, performance issues, white screens, 
    into each plugin's canonical directory name before treating the fatal as an
    application-code regression. Use `wp plugin path <plugin-slug>` or inspect
    `../wordpress/wp-content/plugins/`; do not only verify the active worktree
-   basename.
+   basename. When several local plugins are involved, enumerate each canonical
+   plugin slug and confirm all resolve to their current checkout.
 4. Activate the plugin by canonical slug, then re-check debug.log for the first
    new fatal stack trace.
 


### PR DESCRIPTION
## Summary

Updated headless file-read recovery guidance to make WordPress fatal-error triage start from debug.log and verify every involved plugin's canonical symlink, not only the active worktree basename. Synchronized the durable guidance across AGENTS.md, .agents/AGENTS.md, feedback-triage SOP, and the site troubleshooting skill.

## Files Changed

.agents/AGENTS.md,.agents/scripts/commands/feedback-triage.md,AGENTS.md,includes/Models/skills/site-troubleshooting.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** rg -n "read:file_not_found|missing-file reads|git ls-files|debug.log|canonical plugin|plugin symlink|wp plugin path" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md includes/Models/skills/site-troubleshooting.md; npm run verify (lint, PHPStan, PHPUnit: Tests: 3564, Assertions: 14841, Skipped: 118, Incomplete: 4; build and bundle checks succeeded)

Resolves #2061


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.13 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 6m and 71,948 tokens on this as a headless worker.