### PR TITLE
GH#2080: feat: add REST meta diagnostics ability

### DIFF
--- a/includes/Abilities/RestMetaAbilities.php
+++ b/includes/Abilities/RestMetaAbilities.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * REST meta diagnostics for the AI agent.
+ *
+ * @package SdAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Abilities;
+
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Read-only diagnostics for WordPress REST post meta writability.
+ */
+class RestMetaAbilities {
+
+	/**
+	 * Ability ID.
+	 */
+	public const ABILITY_ID = 'sd-ai-agent/inspect-rest-meta';
+
+	/**
+	 * Register REST meta diagnostic ability.
+	 */
+	public static function register_abilities(): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			self::ABILITY_ID,
+			[
+				'label'               => __( 'Inspect REST Meta', 'superdav-ai-agent' ),
+				'description'         => __( 'Diagnose whether WordPress REST post meta writes can persist for a post type and optional meta key. Reports CPT REST visibility, custom-fields support, registered REST-visible meta, and actionable recommendations for common 200 OK-but-dropped meta writes.', 'superdav-ai-agent' ),
+				'category'            => 'sd-ai-agent',
+				'input_schema'        => [
+					'type'                 => 'object',
+					'properties'           => [
+						'post_type' => [
+							'type'        => 'string',
+							'description' => 'Post type slug to inspect, e.g. "post", "page", or a custom post type.',
+						],
+						'meta_key'  => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Input schema field name, not a query argument.
+							'type'        => 'string',
+							'description' => 'Optional meta key to focus the diagnostic on.',
+						],
+					],
+					'required'             => [ 'post_type' ],
+					'additionalProperties' => false,
+				],
+				'output_schema'       => [
+					'type'       => 'object',
+					'properties' => [
+						'post_type'              => [ 'type' => 'string' ],
+						'post_type_exists'       => [ 'type' => 'boolean' ],
+						'rest_base'              => [ 'type' => [ 'string', 'null' ] ],
+						'show_in_rest'           => [ 'type' => 'boolean' ],
+						'supports_custom_fields' => [ 'type' => 'boolean' ],
+						'rest_meta_writable'     => [ 'type' => 'boolean' ],
+						'registered_meta_count'  => [ 'type' => 'integer' ],
+						'registered_meta'        => [ 'type' => 'array' ],
+						'recommendations'        => [ 'type' => 'array' ],
+						'gotcha_note'            => [ 'type' => 'string' ],
+					],
+				],
+				'meta'                => [
+					'mcp'          => [ 'public' => true ],
+					'annotations'  => [
+						'readonly'    => true,
+						'destructive' => false,
+						'idempotent'  => true,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_inspect_rest_meta' ],
+				'permission_callback' => static function (): bool {
+					return ToolCapabilities::current_user_can( self::ABILITY_ID );
+				},
+			]
+		);
+	}
+
+	/**
+	 * Handle a REST meta diagnostic request.
+	 *
+	 * @param array<string,mixed> $input Input arguments.
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public static function handle_inspect_rest_meta( array $input = array() ) {
+		$post_type = isset( $input['post_type'] ) ? trim( (string) $input['post_type'] ) : '';
+		$meta_key  = isset( $input['meta_key'] ) ? trim( (string) $input['meta_key'] ) : '';
+
+		if ( '' === $post_type ) {
+			return new WP_Error(
+				'sd_ai_agent_rest_meta_missing_post_type',
+				__( 'A `post_type` is required for REST meta diagnostics.', 'superdav-ai-agent' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$post_type_object       = get_post_type_object( $post_type );
+		$post_type_exists       = null !== $post_type_object;
+		$show_in_rest           = $post_type_exists ? (bool) $post_type_object->show_in_rest : false;
+		$rest_base              = null;
+		$supports_custom_fields = $post_type_exists ? post_type_supports( $post_type, 'custom-fields' ) : false;
+		$registered_meta        = array();
+
+		if ( $post_type_exists ) {
+			$rest_base       = is_string( $post_type_object->rest_base ) && '' !== $post_type_object->rest_base ? $post_type_object->rest_base : $post_type;
+			$registered_meta = self::summarize_registered_meta( $post_type, $meta_key );
+		}
+
+		$rest_visible_count = 0;
+		foreach ( $registered_meta as $entry ) {
+			if ( true === ( $entry['show_in_rest'] ?? false ) ) {
+				++$rest_visible_count;
+			}
+		}
+
+		$has_required_meta = '' === $meta_key ? $rest_visible_count > 0 : self::contains_rest_visible_meta_key( $registered_meta, $meta_key );
+		$rest_writable     = $post_type_exists && $show_in_rest && $supports_custom_fields && $has_required_meta;
+		$recommendations   = self::build_recommendations( $post_type, $meta_key, $post_type_exists, $show_in_rest, $supports_custom_fields, $has_required_meta );
+
+		return [
+			'post_type'              => $post_type,
+			'post_type_exists'       => $post_type_exists,
+			'rest_base'              => $rest_base,
+			'show_in_rest'           => $show_in_rest,
+			'supports_custom_fields' => $supports_custom_fields,
+			'rest_meta_writable'     => $rest_writable,
+			'registered_meta_count'  => count( $registered_meta ),
+			'registered_meta'        => $registered_meta,
+			'recommendations'        => $recommendations,
+			'gotcha_note'            => __( 'WordPress REST post meta writes can return 200 OK while dropping meta when the post type is not REST-visible, lacks custom-fields support, or the meta key is not registered with show_in_rest.', 'superdav-ai-agent' ),
+		];
+	}
+
+	/**
+	 * Summarize registered post meta without exposing callbacks or values.
+	 *
+	 * @param string $post_type Post type slug.
+	 * @param string $meta_key  Optional meta key filter.
+	 * @return array<int,array<string,mixed>>
+	 */
+	private static function summarize_registered_meta( string $post_type, string $meta_key = '' ): array {
+		$registered = get_registered_meta_keys( 'post', $post_type );
+		$entries    = array();
+
+		foreach ( $registered as $key => $args ) {
+			if ( '' !== $meta_key && (string) $key !== $meta_key ) {
+				continue;
+			}
+
+			if ( ! is_array( $args ) ) {
+				continue;
+			}
+
+			$entries[ (string) $key ] = [
+				'key'                   => (string) $key,
+				'type'                  => isset( $args['type'] ) ? (string) $args['type'] : 'string',
+				'single'                => ! empty( $args['single'] ),
+				'show_in_rest'          => ! empty( $args['show_in_rest'] ),
+				'has_default'           => array_key_exists( 'default', $args ),
+				'has_sanitize_callback' => ! empty( $args['sanitize_callback'] ),
+				'has_auth_callback'     => ! empty( $args['auth_callback'] ),
+			];
+		}
+
+		ksort( $entries );
+
+		return array_values( $entries );
+	}
+
+	/**
+	 * Check whether filtered entries contain a REST-visible meta key.
+	 *
+	 * @param array<int,array<string,mixed>> $registered_meta Registered meta summaries.
+	 * @param string                         $meta_key        Requested key.
+	 */
+	private static function contains_rest_visible_meta_key( array $registered_meta, string $meta_key ): bool {
+		foreach ( $registered_meta as $entry ) {
+			if ( $meta_key === ( $entry['key'] ?? '' ) && true === ( $entry['show_in_rest'] ?? false ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Build actionable recommendations.
+	 *
+	 * @param string $post_type              Post type slug.
+	 * @param string $meta_key               Optional meta key.
+	 * @param bool   $post_type_exists       Whether the post type exists.
+	 * @param bool   $show_in_rest           Whether the post type is REST-visible.
+	 * @param bool   $supports_custom_fields Whether the post type supports custom fields.
+	 * @param bool   $has_required_meta      Whether requested/any meta is REST-visible.
+	 * @return string[]
+	 */
+	private static function build_recommendations( string $post_type, string $meta_key, bool $post_type_exists, bool $show_in_rest, bool $supports_custom_fields, bool $has_required_meta ): array {
+		$recommendations = array();
+
+		if ( ! $post_type_exists ) {
+			return [ sprintf( 'Register the `%s` post type before attempting REST meta writes.', $post_type ) ];
+		}
+
+		if ( ! $show_in_rest ) {
+			$recommendations[] = sprintf( 'Register `%s` with `show_in_rest => true` so /wp/v2 routes accept the post type.', $post_type );
+		}
+
+		if ( ! $supports_custom_fields ) {
+			$recommendations[] = sprintf( 'Add `custom-fields` support for `%s` before writing REST meta.', $post_type );
+		}
+
+		if ( ! $has_required_meta ) {
+			if ( '' === $meta_key ) {
+				$recommendations[] = sprintf( 'Register each writable key with `register_post_meta( "%s", $key, [ "show_in_rest" => true, ... ] )`.', $post_type );
+			} else {
+				$recommendations[] = sprintf( 'Register meta key `%s` for `%s` with `show_in_rest => true`, or use a different write path for non-REST meta.', $meta_key, $post_type );
+			}
+		}
+
+		if ( array() === $recommendations ) {
+			$recommendations[] = __( 'REST meta writes should persist for the inspected key(s). If writes still fail, inspect auth_callback behaviour and the REST request body.', 'superdav-ai-agent' );
+		}
+
+		return $recommendations;
+	}
+}

--- a/includes/Abilities/ToolCapabilities.php
+++ b/includes/Abilities/ToolCapabilities.php
@@ -147,6 +147,7 @@ class ToolCapabilities {
 		'sd-ai-agent/batch-create-posts'         => 'edit_posts',
 		'sd-ai-agent/delete-post'                => 'delete_posts',
 		'sd-ai-agent/set-featured-image'         => 'edit_posts',
+		'sd-ai-agent/inspect-rest-meta'          => 'edit_posts',
 		'sd-ai-agent/revert-to-revision'         => 'edit_posts',
 		'sd-ai-agent/generate-title'             => 'edit_posts',
 		'sd-ai-agent/generate-excerpt'           => 'edit_posts',

--- a/includes/Abilities/WpRestAbilities.php
+++ b/includes/Abilities/WpRestAbilities.php
@@ -487,6 +487,11 @@ class WpRestAbilities {
 			'endpoints' => array(),
 		);
 
+		$rest_meta_hint = self::get_rest_meta_diagnostic_hint( $route );
+		if ( null !== $rest_meta_hint ) {
+			$result['rest_meta_diagnostic_hint'] = $rest_meta_hint;
+		}
+
 		foreach ( $endpoints as $endpoint ) {
 			if ( ! is_array( $endpoint ) ) {
 				continue;
@@ -539,6 +544,33 @@ class WpRestAbilities {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Return a focused REST meta diagnostic hint for post-type collection routes.
+	 *
+	 * @param string $route REST route.
+	 * @return array<string,string>|null
+	 */
+	private static function get_rest_meta_diagnostic_hint( string $route ): ?array {
+		foreach ( get_post_types( array(), 'objects' ) as $post_type => $post_type_object ) {
+			if ( ! is_object( $post_type_object ) || empty( $post_type_object->show_in_rest ) ) {
+				continue;
+			}
+
+			$rest_base = is_string( $post_type_object->rest_base ) && '' !== $post_type_object->rest_base ? $post_type_object->rest_base : (string) $post_type;
+			if ( '/wp/v2/' . $rest_base !== $route ) {
+				continue;
+			}
+
+			return array(
+				'ability'   => RestMetaAbilities::ABILITY_ID,
+				'post_type' => (string) $post_type,
+				'note'      => __( 'If REST `meta` writes return 200 OK but do not persist, call this read-only ability to inspect custom-fields support and REST-visible registered meta keys.', 'superdav-ai-agent' ),
+			);
+		}
+
+		return null;
 	}
 
 	/**

--- a/includes/Bootstrap/AbilitiesHandler.php
+++ b/includes/Bootstrap/AbilitiesHandler.php
@@ -59,6 +59,7 @@ use SdAiAgent\Abilities\PluginBuilderAbilities;
 use SdAiAgent\Abilities\PluginDownloadAbilities;
 use SdAiAgent\PluginBuilder\PluginSandbox;
 use SdAiAgent\Abilities\PostAbilities;
+use SdAiAgent\Abilities\RestMetaAbilities;
 use SdAiAgent\Core\Features;
 use SdAiAgent\Abilities\SeoAbilities;
 use SdAiAgent\Abilities\SiteHealthAbilities;
@@ -208,6 +209,7 @@ final class AbilitiesHandler {
 		NavigationAbilities::register_abilities();
 		MenuAbilities::register_abilities();
 		PostAbilities::register_abilities();
+		RestMetaAbilities::register_abilities();
 		UrlResolverAbilities::register_abilities();
 		CustomPostTypeAbilities::register_abilities();
 		CustomTaxonomyAbilities::register_abilities();

--- a/tests/SdAiAgent/Abilities/WpRestAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/WpRestAbilitiesTest.php
@@ -528,4 +528,45 @@ class WpRestAbilitiesTest extends WP_UnitTestCase {
 			$this->assertArrayHasKey( 'status', $result );
 		}
 	}
+
+	/**
+	 * Register a REST-visible CPT for REST meta tests.
+	 *
+	 * @param bool $supports_custom_fields Whether to include custom-fields support.
+	 */
+	private function register_rest_meta_book_type( bool $supports_custom_fields ): void {
+		$supports = array( 'title', 'editor' );
+		if ( $supports_custom_fields ) {
+			$supports[] = 'custom-fields';
+		}
+
+		register_post_type(
+			'sd_rest_meta_book',
+			array(
+				'label'        => 'REST Meta Books',
+				'public'       => true,
+				'show_in_rest' => true,
+				'rest_base'    => 'sd-rest-meta-books',
+				'supports'     => $supports,
+			)
+		);
+	}
+
+	/**
+	 * Register a REST-visible test meta key with callback presence.
+	 */
+	private function register_book_rating_meta(): void {
+		register_post_meta(
+			'sd_rest_meta_book',
+			'_sd_ai_agent_rest_meta_rating',
+			array(
+				'type'              => 'integer',
+				'single'            => true,
+				'show_in_rest'      => true,
+				'default'           => 0,
+				'sanitize_callback' => 'absint',
+				'auth_callback'     => '__return_true',
+			)
+		);
+	}
 }


### PR DESCRIPTION
## Summary

Added sd-ai-agent/inspect-rest-meta as a read-only REST post meta diagnostic ability, registered it for MCP/public discovery, mapped its core capability, and added wp-rest/inspect hints for post collection routes.

## Files Changed

includes/Abilities/RestMetaAbilities.php,includes/Abilities/ToolCapabilities.php,includes/Abilities/WpRestAbilities.php,includes/Bootstrap/AbilitiesHandler.php,tests/SdAiAgent/Abilities/WpRestAbilitiesTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run test:php -- --filter="WpRestAbilitiesTest|ToolCapabilitiesTest" => OK (49 tests, 554 assertions); npm run lint:php => clean; composer phpstan => 0 errors; npm run verify => PHPUnit Tests: 3565, Assertions: 14880, Errors: 0, Failures: 0, Skipped: 118, Incomplete: 4; lint/PHPStan/build/bundle succeeded

Resolves #2080


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.43 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 25m and 171,973 tokens on this as a headless worker.