### PR TITLE
fix: propagate Superdav request timeout

### DIFF
--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiTextGenerationModel.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiTextGenerationModel.php
@@ -27,6 +27,6 @@ final class SuperdavAiTextGenerationModel extends AbstractOpenAiCompatibleTextGe
 	 * @return Request
 	 */
 	protected function createRequest( HttpMethodEnum $method, string $path, array $headers = array(), mixed $data = null ): Request {
-		return new Request( $method, SuperdavAiProvider::url( $path ), $headers, $data );
+		return new Request( $method, SuperdavAiProvider::url( $path ), $headers, $data, $this->getRequestOptions() );
 	}
 }

--- a/stubs/wordpress-7-runtime.php
+++ b/stubs/wordpress-7-runtime.php
@@ -547,8 +547,25 @@ namespace WordPress\AiClient\Providers\Http\DTO {
 		 * @param string                                                   $uri     Request URI.
 		 * @param array<string, string|list<string>>                       $headers Request headers.
 		 * @param string|array<string, mixed>|null                         $data    Request data.
+		 * @param RequestOptions|null                                      $options Request options.
 		 */
-		public function __construct( \WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum $method, string $uri, array $headers = array(), $data = null ) {}
+		public function __construct( \WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum $method, string $uri, array $headers = array(), $data = null, ?RequestOptions $options = null ) {}
+	}
+
+	class RequestOptions {
+		public const KEY_TIMEOUT = 'timeout';
+
+		/** @return float|null */
+		public function getTimeout(): ?float { return null; }
+
+		/** @param float|null $timeout Timeout in seconds. */
+		public function setTimeout( ?float $timeout ): void {}
+
+		/**
+		 * @param array<string, mixed> $array Request options.
+		 * @return self
+		 */
+		public static function fromArray( array $array ): self { return new self(); }
 	}
 
 	class Response {
@@ -635,6 +652,12 @@ namespace WordPress\AiClient\Providers\OpenAiCompatibleImplementation {
 		 * @param \WordPress\AiClient\Providers\DTO\ProviderMetadata     $provider_metadata Provider metadata.
 		 */
 		public function __construct( \WordPress\AiClient\Providers\Models\DTO\ModelMetadata $metadata, \WordPress\AiClient\Providers\DTO\ProviderMetadata $provider_metadata ) {}
+
+		/** @param \WordPress\AiClient\Providers\Http\DTO\RequestOptions $request_options Request options. */
+		public function setRequestOptions( \WordPress\AiClient\Providers\Http\DTO\RequestOptions $request_options ): void {}
+
+		/** @return \WordPress\AiClient\Providers\Http\DTO\RequestOptions|null */
+		public function getRequestOptions(): ?\WordPress\AiClient\Providers\Http\DTO\RequestOptions { return null; }
 	}
 }
 

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
@@ -15,9 +15,13 @@ use SdAiAgent\Core\ModelCapabilityRegistry;
 use SdAiAgent\Core\ProviderCredentialLoader;
 use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiModelMetadataDirectory;
 use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiTextGenerationModel;
 use WP_UnitTestCase;
 use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
 use WordPress\AiClient\Providers\Http\DTO\Response;
+use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 use XWP\DI\Decorators\Action;
 
@@ -156,6 +160,42 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 			'https://service.example/v1/site/installations',
 			SuperdavAiProvider::configured_service_url( 'site/installations' )
 		);
+	}
+
+	/**
+	 * Chat completion requests include the SDK request options bound by PromptBuilder.
+	 */
+	public function test_text_generation_request_attaches_sdk_request_options(): void {
+		$this->skip_if_sdk_unavailable();
+
+		$model = new SuperdavAiTextGenerationModel(
+			new ModelMetadata(
+				'example-model',
+				'Example Model',
+				array( CapabilityEnum::textGeneration() ),
+				array()
+			),
+			SuperdavAiProvider::metadata()
+		);
+
+		$options = RequestOptions::fromArray(
+			array(
+				RequestOptions::KEY_TIMEOUT => 123.0,
+			)
+		);
+		$model->setRequestOptions( $options );
+
+		$method  = new \ReflectionMethod( $model, 'createRequest' );
+		$request = $method->invoke(
+			$model,
+			HttpMethodEnum::POST(),
+			'chat/completions',
+			array( 'Content-Type' => 'application/json' ),
+			array( 'model' => 'example-model' )
+		);
+
+		$this->assertNotNull( $request->getOptions() );
+		$this->assertSame( 123.0, $request->getOptions()->getTimeout() );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Propagates WordPress AI Client SDK request options into Superdav chat-completion requests so the AgentLoop 300s timeout reaches the HTTP transport.
- Adds regression coverage proving Superdav text-generation requests retain PromptBuilder-bound timeout options.
- Updates the WordPress 7 runtime stubs so PHPStan knows about the AI Client request-options surface used at runtime.

## Root cause
`RequestTimeoutFilter` correctly raised `wp_ai_client_default_request_timeout` to `AgentLoop::LOOP_TIMEOUT_SECONDS`, but `SuperdavAiTextGenerationModel::createRequest()` did not attach `$this->getRequestOptions()` to the SDK `Request`. The SDK transport therefore fell back to WordPress HTTP's short default timeout, causing long setup prompts to fail with repeated 5s network timeouts.

Resolves #2121

## Verification
- Local repro before fix: AgentLoop failed after 5s with `cURL error 28`.
- Local repro after fix: same AgentLoop request succeeded in 14.6s.
- `npm run test:php -- --filter=SuperdavAiProviderTest`
- `npm run test:php -- --filter='SuperdavAiProviderTest|AgentLoopTest'`
- `npm run verify`

## Worker self-verification
- PHPUnit: Tests: 3617, Assertions: 15066, Errors: 0, Failures: 0, Skipped: 120, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.7 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Text generation requests now include configured request options, such as timeout settings, when sent through the AI client.
  * Requests created for the Superdav provider now carry the full set of instance-level settings instead of only basic request data.
* **Tests**
  * Added coverage to verify request options are attached correctly during text generation request creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->