### PR TITLE
Fix Superdav managed model defaults and retry diagnostics

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -35,6 +35,7 @@ use SdAiAgent\Core\RolePermissions;
 use WP_AI_Client_Ability_Function_Resolver;
 use WP_Error;
 use SdAiAgent\Core\CredentialResolver;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
 use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\DTO\ModelMessage;
@@ -70,13 +71,13 @@ class AgentLoop {
 	const MAX_TOOL_RESULT_CHARS = 40000;
 
 	/** Maximum provider-call attempts for retryable transient failures. */
-	private const PROVIDER_RETRY_MAX_ATTEMPTS = 10;
+	private const PROVIDER_RETRY_MAX_ATTEMPTS = 4;
 
 	/** Retryable upstream/network statuses. */
 	private const PROVIDER_RETRYABLE_STATUS_CODES = array( 408, 429, 500, 502, 503, 504 );
 
-	/** Default exponential backoff schedule in seconds, capped at 60 seconds. */
-	private const PROVIDER_RETRY_DELAYS = array( 1, 2, 4, 8, 16, 32, 60, 60, 60, 60 );
+	/** Default exponential backoff schedule in seconds. */
+	private const PROVIDER_RETRY_DELAYS = array( 1, 2, 4 );
 
 	/** Durable checkpoint phase saved before a provider call is attempted. */
 	public const CHECKPOINT_BEFORE_PROVIDER_CALL = 'before_provider_call';
@@ -365,7 +366,7 @@ class AgentLoop {
 		// Empty string when the loop is not running under a background job.
 		// @phpstan-ignore-next-line
 		$this->active_job_id = (string) ( $options['active_job_id'] ?? '' );
-		// @phpstan-ignore-next-line -- Test/job callers may lower attempts or delays; production defaults remain 10 attempts.
+		// @phpstan-ignore-next-line -- Test/job callers may lower attempts or delays; production defaults remain four attempts.
 		$this->provider_retry_max_attempts = max( 1, (int) ( $options['provider_retry_max_attempts'] ?? self::PROVIDER_RETRY_MAX_ATTEMPTS ) );
 		// @phpstan-ignore-next-line -- Values are normalised below to non-negative integer seconds.
 		$retry_delays = $options['provider_retry_delays'] ?? self::PROVIDER_RETRY_DELAYS;
@@ -1717,6 +1718,9 @@ class AgentLoop {
 			'delay'        => $delay,
 			'sequence'     => $this->next_activity_sequence(),
 		];
+		if ( '' !== $this->active_job_id ) {
+			ActiveJobRepository::heartbeat( $this->active_job_id );
+		}
 		$this->fire_progress();
 	}
 
@@ -1760,6 +1764,11 @@ class AgentLoop {
 			$this->get_provider_error_message( $error )
 		);
 
+		$hint = $this->get_provider_retry_failure_hint();
+		if ( '' !== $hint ) {
+			$message .= ' ' . $hint;
+		}
+
 		if ( $this->session_id > 0 ) {
 			Database::save_paused_state(
 				$this->session_id,
@@ -1790,6 +1799,17 @@ class AgentLoop {
 				]
 			)
 		);
+	}
+
+	/**
+	 * Return provider-specific retry exhaustion guidance.
+	 */
+	private function get_provider_retry_failure_hint(): string {
+		if ( SuperdavAiProvider::PROVIDER_ID !== $this->resolve_provider_id() ) {
+			return '';
+		}
+
+		return __( 'The managed Superdav service could not be reached from this site. Check outbound HTTPS/network access from the host, try again shortly, or switch provider/model if it continues.', 'superdav-ai-agent' );
 	}
 
 	/**

--- a/includes/Core/CostCalculator.php
+++ b/includes/Core/CostCalculator.php
@@ -16,6 +16,9 @@ class CostCalculator {
 	 * Pricing per million tokens [input, output] in USD.
 	 */
 	private const PRICING = [
+		// Superdav managed models.
+		'superdav-chat-fast'                   => [ 0.25, 1.00 ],
+		'superdav-chat-pro'                    => [ 1.50, 6.00 ],
 		// Claude models.
 		'claude-sonnet-4-6'                    => [ 3.00, 15.00 ],
 		'claude-opus-4-6'                      => [ 15.00, 75.00 ],

--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -17,6 +17,8 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Core;
 
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -65,6 +67,9 @@ class Settings {
 	 * @var array<string, int>
 	 */
 	const MODEL_CONTEXT_WINDOWS = array(
+		// Superdav managed models.
+		'superdav-chat-fast'            => 128000,
+		'superdav-chat-pro'             => 200000,
 		// Anthropic.
 		'claude-opus-4-6'               => 200000,
 		'claude-sonnet-4-6'             => 200000,
@@ -163,6 +168,9 @@ class Settings {
 	 * @var array<string, int>
 	 */
 	const MODEL_MAX_OUTPUT_TOKENS = array(
+		// ── Superdav managed models ───────────────────────────────────────
+		'superdav-chat-fast'          => 8192,
+		'superdav-chat-pro'           => 16384,
 		// ── Anthropic ──────────────────────────────────────────────────
 		// Opus 4.6 / 4.7 document 128K; Opus 4.5 documents 64K; Opus 4.1
 		// and Opus 4 document 32K. Newer point releases have higher caps
@@ -690,7 +698,15 @@ class Settings {
 		// must not silently degrade to "SDK picks something different".
 		$filter_pinned = ( $filtered_builtin !== $builtin );
 		if ( '' === $saved_model && ! $filter_pinned ) {
-			return array( self::resolve_provider_hint( $saved_provider, $registered ), '' );
+			$provider_hint = self::resolve_provider_hint( $saved_provider, $registered );
+			if ( SuperdavAiProvider::PROVIDER_ID === $provider_hint ) {
+				$superdav_default_model = self::resolve_superdav_default_model( $registered[ $provider_hint ] ?? array() );
+				if ( '' !== $superdav_default_model ) {
+					return array( $provider_hint, $superdav_default_model );
+				}
+			}
+
+			return array( $provider_hint, '' );
 		}
 
 		// Candidate model = filter override if set, else saved. The saved
@@ -778,6 +794,22 @@ class Settings {
 			return (string) array_key_first( $registered );
 		}
 		return '';
+	}
+
+	/**
+	 * Resolve the clean-install default model for the bundled Superdav provider.
+	 *
+	 * Clean installs normally return an empty model so the SDK can use each
+	 * provider's own default. The managed Superdav provider is the exception:
+	 * realistic setup-assistant site builds should start on the pro alias when
+	 * it is advertised, regardless of the `/models` ordering returned by the
+	 * service.
+	 *
+	 * @param array<int, string> $models Model IDs advertised by the Superdav provider.
+	 */
+	private static function resolve_superdav_default_model( array $models ): string {
+		$default_model = SuperdavAiProvider::default_model_id();
+		return in_array( $default_model, $models, true ) ? $default_model : '';
 	}
 
 	/**

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php
@@ -25,6 +25,67 @@ final class SuperdavAiProvider extends AbstractApiProvider {
 	public const PROVIDER_ID       = 'sd-ai-agent-cloud';
 	public const CREDENTIAL_OPTION = 'connectors_ai_sd_ai_agent_cloud_api_key';
 	public const DEFAULT_BASE_URL  = 'https://api.sdaiagent.com/v1';
+	public const FAST_MODEL_ID     = 'superdav-chat-fast';
+	public const DEFAULT_MODEL_ID  = 'superdav-chat-pro';
+
+	/**
+	 * Reasoning effort hints for managed Superdav model aliases.
+	 *
+	 * The plugin sends these as OpenAI-compatible `reasoning_effort` custom
+	 * options so the managed service receives an explicit effort level instead
+	 * of relying on an opaque backend default. Values intentionally stay within
+	 * the OpenAI-compatible low/medium/high vocabulary.
+	 *
+	 * @var array<string, string>
+	 */
+	private const MODEL_REASONING_EFFORTS = array(
+		self::FAST_MODEL_ID    => 'medium',
+		self::DEFAULT_MODEL_ID => 'high',
+	);
+
+	/**
+	 * Return the managed model that new Superdav-provider installs should prefer.
+	 */
+	public static function default_model_id(): string {
+		/**
+		 * Filter the preferred managed Superdav model ID for clean installs.
+		 *
+		 * The returned value is still validated against the provider's advertised
+		 * models before Settings uses it.
+		 *
+		 * @param string $model_id Built-in preferred model ID.
+		 */
+		$model_id = apply_filters( 'sd_ai_agent_superdav_default_model', self::DEFAULT_MODEL_ID );
+
+		return is_string( $model_id ) && '' !== trim( $model_id )
+			? trim( $model_id )
+			: self::DEFAULT_MODEL_ID;
+	}
+
+	/**
+	 * Return the reasoning-effort hint to send for a managed model alias.
+	 */
+	public static function reasoning_effort_for_model( string $model_id ): string {
+		$normalised = strtolower( trim( $model_id ) );
+		$effort     = self::MODEL_REASONING_EFFORTS[ $normalised ] ?? '';
+
+		/**
+		 * Filter the OpenAI-compatible `reasoning_effort` sent to Superdav cloud.
+		 *
+		 * Return an empty string to omit the field. Non-standard values are ignored
+		 * to avoid sending request bodies the managed endpoint may reject.
+		 *
+		 * @param string $effort   Built-in effort hint: '', 'low', 'medium', or 'high'.
+		 * @param string $model_id Model ID from the outgoing chat-completions body.
+		 */
+		$effort = apply_filters( 'sd_ai_agent_superdav_reasoning_effort', $effort, $model_id );
+		if ( ! is_string( $effort ) ) {
+			return '';
+		}
+
+		$effort = strtolower( trim( $effort ) );
+		return in_array( $effort, array( 'low', 'medium', 'high' ), true ) ? $effort : '';
+	}
 
 	/**
 	 * Create a model instance for the provider.

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiTextGenerationModel.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiTextGenerationModel.php
@@ -27,6 +27,14 @@ final class SuperdavAiTextGenerationModel extends AbstractOpenAiCompatibleTextGe
 	 * @return Request
 	 */
 	protected function createRequest( HttpMethodEnum $method, string $path, array $headers = array(), mixed $data = null ): Request {
+		if ( 'chat/completions' === trim( $path, '/' ) && is_array( $data ) && ! array_key_exists( 'reasoning_effort', $data ) ) {
+			$model_id = isset( $data['model'] ) && is_string( $data['model'] ) ? $data['model'] : '';
+			$effort   = SuperdavAiProvider::reasoning_effort_for_model( $model_id );
+			if ( '' !== $effort ) {
+				$data['reasoning_effort'] = $effort;
+			}
+		}
+
 		return new Request( $method, SuperdavAiProvider::url( $path ), $headers, $data, $this->getRequestOptions() );
 	}
 }

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -787,7 +787,8 @@ final class SettingsController {
 				);
 
 				if ( SuperdavAiProvider::PROVIDER_ID === $provider_id ) {
-					$provider_response['status'] = ( new SuperdavSiteConnectionService() )->get_status();
+					$provider_response['default_model'] = SuperdavAiProvider::default_model_id();
+					$provider_response['status']        = ( new SuperdavSiteConnectionService() )->get_status();
 				}
 
 				$providers[] = $provider_response;

--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -44,6 +44,26 @@ import AbilitiesManager from './abilities-manager';
 import ProviderTraceViewer from './provider-trace-viewer';
 
 /**
+ * Resolve the default model to select for a provider row.
+ *
+ * @param {Object|undefined} provider Provider row from the REST API.
+ * @return {string} Model ID to select, or an empty string.
+ */
+function resolveProviderDefaultModel( provider ) {
+	const models = Array.isArray( provider?.models ) ? provider.models : [];
+	const defaultModelId = provider?.default_model || '';
+
+	if (
+		defaultModelId &&
+		models.some( ( model ) => model.id === defaultModelId )
+	) {
+		return defaultModelId;
+	}
+
+	return models[ 0 ]?.id || '';
+}
+
+/**
  *
  */
 export default function SettingsApp() {
@@ -455,7 +475,7 @@ export default function SettingsApp() {
 			setLocal( ( prev ) => ( {
 				...prev,
 				default_provider: providerId,
-				default_model: provider?.models?.[ 0 ]?.id || '',
+				default_model: resolveProviderDefaultModel( provider ),
 			} ) );
 		},
 		[ providers ]

--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -293,11 +293,12 @@ describe( 'actions', () => {
 } );
 
 describe( 'resolveProviderSelection', () => {
-	test( 'replaces a stale saved model with the first advertised provider model', () => {
+	test( 'replaces a stale saved model with the provider default model', () => {
 		const selection = resolveProviderSelection(
 			[
 				{
 					id: 'sd-ai-agent-cloud',
+					default_model: 'superdav-chat-pro',
 					models: [
 						{ id: 'superdav-chat-fast' },
 						{ id: 'superdav-chat-pro' },
@@ -306,6 +307,28 @@ describe( 'resolveProviderSelection', () => {
 			],
 			'sd-ai-agent-cloud',
 			'chat-fast'
+		);
+
+		expect( selection ).toEqual( {
+			providerId: 'sd-ai-agent-cloud',
+			modelId: 'superdav-chat-pro',
+		} );
+	} );
+
+	test( 'keeps a saved model when it is still advertised', () => {
+		const selection = resolveProviderSelection(
+			[
+				{
+					id: 'sd-ai-agent-cloud',
+					default_model: 'superdav-chat-pro',
+					models: [
+						{ id: 'superdav-chat-fast' },
+						{ id: 'superdav-chat-pro' },
+					],
+				},
+			],
+			'sd-ai-agent-cloud',
+			'superdav-chat-fast'
 		);
 
 		expect( selection ).toEqual( {

--- a/src/store/slices/providersSlice.js
+++ b/src/store/slices/providersSlice.js
@@ -33,10 +33,23 @@ export function resolveProviderSelection(
 
 	const models = Array.isArray( provider.models ) ? provider.models : [];
 	const hasSavedModel = models.some( ( model ) => model.id === savedModelId );
+	const defaultModelId = provider.default_model || '';
+	const hasProviderDefaultModel = models.some(
+		( model ) => model.id === defaultModelId
+	);
+	let modelId = models[ 0 ]?.id || '';
+
+	if ( hasProviderDefaultModel ) {
+		modelId = defaultModelId;
+	}
+
+	if ( hasSavedModel ) {
+		modelId = savedModelId;
+	}
 
 	return {
 		providerId: provider.id,
-		modelId: hasSavedModel ? savedModelId : models[ 0 ]?.id || '',
+		modelId,
 	};
 }
 

--- a/src/types.js
+++ b/src/types.js
@@ -61,10 +61,11 @@
  * An AI provider configuration.
  *
  * @typedef {Object} Provider
- * @property {string}          id       - Provider identifier.
- * @property {string}          name     - Human-readable provider name.
- * @property {ProviderModel[]} [models] - Available models for this provider.
- * @property {Object}          [status] - Provider-specific safe status metadata.
+ * @property {string}          id              - Provider identifier.
+ * @property {string}          name            - Human-readable provider name.
+ * @property {string}          [default_model] - Provider-preferred default model ID.
+ * @property {ProviderModel[]} [models]        - Available models for this provider.
+ * @property {Object}          [status]        - Provider-specific safe status metadata.
  */
 
 /**

--- a/superdav-ai-agent.php
+++ b/superdav-ai-agent.php
@@ -44,7 +44,7 @@ define( 'SD_AI_AGENT_URL', plugin_dir_url( __FILE__ ) );
  * Developers can override the effective default at runtime via the
  * `sd_ai_agent_default_model` filter rather than changing this constant.
  */
-define( 'SD_AI_AGENT_DEFAULT_MODEL', 'claude-sonnet-4' );
+define( 'SD_AI_AGENT_DEFAULT_MODEL', 'superdav-chat-pro' );
 
 // ── Feature flags ─────────────────────────────────────────────────────────────
 // Each constant defaults to `true` (enabled) when not defined.

--- a/tests/SdAiAgent/Core/CostCalculatorTest.php
+++ b/tests/SdAiAgent/Core/CostCalculatorTest.php
@@ -10,6 +10,7 @@
 namespace SdAiAgent\Tests\Core;
 
 use SdAiAgent\Core\CostCalculator;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
 use WP_UnitTestCase;
 
 /**
@@ -52,6 +53,15 @@ class CostCalculatorTest extends WP_UnitTestCase {
 		// 1M input tokens at $0.15 + 1M output tokens at $0.60 = $0.75
 		$cost = CostCalculator::calculate_cost( 'gpt-4o-mini', 1_000_000, 1_000_000 );
 		$this->assertSame( 0.75, $cost );
+	}
+
+	/**
+	 * Test calculate_cost with the managed Superdav pro model.
+	 */
+	public function test_calculate_cost_superdav_pro() {
+		// 1M input tokens at $1.50 + 1M output tokens at $6.00 = $7.50
+		$cost = CostCalculator::calculate_cost( SuperdavAiProvider::DEFAULT_MODEL_ID, 1_000_000, 1_000_000 );
+		$this->assertSame( 7.5, $cost );
 	}
 
 	/**
@@ -113,6 +123,7 @@ class CostCalculatorTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'claude-sonnet-4', $all );
 		$this->assertArrayHasKey( 'gpt-4o', $all );
 		$this->assertArrayHasKey( 'gpt-4o-mini', $all );
+		$this->assertArrayHasKey( SuperdavAiProvider::DEFAULT_MODEL_ID, $all );
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/SettingsTest.php
+++ b/tests/SdAiAgent/Core/SettingsTest.php
@@ -11,6 +11,7 @@ namespace SdAiAgent\Tests\Core;
 
 use SdAiAgent\Core\ModelCapabilityRegistry;
 use SdAiAgent\Core\Settings;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
 use WP_UnitTestCase;
 
 /**
@@ -40,6 +41,8 @@ class SettingsTest extends WP_UnitTestCase {
 		// clear the handful this suite touches so cases stay independent.
 		foreach (
 			array(
+				SuperdavAiProvider::FAST_MODEL_ID,
+				SuperdavAiProvider::DEFAULT_MODEL_ID,
 				'gpt-4o',
 				'hf:moonshotai/Kimi-K2.6',
 				'hf:moonshotai/Kimi-K2.7',
@@ -223,6 +226,21 @@ class SettingsTest extends WP_UnitTestCase {
 		$this->assertSame(
 			Settings::MAX_OUTPUT_TOKENS_FALLBACK,
 			Settings::get_max_output_tokens_for_model( 'wholly-made-up-model-9000' )
+		);
+	}
+
+	/**
+	 * Managed Superdav aliases use stable catalog caps before live /models
+	 * metadata has been ingested.
+	 */
+	public function test_max_output_tokens_resolves_superdav_managed_models(): void {
+		$this->assertSame(
+			8192,
+			Settings::get_max_output_tokens_for_model( SuperdavAiProvider::FAST_MODEL_ID )
+		);
+		$this->assertSame(
+			16384,
+			Settings::get_max_output_tokens_for_model( SuperdavAiProvider::DEFAULT_MODEL_ID )
 		);
 	}
 
@@ -504,8 +522,9 @@ class SettingsTest extends WP_UnitTestCase {
 			)
 		);
 
-		// SD_AI_AGENT_DEFAULT_MODEL is `claude-sonnet-4`, which the fake
-		// registry advertises under anthropic — the resolver picks it.
+		// SD_AI_AGENT_DEFAULT_MODEL is Superdav's pro alias, which this fake
+		// registry does not advertise, so the resolver falls through to the
+		// first registered Anthropic model.
 		$this->assertSame( 'claude-sonnet-4', Settings::instance()->get_default_model() );
 		$this->assertSame( 'anthropic', Settings::instance()->get_default_provider() );
 
@@ -608,6 +627,23 @@ class SettingsTest extends WP_UnitTestCase {
 		// No update() call — saved value is the empty default.
 		$this->assertSame( '', Settings::instance()->get_default_model() );
 		$this->assertSame( 'anthropic', Settings::instance()->get_default_provider() );
+		$this->assertFalse( (bool) get_option( Settings::INVALID_DEFAULT_NOTICE_OPTION ) );
+	}
+
+	/**
+	 * Clean Superdav-provider installs should start on the pro managed alias
+	 * when the service advertises it, even if /models lists fast first.
+	 */
+	public function test_get_default_model_empty_saved_prefers_superdav_pro(): void {
+		$this->fake_registry( array(
+			SuperdavAiProvider::PROVIDER_ID => array(
+				SuperdavAiProvider::FAST_MODEL_ID,
+				SuperdavAiProvider::DEFAULT_MODEL_ID,
+			),
+		) );
+
+		$this->assertSame( SuperdavAiProvider::DEFAULT_MODEL_ID, Settings::instance()->get_default_model() );
+		$this->assertSame( SuperdavAiProvider::PROVIDER_ID, Settings::instance()->get_default_provider() );
 		$this->assertFalse( (bool) get_option( Settings::INVALID_DEFAULT_NOTICE_OPTION ) );
 	}
 

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
@@ -37,6 +37,8 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 		delete_option( SuperdavAiProvider::CREDENTIAL_OPTION );
 		ModelCapabilityRegistry::forget( 'example-model' );
 		remove_all_filters( 'sd_ai_agent_cloud_base_url' );
+		remove_all_filters( 'sd_ai_agent_superdav_default_model' );
+		remove_all_filters( 'sd_ai_agent_superdav_reasoning_effort' );
 		parent::tear_down();
 	}
 
@@ -100,6 +102,62 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 		$this->assertSame(
 			'https://api.sdaiagent.com/v1/site/installations',
 			SuperdavAiProvider::configured_service_url( 'site/installations' )
+		);
+	}
+
+	/**
+	 * The bundled provider defaults clean installs to the pro managed alias.
+	 */
+	public function test_default_model_is_managed_pro_alias(): void {
+		$this->assertSame( 'superdav-chat-pro', SuperdavAiProvider::default_model_id() );
+	}
+
+	/**
+	 * Managed Superdav aliases resolve to explicit effort levels.
+	 *
+	 * @dataProvider managed_model_effort_provider
+	 */
+	public function test_managed_model_reasoning_effort_mapping( string $model_id, string $expected_effort ): void {
+		$this->assertSame( $expected_effort, SuperdavAiProvider::reasoning_effort_for_model( $model_id ) );
+	}
+
+	/**
+	 * The managed provider sends explicit effort hints for Superdav aliases.
+	 *
+	 * @dataProvider managed_model_effort_provider
+	 */
+	public function test_text_generation_request_includes_managed_reasoning_effort( string $model_id, string $expected_effort ): void {
+		$this->skip_if_sdk_unavailable();
+
+		$model  = new SuperdavAiTextGenerationModel(
+			new ModelMetadata( $model_id, $model_id, array(), array() ),
+			SuperdavAiProvider::metadata()
+		);
+		$method = new \ReflectionMethod( $model, 'createRequest' );
+		$method->setAccessible( true );
+
+		$request = $method->invoke(
+			$model,
+			HttpMethodEnum::POST(),
+			'chat/completions',
+			array( 'Content-Type' => 'application/json' ),
+			array( 'model' => $model_id )
+		);
+
+		$this->assertIsObject( $request );
+		$this->assertTrue( method_exists( $request, 'getData' ) );
+		$data = $request->getData();
+		$this->assertIsArray( $data );
+		$this->assertSame( $expected_effort, $data['reasoning_effort'] ?? '' );
+	}
+
+	/**
+	 * @return array<string, array{0:string, 1:string}>
+	 */
+	public function managed_model_effort_provider(): array {
+		return array(
+			'fast' => array( SuperdavAiProvider::FAST_MODEL_ID, 'medium' ),
+			'pro'  => array( SuperdavAiProvider::DEFAULT_MODEL_ID, 'high' ),
 		);
 	}
 

--- a/tests/SdAiAgent/REST/SettingsControllerTest.php
+++ b/tests/SdAiAgent/REST/SettingsControllerTest.php
@@ -127,6 +127,7 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		$this->assertSame( 'sdaist_auto_provisioned_token', get_option( SuperdavAiProvider::CREDENTIAL_OPTION, '' ) );
 		$this->assertNotNull( $superdav );
 		$this->assertTrue( $superdav['configured'] );
+		$this->assertSame( SuperdavAiProvider::DEFAULT_MODEL_ID, $superdav['default_model'] ?? '' );
 		$this->assertTrue( $superdav['status']['connection_notice_pending'] );
 		$this->assertSame( 10000000, $superdav['status']['wallet']['promo_usd_micros'] );
 		$this->assertSame( 'superdav-chat-fast', $superdav['models'][0]['id'] ?? '' );
@@ -241,6 +242,7 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		$this->assertSame( 2, $model_hits );
 		$this->assertSame( 'sdaist_refreshed_token', get_option( SuperdavAiProvider::CREDENTIAL_OPTION, '' ) );
 		$this->assertNotNull( $superdav );
+		$this->assertSame( SuperdavAiProvider::DEFAULT_MODEL_ID, $superdav['default_model'] ?? '' );
 		$this->assertSame( array( 'superdav-chat-fast', 'superdav-chat-pro' ), wp_list_pluck( $superdav['models'] ?? array(), 'id' ) );
 	}
 


### PR DESCRIPTION
## Summary
- default managed Superdav installs to `superdav-chat-pro` and expose that provider default to REST/JS selection
- send explicit Superdav `reasoning_effort` for chat completions so fast/pro effort is traceable
- shorten provider retry exhaustion and add heartbeat/actionable diagnostics for managed-service failures

## Worker self-verification
- PHPUnit: Tests: 3625, Assertions: 15086, Errors: 0, Failures: 0, Skipped: 120
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Resolves #2121

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.23.0 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer default model selection for the bundled provider, including a provider-specific default model on first use.
  * Managed models now carry pricing, context-window, token-limit, and request tuning support.

* **Bug Fixes**
  * Improved retry handling with shorter wait times and refreshed job activity during retries.
  * Show a more helpful error hint when provider retries are exhausted.

* **Tests**
  * Expanded coverage for default model selection, pricing, token limits, and request behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->