### PR TITLE
GH#2083: fix: keep health diagnostics read-only

### DIFF
--- a/includes/Abilities/SiteHealthAbilities.php
+++ b/includes/Abilities/SiteHealthAbilities.php
@@ -211,10 +211,11 @@ class SiteHealthAbilities {
 				'output_schema'       => [
 					'type'       => 'object',
 					'properties' => [
-						'issues'   => [ 'type' => 'array' ],
-						'warnings' => [ 'type' => 'array' ],
-						'passed'   => [ 'type' => 'array' ],
-						'score'    => [ 'type' => 'integer' ],
+						'issues'         => [ 'type' => 'array' ],
+						'warnings'       => [ 'type' => 'array' ],
+						'passed'         => [ 'type' => 'array' ],
+						'score'          => [ 'type' => 'integer' ],
+						'agent_guidance' => [ 'type' => 'string' ],
 					],
 				],
 				'meta'                => [
@@ -305,6 +306,7 @@ class SiteHealthAbilities {
 						'security'       => [ 'type' => 'object' ],
 						'performance'    => [ 'type' => 'object' ],
 						'generated_at'   => [ 'type' => 'string' ],
+						'agent_guidance' => [ 'type' => 'string' ],
 					],
 				],
 				'meta'                => [
@@ -636,10 +638,11 @@ class SiteHealthAbilities {
 		$score = max( 0, $score );
 
 		return [
-			'issues'   => $issues,
-			'warnings' => $warnings,
-			'passed'   => $passed,
-			'score'    => $score,
+			'issues'         => $issues,
+			'warnings'       => $warnings,
+			'passed'         => $passed,
+			'score'          => $score,
+			'agent_guidance' => self::get_read_only_diagnostic_guidance(),
 		];
 	}
 
@@ -775,6 +778,7 @@ class SiteHealthAbilities {
 			'security'       => is_wp_error( $security ) ? [ 'error' => $security->get_error_message() ] : $security,
 			'performance'    => is_wp_error( $performance ) ? [ 'error' => $performance->get_error_message() ] : $performance,
 			'generated_at'   => gmdate( 'Y-m-d H:i:s' ),
+			'agent_guidance' => self::get_read_only_diagnostic_guidance(),
 		];
 	}
 
@@ -811,6 +815,15 @@ class SiteHealthAbilities {
 	// -------------------------------------------------------------------------
 	// Private helpers
 	// -------------------------------------------------------------------------
+
+	/**
+	 * Return model-facing guidance for read-only diagnostic results.
+	 *
+	 * @return string
+	 */
+	private static function get_read_only_diagnostic_guidance(): string {
+		return 'Summarize these diagnostic findings for the user. Do not install plugins, activate plugins, change security settings, write files, run remediation commands, or navigate away unless the user explicitly requested remediation.';
+	}
 
 	/**
 	 * Resolve the PHP/WordPress error log path.

--- a/includes/Core/SystemInstructionBuilder.php
+++ b/includes/Core/SystemInstructionBuilder.php
@@ -299,6 +299,19 @@ class SystemInstructionBuilder {
 	}
 
 	/**
+	 * Build the read-only diagnostics policy for health/security summaries.
+	 *
+	 * @return string
+	 */
+	public static function build_read_only_diagnostics_section(): string {
+		return "## Read-only diagnostic requests\n\n"
+			. 'When the user asks to check, scan, audit, review, or summarize site health, security, performance, updates, or logs, treat the request as read-only unless they explicitly ask you to fix or remediate. '
+			. 'For read-only diagnostic requests, call only inspection abilities, then summarize findings, severity, and recommended next steps. '
+			. 'Do not install or activate plugins, change security settings, write files, run privileged configuration commands, update options, execute remediation PHP/SQL/WP-CLI, or navigate to unrelated admin pages. '
+			. 'If remediation seems useful, ask for explicit approval and name the proposed changes before taking action.';
+	}
+
+	/**
 	 * Build the "## Build vs install" planning section.
 	 *
 	 * Reminds the model to check the wp.org plugin directory and consider
@@ -427,6 +440,7 @@ class SystemInstructionBuilder {
 			. "- If a tool call fails, try a different approach or skip it and continue with the next step.\n"
 			. "- Never stop after a single error — complete as many steps as possible.\n"
 			. "- If you've retried the same tool 2 times with similar args, move on.\n\n"
+			. self::build_read_only_diagnostics_section() . "\n\n"
 			. "## Reporting Inability\n"
 			. "- If you have genuinely tried and cannot complete the user's request, call `sd-ai-agent/report-inability` with a clear reason and the steps you attempted.\n"
 			. "- Use this only as a last resort — after at least 2 different approaches have failed.\n"

--- a/tests/SdAiAgent/Abilities/SiteHealthAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/SiteHealthAbilitiesTest.php
@@ -224,6 +224,7 @@ class SiteHealthAbilitiesTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'warnings', $result );
 		$this->assertArrayHasKey( 'passed', $result );
 		$this->assertArrayHasKey( 'score', $result );
+		$this->assertArrayHasKey( 'agent_guidance', $result );
 	}
 
 	/**
@@ -263,6 +264,18 @@ class SiteHealthAbilitiesTest extends WP_UnitTestCase {
 		$expected_score = max( 0, $expected_score );
 
 		$this->assertSame( $expected_score, $result['score'] );
+	}
+
+	/**
+	 * Security diagnostics must guide the model to summarize instead of remediate.
+	 */
+	public function test_handle_check_security_includes_read_only_guidance() {
+		$result = SiteHealthAbilities::handle_check_security( [] );
+
+		$this->assertIsString( $result['agent_guidance'] );
+		$this->assertStringContainsString( 'Summarize these diagnostic findings', $result['agent_guidance'] );
+		$this->assertStringContainsString( 'Do not install plugins', $result['agent_guidance'] );
+		$this->assertStringContainsString( 'navigate away unless the user explicitly requested remediation', $result['agent_guidance'] );
 	}
 
 	// ─── handle_check_performance ─────────────────────────────────
@@ -330,6 +343,7 @@ class SiteHealthAbilitiesTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'security', $result );
 		$this->assertArrayHasKey( 'performance', $result );
 		$this->assertArrayHasKey( 'generated_at', $result );
+		$this->assertArrayHasKey( 'agent_guidance', $result );
 	}
 
 	/**
@@ -367,6 +381,19 @@ class SiteHealthAbilitiesTest extends WP_UnitTestCase {
 
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'overall_status', $result );
+	}
+
+	/**
+	 * Site-health summaries must not encourage immediate plugin installs or navigation.
+	 */
+	public function test_handle_site_health_summary_includes_read_only_guidance() {
+		$result = SiteHealthAbilities::handle_site_health_summary( [] );
+
+		$this->assertIsArray( $result );
+		$this->assertIsString( $result['agent_guidance'] );
+		$this->assertStringContainsString( 'Do not install plugins', $result['agent_guidance'] );
+		$this->assertStringContainsString( 'activate plugins', $result['agent_guidance'] );
+		$this->assertStringContainsString( 'unless the user explicitly requested remediation', $result['agent_guidance'] );
 	}
 
 	// ─── handle_detect_fresh_install ───────────────────────────────

--- a/tests/SdAiAgent/Core/SystemInstructionBuilderTest.php
+++ b/tests/SdAiAgent/Core/SystemInstructionBuilderTest.php
@@ -110,6 +110,34 @@ class SystemInstructionBuilderTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Diagnostic summary prompts must remain read-only unless remediation is explicit.
+	 *
+	 * Regression: issue #2083 — a site health summary request installed and
+	 * configured Wordfence instead of summarizing findings.
+	 */
+	public function test_default_instruction_includes_read_only_diagnostics_policy(): void {
+		$instruction = SystemInstructionBuilder::default_system_instruction();
+
+		$this->assertStringContainsString( '## Read-only diagnostic requests', $instruction );
+		$this->assertStringContainsString( 'summarize site health, security, performance, updates, or logs', $instruction );
+		$this->assertStringContainsString( 'Do not install or activate plugins', $instruction );
+		$this->assertStringContainsString( 'navigate to unrelated admin pages', $instruction );
+		$this->assertStringContainsString( 'ask for explicit approval', $instruction );
+	}
+
+	/**
+	 * The diagnostics policy is also exposed as a focused builder section.
+	 */
+	public function test_read_only_diagnostics_section_blocks_remediation_tools(): void {
+		$section = SystemInstructionBuilder::build_read_only_diagnostics_section();
+
+		$this->assertStringContainsString( 'read-only', $section );
+		$this->assertStringContainsString( 'write files', $section );
+		$this->assertStringContainsString( 'privileged configuration commands', $section );
+		$this->assertStringContainsString( 'update options', $section );
+	}
+
+	/**
 	 * Test that custom system prompt overrides the default.
 	 */
 	public function test_build_uses_custom_system_prompt(): void {


### PR DESCRIPTION
## Summary

Added read-only diagnostic policy to the default system prompt and added model-facing guidance to site-health/security diagnostic ability responses so summary requests do not trigger plugin installs, security configuration changes, privileged remediation commands, file writes, or unrelated navigation without explicit remediation intent. Added regression coverage for the prompt policy and diagnostic result guidance.

## Files Changed

includes/Abilities/SiteHealthAbilities.php, includes/Core/SystemInstructionBuilder.php, tests/SdAiAgent/Abilities/SiteHealthAbilitiesTest.php, tests/SdAiAgent/Core/SystemInstructionBuilderTest.php

## Worker self-verification
- PHPUnit: Tests: 3572, Assertions: 14917, Errors: 0, Failures: 0, Skipped: 118, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  check passed

## Runtime Testing

- **Risk level:** Low (agent prompts / diagnostic ability result guidance)
- **Verification:** `npm run verify` (lint clean; PHPStan 0 errors; PHPUnit passed; build succeeded; bundle check OK)

Resolves #2083


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.41 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 12m and 210,554 tokens on this as a headless worker.
