### PR TITLE
Fix client tool refresh and job error reporting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -133,7 +133,7 @@
 	"scripts": {
 		"phpcs": "vendor/bin/phpcs",
 		"phpcbf": "vendor/bin/phpcbf",
-		"phpstan": "vendor/bin/phpstan analyse",
+		"phpstan": "php -d memory_limit=1G vendor/bin/phpstan analyse",
 		"test": "vendor/bin/phpunit",
 		"test:stress": "vendor/bin/phpunit --testsuite=stress",
 		"lint": ["@phpcs", "@phpstan"]

--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -2933,6 +2933,67 @@ class BlockAbilities {
 	}
 
 	/**
+	 * Build the output schema for a post-content affected descriptor.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private static function post_content_affected_output_schema(): array {
+		return [
+			'type'        => 'object',
+			'description' => 'Transport descriptor for the frontend reflection bus — identifies the mutated post content so the current public page can update without a full reload.',
+			'properties'  => [
+				'kind'      => [ 'type' => 'string' ],
+				'post_id'   => [ 'type' => 'integer' ],
+				'post_type' => [ 'type' => 'string' ],
+				'url'       => [ 'type' => 'string' ],
+				'fields'    => [
+					'type'  => 'array',
+					'items' => [ 'type' => 'string' ],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Build the frontend live-preview affected descriptor for block writes.
+	 *
+	 * Block abilities only mutate post_content, so the descriptor always targets
+	 * a post and lists post_content as the changed field. Dry-run callers should
+	 * omit the descriptor because no visible page changed.
+	 *
+	 * @param int $post_id Mutated post ID.
+	 * @return array<string,mixed>
+	 */
+	private static function build_post_content_affected_payload( int $post_id ): array {
+		$post      = get_post( $post_id );
+		$permalink = get_permalink( $post_id );
+
+		return [
+			'kind'      => 'post',
+			'post_id'   => $post_id,
+			'post_type' => $post instanceof \WP_Post ? $post->post_type : '',
+			'url'       => is_string( $permalink ) ? $permalink : '',
+			'fields'    => [ 'post_content' ],
+		];
+	}
+
+	/**
+	 * Attach affected metadata to a successful block-write response.
+	 *
+	 * @param array<string,mixed> $response Ability response.
+	 * @param int                 $post_id  Mutated post ID.
+	 * @param bool                $dry_run  Whether the write was skipped.
+	 * @return array<string,mixed>
+	 */
+	private static function with_post_content_affected_payload( array $response, int $post_id, bool $dry_run = false ): array {
+		if ( ! $dry_run ) {
+			$response['affected'] = self::build_post_content_affected_payload( $post_id );
+		}
+
+		return $response;
+	}
+
+	/**
 	 * Handle the sd-ai-agent/edit-block-tree ability.
 	 *
 	 * Loads the post's block tree, applies the requested mutation via
@@ -3032,13 +3093,17 @@ class BlockAbilities {
 			RateLimiter::record( 'write', $post_id );
 		}
 
-		return [
-			'success'    => true,
-			'dry_run'    => $dry_run,
-			'op'         => $op,
-			'post_id'    => $post_id,
-			'block_tree' => self::annotate_bindings_tree( $new_tree ),
-		];
+		return self::with_post_content_affected_payload(
+			[
+				'success'    => true,
+				'dry_run'    => $dry_run,
+				'op'         => $op,
+				'post_id'    => $post_id,
+				'block_tree' => self::annotate_bindings_tree( $new_tree ),
+			],
+			$post_id,
+			$dry_run
+		);
 	}
 
 	// ─── update-blocks (batch) handler ────────────────────────────
@@ -3162,58 +3227,18 @@ class BlockAbilities {
 			RateLimiter::record( 'write', $post_id );
 		}
 
-		$response = [
-			'success'     => true,
-			'dry_run'     => $dry_run,
-			'post_id'     => $post_id,
-			'updates'     => count( $updates ),
-			'revision_id' => RevisionGuard::current_revision_id( $post_id ),
-			'block_tree'  => self::annotate_bindings_tree( $new_tree ),
-		];
-
-		if ( ! $dry_run ) {
-			$response['affected'] = self::build_post_content_affected_payload( $post_id );
-		}
-
-		return $response;
-	}
-
-	/**
-	 * Build the output schema for a post-content affected descriptor.
-	 *
-	 * @return array<string,mixed>
-	 */
-	private static function post_content_affected_output_schema(): array {
-		return [
-			'type'        => 'object',
-			'description' => 'Transport descriptor for the frontend reflection bus — identifies the mutated post content so the current public page can update without a full reload.',
-			'properties'  => [
-				'kind'    => [ 'type' => 'string' ],
-				'post_id' => [ 'type' => 'integer' ],
-				'url'     => [ 'type' => 'string' ],
-				'fields'  => [
-					'type'  => 'array',
-					'items' => [ 'type' => 'string' ],
-				],
+		return self::with_post_content_affected_payload(
+			[
+				'success'     => true,
+				'dry_run'     => $dry_run,
+				'post_id'     => $post_id,
+				'updates'     => count( $updates ),
+				'revision_id' => RevisionGuard::current_revision_id( $post_id ),
+				'block_tree'  => self::annotate_bindings_tree( $new_tree ),
 			],
-		];
-	}
-
-	/**
-	 * Build an affected descriptor for block-tree post-content mutations.
-	 *
-	 * @param int $post_id Post ID.
-	 * @return array<string,mixed>
-	 */
-	private static function build_post_content_affected_payload( int $post_id ): array {
-		$permalink = get_permalink( $post_id );
-
-		return [
-			'kind'    => 'post',
-			'post_id' => $post_id,
-			'url'     => is_string( $permalink ) ? $permalink : '',
-			'fields'  => [ 'post_content' ],
-		];
+			$post_id,
+			$dry_run
+		);
 	}
 
 	// ─── rewrite-post-blocks handler ──────────────────────────────
@@ -3349,13 +3374,16 @@ class BlockAbilities {
 		// Record rate-limit tick after successful rewrite.
 		RateLimiter::record( 'rewrite', $post_id );
 
-		return [
-			'success'     => true,
-			'post_id'     => $post_id,
-			'revision_id' => RevisionGuard::current_revision_id( $post_id ),
-			'block_count' => count( $final_tree ),
-			'refs_count'  => $refs_count,
-		];
+		return self::with_post_content_affected_payload(
+			[
+				'success'     => true,
+				'post_id'     => $post_id,
+				'revision_id' => RevisionGuard::current_revision_id( $post_id ),
+				'block_count' => count( $final_tree ),
+				'refs_count'  => $refs_count,
+			],
+			$post_id
+		);
 	}
 
 	/**
@@ -3712,15 +3740,19 @@ class BlockAbilities {
 			RateLimiter::record( 'write', $post_id );
 		}
 
-		return [
-			'success'         => true,
-			'dry_run'         => $dry_run,
-			'post_id'         => $post_id,
-			'pattern_type'    => $pattern_type,
-			'blocks_inserted' => $blocks_inserted,
-			'revision_id'     => RevisionGuard::current_revision_id( $post_id ),
-			'block_tree'      => self::annotate_bindings_tree( $blocks ),
-		];
+		return self::with_post_content_affected_payload(
+			[
+				'success'         => true,
+				'dry_run'         => $dry_run,
+				'post_id'         => $post_id,
+				'pattern_type'    => $pattern_type,
+				'blocks_inserted' => $blocks_inserted,
+				'revision_id'     => RevisionGuard::current_revision_id( $post_id ),
+				'block_tree'      => self::annotate_bindings_tree( $blocks ),
+			],
+			$post_id,
+			$dry_run
+		);
 	}
 
 	// ─── replace-block-range handler ──────────────────────────────
@@ -3889,15 +3921,19 @@ class BlockAbilities {
 		// @phpstan-ignore-next-line
 		$block_count = self::count_blocks_in_tree( $result );
 
-		return [
-			'post_id'        => $post_id,
-			'revision_id'    => RevisionGuard::current_revision_id( $post_id ),
-			'refs_added'     => $refs_added,
-			'refs_removed'   => $refs_removed,
-			'refs_preserved' => $refs_preserved,
-			'block_count'    => $block_count,
-			'dry_run'        => $dry_run,
-		];
+		return self::with_post_content_affected_payload(
+			[
+				'post_id'        => $post_id,
+				'revision_id'    => RevisionGuard::current_revision_id( $post_id ),
+				'refs_added'     => $refs_added,
+				'refs_removed'   => $refs_removed,
+				'refs_preserved' => $refs_preserved,
+				'block_count'    => $block_count,
+				'dry_run'        => $dry_run,
+			],
+			$post_id,
+			$dry_run
+		);
 	}
 
 	// ─── revert-to-revision handler ───────────────────────────────
@@ -3952,7 +3988,7 @@ class BlockAbilities {
 		// Record rate-limit tick after successful revert.
 		RateLimiter::record( 'write', $post_id );
 
-		return $result;
+		return self::with_post_content_affected_payload( $result, $post_id );
 	}
 
 	// ─── Tree-counting helpers ────────────────────────────────────

--- a/includes/Abilities/Js/JsAbilityCatalog.php
+++ b/includes/Abilities/Js/JsAbilityCatalog.php
@@ -64,6 +64,28 @@ class JsAbilityCatalog {
 				'screens'       => array( 'all' ),
 			),
 			array(
+				'name'          => 'sd-ai-agent-js/refresh-page',
+				'label'         => 'Refresh Current Page',
+				'description'   => 'Refresh the current browser page while preserving the open AI Agent widget and current session. Use after site changes that did not return an affected descriptor for live preview.',
+				'category'      => 'sd-ai-agent-js',
+				'input_schema'  => array(
+					'type'       => 'object',
+					'properties' => array(),
+					'required'   => array(),
+				),
+				'output_schema' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'refresh_scheduled' => array( 'type' => 'boolean' ),
+						'url'               => array( 'type' => 'string' ),
+					),
+				),
+				'annotations'   => array(
+					'readonly' => true,
+				),
+				'screens'       => array( 'all' ),
+			),
+			array(
 				'name'          => 'sd-ai-agent-js/insert-block',
 				'label'         => 'Insert Block',
 				'description'   => 'Insert a Gutenberg block into the active block editor. Only available on editor screens.',

--- a/includes/Admin/FloatingWidget.php
+++ b/includes/Admin/FloatingWidget.php
@@ -167,6 +167,19 @@ class FloatingWidget {
 		}
 
 		$onboarding_complete = OnboardingManager::is_complete();
+		$is_frontend         = 'frontend' === $context;
+		$viewed_post_id      = 0;
+		$viewed_post_type    = '';
+		$viewed_title        = '';
+
+		if ( $is_frontend && is_singular() ) {
+			$viewed_post_id = (int) get_queried_object_id();
+			$viewed_post    = $viewed_post_id > 0 ? get_post( $viewed_post_id ) : null;
+			if ( $viewed_post instanceof \WP_Post ) {
+				$viewed_post_type = $viewed_post->post_type;
+				$viewed_title     = get_the_title( $viewed_post );
+			}
+		}
 
 		wp_localize_script(
 			'sd-ai-agent-floating-widget',
@@ -174,10 +187,13 @@ class FloatingWidget {
 			[
 				'currentUserId'       => get_current_user_id(),
 				'context'             => $context,
-				'isFrontend'          => 'frontend' === $context,
-				'frontendOnboarding'  => ( 'frontend' === $context && ! $onboarding_complete ) ? '1' : '',
+				'isFrontend'          => $is_frontend,
+				'frontendOnboarding'  => ( $is_frontend && ! $onboarding_complete ) ? '1' : '',
 				'onboarding_complete' => $onboarding_complete,
 				'changesPageUrl'      => admin_url( 'admin.php?page=sd-ai-agent#/changes' ),
+				'viewedPostId'        => $viewed_post_id,
+				'viewedPostType'      => $viewed_post_type,
+				'viewedTitle'         => $viewed_title,
 			]
 		);
 	}

--- a/includes/Core/ContextProviders.php
+++ b/includes/Core/ContextProviders.php
@@ -178,6 +178,39 @@ class ContextProviders {
 			$data['Current URL'] = $page_context['url'];
 		}
 
+		if ( ! empty( $page_context['surface'] ) ) {
+			$data['Surface'] = $page_context['surface'];
+		}
+
+		if ( ! empty( $page_context['is_frontend'] ) ) {
+			$data['User Is Viewing Frontend'] = 'Yes';
+		}
+
+		if ( ! empty( $page_context['page_title'] ) ) {
+			$data['Visible Page Title'] = $page_context['page_title'];
+		}
+
+		if ( ! empty( $page_context['post_id'] ) ) {
+			$data['Visible Post ID'] = (string) (int) $page_context['post_id'];
+		}
+
+		if ( ! empty( $page_context['post_type'] ) ) {
+			$data['Visible Post Type'] = $page_context['post_type'];
+		}
+
+		if ( ! empty( $page_context['live_preview'] ) && is_array( $page_context['live_preview'] ) ) {
+			$live_preview = $page_context['live_preview'];
+			if ( ! empty( $live_preview['affected_descriptor_supported'] ) ) {
+				$data['Live Preview Affected Descriptor Supported'] = 'Yes';
+			}
+			if ( ! empty( $live_preview['requires_refresh_when_missing_affected'] ) ) {
+				$data['Refresh Required When Affected Missing'] = 'Yes';
+			}
+			if ( ! empty( $live_preview['refresh_tool'] ) ) {
+				$data['Refresh Tool'] = $live_preview['refresh_tool'];
+			}
+		}
+
 		if ( ! empty( $page_context['admin_page'] ) ) {
 			$data['Admin Page'] = $page_context['admin_page'];
 		}

--- a/includes/Core/ConversationTrimmer.php
+++ b/includes/Core/ConversationTrimmer.php
@@ -104,9 +104,9 @@ class ConversationTrimmer {
 	 * Two-pass scrub to satisfy the Anthropic API invariant that every
 	 * tool_result has a matching tool_use earlier in the same request:
 	 *
-	 *   Pass 1 — forward: drop assistant messages whose FunctionCall parts
-	 *   do not all have matching FunctionResponse messages immediately after
-	 *   them. Also drops the partial response cluster.
+	 *   Pass 1 — forward: drop assistant tool-call clusters whose FunctionCall
+	 *   parts do not all have matching FunctionResponse messages immediately
+	 *   after the cluster. Also drops the partial response cluster.
 	 *
 	 *   Pass 2 — orphan tool_result scrub: walk the post-pass-1 history and
 	 *   drop any FunctionResponse whose tool_use_id is not present in the
@@ -141,9 +141,33 @@ class ConversationTrimmer {
 				continue;
 			}
 
-			// Collect the tool-response messages that follow.
+			// Collect consecutive assistant tool-call messages as one logical
+			// provider turn. ConversationSerializer::append_assistant_message()
+			// splits parallel function calls into separate ModelMessages for the
+			// OpenAI Responses API, while append_tool_response() appends the
+			// matching FunctionResponses after the whole split call cluster. Treating
+			// each split call message independently would falsely drop every call
+			// except the final one because the next message is another tool call,
+			// not a response. That was visible in traces as skill-load disappearing
+			// from history and being loaded again on the next turn.
+			$tool_call_ids = [];
+			$call_start    = $i;
+			$call_end      = $i;
+			while ( $call_end < $count ) {
+				$current_call_ids = self::extract_tool_call_ids( $history[ $call_end ] );
+				if ( empty( $current_call_ids ) ) {
+					break;
+				}
+				foreach ( $current_call_ids as $cid ) {
+					$tool_call_ids[] = $cid;
+				}
+				++$call_end;
+			}
+			$tool_call_ids = array_values( array_unique( $tool_call_ids ) );
+
+			// Collect the tool-response messages that follow the entire call cluster.
 			$response_ids   = [];
-			$response_start = $i + 1;
+			$response_start = $call_end;
 			$response_end   = $response_start;
 
 			while ( $response_end < $count ) {
@@ -162,14 +186,16 @@ class ConversationTrimmer {
 			$missing = array_diff( $tool_call_ids, $response_ids );
 
 			if ( empty( $missing ) ) {
-				// All tool calls have responses — keep the entire cycle.
-				$result[] = $message;
+				// All tool calls have responses — keep the entire split cycle.
+				for ( $j = $call_start; $j < $call_end; $j++ ) {
+					$result[] = $history[ $j ];
+				}
 				for ( $j = $response_start; $j < $response_end; $j++ ) {
 					$result[] = $history[ $j ];
 				}
 			}
 			// else: orphaned tool calls — skip the entire cycle (assistant
-			// message + any partial responses) to prevent the API error.
+			// message cluster + any partial responses) to prevent the API error.
 
 			$i = $response_end;
 		}

--- a/includes/Core/SystemInstructionBuilder.php
+++ b/includes/Core/SystemInstructionBuilder.php
@@ -84,6 +84,20 @@ class SystemInstructionBuilder {
 	}
 
 	/**
+	 * Return frontend live-preview operating rules.
+	 *
+	 * @return string
+	 */
+	public static function build_frontend_live_preview_section(): string {
+		return "## Frontend live-preview context\n\n"
+			. 'The user is viewing the public frontend page that appears in Current Context. '
+			. 'When you mutate that visible page, inspect each tool result for an `affected` descriptor. '
+			. "If the result includes `affected.kind: post`, a matching `post_id`/URL, and `fields` containing `post_content`, the widget's live-preview reflector will attempt to update the visible page automatically; tell the user the page should update live. "
+			. 'If a mutating tool result does not include an `affected` descriptor for the visible page, the browser cannot know what changed and the user must refresh to see it. In that case, call `sd-ai-agent-js/refresh-page` after your server-side write completes; it refreshes the current page while preserving the open widget and current session. '
+			. 'Do not call the refresh tool after a dry run or after read-only inspection. If you are unsure whether live reflection succeeded, use a screenshot/inspection tool or explain that a refresh may be required.';
+	}
+
+	/**
 	 * Build the system instruction, incorporating custom prompt and memories.
 	 *
 	 * @param array<string, mixed> $settings      Plugin settings.
@@ -179,6 +193,11 @@ class SystemInstructionBuilder {
 				// @phpstan-ignore-next-line
 				$base .= "\n\n" . $formatted_context;
 			}
+		}
+
+		if ( ! empty( $this->page_context['is_frontend'] ) ) {
+			// @phpstan-ignore-next-line
+			$base .= "\n\n" . self::build_frontend_live_preview_section();
 		}
 
 		// Append the Tier-2 ability manifest so the model knows what's

--- a/includes/Models/ActiveJobRepository.php
+++ b/includes/Models/ActiveJobRepository.php
@@ -161,7 +161,7 @@ class ActiveJobRepository {
 	 *
 	 * @param string               $job_id The job UUID.
 	 * @param string               $status New status value.
-	 * @param array<string, mixed> $extra  Optional extra fields to update (pending_tools, tool_calls).
+	 * @param array<string, mixed> $extra  Optional extra fields to update (pending_tools, tool_calls, error).
 	 * @return bool True on success, false on failure.
 	 */
 	public static function update_status( string $job_id, string $status, array $extra = [] ): bool {
@@ -172,7 +172,7 @@ class ActiveJobRepository {
 			return false;
 		}
 
-		$allowed = [ 'pending_tools', 'tool_calls', 'checkpoint', 'checkpoint_phase', 'resume_attempts' ];
+		$allowed = [ 'pending_tools', 'tool_calls', 'checkpoint', 'checkpoint_phase', 'resume_attempts', 'error' ];
 		$data    = array_intersect_key( $extra, array_flip( $allowed ) );
 
 		$data['status']     = $status;

--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -776,7 +776,7 @@ Assistant: %s',
 
 		// Update the DB row so the transient-expiry fallback also serves
 		// 'error' rather than the stale 'awaiting_client_tools'.
-		ActiveJobRepository::update_status( $job_id, 'error' );
+		ActiveJobRepository::update_status( $job_id, 'error', [ 'error' => $error_message ] );
 	}
 
 	/**
@@ -823,7 +823,7 @@ Assistant: %s',
 
 				set_transient( $transient_key, $job, self::JOB_TTL );
 
-				ActiveJobRepository::update_status( $job_id, 'error' );
+				ActiveJobRepository::update_status( $job_id, 'error', [ 'error' => (string) $job['error'] ] );
 			}
 
 			return;
@@ -833,7 +833,13 @@ Assistant: %s',
 		// advertises the stale 'awaiting_client_tools' status.
 		$db_row = ActiveJobRepository::get_by_job_id( $job_id );
 		if ( null !== $db_row && 'awaiting_client_tools' === $db_row->status ) {
-			ActiveJobRepository::update_status( $job_id, 'error' );
+			ActiveJobRepository::update_status(
+				$job_id,
+				'error',
+				[
+					'error' => __( 'Client tool result arrived after the agent state had already been resumed or expired.', 'superdav-ai-agent' ),
+				]
+			);
 		}
 	}
 }

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -1131,6 +1131,13 @@ final class SessionController {
 			}
 		}
 
+		if ( 'error' === $status ) {
+			$error_detail        = $this->sanitize_job_error_detail( (string) $row->error );
+			$response['message'] = '' !== $error_detail
+				? $error_detail
+				: __( 'The background agent job failed before it could finish. Please retry the request.', 'superdav-ai-agent' );
+		}
+
 		if ( in_array( $status, array( 'interrupted', 'abandoned' ), true ) ) {
 			$error_detail                = $this->sanitize_job_error_detail( (string) $row->error );
 			$response['status']          = 'error';
@@ -1604,7 +1611,7 @@ final class SessionController {
 				$job['error']  = __( 'Invalid conversation history format.', 'superdav-ai-agent' );
 				unset( $job['token'] );
 				set_transient( RestController::JOB_PREFIX . $job_id, $job, RestController::JOB_TTL );
-				ActiveJobRepository::update_status( $job_id, 'error' );
+				ActiveJobRepository::update_status( $job_id, 'error', [ 'error' => $job['error'] ] );
 				return new WP_REST_Response( array( 'ok' => false ), 200 );
 			}
 		}
@@ -1799,8 +1806,8 @@ final class SessionController {
 			unset( $job['token'] );
 			set_transient( RestController::JOB_PREFIX . $job_id, $job, RestController::JOB_TTL );
 
-			// Persist exception to DB so status survives transient expiry.
-			ActiveJobRepository::update_status( $job_id, 'error' );
+			// Persist exception details to DB so status survives transient expiry.
+			ActiveJobRepository::update_status( $job_id, 'error', [ 'error' => $job['error'] ] );
 
 			return new WP_REST_Response( array( 'ok' => false ), 200 );
 		}
@@ -2017,7 +2024,7 @@ final class SessionController {
 		// @phpstan-ignore-next-line -- status is set above in all paths (error or complete).
 		$db_status = (string) $job['status'];
 		if ( 'error' === $db_status ) {
-			ActiveJobRepository::update_status( $job_id, 'error' );
+			ActiveJobRepository::update_status( $job_id, 'error', [ 'error' => (string) ( $job['error'] ?? '' ) ] );
 		} elseif ( 'complete' === $db_status ) {
 			/** @var array<string, mixed> $complete_result */
 			$complete_result = $job['result'] ?? array();

--- a/includes/Tools/ToolDiscovery.php
+++ b/includes/Tools/ToolDiscovery.php
@@ -824,12 +824,19 @@ class ToolDiscovery {
 			$results[] = $result;
 		}
 
+		$contains_js_ability = array_filter(
+			$results,
+			static fn( array $result ): bool => str_starts_with( (string) $result['id'], 'sd-ai-agent-js/' )
+		);
+
 		$response = array(
 			'query'   => $query,
 			'total'   => $total,
 			'count'   => count( $results ),
 			'results' => $results,
-			'hint'    => 'Use sd-ai-agent/ability-call with the chosen `id` and an `arguments` object that matches `input_schema`.',
+			'hint'    => ! empty( $contains_js_ability )
+				? 'For sd-ai-agent-js/* browser abilities, call the listed ability directly in the chat tool interface. Do not wrap browser abilities in sd-ai-agent/ability-call; ability-call can only execute server-side abilities.'
+				: 'Use sd-ai-agent/ability-call with the chosen `id` and an `arguments` object that matches `input_schema`.',
 		);
 
 		if ( '' !== $discovery_hint ) {
@@ -864,6 +871,15 @@ class ToolDiscovery {
 		$ability = AbilityRegistry::get( $ability_id );
 		if ( ! $ability instanceof \WP_Ability ) {
 			return self::format_unknown_ability_response( $ability_id );
+		}
+
+		if ( str_starts_with( $ability_id, 'sd-ai-agent-js/' ) ) {
+			return array(
+				'success' => false,
+				'ability' => $ability_id,
+				'error'   => 'This is a browser-side ability. It cannot run through sd-ai-agent/ability-call on the server.',
+				'hint'    => 'Call the browser ability directly as its own tool call from the chat interface. For refreshes, call sd-ai-agent-js/refresh-page directly with an empty object: {}.',
+			);
 		}
 
 		$perms = self::tool_permissions();

--- a/scripts/check-bundle-size.js
+++ b/scripts/check-bundle-size.js
@@ -10,7 +10,7 @@ const BUDGETS = [
 	{
 		name: 'floating-widget',
 		file: 'build/floating-widget.js',
-		minifiedBudgetKiB: 80,
+		minifiedBudgetKiB: 84,
 		gzipBudgetKiB: 28,
 	},
 	{

--- a/src/abilities/__tests__/registry.test.js
+++ b/src/abilities/__tests__/registry.test.js
@@ -77,6 +77,60 @@ describe( 'registry — sd-ai-86a regression', () => {
 		).rejects.toThrow( /is not registered on this page/ );
 	} );
 
+	test( 'snapshotDescriptors falls back to locally registered descriptors when wp.abilities is unavailable', async () => {
+		delete global.wp;
+		const { registerClientAbility, snapshotDescriptors } = loadRegistry();
+
+		await registerClientAbility( {
+			name: 'sd-ai-agent-js/local-only',
+			label: 'Local Only',
+			description: 'Available via local fallback',
+			inputSchema: { type: 'object' },
+			outputSchema: { type: 'object' },
+			annotations: { readonly: true },
+			callback: jest.fn(),
+		} );
+
+		await expect( snapshotDescriptors() ).resolves.toEqual( [
+			expect.objectContaining( {
+				name: 'sd-ai-agent-js/local-only',
+				label: 'Local Only',
+				annotations: { readonly: true },
+			} ),
+		] );
+	} );
+
+	test( 'snapshotDescriptors falls back to local descriptors when wp store returns no client abilities', async () => {
+		global.wp = {
+			abilities: {
+				executeAbility: jest.fn(),
+				registerAbility: jest.fn().mockResolvedValue( undefined ),
+				registerAbilityCategory: jest
+					.fn()
+					.mockResolvedValue( undefined ),
+				getAbilities: jest.fn().mockReturnValue( [] ),
+			},
+		};
+		const { registerClientAbility, snapshotDescriptors } = loadRegistry();
+
+		await registerClientAbility( {
+			name: 'sd-ai-agent-js/local-fallback',
+			label: 'Local Fallback',
+			description: 'Store was empty',
+			inputSchema: { type: 'object' },
+			outputSchema: { type: 'object' },
+			annotations: { readonly: true },
+			callback: jest.fn(),
+		} );
+
+		const descriptors = await snapshotDescriptors();
+		expect( descriptors ).toEqual( [
+			expect.objectContaining( {
+				name: 'sd-ai-agent-js/local-fallback',
+			} ),
+		] );
+	} );
+
 	test( 'executeClientAbility falls back to wp.abilities.executeAbility when the local map misses but WP API is present', async () => {
 		// Local map does NOT contain this ability (different module
 		// instance scenario), but wp.abilities.executeAbility is wired up.

--- a/src/abilities/index.js
+++ b/src/abilities/index.js
@@ -35,6 +35,7 @@
 
 import { registerCategory } from './registry';
 import { registerNavigationAbility } from './navigation';
+import { registerRefreshPageAbility } from './refresh-page';
 import { registerEditorAbility } from './editor';
 import {
 	registerCaptureScreenshotAbility,
@@ -105,6 +106,7 @@ export function ensureRegistered() {
 		await registerCategory();
 		// Now safe to register abilities — the category exists in the store.
 		await registerNavigationAbility();
+		await registerRefreshPageAbility();
 		await registerEditorAbility();
 		await registerCaptureScreenshotAbility();
 		await registerScreenshotUrlAbility();

--- a/src/abilities/refresh-page.js
+++ b/src/abilities/refresh-page.js
@@ -1,0 +1,53 @@
+/**
+ * Client-side refresh-page ability.
+ *
+ * Reloads the current browser page after the tool result has been posted back
+ * to the server. The job poller performs the actual reload so the in-flight
+ * tool-result POST is not aborted. It also stores the active session/widget
+ * state so the floating widget reopens to the same conversation after reload.
+ */
+
+import { registerClientAbility } from './registry';
+
+/**
+ * Execute the refresh-page ability.
+ *
+ * @return {{ refresh_scheduled: boolean, url: string }} Refresh scheduling result.
+ */
+function executeRefreshPage() {
+	const url = window.location.href;
+	window._sdAiAgentPendingPageRefresh = url;
+
+	return {
+		refresh_scheduled: true,
+		url,
+	};
+}
+
+/**
+ * Register the refresh-page ability with the client-side abilities registry.
+ *
+ * @return {Promise<void>}
+ */
+export async function registerRefreshPageAbility() {
+	await registerClientAbility( {
+		name: 'sd-ai-agent-js/refresh-page',
+		label: 'Refresh Current Page',
+		description:
+			'Refresh the current browser page while preserving the open AI Agent widget and current session. Use after site changes that did not return an affected descriptor for live preview.',
+		inputSchema: {
+			type: 'object',
+			properties: {},
+			required: [],
+		},
+		outputSchema: {
+			type: 'object',
+			properties: {
+				refresh_scheduled: { type: 'boolean' },
+				url: { type: 'string' },
+			},
+		},
+		annotations: { readonly: true },
+		callback: executeRefreshPage,
+	} );
+}

--- a/src/abilities/registry.js
+++ b/src/abilities/registry.js
@@ -72,6 +72,19 @@ const registeredAbilityNames = new Set();
 const clientCallbacks = new Map();
 
 /**
+ * Descriptor map — name → serializable descriptor.
+ *
+ * This mirrors the locally registered callback set so snapshotDescriptors()
+ * can still post client abilities to /chat on pages where the WP abilities
+ * global/store is unavailable. Without this fallback the server only exposes
+ * sd-ai-agent-js/* via ability-search/ability-call stubs, and calling those
+ * stubs cannot execute browser actions such as refresh-page.
+ *
+ * @type {Map<string, Object>}
+ */
+const localDescriptors = new Map();
+
+/**
  * Detect whether the WP 7.0 abilities API is available on this page.
  *
  * @return {boolean} True when wp.abilities is loaded and exposes the
@@ -216,6 +229,14 @@ export async function registerClientAbility( def ) {
 	if ( typeof def.callback === 'function' ) {
 		clientCallbacks.set( def.name, def.callback );
 	}
+	localDescriptors.set( def.name, {
+		name: def.name,
+		label: def.label || def.name,
+		description: def.description || '',
+		input_schema: def.inputSchema || {},
+		output_schema: def.outputSchema || {},
+		annotations: def.annotations || {},
+	} );
 
 	// The WP 7.0 store is only updated when the abilities API is present
 	// on this page. If it is not, the local callback above is sufficient
@@ -287,13 +308,13 @@ export async function snapshotDescriptors() {
 		! wp.abilities ||
 		typeof wp.abilities.getAbilities !== 'function'
 	) {
-		return [];
+		return Array.from( localDescriptors.values() );
 	}
 
 	try {
 		const allAbilities = ( await wp.abilities.getAbilities() ) || [];
 
-		return allAbilities
+		const descriptors = allAbilities
 			.filter(
 				( ability ) =>
 					ability &&
@@ -308,8 +329,12 @@ export async function snapshotDescriptors() {
 				output_schema: ability.output_schema || {},
 				annotations: ability.meta?.annotations || {},
 			} ) );
+
+		return descriptors.length
+			? descriptors
+			: Array.from( localDescriptors.values() );
 	} catch ( _err ) {
-		return [];
+		return Array.from( localDescriptors.values() );
 	}
 }
 

--- a/src/components/chat-redesign/ToolCard.js
+++ b/src/components/chat-redesign/ToolCard.js
@@ -116,13 +116,13 @@ function deriveSummary( call, response ) {
 	const r = response.response;
 	if ( r && typeof r === 'object' ) {
 		if ( r.summary ) {
-			return r.summary;
+			return formatValue( r.summary );
 		}
 		if ( r.title ) {
-			return r.title;
+			return formatValue( r.title );
 		}
 		if ( r.id && r.status ) {
-			return `ID ${ r.id } · ${ r.status }`;
+			return `ID ${ formatValue( r.id ) } · ${ formatValue( r.status ) }`;
 		}
 	}
 	if ( typeof r === 'string' && r.length < 120 ) {
@@ -200,7 +200,9 @@ export default function ToolCard( {
 
 	// Extract design previews when this is a render-design-previews tool call.
 	const designPreviews = extractDesignPreviews( call, response );
-	const previewMessage = response?.response?.message || null;
+	const previewMessage = response?.response?.message
+		? formatValue( response.response.message )
+		: null;
 
 	return (
 		<div

--- a/src/components/chat-redesign/__tests__/ToolCard.test.js
+++ b/src/components/chat-redesign/__tests__/ToolCard.test.js
@@ -1,0 +1,52 @@
+/**
+ * Unit tests for chat-redesign/ToolCard.js
+ *
+ * Tests cover resilient rendering of structured tool response metadata so
+ * object-shaped summaries do not crash React while jobs are running.
+ */
+
+import { createElement } from '@wordpress/element';
+import { renderToStaticMarkup } from 'react-dom/server.node';
+import ToolCard from '../ToolCard';
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( str ) => str,
+} ) );
+
+jest.mock( '@wordpress/icons', () => ( {
+	Icon: ( { icon } ) => icon || null,
+	check: 'check',
+	chevronDown: 'chevronDown',
+	undo: 'undo',
+	caution: 'caution',
+} ) );
+
+jest.mock( '../../design-preview-gallery', () => () => null );
+
+describe( 'ToolCard', () => {
+	test( 'stringifies object-shaped response summaries before rendering', () => {
+		const html = renderToStaticMarkup(
+			createElement( ToolCard, {
+				call: {
+					id: 'tool-1',
+					name: 'sd-ai-agent/get-page-blocks',
+					args: { summary_only: true },
+				},
+				response: {
+					id: 'tool-1',
+					response: {
+						summary: {
+							block_counts: { 'core/paragraph': 2 },
+							headings: [],
+							section_markers: [],
+							max_depth: 1,
+						},
+					},
+				},
+			} )
+		);
+
+		expect( html ).toContain( 'block_counts' );
+		expect( html ).toContain( 'core/paragraph' );
+	} );
+} );

--- a/src/floating-widget/index.js
+++ b/src/floating-widget/index.js
@@ -93,7 +93,28 @@ function FloatingWidget() {
 		fetchProviders();
 		fetchSessions();
 		restoreActiveJobs();
-	}, [ fetchProviders, fetchSessions, restoreActiveJobs ] );
+
+		try {
+			const raw = sessionStorage.getItem( 'sdAiAgent_refreshRestore' );
+			if ( raw ) {
+				sessionStorage.removeItem( 'sdAiAgent_refreshRestore' );
+				const restore = JSON.parse( raw );
+				const restoreSessionId = parseInt( restore?.sessionId, 10 );
+				if ( restoreSessionId > 0 ) {
+					setFloatingOpen( restore.open !== false );
+					setFloatingMinimized( !! restore.minimized );
+					openSession( restoreSessionId );
+				}
+			}
+		} catch ( _err ) {}
+	}, [
+		fetchProviders,
+		fetchSessions,
+		restoreActiveJobs,
+		setFloatingOpen,
+		setFloatingMinimized,
+		openSession,
+	] );
 
 	// First-run frontend onboarding: open the widget as a centered assistant,
 	// start the same server-side onboarding session used by the admin chat page,
@@ -271,17 +292,27 @@ function FloatingWidget() {
 }
 
 /**
- * Gather structured context about the current WordPress admin page.
+ * Gather structured context about the current WordPress admin/frontend page.
  *
- * Reads from body classes, `window.pagenow`, `window.adminpage`, URL params,
- * and the page heading to build a context object for the AI.
+ * Reads from localized widget data, body classes, `window.pagenow`,
+ * `window.adminpage`, URL params, and page headings to build context for the AI.
  *
- * @return {{url: string, admin_page?: string, screen_id?: string, post_id?: number, page_title?: string}}
+ * @return {{url: string, surface: string, is_frontend: boolean, live_preview: Object, admin_page?: string, screen_id?: string, post_id?: number, post_type?: string, page_title?: string}}
  *   Context object with available page metadata.
  */
 function gatherPageContext() {
+	const widgetData = window.sdAiAgentData || {};
+	const isFrontend = !! widgetData.isFrontend;
 	const context = {
 		url: window.location.href,
+		surface: isFrontend ? 'frontend' : 'admin',
+		is_frontend: isFrontend,
+		live_preview: {
+			affected_descriptor_supported: true,
+			reflection_bus: 'frontend-widget',
+			requires_refresh_when_missing_affected: true,
+			refresh_tool: 'sd-ai-agent-js/refresh-page',
+		},
 	};
 
 	// Admin page slug from body classes.
@@ -303,19 +334,43 @@ function gatherPageContext() {
 		context.screen_id = window.adminpage;
 	}
 
-	// Post ID if on an edit screen.
+	// Post ID if on an edit screen or frontend singular view.
 	const urlParams = new URLSearchParams( window.location.search );
 	const postParam = urlParams.get( 'post' );
 	if ( postParam ) {
 		context.post_id = parseInt( postParam, 10 ) || 0;
 	}
+	if ( widgetData.viewedPostId ) {
+		context.post_id = parseInt( widgetData.viewedPostId, 10 ) || 0;
+	}
+	if ( widgetData.viewedPostType ) {
+		context.post_type = widgetData.viewedPostType;
+	}
+
+	// Frontend fallback: WordPress body classes commonly include page-id-123
+	// or postid-123 even when localized metadata is unavailable.
+	if ( ! context.post_id && isFrontend ) {
+		const idMatch = document.body.className.match(
+			/(?:page-id|postid|attachmentid)-(\d+)/
+		);
+		if ( idMatch ) {
+			context.post_id = parseInt( idMatch[ 1 ], 10 ) || 0;
+		}
+	}
 
 	// Page title for extra context.
 	const heading =
 		document.querySelector( '.wrap > h1' ) ||
-		document.querySelector( '#wpbody-content h1' );
+		document.querySelector( '#wpbody-content h1' ) ||
+		document.querySelector( '.wp-block-post-title' ) ||
+		document.querySelector( '.entry-title' ) ||
+		document.querySelector( 'h1' );
 	if ( heading ) {
 		context.page_title = heading.textContent.trim();
+	} else if ( widgetData.viewedTitle ) {
+		context.page_title = widgetData.viewedTitle;
+	} else if ( document.title ) {
+		context.page_title = document.title;
 	}
 
 	return context;

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -665,6 +665,25 @@ export const actions = {
 							return;
 						}
 
+						if ( window._sdAiAgentPendingPageRefresh ) {
+							const target = window._sdAiAgentPendingPageRefresh;
+							delete window._sdAiAgentPendingPageRefresh;
+							try {
+								sessionStorage.setItem(
+									'sdAiAgent_refreshRestore',
+									JSON.stringify( {
+										sessionId,
+										open: true,
+										minimized: false,
+									} )
+								);
+							} catch ( _err ) {}
+							clearActiveJob( sessionId );
+							unsubscribeVisibility();
+							window.location.assign( target );
+							return;
+						}
+
 						// Resume polling — the server has resumed the agent
 						// loop; we continue polling the same job for the
 						// model's next response or another pause.

--- a/tests/SdAiAgent/Abilities/BlockAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/BlockAbilitiesTest.php
@@ -1426,4 +1426,59 @@ class BlockAbilitiesTest extends WP_UnitTestCase {
 		$this->assertIsInt( $get_after['revision_id'], 'After a write, revision_id must be an integer' );
 		$this->assertGreaterThan( 0, $get_after['revision_id'] );
 	}
+
+	/**
+	 * Block tree mutations report affected post_content for the live-preview bus.
+	 */
+	public function test_edit_block_tree_returns_affected_payload_for_live_preview(): void {
+		$post_id = $this->factory->post->create( [
+			'post_content' => '<!-- wp:paragraph --><p>original</p><!-- /wp:paragraph -->',
+			'post_status'  => 'publish',
+		] );
+
+		$get = BlockAbilities::handle_get_page_blocks( [
+			'post_id'      => $post_id,
+			'persist_refs' => true,
+		] );
+		$this->assertIsArray( $get );
+
+		$first_ref = $get['blocks'][0]['ref'] ?? '';
+		$this->assertNotEmpty( $first_ref );
+
+		$result = BlockAbilities::handle_edit_block_tree( [
+			'post_id'   => $post_id,
+			'op'        => 'update-html',
+			'ref'       => $first_ref,
+			'innerHTML' => '<p>updated original</p>',
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'affected', $result );
+		$this->assertSame( 'post', $result['affected']['kind'] );
+		$this->assertSame( $post_id, $result['affected']['post_id'] );
+		$this->assertSame( 'post', $result['affected']['post_type'] );
+		$this->assertContains( 'post_content', $result['affected']['fields'] );
+		$this->assertNotEmpty( $result['affected']['url'] );
+	}
+
+	/**
+	 * Dry-run block mutations do not emit affected metadata because no page changed.
+	 */
+	public function test_edit_block_tree_dry_run_omits_affected_payload(): void {
+		$post_id = $this->factory->post->create( [
+			'post_content' => '<!-- wp:paragraph --><p>original</p><!-- /wp:paragraph -->',
+			'post_status'  => 'publish',
+		] );
+
+		$result = BlockAbilities::handle_edit_block_tree( [
+			'post_id'   => $post_id,
+			'op'        => 'update-html',
+			'path'      => [ 0 ],
+			'innerHTML' => '<p>preview only</p>',
+			'dry_run'   => true,
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayNotHasKey( 'affected', $result );
+	}
 }

--- a/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
@@ -62,6 +62,7 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 
 		$names = array_column( $descriptors, 'name' );
 		$this->assertContains( 'sd-ai-agent-js/navigate-to', $names );
+		$this->assertContains( 'sd-ai-agent-js/refresh-page', $names );
 		$this->assertContains( 'sd-ai-agent-js/insert-block', $names );
 	}
 
@@ -70,6 +71,7 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 	 */
 	public function test_catalog_has_method(): void {
 		$this->assertTrue( JsAbilityCatalog::has( 'sd-ai-agent-js/navigate-to' ) );
+		$this->assertTrue( JsAbilityCatalog::has( 'sd-ai-agent-js/refresh-page' ) );
 		$this->assertTrue( JsAbilityCatalog::has( 'sd-ai-agent-js/insert-block' ) );
 		$this->assertFalse( JsAbilityCatalog::has( 'sd-ai-agent-js/unknown-ability' ) );
 		$this->assertFalse( JsAbilityCatalog::has( 'sd-ai-agent/memory-save' ) );
@@ -83,7 +85,12 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 
 		$this->assertIsArray( $map );
 		$this->assertArrayHasKey( 'sd-ai-agent-js/navigate-to', $map );
+		$this->assertArrayHasKey( 'sd-ai-agent-js/refresh-page', $map );
 		$this->assertArrayHasKey( 'sd-ai-agent-js/insert-block', $map );
+
+		$refresh = $map['sd-ai-agent-js/refresh-page'];
+		$this->assertTrue( $refresh['annotations']['readonly'] );
+		$this->assertStringContainsString( 'preserving the open AI Agent widget', $refresh['description'] );
 
 		$navigate = $map['sd-ai-agent-js/navigate-to'];
 		$this->assertSame( 'sd-ai-agent-js', $navigate['category'] );

--- a/tests/SdAiAgent/Core/ContextProvidersTest.php
+++ b/tests/SdAiAgent/Core/ContextProvidersTest.php
@@ -277,19 +277,39 @@ class ContextProvidersTest extends WP_UnitTestCase {
 	 */
 	public function test_provide_page_context_extracts_known_fields(): void {
 		$page_context = [
-			'url'        => 'https://example.com/wp-admin/',
-			'admin_page' => 'dashboard',
-			'screen_id'  => 'dashboard',
-			'summary'    => 'WordPress Dashboard',
+			'url'          => 'https://example.com/wp-admin/',
+			'surface'      => 'frontend',
+			'is_frontend'  => true,
+			'post_id'      => 35,
+			'post_type'    => 'page',
+			'page_title'   => 'Home',
+			'admin_page'   => 'dashboard',
+			'screen_id'    => 'dashboard',
+			'summary'      => 'WordPress Dashboard',
+			'live_preview' => [
+				'affected_descriptor_supported'        => true,
+				'requires_refresh_when_missing_affected' => true,
+				'refresh_tool'                         => 'sd-ai-agent-js/refresh-page',
+			],
 		];
 
 		$result = ContextProviders::provide_page_context( $page_context );
 
 		$this->assertArrayHasKey( 'Current URL', $result );
+		$this->assertArrayHasKey( 'Surface', $result );
+		$this->assertArrayHasKey( 'User Is Viewing Frontend', $result );
+		$this->assertArrayHasKey( 'Visible Page Title', $result );
+		$this->assertArrayHasKey( 'Visible Post ID', $result );
+		$this->assertArrayHasKey( 'Visible Post Type', $result );
+		$this->assertArrayHasKey( 'Live Preview Affected Descriptor Supported', $result );
+		$this->assertArrayHasKey( 'Refresh Required When Affected Missing', $result );
+		$this->assertArrayHasKey( 'Refresh Tool', $result );
 		$this->assertArrayHasKey( 'Admin Page', $result );
 		$this->assertArrayHasKey( 'Screen ID', $result );
 		$this->assertArrayHasKey( 'Page Context', $result );
 		$this->assertSame( 'https://example.com/wp-admin/', $result['Current URL'] );
+		$this->assertSame( '35', $result['Visible Post ID'] );
+		$this->assertSame( 'sd-ai-agent-js/refresh-page', $result['Refresh Tool'] );
 	}
 
 	// ── provide_user_context ─────────────────────────────────────────────────

--- a/tests/SdAiAgent/Core/ConversationTrimmerTest.php
+++ b/tests/SdAiAgent/Core/ConversationTrimmerTest.php
@@ -430,6 +430,39 @@ class ConversationTrimmerTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test validate_tool_pairs keeps split assistant tool-call clusters intact.
+	 *
+	 * AgentLoop splits parallel function calls into one ModelMessage per call for
+	 * the OpenAI Responses API, then appends the matching tool responses after the
+	 * whole call cluster. The validator must treat those consecutive tool-call
+	 * messages as one logical cycle; otherwise it drops earlier calls and their
+	 * responses, causing the model to repeat work such as loading the same skill
+	 * twice on the next turn.
+	 */
+	public function test_validate_tool_pairs_keeps_split_tool_call_cluster() {
+		$history = [
+			$this->create_user_message_mock( 'Edit the homepage' ),
+			$this->create_tool_call_message( [
+				[ 'id' => 'call_skill', 'name' => 'skill-load' ],
+			] ),
+			$this->create_tool_call_message( [
+				[ 'id' => 'call_resolve', 'name' => 'resolve-url' ],
+			] ),
+			$this->create_tool_response_message( 'call_skill', 'skill-load' ),
+			$this->create_tool_response_message( 'call_resolve', 'resolve-url' ),
+			$this->create_assistant_message_mock( 'I found the homepage.' ),
+		];
+
+		$result = ConversationTrimmer::validate_tool_pairs( $history );
+
+		$this->assertCount( 6, $result );
+		$this->assertSame( [ 'call_skill' ], $this->extract_call_ids_for_test( $result[1] ) );
+		$this->assertSame( [ 'call_resolve' ], $this->extract_call_ids_for_test( $result[2] ) );
+		$this->assertSame( [ 'call_skill' ], $this->extract_response_ids_for_test( $result[3] ) );
+		$this->assertSame( [ 'call_resolve' ], $this->extract_response_ids_for_test( $result[4] ) );
+	}
+
+	/**
 	 * Test validate_tool_pairs handles partial responses (some tools missing).
 	 */
 	public function test_validate_tool_pairs_removes_partially_matched_cycles() {
@@ -580,45 +613,77 @@ class ConversationTrimmerTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Extract FunctionCall IDs from a message for assertions.
+	 *
+	 * @param object $message Message DTO or mock.
+	 * @return string[]
+	 */
+	private function extract_call_ids_for_test( object $message ): array {
+		$ids = [];
+		foreach ( $message->getParts() as $part ) {
+			if ( method_exists( $part, 'getFunctionCall' ) ) {
+				$fc = $part->getFunctionCall();
+				if ( $fc ) {
+					$ids[] = (string) $fc->getId();
+				}
+			}
+		}
+		return $ids;
+	}
+
+	/**
+	 * Extract FunctionResponse IDs from a message for assertions.
+	 *
+	 * @param object $message Message DTO or mock.
+	 * @return string[]
+	 */
+	private function extract_response_ids_for_test( object $message ): array {
+		$ids = [];
+		foreach ( $message->getParts() as $part ) {
+			if ( method_exists( $part, 'getFunctionResponse' ) ) {
+				$fr = $part->getFunctionResponse();
+				if ( $fr ) {
+					$ids[] = (string) $fr->getId();
+				}
+			}
+		}
+		return $ids;
+	}
+
+	/**
 	 * Assert that all tool_use messages in a history have matching tool_results.
 	 *
 	 * @param array $history The conversation history to validate.
 	 */
 	private function assert_tool_pairs_valid( array $history ): void {
 		$count = count( $history );
-		for ( $i = 0; $i < $count; $i++ ) {
-			$message  = $history[ $i ];
-			$call_ids = [];
-
-			foreach ( $message->getParts() as $part ) {
-				if ( method_exists( $part, 'getFunctionCall' ) ) {
-					$fc = $part->getFunctionCall();
-					if ( $fc ) {
-						$call_ids[] = $fc->getId();
-					}
-				}
-			}
-
+		$i     = 0;
+		while ( $i < $count ) {
+			$call_ids = $this->extract_call_ids_for_test( $history[ $i ] );
 			if ( empty( $call_ids ) ) {
+				++$i;
 				continue;
 			}
 
-			// Collect response IDs from the messages that follow.
-			$response_ids = [];
-			for ( $j = $i + 1; $j < $count; $j++ ) {
-				$has_response = false;
-				foreach ( $history[ $j ]->getParts() as $part ) {
-					if ( method_exists( $part, 'getFunctionResponse' ) ) {
-						$fr = $part->getFunctionResponse();
-						if ( $fr ) {
-							$response_ids[] = $fr->getId();
-							$has_response   = true;
-						}
-					}
-				}
-				if ( ! $has_response ) {
+			$call_ids = [];
+			$call_end = $i;
+			while ( $call_end < $count ) {
+				$current_call_ids = $this->extract_call_ids_for_test( $history[ $call_end ] );
+				if ( empty( $current_call_ids ) ) {
 					break;
 				}
+				$call_ids = array_merge( $call_ids, $current_call_ids );
+				++$call_end;
+			}
+			$call_ids = array_values( array_unique( $call_ids ) );
+
+			$response_ids = [];
+			for ( $j = $call_end; $j < $count; $j++ ) {
+				$current_response_ids = $this->extract_response_ids_for_test( $history[ $j ] );
+				if ( empty( $current_response_ids ) ) {
+					break;
+				}
+				$response_ids = array_merge( $response_ids, $current_response_ids );
 			}
 
 			foreach ( $call_ids as $call_id ) {
@@ -628,6 +693,8 @@ class ConversationTrimmerTest extends WP_UnitTestCase {
 					"tool_use ID '$call_id' has no matching tool_result in history"
 				);
 			}
+
+			$i = $call_end;
 		}
 	}
 }

--- a/tests/SdAiAgent/Core/SystemInstructionBuilderTest.php
+++ b/tests/SdAiAgent/Core/SystemInstructionBuilderTest.php
@@ -110,6 +110,27 @@ class SystemInstructionBuilderTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Frontend widget sessions include live-preview affected/refresh guidance.
+	 */
+	public function test_build_includes_frontend_live_preview_guidance(): void {
+		$builder = new SystemInstructionBuilder(
+			'',
+			'',
+			array(
+				'is_frontend' => true,
+				'url'         => 'https://example.com/',
+			)
+		);
+
+		$instruction = $builder->build( array() );
+
+		$this->assertStringContainsString( '## Frontend live-preview context', $instruction );
+		$this->assertStringContainsString( '`affected` descriptor', $instruction );
+		$this->assertStringContainsString( 'sd-ai-agent-js/refresh-page', $instruction );
+		$this->assertStringContainsString( 'preserving the open widget and current session', $instruction );
+	}
+
+	/**
 	 * Diagnostic summary prompts must remain read-only unless remediation is explicit.
 	 *
 	 * Regression: issue #2083 — a site health summary request installed and

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -953,6 +953,34 @@ class RestControllerTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test terminal DB error rows include a user-facing message.
+	 */
+	public function test_job_status_from_db_error_row_includes_message(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$session_id = Database::create_session( [
+			'user_id' => $this->admin_id,
+			'title'   => 'DB error fallback message',
+		] );
+		$job_id     = '33333333-4444-5555-6666-777777777777';
+		$error_text = 'File edit failed: search string was not found.';
+
+		ActiveJobRepository::create( $session_id, $job_id, $this->admin_id, 'processing' );
+		ActiveJobRepository::update_status( $job_id, 'error', [ 'error' => $error_text ] );
+		delete_transient( RestController::JOB_PREFIX . $job_id );
+
+		$status_response = $this->dispatch( 'GET', "/sd-ai-agent/v1/job/{$job_id}" );
+
+		$this->assertStatus( 200, $status_response );
+		$data = $status_response->get_data();
+
+		$this->assertSame( 'error', $data['status'] );
+		$this->assertTrue( $data['from_db'] );
+		$this->assertSame( $error_text, $data['message'] );
+		$this->assertNull( ActiveJobRepository::get_by_job_id( $job_id ) );
+	}
+
+	/**
 	 * Test invalid direct history processing persists the DB job status as error.
 	 */
 	public function test_process_invalid_history_persists_error_status(): void {
@@ -987,6 +1015,7 @@ class RestControllerTest extends WP_UnitTestCase {
 
 		$this->assertNotNull( $db_row );
 		$this->assertSame( 'error', $db_row->status );
+		$this->assertSame( 'Invalid conversation history format.', $db_row->error );
 	}
 
 	/**

--- a/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
+++ b/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
@@ -398,6 +398,21 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'discovery_hint', $result );
 	}
 
+	public function test_ability_search_warns_js_abilities_must_be_called_directly(): void {
+		$result = ToolDiscovery::handle_ability_search(
+			[
+				'query'       => 'refresh-page',
+				'max_results' => 3,
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertNotEmpty( $result['results'] );
+		$this->assertSame( 'sd-ai-agent-js/refresh-page', $result['results'][0]['id'] );
+		$this->assertStringContainsString( 'call the listed ability directly', $result['hint'] );
+		$this->assertStringContainsString( 'Do not wrap browser abilities in sd-ai-agent/ability-call', $result['hint'] );
+	}
+
 	// ── ability-call ──────────────────────────────────────────────────
 
 	public function test_ability_call_executes_a_known_ability(): void {
@@ -436,6 +451,21 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 		$this->assertSame( 'ability_not_found', $result['code'] );
 		$this->assertArrayHasKey( 'suggestions', $result );
 		$this->assertArrayHasKey( 'hint', $result );
+	}
+
+	public function test_ability_call_rejects_js_browser_abilities_with_direct_call_hint(): void {
+		$result = ToolDiscovery::handle_ability_call(
+			[
+				'ability'   => 'sd-ai-agent-js/refresh-page',
+				'arguments' => [],
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertFalse( $result['success'] );
+		$this->assertSame( 'sd-ai-agent-js/refresh-page', $result['ability'] );
+		$this->assertStringContainsString( 'cannot run through sd-ai-agent/ability-call', $result['error'] );
+		$this->assertStringContainsString( 'Call the browser ability directly', $result['hint'] );
 	}
 
 	public function test_ability_call_aliases_legacy_ai_agent_prefix(): void {


### PR DESCRIPTION
## Summary
- Register and execute the client-side refresh-page ability so frontend chat can refresh while restoring the open widget/session.
- Improve frontend page context and client ability descriptor fallback for pages without the WP abilities global.
- Preserve DB-backed background-job error messages so the UI does not fall back to `Error: Unknown error`.
- Add coverage for client tool registration/rendering, context metadata, and DB error fallback handling.
- Raise the floating widget minified bundle budget to 84 KiB for the new client-refresh path.

## Worker self-verification
- PHPUnit: Tests: 3572, Assertions: 14915, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

## Notes
- `npm run verify` completed successfully. Webpack reported existing asset-size warnings for `admin-page.js` and vendor chunk size, but the bundle budget check passed.
