### PR TITLE
fix: reconcile Superdav model selections

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "superdav-ai-agent",
-	"version": "1.16.2",
+	"version": "1.17.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "superdav-ai-agent",
-			"version": "1.16.2",
+			"version": "1.17.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@codemirror/commands": "^6.10.3",

--- a/src/components/model-pricing-selector.js
+++ b/src/components/model-pricing-selector.js
@@ -22,6 +22,9 @@ import { __ } from '@wordpress/i18n';
  * @type {Object.<string, [number, number]>}
  */
 const PRICING = {
+	// Superdav managed models.
+	'superdav-chat-fast': [ 0.25, 1.0 ],
+	'superdav-chat-pro': [ 1.5, 6.0 ],
 	// Claude models.
 	'claude-haiku-4': [ 0.8, 4.0 ],
 	'claude-sonnet-4': [ 3.0, 15.0 ],
@@ -81,6 +84,19 @@ const TIERS = [
  * @type {Array<{id: string, provider: string, name: string, note: string}>}
  */
 const MODEL_CATALOG = [
+	// Superdav
+	{
+		id: 'superdav-chat-fast',
+		provider: 'sd-ai-agent-cloud',
+		name: 'Superdav Chat Fast',
+		note: __( 'fast', 'sd-ai-agent' ),
+	},
+	{
+		id: 'superdav-chat-pro',
+		provider: 'sd-ai-agent-cloud',
+		name: 'Superdav Chat Pro',
+		note: __( '$10 free credit eligible', 'sd-ai-agent' ),
+	},
 	// Anthropic
 	{
 		id: 'claude-haiku-4',

--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -63,6 +63,7 @@ export default function SettingsApp() {
 		settings,
 		settingsLoaded,
 		providers,
+		selectedProviderId,
 		ttsEnabled,
 		ttsVoiceURI,
 		ttsRate,
@@ -75,6 +76,7 @@ export default function SettingsApp() {
 			settings: select( STORE_NAME ).getSettings(),
 			settingsLoaded: select( STORE_NAME ).getSettingsLoaded(),
 			providers: select( STORE_NAME ).getProviders(),
+			selectedProviderId: select( STORE_NAME ).getSelectedProviderId(),
 			ttsEnabled: select( STORE_NAME ).isTtsEnabled(),
 			ttsVoiceURI: select( STORE_NAME ).getTtsVoiceURI(),
 			ttsRate: select( STORE_NAME ).getTtsRate(),
@@ -447,6 +449,18 @@ export default function SettingsApp() {
 		setLocal( ( prev ) => ( { ...prev, [ key ]: value } ) );
 	}, [] );
 
+	const handleDefaultProviderChange = useCallback(
+		( providerId ) => {
+			const provider = providers.find( ( p ) => p.id === providerId );
+			setLocal( ( prev ) => ( {
+				...prev,
+				default_provider: providerId,
+				default_model: provider?.models?.[ 0 ]?.id || '',
+			} ) );
+		},
+		[ providers ]
+	);
+
 	const handleSave = useCallback( async () => {
 		setSaving( true );
 		try {
@@ -484,9 +498,11 @@ export default function SettingsApp() {
 		...providers.map( ( p ) => ( { label: p.name, value: p.id } ) ),
 	];
 
-	const selectedProvider = providers.find(
-		( p ) => p.id === local.default_provider
-	);
+	const selectedProvider =
+		providers.find( ( p ) => p.id === local.default_provider ) ||
+		providers.find( ( p ) => p.id === selectedProviderId ) ||
+		providers.find( ( p ) => p.models?.length ) ||
+		providers[ 0 ];
 
 	// Provider trace is a debug-only feature — only show the tab when
 	// WP_DEBUG is active (communicated from PHP via sdAiAgentData.wpDebug).
@@ -622,11 +638,8 @@ export default function SettingsApp() {
 															options={
 																providerOptions
 															}
-															onChange={ ( v ) =>
-																updateField(
-																	'default_provider',
-																	v
-																)
+															onChange={
+																handleDefaultProviderChange
 															}
 															__nextHasNoMarginBottom
 														/>

--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -54,6 +54,7 @@ jest.mock( '@wordpress/data', () => ( {
 require( '../index' );
 
 const { reducer, actions, selectors } = capturedConfig;
+const { resolveProviderSelection } = require( '../slices/providersSlice' );
 
 // ─── Default state ────────────────────────────────────────────────────────────
 
@@ -288,6 +289,29 @@ describe( 'actions', () => {
 
 	test( 'sendMessage returns a thunk function', () => {
 		expect( typeof actions.sendMessage( 'hello' ) ).toBe( 'function' );
+	} );
+} );
+
+describe( 'resolveProviderSelection', () => {
+	test( 'replaces a stale saved model with the first advertised provider model', () => {
+		const selection = resolveProviderSelection(
+			[
+				{
+					id: 'sd-ai-agent-cloud',
+					models: [
+						{ id: 'superdav-chat-fast' },
+						{ id: 'superdav-chat-pro' },
+					],
+				},
+			],
+			'sd-ai-agent-cloud',
+			'chat-fast'
+		);
+
+		expect( selection ).toEqual( {
+			providerId: 'sd-ai-agent-cloud',
+			modelId: 'superdav-chat-fast',
+		} );
 	} );
 } );
 

--- a/src/store/slices/providersSlice.js
+++ b/src/store/slices/providersSlice.js
@@ -9,6 +9,37 @@
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Resolve a persisted provider/model selection against a fresh provider list.
+ *
+ * @param {Provider[]} providers       Available providers from REST.
+ * @param {string}     savedProviderId Provider ID from localStorage.
+ * @param {string}     savedModelId    Model ID from localStorage.
+ * @return {{providerId: string, modelId: string}} Resolved provider/model IDs.
+ */
+export function resolveProviderSelection(
+	providers,
+	savedProviderId,
+	savedModelId
+) {
+	const provider =
+		providers.find( ( candidate ) => candidate.id === savedProviderId ) ||
+		providers.find( ( candidate ) => candidate.models?.length ) ||
+		providers[ 0 ];
+
+	if ( ! provider ) {
+		return { providerId: '', modelId: '' };
+	}
+
+	const models = Array.isArray( provider.models ) ? provider.models : [];
+	const hasSavedModel = models.some( ( model ) => model.id === savedModelId );
+
+	return {
+		providerId: provider.id,
+		modelId: hasSavedModel ? savedModelId : models[ 0 ]?.id || '',
+	};
+}
+
 export const initialState = {
 	providers: [],
 	providersLoaded: false,
@@ -79,21 +110,22 @@ export const actions = {
 				} );
 				dispatch.setProviders( providers );
 
-				// Auto-select first provider if none saved or saved one is unavailable.
-				const saved = localStorage.getItem( 'sdAiAgentProvider' );
-				if (
-					( ! saved ||
-						! providers.find( ( p ) => p.id === saved ) ) &&
-					providers.length
-				) {
-					dispatch.setSelectedProvider( providers[ 0 ].id );
-					if ( providers[ 0 ].models?.length ) {
-						dispatch.setSelectedModel(
-							providers[ 0 ].models[ 0 ].id
-						);
-					} else {
-						dispatch.setSelectedModel( '' );
-					}
+				const savedProviderId =
+					localStorage.getItem( 'sdAiAgentProvider' ) || '';
+				const savedModelId =
+					localStorage.getItem( 'sdAiAgentModel' ) || '';
+				const selection = resolveProviderSelection(
+					providers,
+					savedProviderId,
+					savedModelId
+				);
+
+				if ( selection.providerId !== savedProviderId ) {
+					dispatch.setSelectedProvider( selection.providerId );
+				}
+
+				if ( selection.modelId !== savedModelId ) {
+					dispatch.setSelectedModel( selection.modelId );
 				}
 			} catch ( err ) {
 				dispatch.setProviders( [] );


### PR DESCRIPTION
## Summary
- reconcile stale saved Superdav model IDs against advertised provider models
- make settings provider/model selection fall back to a configured provider with models
- add Superdav managed model pricing entries for fast/pro selectors

## Verification
- `npm run test:js -- --runTestsByPath src/store/__tests__/index.test.js`
- `npx wp-scripts lint-js src/store/slices/providersSlice.js src/settings-page/settings-app.js src/components/model-pricing-selector.js src/store/__tests__/index.test.js`
- `npx wp-scripts build`
- WordPress local smoke: plugin provider layer exposed `sd-ai-agent-cloud` with `superdav-chat-fast` and `superdav-chat-pro`
- WordPress plugin runtime smoke: `superdav-chat-pro` returned `PRO_OK`; redacted SDK trace status `200`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.88 plugin for [OpenCode](https://opencode.ai) v1.17.7 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added two new model options: Superdav Chat Fast and Superdav Chat Pro with pricing information.

* **Bug Fixes**
  * Improved default provider and model selection with enhanced fallback logic.
  * Fixed handling of stale saved model selections to ensure compatibility with available providers.

* **Tests**
  * Added validation tests for provider selection resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->