### PR TITLE
GH#2128: feat: add TextBee SMS provider

### DIFF
--- a/includes/Abilities/SmsAbilities.php
+++ b/includes/Abilities/SmsAbilities.php
@@ -1,0 +1,284 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SMS abilities for the AI agent.
+ *
+ * Provides a generic SMS send ability backed by the configured TextBee gateway.
+ *
+ * @package SdAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Abilities;
+
+use SdAiAgent\Core\Settings;
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class SmsAbilities {
+
+	/** Default TextBee API base URL. */
+	public const DEFAULT_API_BASE_URL = 'https://api.textbee.dev';
+
+	/** Maximum SMS message length accepted by the agent. */
+	public const MAX_MESSAGE_LENGTH = 1600;
+
+	/** Redacted placeholder for sensitive values. */
+	private const REDACTED = '[redacted]';
+
+	/**
+	 * Register SMS abilities.
+	 */
+	public static function register_abilities(): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		wp_register_ability(
+			'sd-ai-agent/sms-send',
+			[
+				'label'               => __( 'Send SMS', 'superdav-ai-agent' ),
+				'description'         => __( 'Send an SMS message to one or more E.164 phone numbers through the configured TextBee SMS gateway.', 'superdav-ai-agent' ),
+				'category'            => 'sd-ai-agent',
+				'input_schema'        => [
+					'type'       => 'object',
+					'properties' => [
+						'recipients' => [
+							'type'        => 'array',
+							'description' => 'Recipient phone numbers in E.164 format, for example +15551234567.',
+							'items'       => [ 'type' => 'string' ],
+						],
+						'message'    => [
+							'type'        => 'string',
+							'description' => 'Message body to send. Maximum 1600 characters.',
+						],
+					],
+					'required'   => [ 'recipients', 'message' ],
+				],
+				'meta'                => [
+					'mcp'          => [ 'public' => true ],
+					'annotations'  => [
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => false,
+					],
+					'show_in_rest' => true,
+				],
+				'execute_callback'    => [ __CLASS__, 'handle_sms_send' ],
+				'permission_callback' => static function (): bool {
+					return ToolCapabilities::current_user_can( 'sd-ai-agent/sms-send' );
+				},
+			]
+		);
+	}
+
+	/**
+	 * Send an SMS via the configured provider.
+	 *
+	 * @param array<string, mixed> $input Ability input.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function handle_sms_send( array $input ) {
+		$validation = self::validate_send_input( $input );
+		if ( is_wp_error( $validation ) ) {
+			return $validation;
+		}
+
+		$config = Settings::instance()->get_sms_provider();
+		if ( 'textbee' !== ( $config['provider'] ?? '' ) || empty( $config['api_key'] ) || empty( $config['device_id'] ) ) {
+			return new WP_Error(
+				'sms_not_configured',
+				__( 'TextBee SMS provider is not configured.', 'superdav-ai-agent' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$api_base_url = self::normalise_api_base_url( (string) ( $config['api_base_url'] ?? self::DEFAULT_API_BASE_URL ) );
+		if ( is_wp_error( $api_base_url ) ) {
+			return $api_base_url;
+		}
+
+		/** @var string $api_base_url */
+		/** @var array{recipients: string[], message: string} $validation */
+		return self::send_textbee_sms( $config, $api_base_url, $validation['recipients'], $validation['message'] );
+	}
+
+	/**
+	 * Validate ability input.
+	 *
+	 * @param array<string, mixed> $input Ability input.
+	 * @return array{recipients: string[], message: string}|WP_Error
+	 */
+	private static function validate_send_input( array $input ) {
+		$recipients = $input['recipients'] ?? array();
+		if ( ! is_array( $recipients ) || array() === $recipients ) {
+			return new WP_Error( 'sms_invalid_recipients', __( 'recipients must be a non-empty array.', 'superdav-ai-agent' ), [ 'status' => 400 ] );
+		}
+
+		$valid_recipients = array();
+		foreach ( $recipients as $recipient ) {
+			$phone = is_scalar( $recipient ) ? trim( (string) $recipient ) : '';
+			if ( ! self::is_e164_phone_number( $phone ) ) {
+				return new WP_Error( 'sms_invalid_recipient', __( 'All recipients must be valid E.164 phone numbers.', 'superdav-ai-agent' ), [ 'status' => 400 ] );
+			}
+
+			$valid_recipients[] = $phone;
+		}
+
+		$message = is_scalar( $input['message'] ?? null ) ? trim( (string) $input['message'] ) : '';
+		if ( '' === $message ) {
+			return new WP_Error( 'sms_empty_message', __( 'message is required.', 'superdav-ai-agent' ), [ 'status' => 400 ] );
+		}
+
+		if ( strlen( $message ) > self::MAX_MESSAGE_LENGTH ) {
+			return new WP_Error(
+				'sms_message_too_long',
+				sprintf(
+					/* translators: %d: maximum SMS message length. */
+					__( 'message must be %d characters or fewer.', 'superdav-ai-agent' ),
+					self::MAX_MESSAGE_LENGTH
+				),
+				[ 'status' => 400 ]
+			);
+		}
+
+		return [
+			'recipients' => $valid_recipients,
+			'message'    => $message,
+		];
+	}
+
+	/**
+	 * Validate E.164-ish phone number format.
+	 *
+	 * @param string $phone Phone number.
+	 * @return bool
+	 */
+	private static function is_e164_phone_number( string $phone ): bool {
+		return 1 === preg_match( '/^\+[1-9][0-9]{7,14}$/', $phone );
+	}
+
+	/**
+	 * Normalise and validate the configured API base URL.
+	 *
+	 * @param string $api_base_url API base URL.
+	 * @return string|WP_Error
+	 */
+	public static function normalise_api_base_url( string $api_base_url ) {
+		$api_base_url = untrailingslashit( trim( $api_base_url ) );
+		$scheme       = wp_parse_url( $api_base_url, PHP_URL_SCHEME );
+		$host         = wp_parse_url( $api_base_url, PHP_URL_HOST );
+
+		if ( ! is_string( $scheme ) || ! is_string( $host ) || ! in_array( strtolower( $scheme ), [ 'http', 'https' ], true ) ) {
+			return new WP_Error( 'sms_invalid_api_base_url', __( 'api_base_url must be a valid HTTP or HTTPS URL.', 'superdav-ai-agent' ), [ 'status' => 400 ] );
+		}
+
+		return esc_url_raw( $api_base_url );
+	}
+
+	/**
+	 * Send the TextBee HTTP request.
+	 *
+	 * @param array<string, mixed> $config       SMS provider configuration.
+	 * @param string               $api_base_url Normalised API base URL.
+	 * @param string[]             $recipients   Recipient phone numbers.
+	 * @param string               $message      Message body.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	private static function send_textbee_sms( array $config, string $api_base_url, array $recipients, string $message ) {
+		$device_id = sanitize_text_field( (string) ( $config['device_id'] ?? '' ) );
+		$api_key   = (string) ( $config['api_key'] ?? '' );
+		$url       = $api_base_url . '/api/v1/gateway/devices/' . rawurlencode( $device_id ) . '/send-sms';
+		$body      = wp_json_encode(
+			[
+				'recipients' => $recipients,
+				'message'    => $message,
+			]
+		);
+
+		if ( false === $body ) {
+			return new WP_Error( 'sms_payload_encode_failed', __( 'Failed to encode SMS payload.', 'superdav-ai-agent' ), [ 'status' => 500 ] );
+		}
+
+		$response = wp_remote_post(
+			$url,
+			[
+				'timeout'     => 15,
+				'blocking'    => true,
+				'headers'     => [
+					'Content-Type' => 'application/json',
+					'x-api-key'    => $api_key,
+				],
+				'body'        => $body,
+				'data_format' => 'body',
+			]
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( 'sms_provider_error', $response->get_error_message(), [ 'status' => 502 ] );
+		}
+
+		$http_code = (int) wp_remote_retrieve_response_code( $response );
+		if ( $http_code < 200 || $http_code >= 300 ) {
+			return new WP_Error(
+				'sms_provider_http_error',
+				sprintf(
+					/* translators: %d: HTTP status code. */
+					__( 'TextBee returned HTTP %d.', 'superdav-ai-agent' ),
+					$http_code
+				),
+				[
+					'status'    => 502,
+					'http_code' => $http_code,
+				]
+			);
+		}
+
+		$decoded = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		return [
+			'success'           => true,
+			'provider'          => 'textbee',
+			'http_code'         => $http_code,
+			'recipients'        => array_map( [ __CLASS__, 'redact_phone_number' ], $recipients ),
+			'provider_response' => is_array( $decoded ) ? self::redact_provider_response( $decoded ) : null,
+		];
+	}
+
+	/**
+	 * Redact a phone number for responses and logs.
+	 *
+	 * @param string $phone Phone number.
+	 * @return string
+	 */
+	public static function redact_phone_number( string $phone ): string {
+		$last_four = substr( $phone, -4 );
+		return '+*******' . $last_four;
+	}
+
+	/**
+	 * Recursively redact sensitive provider response values.
+	 *
+	 * @param array<string|int, mixed> $response Provider response.
+	 * @return array<string|int, mixed>
+	 */
+	private static function redact_provider_response( array $response ): array {
+		foreach ( $response as $key => $value ) {
+			$key_string = is_string( $key ) ? strtolower( $key ) : '';
+			if ( in_array( $key_string, [ 'api_key', 'api-key', 'x-api-key', 'authorization', 'token', 'secret' ], true ) ) {
+				$response[ $key ] = self::REDACTED;
+				continue;
+			}
+
+			if ( is_array( $value ) ) {
+				$response[ $key ] = self::redact_provider_response( $value );
+			}
+		}
+
+		return $response;
+	}
+}

--- a/includes/Abilities/ToolCapabilities.php
+++ b/includes/Abilities/ToolCapabilities.php
@@ -246,6 +246,7 @@ class ToolCapabilities {
 		'sd-ai-agent/gsc-top-queries'            => 'manage_options',
 		'sd-ai-agent/gsc-query-details'          => 'manage_options',
 		'sd-ai-agent/gsc-page-performance'       => 'manage_options',
+		'sd-ai-agent/sms-send'                   => 'manage_options',
 
 		// ─── Internet / URL utilities ───────────────────────────────────────
 		'sd-ai-agent/internet-search'            => 'manage_options',

--- a/includes/Bootstrap/AbilitiesHandler.php
+++ b/includes/Bootstrap/AbilitiesHandler.php
@@ -60,6 +60,7 @@ use SdAiAgent\Abilities\RestMetaAbilities;
 use SdAiAgent\Abilities\SeoAbilities;
 use SdAiAgent\Abilities\SiteHealthAbilities;
 use SdAiAgent\Abilities\SkillAbilities;
+use SdAiAgent\Abilities\SmsAbilities;
 use SdAiAgent\Abilities\ThemeBuilderAbilities;
 use SdAiAgent\Abilities\UrlResolverAbilities;
 use SdAiAgent\Abilities\UploadMediaAbility;
@@ -113,6 +114,7 @@ final class AbilitiesHandler {
 		MarketingAbilities::register_abilities();
 		GoogleAnalyticsAbilities::register_abilities();
 		GoogleCalendarAbilities::register_abilities();
+		SmsAbilities::register_abilities();
 		// Wire the block enricher registry before registering block
 		// abilities so handle_get_page_blocks can use it. The registry
 		// is created once (singleton per request), the core/image

--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -45,6 +45,13 @@ class Settings {
 	const GOOGLE_CALENDAR_CREDENTIALS_OPTION = 'sd_ai_agent_google_calendar_credentials';
 
 	/**
+	 * Option name for SMS provider credentials.
+	 * Stored separately from general settings to avoid leaking credentials
+	 * through the GET /settings endpoint.
+	 */
+	const SMS_PROVIDER_OPTION = 'sd_ai_agent_sms_provider';
+
+	/**
 	 * Option name that records the most recent saved default-model value
 	 * which was rejected by {@see resolve_default_provider_and_model()}
 	 * because the configured provider/model was not advertised by any
@@ -602,6 +609,49 @@ class Settings {
 	public function has_google_calendar_credentials(): bool {
 		$creds = $this->get_google_calendar_credentials();
 		return ! empty( $creds['type'] );
+	}
+
+	/**
+	 * Get the stored SMS provider configuration.
+	 *
+	 * Returns raw credentials for internal provider callers only. REST settings
+	 * responses must expose only safe metadata.
+	 *
+	 * @return array<string, mixed> SMS provider configuration or empty array.
+	 */
+	public function get_sms_provider(): array {
+		$config = get_option( self::SMS_PROVIDER_OPTION, array() );
+		/** @var array<string, mixed> $result */
+		$result = is_array( $config ) ? $config : array();
+		return $result;
+	}
+
+	/**
+	 * Persist SMS provider configuration.
+	 *
+	 * Pass an empty array to clear the credentials.
+	 *
+	 * @param array<string, mixed> $config SMS provider configuration.
+	 * @return bool True on success.
+	 */
+	public function set_sms_provider( array $config ): bool {
+		if ( empty( $config ) ) {
+			return delete_option( self::SMS_PROVIDER_OPTION );
+		}
+
+		return update_option( self::SMS_PROVIDER_OPTION, $config );
+	}
+
+	/**
+	 * Check whether SMS provider credentials are configured.
+	 *
+	 * @return bool
+	 */
+	public function has_sms_provider(): bool {
+		$config = $this->get_sms_provider();
+		return 'textbee' === ( $config['provider'] ?? '' )
+			&& ! empty( $config['api_key'] )
+			&& ! empty( $config['device_id'] );
 	}
 
 	/**

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -13,6 +13,7 @@ namespace SdAiAgent\REST;
 
 use SdAiAgent\Abilities\GoogleAnalyticsAbilities;
 use SdAiAgent\Abilities\InternetSearchAbilities;
+use SdAiAgent\Abilities\SmsAbilities;
 use SdAiAgent\Admin\UnifiedAdminMenu;
 use SdAiAgent\Core\AgentLoop;
 use SdAiAgent\Core\BudgetManager;
@@ -179,6 +180,29 @@ final class SettingsController {
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,
 					'callback'            => array( $this, 'handle_delete_gsc_credentials' ),
+					'permission_callback' => array( __CLASS__, 'check_admin_permission' ),
+				),
+			)
+		);
+
+		// SMS provider credentials endpoint.
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/settings/sms-provider',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'handle_get_sms_provider' ),
+					'permission_callback' => array( __CLASS__, 'check_admin_permission' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'handle_set_sms_provider' ),
+					'permission_callback' => array( __CLASS__, 'check_admin_permission' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'handle_delete_sms_provider' ),
 					'permission_callback' => array( __CLASS__, 'check_admin_permission' ),
 				),
 			)
@@ -424,6 +448,8 @@ final class SettingsController {
 		$settings['_brave_search_key_configured'] = '' !== InternetSearchAbilities::get_brave_api_key();
 		// @phpstan-ignore-next-line
 		$settings['_tavily_api_key_configured'] = '' !== InternetSearchAbilities::get_tavily_api_key();
+		// @phpstan-ignore-next-line
+		$settings['_sms_provider'] = $this->get_sms_provider_metadata();
 
 		// Indicate whether a feedback-report receiver API key is configured (boolean only, no key value — t180).
 		// @phpstan-ignore-next-line
@@ -840,6 +866,111 @@ final class SettingsController {
 			),
 			200
 		);
+	}
+
+	/**
+	 * Handle GET /settings/sms-provider — return safe SMS provider metadata.
+	 */
+	public function handle_get_sms_provider(): WP_REST_Response {
+		return new WP_REST_Response( $this->get_sms_provider_metadata(), 200 );
+	}
+
+	/**
+	 * Handle POST /settings/sms-provider — save SMS provider credentials.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 */
+	public function handle_set_sms_provider( WP_REST_Request $request ): WP_REST_Response {
+		$params = $request->get_json_params();
+		if ( empty( $params ) || ! is_array( $params ) ) {
+			return new WP_REST_Response( array( 'error' => 'No data provided.' ), 400 );
+		}
+
+		$provider     = sanitize_text_field( (string) ( $params['provider'] ?? 'textbee' ) );
+		$api_key      = sanitize_text_field( (string) ( $params['api_key'] ?? '' ) );
+		$device_id    = sanitize_text_field( (string) ( $params['device_id'] ?? '' ) );
+		$api_base_url = sanitize_text_field( (string) ( $params['api_base_url'] ?? SmsAbilities::DEFAULT_API_BASE_URL ) );
+
+		if ( 'textbee' !== $provider ) {
+			return new WP_REST_Response( array( 'error' => 'provider must be "textbee".' ), 400 );
+		}
+
+		if ( '' === $api_key ) {
+			return new WP_REST_Response( array( 'error' => 'api_key is required.' ), 400 );
+		}
+
+		if ( '' === $device_id ) {
+			return new WP_REST_Response( array( 'error' => 'device_id is required.' ), 400 );
+		}
+
+		$normalised_api_base_url = SmsAbilities::normalise_api_base_url( $api_base_url );
+		if ( is_wp_error( $normalised_api_base_url ) ) {
+			return new WP_REST_Response( array( 'error' => $normalised_api_base_url->get_error_message() ), 400 );
+		}
+
+		$success = $this->settings->set_sms_provider(
+			array(
+				'provider'     => 'textbee',
+				'api_key'      => $api_key,
+				'device_id'    => $device_id,
+				'api_base_url' => $normalised_api_base_url,
+			)
+		);
+
+		if ( ! $success ) {
+			return new WP_REST_Response( array( 'error' => 'Failed to save SMS provider credentials.' ), 500 );
+		}
+
+		return new WP_REST_Response( array_merge( array( 'saved' => true ), $this->get_sms_provider_metadata() ), 200 );
+	}
+
+	/**
+	 * Handle DELETE /settings/sms-provider — remove SMS provider credentials.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 */
+	public function handle_delete_sms_provider( WP_REST_Request $request ): WP_REST_Response {
+		$this->settings->set_sms_provider( array() );
+
+		return new WP_REST_Response(
+			array(
+				'deleted'     => true,
+				'configured'  => false,
+				'provider'    => null,
+				'has_api_key' => false,
+			),
+			200
+		);
+	}
+
+	/**
+	 * Return safe SMS provider metadata for REST responses.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function get_sms_provider_metadata(): array {
+		$config    = $this->settings->get_sms_provider();
+		$device_id = (string) ( $config['device_id'] ?? '' );
+
+		return array(
+			'configured'         => $this->settings->has_sms_provider(),
+			'provider'           => $config['provider'] ?? null,
+			'has_api_key'        => ! empty( $config['api_key'] ),
+			'has_device_id'      => '' !== $device_id,
+			'device_id_redacted' => '' !== $device_id ? $this->redact_device_id( $device_id ) : null,
+			'api_base_url'       => $config['api_base_url'] ?? SmsAbilities::DEFAULT_API_BASE_URL,
+		);
+	}
+
+	/**
+	 * Redact a TextBee device ID for metadata responses.
+	 *
+	 * @param string $device_id TextBee device ID.
+	 * @return string
+	 */
+	private function redact_device_id( string $device_id ): string {
+		$visible = substr( $device_id, -4 );
+		return '********' . $visible;
 	}
 
 	/**

--- a/tests/SdAiAgent/Abilities/SmsAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/SmsAbilitiesTest.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * Test case for SmsAbilities class.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Abilities;
+
+use SdAiAgent\Abilities\SmsAbilities;
+use SdAiAgent\Core\Settings;
+use WP_Error;
+use WP_UnitTestCase;
+
+/**
+ * Test TextBee-backed SMS ability behavior.
+ */
+class SmsAbilitiesTest extends WP_UnitTestCase {
+
+	/**
+	 * Clear SMS provider state before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		Settings::instance()->set_sms_provider( [] );
+		remove_all_filters( 'pre_http_request' );
+	}
+
+	/**
+	 * Clear SMS provider state after each test.
+	 */
+	public function tearDown(): void {
+		Settings::instance()->set_sms_provider( [] );
+		remove_all_filters( 'pre_http_request' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Missing credentials return a clear WP_Error.
+	 */
+	public function test_handle_sms_send_missing_credentials_returns_wp_error(): void {
+		$result = SmsAbilities::handle_sms_send(
+			[
+				'recipients' => [ '+15551234567' ],
+				'message'    => 'Hello.',
+			]
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sms_not_configured', $result->get_error_code() );
+	}
+
+	/**
+	 * Invalid recipients are rejected before any provider call.
+	 */
+	public function test_handle_sms_send_invalid_recipients_returns_wp_error(): void {
+		$result = SmsAbilities::handle_sms_send(
+			[
+				'recipients' => [ '555-1234' ],
+				'message'    => 'Hello.',
+			]
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sms_invalid_recipient', $result->get_error_code() );
+	}
+
+	/**
+	 * Invalid self-hosted base URLs are rejected.
+	 */
+	public function test_handle_sms_send_invalid_base_url_returns_wp_error(): void {
+		Settings::instance()->set_sms_provider(
+			[
+				'provider'     => 'textbee',
+				'api_key'      => 'tb_secret_key',
+				'device_id'    => 'device-123',
+				'api_base_url' => 'not-a-url',
+			]
+		);
+
+		$result = SmsAbilities::handle_sms_send(
+			[
+				'recipients' => [ '+15551234567' ],
+				'message'    => 'Hello.',
+			]
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sms_invalid_api_base_url', $result->get_error_code() );
+	}
+
+	/**
+	 * Provider transport errors are converted to a scrubbed ability error.
+	 */
+	public function test_handle_sms_send_provider_wp_error_returns_wp_error(): void {
+		$this->configure_sms_provider();
+
+		add_filter(
+			'pre_http_request',
+			static function (): WP_Error {
+				return new WP_Error( 'http_request_failed', 'Connection failed.' );
+			}
+		);
+
+		$result = SmsAbilities::handle_sms_send(
+			[
+				'recipients' => [ '+15551234567' ],
+				'message'    => 'Hello.',
+			]
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sms_provider_error', $result->get_error_code() );
+		$this->assertStringNotContainsString( 'tb_secret_key', $result->get_error_message() );
+	}
+
+	/**
+	 * Non-2xx TextBee responses are reported without leaking response bodies.
+	 */
+	public function test_handle_sms_send_non_2xx_response_returns_wp_error(): void {
+		$this->configure_sms_provider();
+
+		add_filter(
+			'pre_http_request',
+			static function (): array {
+				return [
+					'response' => [
+						'code'    => 401,
+						'message' => 'Unauthorized',
+					],
+					'body'     => '{"api_key":"tb_secret_key"}',
+				];
+			}
+		);
+
+		$result = SmsAbilities::handle_sms_send(
+			[
+				'recipients' => [ '+15551234567' ],
+				'message'    => 'Hello.',
+			]
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sms_provider_http_error', $result->get_error_code() );
+		$this->assertStringNotContainsString( 'tb_secret_key', $result->get_error_message() );
+	}
+
+	/**
+	 * Successful sends call the documented TextBee endpoint and redact output.
+	 */
+	public function test_handle_sms_send_success_returns_scrubbed_result(): void {
+		$this->configure_sms_provider();
+		$captured_url  = '';
+		$captured_args = [];
+
+		add_filter(
+			'pre_http_request',
+			static function ( mixed $preempt, array $parsed_args, string $url ) use ( &$captured_url, &$captured_args ): array {
+				$captured_url  = $url;
+				$captured_args = $parsed_args;
+
+				return [
+					'response' => [
+						'code'    => 200,
+						'message' => 'OK',
+					],
+					'body'     => wp_json_encode(
+						[
+							'id'      => 'sms-123',
+							'api_key' => 'tb_secret_key',
+						]
+					),
+				];
+			},
+			10,
+			3
+		);
+
+		$result = SmsAbilities::handle_sms_send(
+			[
+				'recipients' => [ '+15551234567', '+447700900123' ],
+				'message'    => 'Hello.',
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'https://textbee.example/api/v1/gateway/devices/device-123/send-sms', $captured_url );
+		$this->assertSame( 'tb_secret_key', $captured_args['headers']['x-api-key'] ?? '' );
+		$this->assertSame( [ '+*******4567', '+*******0123' ], $result['recipients'] );
+		$this->assertSame( '[redacted]', $result['provider_response']['api_key'] ?? '' );
+		$this->assertStringNotContainsString( 'tb_secret_key', wp_json_encode( $result ) ?: '' );
+	}
+
+	/**
+	 * Message length is capped before sending.
+	 */
+	public function test_handle_sms_send_message_too_long_returns_wp_error(): void {
+		$result = SmsAbilities::handle_sms_send(
+			[
+				'recipients' => [ '+15551234567' ],
+				'message'    => str_repeat( 'a', SmsAbilities::MAX_MESSAGE_LENGTH + 1 ),
+			]
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sms_message_too_long', $result->get_error_code() );
+	}
+
+	/**
+	 * Configure a valid TextBee provider for tests.
+	 */
+	private function configure_sms_provider(): void {
+		Settings::instance()->set_sms_provider(
+			[
+				'provider'     => 'textbee',
+				'api_key'      => 'tb_secret_key',
+				'device_id'    => 'device-123',
+				'api_base_url' => 'https://textbee.example',
+			]
+		);
+	}
+}

--- a/tests/SdAiAgent/REST/SettingsControllerTest.php
+++ b/tests/SdAiAgent/REST/SettingsControllerTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Tests\REST;
 
 use SdAiAgent\Bootstrap\SuperdavAiProviderHandler;
+use SdAiAgent\Abilities\SmsAbilities;
 use SdAiAgent\Core\Database;
 use SdAiAgent\Core\Settings;
 use SdAiAgent\Core\SuperdavSiteConnectionService;
@@ -40,6 +41,7 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		$this->invalidate_superdav_model_cache();
 		Settings::instance()->set_google_calendar_credentials( array() );
 		delete_option( SuperdavAiProvider::CREDENTIAL_OPTION );
+		delete_option( Settings::SMS_PROVIDER_OPTION );
 		delete_option( SuperdavSiteConnectionService::INSTALLATION_ID_OPTION );
 		delete_option( SuperdavSiteConnectionService::TOKEN_METADATA_OPTION );
 		remove_all_filters( 'sd_ai_agent_cloud_base_url' );
@@ -292,6 +294,83 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * SMS provider settings can be saved and read without exposing the API key.
+	 */
+	public function test_handle_sms_provider_save_and_get_returns_safe_metadata(): void {
+		$controller = new SettingsController( new Settings(), new Database() );
+
+		$response = $controller->handle_set_sms_provider(
+			$this->json_request(
+				[
+					'provider'     => 'textbee',
+					'api_key'      => 'tb_secret_key',
+					'device_id'    => 'android-device-1234',
+					'api_base_url' => 'https://textbee.example/',
+				]
+			)
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertIsArray( $data );
+		$this->assertTrue( $data['configured'] );
+		$this->assertTrue( $data['has_api_key'] );
+		$this->assertSame( 'textbee', $data['provider'] );
+		$this->assertSame( 'https://textbee.example', $data['api_base_url'] );
+		$this->assertSame( '********1234', $data['device_id_redacted'] );
+		$this->assertArrayNotHasKey( 'api_key', $data );
+		$this->assertStringNotContainsString( 'tb_secret_key', wp_json_encode( $data ) ?: '' );
+
+		$get_response = $controller->handle_get_sms_provider();
+		$get_data     = $get_response->get_data();
+		$this->assertIsArray( $get_data );
+		$this->assertTrue( $get_data['configured'] );
+		$this->assertArrayNotHasKey( 'api_key', $get_data );
+		$this->assertStringNotContainsString( 'tb_secret_key', wp_json_encode( $get_data ) ?: '' );
+	}
+
+	/**
+	 * Invalid SMS provider base URLs are rejected.
+	 */
+	public function test_handle_sms_provider_invalid_base_url_returns_error(): void {
+		$controller = new SettingsController( new Settings(), new Database() );
+		$response   = $controller->handle_set_sms_provider(
+			$this->json_request(
+				[
+					'provider'     => 'textbee',
+					'api_key'      => 'tb_secret_key',
+					'device_id'    => 'android-device-1234',
+					'api_base_url' => 'not-a-url',
+				]
+			)
+		);
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertFalse( ( new Settings() )->has_sms_provider() );
+	}
+
+	/**
+	 * SMS provider credentials can be deleted.
+	 */
+	public function test_handle_sms_provider_delete_clears_credentials(): void {
+		$settings = new Settings();
+		$settings->set_sms_provider(
+			[
+				'provider'     => 'textbee',
+				'api_key'      => 'tb_secret_key',
+				'device_id'    => 'android-device-1234',
+				'api_base_url' => SmsAbilities::DEFAULT_API_BASE_URL,
+			]
+		);
+
+		$controller = new SettingsController( $settings, new Database() );
+		$response   = $controller->handle_delete_sms_provider( new WP_REST_Request( 'DELETE', '/sd-ai-agent/v1/settings/sms-provider' ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertFalse( $settings->has_sms_provider() );
+	}
+
+	/**
 	 * Find a provider entry by ID.
 	 *
 	 * @param array<int, array<string, mixed>> $providers Provider rows.
@@ -329,6 +408,20 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		}
 
 		return '';
+	}
+
+	/**
+	 * Build a JSON REST request for controller tests.
+	 *
+	 * @param array<string, mixed> $params JSON request parameters.
+	 * @return WP_REST_Request
+	 */
+	private function json_request( array $params ): WP_REST_Request {
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/settings/sms-provider' );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$request->set_body( wp_json_encode( $params ) ?: '{}' );
+
+		return $request;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Added dedicated TextBee SMS provider credential storage, admin-only SMS provider settings routes, the sd-ai-agent/sms-send ability, TextBee HTTP send handling with input validation and secret/phone redaction, capability mapping, ability registration, and PHPUnit coverage.

## Files Changed

includes/Abilities/SmsAbilities.php,includes/Abilities/ToolCapabilities.php,includes/Bootstrap/AbilitiesHandler.php,includes/Core/Settings.php,includes/REST/SettingsController.php,tests/SdAiAgent/Abilities/SmsAbilitiesTest.php,tests/SdAiAgent/REST/SettingsControllerTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run test:php -- --filter='SmsAbilitiesTest|SettingsControllerTest|ToolCapabilitiesTest' -> OK (48 tests, 422 assertions); npm run lint:php -> passed; composer phpstan -> 0 errors; npm run verify -> passed (PHPUnit: Tests: 3663, Assertions: 15245, Skipped: 120, Incomplete: 4; lint/PHPStan/build/archive/bundle passed)

Resolves #2128


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.31 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 12m and 134,682 tokens on this with the user in an interactive session.