### PR TITLE
Fix confirmed ability resume approvals

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -205,6 +205,9 @@ class AgentLoop {
 	/** @var list<string> Per-agent Tier 1 tool override (empty = use global default). */
 	private array $agent_tier_1_tools = array();
 
+	/** @var list<string> Ability names approved for one resumed confirmation turn. */
+	private array $approved_once_abilities = array();
+
 	/** @var int Consecutive preamble-only truncations observed this run. */
 	private int $preamble_truncation_retries = 0;
 
@@ -354,6 +357,8 @@ class AgentLoop {
 		$this->tool_call_log     = self::normalize_activity_log( $options['tool_call_log'] ?? array() );
 		$this->message_log       = self::normalize_activity_log( $options['message_log'] ?? array() );
 		$this->activity_sequence = $this->get_max_activity_sequence( $this->tool_call_log, $this->message_log );
+		// @phpstan-ignore-next-line -- Resumed confirmation state carries scalar ability names.
+		$this->approved_once_abilities = $this->normalize_ability_names( $options['approved_once_abilities'] ?? array() );
 		// @phpstan-ignore-next-line
 		$this->session_id = (int) ( $options['session_id'] ?? 0 );
 		// Active job UUID for heartbeat and shutdown-handler updates.
@@ -1154,16 +1159,19 @@ class AgentLoop {
 			$confirm_needed = $this->permission_resolver->get_tools_needing_confirmation( $assistant_message );
 
 			if ( ! empty( $confirm_needed ) ) {
+				$this->approved_once_abilities = $this->extract_pending_ability_names( $confirm_needed );
+
 				return $this->with_paused_logs(
 					array(
-						'awaiting_confirmation' => true,
-						'pending_tools'         => $confirm_needed,
-						'history'               => $this->serialize_history(),
-						'tool_call_log'         => $this->tool_call_log,
-						'token_usage'           => $this->token_usage,
-						'iterations_remaining'  => $iterations,
-						'iterations_used'       => $this->iterations_used,
-						'model_id'              => $this->model_id,
+						'awaiting_confirmation'   => true,
+						'pending_tools'           => $confirm_needed,
+						'approved_once_abilities' => $this->approved_once_abilities,
+						'history'                 => $this->serialize_history(),
+						'tool_call_log'           => $this->tool_call_log,
+						'token_usage'             => $this->token_usage,
+						'iterations_remaining'    => $iterations,
+						'iterations_used'         => $this->iterations_used,
+						'model_id'                => $this->model_id,
 					)
 				);
 			}
@@ -2170,6 +2178,60 @@ class AgentLoop {
 	// ── Resolve abilities ─────────────────────────────────────────────────
 
 	/**
+	 * Normalise a mixed list of ability names to unique non-empty strings.
+	 *
+	 * @param mixed $raw Raw ability-name list.
+	 * @return list<string> Unique ability names.
+	 */
+	private function normalize_ability_names( $raw ): array {
+		if ( ! is_array( $raw ) ) {
+			return array();
+		}
+
+		$names = array();
+		foreach ( $raw as $name ) {
+			if ( ! is_string( $name ) ) {
+				continue;
+			}
+			$name = trim( $name );
+			if ( '' !== $name ) {
+				$names[ $name ] = true;
+			}
+		}
+
+		return array_keys( $names );
+	}
+
+	/**
+	 * Extract one-turn approved ability names from pending confirmation tools.
+	 *
+	 * @param list<array<string, mixed>> $pending_tools Pending confirmation tool data.
+	 * @return list<string> Ability names approved if the user confirms this pause.
+	 */
+	private function extract_pending_ability_names( array $pending_tools ): array {
+		$names = array();
+
+		foreach ( $pending_tools as $tool ) {
+			$ability_name = '';
+			if ( isset( $tool['ability'] ) && is_string( $tool['ability'] ) ) {
+				$ability_name = $tool['ability'];
+			} elseif ( isset( $tool['name'] ) && is_string( $tool['name'] ) ) {
+				$ability_name = $tool['name'];
+				if ( str_starts_with( $ability_name, 'wpab__' ) && class_exists( 'WP_AI_Client_Ability_Function_Resolver' ) ) {
+					$ability_name = \WP_AI_Client_Ability_Function_Resolver::function_name_to_ability_name( $ability_name );
+				}
+			}
+
+			$ability_name = trim( $ability_name );
+			if ( '' !== $ability_name ) {
+				$names[ $ability_name ] = true;
+			}
+		}
+
+		return array_keys( $names );
+	}
+
+	/**
 	 * Resolve which abilities should be loaded as direct (Tier-1) tools for
 	 * this run. Returns the WP_Ability objects matching {@see ToolDiscovery::tier_1_for_run()}
 	 * (curated cold-start list ∪ top-N most-used ∪ meta-tools), filtered
@@ -2196,7 +2258,7 @@ class AgentLoop {
 		// When set, bypass the auto-discovery layer and return exactly what was asked for.
 		if ( ! empty( $this->abilities ) ) {
 			$resolved = array();
-			foreach ( $this->abilities as $name ) {
+			foreach ( array_merge( $this->abilities, $this->approved_once_abilities ) as $name ) {
 				$ability = AbilityRegistry::get( $name );
 				if ( $ability instanceof \WP_Ability ) {
 					$resolved[] = $ability;
@@ -2214,7 +2276,7 @@ class AgentLoop {
 		$perms        = $this->tool_permissions;
 
 		$resolved = array();
-		foreach ( $tier_1 as $name ) {
+		foreach ( array_merge( $tier_1, $this->approved_once_abilities ) as $name ) {
 			if ( null !== $role_allowed && ! in_array( $name, $role_allowed, true ) ) {
 				continue;
 			}

--- a/includes/Core/ToolPermissionResolver.php
+++ b/includes/Core/ToolPermissionResolver.php
@@ -78,9 +78,10 @@ class ToolPermissionResolver {
 					// Explicit permission set for this tool.
 					if ( 'confirm' === $permission ) {
 						$confirm[] = array(
-							'id'   => $call->getId(),
-							'name' => $fn_name,
-							'args' => $call->getArgs(),
+							'id'      => $call->getId(),
+							'name'    => $fn_name,
+							'ability' => $ability_name,
+							'args'    => $call->getArgs(),
 						);
 					}
 					// 'auto', 'always_allow', 'disabled' → no confirmation needed.
@@ -96,9 +97,10 @@ class ToolPermissionResolver {
 
 				if ( 'destructive' === $classification ) {
 					$confirm[] = array(
-						'id'   => $call->getId(),
-						'name' => $fn_name,
-						'args' => $call->getArgs(),
+						'id'      => $call->getId(),
+						'name'    => $fn_name,
+						'ability' => $ability_name,
+						'args'    => $call->getArgs(),
 					);
 				}
 				// 'read' and 'write' → auto-execute.
@@ -106,9 +108,10 @@ class ToolPermissionResolver {
 				// Ability not found in registry (e.g. custom tool) — default
 				// to requiring confirmation for safety.
 				$confirm[] = array(
-					'id'   => $call->getId(),
-					'name' => $fn_name,
-					'args' => $call->getArgs(),
+					'id'      => $call->getId(),
+					'name'    => $fn_name,
+					'ability' => $ability_name,
+					'args'    => $call->getArgs(),
 				);
 			}
 		}

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -1764,6 +1764,8 @@ final class SessionController {
 					'prompt'     => 0,
 					'completion' => 0,
 				);
+				// @phpstan-ignore-next-line
+				$resume_options['approved_once_abilities'] = $state['approved_once_abilities'] ?? array();
 
 				$loop = new AgentLoop( '', array(), $resume_history, $resume_options );
 				// Fallback to 100 matches the rest of the codebase
@@ -1842,14 +1844,15 @@ final class SessionController {
 			$job['pending_tools']      = $result['pending_tools'] ?? array();
 			$job['messages']           = $result['message_log'] ?? array();
 			$job['confirmation_state'] = array(
-				'history'              => $result['history'] ?? array(),
-				'tool_call_log'        => $result['tool_call_log'] ?? array(),
-				'message_log'          => $result['message_log'] ?? array(),
-				'token_usage'          => $result['token_usage'] ?? array(
+				'history'                 => $result['history'] ?? array(),
+				'tool_call_log'           => $result['tool_call_log'] ?? array(),
+				'message_log'             => $result['message_log'] ?? array(),
+				'token_usage'             => $result['token_usage'] ?? array(
 					'prompt'     => 0,
 					'completion' => 0,
 				),
-				'iterations_remaining' => $result['iterations_remaining'] ?? 5,
+				'approved_once_abilities' => $result['approved_once_abilities'] ?? array(),
+				'iterations_remaining'    => $result['iterations_remaining'] ?? 5,
 			);
 			// Keep token and params for the resume flow.
 			unset( $job['token'] );

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -1566,6 +1566,114 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'not save', $result['reply'] );
 	}
 
+	/**
+	 * Test confirmed tools that were not in the original direct-tool set are
+	 * allowed for the single resumed execution.
+	 */
+	public function test_resume_after_confirmation_allows_confirmed_tool_once(): void {
+		$this->skip_if_sdk_unavailable();
+		if ( ! class_exists( 'WP_AI_Client_Ability_Function_Resolver' ) ) {
+			$this->markTestSkipped( 'WP_AI_Client_Ability_Function_Resolver not available.' );
+		}
+
+		Settings::instance()->update(
+			[
+				'tool_permissions' => [
+					'sd-ai-agent/memory-save' => 'confirm',
+				],
+			]
+		);
+
+		$first_body = wp_json_encode(
+			[
+				'id'      => 'chatcmpl-confirm-once',
+				'object'  => 'chat.completion',
+				'choices' => [
+					[
+						'index'         => 0,
+						'message'       => [
+							'role'       => 'assistant',
+							'content'    => null,
+							'tool_calls' => [
+								[
+									'id'       => 'call_confirm_once',
+									'type'     => 'function',
+									'function' => [
+										'name'      => 'wpab__sd-ai-agent__memory-save',
+										'arguments' => wp_json_encode(
+											[
+												'category' => 'general',
+												'content'  => 'Confirmed one-time tool execution',
+											]
+										),
+									],
+								],
+							],
+						],
+						'finish_reason' => 'tool_calls',
+					],
+				],
+				'usage'   => [ 'prompt_tokens' => 10, 'completion_tokens' => 5, 'total_tokens' => 15 ],
+			]
+		);
+
+		$call_count = 0;
+		$this->mock_ai_response_sequence(
+			[
+				[ 'body' => $first_body ],
+				[ 'reply' => 'Saved after approval.' ],
+			],
+			$call_count
+		);
+
+		$loop   = new AgentLoop( 'Save this after approval', [ 'sd-ai-agent/memory-list' ] );
+		$paused = $loop->run();
+
+		$this->assertIsArray( $paused );
+		$this->assertTrue( $paused['awaiting_confirmation'] ?? false );
+		$this->assertContains( 'sd-ai-agent/memory-save', $paused['approved_once_abilities'] ?? [] );
+
+		$result = $loop->resume_after_confirmation( true, (int) $paused['iterations_remaining'] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'Saved after approval.', $result['reply'] );
+		$this->assertStringNotContainsString( 'ability_not_allowed', wp_json_encode( $result ) ?: '' );
+	}
+
+	/**
+	 * Test one-time confirmed abilities are merged into the resolver tool set.
+	 */
+	public function test_resolve_abilities_includes_approved_once_abilities(): void {
+		if ( ! function_exists( 'wp_get_abilities' ) ) {
+			$this->markTestSkipped( 'Abilities API not available.' );
+		}
+
+		$loop = new AgentLoop(
+			'Test prompt',
+			[ 'sd-ai-agent/memory-list' ],
+			[],
+			[
+				'approved_once_abilities' => [ 'sd-ai-agent/memory-save' ],
+			]
+		);
+
+		$method = new \ReflectionMethod( AgentLoop::class, 'resolve_abilities' );
+		$method->setAccessible( true );
+
+		$resolved = $method->invoke( $loop );
+		$this->assertIsArray( $resolved );
+
+		$names = array_map(
+			static function ( $ability ): string {
+				return $ability instanceof \WP_Ability ? $ability->get_name() : '';
+			},
+			$resolved
+		);
+
+		$this->assertContains( 'sd-ai-agent/memory-list', $names );
+		$this->assertContains( 'sd-ai-agent/memory-save', $names );
+	}
+
 	// -------------------------------------------------------------------------
 	// ensure_provider_credentials_static
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Preserve canonical ability IDs in pending confirmation payloads.
- Carry one-turn approved abilities through paused job state and merge them into the resolver on confirmed resume.
- Add regression coverage for confirmed abilities that were not part of the original direct tool set.

## Testing
- `npm run test:php` — passed.
- `npm run lint:php` — passed.
- `npm run lint:js` — passed.
- `npm run lint:css` — passed.
- `php -d memory_limit=2G vendor/bin/phpstan analyse --memory-limit=2G` — passed with 0 errors.
- `npm run build` — succeeded; webpack reported existing asset-size warnings.

## Worker self-verification
- PHPUnit: Tests: 3583, Assertions: 14973, Errors: 0, Failures: 0, Skipped: 120
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.55 plugin for [OpenCode](https://opencode.ai) v1.17.3 with gpt-5.5 spent 1h 2m and 639,222 tokens on this with the user in an interactive session.