### PR TITLE
GH#2067: docs: clarify vendor read fatal triage

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -87,7 +87,8 @@ working here in OpenCode headless mode:
   `../wordpress/wp-content/debug.log` (enable `WP_DEBUG_LOG` and reproduce once if
   absent), then verify the shared install's plugin symlinks point at every
   checked-out plugin worktree's canonical plugin directory name, not just the
-  current basename. Use `wp plugin path <plugin-slug>` or inspect
+  current basename. If the failed read was `vendor/`, do this before assuming a
+  Composer dependency problem. Use `wp plugin path <plugin-slug>` or inspect
   `../wordpress/wp-content/plugins/` before retrying unrelated repository paths;
   enumerate all involved plugin slugs when multiple local plugins or worktrees
   participate in the failing activation path.

--- a/.agents/scripts/commands/feedback-triage.md
+++ b/.agents/scripts/commands/feedback-triage.md
@@ -244,7 +244,10 @@ before creating the issue:
   `wp plugin path <plugin-slug>` or `../wordpress/wp-content/plugins/` as the
   concrete check so workers do not only verify the active worktree basename;
   when multiple plugins or worktrees are mentioned, require guidance to enumerate
-  each canonical plugin slug and confirm all resolve to the intended checkout.
+  each canonical plugin slug and confirm all resolve to the intended checkout. If
+  the summarized failed command is `read vendor`, explicitly steer workers away
+  from Composer diagnosis until the debug log and canonical symlink checks have
+  been completed.
 - If recurring tool errors mention `bash:file_not_found`, `gh-signature-helper.sh
   invocation failed`, `signature gate`, or blocked `gh` writes, require durable
   worker guidance to create the issue/PR/comment body as an existing stable file,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,6 +262,9 @@ completion state:
   paths such as `vendor/` after a missing-file read. First inspect the runtime
   artifact that contains the failure: `../wordpress/wp-content/debug.log`, or
   enable `WP_DEBUG_LOG` and reproduce once if the log does not exist.
+- If the first failed read was `vendor/`, treat it as a symptom of looking in
+  the wrong layer until runtime evidence says otherwise: read the WordPress
+  debug log before checking Composer install state or adding dependency fixes.
 - Before blaming plugin code for local activation fatals, verify the shared
   WordPress install has symlinks for every checked-out plugin worktree under each
   plugin's canonical directory name, not only the active worktree basename. Use

--- a/includes/Models/skills/site-troubleshooting.md
+++ b/includes/Models/skills/site-troubleshooting.md
@@ -48,7 +48,9 @@ Use this skill when the user reports errors, performance issues, white screens, 
 ### Plugin Activation Fatal Error
 1. Verify `WP_DEBUG_LOG` is enabled and reproduce the activation once.
 2. Read `../wordpress/wp-content/debug.log` or use the guarded `wp eval` command
-   above; do not stop after a missing repository path such as `vendor/`.
+   above; do not stop after a missing repository path such as `vendor/`, and do
+   not assume Composer dependencies are the root cause until the runtime log is
+   checked.
 3. Confirm the shared WordPress install symlinks every checked-out plugin worktree
    into each plugin's canonical directory name before treating the fatal as an
    application-code regression. Use `wp plugin path <plugin-slug>` or inspect


### PR DESCRIPTION
## Summary

Tightened headless file-read recovery guidance so a failed vendor/ read during WordPress fatal-error triage sends workers to debug.log and canonical plugin symlink checks before Composer diagnosis. Updated root and project worker guidance, feedback triage guidance generation, and the site troubleshooting skill.

## Files Changed

.agents/AGENTS.md,.agents/scripts/commands/feedback-triage.md,AGENTS.md,includes/Models/skills/site-troubleshooting.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** rg -n "read:file_not_found|missing-file reads|git ls-files|debug.log|canonical plugin|vendor/|Composer" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md includes/Models/skills/site-troubleshooting.md

Resolves #2067


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.27 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 1m and 77,021 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced troubleshooting guides for WordPress fatal errors with improved plugin activation diagnostics
  * Expanded guidance on plugin path verification and symlink checks to ensure accurate root cause identification
  * Updated workflow to emphasize checking runtime debug logs before pursuing dependency-related solutions
  * Clarified troubleshooting sequence across multiple documentation sections for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->