### PR TITLE
fix: align Superdav service registration

### DIFF
--- a/includes/Core/SuperdavSiteConnectionService.php
+++ b/includes/Core/SuperdavSiteConnectionService.php
@@ -34,7 +34,7 @@ final class SuperdavSiteConnectionService {
 		$token    = $this->get_stored_token();
 		$metadata = $this->get_metadata();
 
-		return array(
+		$status = array(
 			'configured'                => '' !== $token,
 			'provider'                  => SuperdavAiProvider::PROVIDER_ID,
 			'connection_mode'           => $metadata['connection_mode'] ?? ( '' !== $token ? 'site' : 'none' ),
@@ -44,6 +44,14 @@ final class SuperdavSiteConnectionService {
 			'account_connect_available' => '' !== $this->get_account_connect_url(),
 			'account_connect_url'       => $this->get_account_connect_url(),
 		);
+
+		foreach ( array( 'tier', 'verified', 'usage', 'verification', 'request_id' ) as $key ) {
+			if ( array_key_exists( $key, $metadata ) ) {
+				$status[ $key ] = $metadata[ $key ];
+			}
+		}
+
+		return $status;
 	}
 
 	/**
@@ -52,18 +60,23 @@ final class SuperdavSiteConnectionService {
 	 * @return array<string, mixed>|WP_Error Safe status metadata or error.
 	 */
 	public function provision_site_token(): array|WP_Error {
-		$remote_token = $this->request_remote_site_token();
-		if ( $remote_token instanceof WP_Error ) {
-			return $remote_token;
+		$remote_registration = $this->request_remote_site_token();
+		if ( $remote_registration instanceof WP_Error ) {
+			return $remote_registration;
 		}
 
-		$token = '' !== $remote_token ? $remote_token : $this->create_local_site_token();
+		$remote_token    = is_array( $remote_registration ) ? (string) ( $remote_registration['token'] ?? '' ) : $remote_registration;
+		$remote_metadata = is_array( $remote_registration ) ? (array) ( $remote_registration['metadata'] ?? array() ) : array();
+		$token           = '' !== $remote_token ? $remote_token : $this->create_local_site_token();
 		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, $token, false );
 		update_option(
 			self::TOKEN_METADATA_OPTION,
-			array(
-				'connection_mode' => '' !== $remote_token ? 'site' : 'local-site',
-				'connected_at'    => gmdate( 'c' ),
+			array_merge(
+				$remote_metadata,
+				array(
+					'connection_mode' => '' !== $remote_token ? 'site' : 'local-site',
+					'connected_at'    => gmdate( 'c' ),
+				)
 			),
 			false
 		);
@@ -134,9 +147,9 @@ final class SuperdavSiteConnectionService {
 	/**
 	 * Request a token from a configured cloud registration endpoint.
 	 *
-	 * @return string|WP_Error Token, empty string when no endpoint is configured, or error.
+	 * @return array{token: string, metadata: array<string, mixed>}|string|WP_Error Token registration, empty string when no endpoint is configured, or error.
 	 */
-	private function request_remote_site_token(): string|WP_Error {
+	private function request_remote_site_token(): array|string|WP_Error {
 		/**
 		 * Filters the Superdav site registration endpoint.
 		 *
@@ -150,6 +163,13 @@ final class SuperdavSiteConnectionService {
 			return '';
 		}
 
+		$payload = array(
+			'installation_id'   => $this->get_installation_id(),
+			'site_url'          => $this->get_verified_site_url(),
+			'plugin_version'    => defined( 'SD_AI_AGENT_VERSION' ) ? (string) SD_AI_AGENT_VERSION : 'unknown',
+			'wordpress_version' => get_bloginfo( 'version' ),
+		);
+
 		$response = wp_remote_post(
 			$endpoint,
 			array(
@@ -157,12 +177,7 @@ final class SuperdavSiteConnectionService {
 				'headers' => array(
 					'Content-Type' => 'application/json',
 				),
-				'body'    => wp_json_encode(
-					array(
-						'installation_id' => $this->get_installation_id(),
-						'site_url'        => $this->get_verified_site_url(),
-					)
-				),
+				'body'    => wp_json_encode( $payload ),
 			)
 		);
 
@@ -176,11 +191,21 @@ final class SuperdavSiteConnectionService {
 		}
 
 		$body = json_decode( wp_remote_retrieve_body( $response ), true );
-		if ( ! is_array( $body ) || empty( $body['access_token'] ) || ! is_string( $body['access_token'] ) ) {
+		if ( ! is_array( $body ) ) {
 			return new WP_Error( 'sd_ai_agent_cloud_registration_invalid', __( 'Superdav AI connection response was invalid.', 'superdav-ai-agent' ), array( 'status' => 502 ) );
 		}
 
-		return $body['access_token'];
+		$token = $body['site_token'] ?? $body['access_token'] ?? '';
+		if ( ! is_string( $token ) || '' === $token ) {
+			return new WP_Error( 'sd_ai_agent_cloud_registration_invalid', __( 'Superdav AI connection response was invalid.', 'superdav-ai-agent' ), array( 'status' => 502 ) );
+		}
+
+		unset( $body['site_token'], $body['access_token'] );
+
+		return array(
+			'token'    => $token,
+			'metadata' => $this->sanitize_remote_metadata( $body ),
+		);
 	}
 
 	/**
@@ -227,6 +252,46 @@ final class SuperdavSiteConnectionService {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Keep only safe scalar registration metadata from the remote service.
+	 *
+	 * @param array<string, mixed> $metadata Remote response without token fields.
+	 * @return array<string, mixed>
+	 */
+	private function sanitize_remote_metadata( array $metadata ): array {
+		$allowed_keys = array(
+			'installation_id',
+			'token_expires_at',
+			'tier',
+			'verified',
+			'connect_required',
+			'request_id',
+		);
+		$safe         = array();
+
+		foreach ( $allowed_keys as $key ) {
+			if ( array_key_exists( $key, $metadata ) && ( is_scalar( $metadata[ $key ] ) || null === $metadata[ $key ] ) ) {
+				$safe[ $key ] = $metadata[ $key ];
+			}
+		}
+
+		if ( isset( $metadata['usage'] ) && is_array( $metadata['usage'] ) ) {
+			$safe['usage'] = array_filter(
+				$metadata['usage'],
+				static fn( mixed $value ): bool => is_scalar( $value ) || null === $value
+			);
+		}
+
+		if ( isset( $metadata['verification'] ) && is_array( $metadata['verification'] ) ) {
+			$safe['verification'] = array_filter(
+				$metadata['verification'],
+				static fn( mixed $value ): bool => is_scalar( $value ) || null === $value
+			);
+		}
+
+		return $safe;
 	}
 
 	/**

--- a/tests/SdAiAgent/REST/ConnectorsControllerTest.php
+++ b/tests/SdAiAgent/REST/ConnectorsControllerTest.php
@@ -25,6 +25,8 @@ final class ConnectorsControllerTest extends WP_UnitTestCase {
 	 * Clean up connector options.
 	 */
 	public function tear_down(): void {
+		remove_all_filters( 'sd_ai_agent_cloud_registration_endpoint' );
+		remove_all_filters( 'pre_http_request' );
 		delete_option( SuperdavAiProvider::CREDENTIAL_OPTION );
 		delete_option( SuperdavSiteConnectionService::INSTALLATION_ID_OPTION );
 		delete_option( SuperdavSiteConnectionService::TOKEN_METADATA_OPTION );
@@ -69,6 +71,67 @@ final class ConnectorsControllerTest extends WP_UnitTestCase {
 		$this->assertTrue( $data['configured'] );
 		$this->assertSame( SuperdavAiProvider::PROVIDER_ID, $data['provider'] );
 		$this->assertStringNotContainsString( $token, wp_json_encode( $data ) ?: '' );
+	}
+
+	/**
+	 * Managed remote connection sends private-site metadata and stores returned site_token.
+	 */
+	public function test_connect_registers_remote_self_declared_site_token(): void {
+		$endpoint      = 'https://service.example/v1/site/installations';
+		$captured_body = array();
+
+		add_filter( 'sd_ai_agent_cloud_registration_endpoint', static fn(): string => $endpoint );
+		add_filter(
+			'pre_http_request',
+			static function ( mixed $preempt, array $parsed_args, string $url ) use ( $endpoint, &$captured_body ): mixed {
+				if ( $endpoint !== $url ) {
+					return $preempt;
+				}
+
+				$captured_body = json_decode( (string) ( $parsed_args['body'] ?? '' ), true );
+
+				return array(
+					'response' => array(
+						'code'    => 201,
+						'message' => 'Created',
+					),
+					'body'     => wp_json_encode(
+						array(
+							'installation_id'  => $captured_body['installation_id'] ?? '',
+							'site_token'       => 'sdaist_remote_site_token',
+							'tier'             => 'free',
+							'verified'         => false,
+							'connect_required' => false,
+							'verification'     => array(
+								'state' => 'self_declared',
+							),
+						)
+					),
+				);
+			},
+			10,
+			3
+		);
+
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/connectors/' . SuperdavAiProvider::PROVIDER_ID . '/connect' );
+		$request->set_param( 'provider', SuperdavAiProvider::PROVIDER_ID );
+
+		$response = ( new ConnectorsController() )->handle_connect( $request );
+		$this->assertNotWPError( $response );
+
+		$this->assertSame( 'sdaist_remote_site_token', get_option( SuperdavAiProvider::CREDENTIAL_OPTION, '' ) );
+		$this->assertIsArray( $captured_body );
+		$this->assertNotEmpty( $captured_body['installation_id'] );
+		$this->assertSame( home_url( '/' ), $captured_body['site_url'] );
+		$this->assertSame( SD_AI_AGENT_VERSION, $captured_body['plugin_version'] );
+		$this->assertNotEmpty( $captured_body['wordpress_version'] );
+		$this->assertArrayNotHasKey( 'verification', $captured_body );
+
+		$data = $response->get_data();
+		$this->assertTrue( $data['configured'] );
+		$this->assertSame( 'site', $data['status']['connection_mode'] );
+		$this->assertFalse( $data['status']['verified'] );
+		$this->assertStringNotContainsString( 'sdaist_remote_site_token', wp_json_encode( $data ) ?: '' );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- send plugin and WordPress metadata when registering with the Superdav service
- accept the service `site_token` response field with `access_token` fallback
- store only sanitized service metadata and never return the token in connector status
- add connector regression coverage for remote self-declared free-tier registration

## Related
- Service PR: https://github.com/Ultimate-Multisite/superdav-ai-service/pull/43

## Verification
- `npm run test:php -- --filter ConnectorsControllerTest`
- `vendor/bin/phpcs includes/Core/SuperdavSiteConnectionService.php tests/SdAiAgent/REST/ConnectorsControllerTest.php`
- Local plugin/service smoke: registration succeeded, `/v1/site/status` 200, `/v1/models` 200, `/v1/chat/completions` 200

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.17 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes & Improvements**
  * Enhanced site connection registration with improved remote metadata handling
  * Added plugin and WordPress version tracking during registration
  * Strengthened validation of remote registration responses
  * Improved sanitization and security of metadata from remote endpoints

* **Tests**
  * Added test coverage for remote site token registration flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->