### PR TITLE
GH#2131: feat: add calendar reminder idempotency state

### DIFF
--- a/includes/Automations/CalendarReminderRecords.php
+++ b/includes/Automations/CalendarReminderRecords.php
@@ -1,0 +1,291 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Calendar reminder state records for idempotent reminder delivery.
+ *
+ * @package SdAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Automations;
+
+use SdAiAgent\Core\Database;
+
+class CalendarReminderRecords {
+
+	public const STATUS_SENT             = 'sent';
+	public const STATUS_SKIPPED          = 'skipped';
+	public const STATUS_PENDING_APPROVAL = 'pending_approval';
+	public const STATUS_FAILED           = 'failed';
+
+	/**
+	 * Get the reminder records table name.
+	 */
+	public static function table_name(): string {
+		return Database::calendar_reminders_table_name();
+	}
+
+	/**
+	 * Check whether a reminder window has already reached any terminal or queued state.
+	 */
+	public static function already_processed( string $calendar_id, string $event_id, string $attendee_email, string $reminder_date ): bool {
+		return null !== self::find_by_identity( $calendar_id, $event_id, $attendee_email, $reminder_date );
+	}
+
+	/**
+	 * Record a sent reminder.
+	 *
+	 * @param array<string, mixed> $data Reminder data.
+	 */
+	public static function record_sent( array $data ): int|false {
+		return self::record_status(
+			$data,
+			self::STATUS_SENT,
+			[
+				'provider'            => sanitize_text_field( (string) ( $data['provider'] ?? '' ) ),
+				'provider_message_id' => sanitize_text_field( (string) ( $data['provider_message_id'] ?? '' ) ),
+				'sent_at'             => self::sanitize_datetime( (string) ( $data['sent_at'] ?? current_time( 'mysql', true ) ) ),
+			]
+		);
+	}
+
+	/**
+	 * Record a skipped reminder.
+	 *
+	 * @param array<string, mixed> $data Reminder data.
+	 */
+	public static function record_skipped( array $data ): int|false {
+		return self::record_status(
+			$data,
+			self::STATUS_SKIPPED,
+			[
+				'skip_reason' => sanitize_textarea_field( (string) ( $data['skip_reason'] ?? '' ) ),
+			]
+		);
+	}
+
+	/**
+	 * Record a reminder queued for human approval.
+	 *
+	 * @param array<string, mixed> $data Reminder data.
+	 */
+	public static function record_pending_approval( array $data ): int|false {
+		return self::record_status(
+			$data,
+			self::STATUS_PENDING_APPROVAL,
+			[
+				'approval_request_id' => sanitize_text_field( (string) ( $data['approval_request_id'] ?? '' ) ),
+			]
+		);
+	}
+
+	/**
+	 * Record a failed reminder attempt.
+	 *
+	 * @param array<string, mixed> $data Reminder data.
+	 */
+	public static function record_failed( array $data ): int|false {
+		return self::record_status(
+			$data,
+			self::STATUS_FAILED,
+			[
+				'provider'            => sanitize_text_field( (string) ( $data['provider'] ?? '' ) ),
+				'provider_message_id' => sanitize_text_field( (string) ( $data['provider_message_id'] ?? '' ) ),
+				'skip_reason'         => sanitize_textarea_field( (string) ( $data['error_message'] ?? $data['skip_reason'] ?? '' ) ),
+			]
+		);
+	}
+
+	/**
+	 * Get a reminder record by ID.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public static function get( int $id ): ?array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
+		$row = $wpdb->get_row(
+			$wpdb->prepare( 'SELECT * FROM %i WHERE id = %d', self::table_name(), $id )
+		);
+
+		return $row ? self::decode_row( $row ) : null;
+	}
+
+	/**
+	 * Find a reminder record by duplicate-prevention identity.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public static function find_by_identity( string $calendar_id, string $event_id, string $attendee_email, string $reminder_date ): ?array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE calendar_id = %s AND event_id = %s AND attendee_email = %s AND reminder_date = %s',
+				self::table_name(),
+				self::sanitize_identifier( $calendar_id ),
+				self::sanitize_identifier( $event_id ),
+				self::sanitize_email( $attendee_email ),
+				self::sanitize_date( $reminder_date )
+			)
+		);
+
+		return $row ? self::decode_row( $row ) : null;
+	}
+
+	/**
+	 * Hash a phone number for storage without retaining the raw value.
+	 */
+	public static function hash_phone( string $phone ): string {
+		$digits = preg_replace( '/\D+/', '', $phone ) ?: '';
+
+		return '' === $digits ? '' : hash( 'sha256', $digits );
+	}
+
+	/**
+	 * Insert or update a reminder state record.
+	 *
+	 * @param array<string, mixed> $data   Reminder data.
+	 * @param string               $status Reminder status.
+	 * @param array<string, mixed> $fields Additional fields.
+	 * @return int|false Record ID or false.
+	 */
+	private static function record_status( array $data, string $status, array $fields = [] ): int|false {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$now           = current_time( 'mysql', true );
+		$reminder_date = self::sanitize_date( (string) ( $data['reminder_date'] ?? $data['event_start_at'] ?? $now ) );
+		$base          = [
+			'calendar_id'         => self::sanitize_identifier( (string) ( $data['calendar_id'] ?? '' ) ),
+			'event_id'            => self::sanitize_identifier( (string) ( $data['event_id'] ?? '' ) ),
+			'event_start_at'      => self::sanitize_datetime( (string) ( $data['event_start_at'] ?? $now ) ),
+			'reminder_date'       => $reminder_date,
+			'attendee_email'      => self::sanitize_email( (string) ( $data['attendee_email'] ?? '' ) ),
+			'phone_hash'          => self::phone_hash_from_data( $data ),
+			'status'              => self::sanitize_status( $status ),
+			'skip_reason'         => '',
+			'provider'            => '',
+			'provider_message_id' => '',
+			'approval_request_id' => '',
+			'sent_at'             => null,
+			'created_at'          => $now,
+			'updated_at'          => $now,
+		];
+
+		$record = array_merge( $base, $fields );
+
+		$existing = self::find_by_identity(
+			$record['calendar_id'],
+			$record['event_id'],
+			$record['attendee_email'],
+			$record['reminder_date']
+		);
+
+		if ( null !== $existing ) {
+			$update = $record;
+			unset( $update['calendar_id'], $update['event_id'], $update['event_start_at'], $update['reminder_date'], $update['attendee_email'], $update['created_at'] );
+			$update['updated_at'] = $now;
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
+			$updated = $wpdb->update(
+				self::table_name(),
+				$update,
+				[ 'id' => (int) $existing['id'] ]
+			);
+
+			return false === $updated ? false : (int) $existing['id'];
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Custom table query; caching not applicable.
+		$result = $wpdb->insert( self::table_name(), $record );
+
+		return $result ? (int) $wpdb->insert_id : false;
+	}
+
+	/**
+	 * Decode a database row.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function decode_row( object $row ): array {
+		return [
+			'id'                  => (int) $row->id,
+			'calendar_id'         => $row->calendar_id,
+			'event_id'            => $row->event_id,
+			'event_start_at'      => $row->event_start_at,
+			'reminder_date'       => $row->reminder_date,
+			'attendee_email'      => $row->attendee_email,
+			'phone_hash'          => $row->phone_hash,
+			'status'              => $row->status,
+			'skip_reason'         => $row->skip_reason,
+			'provider'            => $row->provider,
+			'provider_message_id' => $row->provider_message_id,
+			'approval_request_id' => $row->approval_request_id,
+			'sent_at'             => $row->sent_at,
+			'created_at'          => $row->created_at,
+			'updated_at'          => $row->updated_at,
+		];
+	}
+
+	/**
+	 * Get a phone hash from explicit hash or raw phone input.
+	 *
+	 * @param array<string, mixed> $data Reminder data.
+	 */
+	private static function phone_hash_from_data( array $data ): string {
+		$phone_hash = sanitize_text_field( (string) ( $data['phone_hash'] ?? '' ) );
+
+		if ( '' !== $phone_hash ) {
+			return substr( $phone_hash, 0, 64 );
+		}
+
+		return self::hash_phone( (string) ( $data['phone'] ?? '' ) );
+	}
+
+	/**
+	 * Sanitize a short identifier.
+	 */
+	private static function sanitize_identifier( string $value ): string {
+		return substr( sanitize_text_field( $value ), 0, 191 );
+	}
+
+	/**
+	 * Sanitize and normalize an email address.
+	 */
+	private static function sanitize_email( string $email ): string {
+		return substr( sanitize_email( strtolower( $email ) ), 0, 191 );
+	}
+
+	/**
+	 * Sanitize a supported status.
+	 */
+	private static function sanitize_status( string $status ): string {
+		$allowed = [ self::STATUS_SENT, self::STATUS_SKIPPED, self::STATUS_PENDING_APPROVAL, self::STATUS_FAILED ];
+
+		return in_array( $status, $allowed, true ) ? $status : self::STATUS_FAILED;
+	}
+
+	/**
+	 * Sanitize a MySQL datetime string.
+	 */
+	private static function sanitize_datetime( string $datetime ): string {
+		$timestamp = strtotime( $datetime );
+
+		return false === $timestamp ? current_time( 'mysql', true ) : gmdate( 'Y-m-d H:i:s', $timestamp );
+	}
+
+	/**
+	 * Sanitize a MySQL date string.
+	 */
+	private static function sanitize_date( string $date ): string {
+		$timestamp = strtotime( $date );
+
+		return false === $timestamp ? gmdate( 'Y-m-d' ) : gmdate( 'Y-m-d', $timestamp );
+	}
+}

--- a/includes/Core/Database.php
+++ b/includes/Core/Database.php
@@ -36,7 +36,7 @@ use SdAiAgent\Tools\CustomTools;
 class Database {
 
 	const DB_VERSION_OPTION = 'sd_ai_agent_db_version';
-	const DB_VERSION        = '19.5.4';
+	const DB_VERSION        = '19.5.5';
 
 	// ─── Table Name Registry ──────────────────────────────────────────────────
 
@@ -110,6 +110,15 @@ class Database {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 		return $wpdb->prefix . 'sd_ai_agent_approval_requests';
+	}
+
+	/**
+	 * Get the calendar reminder state table name.
+	 */
+	public static function calendar_reminders_table_name(): string {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+		return $wpdb->prefix . 'sd_ai_agent_calendar_reminders';
 	}
 
 	/**
@@ -272,6 +281,7 @@ class Database {
 		$automations_table            = self::automations_table_name();
 		$automation_logs_table        = self::automation_logs_table_name();
 		$approval_requests_table      = self::approval_requests_table_name();
+		$calendar_reminders_table     = self::calendar_reminders_table_name();
 		$event_automations_table      = self::event_automations_table_name();
 		$conversation_templates_table = self::conversation_templates_table_name();
 		$git_tracked_files_table      = self::git_tracked_files_table_name();
@@ -440,6 +450,30 @@ class Database {
 			KEY payload_hash (payload_hash),
 			KEY expires_at (expires_at),
 			KEY created_at (created_at)
+		) {$charset};
+
+		CREATE TABLE {$calendar_reminders_table} (
+			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+			calendar_id varchar(191) NOT NULL,
+			event_id varchar(191) NOT NULL,
+			event_start_at datetime NOT NULL,
+			reminder_date date NOT NULL,
+			attendee_email varchar(191) NOT NULL,
+			phone_hash varchar(64) NOT NULL DEFAULT '',
+			status varchar(20) NOT NULL DEFAULT 'pending_approval',
+			skip_reason text NOT NULL DEFAULT '',
+			provider varchar(100) NOT NULL DEFAULT '',
+			provider_message_id varchar(191) NOT NULL DEFAULT '',
+			approval_request_id varchar(191) NOT NULL DEFAULT '',
+			sent_at datetime DEFAULT NULL,
+			created_at datetime NOT NULL,
+			updated_at datetime NOT NULL,
+			PRIMARY KEY  (id),
+			UNIQUE KEY reminder_dedupe (calendar_id(80), event_id(120), attendee_email(120), reminder_date),
+			KEY status (status),
+			KEY reminder_date (reminder_date),
+			KEY approval_request_id (approval_request_id),
+			KEY provider_message_id (provider_message_id)
 		) {$charset};
 
 		CREATE TABLE {$event_automations_table} (

--- a/tests/SdAiAgent/Automations/CalendarReminderRecordsTest.php
+++ b/tests/SdAiAgent/Automations/CalendarReminderRecordsTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Integration tests for calendar reminder idempotency state records.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Automations;
+
+use SdAiAgent\Automations\CalendarReminderRecords;
+use SdAiAgent\Core\Database;
+use WP_UnitTestCase;
+
+class CalendarReminderRecordsTest extends WP_UnitTestCase {
+
+	/**
+	 * Ensure the reminder state table exists and is empty before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+		Database::install();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test-only table reset.
+		$wpdb->query( 'TRUNCATE TABLE ' . CalendarReminderRecords::table_name() );
+	}
+
+	/**
+	 * Build a valid reminder payload.
+	 *
+	 * @param array<string, mixed> $overrides Field overrides.
+	 * @return array<string, mixed>
+	 */
+	private function make_reminder( array $overrides = [] ): array {
+		return array_merge(
+			[
+				'calendar_id'    => 'primary',
+				'event_id'       => 'event-123',
+				'event_start_at' => '2026-07-01 09:00:00',
+				'reminder_date'  => '2026-07-01',
+				'attendee_email' => 'Person@Example.com',
+				'phone'          => '+1 (555) 123-4567',
+			],
+			$overrides
+		);
+	}
+
+	/**
+	 * Recording a sent reminder stores state without retaining a raw phone number.
+	 */
+	public function test_record_sent_stores_hashed_phone_only(): void {
+		$id = CalendarReminderRecords::record_sent(
+			$this->make_reminder(
+				[
+					'provider'            => 'textbee',
+					'provider_message_id' => 'msg-123',
+				]
+			)
+		);
+
+		$this->assertIsInt( $id );
+		$record = CalendarReminderRecords::get( $id );
+
+		$this->assertNotNull( $record );
+		$this->assertSame( CalendarReminderRecords::STATUS_SENT, $record['status'] );
+		$this->assertSame( 'person@example.com', $record['attendee_email'] );
+		$this->assertSame( hash( 'sha256', '15551234567' ), $record['phone_hash'] );
+		$this->assertStringNotContainsString( '555', implode( ' ', array_map( 'strval', $record ) ) );
+		$this->assertNotEmpty( $record['sent_at'] );
+	}
+
+	/**
+	 * Duplicate records for the same reminder window update the existing row.
+	 */
+	public function test_duplicate_identity_reuses_existing_record(): void {
+		$first_id  = CalendarReminderRecords::record_pending_approval( $this->make_reminder( [ 'approval_request_id' => 'approval-1' ] ) );
+		$second_id = CalendarReminderRecords::record_sent( $this->make_reminder( [ 'provider_message_id' => 'msg-456' ] ) );
+
+		$this->assertSame( $first_id, $second_id );
+		$record = CalendarReminderRecords::get( (int) $first_id );
+
+		$this->assertSame( CalendarReminderRecords::STATUS_SENT, $record['status'] );
+		$this->assertSame( 'msg-456', $record['provider_message_id'] );
+
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test-only assertion.
+		$count = (int) $wpdb->get_var( 'SELECT COUNT(*) FROM ' . CalendarReminderRecords::table_name() );
+		$this->assertSame( 1, $count );
+	}
+
+	/**
+	 * Processed reminders can be detected before another SMS send is attempted.
+	 */
+	public function test_already_processed_checks_duplicate_identity(): void {
+		$this->assertFalse( CalendarReminderRecords::already_processed( 'primary', 'event-123', 'person@example.com', '2026-07-01' ) );
+
+		CalendarReminderRecords::record_skipped( $this->make_reminder( [ 'skip_reason' => 'Missing consent' ] ) );
+
+		$this->assertTrue( CalendarReminderRecords::already_processed( 'primary', 'event-123', 'PERSON@example.com', '2026-07-01' ) );
+		$this->assertFalse( CalendarReminderRecords::already_processed( 'primary', 'event-123', 'person@example.com', '2026-07-02' ) );
+	}
+
+	/**
+	 * Reminder state can represent skipped, pending approval, failed, and sent outcomes.
+	 */
+	public function test_status_helpers_record_supported_states(): void {
+		$pending = CalendarReminderRecords::record_pending_approval( $this->make_reminder( [ 'event_id' => 'pending', 'approval_request_id' => 'approval-2' ] ) );
+		$skipped = CalendarReminderRecords::record_skipped( $this->make_reminder( [ 'event_id' => 'skipped', 'skip_reason' => 'No phone' ] ) );
+		$failed  = CalendarReminderRecords::record_failed( $this->make_reminder( [ 'event_id' => 'failed', 'provider' => 'textbee', 'error_message' => 'Provider timeout' ] ) );
+		$sent    = CalendarReminderRecords::record_sent( $this->make_reminder( [ 'event_id' => 'sent', 'provider_message_id' => 'msg-789' ] ) );
+
+		$this->assertSame( CalendarReminderRecords::STATUS_PENDING_APPROVAL, CalendarReminderRecords::get( (int) $pending )['status'] );
+		$this->assertSame( CalendarReminderRecords::STATUS_SKIPPED, CalendarReminderRecords::get( (int) $skipped )['status'] );
+		$this->assertSame( CalendarReminderRecords::STATUS_FAILED, CalendarReminderRecords::get( (int) $failed )['status'] );
+		$this->assertSame( CalendarReminderRecords::STATUS_SENT, CalendarReminderRecords::get( (int) $sent )['status'] );
+	}
+}

--- a/tests/SdAiAgent/Core/DatabaseSchemaTest.php
+++ b/tests/SdAiAgent/Core/DatabaseSchemaTest.php
@@ -44,6 +44,7 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 		'sd_ai_agent_automations',
 		'sd_ai_agent_automation_logs',
 		'sd_ai_agent_approval_requests',
+		'sd_ai_agent_calendar_reminders',
 		'sd_ai_agent_event_automations',
 		'sd_ai_agent_knowledge_collections',
 		'sd_ai_agent_knowledge_sources',
@@ -270,6 +271,26 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 		foreach ( [ 'id', 'source_type', 'source_id', 'action_type', 'status', 'payload', 'payload_hash', 'result', 'requested_by', 'approved_by', 'expires_at', 'created_at', 'updated_at' ] as $col ) {
 			$this->assertContains( $col, $columns, "Approval requests table missing column '{$col}'." );
 		}
+	}
+
+	/**
+	 * Calendar reminder state table has the required columns and duplicate guard.
+	 */
+	public function test_calendar_reminders_table_has_required_columns_and_indexes(): void {
+		global $wpdb;
+
+		Database::install();
+
+		$table   = Database::calendar_reminders_table_name();
+		$columns = $this->get_column_names( $table );
+
+		foreach ( [ 'id', 'calendar_id', 'event_id', 'event_start_at', 'reminder_date', 'attendee_email', 'phone_hash', 'status', 'skip_reason', 'provider', 'provider_message_id', 'approval_request_id', 'sent_at', 'created_at', 'updated_at' ] as $col ) {
+			$this->assertContains( $col, $columns, "Calendar reminders table missing column '{$col}'." );
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test-only introspection query.
+		$unique_exists = $wpdb->get_var( "SHOW INDEX FROM {$table} WHERE Key_name = 'reminder_dedupe' AND Non_unique = 0" );
+		$this->assertNotNull( $unique_exists, "Calendar reminders table should have UNIQUE KEY 'reminder_dedupe'." );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Added sd_ai_agent_calendar_reminders schema with DB version bump, duplicate-prevention key, CalendarReminderRecords CRUD/state helpers, hashed phone storage, and PHPUnit coverage for duplicate guards and supported reminder states.

## Files Changed

includes/Automations/CalendarReminderRecords.php,includes/Core/Database.php,tests/SdAiAgent/Automations/CalendarReminderRecordsTest.php,tests/SdAiAgent/Core/DatabaseSchemaTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused: npm run test:php -- --filter='CalendarReminder|DatabaseSchemaTest' => OK (32 tests, 239 assertions). Full: npm run verify => lint clean, PHPStan 0 errors, PHPUnit Tests: 3658, Assertions: 15241, Skipped: 120, Incomplete: 4, build succeeded, bundle check passed.

Resolves #2131


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.31 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 10m and 83,652 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking calendar reminder delivery status, including sent, skipped, pending approval, and failed states.
  * Calendar reminders now use a dedicated storage area to keep reminder records organized and searchable.

* **Bug Fixes**
  * Improved reminder processing to avoid duplicate sends for the same calendar/event/attendee/date combination.
  * Reminder contact details are now stored more safely, with phone values protected before saving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->