### PR TITLE
Fix live homepage content reflection

### DIFF
--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -862,6 +862,7 @@ class BlockAbilities {
 							'type'        => 'array',
 							'description' => 'The resulting block tree after all updates.',
 						],
+						'affected'    => self::post_content_affected_output_schema(),
 						'dry_run'     => [ 'type' => 'boolean' ],
 						'error'       => [ 'type' => 'string' ],
 					],
@@ -3161,13 +3162,57 @@ class BlockAbilities {
 			RateLimiter::record( 'write', $post_id );
 		}
 
-		return [
+		$response = [
 			'success'     => true,
 			'dry_run'     => $dry_run,
 			'post_id'     => $post_id,
 			'updates'     => count( $updates ),
 			'revision_id' => RevisionGuard::current_revision_id( $post_id ),
 			'block_tree'  => self::annotate_bindings_tree( $new_tree ),
+		];
+
+		if ( ! $dry_run ) {
+			$response['affected'] = self::build_post_content_affected_payload( $post_id );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Build the output schema for a post-content affected descriptor.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private static function post_content_affected_output_schema(): array {
+		return [
+			'type'        => 'object',
+			'description' => 'Transport descriptor for the frontend reflection bus — identifies the mutated post content so the current public page can update without a full reload.',
+			'properties'  => [
+				'kind'    => [ 'type' => 'string' ],
+				'post_id' => [ 'type' => 'integer' ],
+				'url'     => [ 'type' => 'string' ],
+				'fields'  => [
+					'type'  => 'array',
+					'items' => [ 'type' => 'string' ],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Build an affected descriptor for block-tree post-content mutations.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return array<string,mixed>
+	 */
+	private static function build_post_content_affected_payload( int $post_id ): array {
+		$permalink = get_permalink( $post_id );
+
+		return [
+			'kind'    => 'post',
+			'post_id' => $post_id,
+			'url'     => is_string( $permalink ) ? $permalink : '',
+			'fields'  => [ 'post_content' ],
 		];
 	}
 

--- a/src/floating-widget/reflectors/__tests__/post.test.js
+++ b/src/floating-widget/reflectors/__tests__/post.test.js
@@ -82,6 +82,22 @@ describe( 'post reflector', () => {
 		).toEqual( [ '.entry-title', '.entry-content' ] );
 	} );
 
+	test( 'pickTargetsForFields falls back to the block-theme site tree for post content', () => {
+		document.body.innerHTML = `
+			<div class="wp-site-blocks"><h1>Old homepage</h1></div>
+		`;
+		const fresh = new DOMParser().parseFromString(
+			`
+				<div class="wp-site-blocks"><h1>Fresh homepage</h1></div>
+			`,
+			'text/html'
+		);
+
+		expect(
+			pickTargetsForFields( document, fresh, [ 'post_content' ] )
+		).toEqual( [ '.wp-site-blocks' ] );
+	} );
+
 	test( 'reflectPost fetches the current post and morphs changed field targets', async () => {
 		document.body.innerHTML = `
 			<h1 class="entry-title">Old title</h1>

--- a/src/floating-widget/reflectors/post.js
+++ b/src/floating-widget/reflectors/post.js
@@ -28,15 +28,13 @@ const FIELD_SELECTORS = {
  * Normalize a URL to a comparable path without query, hash, or trailing slash.
  *
  * @param {string} url URL or path to normalize.
- * @return {string} Normalized pathname.
+ * @return {string|undefined} Normalized pathname.
  */
 function normalizePath( url ) {
 	try {
 		const parsed = new URL( url, window.location.origin );
 		return parsed.pathname.replace( /\/+$/, '' ) || '/';
-	} catch {
-		return '';
-	}
+	} catch {}
 }
 
 /**

--- a/src/floating-widget/reflectors/post.js
+++ b/src/floating-widget/reflectors/post.js
@@ -13,6 +13,10 @@ const FIELD_SELECTORS = {
 		'.wp-block-post-content',
 		'.entry-content',
 		'article .entry-content',
+		// Block themes can render the homepage/front-page template without a
+		// dedicated post-content wrapper. In that case, morph the public site
+		// block tree so content edited through the agent appears immediately.
+		'.wp-site-blocks',
 	],
 	post_excerpt: [ '.wp-block-post-excerpt', '.entry-summary' ],
 	featured_image: [

--- a/src/floating-widget/reflectors/post.js
+++ b/src/floating-widget/reflectors/post.js
@@ -12,7 +12,6 @@ const FIELD_SELECTORS = {
 	post_content: [
 		'.wp-block-post-content',
 		'.entry-content',
-		'article .entry-content',
 		// Block themes can render the homepage/front-page template without a
 		// dedicated post-content wrapper. In that case, morph the public site
 		// block tree so content edited through the agent appears immediately.

--- a/tests/SdAiAgent/Core/BlockMutatorBatchTest.php
+++ b/tests/SdAiAgent/Core/BlockMutatorBatchTest.php
@@ -456,6 +456,11 @@ class BlockMutatorBatchTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result );
 		$this->assertTrue( $result['success'] );
 		$this->assertSame( 5, $result['updates'] );
+		$this->assertArrayHasKey( 'affected', $result );
+		$this->assertSame( 'post', $result['affected']['kind'] );
+		$this->assertSame( $post_id, $result['affected']['post_id'] );
+		$this->assertNotEmpty( $result['affected']['url'] );
+		$this->assertContains( 'post_content', $result['affected']['fields'] );
 
 		// Count revisions after.
 		$revisions_after = count( wp_get_post_revisions( $post_id ) );


### PR DESCRIPTION
## Summary
- Add an `affected` descriptor to `sd-ai-agent/update-blocks` results so block mutations emit live-preview reflection events.
- Add a block-theme `.wp-site-blocks` fallback target so homepage/front-page content can morph when there is no post-content wrapper.
- Cover both the PHP affected payload and JS reflector fallback with tests.

## Worker self-verification
- PHPUnit: `npm run test:php -- --filter=BlockMutatorBatchTest` — OK (21 tests, 86 assertions)
- JS: `npm run test:js -- --runTestsByPath src/floating-widget/reflectors/__tests__/post.test.js --runInBand` — PASS (7 tests)
- PHPCS: `vendor/bin/phpcs includes/Abilities/BlockAbilities.php tests/SdAiAgent/Core/BlockMutatorBatchTest.php` — clean
- Full suite/build: not run (targeted live-update fix; `npm run start` already running per request)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Block updates now expose an "affected" field identifying which posts were modified and which content fields were changed

* **Improvements**
  * Enhanced content reflector to support block themes that render post content without dedicated wrapper elements

* **Tests**
  * Added test coverage for the new affected field tracking and fallback content selection in block themes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->