### PR TITLE
GH#2130: feat: add human approval gates

### DIFF
--- a/includes/Automations/HumanApprovalGate.php
+++ b/includes/Automations/HumanApprovalGate.php
@@ -1,0 +1,492 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Durable human approval requests for sensitive automation actions.
+ *
+ * @package SdAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Automations;
+
+use SdAiAgent\Core\Database;
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class HumanApprovalGate {
+
+	public const STATUS_PENDING  = 'pending';
+	public const STATUS_APPROVED = 'approved';
+	public const STATUS_REJECTED = 'rejected';
+	public const STATUS_EXPIRED  = 'expired';
+	public const STATUS_EXECUTED = 'executed';
+	public const STATUS_FAILED   = 'failed';
+
+	private const SECRET_REDACTED_PLACEHOLDER = '[redacted]';
+
+	/**
+	 * Registered action handlers.
+	 *
+	 * @var array<string, callable(array<string, mixed>, array<string, mixed>): mixed>
+	 */
+	private static array $handlers = [];
+
+	/**
+	 * Get the approval request table name.
+	 */
+	public static function table_name(): string {
+		return Database::approval_requests_table_name();
+	}
+
+	/**
+	 * Register an executable action handler.
+	 *
+	 * @param string   $action_type Action type such as sms-send.
+	 * @param callable $handler     Handler callback.
+	 */
+	public static function register_handler( string $action_type, callable $handler ): void {
+		$action_type = sanitize_key( $action_type );
+		if ( '' === $action_type ) {
+			return;
+		}
+
+		self::$handlers[ $action_type ] = $handler;
+	}
+
+	/**
+	 * Clear registered handlers. Intended for tests.
+	 */
+	public static function clear_handlers(): void {
+		self::$handlers = [];
+	}
+
+	/**
+	 * Create or reuse a pending approval request for a sensitive action.
+	 *
+	 * @param array<string, mixed> $args Request fields.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function create_pending( array $args ) {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$source_type = sanitize_key( (string) ( $args['source_type'] ?? 'automation' ) );
+		$source_id   = absint( $args['source_id'] ?? 0 );
+		$action_type = sanitize_key( (string) ( $args['action_type'] ?? '' ) );
+		$payload     = self::sanitize_payload( is_array( $args['payload'] ?? null ) ? $args['payload'] : [] );
+
+		if ( '' === $source_type || '' === $action_type ) {
+			return new WP_Error( 'sd_ai_agent_approval_invalid_request', __( 'Approval request source and action type are required.', 'superdav-ai-agent' ), [ 'status' => 400 ] );
+		}
+
+		$payload_json = wp_json_encode( $payload );
+		if ( false === $payload_json ) {
+			return new WP_Error( 'sd_ai_agent_approval_invalid_payload', __( 'Approval request payload could not be encoded.', 'superdav-ai-agent' ), [ 'status' => 400 ] );
+		}
+
+		$payload_hash = hash( 'sha256', $payload_json );
+		$existing     = self::find_equivalent_pending( $source_type, $source_id, $action_type, $payload_hash );
+		if ( null !== $existing ) {
+			return $existing;
+		}
+
+		$now        = current_time( 'mysql', true );
+		$expires_at = self::normalize_datetime( $args['expires_at'] ?? null );
+		$result     = $wpdb->insert(
+			self::table_name(),
+			[
+				'source_type'  => $source_type,
+				'source_id'    => $source_id,
+				'action_type'  => $action_type,
+				'status'       => self::STATUS_PENDING,
+				'payload'      => $payload_json,
+				'payload_hash' => $payload_hash,
+				'result'       => '',
+				'requested_by' => absint( $args['requested_by'] ?? get_current_user_id() ),
+				'approved_by'  => 0,
+				'expires_at'   => $expires_at,
+				'created_at'   => $now,
+				'updated_at'   => $now,
+			],
+			[ '%s', '%d', '%s', '%s', '%s', '%s', '%s', '%d', '%d', '%s', '%s', '%s' ]
+		);
+
+		if ( false === $result ) {
+			return new WP_Error( 'sd_ai_agent_approval_create_failed', __( 'Failed to create approval request.', 'superdav-ai-agent' ), [ 'status' => 500 ] );
+		}
+
+		$created = self::get( (int) $wpdb->insert_id );
+		if ( null === $created ) {
+			return new WP_Error( 'sd_ai_agent_approval_create_failed', __( 'Failed to load approval request after creation.', 'superdav-ai-agent' ), [ 'status' => 500 ] );
+		}
+
+		return $created;
+	}
+
+	/**
+	 * List approval requests.
+	 *
+	 * @param string $status Optional status filter.
+	 * @param int    $limit  Maximum rows.
+	 * @return list<array<string, mixed>>
+	 */
+	public static function list( string $status = '', int $limit = 50 ): array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$status = sanitize_key( $status );
+		$limit  = max( 1, min( 100, $limit ) );
+
+		if ( '' !== $status ) {
+			$rows = $wpdb->get_results(
+				$wpdb->prepare( 'SELECT * FROM %i WHERE status = %s ORDER BY created_at DESC LIMIT %d', self::table_name(), $status, $limit )
+			);
+		} else {
+			$rows = $wpdb->get_results(
+				$wpdb->prepare( 'SELECT * FROM %i ORDER BY created_at DESC LIMIT %d', self::table_name(), $limit )
+			);
+		}
+
+		return array_map( [ __CLASS__, 'decode_row' ], $rows ?: [] );
+	}
+
+	/**
+	 * Get one approval request.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public static function get( int $id ): ?array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$row = $wpdb->get_row( $wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', self::table_name(), $id ) );
+
+		return $row ? self::decode_row( $row ) : null;
+	}
+
+	/**
+	 * Approve a pending request and optionally execute it.
+	 *
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function approve( int $id, int $approved_by = 0, bool $execute = true ) {
+		$request = self::transition( $id, self::STATUS_PENDING, self::STATUS_APPROVED, [ 'approved_by' => absint( $approved_by ?: get_current_user_id() ) ] );
+		if ( is_wp_error( $request ) || ! $execute || self::STATUS_APPROVED !== $request['status'] ) {
+			return $request;
+		}
+
+		return self::execute( $id );
+	}
+
+	/**
+	 * Reject a pending request.
+	 *
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function reject( int $id, int $approved_by = 0 ) {
+		return self::transition( $id, self::STATUS_PENDING, self::STATUS_REJECTED, [ 'approved_by' => absint( $approved_by ?: get_current_user_id() ) ] );
+	}
+
+	/**
+	 * Execute an approved request exactly once through its registered handler.
+	 *
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function execute( int $id ) {
+		$request = self::get( $id );
+		if ( null === $request ) {
+			return new WP_Error( 'sd_ai_agent_approval_not_found', __( 'Approval request not found.', 'superdav-ai-agent' ), [ 'status' => 404 ] );
+		}
+
+		if ( self::STATUS_EXECUTED === $request['status'] ) {
+			return $request;
+		}
+
+		if ( self::STATUS_APPROVED !== $request['status'] ) {
+			return new WP_Error( 'sd_ai_agent_approval_not_executable', __( 'Approval request is not approved for execution.', 'superdav-ai-agent' ), [ 'status' => 409 ] );
+		}
+
+		if ( self::is_expired( $request ) ) {
+			return self::transition( $id, self::STATUS_APPROVED, self::STATUS_EXPIRED );
+		}
+
+		$action_type = (string) $request['action_type'];
+		if ( ! isset( self::$handlers[ $action_type ] ) ) {
+			$error = new WP_Error( 'sd_ai_agent_approval_handler_missing', __( 'No approval action handler is registered for this action type.', 'superdav-ai-agent' ), [ 'status' => 501 ] );
+			self::store_result( $id, self::STATUS_FAILED, self::error_to_array( $error ) );
+			return $error;
+		}
+
+		$payload = is_array( $request['payload'] ) ? $request['payload'] : [];
+		$result  = call_user_func( self::$handlers[ $action_type ], $payload, $request );
+		if ( is_wp_error( $result ) ) {
+			self::store_result( $id, self::STATUS_FAILED, self::error_to_array( $result ) );
+			return $result;
+		}
+
+		return self::store_result(
+			$id,
+			self::STATUS_EXECUTED,
+			[
+				'success' => true,
+				'data'    => self::sanitize_payload( is_array( $result ) ? $result : [ 'result' => $result ] ),
+			]
+		);
+	}
+
+	/**
+	 * Sanitize and redact payload data before storage or output.
+	 *
+	 * @param array<string, mixed> $payload Payload.
+	 * @return array<string, mixed>
+	 */
+	public static function sanitize_payload( array $payload ): array {
+		$clean = [];
+		foreach ( $payload as $key => $value ) {
+			$clean_key = is_string( $key ) ? sanitize_key( $key ) : (string) $key;
+			if ( '' === $clean_key ) {
+				continue;
+			}
+
+			if ( self::is_sensitive_key( $clean_key ) ) {
+				$clean[ $clean_key ] = self::SECRET_REDACTED_PLACEHOLDER;
+				continue;
+			}
+
+			if ( is_array( $value ) ) {
+				$clean[ $clean_key ] = self::sanitize_payload( $value );
+			} elseif ( is_scalar( $value ) || null === $value ) {
+				$clean[ $clean_key ] = self::sanitize_scalar( $clean_key, $value );
+			}
+		}
+
+		return $clean;
+	}
+
+	/**
+	 * Decode a request row.
+	 *
+	 * @param object $row Database row.
+	 * @return array<string, mixed>
+	 */
+	private static function decode_row( object $row ): array {
+		return [
+			'id'           => (int) $row->id,
+			'source_type'  => (string) $row->source_type,
+			'source_id'    => (int) $row->source_id,
+			'action_type'  => (string) $row->action_type,
+			'status'       => (string) $row->status,
+			'payload'      => json_decode( (string) $row->payload, true ) ?: [],
+			'payload_hash' => (string) $row->payload_hash,
+			'result'       => json_decode( (string) $row->result, true ) ?: [],
+			'requested_by' => (int) $row->requested_by,
+			'approved_by'  => (int) $row->approved_by,
+			'expires_at'   => $row->expires_at,
+			'created_at'   => (string) $row->created_at,
+			'updated_at'   => (string) $row->updated_at,
+		];
+	}
+
+	/**
+	 * Find an equivalent pending request.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	private static function find_equivalent_pending( string $source_type, int $source_id, string $action_type, string $payload_hash ): ?array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE source_type = %s AND source_id = %d AND action_type = %s AND payload_hash = %s AND status = %s ORDER BY created_at DESC LIMIT 1',
+				self::table_name(),
+				$source_type,
+				$source_id,
+				$action_type,
+				$payload_hash,
+				self::STATUS_PENDING
+			)
+		);
+
+		return $row ? self::decode_row( $row ) : null;
+	}
+
+	/**
+	 * Transition status with optimistic current-status check.
+	 *
+	 * @param int                  $id    Request ID.
+	 * @param string               $from  Required current status.
+	 * @param string               $to    New status.
+	 * @param array<string, mixed> $extra Extra fields.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	private static function transition( int $id, string $from, string $to, array $extra = [] ) {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$request = self::get( $id );
+		if ( null === $request ) {
+			return new WP_Error( 'sd_ai_agent_approval_not_found', __( 'Approval request not found.', 'superdav-ai-agent' ), [ 'status' => 404 ] );
+		}
+
+		if ( self::is_expired( $request ) && self::STATUS_PENDING === $request['status'] ) {
+			$from = self::STATUS_PENDING;
+			$to   = self::STATUS_EXPIRED;
+		}
+
+		if ( $from !== $request['status'] ) {
+			return new WP_Error( 'sd_ai_agent_approval_invalid_transition', __( 'Approval request cannot be changed from its current status.', 'superdav-ai-agent' ), [ 'status' => 409 ] );
+		}
+
+		$data    = array_merge(
+			$extra,
+			[
+				'status'     => $to,
+				'updated_at' => current_time( 'mysql', true ),
+			]
+		);
+		$formats = [];
+		foreach ( $data as $key => $value ) {
+			$formats[] = in_array( $key, [ 'approved_by' ], true ) ? '%d' : '%s';
+		}
+
+		$updated = $wpdb->update(
+			self::table_name(),
+			$data,
+			[
+				'id'     => $id,
+				'status' => $from,
+			],
+			$formats,
+			[ '%d', '%s' ]
+		);
+		if ( false === $updated || 0 === $updated ) {
+			return new WP_Error( 'sd_ai_agent_approval_update_failed', __( 'Failed to update approval request.', 'superdav-ai-agent' ), [ 'status' => 409 ] );
+		}
+
+		$updated_request = self::get( $id );
+		if ( null === $updated_request ) {
+			return new WP_Error( 'sd_ai_agent_approval_update_failed', __( 'Failed to load approval request after update.', 'superdav-ai-agent' ), [ 'status' => 500 ] );
+		}
+
+		return $updated_request;
+	}
+
+	/**
+	 * Persist an execution result.
+	 *
+	 * @param int                  $id     Request ID.
+	 * @param string               $status Result status.
+	 * @param array<string, mixed> $result Result payload.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	private static function store_result( int $id, string $status, array $result ) {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$result_json = wp_json_encode( self::sanitize_payload( $result ) );
+		if ( false === $result_json ) {
+			$result_json = '{}';
+		}
+
+		$updated = $wpdb->update(
+			self::table_name(),
+			[
+				'status'     => $status,
+				'result'     => $result_json,
+				'updated_at' => current_time( 'mysql', true ),
+			],
+			[
+				'id'     => $id,
+				'status' => self::STATUS_APPROVED,
+			],
+			[ '%s', '%s', '%s' ],
+			[ '%d', '%s' ]
+		);
+
+		if ( false === $updated || 0 === $updated ) {
+			return new WP_Error( 'sd_ai_agent_approval_execute_race', __( 'Approval request was already executed or changed.', 'superdav-ai-agent' ), [ 'status' => 409 ] );
+		}
+
+		$updated_request = self::get( $id );
+		if ( null === $updated_request ) {
+			return new WP_Error( 'sd_ai_agent_approval_execute_race', __( 'Failed to load approval request after execution.', 'superdav-ai-agent' ), [ 'status' => 500 ] );
+		}
+
+		return $updated_request;
+	}
+
+	/**
+	 * Check whether a request is expired.
+	 *
+	 * @param array<string, mixed> $request Request.
+	 */
+	private static function is_expired( array $request ): bool {
+		$expires_at = (string) ( $request['expires_at'] ?? '' );
+		return '' !== $expires_at && strtotime( $expires_at ) <= time();
+	}
+
+	/**
+	 * Normalize a date/time string for storage.
+	 */
+	private static function normalize_datetime( mixed $value ): ?string {
+		if ( ! is_string( $value ) || '' === $value ) {
+			return null;
+		}
+
+		$timestamp = strtotime( $value );
+		return false === $timestamp ? null : gmdate( 'Y-m-d H:i:s', $timestamp );
+	}
+
+	/**
+	 * Redact known secret-bearing keys.
+	 */
+	private static function is_sensitive_key( string $key ): bool {
+		return (bool) preg_match( '/(api[_-]?key|token|secret|password|authorization|credential|webhook|private[_-]?key)/i', $key );
+	}
+
+	/**
+	 * Sanitize scalar values and mask phone-like fields.
+	 */
+	private static function sanitize_scalar( string $key, mixed $value ): mixed {
+		if ( is_bool( $value ) || is_int( $value ) || is_float( $value ) || null === $value ) {
+			return $value;
+		}
+
+		$value = sanitize_text_field( (string) $value );
+		if ( str_contains( $key, 'phone' ) || str_contains( $key, 'recipient' ) || str_contains( $key, 'to' ) ) {
+			return self::mask_phone_like_value( $value );
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Mask phone-like values while preserving enough context for review.
+	 */
+	private static function mask_phone_like_value( string $value ): string {
+		$digits = preg_replace( '/\D+/', '', $value ) ?? '';
+		if ( strlen( $digits ) < 7 ) {
+			return $value;
+		}
+
+		return '***' . substr( $digits, -4 );
+	}
+
+	/**
+	 * Convert a WP_Error to a storable array.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function error_to_array( WP_Error $error ): array {
+		return [
+			'success' => false,
+			'code'    => $error->get_error_code(),
+			'message' => $error->get_error_message(),
+		];
+	}
+}

--- a/includes/Core/Database.php
+++ b/includes/Core/Database.php
@@ -36,7 +36,7 @@ use SdAiAgent\Tools\CustomTools;
 class Database {
 
 	const DB_VERSION_OPTION = 'sd_ai_agent_db_version';
-	const DB_VERSION        = '19.5.3';
+	const DB_VERSION        = '19.5.4';
 
 	// ─── Table Name Registry ──────────────────────────────────────────────────
 
@@ -101,6 +101,15 @@ class Database {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 		return $wpdb->prefix . 'sd_ai_agent_automation_logs';
+	}
+
+	/**
+	 * Get the human approval requests table name.
+	 */
+	public static function approval_requests_table_name(): string {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+		return $wpdb->prefix . 'sd_ai_agent_approval_requests';
 	}
 
 	/**
@@ -253,6 +262,7 @@ class Database {
 		$custom_tools_table           = self::custom_tools_table_name();
 		$automations_table            = self::automations_table_name();
 		$automation_logs_table        = self::automation_logs_table_name();
+		$approval_requests_table      = self::approval_requests_table_name();
 		$event_automations_table      = self::event_automations_table_name();
 		$conversation_templates_table = self::conversation_templates_table_name();
 		$git_tracked_files_table      = self::git_tracked_files_table_name();
@@ -396,6 +406,29 @@ class Database {
 			PRIMARY KEY  (id),
 			KEY automation_id (automation_id),
 			KEY trigger_type (trigger_type),
+			KEY created_at (created_at)
+		) {$charset};
+
+		CREATE TABLE {$approval_requests_table} (
+			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+			source_type varchar(40) NOT NULL DEFAULT 'automation',
+			source_id bigint(20) unsigned NOT NULL DEFAULT 0,
+			action_type varchar(100) NOT NULL DEFAULT '',
+			status varchar(20) NOT NULL DEFAULT 'pending',
+			payload longtext NOT NULL,
+			payload_hash varchar(64) NOT NULL DEFAULT '',
+			result longtext NOT NULL,
+			requested_by bigint(20) unsigned NOT NULL DEFAULT 0,
+			approved_by bigint(20) unsigned NOT NULL DEFAULT 0,
+			expires_at datetime DEFAULT NULL,
+			created_at datetime NOT NULL,
+			updated_at datetime NOT NULL,
+			PRIMARY KEY  (id),
+			KEY source_lookup (source_type, source_id),
+			KEY action_type (action_type),
+			KEY status (status),
+			KEY payload_hash (payload_hash),
+			KEY expires_at (expires_at),
 			KEY created_at (created_at)
 		) {$charset};
 

--- a/includes/REST/AutomationController.php
+++ b/includes/REST/AutomationController.php
@@ -16,6 +16,7 @@ use SdAiAgent\Automations\AutomationRunner;
 use SdAiAgent\Automations\Automations;
 use SdAiAgent\Automations\EventAutomations;
 use SdAiAgent\Automations\EventTriggerRegistry;
+use SdAiAgent\Automations\HumanApprovalGate;
 use SdAiAgent\Automations\NotificationDispatcher;
 use WP_Error;
 use WP_REST_Request;
@@ -246,6 +247,84 @@ final class AutomationController {
 
 		register_rest_route(
 			RestController::NAMESPACE,
+			'/automation-approvals',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'handle_list_approval_requests' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+				'args'                => array(
+					'status' => array(
+						'required'          => false,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_key',
+					),
+					'limit'  => array(
+						'required'          => false,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/automation-approvals/(?P<id>\d+)',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'handle_get_approval_request' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+				'args'                => array(
+					'id' => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/automation-approvals/(?P<id>\d+)/approve',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'handle_approve_request' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+				'args'                => array(
+					'id'      => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+					'execute' => array(
+						'required' => false,
+						'type'     => 'boolean',
+						'default'  => true,
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/automation-approvals/(?P<id>\d+)/reject',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'handle_reject_request' ),
+				'permission_callback' => array( $this, 'check_permission' ),
+				'args'                => array(
+					'id' => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			RestController::NAMESPACE,
 			'/automations/test-notification',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
@@ -406,6 +485,57 @@ final class AutomationController {
 	 */
 	public function handle_list_all_logs(): WP_REST_Response {
 		return new WP_REST_Response( AutomationLogs::list_recent(), 200 );
+	}
+
+	/**
+	 * List approval requests.
+	 */
+	public function handle_list_approval_requests( WP_REST_Request $request ): WP_REST_Response {
+		$status = (string) $request->get_param( 'status' );
+		$limit  = absint( $request->get_param( 'limit' ) ?: 50 );
+
+		return new WP_REST_Response( HumanApprovalGate::list( $status, $limit ), 200 );
+	}
+
+	/**
+	 * Get one approval request.
+	 */
+	public function handle_get_approval_request( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$approval = HumanApprovalGate::get( self::get_int_param( $request, 'id' ) );
+
+		if ( null === $approval ) {
+			return new WP_Error( 'not_found', __( 'Approval request not found.', 'superdav-ai-agent' ), array( 'status' => 404 ) );
+		}
+
+		return new WP_REST_Response( $approval, 200 );
+	}
+
+	/**
+	 * Approve and optionally execute a request.
+	 */
+	public function handle_approve_request( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$execute_param = $request->get_param( 'execute' );
+		$execute       = is_bool( $execute_param ) || is_int( $execute_param ) || is_string( $execute_param ) ? rest_sanitize_boolean( $execute_param ) : true;
+		$result        = HumanApprovalGate::approve( self::get_int_param( $request, 'id' ), get_current_user_id(), $execute );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return new WP_REST_Response( $result, 200 );
+	}
+
+	/**
+	 * Reject a request.
+	 */
+	public function handle_reject_request( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$result = HumanApprovalGate::reject( self::get_int_param( $request, 'id' ), get_current_user_id() );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		return new WP_REST_Response( $result, 200 );
 	}
 
 	/**

--- a/tests/SdAiAgent/Automations/HumanApprovalGateTest.php
+++ b/tests/SdAiAgent/Automations/HumanApprovalGateTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Tests for durable human approval requests.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests\Automations
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Automations;
+
+use SdAiAgent\Automations\HumanApprovalGate;
+use SdAiAgent\Core\Database;
+use WP_Error;
+use WP_UnitTestCase;
+
+class HumanApprovalGateTest extends WP_UnitTestCase {
+
+	private int $admin_id;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+		Database::install();
+		HumanApprovalGate::clear_handlers();
+		$this->admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $this->admin_id );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test cleanup for custom table.
+		$wpdb->query( $wpdb->prepare( 'DELETE FROM %i', HumanApprovalGate::table_name() ) );
+	}
+
+	public function tear_down(): void {
+		HumanApprovalGate::clear_handlers();
+		parent::tear_down();
+	}
+
+	public function test_create_pending_redacts_secrets_and_masks_phone_numbers(): void {
+		$request = HumanApprovalGate::create_pending( $this->make_request_args() );
+
+		$this->assertIsArray( $request );
+		$this->assertSame( HumanApprovalGate::STATUS_PENDING, $request['status'] );
+		$this->assertSame( '[redacted]', $request['payload']['api_key'] );
+		$this->assertSame( '[redacted]', $request['payload']['nested']['token'] );
+		$this->assertSame( '***4567', $request['payload']['recipient_phone'] );
+	}
+
+	public function test_create_pending_reuses_equivalent_pending_request(): void {
+		$first  = HumanApprovalGate::create_pending( $this->make_request_args() );
+		$second = HumanApprovalGate::create_pending( $this->make_request_args() );
+
+		$this->assertIsArray( $first );
+		$this->assertIsArray( $second );
+		$this->assertSame( $first['id'], $second['id'] );
+	}
+
+	public function test_approve_executes_registered_handler_exactly_once(): void {
+		$calls = 0;
+		HumanApprovalGate::register_handler(
+			'sms-send',
+			static function ( array $payload ) use ( &$calls ): array {
+				++$calls;
+				return [ 'message_id' => 'msg_' . $payload['source_id'] ];
+			}
+		);
+
+		$request = HumanApprovalGate::create_pending( $this->make_request_args( [ 'payload' => [ 'source_id' => 42 ] ] ) );
+		$this->assertIsArray( $request );
+
+		$approved = HumanApprovalGate::approve( (int) $request['id'], $this->admin_id );
+		$again    = HumanApprovalGate::execute( (int) $request['id'] );
+
+		$this->assertIsArray( $approved );
+		$this->assertSame( HumanApprovalGate::STATUS_EXECUTED, $approved['status'] );
+		$this->assertSame( 'msg_42', $approved['result']['data']['message_id'] );
+		$this->assertSame( $approved['id'], $again['id'] );
+		$this->assertSame( 1, $calls );
+	}
+
+	public function test_reject_prevents_execution(): void {
+		$request = HumanApprovalGate::create_pending( $this->make_request_args() );
+		$this->assertIsArray( $request );
+
+		$rejected = HumanApprovalGate::reject( (int) $request['id'], $this->admin_id );
+		$execute  = HumanApprovalGate::execute( (int) $request['id'] );
+
+		$this->assertIsArray( $rejected );
+		$this->assertSame( HumanApprovalGate::STATUS_REJECTED, $rejected['status'] );
+		$this->assertInstanceOf( WP_Error::class, $execute );
+	}
+
+	public function test_expired_pending_request_cannot_be_approved(): void {
+		$request = HumanApprovalGate::create_pending( $this->make_request_args( [ 'expires_at' => '2000-01-01 00:00:00' ] ) );
+		$this->assertIsArray( $request );
+
+		$approved = HumanApprovalGate::approve( (int) $request['id'], $this->admin_id );
+
+		$this->assertIsArray( $approved );
+		$this->assertSame( HumanApprovalGate::STATUS_EXPIRED, $approved['status'] );
+	}
+
+	/**
+	 * @param array<string, mixed> $overrides Overrides.
+	 * @return array<string, mixed>
+	 */
+	private function make_request_args( array $overrides = [] ): array {
+		return array_replace_recursive(
+			[
+				'source_type'  => 'automation',
+				'source_id'    => 123,
+				'action_type'  => 'sms-send',
+				'requested_by' => $this->admin_id,
+				'payload'      => [
+					'recipient_phone' => '+1 (555) 123-4567',
+					'message'         => 'Reminder message',
+					'api_key'         => 'secret-key',
+					'nested'          => [ 'token' => 'secret-token' ],
+				],
+			],
+			$overrides
+		);
+	}
+}

--- a/tests/SdAiAgent/Core/DatabaseSchemaTest.php
+++ b/tests/SdAiAgent/Core/DatabaseSchemaTest.php
@@ -43,6 +43,7 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 		'sd_ai_agent_custom_tools',
 		'sd_ai_agent_automations',
 		'sd_ai_agent_automation_logs',
+		'sd_ai_agent_approval_requests',
 		'sd_ai_agent_event_automations',
 		'sd_ai_agent_knowledge_collections',
 		'sd_ai_agent_knowledge_sources',
@@ -234,6 +235,19 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 
 		foreach ( [ 'id', 'automation_id', 'trigger_type', 'status', 'reply', 'tool_calls', 'prompt_tokens', 'completion_tokens', 'duration_ms', 'created_at' ] as $col ) {
 			$this->assertContains( $col, $columns, "Automation logs table missing column '{$col}'." );
+		}
+	}
+
+	/**
+	 * Approval requests table has the required columns.
+	 */
+	public function test_approval_requests_table_has_required_columns(): void {
+		Database::install();
+
+		$columns = $this->get_column_names( Database::approval_requests_table_name() );
+
+		foreach ( [ 'id', 'source_type', 'source_id', 'action_type', 'status', 'payload', 'payload_hash', 'result', 'requested_by', 'approved_by', 'expires_at', 'created_at', 'updated_at' ] as $col ) {
+			$this->assertContains( $col, $columns, "Approval requests table missing column '{$col}'." );
 		}
 	}
 

--- a/tests/SdAiAgent/Core/DatabaseTest.php
+++ b/tests/SdAiAgent/Core/DatabaseTest.php
@@ -81,6 +81,15 @@ class DatabaseTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test approval_requests_table_name returns correct table name.
+	 */
+	public function test_approval_requests_table_name() {
+		global $wpdb;
+		$expected = $wpdb->prefix . 'sd_ai_agent_approval_requests';
+		$this->assertSame( $expected, Database::approval_requests_table_name() );
+	}
+
+	/**
 	 * Test event_automations_table_name returns correct table name.
 	 */
 	public function test_event_automations_table_name() {

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Tests\REST;
 
 use SdAiAgent\Core\Database;
+use SdAiAgent\Automations\HumanApprovalGate;
 use SdAiAgent\Models\ActiveJobRepository;
 use SdAiAgent\Models\Memory;
 use SdAiAgent\Models\Skill;
@@ -1353,6 +1354,54 @@ class RestControllerTest extends WP_UnitTestCase {
 		$response = $this->dispatch( 'GET', '/sd-ai-agent/v1/automation-logs' );
 		$this->assertStatus( 200, $response );
 		$this->assertIsArray( $response->get_data() );
+	}
+
+	/**
+	 * Test approval request REST routes are admin gated and redact payload data.
+	 */
+	public function test_automation_approvals_rest_flow(): void {
+		wp_set_current_user( $this->admin_id );
+		HumanApprovalGate::register_handler(
+			'sms-send',
+			static function (): array {
+				return [ 'provider_token' => 'secret-token', 'message_id' => 'msg_123' ];
+			}
+		);
+
+		$request = HumanApprovalGate::create_pending(
+			[
+				'source_type' => 'automation',
+				'source_id'   => 999,
+				'action_type' => 'sms-send',
+				'payload'     => [
+					'recipient_phone' => '+1 555 222 3333',
+					'api_key'         => 'secret-api-key',
+					'message'         => 'Please review this SMS.',
+				],
+			]
+		);
+		$this->assertIsArray( $request );
+
+		$list = $this->dispatch( 'GET', '/sd-ai-agent/v1/automation-approvals', [ 'status' => 'pending' ] );
+		$this->assertStatus( 200, $list );
+		$data = $list->get_data();
+		$this->assertSame( '***3333', $data[0]['payload']['recipient_phone'] );
+		$this->assertSame( '[redacted]', $data[0]['payload']['api_key'] );
+
+		$approved = $this->dispatch( 'POST', '/sd-ai-agent/v1/automation-approvals/' . $request['id'] . '/approve' );
+		$this->assertStatus( 200, $approved );
+		$approved_data = $approved->get_data();
+		$this->assertSame( HumanApprovalGate::STATUS_EXECUTED, $approved_data['status'] );
+		$this->assertSame( '[redacted]', $approved_data['result']['data']['provider_token'] );
+	}
+
+	/**
+	 * Test unauthenticated access to approval requests is rejected.
+	 */
+	public function test_automation_approvals_require_auth(): void {
+		wp_set_current_user( 0 );
+		$response = $this->dispatch( 'GET', '/sd-ai-agent/v1/automation-approvals' );
+		$this->assertStatus( 401, $response );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Added a durable HumanApprovalGate service with approval request storage, duplicate pending detection, payload/secret redaction, status transitions, and exactly-once handler execution. Added admin-only REST routes for listing, viewing, approving, and rejecting approval requests. Extended database schema/table-name coverage and REST/service tests.

## Files Changed

includes/Automations/HumanApprovalGate.php,includes/Core/Database.php,includes/REST/AutomationController.php,tests/SdAiAgent/Automations/HumanApprovalGateTest.php,tests/SdAiAgent/Core/DatabaseSchemaTest.php,tests/SdAiAgent/Core/DatabaseTest.php,tests/SdAiAgent/REST/RestControllerTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Targeted PHPUnit passed before local DB contention: npm run test:php -- --filter='HumanApproval|Automation|Permission|DatabaseSchemaTest' => OK (238 tests, 830 assertions). Isolated schema retry passed: WP_TESTS_DB_NAME=sd_ai_agent_tests_2130 npm run test:php -- --filter=DatabaseSchemaTest => OK (26 tests, 193 assertions). npm run lint:php passed. npm run lint:js && npm run lint:css passed. composer phpstan passed with 0 errors. npm run build succeeded with existing webpack size warnings. Full npm run verify could not complete locally because concurrent worker PHPUnit runs and a stale shared wp-tests-config caused test DB deadlocks/credential failures; implementation branch is clean.

Resolves #2130


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.31 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 34m and 197,111 tokens on this as a headless worker.