### PR TITLE
GH#2081: docs: map contributor insight 2081

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -128,7 +128,8 @@ to change, do not answer only in the issue thread. Make the durable repo change:
   finding, includes verification commands, and avoids broad "everything is fixed"
   or "remaining issues are false positives" claims unless each claim is tied to
   exact file or pattern evidence.
-- For mixed reports like issues #2034, #2050, #2060, #2066, and #2074, include the source map
+- For mixed reports like issues #2034, #2050, #2060, #2066, #2074, and #2081,
+  include the source map
   in the PR body: block-theme excerpts →
   `includes/Models/skills/wp-block-themes.md`; REST
   hardening → root `AGENTS.md`, `includes/REST/`, and
@@ -136,8 +137,8 @@ to change, do not answer only in the issue thread. Make the durable repo change:
   `includes/Abilities/GscAbilities.php`, `includes/Core/Settings.php`,
   `includes/REST/SettingsController.php`, and
   `includes/Abilities/ToolCapabilities.php`; WordPress.org review responses →
-  root `AGENTS.md` review-response policy. For #2060/#2066/#2074-style reports with only
-  block-theme, Google Search Console, and WordPress.org review-response notes,
+  root `AGENTS.md` review-response policy. For #2060/#2066/#2074/#2081-style
+  reports with only block-theme, Google Search Console, and WordPress.org review-response notes,
   do not invent REST work; cite the three inspected durable sources instead. If
   code already has the requested guard, cite the exact inspected guard instead of
   claiming "already documented".

--- a/.agents/scripts/commands/feedback-triage.md
+++ b/.agents/scripts/commands/feedback-triage.md
@@ -129,7 +129,7 @@ the only implementation guidance.
 For mixed contributor-insight issues, the body must also include a concise
 source map so the worker can start with implementation instead of rediscovering
 the lesson. For the recurring mixed-report pattern seen in issues #2034, #2050,
-#2060, and #2066, map each note independently. For #2034-style reports, map the four
+#2060, #2066, #2074, and #2081, map each note independently. For #2034-style reports, map the four
 notes as:
 `Block Themes` excerpts → `includes/Models/skills/wp-block-themes.md`; REST
 security shorthand → root `AGENTS.md`, `includes/REST/`, and
@@ -139,8 +139,8 @@ security shorthand → root `AGENTS.md`, `includes/REST/`, and
 `includes/Abilities/ToolCapabilities.php`; WordPress.org review-response prompts
 → root `AGENTS.md` "WordPress.org Review Responses". Require the PR body to cite
 the inspected guard or policy when no code change is needed.
-For #2050/#2060/#2066-style reports that include only block-theme excerpts, Google
-Search Console usage questions, and WordPress.org review-response prompts,
+For #2050/#2060/#2066/#2074/#2081-style reports that include only block-theme
+excerpts, Google Search Console usage questions, and WordPress.org review-response prompts,
 update the block-theme skill, the GSC usage map, and the review-response policy
 only; do not add unrelated REST hardening work unless the report actually
 includes REST shorthand. When filing the issue, include Worker Guidance that maps

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,7 +157,8 @@ note to a committed, future-loaded source before editing:
   summarize each reviewer finding, cite the merged fix or evidence-backed
   rationale, include verification commands, and avoid blanket "all fixed" or
   "false positive" claims that are not tied to a specific finding.
-- For mixed reports like issues #2034, #2050, #2060, #2066, and #2074, make the mapping
+- For mixed reports like issues #2034, #2050, #2060, #2066, #2074, and #2081,
+  make the mapping
   explicit in the PR body: block-theme excerpts map to
   `includes/Models/skills/wp-block-themes.md`; REST hardening shorthand maps to
   this root REST policy plus `includes/REST/` and
@@ -167,7 +168,7 @@ note to a committed, future-loaded source before editing:
   do not invent work for it; state the inspected candidate list and the durable
   source chosen for each note. State when the implementation is a guidance
   hardening only because the inspected code already has the required guard.
-- For #2060/#2066/#2074-style reports that include the three candidates `Block Themes`,
+- For #2060/#2066/#2074/#2081-style reports that include the three candidates `Block Themes`,
   "where do we use Google Search Console API?", and a WordPress.org
   review-response prompt, update or verify only those three durable sources:
   `includes/Models/skills/wp-block-themes.md`, the Google Search Console usage

--- a/includes/Models/skills/wp-block-themes.md
+++ b/includes/Models/skills/wp-block-themes.md
@@ -26,7 +26,7 @@ style variations, treat that excerpt as a source-mapping clue only. Update this
 committed skill file (and the root `AGENTS.md` summary when repo-wide guidance is
 needed); do not copy private local paths or duplicate the full excerpt into
 issues, PRs, templates, or generated theme files. In mixed reports like issues
-#2034, #2050, #2060, #2066, and #2074, this file is only the block-theme target; REST,
+#2034, #2050, #2060, #2066, #2074, and #2081, this file is only the block-theme target; REST,
 Google Search Console, and WordPress.org review-response notes must be mapped to
 their own committed source files instead of being folded into this skill.
 


### PR DESCRIPTION
## Summary

Mapped the issue #2081 three-candidate contributor insight pattern into the future-loaded guidance surfaces: root AGENTS.md, .agents/AGENTS.md, feedback-triage command guidance, and the wp-block-themes skill. The change makes #2081 explicit alongside the earlier matching reports and keeps the Block Themes, Google Search Console, and WordPress.org review-response notes routed to their committed sources without inventing unrelated REST hardening work.

## Files Changed

.agents/AGENTS.md,.agents/scripts/commands/feedback-triage.md,AGENTS.md,includes/Models/skills/wp-block-themes.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** rg -n "Contributor Insight|source mapping|local-path|sd-ai-agent/v1|file upload|WordPress.org Review|false positive" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md; rg -n "wp-block-themes|Full Site Editing|theme.json|validate-block-content" AGENTS.md includes/Models/skills/wp-block-themes.md

Resolves #2081


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.41 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 3m and 127,777 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal contributor guidance documents for mixed report handling and expanded issue reference scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->