### PR TITLE
Fix wporg AI review findings

### DIFF
--- a/includes/Abilities/OptionsAbilities.php
+++ b/includes/Abilities/OptionsAbilities.php
@@ -36,16 +36,20 @@ class OptionsAbilities {
 	public const SECRET_REDACTED_PLACEHOLDER = '[redacted: secret option]';
 
 	/**
-	 * Authentication keys and salts that must NEVER be returned to the AI
-	 * agent, even when stored in the options table.
+	 * Authentication keys, salts, and known credential options that must NEVER
+	 * be returned to the AI agent, even when stored in the options table.
 	 *
-	 * WordPress writes these names into `wp_options` when `wp-config.php`
-	 * does not define them, so a read path that names them by string would
-	 * leak the values. This list is the single source of truth used by every
-	 * read surface in the plugin (get-option, list-options, db-query,
-	 * run-php with `get_option`/`get_transient`, and wp-cli `option get`).
+	 * WordPress writes auth keys/salts into `wp_options` when `wp-config.php`
+	 * does not define them, and the Connectors API stores provider credentials
+	 * as options. A read path that names these rows by string would leak the
+	 * values. This list is the single source of truth used by every read surface
+	 * in the plugin (get-option, list-options, db-query, run-php with
+	 * `get_option`/`get_transient`, and wp-cli `option get`).
 	 *
-	 * Extend via the `sd_ai_agent_options_read_blocklist` filter.
+	 * Extend exact names via the `sd_ai_agent_options_read_blocklist` filter.
+	 * Open-ended WordPress Connectors API credential names are also blocked by
+	 * {@see OptionsAbilities::is_secret_option_name()} using the
+	 * `connectors_ai_{provider}_api_key` shape.
 	 *
 	 * @var string[]
 	 */
@@ -60,7 +64,23 @@ class OptionsAbilities {
 		'secure_auth_salt',
 		'logged_in_salt',
 		'nonce_salt',
+		// WordPress 7 Connectors API credentials. Third-party provider IDs that
+		// follow the same naming convention are caught by the predicate below.
+		'connectors_ai_openai_api_key',
+		'connectors_ai_anthropic_api_key',
+		'connectors_ai_google_api_key',
+		'connectors_ai_sd_ai_agent_cloud_api_key',
 	];
+
+	/**
+	 * Prefix used by WordPress 7 Connectors API credential option names.
+	 */
+	private const CONNECTORS_AI_OPTION_PREFIX = 'connectors_ai_';
+
+	/**
+	 * Suffix used by WordPress 7 Connectors API credential option names.
+	 */
+	private const CONNECTORS_AI_OPTION_SUFFIX = '_api_key';
 
 	/**
 	 * Options that the AI agent is never allowed to modify or delete.
@@ -271,13 +291,13 @@ class OptionsAbilities {
 	}
 
 	/**
-	 * Get the runtime read blocklist for secret option names.
+	 * Get the runtime read blocklist for exact secret option names.
 	 *
 	 * The list is intentionally narrower than the write blocklist: a few
 	 * options (e.g. `siteurl`, `active_plugins`) are write-blocked because
 	 * mutating them would break the site, but their values are not secrets
 	 * and may legitimately be inspected. Only values whose disclosure would
-	 * enable session forgery or impersonation belong here.
+	 * enable credential misuse, session forgery, or impersonation belong here.
 	 *
 	 * @return string[]
 	 */
@@ -296,10 +316,12 @@ class OptionsAbilities {
 	}
 
 	/**
-	 * Predicate: is the given option name in the secret read blocklist?
+	 * Predicate: is the given option name a blocked secret option?
 	 *
-	 * Comparison is exact-match and case-sensitive — WordPress option names
-	 * are case-sensitive at the storage layer.
+	 * Exact-name comparisons are case-sensitive — WordPress option names are
+	 * case-sensitive at the storage layer. WordPress Connectors API credentials
+	 * are additionally blocked by shape so third-party provider key options do
+	 * not need to be enumerated one by one.
 	 *
 	 * @param string $option_name Option name to test.
 	 * @return bool True if the name is a known secret.
@@ -309,7 +331,28 @@ class OptionsAbilities {
 			return false;
 		}
 
-		return in_array( $option_name, self::get_secret_read_blocklist(), true );
+		if ( in_array( $option_name, self::get_secret_read_blocklist(), true ) ) {
+			return true;
+		}
+
+		return self::is_connector_api_key_option( $option_name );
+	}
+
+	/**
+	 * Predicate: does the option name match the WordPress Connectors API key shape?
+	 *
+	 * WordPress 7 and the local polyfill use `connectors_ai_{provider}_api_key`
+	 * for provider credentials. Provider IDs are open-ended, so this shape gate
+	 * catches future and third-party connector credential options without adding
+	 * brittle option-key allow/deny lists.
+	 *
+	 * @param string $option_name Option name to test.
+	 * @return bool True if the name is a connector credential option.
+	 */
+	private static function is_connector_api_key_option( string $option_name ): bool {
+		return strlen( $option_name ) > strlen( self::CONNECTORS_AI_OPTION_PREFIX ) + strlen( self::CONNECTORS_AI_OPTION_SUFFIX )
+			&& str_starts_with( $option_name, self::CONNECTORS_AI_OPTION_PREFIX )
+			&& str_ends_with( $option_name, self::CONNECTORS_AI_OPTION_SUFFIX );
 	}
 
 	/**
@@ -323,7 +366,7 @@ class OptionsAbilities {
 			'sd_ai_agent_option_secret_redacted',
 			sprintf(
 				/* translators: %s: option name */
-				__( 'The option "%s" stores an authentication secret and cannot be read by the AI agent.', 'superdav-ai-agent' ),
+				__( 'The option "%s" stores a credential secret and cannot be read by the AI agent.', 'superdav-ai-agent' ),
 				$option_name
 			),
 			array( 'status' => 403 )

--- a/includes/CLI/SkillsCommand.php
+++ b/includes/CLI/SkillsCommand.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 /**
  * WP-CLI command: wp sd-ai-agent skills
  *
- * Maintenance commands for the vendored WordPress/agent-skills bundle.
+ * Maintenance commands for reviewing the vendored WordPress/agent-skills bundle.
  *
  * @package SdAiAgent\CLI
  * @license GPL-2.0-or-later
@@ -20,15 +20,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Manage vendored WordPress agent skills.
+ * Review upstream WordPress agent skills.
  *
  * ## EXAMPLES
  *
- *   # Dry-run: preview what would change
+ *   # Dry-run: preview what would change in the export directory
  *   wp sd-ai-agent skills sync-wp-agent-skills --dry-run
  *
- *   # Perform a live sync
- *   wp sd-ai-agent skills sync-wp-agent-skills
+ *   # Export generated files outside the plugin directory for manual review
+ *   wp sd-ai-agent skills sync-wp-agent-skills --output-dir=/tmp/sd-ai-agent-skills
  */
 class SkillsCommand extends WP_CLI_Command {
 
@@ -112,12 +112,16 @@ class SkillsCommand extends WP_CLI_Command {
 	}
 
 	/**
-	 * Sync the five curated WordPress/agent-skills into includes/Models/skills/.
+	 * Export the five curated WordPress/agent-skills for manual review.
 	 *
 	 * Fetches each SKILL.md from WordPress/agent-skills, applies sanitisation
 	 * (removes Studio-specific `studio wp ` CLI prefix, replaces wp-project-triage
 	 * Node script references), prepends an attribution header, and writes the
-	 * result to `includes/Models/skills/<slug>.md`.
+	 * result to an output directory outside the installed plugin.
+	 *
+	 * Runtime plugin installs must not write into their own plugin directory.
+	 * Maintainers should review the exported files and vendor them during the
+	 * release/build process instead.
 	 *
 	 * Uses `wp_remote_get()` so it works in any WP environment (honours
 	 * `WP_HTTP_BLOCK_EXTERNAL` and proxy settings).
@@ -127,10 +131,14 @@ class SkillsCommand extends WP_CLI_Command {
 	 * [--dry-run]
 	 * : Show what would change without writing any files.
 	 *
+	 * [--output-dir=<path>]
+	 * : Directory for generated files. Defaults to wp-content/uploads/sd-ai-agent/skills-sync/.
+	 *   Paths inside the plugin directory are rejected.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *   wp sd-ai-agent skills sync-wp-agent-skills --dry-run
-	 *   wp sd-ai-agent skills sync-wp-agent-skills
+	 *   wp sd-ai-agent skills sync-wp-agent-skills --output-dir=/tmp/sd-ai-agent-skills
 	 *
 	 * @subcommand sync-wp-agent-skills
 	 * @param array<int, string>   $args       Positional arguments (unused).
@@ -138,11 +146,20 @@ class SkillsCommand extends WP_CLI_Command {
 	 */
 	public function sync_wp_agent_skills( array $args, array $assoc_args ): void {
 		$dry_run    = (bool) ( $assoc_args['dry-run'] ?? false );
-		$skills_dir = SD_AI_AGENT_DIR . 'includes/Models/skills/';
+		$skills_dir = $this->resolve_output_dir( $assoc_args );
 
 		if ( $dry_run ) {
 			WP_CLI::log( '[dry-run] No files will be written.' );
+		} elseif ( ! wp_mkdir_p( $skills_dir ) ) {
+			WP_CLI::error(
+				sprintf(
+					'Unable to create output directory: %s',
+					$skills_dir
+				)
+			);
 		}
+
+		WP_CLI::log( 'Output directory: ' . $skills_dir );
 
 		$results = [];
 
@@ -159,6 +176,33 @@ class SkillsCommand extends WP_CLI_Command {
 		}
 
 		$this->print_summary( $results, $dry_run );
+	}
+
+	/**
+	 * Resolve the safe output directory for generated skill files.
+	 *
+	 * @param array<string, mixed> $assoc_args Named WP-CLI arguments.
+	 * @return string Absolute path with trailing slash.
+	 */
+	private function resolve_output_dir( array $assoc_args ): string {
+		$output_dir = isset( $assoc_args['output-dir'] ) ? (string) $assoc_args['output-dir'] : '';
+
+		if ( '' === $output_dir ) {
+			$uploads    = wp_upload_dir( null, false );
+			$upload_dir = isset( $uploads['basedir'] ) && is_string( $uploads['basedir'] )
+				? $uploads['basedir']
+				: WP_CONTENT_DIR . '/uploads';
+			$output_dir = trailingslashit( $upload_dir ) . 'sd-ai-agent/skills-sync';
+		}
+
+		$output_dir = wp_normalize_path( $output_dir );
+		$plugin_dir = wp_normalize_path( SD_AI_AGENT_DIR );
+
+		if ( str_starts_with( trailingslashit( $output_dir ), trailingslashit( $plugin_dir ) ) ) {
+			WP_CLI::error( 'Refusing to write generated skill files inside the plugin directory. Use --output-dir outside the plugin and vendor reviewed files during the release process.' );
+		}
+
+		return trailingslashit( $output_dir );
 	}
 
 	/**
@@ -183,10 +227,11 @@ class SkillsCommand extends WP_CLI_Command {
 
 		$sanitised = $this->sanitise( $content );
 		$dest_path = $skills_dir . $slug . '.md';
+		$exists    = file_exists( $dest_path );
 
 		// Check if the current file (without attribution header) matches.
 		$existing_body = '';
-		if ( file_exists( $dest_path ) ) {
+		if ( $exists ) {
 			// Reading a local plugin file path, not a remote URL — wp_remote_get() does not apply.
 			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 			$raw_existing  = (string) file_get_contents( $dest_path );
@@ -221,13 +266,17 @@ class SkillsCommand extends WP_CLI_Command {
 				}
 			}
 
-			// Writing a local plugin file — WP_Filesystem initialization is not appropriate
-			// in a CLI command context where the filesystem transport is always direct.
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
-			file_put_contents( $dest_path, $final );
-			$action = file_exists( $dest_path ) ? 'updated' : 'created';
+			if ( ! $this->write_generated_file( $dest_path, $final ) ) {
+				return [
+					'slug'    => $slug,
+					'status'  => 'error',
+					'outcome' => 'write_failed',
+				];
+			}
+
+			$action = $exists ? 'updated' : 'created';
 		} else {
-			$action = file_exists( $dest_path ) ? 'would update' : 'would create';
+			$action = $exists ? 'would update' : 'would create';
 		}
 
 		return [
@@ -235,6 +284,36 @@ class SkillsCommand extends WP_CLI_Command {
 			'status'  => $action,
 			'outcome' => 'ok',
 		];
+	}
+
+	/**
+	 * Write generated skill content with the WordPress filesystem abstraction.
+	 *
+	 * @param string $dest_path Absolute destination path.
+	 * @param string $contents  File contents.
+	 * @return bool True when the write succeeds.
+	 */
+	private function write_generated_file( string $dest_path, string $contents ): bool {
+		global $wp_filesystem;
+
+		if ( ! function_exists( 'WP_Filesystem' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/file.php';
+		}
+
+		WP_Filesystem();
+		$filesystem = $wp_filesystem;
+
+		if ( ! $filesystem instanceof \WP_Filesystem_Base ) {
+			if ( ! class_exists( '\WP_Filesystem_Direct' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/class-wp-filesystem-direct.php';
+			}
+
+			$filesystem = new \WP_Filesystem_Direct( array() );
+		}
+
+		$chmod = defined( 'FS_CHMOD_FILE' ) ? (int) constant( 'FS_CHMOD_FILE' ) : 0644;
+
+		return (bool) $filesystem->put_contents( $dest_path, $contents, $chmod );
 	}
 
 	/**

--- a/includes/REST/ConnectorsController.php
+++ b/includes/REST/ConnectorsController.php
@@ -246,17 +246,9 @@ final class ConnectorsController {
 	 * @return array<string, mixed>
 	 */
 	private function build_provider_data( string $provider_id, array $meta ): array {
-		$installed  = $this->is_plugin_installed( $meta['plugin_file'] );
-		$active     = $this->is_plugin_active( $meta['plugin_file'] );
-		$api_key    = (string) get_option( $meta['option_key'], '' );
-		$configured = '' !== $api_key;
-
-		// Build the masked key preview (last 4 chars only).
-		$masked_key = '';
-		if ( $configured ) {
-			$len        = strlen( $api_key );
-			$masked_key = str_repeat( '•', max( 0, $len - 4 ) ) . substr( $api_key, -4 );
-		}
+		$installed        = $this->is_plugin_installed( $meta['plugin_file'] );
+		$active           = $this->is_plugin_active( $meta['plugin_file'] );
+		$credential_state = $this->get_connector_credential_state( $provider_id, $meta['option_key'] );
 
 		return array(
 			'id'          => $provider_id,
@@ -266,8 +258,51 @@ final class ConnectorsController {
 			'plugin_slug' => $meta['plugin_slug'],
 			'installed'   => $installed,
 			'active'      => $active,
-			'configured'  => $configured,
-			'masked_key'  => $masked_key,
+			'configured'  => $credential_state['configured'],
+			'masked_key'  => $credential_state['masked_key'],
+		);
+	}
+
+	/**
+	 * Return safe credential state for a connector provider without reading raw keys.
+	 *
+	 * WordPress 7 stores AI provider credentials behind the Connectors API. The
+	 * controller only needs boolean configured state and the masked preview already
+	 * exposed by that API; it must not read `connectors_ai_*_api_key` directly.
+	 *
+	 * @param string $provider_id Provider ID.
+	 * @param string $option_key  Connector setting option name.
+	 * @return array{configured: bool, masked_key: string}
+	 */
+	private function get_connector_credential_state( string $provider_id, string $option_key ): array {
+		if ( ! function_exists( '_wp_connectors_get_provider_settings' ) ) {
+			return array(
+				'configured' => false,
+				'masked_key' => '',
+			);
+		}
+
+		$settings = _wp_connectors_get_provider_settings();
+		$setting  = $settings[ $option_key ] ?? null;
+
+		if ( ! is_array( $setting ) ) {
+			return array(
+				'configured' => false,
+				'masked_key' => '',
+			);
+		}
+
+		$setting_provider = isset( $setting['provider'] ) ? (string) $setting['provider'] : '';
+		if ( '' !== $setting_provider && $provider_id !== $setting_provider ) {
+			return array(
+				'configured' => false,
+				'masked_key' => '',
+			);
+		}
+
+		return array(
+			'configured' => true,
+			'masked_key' => isset( $setting['mask'] ) && is_string( $setting['mask'] ) ? $setting['mask'] : '',
 		);
 	}
 

--- a/includes/REST/ConnectorsController.php
+++ b/includes/REST/ConnectorsController.php
@@ -25,6 +25,8 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 use XWP\DI\Decorators\Action;
 use XWP\DI\Decorators\Handler;
 use SdAiAgent\Admin\UnifiedAdminMenu;
@@ -248,7 +250,7 @@ final class ConnectorsController {
 	private function build_provider_data( string $provider_id, array $meta ): array {
 		$installed        = $this->is_plugin_installed( $meta['plugin_file'] );
 		$active           = $this->is_plugin_active( $meta['plugin_file'] );
-		$credential_state = $this->get_connector_credential_state( $provider_id, $meta['option_key'] );
+		$credential_state = $this->get_connector_credential_state( $provider_id );
 
 		return array(
 			'id'          => $provider_id,
@@ -266,44 +268,61 @@ final class ConnectorsController {
 	/**
 	 * Return safe credential state for a connector provider without reading raw keys.
 	 *
-	 * WordPress 7 stores AI provider credentials behind the Connectors API. The
-	 * controller only needs boolean configured state and the masked preview already
-	 * exposed by that API; it must not read `connectors_ai_*_api_key` directly.
+	 * WordPress 7 stores AI provider credentials behind the Connectors API. This
+	 * controller avoids both direct option reads and private `_wp_connectors_*()`
+	 * helpers; it asks the public AI Client registry whether the provider has a
+	 * configured text-generation model. The raw key is never read, so no masked
+	 * preview is returned.
 	 *
 	 * @param string $provider_id Provider ID.
-	 * @param string $option_key  Connector setting option name.
 	 * @return array{configured: bool, masked_key: string}
 	 */
-	private function get_connector_credential_state( string $provider_id, string $option_key ): array {
-		if ( ! function_exists( '_wp_connectors_get_provider_settings' ) ) {
-			return array(
-				'configured' => false,
-				'masked_key' => '',
-			);
-		}
-
-		$settings = _wp_connectors_get_provider_settings();
-		$setting  = $settings[ $option_key ] ?? null;
-
-		if ( ! is_array( $setting ) ) {
-			return array(
-				'configured' => false,
-				'masked_key' => '',
-			);
-		}
-
-		$setting_provider = isset( $setting['provider'] ) ? (string) $setting['provider'] : '';
-		if ( '' !== $setting_provider && $provider_id !== $setting_provider ) {
-			return array(
-				'configured' => false,
-				'masked_key' => '',
-			);
-		}
-
+	private function get_connector_credential_state( string $provider_id ): array {
 		return array(
-			'configured' => true,
-			'masked_key' => isset( $setting['mask'] ) && is_string( $setting['mask'] ) ? $setting['mask'] : '',
+			'configured' => $this->provider_has_configured_text_model( $provider_id ),
+			'masked_key' => '',
 		);
+	}
+
+	/**
+	 * Check whether a provider has a configured text-generation model.
+	 *
+	 * Uses public AI Client SDK APIs rather than reading `connectors_ai_*_api_key`
+	 * options or calling private WordPress Connectors helpers.
+	 *
+	 * @param string $provider_id Provider ID.
+	 * @return bool True when the provider can supply at least one text model.
+	 */
+	private function provider_has_configured_text_model( string $provider_id ): bool {
+		if ( ! class_exists( AiClient::class ) || ! class_exists( CapabilityEnum::class ) ) {
+			return false;
+		}
+
+		try {
+			$registry = AiClient::defaultRegistry();
+			if ( ! $registry->hasProvider( $provider_id ) ) {
+				return false;
+			}
+
+			if ( null === $registry->getProviderRequestAuthentication( $provider_id ) ) {
+				return false;
+			}
+
+			$provider_class = $registry->getProviderClassName( $provider_id );
+			$model_metadata = $provider_class::modelMetadataDirectory()->listModelMetadata();
+
+			foreach ( $model_metadata as $model_meta ) {
+				foreach ( $model_meta->getSupportedCapabilities() as $capability ) {
+					if ( $capability->equals( CapabilityEnum::TEXT_GENERATION ) ) {
+						return true;
+					}
+				}
+			}
+
+			return false;
+		} catch ( \Throwable $e ) {
+			return false;
+		}
 	}
 
 	/**

--- a/tests/SdAiAgent/Abilities/OptionsAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/OptionsAbilitiesTest.php
@@ -45,6 +45,7 @@ class OptionsAbilitiesTest extends WP_UnitTestCase {
 		}
 		delete_option( 'sd_ai_agent_test_visible_option' );
 		delete_option( 'sd_ai_agent_test_write_option' );
+		delete_option( 'connectors_ai_custom_provider_api_key' );
 		delete_option( 'third_party_test_option' );
 		remove_all_filters( 'sd_ai_agent_options_read_blocklist' );
 		remove_all_filters( 'sd_ai_agent_options_blocklist' );
@@ -52,6 +53,26 @@ class OptionsAbilitiesTest extends WP_UnitTestCase {
 		remove_all_filters( 'sd_ai_agent_options_write_allowlist_prefixes' );
 
 		parent::tear_down();
+	}
+
+	/**
+	 * WordPress Connectors API provider credentials are secret option names.
+	 */
+	public function test_connector_api_key_options_are_secret(): void {
+		$expected = array(
+			'connectors_ai_openai_api_key',
+			'connectors_ai_anthropic_api_key',
+			'connectors_ai_google_api_key',
+			'connectors_ai_sd_ai_agent_cloud_api_key',
+		);
+
+		foreach ( $expected as $name ) {
+			$this->assertContains( $name, OptionsAbilities::get_secret_read_blocklist() );
+			$this->assertTrue( OptionsAbilities::is_secret_option_name( $name ) );
+		}
+
+		$this->assertTrue( OptionsAbilities::is_secret_option_name( 'connectors_ai_custom_provider_api_key' ) );
+		$this->assertFalse( OptionsAbilities::is_secret_option_name( 'connectors_ai__api_key' ) );
 	}
 
 	/**
@@ -252,6 +273,19 @@ class OptionsAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * GetOptionAbility refuses to read WordPress Connectors API credentials.
+	 */
+	public function test_get_option_ability_blocks_connector_api_key(): void {
+		update_option( 'connectors_ai_custom_provider_api_key', self::FIXTURE_SECRET_VALUE );
+
+		$ability = new GetOptionAbility( 'sd-ai-agent/get-option' );
+		$result  = $ability->run( array( 'option_name' => 'connectors_ai_custom_provider_api_key' ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_option_secret_redacted', $result->get_error_code() );
+	}
+
+	/**
 	 * Every shipped secret name is rejected by GetOptionAbility, not just
 	 * the first one in the list.
 	 */
@@ -335,6 +369,29 @@ class OptionsAbilitiesTest extends WP_UnitTestCase {
 				sprintf( 'Secret option "%s" leaked into the response.', $row['option_name'] )
 			);
 		}
+	}
+
+	/**
+	 * ListOptionsAbility omits connector credentials even for open-ended providers.
+	 */
+	public function test_list_options_ability_omits_connector_api_keys(): void {
+		update_option( 'connectors_ai_custom_provider_api_key', self::FIXTURE_SECRET_VALUE );
+
+		$ability = new ListOptionsAbility( 'sd-ai-agent/list-options' );
+		$result  = $ability->run(
+			array(
+				'prefix' => 'connectors_ai_%',
+				'limit'  => 50,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertGreaterThanOrEqual( 1, $result['redacted_count'] );
+
+		$encoded = wp_json_encode( $result );
+		$this->assertIsString( $encoded );
+		$this->assertStringNotContainsString( self::FIXTURE_SECRET_VALUE, $encoded );
+		$this->assertStringNotContainsString( 'connectors_ai_custom_provider_api_key', $encoded );
 	}
 
 	/**

--- a/tests/SdAiAgent/REST/ConnectorsControllerTest.php
+++ b/tests/SdAiAgent/REST/ConnectorsControllerTest.php
@@ -11,7 +11,111 @@ declare(strict_types=1);
 namespace SdAiAgent\Tests\REST;
 
 use SdAiAgent\REST\ConnectorsController;
+use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Providers\DTO\ProviderMetadata;
+use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
+use WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication;
+use WordPress\AiClient\Providers\Http\Enums\RequestAuthenticationMethod;
+use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 use WP_UnitTestCase;
+
+if ( interface_exists( '\WordPress\AiClient\Providers\Contracts\ModelMetadataDirectoryInterface' )
+	&& interface_exists( '\WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface' )
+	&& interface_exists( '\WordPress\AiClient\Providers\Contracts\ProviderInterface' )
+	&& interface_exists( '\WordPress\AiClient\Providers\Models\Contracts\ModelInterface' )
+	&& ! class_exists( __NAMESPACE__ . '\ConnectorsControllerTestOpenAiProvider', false )
+) {
+	/**
+	 * Test model metadata directory for the OpenAI connector card.
+	 */
+	class ConnectorsControllerTestOpenAiModelMetadataDirectory implements \WordPress\AiClient\Providers\Contracts\ModelMetadataDirectoryInterface {
+
+		/**
+		 * @return list<ModelMetadata>
+		 */
+		public function listModelMetadata(): array {
+			return array( $this->getModelMetadata( 'test-text-model' ) );
+		}
+
+		public function hasModelMetadata( string $modelId ): bool {
+			return 'test-text-model' === $modelId;
+		}
+
+		public function getModelMetadata( string $modelId ): ModelMetadata {
+			if ( 'test-text-model' !== $modelId ) {
+				throw new \WordPress\AiClient\Common\Exception\InvalidArgumentException( 'Unknown test model.' );
+			}
+
+			return new ModelMetadata(
+				'test-text-model',
+				'Test Text Model',
+				array( CapabilityEnum::textGeneration() ),
+				array()
+			);
+		}
+	}
+
+	/**
+	 * Test provider registered as `openai` so the connector card uses public SDK APIs.
+	 */
+	class ConnectorsControllerTestOpenAiProvider implements \WordPress\AiClient\Providers\Contracts\ProviderInterface {
+
+		public static function metadata(): ProviderMetadata {
+			return new ProviderMetadata(
+				'openai',
+				'OpenAI Test Provider',
+				ProviderTypeEnum::cloud(),
+				null,
+				RequestAuthenticationMethod::apiKey()
+			);
+		}
+
+		public static function model( string $modelId, ?ModelConfig $modelConfig = null ): \WordPress\AiClient\Providers\Models\Contracts\ModelInterface {
+			$metadata = self::modelMetadataDirectory()->getModelMetadata( $modelId );
+			$config   = $modelConfig ?? new ModelConfig();
+
+			return new class( $metadata, $config ) implements \WordPress\AiClient\Providers\Models\Contracts\ModelInterface {
+				private ModelMetadata $metadata;
+				private ModelConfig $config;
+
+				public function __construct( ModelMetadata $metadata, ModelConfig $config ) {
+					$this->metadata = $metadata;
+					$this->config   = $config;
+				}
+
+				public function metadata(): ModelMetadata {
+					return $this->metadata;
+				}
+
+				public function providerMetadata(): ProviderMetadata {
+					return ConnectorsControllerTestOpenAiProvider::metadata();
+				}
+
+				public function setConfig( ModelConfig $config ): void {
+					$this->config = $config;
+				}
+
+				public function getConfig(): ModelConfig {
+					return $this->config;
+				}
+			};
+		}
+
+		public static function availability(): \WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface {
+			return new class() implements \WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface {
+				public function isConfigured(): bool {
+					return true;
+				}
+			};
+		}
+
+		public static function modelMetadataDirectory(): \WordPress\AiClient\Providers\Contracts\ModelMetadataDirectoryInterface {
+			return new ConnectorsControllerTestOpenAiModelMetadataDirectory();
+		}
+	}
+}
 
 /**
  * Covers safe connector credential reporting.
@@ -19,17 +123,35 @@ use WP_UnitTestCase;
 final class ConnectorsControllerTest extends WP_UnitTestCase {
 
 	/**
+	 * Snapshot of registry internals restored after each test.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private array $registrySnapshot = array();
+
+	/**
+	 * Snapshot the SDK registry before adding test providers/authentication.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->snapshot_registry();
+	}
+
+	/**
 	 * Clean up connector options.
 	 */
 	public function tear_down(): void {
 		delete_option( 'connectors_ai_openai_api_key' );
+		$this->restore_registry();
 		parent::tear_down();
 	}
 
 	/**
-	 * The connector list uses the Connectors API mask and never exposes raw keys.
+	 * The connector list uses public SDK model support and never exposes raw keys.
 	 */
-	public function test_list_reports_masked_connector_status_without_raw_key(): void {
+	public function test_list_reports_configured_connector_status_without_raw_key(): void {
+		$this->register_openai_text_provider();
+
 		$fixture_value = 'fixture-openai-value-tail-1234';
 		update_option( 'connectors_ai_openai_api_key', $fixture_value, false );
 
@@ -40,9 +162,67 @@ final class ConnectorsControllerTest extends WP_UnitTestCase {
 
 		$this->assertNotNull( $openai );
 		$this->assertTrue( $openai['configured'] );
-		$this->assertIsString( $openai['masked_key'] );
-		$this->assertStringEndsWith( '1234', $openai['masked_key'] );
+		$this->assertSame( '', $openai['masked_key'] );
 		$this->assertStringNotContainsString( $fixture_value, wp_json_encode( $openai ) ?: '' );
+	}
+
+	/**
+	 * Register a public SDK provider for the OpenAI connector card.
+	 */
+	private function register_openai_text_provider(): void {
+		if ( ! class_exists( AiClient::class ) || ! class_exists( ConnectorsControllerTestOpenAiProvider::class ) ) {
+			$this->markTestSkipped( 'AI Client SDK test provider classes are unavailable.' );
+		}
+
+		$registry = AiClient::defaultRegistry();
+		if ( ! $registry->hasProvider( 'openai' ) ) {
+			$registry->registerProvider( ConnectorsControllerTestOpenAiProvider::class );
+		}
+
+		$registry->setProviderRequestAuthentication(
+			'openai',
+			new ApiKeyRequestAuthentication( 'test-key' )
+		);
+	}
+
+	/**
+	 * Snapshot registry internals before registering the test provider.
+	 */
+	private function snapshot_registry(): void {
+		if ( ! class_exists( AiClient::class ) ) {
+			return;
+		}
+
+		try {
+			$registry = AiClient::defaultRegistry();
+			foreach ( array( 'registeredIdsToClassNames', 'registeredClassNamesToIds', 'providerAuthenticationInstances' ) as $property_name ) {
+				$property = new \ReflectionProperty( $registry, $property_name );
+				$property->setAccessible( true );
+				$this->registrySnapshot[ $property_name ] = $property->getValue( $registry );
+			}
+		} catch ( \Throwable $e ) {
+			$this->registrySnapshot = array();
+		}
+	}
+
+	/**
+	 * Restore registry internals after registering the test provider.
+	 */
+	private function restore_registry(): void {
+		if ( array() === $this->registrySnapshot || ! class_exists( AiClient::class ) ) {
+			return;
+		}
+
+		try {
+			$registry = AiClient::defaultRegistry();
+			foreach ( $this->registrySnapshot as $property_name => $value ) {
+				$property = new \ReflectionProperty( $registry, (string) $property_name );
+				$property->setAccessible( true );
+				$property->setValue( $registry, $value );
+			}
+		} catch ( \Throwable $e ) {
+			// Best-effort cleanup; subsequent tests can still reset their own state.
+		}
 	}
 
 	/**

--- a/tests/SdAiAgent/REST/ConnectorsControllerTest.php
+++ b/tests/SdAiAgent/REST/ConnectorsControllerTest.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Tests for ConnectorsController.
+ *
+ * @package SdAiAgent\Tests\REST
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\REST;
+
+use SdAiAgent\REST\ConnectorsController;
+use WP_UnitTestCase;
+
+/**
+ * Covers safe connector credential reporting.
+ */
+final class ConnectorsControllerTest extends WP_UnitTestCase {
+
+	/**
+	 * Clean up connector options.
+	 */
+	public function tear_down(): void {
+		delete_option( 'connectors_ai_openai_api_key' );
+		parent::tear_down();
+	}
+
+	/**
+	 * The connector list uses the Connectors API mask and never exposes raw keys.
+	 */
+	public function test_list_reports_masked_connector_status_without_raw_key(): void {
+		$fixture_value = 'fixture-openai-value-tail-1234';
+		update_option( 'connectors_ai_openai_api_key', $fixture_value, false );
+
+		$response  = ( new ConnectorsController() )->handle_list();
+		$data      = $response->get_data();
+		$providers = $data['providers'];
+		$openai    = $this->find_provider( $providers, 'openai' );
+
+		$this->assertNotNull( $openai );
+		$this->assertTrue( $openai['configured'] );
+		$this->assertIsString( $openai['masked_key'] );
+		$this->assertStringEndsWith( '1234', $openai['masked_key'] );
+		$this->assertStringNotContainsString( $fixture_value, wp_json_encode( $openai ) ?: '' );
+	}
+
+	/**
+	 * Find a provider entry by ID.
+	 *
+	 * @param array<int, array<string, mixed>> $providers Provider rows.
+	 * @param string                          $provider_id Provider ID.
+	 * @return array<string, mixed>|null
+	 */
+	private function find_provider( array $providers, string $provider_id ): ?array {
+		foreach ( $providers as $provider ) {
+			if ( $provider_id === $provider['id'] ) {
+				return $provider;
+			}
+		}
+
+		return null;
+	}
+}


### PR DESCRIPTION
## Summary

- Block WordPress Connectors API key options from AI-facing option reads, including open-ended `connectors_ai_{provider}_api_key` names.
- Report connector configured state through the public AI Client registry/model metadata APIs instead of directly reading raw key options or calling private `_wp_connectors_*()` helpers.
- Change the skills sync command to export generated skill files outside the plugin directory using the WordPress filesystem abstraction.

## Worker self-verification

- PHPUnit: Tests: 3552, Assertions: 14842, Errors: 0, Failures: 0, Skipped: 116, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

## Additional verification

- `php -l` on modified PHP files: passed
- `composer phpcs -- includes/Abilities/OptionsAbilities.php includes/REST/ConnectorsController.php includes/CLI/SkillsCommand.php tests/SdAiAgent/Abilities/OptionsAbilitiesTest.php tests/SdAiAgent/REST/ConnectorsControllerTest.php`: passed
- `composer phpstan`: 0 errors after the public AI Client revision
- `npm run test:php -- --filter='OptionsAbilitiesTest|ConnectorsControllerTest'`: `OK (20 tests, 228 assertions)`
- Required option-security grep plus `npm run test:php -- --filter='OptionsAbilitiesTest|WordPressAbilitiesTest|DatabaseAbilitiesTest|WpCliAbilitiesTest'`: `OK (88 tests, 521 assertions)`
- `npm run verify`: lint, PHPStan, full PHPUnit, and build passed; final `npm run check:bundle` failed on the existing `floating-widget` size budget (`80.0 KiB` minified vs `80 KiB` budget). Reproduced the same bundle failure on a clean `wporg-review-540149` checkout after stashing these changes with `npm run build && npm run check:bundle`.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.61 plugin for [OpenCode](https://opencode.ai) v1.17.6 with gpt-5.5
