### PR TITLE
fix: register active jobs cleanup cron

### DIFF
--- a/includes/Bootstrap/AdminHandler.php
+++ b/includes/Bootstrap/AdminHandler.php
@@ -19,6 +19,7 @@ use SdAiAgent\Admin\FloatingWidget;
 use SdAiAgent\Admin\ThirdPartyAbilityNoticeHandler;
 use SdAiAgent\Admin\UnifiedAdminMenu;
 use SdAiAgent\Compat\GutenbergConnectorsBridge;
+use SdAiAgent\Core\ActiveJobsCleanupService;
 use SdAiAgent\Core\Database;
 use XWP\DI\Decorators\Action;
 use XWP\DI\Decorators\Filter;
@@ -75,6 +76,7 @@ final class AdminHandler {
 	 * Admin init hooks.
 	 *
 	 * - DB schema safety-net (dbDelta is no-op when schema is current).
+	 * - Active job stale-cleanup cron safety-net for cloned/provisioned tenants.
 	 * - Per-tool capabilities for role-management plugins.
 	 * - Legacy URL redirects to unified menu.
 	 * - Handle third-party ability notice dismissal.
@@ -83,6 +85,7 @@ final class AdminHandler {
 	#[Action( tag: 'admin_init', priority: 10 )]
 	public function on_admin_init(): void {
 		Database::install();
+		ActiveJobsCleanupService::schedule();
 		ToolCapabilities::register_capabilities( ToolCapabilities::all_ability_ids() );
 		UnifiedAdminMenu::handleLegacyRedirects();
 		ThirdPartyAbilityNoticeHandler::handle_dismiss();

--- a/superdav-ai-agent.php
+++ b/superdav-ai-agent.php
@@ -274,6 +274,7 @@ use SdAiAgent\Bootstrap\LifecycleHandler;
 use SdAiAgent\Compat\AiBridgeLoader;
 use SdAiAgent\Compat\GutenbergConnectorsBridge;
 use SdAiAgent\Compat\SdkLoader;
+use SdAiAgent\Core\ActiveJobsCleanupService;
 use SdAiAgent\Plugin;
 
 // Phase 1 (t227): Register the bundled wordpress/php-ai-client SDK autoloader.
@@ -304,6 +305,11 @@ require_once SD_AI_AGENT_DIR . '/includes/Compat/wp-connectors-polyfill.php';
 // directly requiring Gutenberg's loader restores the full subsystem.
 // On WP 7.0+ (or without Gutenberg ≥ 22.8.0) this hook is a no-op.
 add_action( 'plugins_loaded', [ GutenbergConnectorsBridge::class, 'force_load_connectors_subsystem' ], 1 );
+
+// Register the stale active-jobs cron callback directly from the plugin file so
+// standalone cron runners and queue-worker subprocesses do not depend on admin
+// or REST DI contexts before the hook can be executed.
+add_action( ActiveJobsCleanupService::CRON_HOOK, [ ActiveJobsCleanupService::class, 'run' ] );
 
 // Activation / deactivation hooks fire *before* `plugins_loaded`, so they
 // cannot be wired through the DI container. `LifecycleHandler` consolidates


### PR DESCRIPTION
## Summary
- Register the stale active-jobs cleanup cron callback from plugin bootstrap.
- Schedule cleanup during `admin_init` as a safety net for cloned/provisioned tenants.

## Verification
- `php -l includes/Bootstrap/AdminHandler.php`
- `php -l superdav-ai-agent.php`
- Pre-commit hook ran `vendor/bin/phpcbf` and `vendor/bin/phpcs` successfully for the staged PHP files.

## Notes
- Direct push to `main` was blocked by repository rules; this PR carries the preserved branch fix.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.43 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5
