### PR TITLE
Fix invalid tool-call retry guidance

### DIFF
--- a/includes/Core/AbilityFunctionResolver.php
+++ b/includes/Core/AbilityFunctionResolver.php
@@ -163,6 +163,8 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 			// @phpstan-ignore-next-line — execute() exists at runtime in WP 7.0.
 			$result = $ability->execute( $args );
 		} catch ( \Throwable $e ) {
+			$error_code = self::is_input_validation_exception( $e ) ? 'ability_invalid_input' : 'ability_exception';
+
 			// Errors in schema validation (validate_input/validate_output)
 			// are not caught by WP core's invoke_callback(). Capture them
 			// here with full context so the model can report the location.
@@ -178,24 +180,31 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 				AgentEventLog::SEVERITY_ERROR,
 				array(
 					'ability' => $ability_name,
-					'code'    => 'ability_exception',
+					'code'    => $error_code,
 					'message' => $e->getMessage(),
 				)
 			);
 
+			$response_data = array(
+				'error'         => $e->getMessage(),
+				'code'          => $error_code,
+				'error_context' => sprintf(
+					'%s:%d — %s',
+					$e->getFile(),
+					$e->getLine(),
+					implode( ' → ', array_slice( $trace_frames, 0, 3 ) )
+				),
+			);
+
+			if ( 'ability_invalid_input' === $error_code ) {
+				$response_data = self::enrich_validation_error_response( $response_data, $ability, (string) $e->getMessage() );
+				$response_data = self::enrich_identical_failure_response( $response_data, $ability_name, $args, $error_code, $ability );
+			}
+
 			return new FunctionResponse(
 				$function_id,
 				$function_name,
-				array(
-					'error'         => $e->getMessage(),
-					'code'          => 'ability_exception',
-					'error_context' => sprintf(
-						'%s:%d — %s',
-						$e->getFile(),
-						$e->getLine(),
-						implode( ' → ', array_slice( $trace_frames, 0, 3 ) )
-					),
-				)
+				$response_data
 			);
 		}
 
@@ -240,31 +249,14 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 			// the same arguments forever. Also feeds model-health telemetry
 			// so weak models accumulate a worse score over time.
 			if ( 'ability_invalid_input' === $error_code ) {
-				// @phpstan-ignore-next-line — get_input_schema() exists at runtime in WP 7.0.
-				$schema                        = $ability->get_input_schema();
-				$response_data['input_schema'] = $schema;
-
-				// Pull the specific missing field name(s) from the error
-				// message and synthesise a copy-paste-ready example. This
-				// is the single biggest weak-model unblocker.
-				$missing                                  = SchemaExampleBuilder::extract_missing_required( (string) $result->get_error_message() );
-				$response_data['missing_required_fields'] = $missing;
-				$response_data['example_arguments']       = SchemaExampleBuilder::build_example( $schema );
-				$response_data['hint']                    = 'Copy `example_arguments`, replace each `<placeholder>` with a real value, then call ability-call again. Do not retry with empty arguments.';
-
-				ModelHealthTracker::record_validation_error();
+				$response_data = self::enrich_validation_error_response( $response_data, $ability, (string) $result->get_error_message() );
 			}
 
 			// Per-call spin detection: after the second identical failure
 			// (same ability + same args + same error code), replace the
 			// hint with a hard nudge that tells the model to stop and
 			// either supply different args or call a different ability.
-			$count = IdenticalFailureTracker::record( $ability_name, $args, $error_code );
-			if ( IdenticalFailureTracker::should_nudge( $count ) ) {
-				$schema_for_nudge       = $response_data['input_schema'] ?? $ability->get_input_schema();
-				$response_data['nudge'] = IdenticalFailureTracker::nudge_message( $ability_name, $schema_for_nudge );
-				ModelHealthTracker::record_nudge();
-			}
+			$response_data = self::enrich_identical_failure_response( $response_data, $ability_name, $args, $error_code, $ability );
 
 			return new FunctionResponse(
 				$function_id,
@@ -300,5 +292,72 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 			}
 		}
 		return $args;
+	}
+
+	/**
+	 * Determine whether a thrown ability error is input-schema validation.
+	 *
+	 * WordPress ability validation can throw before the callback is invoked,
+	 * which bypasses the WP_Error branch that already inlines schemas for model
+	 * self-correction. Detect the validator's stable message shapes so direct
+	 * tool calls such as `skill-load({})` and `ability-search({})` get the same
+	 * corrective payload instead of a bare `ability_exception`.
+	 *
+	 * @param \Throwable $e Throwable raised while executing the ability.
+	 * @return bool True when the error came from input-schema validation.
+	 */
+	private static function is_input_validation_exception( \Throwable $e ): bool {
+		$message = trim( $e->getMessage() );
+		if ( '' === $message ) {
+			return false;
+		}
+
+		return 1 === preg_match( '/`?[\w_-]+`?\s+is\s+a\s+required\s+property\s+of\s+input\b/i', $message )
+			|| 1 === preg_match( '/\binput(?:\[[^\]]+\])?\s+is\s+not\s+of\s+type\b/i', $message )
+			|| 1 === preg_match( '/\binput(?:\[[^\]]+\])?\s+is\s+not\s+one\s+of\b/i', $message );
+	}
+
+	/**
+	 * Add schema, missing-field, example, and hint data to validation failures.
+	 *
+	 * @param array<string, mixed> $response_data Existing response payload.
+	 * @param \WP_Ability          $ability       Ability that failed validation.
+	 * @param string               $error_message Validation error message.
+	 * @return array<string, mixed> Enriched response payload.
+	 */
+	private static function enrich_validation_error_response( array $response_data, \WP_Ability $ability, string $error_message ): array {
+		// @phpstan-ignore-next-line — get_input_schema() exists at runtime in WP 7.0.
+		$schema = $ability->get_input_schema();
+
+		$response_data['input_schema']            = $schema;
+		$response_data['missing_required_fields'] = SchemaExampleBuilder::extract_missing_required( $error_message );
+		$response_data['example_arguments']       = SchemaExampleBuilder::build_example( $schema );
+		$response_data['hint']                    = 'Copy `example_arguments`, replace each `<placeholder>` with a real value, then retry the ability with those arguments. Do not retry with empty arguments.';
+
+		ModelHealthTracker::record_validation_error();
+
+		return $response_data;
+	}
+
+	/**
+	 * Add a hard nudge after repeated identical failures.
+	 *
+	 * @param array<string, mixed> $response_data Existing response payload.
+	 * @param string               $ability_name  Ability that failed.
+	 * @param array<string, mixed> $args          Normalised arguments passed to the ability.
+	 * @param string               $error_code    Failure code used in the response.
+	 * @param \WP_Ability          $ability       Ability that failed.
+	 * @return array<string, mixed> Response payload, possibly with a nudge.
+	 */
+	private static function enrich_identical_failure_response( array $response_data, string $ability_name, array $args, string $error_code, \WP_Ability $ability ): array {
+		$count = IdenticalFailureTracker::record( $ability_name, $args, $error_code );
+		if ( IdenticalFailureTracker::should_nudge( $count ) ) {
+			// @phpstan-ignore-next-line — get_input_schema() exists at runtime in WP 7.0.
+			$schema_for_nudge       = $response_data['input_schema'] ?? $ability->get_input_schema();
+			$response_data['nudge'] = IdenticalFailureTracker::nudge_message( $ability_name, $schema_for_nudge );
+			ModelHealthTracker::record_nudge();
+		}
+
+		return $response_data;
 	}
 }

--- a/includes/Core/IdenticalFailureTracker.php
+++ b/includes/Core/IdenticalFailureTracker.php
@@ -88,7 +88,7 @@ class IdenticalFailureTracker {
 		$example_json = empty( $example ) ? '{}' : (string) wp_json_encode( $example );
 
 		return sprintf(
-			"STOP. You have called `%s` with the same arguments and received the same error twice in a row. Do not retry with empty or unchanged arguments.\n\nYou MUST either:\n  (1) Call ability-call again with arguments that look like this stub (replace every `<placeholder>` with a real value):\n      %s\n  (2) Or call a different ability that does not need those fields.\n\nIf you do not know a value, call a different ability to fetch it first.",
+			"STOP. You have called `%s` with the same arguments and received the same error twice in a row. Do not retry with empty or unchanged arguments.\n\nYou MUST either:\n  (1) Retry only with arguments that look like this stub (replace every `<placeholder>` with a real value):\n      %s\n  (2) Or call a different ability that does not need those fields.\n\nIf you do not know a value, call a different ability to fetch it first.",
 			$ability_name,
 			$example_json
 		);

--- a/includes/Core/SkillAutoInjector.php
+++ b/includes/Core/SkillAutoInjector.php
@@ -157,9 +157,15 @@ class SkillAutoInjector {
 			return '';
 		}
 
-		return '> **Skill hint:** the following skill guide(s) are likely relevant to this request — '
-			. 'call `sd-ai-agent/skill-load` before proceeding: `'
+		$examples = array_map(
+			static fn( string $slug ): string => '{"slug":"' . $slug . '"}',
+			$matched_slugs
+		);
+
+		return '> **Skill hint:** likely guide(s): `'
 			. implode( '`, `', $matched_slugs )
+			. '`. Before proceeding, call `sd-ai-agent/skill-load` with `'
+			. implode( '`, `', $examples )
 			. '`';
 	}
 

--- a/includes/Tools/ModelHealthTracker.php
+++ b/includes/Tools/ModelHealthTracker.php
@@ -65,11 +65,15 @@ class ModelHealthTracker {
 
 	/**
 	 * Substrings in a model id that flag it as weak by name. Conservative
-	 * — limited to small parameter counts and known-weak quantizations.
+	 * — limited to explicit managed-model overrides, small parameter counts,
+	 * and known-weak quantizations.
 	 *
 	 * @var string[]
 	 */
 	private const WEAK_NAME_HINTS = array(
+		// Managed cloud fast route: bootstrap with stricter schema-following
+		// guidance after field reports of empty required-argument tool calls.
+		'superdav-chat-fast',
 		// Small parameter counts.
 		'-1b',
 		'-2b',

--- a/tests/SdAiAgent/Core/AbilityFunctionResolverTest.php
+++ b/tests/SdAiAgent/Core/AbilityFunctionResolverTest.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * Tests for the ability function resolver wrapper.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\AbilityFunctionResolver;
+use SdAiAgent\Core\IdenticalFailureTracker;
+use WordPress\AiClient\Tools\DTO\FunctionCall;
+use WP_UnitTestCase;
+
+final class ThrowingValidationAbility extends \WP_Ability {
+
+	/**
+	 * @param mixed $input Input passed by the resolver.
+	 * @return mixed
+	 */
+	public function execute( $input = null ) {
+		unset( $input );
+		throw new \InvalidArgumentException( 'query is a required property of input.' );
+	}
+}
+
+class AbilityFunctionResolverTest extends WP_UnitTestCase {
+
+	/**
+	 * Ability category slugs registered during a test.
+	 *
+	 * @var string[]
+	 */
+	private array $registered_test_categories = array();
+
+	public function set_up(): void {
+		parent::set_up();
+		IdenticalFailureTracker::reset();
+	}
+
+	public function tear_down(): void {
+		IdenticalFailureTracker::reset();
+		if ( function_exists( 'wp_unregister_ability' ) ) {
+			wp_unregister_ability( 'test-plugin/schema-thrower' );
+		}
+		if ( function_exists( 'wp_unregister_ability_category' ) ) {
+			foreach ( $this->registered_test_categories as $category_slug ) {
+				wp_unregister_ability_category( $category_slug );
+			}
+		}
+		$this->registered_test_categories = array();
+		parent::tear_down();
+	}
+
+	public function test_validation_exceptions_return_schema_guidance(): void {
+		$this->skip_if_resolver_unavailable();
+
+		$ability = $this->register_schema_thrower_ability();
+		$this->assertNotNull( $ability );
+
+		$resolver = new AbilityFunctionResolver( $ability );
+		$response = $resolver->execute_ability(
+			new FunctionCall(
+				'call_validation_exception',
+				\WP_AI_Client_Ability_Function_Resolver::ability_name_to_function_name( 'test-plugin/schema-thrower' ),
+				array( 'query' => 'trigger callback validation exception' )
+			)
+		);
+
+		$payload = $this->normalise_response_payload( $response->getResponse() );
+
+		$this->assertSame( 'ability_invalid_input', $payload['code'] );
+		$this->assertArrayHasKey( 'input_schema', $payload );
+		$this->assertSame( array( 'query' ), $payload['missing_required_fields'] );
+		$this->assertSame( array( 'query' => '<string — Search keywords. Required.>' ), $payload['example_arguments'] );
+		$this->assertStringContainsString( 'Do not retry with empty arguments', $payload['hint'] );
+	}
+
+	public function test_repeated_validation_exceptions_return_hard_nudge(): void {
+		$this->skip_if_resolver_unavailable();
+
+		$ability = $this->register_schema_thrower_ability();
+		$this->assertNotNull( $ability );
+
+		$resolver      = new AbilityFunctionResolver( $ability );
+		$function_name = \WP_AI_Client_Ability_Function_Resolver::ability_name_to_function_name( 'test-plugin/schema-thrower' );
+
+		$args = array( 'query' => 'trigger callback validation exception' );
+
+		$resolver->execute_ability( new FunctionCall( 'call_validation_exception_1', $function_name, $args ) );
+		$response = $resolver->execute_ability( new FunctionCall( 'call_validation_exception_2', $function_name, $args ) );
+
+		$payload = $this->normalise_response_payload( $response->getResponse() );
+
+		$this->assertArrayHasKey( 'nudge', $payload );
+		$this->assertStringContainsString( 'STOP', $payload['nudge'] );
+		$this->assertStringContainsString( 'test-plugin/schema-thrower', $payload['nudge'] );
+		$this->assertStringContainsString( 'Retry only with arguments', $payload['nudge'] );
+	}
+
+	private function skip_if_resolver_unavailable(): void {
+		if (
+			! class_exists( 'WP_AI_Client_Ability_Function_Resolver' )
+			|| ! class_exists( FunctionCall::class )
+			|| ! function_exists( 'wp_register_ability' )
+		) {
+			$this->markTestSkipped( 'WordPress AI Client ability resolver is unavailable.' );
+		}
+	}
+
+	private function register_schema_thrower_ability(): ?\WP_Ability {
+		$this->ensure_test_category( 'test-plugin' );
+
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Standard WordPress hook stack global.
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_init';
+
+		try {
+			return wp_register_ability(
+				'test-plugin/schema-thrower',
+				array(
+					'ability_class'       => ThrowingValidationAbility::class,
+					'label'               => 'Schema Thrower',
+					'description'         => 'Test ability that throws a WordPress input validation-shaped error.',
+					'category'            => 'test-plugin',
+					'input_schema'        => array(
+						'type'       => 'object',
+						'properties' => array(
+							'query' => array(
+								'type'        => 'string',
+								'description' => 'Search keywords. Required.',
+							),
+						),
+						'required'   => array( 'query' ),
+					),
+					'execute_callback'    => static function ( array $input ): array {
+						unset( $input );
+						return array( 'unused' => true );
+					},
+					'permission_callback' => static function (): bool {
+						return true;
+					},
+				)
+			);
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+	}
+
+	private function ensure_test_category( string $slug ): void {
+		if (
+			! function_exists( 'wp_register_ability_category' )
+			|| ! function_exists( 'wp_has_ability_category' )
+			|| wp_has_ability_category( $slug )
+		) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Standard WordPress hook stack global.
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_categories_init';
+
+		try {
+			wp_register_ability_category(
+				$slug,
+				array(
+					'label'       => 'Test Category ' . $slug,
+					'description' => 'Auto-registered by AbilityFunctionResolverTest for ' . $slug,
+				)
+			);
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+
+		$this->registered_test_categories[] = $slug;
+	}
+
+	/**
+	 * @param mixed $payload Raw FunctionResponse payload.
+	 * @return array<string, mixed>
+	 */
+	private function normalise_response_payload( $payload ): array {
+		if ( is_string( $payload ) ) {
+			$decoded = json_decode( $payload, true );
+			return is_array( $decoded ) ? $decoded : array();
+		}
+
+		return is_array( $payload ) ? $payload : array();
+	}
+}

--- a/tests/SdAiAgent/Core/SkillAutoInjectorTest.php
+++ b/tests/SdAiAgent/Core/SkillAutoInjectorTest.php
@@ -176,6 +176,7 @@ class SkillAutoInjectorTest extends WP_UnitTestCase {
 		$this->assertNotEmpty( $result );
 		$this->assertStringContainsString( 'site-troubleshooting', $result );
 		$this->assertStringContainsString( 'skill-load', $result );
+		$this->assertStringContainsString( '{"slug":"site-troubleshooting"}', $result );
 	}
 
 	/**

--- a/tests/SdAiAgent/Tools/ModelHealthTrackerTest.php
+++ b/tests/SdAiAgent/Tools/ModelHealthTrackerTest.php
@@ -35,6 +35,7 @@ class ModelHealthTrackerTest extends WP_UnitTestCase {
 		$this->assertTrue( ModelHealthTracker::matches_weak_name( 'phi-3-mini' ) );
 		$this->assertTrue( ModelHealthTracker::matches_weak_name( 'tinyllama' ) );
 		$this->assertTrue( ModelHealthTracker::matches_weak_name( 'mistral-7b-q4_k_m.gguf' ) );
+		$this->assertTrue( ModelHealthTracker::matches_weak_name( 'superdav-chat-fast' ) );
 	}
 
 	public function test_name_heuristic_does_not_flag_strong_models(): void {


### PR DESCRIPTION
## Summary

- Treat validation-shaped ability exceptions as `ability_invalid_input` so direct `skill-load({})` / `ability-search({})` failures return schemas, missing fields, examples, and retry guidance.
- Add a hard nudge for repeated identical validation exceptions without telling direct-tool callers to switch through `ability-call`.
- Bootstrap `superdav-chat-fast` with weak-model tool-use guidance and make skill hints show the required `{"slug":"..."}` argument.
- Add resolver, model-health, and skill-hint regression coverage.

Resolves #2123.

## Worker self-verification
- PHPUnit: Tests: 3627, Assertions: 15099, Errors: 0, Failures: 0, Skipped: 120, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.23.1 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 33m and 242,962 tokens on this with the user in an interactive session. Solved in 34m.
