### PR TITLE
feat: wire managed Superdav service endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ AI Agent works with any connector plugin registered through the WordPress Connec
 
 All connectors are included in the [WordPress Playground demo](https://playground.wordpress.net/?blueprint-url=https://raw.githubusercontent.com/Ultimate-Multisite/sd-ai-agent/refs/heads/main/.wordpress-org/blueprints/blueprint.json).
 
+### Managed Superdav AI service
+
+The bundled **Superdav AI** connector uses a service-managed site token instead of a customer-provided provider key. For local Superdav AI Service testing, configure the OpenAI-compatible `/v1` base URL in `wp-config.php`:
+
+```php
+define( 'SD_AI_AGENT_CLOUD_BASE_URL', 'http://127.0.0.1:3000/v1' );
+```
+
+When this base URL is set, plugin activation and the connector **Connect** action register the site at `POST /v1/site/installations`; model listing and chat use `GET /v1/models` and `POST /v1/chat/completions` with the stored site token as `Authorization: Bearer <SITE_ACCESS_TOKEN>`. Override `SD_AI_AGENT_CLOUD_REGISTRATION_ENDPOINT` or `SD_AI_AGENT_CLOUD_REVOCATION_ENDPOINT` only when those endpoints live outside the configured base URL.
+
 ## Features
 
 ### Agentic chat

--- a/includes/Bootstrap/LifecycleHandler.php
+++ b/includes/Bootstrap/LifecycleHandler.php
@@ -29,6 +29,7 @@ use SdAiAgent\Core\Database;
 use SdAiAgent\Core\OnboardingManager;
 use SdAiAgent\Core\SkillUpdateChecker;
 use SdAiAgent\Core\SiteScanner;
+use SdAiAgent\Core\SuperdavSiteConnectionService;
 use SdAiAgent\Knowledge\KnowledgeHooks;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -58,6 +59,7 @@ final class LifecycleHandler {
 		SkillUpdateChecker::schedule();
 		ActiveJobsCleanupService::schedule();
 		ToolCapabilities::register_capabilities( ToolCapabilities::all_ability_ids() );
+		self::maybe_provision_superdav_site_connection();
 	}
 
 	/**
@@ -74,5 +76,27 @@ final class LifecycleHandler {
 		SkillUpdateChecker::unschedule();
 		ActiveJobsCleanupService::unschedule();
 		BlockInventory::unschedule();
+	}
+
+	/**
+	 * Provision the first-party site token during activation when a remote edge is configured.
+	 *
+	 * Activation must not fail only because the managed AI service is temporarily
+	 * unavailable, so connection errors are intentionally ignored here. The
+	 * connector page can retry the same registration flow interactively.
+	 */
+	private static function maybe_provision_superdav_site_connection(): void {
+		try {
+			$service = new SuperdavSiteConnectionService();
+			$status  = $service->get_status();
+
+			if ( ! empty( $status['configured'] ) || ! $service->has_remote_registration_endpoint() ) {
+				return;
+			}
+
+			$service->provision_site_token();
+		} catch ( \Throwable ) {
+			return;
+		}
 	}
 }

--- a/includes/Core/SuperdavSiteConnectionService.php
+++ b/includes/Core/SuperdavSiteConnectionService.php
@@ -25,6 +25,9 @@ final class SuperdavSiteConnectionService {
 	public const INSTALLATION_ID_OPTION = 'sd_ai_agent_site_installation_id';
 	public const TOKEN_METADATA_OPTION  = 'sd_ai_agent_cloud_connection_metadata';
 
+	private const REGISTRATION_ENDPOINT_PATH = 'site/installations';
+	private const REVOCATION_ENDPOINT_PATH   = 'site/token/revoke';
+
 	/**
 	 * Build safe connector status metadata.
 	 *
@@ -82,6 +85,13 @@ final class SuperdavSiteConnectionService {
 		);
 
 		return $this->get_status();
+	}
+
+	/**
+	 * Determine whether a remote Superdav registration endpoint is configured.
+	 */
+	public function has_remote_registration_endpoint(): bool {
+		return '' !== $this->get_registration_endpoint();
 	}
 
 	/**
@@ -150,15 +160,7 @@ final class SuperdavSiteConnectionService {
 	 * @return array{token: string, metadata: array<string, mixed>}|string|WP_Error Token registration, empty string when no endpoint is configured, or error.
 	 */
 	private function request_remote_site_token(): array|string|WP_Error {
-		/**
-		 * Filters the Superdav site registration endpoint.
-		 *
-		 * Return an empty string to use local development provisioning.
-		 *
-		 * @param string $endpoint Registration endpoint URL.
-		 */
-		$endpoint = apply_filters( 'sd_ai_agent_cloud_registration_endpoint', '' );
-		$endpoint = is_string( $endpoint ) ? esc_url_raw( $endpoint ) : '';
+		$endpoint = $this->get_registration_endpoint();
 		if ( '' === $endpoint ) {
 			return '';
 		}
@@ -212,15 +214,7 @@ final class SuperdavSiteConnectionService {
 	 * Revoke a token against a configured endpoint when available.
 	 */
 	private function revoke_remote_token( string $token ): bool|WP_Error {
-		/**
-		 * Filters the Superdav token revocation endpoint.
-		 *
-		 * Return an empty string when revocation is unavailable.
-		 *
-		 * @param string $endpoint Revocation endpoint URL.
-		 */
-		$endpoint = apply_filters( 'sd_ai_agent_cloud_revocation_endpoint', '' );
-		$endpoint = is_string( $endpoint ) ? esc_url_raw( $endpoint ) : '';
+		$endpoint = $this->get_revocation_endpoint();
 		if ( '' === $endpoint ) {
 			return true;
 		}
@@ -252,6 +246,65 @@ final class SuperdavSiteConnectionService {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Resolve the site registration endpoint from explicit config or base URL.
+	 */
+	private function get_registration_endpoint(): string {
+		$endpoint = $this->configured_endpoint( 'SD_AI_AGENT_CLOUD_REGISTRATION_ENDPOINT', self::REGISTRATION_ENDPOINT_PATH );
+
+		/**
+		 * Filters the Superdav site registration endpoint.
+		 *
+		 * Return an empty string to use local development provisioning.
+		 * The default is SD_AI_AGENT_CLOUD_REGISTRATION_ENDPOINT, or the
+		 * configured cloud base URL plus `/site/installations`.
+		 *
+		 * @param string $endpoint Registration endpoint URL.
+		 */
+		$endpoint = apply_filters( 'sd_ai_agent_cloud_registration_endpoint', $endpoint );
+
+		return is_string( $endpoint ) ? esc_url_raw( $endpoint ) : '';
+	}
+
+	/**
+	 * Resolve the token revocation endpoint from explicit config or base URL.
+	 */
+	private function get_revocation_endpoint(): string {
+		$endpoint = $this->configured_endpoint( 'SD_AI_AGENT_CLOUD_REVOCATION_ENDPOINT', self::REVOCATION_ENDPOINT_PATH );
+
+		/**
+		 * Filters the Superdav token revocation endpoint.
+		 *
+		 * Return an empty string when revocation is unavailable.
+		 * The default is SD_AI_AGENT_CLOUD_REVOCATION_ENDPOINT, or the
+		 * configured cloud base URL plus `/site/token/revoke`.
+		 *
+		 * @param string $endpoint Revocation endpoint URL.
+		 */
+		$endpoint = apply_filters( 'sd_ai_agent_cloud_revocation_endpoint', $endpoint );
+
+		return is_string( $endpoint ) ? esc_url_raw( $endpoint ) : '';
+	}
+
+	/**
+	 * Resolve a service endpoint from a specific constant or the cloud base URL.
+	 *
+	 * @param string $constant_name Endpoint override constant name.
+	 * @param string $path          Path relative to the configured cloud base URL.
+	 * @return string Resolved endpoint URL, or empty when not configured.
+	 */
+	private function configured_endpoint( string $constant_name, string $path ): string {
+		$endpoint = defined( $constant_name ) && is_string( constant( $constant_name ) )
+			? (string) constant( $constant_name )
+			: '';
+
+		if ( '' === $endpoint ) {
+			$endpoint = SuperdavAiProvider::configured_service_url( $path );
+		}
+
+		return is_string( $endpoint ) ? esc_url_raw( $endpoint ) : '';
 	}
 
 	/**

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php
@@ -94,6 +94,30 @@ final class SuperdavAiProvider extends AbstractApiProvider {
 	}
 
 	/**
+	 * Return the configured OpenAI-compatible API base URL.
+	 *
+	 * @return string Base URL without a trailing slash, or empty when not configured.
+	 */
+	public static function configured_base_url(): string {
+		return self::baseUrl();
+	}
+
+	/**
+	 * Build a Superdav service URL from the configured cloud base URL.
+	 *
+	 * @param string $path Service path relative to the configured base URL.
+	 * @return string Full URL, or empty when the cloud base URL is not configured.
+	 */
+	public static function configured_service_url( string $path ): string {
+		$base_url = self::configured_base_url();
+		if ( '' === $base_url ) {
+			return '';
+		}
+
+		return $base_url . '/' . ltrim( $path, '/' );
+	}
+
+	/**
 	 * Return the configured API host for provider `/models` ingestion gates.
 	 *
 	 * @return string Lowercase host, or an empty string when no base URL is configured.

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
@@ -133,6 +133,21 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Service helper URLs use the same configured `/v1` base as the OpenAI-compatible provider.
+	 */
+	public function test_configured_service_url_uses_filtered_cloud_base_url(): void {
+		add_filter(
+			'sd_ai_agent_cloud_base_url',
+			static fn(): string => 'https://service.example/v1'
+		);
+
+		$this->assertSame(
+			'https://service.example/v1/site/installations',
+			SuperdavAiProvider::configured_service_url( 'site/installations' )
+		);
+	}
+
+	/**
 	 * Skip when the SDK was not loaded in the current test environment.
 	 */
 	private function skip_if_sdk_unavailable(): void {

--- a/tests/SdAiAgent/REST/ConnectorsControllerTest.php
+++ b/tests/SdAiAgent/REST/ConnectorsControllerTest.php
@@ -25,7 +25,9 @@ final class ConnectorsControllerTest extends WP_UnitTestCase {
 	 * Clean up connector options.
 	 */
 	public function tear_down(): void {
+		remove_all_filters( 'sd_ai_agent_cloud_base_url' );
 		remove_all_filters( 'sd_ai_agent_cloud_registration_endpoint' );
+		remove_all_filters( 'sd_ai_agent_cloud_revocation_endpoint' );
 		remove_all_filters( 'pre_http_request' );
 		delete_option( SuperdavAiProvider::CREDENTIAL_OPTION );
 		delete_option( SuperdavSiteConnectionService::INSTALLATION_ID_OPTION );
@@ -135,6 +137,51 @@ final class ConnectorsControllerTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The configured cloud base URL defaults site registration to `/site/installations`.
+	 */
+	public function test_connect_registers_against_cloud_base_url_default_endpoint(): void {
+		$base_url     = 'https://service.example/v1';
+		$expected_url = $base_url . '/site/installations';
+		$captured_url = '';
+
+		add_filter( 'sd_ai_agent_cloud_base_url', static fn(): string => $base_url );
+		add_filter(
+			'pre_http_request',
+			static function ( mixed $preempt, array $parsed_args, string $url ) use ( $expected_url, &$captured_url ): mixed {
+				$captured_url = $url;
+				$body         = json_decode( (string) ( $parsed_args['body'] ?? '' ), true );
+
+				return array(
+					'response' => array(
+						'code'    => $expected_url === $url ? 201 : 404,
+						'message' => $expected_url === $url ? 'Created' : 'Not Found',
+					),
+					'body'     => wp_json_encode(
+						array(
+							'installation_id'  => is_array( $body ) ? (string) ( $body['installation_id'] ?? '' ) : '',
+							'site_token'       => 'sdaist_remote_site_token',
+							'tier'             => 'free',
+							'verified'         => false,
+							'connect_required' => false,
+						)
+					),
+				);
+			},
+			10,
+			3
+		);
+
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/connectors/' . SuperdavAiProvider::PROVIDER_ID . '/connect' );
+		$request->set_param( 'provider', SuperdavAiProvider::PROVIDER_ID );
+
+		$response = ( new ConnectorsController() )->handle_connect( $request );
+		$this->assertNotWPError( $response );
+
+		$this->assertSame( $expected_url, $captured_url );
+		$this->assertSame( 'sdaist_remote_site_token', get_option( SuperdavAiProvider::CREDENTIAL_OPTION, '' ) );
+	}
+
+	/**
 	 * Managed providers reject manual raw API-key storage.
 	 */
 	public function test_managed_provider_rejects_manual_api_key(): void {
@@ -163,6 +210,49 @@ final class ConnectorsControllerTest extends WP_UnitTestCase {
 
 		$data = $response->get_data();
 		$this->assertFalse( $data['configured'] );
+		$this->assertSame( '', get_option( SuperdavAiProvider::CREDENTIAL_OPTION, '' ) );
+	}
+
+	/**
+	 * The configured cloud base URL defaults token revocation to `/site/token/revoke`.
+	 */
+	public function test_disconnect_revokes_against_cloud_base_url_default_endpoint(): void {
+		$base_url        = 'https://service.example/v1';
+		$expected_url    = $base_url . '/site/token/revoke';
+		$captured_url    = '';
+		$captured_header = '';
+
+		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, 'secret-site-token', false );
+		add_filter( 'sd_ai_agent_cloud_base_url', static fn(): string => $base_url );
+		add_filter(
+			'pre_http_request',
+			static function ( mixed $preempt, array $parsed_args, string $url ) use ( $expected_url, &$captured_url, &$captured_header ): mixed {
+				$captured_url    = $url;
+				$headers         = isset( $parsed_args['headers'] ) && is_array( $parsed_args['headers'] ) ? $parsed_args['headers'] : array();
+				$captured_header = is_string( $headers['Authorization'] ?? null ) ? $headers['Authorization'] : '';
+
+				return array(
+					'response' => array(
+						'code'    => $expected_url === $url ? 200 : 404,
+						'message' => $expected_url === $url ? 'OK' : 'Not Found',
+					),
+					'body'     => '{}',
+				);
+			},
+			10,
+			3
+		);
+
+		$request = new WP_REST_Request( 'DELETE', '/sd-ai-agent/v1/connectors/' . SuperdavAiProvider::PROVIDER_ID . '/key' );
+		$request->set_param( 'provider', SuperdavAiProvider::PROVIDER_ID );
+
+		$response = ( new ConnectorsController() )->handle_clear_key( $request );
+		$this->assertNotWPError( $response );
+
+		$data = $response->get_data();
+		$this->assertFalse( $data['configured'] );
+		$this->assertSame( $expected_url, $captured_url );
+		$this->assertSame( 'Bearer secret-site-token', $captured_header );
 		$this->assertSame( '', get_option( SuperdavAiProvider::CREDENTIAL_OPTION, '' ) );
 	}
 


### PR DESCRIPTION
## Summary

- Derive managed Superdav site registration and revocation endpoints from `SD_AI_AGENT_CLOUD_BASE_URL`.
- Attempt service-managed site-token provisioning during activation when a remote edge is configured, without failing activation on service errors.
- Document local Superdav AI Service setup and cover endpoint derivation with PHPUnit tests.

## Files and patterns

- `includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php`: exposes the configured `/v1` base URL and service URL helper.
- `includes/Core/SuperdavSiteConnectionService.php`: resolves registration/revocation endpoints from explicit constants or the base URL.
- `includes/Bootstrap/LifecycleHandler.php`: retries the existing managed connect flow during activation when remote configuration exists.
- `tests/SdAiAgent/REST/ConnectorsControllerTest.php` and `tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php`: assert URL derivation and token-safe connector behaviour.

## Verification

- `php -l` on modified PHP files
- `php bin/run-wp-phpunit.php --filter 'ConnectorsControllerTest|SuperdavAiProviderTest'`
- `vendor/bin/phpcs ...modified PHP files...`
- `php -d memory_limit=2G vendor/bin/phpstan analyse --memory-limit=2G`
- `composer validate --strict`
- `git diff --check`
- Redacted local smoke against Superdav AI Service: site connect, `GET /v1/models`, and `POST /v1/chat/completions` returned expected non-secret statuses.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.88 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5 spent 7d 18h and 2,148,616 tokens on this with the user in an interactive session.