### PR TITLE
GH#1902: fix: intercept raw text tool calls

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -983,6 +983,15 @@ class AgentLoop {
 			// name+arguments pair so metrics and provider time reflect real work.
 			$assistant_message = $this->deduplicate_tool_calls( $assistant_message );
 
+			$intercepted_xml_tool_call = $this->intercept_text_tool_call( $assistant_message );
+			if ( $intercepted_xml_tool_call instanceof Message ) {
+				$assistant_message = $intercepted_xml_tool_call;
+			} elseif ( is_string( $intercepted_xml_tool_call ) ) {
+				$this->history[]       = new UserMessage( array( new MessagePart( $intercepted_xml_tool_call ) ) );
+				$this->last_loop_phase = 'text_tool_call_corrective_prompt';
+				continue;
+			}
+
 			// Split multi-part assistant messages so each function_call lives
 			// in its own ModelMessage. The OpenAI Responses API rejects
 			// "function_call + other part" shapes (see
@@ -1963,6 +1972,120 @@ class AgentLoop {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Convert raw XML-ish tool-call text into an executable ability-call turn.
+	 *
+	 * Some OpenAI-compatible models trained on XML tool-use traces emit strings
+	 * such as `<tool_call>wpab__sd-ai-agent__get-themes</tool_call>` in assistant
+	 * content instead of using the provider's structured tool-call channel. Catch
+	 * that before the text can become the user-visible final reply.
+	 *
+	 * @param Message $message Assistant message returned by the model.
+	 * @return Message|string|null Synthetic tool-call message, corrective prompt, or null.
+	 */
+	private function intercept_text_tool_call( Message $message ): Message|string|null {
+		if ( $this->message_has_function_calls( $message ) ) {
+			return null;
+		}
+
+		$text = $this->message_text( $message );
+		if ( '' === trim( $text ) ) {
+			return null;
+		}
+
+		$raw_tool_name = $this->extract_text_tool_call_name( $text );
+		if ( null === $raw_tool_name ) {
+			return null;
+		}
+
+		$ability_name = $this->resolve_text_tool_call_ability_name( $raw_tool_name );
+		if ( null === $ability_name ) {
+			return sprintf(
+				/* translators: %s: invalid tool name emitted as text. */
+				__( 'Tool "%s" is not invokable as assistant text. Do not write XML-like tool calls in the reply. Use `sd-ai-agent/ability-search` to find a valid ability, then call `sd-ai-agent/ability-call` with the ability name and arguments.', 'superdav-ai-agent' ),
+				$raw_tool_name
+			);
+		}
+
+		return new ModelMessage(
+			array(
+				new MessagePart(
+					new FunctionCall(
+						'text_tool_call_' . substr( md5( $raw_tool_name ), 0, 12 ),
+						'wpab__sd-ai-agent__ability-call',
+						array(
+							'ability'   => $ability_name,
+							'arguments' => array(),
+						)
+					)
+				),
+			)
+		);
+	}
+
+	/**
+	 * Concatenate text parts from an assistant message.
+	 *
+	 * @param Message $message Assistant message returned by the model.
+	 * @return string Text content.
+	 */
+	private function message_text( Message $message ): string {
+		$text = '';
+
+		foreach ( $message->getParts() as $part ) {
+			if ( method_exists( $part, 'getText' ) && is_string( $part->getText() ) ) {
+				$text .= $part->getText() . "\n";
+			}
+		}
+
+		return trim( $text );
+	}
+
+	/**
+	 * Extract the first XML-ish tool-call name from assistant text.
+	 *
+	 * @param string $text Assistant text.
+	 * @return string|null Raw tool/function name.
+	 */
+	private function extract_text_tool_call_name( string $text ): ?string {
+		$patterns = array(
+			'/<tool_call>\s*([^\s<>]+)\s*<\/tool_call>/i',
+			'/<tool>\s*([^\s<>]+)\s*<\/tool>/i',
+			'/<function_call\s+name=["\']([^"\'<>]+)["\']\s*\/?\s*>/i',
+		);
+
+		foreach ( $patterns as $pattern ) {
+			$matches = array();
+			if ( preg_match( $pattern, $text, $matches ) ) {
+				return trim( (string) $matches[1] );
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Resolve a raw function/tool name from text into a registered ability name.
+	 *
+	 * @param string $raw_tool_name Raw name from assistant text.
+	 * @return string|null Registered ability name, or null when unknown.
+	 */
+	private function resolve_text_tool_call_ability_name( string $raw_tool_name ): ?string {
+		$ability_name = $raw_tool_name;
+
+		if ( str_starts_with( $ability_name, 'wpab__' ) && class_exists( 'WP_AI_Client_Ability_Function_Resolver' ) ) {
+			$ability_name = \WP_AI_Client_Ability_Function_Resolver::function_name_to_ability_name( $ability_name );
+		} elseif ( str_starts_with( $ability_name, 'wpab__sd-ai-agent__' ) ) {
+			$ability_name = 'sd-ai-agent/' . substr( $ability_name, strlen( 'wpab__sd-ai-agent__' ) );
+		}
+
+		if ( ! str_contains( $ability_name, '/' ) ) {
+			return null;
+		}
+
+		return AbilityRegistry::get( $ability_name ) instanceof \WP_Ability ? $ability_name : null;
 	}
 
 	/**

--- a/includes/Core/SystemInstructionBuilder.php
+++ b/includes/Core/SystemInstructionBuilder.php
@@ -295,7 +295,8 @@ class SystemInstructionBuilder {
 			. 'Only call abilities that are present in the current direct tool list. '
 			. 'Active first-party direct tools this turn: ' . $direct_list . ".\n"
 			. 'If any prompt, memory, or manifest text mentions another `sd-ai-agent/<ability>` name, do not emit its direct `wpab__...` tool call. '
-			. 'Use `sd-ai-agent/ability-search` to fetch its schema, then invoke it through `sd-ai-agent/ability-call`.';
+			. 'Use `sd-ai-agent/ability-search` to fetch its schema, then invoke it through `sd-ai-agent/ability-call`. '
+			. 'For any ability listed in the catalog below, you MUST call `sd-ai-agent/ability-call` with `{"ability":"<name>","arguments":{...}}`; never write `<tool_call>wpab__...` or the ability name as text in the reply.';
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -170,6 +170,70 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertCount( 3, $history, 'Non-DeepSeek providers should keep the generic split behavior.' );
 	}
 
+	/**
+	 * XML-ish tool-call text should become an ability-call function part, not a final reply.
+	 */
+	public function test_intercepts_xml_tool_call_text_as_ability_call(): void {
+		if ( ! class_exists( 'WordPress\AiClient\Messages\DTO\ModelMessage' ) ) {
+			$this->markTestSkipped( 'WP AI Client message classes are not available.' );
+		}
+
+		if ( ! function_exists( 'wp_has_ability' ) || ! wp_has_ability( 'sd-ai-agent/get-themes' ) ) {
+			$this->markTestSkipped( 'sd-ai-agent/get-themes ability is not registered.' );
+		}
+
+		$loop    = new AgentLoop( 'List installed themes.' );
+		$message = new \WordPress\AiClient\Messages\DTO\ModelMessage(
+			array(
+				new \WordPress\AiClient\Messages\DTO\MessagePart( '<tool_call>wpab__sd-ai-agent__get-themes</tool_call>' ),
+			)
+		);
+
+		$method = new \ReflectionMethod( AgentLoop::class, 'intercept_text_tool_call' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $loop, $message );
+
+		$this->assertInstanceOf( \WordPress\AiClient\Messages\DTO\Message::class, $result );
+		$this->assertCount( 1, $result->getParts() );
+
+		$call = $result->getParts()[0]->getFunctionCall();
+		$this->assertInstanceOf( \WordPress\AiClient\Tools\DTO\FunctionCall::class, $call );
+		$this->assertSame( 'wpab__sd-ai-agent__ability-call', $call->getName() );
+		$this->assertSame(
+			array(
+				'ability'   => 'sd-ai-agent/get-themes',
+				'arguments' => array(),
+			),
+			$call->getArgs()
+		);
+	}
+
+	/**
+	 * Unknown XML-ish tool-call text should produce corrective guidance for another loop turn.
+	 */
+	public function test_unknown_xml_tool_call_text_gets_corrective_prompt(): void {
+		if ( ! class_exists( 'WordPress\AiClient\Messages\DTO\ModelMessage' ) ) {
+			$this->markTestSkipped( 'WP AI Client message classes are not available.' );
+		}
+
+		$loop    = new AgentLoop( 'Do something.' );
+		$message = new \WordPress\AiClient\Messages\DTO\ModelMessage(
+			array(
+				new \WordPress\AiClient\Messages\DTO\MessagePart( '<function_call name="wpab__sd-ai-agent__missing-tool"/>' ),
+			)
+		);
+
+		$method = new \ReflectionMethod( AgentLoop::class, 'intercept_text_tool_call' );
+		$method->setAccessible( true );
+
+		$result = $method->invoke( $loop, $message );
+
+		$this->assertIsString( $result );
+		$this->assertStringContainsString( 'not invokable as assistant text', $result );
+		$this->assertStringContainsString( 'sd-ai-agent/ability-call', $result );
+	}
+
 	// -------------------------------------------------------------------------
 	// Helpers
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Intercept XML-like assistant content tool-call strings before they can become final user-visible replies; known registered abilities are routed through sd-ai-agent/ability-call and unknown names trigger corrective model guidance. Strengthened Tier-2 tool-routing prompt guidance and added AgentLoop regression coverage.

## Files Changed

includes/Core/AgentLoop.php,includes/Core/SystemInstructionBuilder.php,tests/SdAiAgent/Core/AgentLoopTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify — PHPUnit: Tests: 3574, Assertions: 14924, Errors: 0, Failures: 0, Skipped: 118, Incomplete: 4; lint PHP/JS/CSS clean; PHPStan 0 errors; build succeeded; bundle check passed

Resolves #1902


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.43 plugin for [OpenCode](https://opencode.ai) v1.16.2 with gpt-5.5 spent 12m and 222,593 tokens on this as a headless worker.