### PR TITLE
fix: force frontend onboarding query launch

### DIFF
--- a/includes/Admin/FloatingWidget.php
+++ b/includes/Admin/FloatingWidget.php
@@ -168,9 +168,16 @@ class FloatingWidget {
 
 		$onboarding_complete = OnboardingManager::is_complete();
 		$is_frontend         = 'frontend' === $context;
+		$force_onboarding    = false;
 		$viewed_post_id      = 0;
 		$viewed_post_type    = '';
 		$viewed_title        = '';
+
+		// Read-only launch hint for the frontend widget; no state changes happen here.
+		if ( $is_frontend && isset( $_GET['sd_ai_agent_onboarding'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$force_onboarding = '1' === sanitize_text_field( wp_unslash( $_GET['sd_ai_agent_onboarding'] ) );
+		}
 
 		if ( $is_frontend && is_singular() ) {
 			$viewed_post_id = (int) get_queried_object_id();
@@ -185,15 +192,16 @@ class FloatingWidget {
 			'sd-ai-agent-floating-widget',
 			'sdAiAgentData',
 			[
-				'currentUserId'       => get_current_user_id(),
-				'context'             => $context,
-				'isFrontend'          => $is_frontend,
-				'frontendOnboarding'  => ( $is_frontend && ! $onboarding_complete ) ? '1' : '',
-				'onboarding_complete' => $onboarding_complete,
-				'changesPageUrl'      => admin_url( 'admin.php?page=sd-ai-agent#/changes' ),
-				'viewedPostId'        => $viewed_post_id,
-				'viewedPostType'      => $viewed_post_type,
-				'viewedTitle'         => $viewed_title,
+				'currentUserId'            => get_current_user_id(),
+				'context'                  => $context,
+				'isFrontend'               => $is_frontend,
+				'frontendOnboarding'       => ( $is_frontend && ( ! $onboarding_complete || $force_onboarding ) ) ? '1' : '',
+				'frontendOnboardingForced' => $force_onboarding ? '1' : '',
+				'onboarding_complete'      => $onboarding_complete,
+				'changesPageUrl'           => admin_url( 'admin.php?page=sd-ai-agent#/changes' ),
+				'viewedPostId'             => $viewed_post_id,
+				'viewedPostType'           => $viewed_post_type,
+				'viewedTitle'              => $viewed_title,
 			]
 		);
 	}

--- a/includes/Core/OnboardingManager.php
+++ b/includes/Core/OnboardingManager.php
@@ -345,11 +345,16 @@ class OnboardingManager {
 	 * Idempotent: repeat calls return the originally-created session ID with
 	 * already_complete=true instead of creating a duplicate session.
 	 *
+	 * @param \WP_REST_Request|null $request Request with optional force flag.
 	 * @return \WP_REST_Response|\WP_Error
 	 */
-	public static function rest_start(): \WP_REST_Response|\WP_Error {
-		$settings = Settings::instance();
-		$all      = $settings->get();
+	public static function rest_start( ?\WP_REST_Request $request = null ): \WP_REST_Response|\WP_Error {
+		$settings    = Settings::instance();
+		$all         = $settings->get();
+		$force_param = $request instanceof \WP_REST_Request ? $request->get_param( 'force' ) : false;
+		$force       = is_bool( $force_param ) || is_int( $force_param ) || is_string( $force_param )
+			? rest_sanitize_boolean( $force_param )
+			: false;
 
 		// Resolve the Setup Assistant agent so the frontend can attach it to
 		// the onboarding session. The agent's stored system prompt is the
@@ -369,7 +374,10 @@ class OnboardingManager {
 		// Early-return if onboarding was already completed. Reuse the persisted
 		// session ID so the frontend can resume the same conversation.
 		$existing_session_id = get_option( self::BOOTSTRAP_SESSION_OPTION );
-		if ( self::is_complete() || ! empty( $all['onboarding_complete'] ) ) {
+		if (
+			( self::is_complete() || ! empty( $all['onboarding_complete'] ) )
+			&& ( ! $force || ! empty( $existing_session_id ) )
+		) {
 			// Ensure both persistence layers are consistent on legacy installs
 			// where only one of the two stores was set.
 			self::mark_complete();

--- a/src/floating-widget/__tests__/frontend-onboarding.test.js
+++ b/src/floating-widget/__tests__/frontend-onboarding.test.js
@@ -46,6 +46,14 @@ describe( 'frontend onboarding helpers', () => {
 				onboarding_complete: '1',
 			} )
 		).toBe( false );
+
+		expect(
+			isFrontendOnboardingEnabled( {
+				context: 'frontend',
+				onboarding_complete: '1',
+				frontendOnboardingForced: '1',
+			} )
+		).toBe( true );
 	} );
 
 	test( 'falls back to page context when localized context is absent', () => {
@@ -154,6 +162,19 @@ describe( 'frontend onboarding helpers', () => {
 				currentSessionId: null,
 			} )
 		).toBe( true );
+
+		expect(
+			shouldStartFrontendOnboarding( {
+				enabled: true,
+				started: false,
+				providersLoaded: true,
+				providerCount: 1,
+				sessionsLoaded: true,
+				sessionCount: 2,
+				currentSessionId: 12,
+				force: true,
+			} )
+		).toBe( true );
 	} );
 
 	test( 'starts unified onboarding from the frontend', async () => {
@@ -181,6 +202,29 @@ describe( 'frontend onboarding helpers', () => {
 		expect( setSelectedAgentId ).toHaveBeenCalledWith( 7 );
 		expect( openSession ).toHaveBeenCalledWith( 42 );
 		expect( sendMessage ).toHaveBeenCalledWith( 'Welcome' );
+	} );
+
+	test( 'sends force when starting explicitly requested onboarding', async () => {
+		const apiFetch = jest.fn().mockResolvedValueOnce( {
+			session_id: 42,
+		} );
+		const openSession = jest.fn().mockResolvedValue( undefined );
+		const sendMessage = jest.fn().mockResolvedValue( undefined );
+
+		await startOnboarding( {
+			apiFetch,
+			openSession,
+			sendMessage,
+			setSelectedAgentId: jest.fn(),
+			fallbackMessage: 'Fallback',
+			force: true,
+		} );
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/sd-ai-agent/v1/onboarding/start',
+			method: 'POST',
+			data: { force: true },
+		} );
 	} );
 
 	test( 'returns null when onboarding start omits a session id', async () => {

--- a/src/floating-widget/frontend-onboarding.js
+++ b/src/floating-widget/frontend-onboarding.js
@@ -33,7 +33,9 @@ function isTruthyFlag( value ) {
  * @return {boolean} True when the frontend widget should bootstrap onboarding.
  */
 export function isFrontendOnboardingEnabled( data ) {
-	if ( isTruthyFlag( data?.onboarding_complete ) ) {
+	const forced = isTruthyFlag( data?.frontendOnboardingForced );
+
+	if ( isTruthyFlag( data?.onboarding_complete ) && ! forced ) {
 		return false;
 	}
 
@@ -139,6 +141,7 @@ export function getHydrationSessionId( sessions, sessionJobs = {} ) {
  * @param {boolean} options.sessionsLoaded   Whether sessions finished loading.
  * @param {number}  options.sessionCount     Number of existing sessions.
  * @param {?number} options.currentSessionId Currently opened session ID.
+ * @param {boolean} options.force            Whether an explicit launch requested onboarding.
  * @return {boolean} True when it is safe to create the setup session.
  */
 export function shouldStartFrontendOnboarding( {
@@ -149,6 +152,7 @@ export function shouldStartFrontendOnboarding( {
 	sessionsLoaded,
 	sessionCount,
 	currentSessionId,
+	force = false,
 } ) {
 	return (
 		!! enabled &&
@@ -156,8 +160,8 @@ export function shouldStartFrontendOnboarding( {
 		!! providersLoaded &&
 		providerCount > 0 &&
 		!! sessionsLoaded &&
-		sessionCount === 0 &&
-		! currentSessionId
+		( !! force || sessionCount === 0 ) &&
+		( !! force || ! currentSessionId )
 	);
 }
 
@@ -170,6 +174,7 @@ export function shouldStartFrontendOnboarding( {
  * @param {Function} options.sendMessage        Store action to send a message.
  * @param {Function} options.setSelectedAgentId Store action to select an agent.
  * @param {string}   options.fallbackMessage    Message used when REST omits one.
+ * @param {boolean}  options.force              Recover from completed state without a persisted session.
  * @return {Promise<Object|null>} Start metadata, or null if no session returned.
  */
 export async function startOnboarding( {
@@ -178,11 +183,18 @@ export async function startOnboarding( {
 	sendMessage,
 	setSelectedAgentId,
 	fallbackMessage = "Hi! I'm ready to set up this site.",
+	force = false,
 } ) {
-	const data = await apiFetch( {
+	const request = {
 		path: ONBOARDING_START_PATH,
 		method: 'POST',
-	} );
+	};
+
+	if ( force ) {
+		request.data = { force: true };
+	}
+
+	const data = await apiFetch( request );
 
 	if ( data?.agent_id ) {
 		setSelectedAgentId( data.agent_id );

--- a/src/floating-widget/index.js
+++ b/src/floating-widget/index.js
@@ -52,6 +52,8 @@ function FloatingWidget() {
 
 	const frontendOnboardingEnabled =
 		!! window.sdAiAgentData?.frontendOnboarding;
+	const frontendOnboardingForced =
+		!! window.sdAiAgentData?.frontendOnboardingForced;
 	const [ frontendOnboardingMode, setFrontendOnboardingMode ] = useState(
 		frontendOnboardingEnabled ? 'intro' : null
 	);
@@ -136,7 +138,13 @@ function FloatingWidget() {
 
 		// Keep the public widget attached to the same active/latest conversation as
 		// the dedicated chat page after reloads or frontend navigation.
-		if ( sessions.length || ! providers.length ) {
+		const shouldForceStartWithExistingSessions =
+			frontendOnboardingForced && providers.length > 0;
+
+		if (
+			( sessions.length || ! providers.length ) &&
+			! shouldForceStartWithExistingSessions
+		) {
 			setFrontendOnboardingMode( null );
 			if ( sessions.length && ! currentSessionId ) {
 				import( './frontend-onboarding' ).then(
@@ -158,11 +166,12 @@ function FloatingWidget() {
 			! frontendOnboardingEnabled ||
 			frontendOnboardingStartedRef.current ||
 			! providersLoaded ||
-			currentSessionId
+			( ! frontendOnboardingForced && currentSessionId )
 		) {
 			return;
 		}
 
+		setFrontendOnboardingMode( 'intro' );
 		frontendOnboardingStartedRef.current = true;
 		import( './frontend-onboarding' )
 			.then( ( { startOnboarding } ) =>
@@ -170,6 +179,7 @@ function FloatingWidget() {
 					openSession,
 					sendMessage,
 					setSelectedAgentId,
+					force: frontendOnboardingForced,
 				} )
 			)
 			.catch( () => {
@@ -177,6 +187,7 @@ function FloatingWidget() {
 			} );
 	}, [
 		frontendOnboardingEnabled,
+		frontendOnboardingForced,
 		providersLoaded,
 		providers.length,
 		sessionsLoaded,

--- a/tests/SdAiAgent/Admin/FloatingWidgetTest.php
+++ b/tests/SdAiAgent/Admin/FloatingWidgetTest.php
@@ -13,6 +13,7 @@ namespace SdAiAgent\Tests\Admin;
 
 use SdAiAgent\Admin\FloatingWidget;
 use SdAiAgent\Admin\UnifiedAdminMenu;
+use SdAiAgent\Core\OnboardingManager;
 use SdAiAgent\Core\Settings;
 use WP_UnitTestCase;
 
@@ -36,6 +37,13 @@ class FloatingWidgetTest extends WP_UnitTestCase {
 	protected int $subscriber_id;
 
 	/**
+	 * Temporary build directory for enqueue tests.
+	 *
+	 * @var string
+	 */
+	protected string $fake_build_dir = '';
+
+	/**
 	 * Set up test users before each test.
 	 */
 	public function set_up(): void {
@@ -48,10 +56,43 @@ class FloatingWidgetTest extends WP_UnitTestCase {
 	 * Clean up settings and dequeue scripts after each test.
 	 */
 	public function tear_down(): void {
+		unset( $_GET['sd_ai_agent_onboarding'] );
+		delete_option( OnboardingManager::COMPLETE_OPTION );
+		delete_option( OnboardingManager::BOOTSTRAP_SESSION_OPTION );
+		remove_all_filters( 'sd_ai_agent_build_dir' );
+
+		if ( '' !== $this->fake_build_dir ) {
+			$asset_file = $this->fake_build_dir . '/floating-widget.asset.php';
+			if ( file_exists( $asset_file ) ) {
+				unlink( $asset_file );
+			}
+			if ( is_dir( $this->fake_build_dir ) ) {
+				rmdir( $this->fake_build_dir );
+			}
+			$this->fake_build_dir = '';
+		}
+
 		parent::tear_down();
 		delete_option( Settings::OPTION_NAME );
 		wp_dequeue_script( 'sd-ai-agent-floating-widget' );
 		wp_deregister_script( 'sd-ai-agent-floating-widget' );
+	}
+
+	/**
+	 * Provide a fake floating widget asset manifest so enqueue can proceed.
+	 */
+	private function add_fake_floating_widget_asset(): void {
+		$this->fake_build_dir = sys_get_temp_dir() . '/sd-ai-agent-floating-widget-' . wp_generate_uuid4();
+		wp_mkdir_p( $this->fake_build_dir );
+		file_put_contents(
+			$this->fake_build_dir . '/floating-widget.asset.php',
+			"<?php\nreturn [ 'dependencies' => [], 'version' => 'test' ];\n"
+		);
+
+		add_filter(
+			'sd_ai_agent_build_dir',
+			fn() => $this->fake_build_dir
+		);
 	}
 
 	// ─── Hook Registration ────────────────────────────────────────────────────
@@ -176,5 +217,24 @@ class FloatingWidgetTest extends WP_UnitTestCase {
 		remove_all_filters( 'sd_ai_agent_build_dir' );
 
 		$this->assertFalse( wp_script_is( 'sd-ai-agent-floating-widget', 'enqueued' ) );
+	}
+
+	/**
+	 * Test enqueue_assets_frontend() lets the query parameter force onboarding.
+	 */
+	public function test_enqueue_assets_frontend_query_forces_onboarding_when_complete(): void {
+		wp_set_current_user( $this->admin_id );
+		Settings::instance()->update( [ 'show_on_frontend' => true ] );
+		update_option( OnboardingManager::COMPLETE_OPTION, true );
+		$_GET['sd_ai_agent_onboarding'] = '1';
+		$this->add_fake_floating_widget_asset();
+
+		FloatingWidget::enqueue_assets_frontend();
+
+		$localized_data = (string) wp_scripts()->get_data( 'sd-ai-agent-floating-widget', 'data' );
+		$this->assertTrue( wp_script_is( 'sd-ai-agent-floating-widget', 'enqueued' ) );
+		$this->assertStringContainsString( '"frontendOnboarding":"1"', $localized_data );
+		$this->assertStringContainsString( '"frontendOnboardingForced":"1"', $localized_data );
+		$this->assertStringContainsString( '"onboarding_complete":"1"', $localized_data );
 	}
 }

--- a/tests/SdAiAgent/Core/OnboardingManagerTest.php
+++ b/tests/SdAiAgent/Core/OnboardingManagerTest.php
@@ -484,6 +484,30 @@ class OnboardingManagerTest extends WP_UnitTestCase {
 		$this->assertNotNull( \SdAiAgent\Core\Database::get_shared_session( $session_id ) );
 	}
 
+	/**
+	 * rest_start() force mode creates a setup session when completed state exists
+	 * without a persisted onboarding session.
+	 */
+	public function test_rest_start_force_creates_session_when_completed_without_persisted_session(): void {
+		$admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+		\SdAiAgent\Core\Settings::instance()->update( [ 'onboarding_complete' => true ] );
+		update_option( OnboardingManager::COMPLETE_OPTION, true );
+		delete_option( OnboardingManager::BOOTSTRAP_SESSION_OPTION );
+
+		$request = new \WP_REST_Request( 'POST', '/sd-ai-agent/v1/onboarding/start' );
+		$request->set_param( 'force', true );
+
+		$response = OnboardingManager::rest_start( $request );
+		$data     = $response->get_data();
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertNotEmpty( $data['session_id'] );
+		$this->assertSame( $data['session_id'], get_option( OnboardingManager::BOOTSTRAP_SESSION_OPTION ) );
+		$this->assertArrayNotHasKey( 'already_complete', $data );
+	}
+
 	// ── rest_reset ────────────────────────────────────────────────────────
 
 	/**


### PR DESCRIPTION
## Summary

- Honor `?sd_ai_agent_onboarding=1` on frontend pages even when onboarding is already marked complete.
- Carry a forced onboarding flag through the floating widget so existing sessions do not block the Setup Assistant start flow.
- Allow `/sd-ai-agent/v1/onboarding/start` to recover a completed-but-sessionless state when the forced frontend launch is requested.

## Testing

- `npm run lint`
- `php -d memory_limit=2G vendor/bin/phpstan analyse`
- `npm run test:php`
- `./node_modules/.bin/wp-scripts build`
- `npm run check:bundle`

Notes: `composer phpstan` initially hit the repository script's configured 1G memory limit; rerunning the same PHPStan analysis with a 2G PHP memory limit completed with 0 errors. Webpack build succeeded with the existing admin-page asset-size warnings; `check:bundle` passed.

## Worker self-verification

- PHPUnit: Tests: 3583, Assertions: 14979, Errors: 0, Failures: 0, Skipped: 119, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.86 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5
