### PR TITLE
fix: allow frontend onboarding query launch

### DIFF
--- a/includes/Admin/FloatingWidget.php
+++ b/includes/Admin/FloatingWidget.php
@@ -168,9 +168,16 @@ class FloatingWidget {
 
 		$onboarding_complete = OnboardingManager::is_complete();
 		$is_frontend         = 'frontend' === $context;
+		$force_onboarding    = false;
 		$viewed_post_id      = 0;
 		$viewed_post_type    = '';
 		$viewed_title        = '';
+
+		// Read-only launch hint for the frontend widget; no state changes happen here.
+		if ( $is_frontend && isset( $_GET['sd_ai_agent_onboarding'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$force_onboarding = '1' === sanitize_text_field( wp_unslash( $_GET['sd_ai_agent_onboarding'] ) );
+		}
 
 		if ( $is_frontend && is_singular() ) {
 			$viewed_post_id = (int) get_queried_object_id();
@@ -188,7 +195,7 @@ class FloatingWidget {
 				'currentUserId'       => get_current_user_id(),
 				'context'             => $context,
 				'isFrontend'          => $is_frontend,
-				'frontendOnboarding'  => ( $is_frontend && ! $onboarding_complete ) ? '1' : '',
+				'frontendOnboarding'  => ( $is_frontend && ( ! $onboarding_complete || $force_onboarding ) ) ? '1' : '',
 				'onboarding_complete' => $onboarding_complete,
 				'changesPageUrl'      => admin_url( 'admin.php?page=sd-ai-agent#/changes' ),
 				'viewedPostId'        => $viewed_post_id,


### PR DESCRIPTION
## Summary

- Adds a read-only `sd_ai_agent_onboarding=1` frontend launch hint for the floating widget.
- Forces the localized `frontendOnboarding` flag when that hint is present, so the Setup Assistant opens from redirect flows.
- Keeps the existing incomplete-onboarding auto-start behavior unchanged.

## Verification

- `vendor/bin/phpcs includes/Admin/FloatingWidget.php` — passed.
- `php -l includes/Admin/FloatingWidget.php` — passed.
- `npm run verify` — lint passed, then PHPStan hit the configured `1G` memory limit.
- `php -d memory_limit=2G vendor/bin/phpstan analyse` — 0 errors.
- `npm run test:php` — Tests: 3581, Assertions: 14970, Skipped: 119, Incomplete: 4.
- `npm run build` — succeeded; webpack reported existing size warnings for `admin-page` assets.
- `npm run check:bundle` — passed.

## Worker self-verification

- PHPUnit: Tests: 3581, Assertions: 14970, Errors: 0, Failures: 0, Skipped: 119, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors with `php -d memory_limit=2G vendor/bin/phpstan analyse`
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.55 plugin for [OpenCode](https://opencode.ai) v1.17.3 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to override the onboarding display state using a frontend query parameter. This enables testing and demonstrating the onboarding experience without requiring initial setup conditions, providing flexibility for QA and demonstration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->