### PR TITLE
GH#2082: docs: clarify read vendor fatal recovery

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -88,10 +88,13 @@ working here in OpenCode headless mode:
   and reproduce once if absent), then verify the shared install's plugin symlinks
   point at every checked-out plugin worktree's canonical plugin directory name,
   not just the current basename. If the failed read was `vendor/`, do this before
-  assuming a Composer dependency problem. Use `wp plugin path <plugin-slug>` or inspect
-  `../wordpress/wp-content/plugins/` before retrying unrelated repository paths;
-  enumerate all involved plugin slugs when multiple local plugins or worktrees
-  participate in the failing activation path.
+  assuming a Composer dependency problem. If maintainer recovery says a fatal
+  appeared after `read vendor`, treat that as a direct instruction to read
+  debug.log and check canonical plugin symlinks before touching dependencies. Use
+  `wp plugin path <plugin-slug>` or inspect `../wordpress/wp-content/plugins/`
+  before retrying unrelated repository paths; enumerate all involved plugin slugs
+  when multiple local plugins or worktrees participate in the failing activation
+  path.
 - Treat `bash:other` / `Tool execution aborted` as a recoverable command-shape or
   hook failure first. Inspect the preceding command, retry once with a narrower
   non-inline command and a clear `description`, avoid heredocs/process or command

--- a/.agents/scripts/commands/feedback-triage.md
+++ b/.agents/scripts/commands/feedback-triage.md
@@ -121,6 +121,13 @@ issue. Examples:
   "WordPress.org Review Responses" policy. The issue body should require a
   concise issue-by-issue response, concrete fix/rationale references, verification
   evidence, and no broad "false positive" claims without finding-specific proof.
+- `read:file_not_found` reports whose summarized command is `read vendor` and
+  maintainer recovery mentions a fatal error map to headless file-read recovery
+  plus local WordPress activation triage: root `AGENTS.md`, `.agents/AGENTS.md`,
+  and `includes/Models/skills/site-troubleshooting.md`. The Worker Guidance must
+  tell implementers to make `../wordpress/wp-content/debug.log` the next evidence
+  source, then verify every involved plugin resolves through its canonical plugin
+  directory or symlink before diagnosing Composer dependencies.
 
 The resulting issue body must name the target files, expected behaviour, and at
 least one verification command; do not leave private local paths or shorthand as
@@ -147,6 +154,13 @@ includes REST shorthand. When filing the issue, include Worker Guidance that map
 the exact three candidates to `includes/Models/skills/wp-block-themes.md`,
 `AGENTS.md` Google Search Console API Usage Mapping, and `AGENTS.md`
 WordPress.org Review Responses.
+
+For #2082-style `read:file_not_found` reports with `read vendor` plus fatal-error
+recovery, include Worker Guidance that maps the issue to root `AGENTS.md`
+"Headless File Read Recovery", `.agents/AGENTS.md` "Headless Worker Tool
+Guardrails", and `includes/Models/skills/site-troubleshooting.md` "Plugin
+Activation Fatal Error". Require verification with
+`rg -n "read:file_not_found|missing-file reads|read vendor|debug.log|canonical plugin|wp plugin path" AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md includes/Models/skills/site-troubleshooting.md`.
 
 Full payload schema (top-level keys):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,6 +265,10 @@ completion state:
 - If the first failed read was `vendor/`, treat it as a symptom of looking in
   the wrong layer until runtime evidence says otherwise: read the WordPress
   debug log before checking Composer install state or adding dependency fixes.
+- When the maintainer recovery mentions a fatal error after `read vendor`, map
+  the report to local WordPress activation triage, not dependency discovery:
+  read `../wordpress/wp-content/debug.log`, then verify every related plugin is
+  symlinked under its canonical plugin slug before changing Composer files.
 - Before blaming plugin code for local activation fatals, verify the shared
   WordPress install has symlinks for every checked-out plugin worktree under each
   plugin's canonical directory name, not only the active worktree basename. Use

--- a/includes/Models/skills/site-troubleshooting.md
+++ b/includes/Models/skills/site-troubleshooting.md
@@ -51,6 +51,9 @@ Use this skill when the user reports errors, performance issues, white screens, 
    above; after a missing repository path such as `vendor/`, make this runtime
    log the next evidence source and do not assume Composer dependencies are the
    root cause until it is checked.
+   If the failed tool call was literally `read vendor`, treat the missing read as
+   a path/layer mistake: inspect the WordPress debug log before checking
+   `vendor/`, `composer install`, or autoload state.
 3. Confirm the shared WordPress install symlinks every checked-out plugin worktree
    into each plugin's canonical directory name before treating the fatal as an
    application-code regression. Use `wp plugin path <plugin-slug>` or inspect


### PR DESCRIPTION
## Summary

Mapped the recurring read:file_not_found/read vendor fatal pattern to durable worker guidance in root AGENTS.md, .agents/AGENTS.md, feedback-triage SOP, and the site troubleshooting skill.

## Files Changed

.agents/AGENTS.md,.agents/scripts/commands/feedback-triage.md,AGENTS.md,includes/Models/skills/site-troubleshooting.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** rg -n 'read:file_not_found|missing-file reads|read vendor|debug.log|canonical plugin|wp plugin path' AGENTS.md .agents/AGENTS.md .agents/scripts/commands/feedback-triage.md includes/Models/skills/site-troubleshooting.md

Resolves #2082


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.41 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 2m and 97,001 tokens on this as a headless worker.