### PR TITLE
Fix Superdav AI auto-provisioning and chat startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,17 @@ All connectors are included in the [WordPress Playground demo](https://playgroun
 
 ### Managed Superdav AI service
 
-The bundled **Superdav AI** connector uses a service-managed site token instead of a customer-provided provider key. For local Superdav AI Service testing, configure the OpenAI-compatible `/v1` base URL in `wp-config.php`:
+The bundled **Superdav AI** connector uses a service-managed site token instead of a customer-provided provider key. New installs default to the production Superdav edge at `https://api.sdaiagent.com/v1`; plugin activation and the first provider-list request both try to register the site automatically so the chat can open without a manual Connect step.
+
+Registration is keyed by the plugin's durable site installation ID. The Superdav edge must treat repeated `/site/installations` calls for that ID as an idempotent refresh of the same free plan and starter-credit wallet, not a new free-credit grant.
+
+For local Superdav AI Service testing, override the OpenAI-compatible `/v1` base URL in `wp-config.php`:
 
 ```php
 define( 'SD_AI_AGENT_CLOUD_BASE_URL', 'http://127.0.0.1:3000/v1' );
 ```
 
-When this base URL is set, plugin activation and the connector **Connect** action register the site at `POST /v1/site/installations`; model listing and chat use `GET /v1/models` and `POST /v1/chat/completions` with the stored site token as `Authorization: Bearer <SITE_ACCESS_TOKEN>`. Override `SD_AI_AGENT_CLOUD_REGISTRATION_ENDPOINT` or `SD_AI_AGENT_CLOUD_REVOCATION_ENDPOINT` only when those endpoints live outside the configured base URL.
+Model listing and chat use `GET /v1/models` and `POST /v1/chat/completions` with the stored site token as `Authorization: Bearer <SITE_ACCESS_TOKEN>`. Override `SD_AI_AGENT_CLOUD_REGISTRATION_ENDPOINT` or `SD_AI_AGENT_CLOUD_REVOCATION_ENDPOINT` only when those endpoints live outside the configured base URL.
 
 ## Features
 

--- a/includes/Bootstrap/LifecycleHandler.php
+++ b/includes/Bootstrap/LifecycleHandler.php
@@ -87,14 +87,7 @@ final class LifecycleHandler {
 	 */
 	private static function maybe_provision_superdav_site_connection(): void {
 		try {
-			$service = new SuperdavSiteConnectionService();
-			$status  = $service->get_status();
-
-			if ( ! empty( $status['configured'] ) || ! $service->has_remote_registration_endpoint() ) {
-				return;
-			}
-
-			$service->provision_site_token();
+			( new SuperdavSiteConnectionService() )->ensure_site_token();
 		} catch ( \Throwable ) {
 			return;
 		}

--- a/includes/Core/SuperdavSiteConnectionService.php
+++ b/includes/Core/SuperdavSiteConnectionService.php
@@ -48,7 +48,17 @@ final class SuperdavSiteConnectionService {
 			'account_connect_url'       => $this->get_account_connect_url(),
 		);
 
-		foreach ( array( 'tier', 'verified', 'usage', 'verification', 'request_id' ) as $key ) {
+		$metadata_keys = array(
+			'tier',
+			'verified',
+			'usage',
+			'verification',
+			'request_id',
+			'wallet',
+			'connection_notice_pending',
+		);
+
+		foreach ( $metadata_keys as $key ) {
 			if ( array_key_exists( $key, $metadata ) ) {
 				$status[ $key ] = $metadata[ $key ];
 			}
@@ -63,28 +73,76 @@ final class SuperdavSiteConnectionService {
 	 * @return array<string, mixed>|WP_Error Safe status metadata or error.
 	 */
 	public function provision_site_token(): array|WP_Error {
+		$created             = '' === $this->get_stored_token();
 		$remote_registration = $this->request_remote_site_token();
 		if ( $remote_registration instanceof WP_Error ) {
 			return $remote_registration;
 		}
 
-		$remote_token    = is_array( $remote_registration ) ? (string) ( $remote_registration['token'] ?? '' ) : $remote_registration;
-		$remote_metadata = is_array( $remote_registration ) ? (array) ( $remote_registration['metadata'] ?? array() ) : array();
+		$remote_token    = is_array( $remote_registration )
+			? (string) ( $remote_registration['token'] ?? '' )
+			: $remote_registration;
+		$remote_metadata = is_array( $remote_registration )
+			? (array) ( $remote_registration['metadata'] ?? array() )
+			: array();
 		$token           = '' !== $remote_token ? $remote_token : $this->create_local_site_token();
-		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, $token, false );
-		update_option(
-			self::TOKEN_METADATA_OPTION,
-			array_merge(
-				$remote_metadata,
-				array(
-					'connection_mode' => '' !== $remote_token ? 'site' : 'local-site',
-					'connected_at'    => gmdate( 'c' ),
-				)
-			),
-			false
+		$metadata        = array_merge(
+			$remote_metadata,
+			array(
+				'connection_mode' => '' !== $remote_token ? 'site' : 'local-site',
+				'connected_at'    => gmdate( 'c' ),
+			)
 		);
 
+		if ( $created ) {
+			$metadata['connection_notice_pending'] = true;
+		}
+
+		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, $token, false );
+		update_option( self::TOKEN_METADATA_OPTION, $metadata, false );
+
 		return $this->get_status();
+	}
+
+	/**
+	 * Store a freshly provisioned local development token when no remote edge is configured.
+	 *
+	 * Production installs should use the managed edge so the durable installation
+	 * ID maps to exactly one free plan and one starter-credit grant. Local tokens
+	 * are intentionally marked as local-site and never claim a remote free wallet.
+	 *
+	 * @return array<string, mixed> Safe status metadata.
+	 */
+	public function provision_local_site_token(): array {
+		$created  = '' === $this->get_stored_token();
+		$token    = $this->create_local_site_token();
+		$metadata = array(
+			'connection_mode' => 'local-site',
+			'connected_at'    => gmdate( 'c' ),
+		);
+
+		if ( $created ) {
+			$metadata['connection_notice_pending'] = true;
+		}
+
+		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, $token, false );
+		update_option( self::TOKEN_METADATA_OPTION, $metadata, false );
+
+		return $this->get_status();
+	}
+
+	/**
+	 * Ensure the site has a service-managed Superdav token when the edge is configured.
+	 *
+	 * @return array<string, mixed>|WP_Error Safe status metadata or provisioning error.
+	 */
+	public function ensure_site_token(): array|WP_Error {
+		$status = $this->get_status();
+		if ( ! empty( $status['configured'] ) || ! $this->has_remote_registration_endpoint() ) {
+			return $status;
+		}
+
+		return $this->provision_site_token();
 	}
 
 	/**
@@ -341,6 +399,23 @@ final class SuperdavSiteConnectionService {
 			$safe['verification'] = array_filter(
 				$metadata['verification'],
 				static fn( mixed $value ): bool => is_scalar( $value ) || null === $value
+			);
+		}
+
+		if ( isset( $metadata['wallet'] ) && is_array( $metadata['wallet'] ) ) {
+			$safe['wallet'] = array_intersect_key(
+				array_filter(
+					$metadata['wallet'],
+					static fn( mixed $value ): bool => is_scalar( $value ) || null === $value
+				),
+				array_flip(
+					array(
+						'currency',
+						'promo_usd_micros',
+						'cash_usd_micros',
+						'total_usd_micros',
+					)
+				)
 			);
 		}
 

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php
@@ -24,6 +24,7 @@ final class SuperdavAiProvider extends AbstractApiProvider {
 
 	public const PROVIDER_ID       = 'sd-ai-agent-cloud';
 	public const CREDENTIAL_OPTION = 'connectors_ai_sd_ai_agent_cloud_api_key';
+	public const DEFAULT_BASE_URL  = 'https://api.sdaiagent.com/v1';
 
 	/**
 	 * Create a model instance for the provider.
@@ -78,7 +79,7 @@ final class SuperdavAiProvider extends AbstractApiProvider {
 	protected static function baseUrl(): string {
 		$base_url = defined( 'SD_AI_AGENT_CLOUD_BASE_URL' ) && is_string( constant( 'SD_AI_AGENT_CLOUD_BASE_URL' ) )
 			? (string) constant( 'SD_AI_AGENT_CLOUD_BASE_URL' )
-			: '';
+			: self::DEFAULT_BASE_URL;
 
 		/**
 		 * Filter the Superdav AI cloud OpenAI-compatible API base URL.

--- a/includes/REST/ConnectorsController.php
+++ b/includes/REST/ConnectorsController.php
@@ -318,7 +318,15 @@ final class ConnectorsController {
 			);
 		}
 
-		$status = ( new SuperdavSiteConnectionService() )->provision_site_token();
+		$service        = new SuperdavSiteConnectionService();
+		$was_configured = ! empty( $service->get_status()['configured'] );
+		if ( $was_configured ) {
+			$status = $service->get_status();
+		} elseif ( $service->has_remote_registration_endpoint() ) {
+			$status = $service->provision_site_token();
+		} else {
+			$status = $service->provision_local_site_token();
+		}
 		if ( $status instanceof WP_Error ) {
 			return $status;
 		}
@@ -328,6 +336,7 @@ final class ConnectorsController {
 				'success'    => true,
 				'provider'   => $provider_id,
 				'configured' => true,
+				'created'    => ! $was_configured,
 				'status'     => $status,
 			),
 			200

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -22,11 +22,14 @@ use SdAiAgent\Core\ModelCapabilityRegistry;
 use SdAiAgent\Core\ProviderCredentialLoader;
 use SdAiAgent\Core\RolePermissions;
 use SdAiAgent\Core\Settings;
+use SdAiAgent\Core\SuperdavSiteConnectionService;
 use SdAiAgent\Core\SystemInstructionBuilder;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
+use WordPress\AiClient\Providers\Http\Exception\ClientException;
 use XWP\DI\Decorators\Action;
 use XWP\DI\Decorators\Handler;
 
@@ -732,6 +735,7 @@ final class SettingsController {
 			return new WP_REST_Response( $providers, 200 );
 		}
 
+		$this->maybe_auto_provision_superdav_provider();
 		ProviderCredentialLoader::load();
 
 		foreach ( $provider_ids as $provider_id ) {
@@ -771,34 +775,126 @@ final class SettingsController {
 						}
 					}
 				} else {
-					try {
-						$directory      = $class::modelMetadataDirectory();
-						$model_metadata = $directory->listModelMetadata();
-
-						foreach ( $model_metadata as $model_meta ) {
-							if ( ! is_object( $model_meta ) ) {
-								continue;
-							}
-							$models[] = self::format_model_metadata_for_response( $model_meta );
-						}
-					} catch ( \Throwable $e ) {
-						// Model listing failed — still include the provider.
-					}
+					$models = $this->list_model_metadata_for_provider( $provider_id, $class );
 				}
 
-				$providers[] = array(
+				$provider_response = array(
 					'id'         => $provider_id,
 					'name'       => $metadata->getName(),
 					'type'       => (string) $metadata->getType(),
 					'configured' => true,
 					'models'     => $models,
 				);
+
+				if ( SuperdavAiProvider::PROVIDER_ID === $provider_id ) {
+					$provider_response['status'] = ( new SuperdavSiteConnectionService() )->get_status();
+				}
+
+				$providers[] = $provider_response;
 			} catch ( \Throwable $e ) {
 				continue;
 			}
 		}
 
 		return new WP_REST_Response( $providers, 200 );
+	}
+
+	/**
+	 * Provision the bundled managed Superdav provider before the provider list is returned.
+	 *
+	 * First-install screens call /providers before onboarding can start. If the
+	 * activation hook could not provision yet, retry here so users can move
+	 * straight into the Setup Assistant instead of seeing a manual connect gate.
+	 */
+	private function maybe_auto_provision_superdav_provider(): void {
+		try {
+			( new SuperdavSiteConnectionService() )->ensure_site_token();
+		} catch ( \Throwable ) {
+			return;
+		}
+	}
+
+	/**
+	 * List provider model metadata, refreshing the managed Superdav token once when it is stale.
+	 *
+	 * @param string $provider_id Provider ID.
+	 * @param string $class       Provider class name.
+	 * @return array<int, array<string, mixed>> Safe model rows for the provider picker.
+	 */
+	private function list_model_metadata_for_provider( string $provider_id, string $class ): array {
+		try {
+			return self::list_model_metadata_from_directory( $class::modelMetadataDirectory() );
+		} catch ( \Throwable $e ) {
+			if ( SuperdavAiProvider::PROVIDER_ID !== $provider_id || ! self::is_unauthorized_model_listing_error( $e ) ) {
+				return array();
+			}
+		}
+
+		$status = ( new SuperdavSiteConnectionService() )->provision_site_token();
+		if ( $status instanceof WP_Error ) {
+			return array();
+		}
+
+		ProviderCredentialLoader::load();
+
+		try {
+			$directory = $class::modelMetadataDirectory();
+			if ( is_object( $directory ) && method_exists( $directory, 'invalidateCaches' ) ) {
+				$directory->invalidateCaches();
+			}
+
+			return self::list_model_metadata_from_directory( $directory );
+		} catch ( \Throwable ) {
+			return array();
+		}
+	}
+
+	/**
+	 * List and format model metadata from an SDK directory-like object.
+	 *
+	 * @param mixed $directory SDK model metadata directory candidate.
+	 * @return array<int, array<string, mixed>> Safe model rows for the provider picker.
+	 */
+	private static function list_model_metadata_from_directory( mixed $directory ): array {
+		if ( ! is_object( $directory ) || ! method_exists( $directory, 'listModelMetadata' ) ) {
+			return array();
+		}
+
+		$model_metadata = $directory->listModelMetadata();
+		if ( ! is_array( $model_metadata ) ) {
+			return array();
+		}
+
+		return self::format_model_metadata_list_for_response( array_values( $model_metadata ) );
+	}
+
+	/**
+	 * Format SDK model metadata entries for the provider picker response.
+	 *
+	 * @param array<int, mixed> $model_metadata SDK model metadata entries.
+	 * @return array<int, array<string, mixed>> Safe model rows for the provider picker.
+	 */
+	private static function format_model_metadata_list_for_response( array $model_metadata ): array {
+		$models = array();
+		foreach ( $model_metadata as $model_meta ) {
+			if ( ! is_object( $model_meta ) ) {
+				continue;
+			}
+			$models[] = self::format_model_metadata_for_response( $model_meta );
+		}
+
+		return $models;
+	}
+
+	/**
+	 * Determine whether a model listing failure is due to an invalid/stale site token.
+	 */
+	private static function is_unauthorized_model_listing_error( \Throwable $error ): bool {
+		if ( $error instanceof ClientException && 401 === (int) $error->getCode() ) {
+			return true;
+		}
+
+		return str_contains( $error->getMessage(), 'Unauthorized (401)' );
 	}
 
 	/**

--- a/src/admin-page/__tests__/superdav-autoconnect.test.js
+++ b/src/admin-page/__tests__/superdav-autoconnect.test.js
@@ -1,0 +1,47 @@
+import {
+	buildConnectionNoticeText,
+	findSuperdavProvider,
+	formatUsdMicros,
+	getStarterCreditAmount,
+	SUPERDAV_PROVIDER_ID,
+} from '../superdav-autoconnect';
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( str ) => str,
+	sprintf: ( str, ...args ) =>
+		args.reduce( ( result, value ) => result.replace( '%s', value ), str ),
+} ) );
+
+describe( 'superdav-autoconnect helpers', () => {
+	test( 'finds the bundled Superdav AI provider', () => {
+		const provider = { id: SUPERDAV_PROVIDER_ID, name: 'Superdav AI' };
+
+		expect( findSuperdavProvider( [ { id: 'openai' }, provider ] ) ).toBe(
+			provider
+		);
+	} );
+
+	test( 'formats USD micros without unnecessary cents', () => {
+		expect( formatUsdMicros( 10000000 ) ).toBe( '$10' );
+		expect( formatUsdMicros( 10500000 ) ).toBe( '$10.50' );
+	} );
+
+	test( 'uses wallet promo credit for the free-tier starter amount', () => {
+		expect(
+			getStarterCreditAmount( {
+				wallet: { promo_usd_micros: 10000000 },
+			} )
+		).toBe( '$10' );
+	} );
+
+	test( 'builds a free-tier token-created notice', () => {
+		const notice = buildConnectionNoticeText( {
+			tier: 'free',
+			wallet: { promo_usd_micros: 10000000 },
+		} );
+
+		expect( notice ).toContain( 'secure site token' );
+		expect( notice ).toContain( 'free tier' );
+		expect( notice ).toContain( '$10' );
+	} );
+} );

--- a/src/admin-page/index.js
+++ b/src/admin-page/index.js
@@ -3,8 +3,11 @@
  */
 import {
 	createRoot,
+	useCallback,
 	useEffect,
 	useMemo,
+	useRef,
+	useState,
 	lazy,
 	Suspense,
 } from '@wordpress/element';
@@ -20,22 +23,20 @@ import '../abilities';
 import ChatRedesign from '../components/chat-redesign';
 import BootError from '../components/boot-error';
 import { useKeyboardShortcuts } from '../utils/keyboard-shortcuts';
+import {
+	buildConnectionNoticeText,
+	claimConnectionNotice,
+	findSuperdavProvider,
+} from './superdav-autoconnect';
 import '../components/shared.css';
 import './style.css';
 
 // These components are rendered only in specific, uncommon states:
-//  - ConnectorGate          → zero providers configured (first install)
 //  - OnboardingBootstrap    → first install after a provider is configured
 //                             (drops the user straight into the unified
 //                             Setup Assistant agent)
 //  - ShortcutsHelp          → user presses Mod+/ (explicitly intentional)
 // None of them appear during a normal chat session, so they are lazy-loaded.
-const ConnectorGate = lazy( () =>
-	import(
-		/* webpackChunkName: "connector-gate", webpackPrefetch: true */
-		'../components/connector-gate'
-	)
-);
 const OnboardingBootstrap = lazy( () =>
 	import(
 		/* webpackChunkName: "onboarding-bootstrap", webpackPrefetch: true */
@@ -56,9 +57,9 @@ const ShortcutsHelp = lazy( () =>
  * + AI-Driven Discovery"). The legacy multi-step wizard is gone — the AI
  * agent drives discovery conversationally.
  *
- * 1. **Connector gate** — shown when no AI provider is configured. The user
- *    is directed to the WordPress Connectors page. The gate polls every 5 s
- *    so it disappears automatically once a provider becomes available.
+ * 1. **Silent service connection** — the chat opens immediately. If no AI
+ *    provider is configured yet, /providers auto-provisions the bundled
+ *    Superdav AI service token and the chat shows a one-time notice.
  *
  * 2. **First-run agent** — shown when a provider exists but onboarding has
  *    not yet completed. The app opens one unified Setup Assistant session;
@@ -77,7 +78,15 @@ function AdminPageApp() {
 		clearCurrentSession,
 		restoreActiveJobs,
 		setShowShortcutsHelp,
+		appendMessage,
 	} = useDispatch( STORE_NAME );
+	const serviceNoticeDisplayedRef = useRef( false );
+	const [ serviceConnectionNotice, setServiceConnectionNotice ] =
+		useState( '' );
+	const [
+		serviceConnectionNoticeSettled,
+		setServiceConnectionNoticeSettled,
+	] = useState( false );
 	const {
 		settings,
 		settingsLoaded,
@@ -104,8 +113,48 @@ function AdminPageApp() {
 		restoreActiveJobs();
 	}, [ fetchProviders, fetchSessions, fetchSettings, restoreActiveJobs ] );
 
-	// Poll for providers every 5 s while the connector gate is shown.
-	// Stops once at least one provider appears.
+	const appendServiceConnectionNotice = useCallback(
+		( notice ) => {
+			if ( ! notice || serviceNoticeDisplayedRef.current ) {
+				return;
+			}
+
+			serviceNoticeDisplayedRef.current = true;
+			appendMessage( {
+				role: 'system',
+				parts: [ { text: notice } ],
+				ts: new Date().toISOString(),
+			} );
+		},
+		[ appendMessage ]
+	);
+	const markServiceConnectionNoticeDisplayed = useCallback( () => {
+		serviceNoticeDisplayedRef.current = true;
+	}, [] );
+
+	// Build a one-time chat notice when the backend reports a freshly-created
+	// managed service token. This notice is held back from the normal chat path
+	// when onboarding will open a session so it can be inserted after openSession()
+	// and before the Setup Assistant kickoff message.
+	useEffect( () => {
+		if ( ! settingsLoaded || ! providersLoaded ) {
+			return;
+		}
+
+		const superdavProvider = findSuperdavProvider( providers );
+		const status = superdavProvider?.status || {};
+		if (
+			status.connection_notice_pending &&
+			claimConnectionNotice( status )
+		) {
+			setServiceConnectionNotice( buildConnectionNoticeText( status ) );
+		}
+		setServiceConnectionNoticeSettled( true );
+	}, [ settingsLoaded, providersLoaded, providers ] );
+
+	// Poll for providers while /providers is still trying to auto-provision the
+	// managed Superdav connection. The chat remains open; no connector screen is
+	// rendered for this state.
 	useEffect( () => {
 		const hasProvider = providers.length > 0;
 		if ( ! providersLoaded || hasProvider ) {
@@ -137,6 +186,20 @@ function AdminPageApp() {
 	}, [ providersLoaded, fetchProviders ] );
 
 	const onboardingComplete = settings?.onboarding_complete !== false;
+	const hasProvider = providersLoaded && providers.length > 0;
+
+	useEffect( () => {
+		if ( ! settingsLoaded || ! onboardingComplete ) {
+			return;
+		}
+
+		appendServiceConnectionNotice( serviceConnectionNotice );
+	}, [
+		settingsLoaded,
+		onboardingComplete,
+		serviceConnectionNotice,
+		appendServiceConnectionNotice,
+	] );
 
 	// Keyboard shortcuts.
 	const shortcuts = useMemo(
@@ -166,26 +229,20 @@ function AdminPageApp() {
 	// providersLoaded (~1,180 ms with the SDK's live model-listing call) so
 	// the chat shell renders within one network round-trip.
 	//
-	// Gating logic while providers are still loading:
+	// Startup logic while providers are still loading:
 	//   - Assume a provider exists (optimistic) so ChatRedesign renders.
 	//   - The model picker already handles an empty providers array gracefully.
-	//   - If providers finish loading with an empty list, we swap to ConnectorGate.
-	//   - Onboarding state is derived from settings (already loaded), so that
-	//     gate can still fire correctly without waiting for providers.
+	//   - If providers finish loading with an empty list, background /providers
+	//     retries keep running without replacing the chat shell.
+	//   - Onboarding waits until a provider exists so the Setup Assistant kickoff
+	//     can use the managed service token that was just provisioned.
 	if ( ! settingsLoaded ) {
 		return null;
 	}
 
-	// Phase 1 gate: no connector → show connector gate.
-	// While providers are still loading we skip this gate (assume configured).
-	const hasProvider = ! providersLoaded || providers.length > 0;
-	if ( ! hasProvider ) {
-		return (
-			<Suspense fallback={ null }>
-				<ConnectorGate onConnected={ fetchProviders } />
-			</Suspense>
-		);
-	}
+	// Phase 1 is intentionally not a visible gate. The chat opens immediately;
+	// /providers handles managed Superdav auto-provisioning and this component
+	// only surfaces the resulting token-created notice inside the conversation.
 
 	// Phase 2 gate: connector exists but onboarding not yet complete.
 	//
@@ -193,10 +250,19 @@ function AdminPageApp() {
 	// The bootstrapper opens one unified Setup Assistant session through
 	// /onboarding/start. The agent investigates first and can build a theme if
 	// the user asks or the site requires it.
-	if ( ! onboardingComplete ) {
+	if (
+		! onboardingComplete &&
+		hasProvider &&
+		serviceConnectionNoticeSettled
+	) {
 		return (
 			<Suspense fallback={ null }>
-				<OnboardingBootstrap />
+				<OnboardingBootstrap
+					initialSystemNotice={ serviceConnectionNotice }
+					onInitialSystemNoticeAppended={
+						markServiceConnectionNoticeDisplayed
+					}
+				/>
 			</Suspense>
 		);
 	}

--- a/src/admin-page/superdav-autoconnect.js
+++ b/src/admin-page/superdav-autoconnect.js
@@ -1,0 +1,121 @@
+/**
+ * Helpers for silent Superdav AI service connection onboarding.
+ */
+
+import { __, sprintf } from '@wordpress/i18n';
+
+export const SUPERDAV_PROVIDER_ID = 'sd-ai-agent-cloud';
+
+const NOTICE_STORAGE_PREFIX = 'sdAiAgentSuperdavConnectionNotice';
+
+/**
+ * Find the bundled Superdav AI provider in a provider list.
+ *
+ * @param {Array} providers Provider response rows.
+ * @return {Object|null} Superdav provider row, or null.
+ */
+export function findSuperdavProvider( providers ) {
+	if ( ! Array.isArray( providers ) ) {
+		return null;
+	}
+
+	return (
+		providers.find(
+			( provider ) => provider?.id === SUPERDAV_PROVIDER_ID
+		) || null
+	);
+}
+
+/**
+ * Build a localStorage key for a connection notice.
+ *
+ * @param {Object} status Safe Superdav connection status metadata.
+ * @return {string} localStorage key.
+ */
+export function getConnectionNoticeStorageKey( status = {} ) {
+	const installationId = status.installation_id || 'site';
+	const connectedAt = status.connected_at || 'unknown';
+
+	return `${ NOTICE_STORAGE_PREFIX }:${ installationId }:${ connectedAt }`;
+}
+
+/**
+ * Format USD micros as a compact dollar amount.
+ *
+ * @param {number|string} micros USD micros.
+ * @return {string} Formatted USD amount.
+ */
+export function formatUsdMicros( micros ) {
+	const value = Number( micros );
+	if ( ! Number.isFinite( value ) || value <= 0 ) {
+		return '';
+	}
+
+	const dollars = value / 1000000;
+	const hasCents = Math.round( dollars * 100 ) % 100 !== 0;
+	return new Intl.NumberFormat( undefined, {
+		style: 'currency',
+		currency: 'USD',
+		minimumFractionDigits: hasCents ? 2 : 0,
+		maximumFractionDigits: 2,
+	} ).format( dollars );
+}
+
+/**
+ * Extract the starter/free-tier credit amount from safe status metadata.
+ *
+ * @param {Object} status Safe Superdav connection status metadata.
+ * @return {string} Formatted starter credit, or default free-tier amount.
+ */
+export function getStarterCreditAmount( status = {} ) {
+	const wallet = status.wallet || {};
+	const amount =
+		formatUsdMicros( wallet.promo_usd_micros ) ||
+		formatUsdMicros( wallet.total_usd_micros );
+
+	return amount || '$10';
+}
+
+/**
+ * Build the transient chat notice shown after a new service token is created.
+ *
+ * @param {Object} status Safe Superdav connection status metadata.
+ * @return {string} Notice text.
+ */
+export function buildConnectionNoticeText( status = {} ) {
+	if ( status.tier === 'free' ) {
+		return sprintf(
+			/* translators: %s: formatted starter usage credit, for example $10. */
+			__(
+				'Superdav AI is connected. A secure site token was created and stored safely for this site; raw token values are never shown. This site is on the free tier with %s of starter usage credit.',
+				'superdav-ai-agent'
+			),
+			getStarterCreditAmount( status )
+		);
+	}
+
+	return __(
+		'Superdav AI is connected. A secure site token was created and stored safely for this site; raw token values are never shown.',
+		'superdav-ai-agent'
+	);
+}
+
+/**
+ * Remember that a connection notice was already displayed in this browser.
+ *
+ * @param {Object} status Safe Superdav connection status metadata.
+ * @return {boolean} True when the notice may be shown now.
+ */
+export function claimConnectionNotice( status = {} ) {
+	const key = getConnectionNoticeStorageKey( status );
+	try {
+		if ( window.localStorage?.getItem( key ) ) {
+			return false;
+		}
+		window.localStorage?.setItem( key, '1' );
+	} catch {
+		// Storage failures should not suppress the one useful chat notice.
+	}
+
+	return true;
+}

--- a/src/components/__tests__/OnboardingBootstrap.test.js
+++ b/src/components/__tests__/OnboardingBootstrap.test.js
@@ -58,16 +58,19 @@ describe( 'OnboardingBootstrap', () => {
 	let openSessionMock;
 	let sendMessageMock;
 	let setSelectedAgentIdMock;
+	let appendMessageMock;
 
 	beforeEach( () => {
 		openSessionMock = jest.fn().mockResolvedValue( undefined );
 		sendMessageMock = jest.fn().mockResolvedValue( undefined );
 		setSelectedAgentIdMock = jest.fn();
+		appendMessageMock = jest.fn();
 
 		useDispatch.mockReturnValue( {
 			openSession: openSessionMock,
 			sendMessage: sendMessageMock,
 			setSelectedAgentId: setSelectedAgentIdMock,
+			appendMessage: appendMessageMock,
 		} );
 
 		container = document.createElement( 'div' );
@@ -84,11 +87,13 @@ describe( 'OnboardingBootstrap', () => {
 	} );
 
 	/**
+	 * Render the onboarding bootstrap component.
 	 *
+	 * @param {Object} props Component props.
 	 */
-	async function renderBootstrap() {
+	async function renderBootstrap( props = {} ) {
 		await act( async () => {
-			root.render( createElement( OnboardingBootstrap, {} ) );
+			root.render( createElement( OnboardingBootstrap, props ) );
 		} );
 	}
 
@@ -133,6 +138,31 @@ describe( 'OnboardingBootstrap', () => {
 		} );
 		await renderBootstrap();
 		expect( sendMessageMock ).toHaveBeenCalledWith( 'Hello from kickoff' );
+	} );
+
+	test( 'appends the initial system notice before kickoff', async () => {
+		const onInitialSystemNoticeAppended = jest.fn();
+		apiFetch.mockResolvedValue( {
+			session_id: 42,
+			agent_id: 7,
+			kickoff_message: 'Hello from kickoff',
+		} );
+
+		await renderBootstrap( {
+			initialSystemNotice: 'Superdav AI is connected.',
+			onInitialSystemNoticeAppended,
+		} );
+
+		expect( appendMessageMock ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				role: 'system',
+				parts: [ { text: 'Superdav AI is connected.' } ],
+			} )
+		);
+		expect( onInitialSystemNoticeAppended ).toHaveBeenCalledTimes( 1 );
+		expect( appendMessageMock.mock.invocationCallOrder[ 0 ] ).toBeLessThan(
+			sendMessageMock.mock.invocationCallOrder[ 0 ]
+		);
 	} );
 
 	test( 'skips agent selection when no agent_id returned', async () => {

--- a/src/components/onboarding-bootstrap.js
+++ b/src/components/onboarding-bootstrap.js
@@ -26,10 +26,16 @@ import ChatRedesign from './chat-redesign';
  * performs initial investigation and can build a theme if requested or
  * required. No parallel onboarding prompt or empty-site route exists.
  *
+ * @param {Object}   root0                               Component props.
+ * @param {string}   root0.initialSystemNotice           Optional notice to append before kickoff.
+ * @param {Function} root0.onInitialSystemNoticeAppended Optional callback after notice append.
  * @return {JSX.Element} The onboarding bootstrap element.
  */
-export default function OnboardingBootstrap() {
-	const { openSession, sendMessage, setSelectedAgentId } =
+export default function OnboardingBootstrap( {
+	initialSystemNotice = '',
+	onInitialSystemNoticeAppended = () => {},
+} ) {
+	const { openSession, sendMessage, setSelectedAgentId, appendMessage } =
 		useDispatch( STORE_NAME );
 	const bootstrappedRef = useRef( false );
 
@@ -60,15 +66,24 @@ export default function OnboardingBootstrap() {
 
 				// Activate the bootstrap session in the store.
 				openSession( data.session_id )
-					.then( () =>
-						sendMessage(
+					.then( () => {
+						if ( initialSystemNotice ) {
+							appendMessage( {
+								role: 'system',
+								parts: [ { text: initialSystemNotice } ],
+								ts: new Date().toISOString(),
+							} );
+							onInitialSystemNoticeAppended();
+						}
+
+						return sendMessage(
 							data.kickoff_message ||
 								__(
 									"Hi! I just set up this plugin and I'm ready to get started.",
 									'superdav-ai-agent'
 								)
-						)
-					)
+						);
+					} )
 					.catch( () => {
 						// Non-fatal: user can continue manually from chat UI.
 					} );
@@ -76,7 +91,14 @@ export default function OnboardingBootstrap() {
 			.catch( () => {
 				// Non-fatal: the user can start chatting manually.
 			} );
-	}, [ openSession, sendMessage, setSelectedAgentId ] );
+	}, [
+		openSession,
+		sendMessage,
+		setSelectedAgentId,
+		appendMessage,
+		initialSystemNotice,
+		onInitialSystemNoticeAppended,
+	] );
 
 	return <ChatRedesign />;
 }

--- a/src/types.js
+++ b/src/types.js
@@ -64,6 +64,7 @@
  * @property {string}          id       - Provider identifier.
  * @property {string}          name     - Human-readable provider name.
  * @property {ProviderModel[]} [models] - Available models for this provider.
+ * @property {Object}          [status] - Provider-specific safe status metadata.
  */
 
 /**

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
@@ -89,6 +89,17 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The managed provider defaults to the production edge for first-install setup.
+	 */
+	public function test_default_base_url_points_to_production_edge(): void {
+		$this->assertSame( SuperdavAiProvider::DEFAULT_BASE_URL, SuperdavAiProvider::configured_base_url() );
+		$this->assertSame(
+			'https://api.sdaiagent.com/v1/site/installations',
+			SuperdavAiProvider::configured_service_url( 'site/installations' )
+		);
+	}
+
+	/**
 	 * Model metadata parsing exposes OpenAI-compatible text generation models.
 	 */
 	public function test_model_metadata_contains_text_generation_capability(): void {

--- a/tests/SdAiAgent/REST/ConnectorsControllerTest.php
+++ b/tests/SdAiAgent/REST/ConnectorsControllerTest.php
@@ -59,6 +59,8 @@ final class ConnectorsControllerTest extends WP_UnitTestCase {
 	 * Managed connection provisions a local site token and returns safe metadata.
 	 */
 	public function test_connect_provisions_site_token_without_returning_secret(): void {
+		add_filter( 'sd_ai_agent_cloud_registration_endpoint', static fn(): string => '' );
+
 		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/connectors/' . SuperdavAiProvider::PROVIDER_ID . '/connect' );
 		$request->set_param( 'provider', SuperdavAiProvider::PROVIDER_ID );
 
@@ -71,7 +73,9 @@ final class ConnectorsControllerTest extends WP_UnitTestCase {
 
 		$data = $response->get_data();
 		$this->assertTrue( $data['configured'] );
+		$this->assertTrue( $data['created'] );
 		$this->assertSame( SuperdavAiProvider::PROVIDER_ID, $data['provider'] );
+		$this->assertTrue( $data['status']['connection_notice_pending'] );
 		$this->assertStringNotContainsString( $token, wp_json_encode( $data ) ?: '' );
 	}
 
@@ -104,6 +108,14 @@ final class ConnectorsControllerTest extends WP_UnitTestCase {
 							'tier'             => 'free',
 							'verified'         => false,
 							'connect_required' => false,
+							'wallet'           => array(
+								'account_id'        => 'acct_internal_123',
+								'currency'          => 'USD',
+								'promo_usd_micros'  => 10000000,
+								'cash_usd_micros'   => 0,
+								'total_usd_micros'  => 10000000,
+								'internal_metadata' => 'hidden',
+							),
 							'verification'     => array(
 								'state' => 'self_declared',
 							),
@@ -131,9 +143,50 @@ final class ConnectorsControllerTest extends WP_UnitTestCase {
 
 		$data = $response->get_data();
 		$this->assertTrue( $data['configured'] );
+		$this->assertTrue( $data['created'] );
 		$this->assertSame( 'site', $data['status']['connection_mode'] );
 		$this->assertFalse( $data['status']['verified'] );
+		$this->assertTrue( $data['status']['connection_notice_pending'] );
+		$this->assertSame( 10000000, $data['status']['wallet']['promo_usd_micros'] );
+		$this->assertArrayNotHasKey( 'account_id', $data['status']['wallet'] );
+		$this->assertArrayNotHasKey( 'internal_metadata', $data['status']['wallet'] );
 		$this->assertStringNotContainsString( 'sdaist_remote_site_token', wp_json_encode( $data ) ?: '' );
+	}
+
+	/**
+	 * Existing managed tokens are reported without re-registering a new free entitlement.
+	 */
+	public function test_connect_does_not_re_register_existing_managed_token(): void {
+		$endpoint          = 'https://service.example/v1/site/installations';
+		$registration_hits = 0;
+
+		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, 'existing-site-token', false );
+		add_filter( 'sd_ai_agent_cloud_registration_endpoint', static fn(): string => $endpoint );
+		add_filter(
+			'pre_http_request',
+			static function ( mixed $preempt, array $parsed_args, string $url ) use ( $endpoint, &$registration_hits ): mixed {
+				if ( $endpoint === $url ) {
+					++$registration_hits;
+				}
+
+				return $preempt;
+			},
+			10,
+			3
+		);
+
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/connectors/' . SuperdavAiProvider::PROVIDER_ID . '/connect' );
+		$request->set_param( 'provider', SuperdavAiProvider::PROVIDER_ID );
+
+		$response = ( new ConnectorsController() )->handle_connect( $request );
+		$this->assertNotWPError( $response );
+
+		$data = $response->get_data();
+		$this->assertTrue( $data['configured'] );
+		$this->assertFalse( $data['created'] );
+		$this->assertSame( 0, $registration_hits );
+		$this->assertSame( 'existing-site-token', get_option( SuperdavAiProvider::CREDENTIAL_OPTION, '' ) );
+		$this->assertArrayNotHasKey( 'connection_notice_pending', $data['status'] );
 	}
 
 	/**
@@ -201,6 +254,7 @@ final class ConnectorsControllerTest extends WP_UnitTestCase {
 	 */
 	public function test_disconnect_clears_managed_provider_token(): void {
 		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, 'secret-site-token', false );
+		add_filter( 'sd_ai_agent_cloud_revocation_endpoint', static fn(): string => '' );
 
 		$request = new WP_REST_Request( 'DELETE', '/sd-ai-agent/v1/connectors/' . SuperdavAiProvider::PROVIDER_ID . '/key' );
 		$request->set_param( 'provider', SuperdavAiProvider::PROVIDER_ID );

--- a/tests/SdAiAgent/REST/SettingsControllerTest.php
+++ b/tests/SdAiAgent/REST/SettingsControllerTest.php
@@ -1,0 +1,304 @@
+<?php
+/**
+ * Tests for SettingsController provider bootstrap behavior.
+ *
+ * @package SdAiAgent\Tests\REST
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\REST;
+
+use SdAiAgent\Bootstrap\SuperdavAiProviderHandler;
+use SdAiAgent\Core\Database;
+use SdAiAgent\Core\Settings;
+use SdAiAgent\Core\SuperdavSiteConnectionService;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
+use SdAiAgent\REST\SettingsController;
+use WP_UnitTestCase;
+use WordPress\AiClient\AiClient;
+
+/**
+ * Covers first-install provider auto-provisioning.
+ */
+final class SettingsControllerTest extends WP_UnitTestCase {
+
+	/**
+	 * Reset cached SDK model metadata before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		$this->invalidate_superdav_model_cache();
+	}
+
+	/**
+	 * Clean up provider-specific options and filters.
+	 */
+	public function tear_down(): void {
+		$this->invalidate_superdav_model_cache();
+		delete_option( SuperdavAiProvider::CREDENTIAL_OPTION );
+		delete_option( SuperdavSiteConnectionService::INSTALLATION_ID_OPTION );
+		delete_option( SuperdavSiteConnectionService::TOKEN_METADATA_OPTION );
+		remove_all_filters( 'sd_ai_agent_cloud_base_url' );
+		remove_all_filters( 'pre_http_request' );
+		parent::tear_down();
+	}
+
+	/**
+	 * /providers auto-provisions the managed Superdav token before listing providers.
+	 */
+	public function test_handle_providers_auto_provisions_managed_superdav_provider(): void {
+		if ( ! class_exists( AiClient::class ) ) {
+			$this->markTestSkipped( 'WordPress AI Client SDK is unavailable.' );
+		}
+
+		$base_url         = 'https://service.example/v1';
+		$registration_url = $base_url . '/site/installations';
+		$models_url       = $base_url . '/models';
+		$registration_hits = 0;
+
+		add_filter( 'sd_ai_agent_cloud_base_url', static fn(): string => $base_url );
+		add_filter(
+			'pre_http_request',
+			static function ( mixed $preempt, array $parsed_args, string $url ) use ( $registration_url, $models_url, &$registration_hits ): mixed {
+				if ( $registration_url === $url ) {
+					++$registration_hits;
+					$body             = json_decode( (string) ( $parsed_args['body'] ?? '' ), true );
+
+					return array(
+						'response' => array(
+							'code'    => 201,
+							'message' => 'Created',
+						),
+						'body'     => wp_json_encode(
+							array(
+								'installation_id' => is_array( $body ) ? (string) ( $body['installation_id'] ?? '' ) : '',
+								'site_token'      => 'sdaist_auto_provisioned_token',
+								'tier'            => 'free',
+								'verified'        => true,
+								'wallet'          => array(
+									'currency'         => 'USD',
+									'promo_usd_micros' => 10000000,
+									'cash_usd_micros'  => 0,
+									'total_usd_micros' => 10000000,
+								),
+							)
+						),
+					);
+				}
+
+				if ( $models_url === $url ) {
+					return array(
+						'response' => array(
+							'code'    => 200,
+							'message' => 'OK',
+						),
+						'body'     => wp_json_encode(
+							array(
+								'data' => array(
+									array(
+										'id'                => 'superdav-chat-fast',
+										'name'              => 'Superdav Chat Fast',
+										'context_length'    => 128000,
+										'max_output_length' => 8192,
+									),
+								),
+							)
+						),
+					);
+				}
+
+				return $preempt;
+			},
+			10,
+			3
+		);
+
+		( new SuperdavAiProviderHandler() )->register_provider();
+
+		$controller = new SettingsController( new Settings(), new Database() );
+		$response   = $controller->handle_providers();
+		$providers = $response->get_data();
+		$superdav  = $this->find_provider( is_array( $providers ) ? $providers : array(), SuperdavAiProvider::PROVIDER_ID );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 1, $registration_hits );
+		$this->assertSame( 'sdaist_auto_provisioned_token', get_option( SuperdavAiProvider::CREDENTIAL_OPTION, '' ) );
+		$this->assertNotNull( $superdav );
+		$this->assertTrue( $superdav['configured'] );
+		$this->assertTrue( $superdav['status']['connection_notice_pending'] );
+		$this->assertSame( 10000000, $superdav['status']['wallet']['promo_usd_micros'] );
+		$this->assertSame( 'superdav-chat-fast', $superdav['models'][0]['id'] ?? '' );
+		$this->assertStringNotContainsString( 'sdaist_auto_provisioned_token', wp_json_encode( $superdav ) ?: '' );
+
+		$second_response = $controller->handle_providers();
+		$this->assertSame( 200, $second_response->get_status() );
+		$this->assertSame( 1, $registration_hits );
+	}
+
+	/**
+	 * /providers refreshes a stale managed Superdav token when model listing returns 401.
+	 */
+	public function test_handle_providers_refreshes_stale_managed_superdav_token(): void {
+		if ( ! class_exists( AiClient::class ) ) {
+			$this->markTestSkipped( 'WordPress AI Client SDK is unavailable.' );
+		}
+
+		$base_url          = 'https://service.example/v1';
+		$registration_url  = $base_url . '/site/installations';
+		$models_url        = $base_url . '/models';
+		$registration_hits = 0;
+		$model_hits        = 0;
+		$registration_ids  = array();
+
+		add_filter( 'sd_ai_agent_cloud_base_url', static fn(): string => $base_url );
+		add_filter(
+			'pre_http_request',
+			static function ( mixed $preempt, array $parsed_args, string $url ) use ( $registration_url, $models_url, &$registration_hits, &$model_hits, &$registration_ids ): mixed {
+				if ( $registration_url === $url ) {
+					++$registration_hits;
+					$body               = json_decode( (string) ( $parsed_args['body'] ?? '' ), true );
+					$registration_ids[] = is_array( $body ) ? (string) ( $body['installation_id'] ?? '' ) : '';
+
+					return array(
+						'response' => array(
+							'code'    => 201,
+							'message' => 'Created',
+						),
+						'body'     => wp_json_encode(
+							array(
+								'site_token' => 'sdaist_refreshed_token',
+								'tier'       => 'free',
+								'verified'   => true,
+							)
+						),
+					);
+				}
+
+				if ( $models_url === $url ) {
+					++$model_hits;
+					$authorization = self::authorization_header_from_args( $parsed_args );
+					if ( 'Bearer sdaist_refreshed_token' !== $authorization ) {
+						return array(
+							'response' => array(
+								'code'    => 401,
+								'message' => 'Unauthorized',
+							),
+							'body'     => wp_json_encode(
+								array(
+									'error' => array(
+										'code'    => 'site_token_invalid',
+										'message' => 'Invalid or missing site token.',
+									),
+								)
+							),
+						);
+					}
+
+					return array(
+						'response' => array(
+							'code'    => 200,
+							'message' => 'OK',
+						),
+						'body'     => wp_json_encode(
+							array(
+								'data' => array(
+									array(
+										'id'                => 'superdav-chat-fast',
+										'name'              => 'Superdav Chat Fast',
+										'context_length'    => 128000,
+										'max_output_length' => 8192,
+									),
+									array(
+										'id'                => 'superdav-chat-pro',
+										'name'              => 'Superdav Chat Pro',
+										'context_length'    => 200000,
+										'max_output_length' => 16384,
+									),
+								),
+							)
+						),
+					);
+				}
+
+				return $preempt;
+			},
+			10,
+			3
+		);
+
+		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, 'sdaist_stale_token', false );
+		( new SuperdavAiProviderHandler() )->register_provider();
+
+		$response  = ( new SettingsController( new Settings(), new Database() ) )->handle_providers();
+		$providers = $response->get_data();
+		$superdav  = $this->find_provider( is_array( $providers ) ? $providers : array(), SuperdavAiProvider::PROVIDER_ID );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 1, $registration_hits );
+		$this->assertSame( get_option( SuperdavSiteConnectionService::INSTALLATION_ID_OPTION, '' ), $registration_ids[0] ?? '' );
+		$this->assertSame( 2, $model_hits );
+		$this->assertSame( 'sdaist_refreshed_token', get_option( SuperdavAiProvider::CREDENTIAL_OPTION, '' ) );
+		$this->assertNotNull( $superdav );
+		$this->assertSame( array( 'superdav-chat-fast', 'superdav-chat-pro' ), wp_list_pluck( $superdav['models'] ?? array(), 'id' ) );
+	}
+
+	/**
+	 * Find a provider entry by ID.
+	 *
+	 * @param array<int, array<string, mixed>> $providers Provider rows.
+	 * @param string                          $provider_id Provider ID.
+	 * @return array<string, mixed>|null
+	 */
+	private function find_provider( array $providers, string $provider_id ): ?array {
+		foreach ( $providers as $provider ) {
+			if ( $provider_id === ( $provider['id'] ?? '' ) ) {
+				return $provider;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Extract the Authorization header from a pre_http_request argument array.
+	 *
+	 * @param array<string, mixed> $parsed_args Parsed HTTP arguments.
+	 * @return string Authorization header value.
+	 */
+	private static function authorization_header_from_args( array $parsed_args ): string {
+		$headers = (array) ( $parsed_args['headers'] ?? array() );
+		foreach ( $headers as $name => $value ) {
+			if ( 'authorization' !== strtolower( (string) $name ) ) {
+				continue;
+			}
+
+			if ( is_array( $value ) ) {
+				$value = reset( $value );
+			}
+
+			return is_string( $value ) ? $value : '';
+		}
+
+		return '';
+	}
+
+	/**
+	 * Invalidate the SDK cache for Superdav model metadata.
+	 */
+	private function invalidate_superdav_model_cache(): void {
+		if ( ! class_exists( AiClient::class ) ) {
+			return;
+		}
+
+		try {
+			$directory = SuperdavAiProvider::modelMetadataDirectory();
+			if ( method_exists( $directory, 'invalidateCaches' ) ) {
+				$directory->invalidateCaches();
+			}
+		} catch ( \Throwable ) {
+			return;
+		}
+	}
+}

--- a/tests/mu-plugins/ai-agent-test-helpers.php
+++ b/tests/mu-plugins/ai-agent-test-helpers.php
@@ -51,10 +51,11 @@ add_action(
 /**
  * Register a deterministic AI Client SDK provider for Playwright E2E tests.
  *
- * The admin chat UI intentionally renders the ConnectorGate when the
- * /sd-ai-agent/v1/providers endpoint returns no authenticated SDK providers.
- * CI does not install third-party ai-provider-for-* plugins, so the workflow
- * opts into this provider with the sd_ai_agent_e2e_register_provider option.
+ * The admin chat UI now opens immediately and relies on managed Superdav AI
+ * auto-provisioning when /sd-ai-agent/v1/providers returns no authenticated
+ * SDK providers. CI can still opt into this deterministic provider with the
+ * sd_ai_agent_e2e_register_provider option when tests need a stable
+ * provider/model list without calling the managed service.
  *
  * Fallback: If the SDK provider registration fails (e.g., on WP trunk where
  * the SDK shape may differ), set a fake OpenAI key via the Connectors API


### PR DESCRIPTION
## Summary
- Default the bundled Superdav AI provider to the managed production edge and auto-provision a site token from activation or the first `/providers` request.
- Make Superdav connection flows idempotent: existing site tokens are reused, durable installation IDs key the edge registration, and wallet/status metadata is scrubbed before REST responses.
- Remove the visible chat connector gate so chat opens immediately, while showing a one-time system notice only when a new secure service token/free-tier wallet is created.
- Add backend and frontend coverage for provider auto-provisioning, stale-token refresh, wallet metadata sanitization, and onboarding notice ordering.

## Testing
- `npm run test:php -- --filter='ConnectorsControllerTest|SettingsControllerTest|SuperdavAiProviderTest'` — OK, 18 tests / 91 assertions.
- `npm run test:js -- --runTestsByPath src/admin-page/__tests__/superdav-autoconnect.test.js src/components/__tests__/OnboardingBootstrap.test.js` — 13 tests passed.
- `git diff --check` — clean.
- `npm run lint && php -d memory_limit=2G vendor/bin/phpstan analyse && npm run test:php` — lint clean, PHPStan 0 errors, full PHPUnit passed.
- `npm run build && npm run check:bundle && composer install` — build and bundle check succeeded; Composer dev dependencies restored after archive build.

## Worker self-verification
- PHPUnit: Tests: 3597, Assertions: 15033, Errors: 0, Failures: 0, Skipped: 120, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors (`php -d memory_limit=2G vendor/bin/phpstan analyse`)
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.1 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic setup for the managed AI service, including first-time provider provisioning and streamlined onboarding.
  * Introduced clearer connection status details and a one-time notice when a managed connection is created.
  * Updated provider responses to include additional safe status information, including wallet-related summaries.

* **Bug Fixes**
  * Improved handling of existing connections so users are not repeatedly re-registered.
  * Added automatic refresh for stale connections during provider loading, helping model lists load reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->