### PR TITLE
GH#2106: fix: continue reset after plugin activation failures

### DIFF
--- a/scripts/local-wp/reset-site.sh
+++ b/scripts/local-wp/reset-site.sh
@@ -77,7 +77,9 @@ log "Reactivating previously active plugins"
 while IFS= read -r plugin_slug; do
 	[ -n "$plugin_slug" ] || continue
 	if wp_cli plugin is-installed "$plugin_slug" --path="$wp_root" >/dev/null 2>&1; then
-		run_cmd wp_cli plugin activate "$plugin_slug" --path="$wp_root"
+		if ! run_cmd wp_cli plugin activate "$plugin_slug" --path="$wp_root"; then
+			warn "Plugin activation failed: $plugin_slug"
+		fi
 	else
 		warn "Plugin not installed after reset, cannot reactivate: $plugin_slug"
 	fi


### PR DESCRIPTION
## Summary

Updated scripts/local-wp/reset-site.sh so reset reactivation logs plugin activation failures and continues trying later plugins instead of aborting the reset loop.

## Files Changed

scripts/local-wp/reset-site.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck scripts/local-wp/reset-site.sh (pre-existing informational SC1091/SC2016 only); npm run verify reached PHPStan and hit the configured 1G memory limit; php -d memory_limit=2G vendor/bin/phpstan analyse passed with 0 errors; npm run test:php passed: Tests: 3581, Assertions: 14970, Skipped: 119, Incomplete: 4; npm run build succeeded; npm run check:bundle succeeded

Resolves #2106


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.53 plugin for [OpenCode](https://opencode.ai) v1.17.3 with gpt-5.5 spent 9m and 88,933 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during plugin reactivation in the local development site reset process. Failed plugin activations now display a warning and allow processing to continue with remaining plugins instead of stopping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->