### PR TITLE
Fix Kimi reasoning text leakage

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -2043,12 +2043,44 @@ class AgentLoop {
 		$text = '';
 
 		foreach ( $message->getParts() as $part ) {
-			if ( method_exists( $part, 'getText' ) && is_string( $part->getText() ) ) {
-				$text .= $part->getText() . "\n";
+			$part_text = $this->visible_content_text( $part );
+			if ( '' !== $part_text ) {
+				$text .= $part_text . "\n";
 			}
 		}
 
 		return trim( $text );
+	}
+
+	/**
+	 * Return user-visible content-channel text for a message part.
+	 *
+	 * Thought-channel text is preserved in history for provider round-trips, but
+	 * it must never be treated as assistant preamble, XML tool-call text, or final
+	 * display text.
+	 *
+	 * @param MessagePart $part Message part to inspect.
+	 */
+	private function visible_content_text( MessagePart $part ): string {
+		$text = $part->getText();
+		if ( ! is_string( $text ) || '' === trim( $text ) ) {
+			return '';
+		}
+
+		$channel = method_exists( $part, 'getChannel' ) ? $part->getChannel() : null;
+		if ( is_object( $channel ) && is_callable( array( $channel, 'isContent' ) ) ) {
+			return (bool) $channel->isContent() ? $text : '';
+		}
+
+		if ( is_object( $channel ) && isset( $channel->value ) ) {
+			return 'content' === strtolower( (string) $channel->value ) ? $text : '';
+		}
+
+		if ( is_string( $channel ) ) {
+			return ( '' === $channel || 'content' === strtolower( $channel ) ) ? $text : '';
+		}
+
+		return $text;
 	}
 
 	/**
@@ -2809,8 +2841,8 @@ class AgentLoop {
 	 */
 	private function log_tool_calls( Message $message ): void {
 		foreach ( $message->getParts() as $part ) {
-			$text = $part->getText();
-			if ( is_string( $text ) && '' !== trim( $text ) ) {
+			$text = $this->visible_content_text( $part );
+			if ( '' !== $text ) {
 				$this->message_log[] = array(
 					'type'     => 'preamble',
 					'text'     => $text,
@@ -2903,8 +2935,7 @@ class AgentLoop {
 	 */
 	private function message_has_assistant_text( Message $message ): bool {
 		foreach ( $message->getParts() as $part ) {
-			$text = $part->getText();
-			if ( is_string( $text ) && '' !== trim( $text ) ) {
+			if ( '' !== $this->visible_content_text( $part ) ) {
 				return true;
 			}
 		}

--- a/includes/Core/ConversationDisplaySanitizer.php
+++ b/includes/Core/ConversationDisplaySanitizer.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Sanitizes conversation history for user-facing display surfaces.
+ *
+ * Provider adapters may preserve hidden reasoning as thought-channel message
+ * parts so later provider requests can satisfy reasoning round-trip contracts.
+ * Those parts must never be returned to the browser, exports, or transcript
+ * renderers as visible assistant text.
+ *
+ * @package SdAiAgent\Core
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Core;
+
+class ConversationDisplaySanitizer {
+
+	/**
+	 * Strip hidden/non-content message parts from a list of serialized messages.
+	 *
+	 * Messages are kept even when all parts are removed so UI message indices stay
+	 * aligned with the persisted conversation used by feedback/report endpoints.
+	 *
+	 * @param array<mixed> $messages Serialized conversation messages.
+	 * @return list<array<string, mixed>> Display-safe messages.
+	 */
+	public static function sanitize_messages( array $messages ): array {
+		$sanitized = array();
+
+		foreach ( $messages as $message ) {
+			if ( ! is_array( $message ) ) {
+				continue;
+			}
+
+			$sanitized_message = array();
+			foreach ( $message as $key => $value ) {
+				if ( is_string( $key ) ) {
+					$sanitized_message[ $key ] = $value;
+				}
+			}
+
+			$parts = $sanitized_message['parts'] ?? null;
+			if ( is_array( $parts ) ) {
+				$sanitized_message['parts'] = self::sanitize_parts( $parts );
+			}
+
+			$sanitized[] = $sanitized_message;
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Extract visible text from one serialized message.
+	 *
+	 * @param array<string, mixed> $message Serialized conversation message.
+	 * @return string Visible content-channel text.
+	 */
+	public static function extract_text( array $message ): string {
+		$parts = $message['parts'] ?? null;
+		if ( ! is_array( $parts ) ) {
+			return '';
+		}
+
+		$text = '';
+		foreach ( self::sanitize_parts( $parts ) as $part ) {
+			$part_text = $part['text'] ?? null;
+			if ( is_string( $part_text ) ) {
+				$text .= $part_text;
+			}
+		}
+
+		return $text;
+	}
+
+	/**
+	 * Strip hidden/non-content parts from serialized message parts.
+	 *
+	 * @param array<mixed> $parts Serialized message parts.
+	 * @return list<array<string, mixed>> Display-safe message parts.
+	 */
+	private static function sanitize_parts( array $parts ): array {
+		$sanitized = array();
+
+		foreach ( $parts as $part ) {
+			if ( ! is_array( $part ) ) {
+				continue;
+			}
+
+			$sanitized_part = array();
+			foreach ( $part as $key => $value ) {
+				if ( is_string( $key ) ) {
+					$sanitized_part[ $key ] = $value;
+				}
+			}
+
+			if ( ! self::is_content_channel( $sanitized_part['channel'] ?? null ) ) {
+				continue;
+			}
+
+			$sanitized[] = $sanitized_part;
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Whether a serialized part belongs to the user-visible content channel.
+	 *
+	 * Older stored messages may omit the channel; the AI Client SDK defaults such
+	 * parts to content, so missing/null/empty channel remains visible. Explicit
+	 * `thought` and any future non-content channels are hidden.
+	 *
+	 * @param mixed $channel Serialized channel value.
+	 */
+	private static function is_content_channel( $channel ): bool {
+		if ( null === $channel || '' === $channel ) {
+			return true;
+		}
+
+		return is_string( $channel ) && 'content' === strtolower( $channel );
+	}
+}

--- a/includes/Core/Export.php
+++ b/includes/Core/Export.php
@@ -38,13 +38,16 @@ class Export {
 	public static function export_json( object $session ): array {
 		$messages   = json_decode( $session->messages, true ) ?: [];
 		$tool_calls = json_decode( $session->tool_calls, true ) ?: [];
+		if ( ! is_array( $messages ) ) {
+			$messages = [];
+		}
 
 		$data = [
 			'format'      => 'sd-ai-agent-v1',
 			'title'       => $session->title,
 			'provider_id' => $session->provider_id,
 			'model_id'    => $session->model_id,
-			'messages'    => $messages,
+			'messages'    => ConversationDisplaySanitizer::sanitize_messages( $messages ),
 			'tool_calls'  => $tool_calls,
 			'token_usage' => [
 				'prompt'     => (int) $session->prompt_tokens,
@@ -70,7 +73,10 @@ class Export {
 	 */
 	public static function export_markdown( object $session ): array {
 		$messages = json_decode( $session->messages, true ) ?: [];
-		$lines    = [];
+		if ( ! is_array( $messages ) ) {
+			$messages = [];
+		}
+		$lines = [];
 
 		$lines[] = '# ' . ( $session->title ?: 'Conversation' );
 		$lines[] = '';
@@ -93,18 +99,7 @@ class Export {
 				continue;
 			}
 
-			$text = '';
-			// @phpstan-ignore-next-line
-			if ( ! empty( $msg['parts'] ) ) {
-				// @phpstan-ignore-next-line
-				foreach ( $msg['parts'] as $part ) {
-					// @phpstan-ignore-next-line
-					if ( ! empty( $part['text'] ) ) {
-						// @phpstan-ignore-next-line
-						$text .= $part['text'];
-					}
-				}
-			}
+			$text = is_array( $msg ) ? ConversationDisplaySanitizer::extract_text( $msg ) : '';
 
 			if ( empty( $text ) ) {
 				continue;

--- a/includes/Feedback/ReportSanitizer.php
+++ b/includes/Feedback/ReportSanitizer.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Feedback;
 
+use SdAiAgent\Core\ConversationDisplaySanitizer;
+
 class ReportSanitizer {
 
 	/**
@@ -78,6 +80,8 @@ class ReportSanitizer {
 	 * @return array<int, array<string, mixed>> Sanitized messages.
 	 */
 	private static function sanitize_messages( array $messages ): array {
+		$messages = ConversationDisplaySanitizer::sanitize_messages( $messages );
+
 		return array_map(
 			static function ( array $msg ): array {
 				if ( is_string( $msg['content'] ?? null ) ) {
@@ -97,6 +101,23 @@ class ReportSanitizer {
 							return $part;
 						},
 						$msg['content']
+					);
+				}
+				if ( is_array( $msg['parts'] ?? null ) ) {
+					$msg['parts'] = array_map(
+						static function ( mixed $part ): mixed {
+							if ( ! is_array( $part ) ) {
+								return $part;
+							}
+							if ( is_string( $part['text'] ?? null ) ) {
+								$part['text'] = self::sanitize_string( $part['text'] );
+							}
+							if ( is_string( $part['content'] ?? null ) ) {
+								$part['content'] = self::sanitize_string( $part['content'] );
+							}
+							return $part;
+						},
+						$msg['parts']
 					);
 				}
 				return $msg;

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -13,6 +13,7 @@ namespace SdAiAgent\REST;
 
 use SdAiAgent\Abilities\OptionsAbilities;
 use SdAiAgent\Core\AgentLoop;
+use SdAiAgent\Core\ConversationDisplaySanitizer;
 use SdAiAgent\Core\ConversationSerializer;
 use SdAiAgent\Core\ConversationTrimmer;
 use SdAiAgent\Core\CostCalculator;
@@ -655,13 +656,18 @@ final class SessionController {
 		$shared    = Database::get_shared_session( (int) $session->id );
 		$is_shared = $shared !== null;
 
+		$messages = json_decode( $session->messages, true ) ?: array();
+		if ( ! is_array( $messages ) ) {
+			$messages = array();
+		}
+
 		return new WP_REST_Response(
 			array(
 				'id'          => (int) $session->id,
 				'title'       => $session->title,
 				'provider_id' => $session->provider_id,
 				'model_id'    => $session->model_id,
-				'messages'    => json_decode( $session->messages, true ) ?: array(),
+				'messages'    => ConversationDisplaySanitizer::sanitize_messages( $messages ),
 				'tool_calls'  => json_decode( $session->tool_calls, true ) ?: array(),
 				'token_usage' => array(
 					'prompt'     => (int) ( $session->prompt_tokens ?? 0 ),
@@ -994,7 +1000,8 @@ final class SessionController {
 			// @phpstan-ignore-next-line
 			$response['reply'] = $job['result']['reply'] ?? '';
 			// @phpstan-ignore-next-line
-			$response['history'] = $job['result']['history'] ?? array();
+			$history             = $job['result']['history'] ?? array();
+			$response['history'] = is_array( $history ) ? ConversationDisplaySanitizer::sanitize_messages( $history ) : array();
 			// @phpstan-ignore-next-line
 			$response['tool_calls'] = $job['result']['tool_calls'] ?? array();
 			// @phpstan-ignore-next-line

--- a/src/components/chat-redesign/__tests__/message-helpers.test.js
+++ b/src/components/chat-redesign/__tests__/message-helpers.test.js
@@ -43,11 +43,18 @@ describe( 'extractText', () => {
 		const msg = {
 			parts: [
 				{
-					channel: 'thought',
+					channel: 'THOUGHT',
 					text: 'The user wants me to reveal private reasoning.',
 				},
 				{ channel: 'content', text: 'Visible answer.' },
 			],
+		};
+		expect( extractText( msg ) ).toBe( 'Visible answer.' );
+	} );
+
+	test( 'treats content channel matching as case-insensitive', () => {
+		const msg = {
+			parts: [ { channel: 'CONTENT', text: 'Visible answer.' } ],
 		};
 		expect( extractText( msg ) ).toBe( 'Visible answer.' );
 	} );

--- a/src/components/chat-redesign/__tests__/message-helpers.test.js
+++ b/src/components/chat-redesign/__tests__/message-helpers.test.js
@@ -39,6 +39,26 @@ describe( 'extractText', () => {
 		expect( extractText( msg ) ).toBe( 'Hi there' );
 	} );
 
+	test( 'ignores hidden thought-channel text parts', () => {
+		const msg = {
+			parts: [
+				{
+					channel: 'thought',
+					text: 'The user wants me to reveal private reasoning.',
+				},
+				{ channel: 'content', text: 'Visible answer.' },
+			],
+		};
+		expect( extractText( msg ) ).toBe( 'Visible answer.' );
+	} );
+
+	test( 'treats missing channel as visible content', () => {
+		const msg = {
+			parts: [ { text: 'Legacy visible text.' } ],
+		};
+		expect( extractText( msg ) ).toBe( 'Legacy visible text.' );
+	} );
+
 	test( 'returns empty string for missing/empty parts', () => {
 		expect( extractText( {} ) ).toBe( '' );
 		expect( extractText( { parts: [] } ) ).toBe( '' );

--- a/src/components/chat-redesign/message-helpers.js
+++ b/src/components/chat-redesign/message-helpers.js
@@ -4,18 +4,14 @@
  * in one place so the two UIs render the same store data identically.
  */
 
+import { extractMessageText } from '../../utils/message-parts';
+
 /**
  *
  * @param {Object} message
  */
 export function extractText( message ) {
-	if ( ! message.parts?.length ) {
-		return '';
-	}
-	return message.parts
-		.filter( ( p ) => p.text )
-		.map( ( p ) => p.text )
-		.join( '' );
+	return extractMessageText( message );
 }
 
 /**

--- a/src/components/message-actions.js
+++ b/src/components/message-actions.js
@@ -12,6 +12,7 @@ import { Icon, copy, pencil, redo, check, thumbsDown } from '@wordpress/icons';
  */
 import STORE_NAME from '../store';
 import { copyToClipboard } from '../utils/clipboard';
+import { extractMessageText } from '../utils/message-parts';
 
 /**
  * Per-message action buttons (Copy, Edit, Regenerate, Thumbs-down).
@@ -47,10 +48,7 @@ export default function MessageActions( { message, index, onThumbsDown } ) {
 		[]
 	);
 
-	const text = message.parts
-		?.filter( ( p ) => p.text )
-		.map( ( p ) => p.text )
-		.join( '' );
+	const text = extractMessageText( message );
 
 	const handleCopy = useCallback( () => {
 		copyToClipboard( text || '' ).then( () => {

--- a/src/store/slices/sessionsSlice.js
+++ b/src/store/slices/sessionsSlice.js
@@ -19,6 +19,10 @@ import { __ } from '@wordpress/i18n';
 import { snapshotDescriptors } from '../../abilities/registry';
 import { ensureRegistered as ensureClientAbilitiesRegistered } from '../../abilities';
 import { clearNotification } from '../../utils/notification-manager';
+import {
+	extractMessageText,
+	isVisibleTextPart,
+} from '../../utils/message-parts';
 
 /**
  * Coerce session-like objects from the REST API so that `id` is always an
@@ -81,7 +85,7 @@ function associateToolCallsWithMessages( messages, toolCalls ) {
 			}
 
 			// Check if this model message has text content (visible message).
-			const hasText = msg.parts.some( ( p ) => p.text );
+			const hasText = msg.parts.some( isVisibleTextPart );
 			if ( hasText && pendingCallIds.length > 0 ) {
 				// Build the toolCalls array for this message from matched pairs.
 				const msgToolCalls = [];
@@ -846,10 +850,7 @@ export const actions = {
 			if ( userIdx < 0 ) {
 				return;
 			}
-			const userText = messages[ userIdx ]?.parts
-				?.filter( ( p ) => p.text )
-				.map( ( p ) => p.text )
-				.join( '' );
+			const userText = extractMessageText( messages[ userIdx ] );
 			if ( ! userText ) {
 				return;
 			}
@@ -1363,10 +1364,7 @@ export const actions = {
 			const summaryText = messages
 				.map( ( m ) => {
 					const role = m.role === 'model' ? 'Assistant' : 'User';
-					const text = m.parts
-						?.filter( ( p ) => p.text )
-						.map( ( p ) => p.text )
-						.join( '' );
+					const text = extractMessageText( m );
 					return text ? `${ role }: ${ text }` : null;
 				} )
 				.filter( Boolean )

--- a/src/utils/message-parts.js
+++ b/src/utils/message-parts.js
@@ -1,0 +1,54 @@
+/**
+ * Helpers for serialized AI Client message parts.
+ *
+ * Missing channel means content in the PHP AI Client SDK. Explicit thought (or
+ * any future non-content channel) is hidden from display, copy, speech, exports,
+ * and local transcript summaries.
+ */
+
+/**
+ * Whether a serialized message part belongs to the visible content channel.
+ *
+ * @param {Object} part Serialized message part.
+ * @return {boolean} True when the part is visible user-facing content.
+ */
+export function isContentPart( part ) {
+	const channel = part?.channel;
+	return (
+		channel === undefined ||
+		channel === null ||
+		channel === '' ||
+		channel === 'content'
+	);
+}
+
+/**
+ * Whether a serialized message part has visible text.
+ *
+ * @param {Object} part Serialized message part.
+ * @return {boolean} True when the part has visible text.
+ */
+export function isVisibleTextPart( part ) {
+	return (
+		typeof part?.text === 'string' &&
+		part.text !== '' &&
+		isContentPart( part )
+	);
+}
+
+/**
+ * Extract visible text from a serialized message.
+ *
+ * @param {Object} message Serialized message.
+ * @return {string} Concatenated visible text.
+ */
+export function extractMessageText( message ) {
+	if ( ! message?.parts?.length ) {
+		return '';
+	}
+
+	return message.parts
+		.filter( isVisibleTextPart )
+		.map( ( part ) => part.text )
+		.join( '' );
+}

--- a/src/utils/message-parts.js
+++ b/src/utils/message-parts.js
@@ -13,10 +13,12 @@
  * @return {boolean} True when the part is visible user-facing content.
  */
 export function isContentPart( part ) {
-	const channel = part?.channel;
+	const rawChannel = part?.channel;
+	const channel =
+		typeof rawChannel === 'string' ? rawChannel.toLowerCase() : rawChannel;
 	return (
-		channel === undefined ||
-		channel === null ||
+		rawChannel === undefined ||
+		rawChannel === null ||
 		channel === '' ||
 		channel === 'content'
 	);

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -171,6 +171,50 @@ class AgentLoopTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Thought-channel text must not be logged as live assistant preamble.
+	 */
+	public function test_thought_channel_text_is_not_logged_as_preamble(): void {
+		if ( ! class_exists( 'WordPress\AiClient\Messages\DTO\ModelMessage' ) ) {
+			$this->markTestSkipped( 'WP AI Client message classes are not available.' );
+		}
+
+		$loop = new AgentLoop(
+			'Test prompt',
+			[],
+			[],
+			[
+				'provider_id' => 'openai_compat',
+				'model_id'    => 'moonshotai/Kimi-K2.6',
+			]
+		);
+
+		$message = new \WordPress\AiClient\Messages\DTO\ModelMessage(
+			[
+				new \WordPress\AiClient\Messages\DTO\MessagePart(
+					'The user wants me to expose hidden reasoning.',
+					\WordPress\AiClient\Messages\Enums\MessagePartChannelEnum::thought()
+				),
+				new \WordPress\AiClient\Messages\DTO\MessagePart( 'Visible preamble.' ),
+				new \WordPress\AiClient\Messages\DTO\MessagePart(
+					new \WordPress\AiClient\Tools\DTO\FunctionCall( 'call_1', 'wpab__sd-ai-agent__site-info', [] )
+				),
+			]
+		);
+
+		$method = new \ReflectionMethod( AgentLoop::class, 'log_tool_calls' );
+		$method->setAccessible( true );
+		$method->invoke( $loop, $message );
+
+		$message_log_property = new \ReflectionProperty( AgentLoop::class, 'message_log' );
+		$message_log_property->setAccessible( true );
+		$message_log = $message_log_property->getValue( $loop );
+
+		$this->assertCount( 1, $message_log, 'Only content-channel text should be logged as preamble.' );
+		$this->assertSame( 'Visible preamble.', $message_log[0]['text'] );
+		$this->assertStringNotContainsString( 'hidden reasoning', (string) wp_json_encode( $message_log ) );
+	}
+
+	/**
 	 * XML-ish tool-call text should become an ability-call function part, not a final reply.
 	 */
 	public function test_intercepts_xml_tool_call_text_as_ability_call(): void {

--- a/tests/SdAiAgent/Core/ConversationDisplaySanitizerTest.php
+++ b/tests/SdAiAgent/Core/ConversationDisplaySanitizerTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Test case for ConversationDisplaySanitizer.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\ConversationDisplaySanitizer;
+use WP_UnitTestCase;
+
+/**
+ * Tests for hiding provider thought-channel content from display surfaces.
+ */
+class ConversationDisplaySanitizerTest extends WP_UnitTestCase {
+
+	/**
+	 * sanitize_messages() removes thought parts while preserving visible content.
+	 */
+	public function test_sanitize_messages_removes_thought_parts(): void {
+		$messages = [
+			[
+				'role'  => 'assistant',
+				'parts' => [
+					[
+						'channel' => 'thought',
+						'type'    => 'text',
+						'text'    => 'The user wants hidden reasoning.',
+					],
+					[
+						'channel' => 'content',
+						'type'    => 'text',
+						'text'    => 'Visible answer.',
+					],
+				],
+			],
+		];
+
+		$sanitized = ConversationDisplaySanitizer::sanitize_messages( $messages );
+
+		$this->assertCount( 1, $sanitized );
+		$this->assertCount( 1, $sanitized[0]['parts'] );
+		$this->assertSame( 'Visible answer.', $sanitized[0]['parts'][0]['text'] );
+		$this->assertStringNotContainsString( 'hidden reasoning', (string) wp_json_encode( $sanitized ) );
+	}
+
+	/**
+	 * sanitize_messages() keeps empty messages so persisted indices remain stable.
+	 */
+	public function test_sanitize_messages_keeps_thought_only_messages_empty(): void {
+		$messages = [
+			[
+				'role'  => 'assistant',
+				'parts' => [
+					[
+						'channel' => 'thought',
+						'text'    => 'Private chain of thought.',
+					],
+				],
+			],
+			[
+				'role'  => 'assistant',
+				'parts' => [ [ 'text' => 'Legacy visible answer.' ] ],
+			],
+		];
+
+		$sanitized = ConversationDisplaySanitizer::sanitize_messages( $messages );
+
+		$this->assertCount( 2, $sanitized );
+		$this->assertSame( array(), $sanitized[0]['parts'] );
+		$this->assertSame( 'Legacy visible answer.', $sanitized[1]['parts'][0]['text'] );
+	}
+
+	/**
+	 * extract_text() concatenates only content-channel or legacy unchannelled text.
+	 */
+	public function test_extract_text_uses_only_visible_content(): void {
+		$message = [
+			'role'  => 'assistant',
+			'parts' => [
+				[
+					'channel' => 'thought',
+					'text'    => 'Do not show this.',
+				],
+				[
+					'channel' => 'content',
+					'text'    => 'Visible ',
+				],
+				[ 'text' => 'legacy.' ],
+			],
+		];
+
+		$this->assertSame( 'Visible legacy.', ConversationDisplaySanitizer::extract_text( $message ) );
+	}
+}

--- a/tests/SdAiAgent/Core/ExportTest.php
+++ b/tests/SdAiAgent/Core/ExportTest.php
@@ -143,6 +143,36 @@ class ExportTest extends WP_UnitTestCase {
 		$this->assertEmpty( $result['content']['messages'] );
 	}
 
+	/**
+	 * export_json() strips hidden thought-channel parts from transcript data.
+	 */
+	public function test_export_json_strips_thought_channel_parts(): void {
+		$session = $this->make_session( [
+			'messages' => wp_json_encode( [
+				[
+					'role'  => 'assistant',
+					'parts' => [
+						[
+							'channel' => 'thought',
+							'text'    => 'The user wants hidden reasoning.',
+						],
+						[
+							'channel' => 'content',
+							'text'    => 'Visible answer.',
+						],
+					],
+				],
+			] ),
+		] );
+
+		$result  = Export::export_json( $session );
+		$content = wp_json_encode( $result['content'] );
+
+		$this->assertIsString( $content );
+		$this->assertStringNotContainsString( 'hidden reasoning', $content );
+		$this->assertStringContainsString( 'Visible answer.', $content );
+	}
+
 	// ── export_markdown ───────────────────────────────────────────────────────
 
 	/**
@@ -212,6 +242,34 @@ class ExportTest extends WP_UnitTestCase {
 
 		// Only the assistant message should appear.
 		$this->assertStringContainsString( 'Response', $result['content'] );
+	}
+
+	/**
+	 * export_markdown() excludes hidden thought-channel reasoning.
+	 */
+	public function test_export_markdown_strips_thought_channel_text(): void {
+		$session = $this->make_session( [
+			'messages' => wp_json_encode( [
+				[
+					'role'  => 'assistant',
+					'parts' => [
+						[
+							'channel' => 'thought',
+							'text'    => 'The user wants hidden reasoning.',
+						],
+						[
+							'channel' => 'content',
+							'text'    => 'Visible answer.',
+						],
+					],
+				],
+			] ),
+		] );
+
+		$result = Export::export_markdown( $session );
+
+		$this->assertStringNotContainsString( 'hidden reasoning', $result['content'] );
+		$this->assertStringContainsString( 'Visible answer.', $result['content'] );
 	}
 
 	/**

--- a/tests/SdAiAgent/Feedback/ReportSanitizerTest.php
+++ b/tests/SdAiAgent/Feedback/ReportSanitizerTest.php
@@ -72,4 +72,35 @@ class ReportSanitizerTest extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'secret-password-value', $encoded );
 		$this->assertStringContainsString( '[REDACTED:', $encoded );
 	}
+
+	/**
+	 * Test hidden thought-channel parts are stripped before feedback leaves site.
+	 */
+	public function test_sanitize_strips_thought_channel_parts_from_feedback_messages(): void {
+		$payload = array(
+			'session_data' => array(
+				'messages' => array(
+					array(
+						'role'  => 'assistant',
+						'parts' => array(
+							array(
+								'channel' => 'thought',
+								'text'    => 'The user wants hidden reasoning.',
+							),
+							array(
+								'channel' => 'content',
+								'text'    => 'Visible answer.',
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$sanitized = ReportSanitizer::sanitize( $payload );
+		$encoded   = (string) wp_json_encode( $sanitized );
+
+		$this->assertStringNotContainsString( 'hidden reasoning', $encoded );
+		$this->assertStringContainsString( 'Visible answer.', $encoded );
+	}
 }


### PR DESCRIPTION
## Summary
- Hide AI Client thought-channel reasoning from chat display, copy/TTS, session REST responses, exports, and feedback reports.
- Keep thought-channel parts in persisted history for provider round-trips while returning display-safe message parts to the browser.
- Add PHP and JS regressions covering Kimi-style `channel: "thought"` reasoning leakage.

## Worker self-verification
- PHPUnit: Tests: 3590, Assertions: 14991, Errors: 0, Failures: 0, Skipped: 120, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Additional verification:
- `npm run test:js`: 313 passed
- `npx wp-scripts build`: succeeded with existing webpack asset-size warnings

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.88 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed internal AI reasoning text appearing in exported conversations and API responses; only assistant-visible answers now display.

* **Tests**
  * Added comprehensive test coverage for content filtering across exports and API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->