### PR TITLE
GH#2075: docs: clarify fatal read recovery

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -83,12 +83,12 @@ working here in OpenCode headless mode:
   headless run solely because one optional screenshot, prompt, or generated
   artifact path was stale.
 - When a missing-file read happens during WordPress fatal-error triage, switch to
-  the runtime evidence before more repo-path probing: inspect
-  `../wordpress/wp-content/debug.log` (enable `WP_DEBUG_LOG` and reproduce once if
-  absent), then verify the shared install's plugin symlinks point at every
-  checked-out plugin worktree's canonical plugin directory name, not just the
-  current basename. If the failed read was `vendor/`, do this before assuming a
-  Composer dependency problem. Use `wp plugin path <plugin-slug>` or inspect
+  the runtime evidence before more repo-path probing: make
+  `../wordpress/wp-content/debug.log` the next read target (enable `WP_DEBUG_LOG`
+  and reproduce once if absent), then verify the shared install's plugin symlinks
+  point at every checked-out plugin worktree's canonical plugin directory name,
+  not just the current basename. If the failed read was `vendor/`, do this before
+  assuming a Composer dependency problem. Use `wp plugin path <plugin-slug>` or inspect
   `../wordpress/wp-content/plugins/` before retrying unrelated repository paths;
   enumerate all involved plugin slugs when multiple local plugins or worktrees
   participate in the failing activation path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,9 +259,9 @@ completion state:
   before retrying `Read`; for untracked/runtime artifacts, inspect the known
   parent directory or rerun the command that generated the artifact.
 - For local WordPress fatal-error reports, do not keep retrying unrelated project
-  paths such as `vendor/` after a missing-file read. First inspect the runtime
-  artifact that contains the failure: `../wordpress/wp-content/debug.log`, or
-  enable `WP_DEBUG_LOG` and reproduce once if the log does not exist.
+  paths such as `vendor/` after a missing-file read. Make the runtime evidence
+  artifact `../wordpress/wp-content/debug.log` the next read target, or enable
+  `WP_DEBUG_LOG` and reproduce once if the log does not exist.
 - If the first failed read was `vendor/`, treat it as a symptom of looking in
   the wrong layer until runtime evidence says otherwise: read the WordPress
   debug log before checking Composer install state or adding dependency fixes.

--- a/includes/Models/skills/site-troubleshooting.md
+++ b/includes/Models/skills/site-troubleshooting.md
@@ -48,9 +48,9 @@ Use this skill when the user reports errors, performance issues, white screens, 
 ### Plugin Activation Fatal Error
 1. Verify `WP_DEBUG_LOG` is enabled and reproduce the activation once.
 2. Read `../wordpress/wp-content/debug.log` or use the guarded `wp eval` command
-   above; do not stop after a missing repository path such as `vendor/`, and do
-   not assume Composer dependencies are the root cause until the runtime log is
-   checked.
+   above; after a missing repository path such as `vendor/`, make this runtime
+   log the next evidence source and do not assume Composer dependencies are the
+   root cause until it is checked.
 3. Confirm the shared WordPress install symlinks every checked-out plugin worktree
    into each plugin's canonical directory name before treating the fatal as an
    application-code regression. Use `wp plugin path <plugin-slug>` or inspect


### PR DESCRIPTION
## Summary

Clarified headless file-read recovery guidance so WordPress fatal-error triage makes ../wordpress/wp-content/debug.log the next read target after missing repository paths such as vendor, and aligned the repository plus in-plugin troubleshooting guidance with canonical plugin symlink checks.

## Files Changed

.agents/AGENTS.md,AGENTS.md,includes/Models/skills/site-troubleshooting.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** rg -n "read:file_not_found|missing-file reads|git ls-files|debug.log|canonical plugin" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md includes/Models/skills/site-troubleshooting.md; npm run verify (lint, PHPStan, PHPUnit, build, bundle check)

Resolves #2075


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.36 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 6m and 151,784 tokens on this as a headless worker.