### PR TITLE
GH#2141: fix: harden calendar reminder dedupe records

### DIFF
--- a/includes/Automations/CalendarReminderRecords.php
+++ b/includes/Automations/CalendarReminderRecords.php
@@ -144,7 +144,7 @@ class CalendarReminderRecords {
 	public static function hash_phone( string $phone ): string {
 		$digits = preg_replace( '/\D+/', '', $phone ) ?: '';
 
-		return '' === $digits ? '' : hash( 'sha256', $digits );
+		return '' === $digits ? '' : hash_hmac( 'sha256', $digits, wp_salt( 'auth' ) );
 	}
 
 	/**
@@ -188,24 +188,56 @@ class CalendarReminderRecords {
 		);
 
 		if ( null !== $existing ) {
-			$update = $record;
-			unset( $update['calendar_id'], $update['event_id'], $update['event_start_at'], $update['reminder_date'], $update['attendee_email'], $update['created_at'] );
-			$update['updated_at'] = $now;
-
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
-			$updated = $wpdb->update(
-				self::table_name(),
-				$update,
-				[ 'id' => (int) $existing['id'] ]
-			);
-
-			return false === $updated ? false : (int) $existing['id'];
+			return self::update_existing_record( (int) $existing['id'], $record, $now );
 		}
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Custom table query; caching not applicable.
 		$result = $wpdb->insert( self::table_name(), $record );
 
-		return $result ? (int) $wpdb->insert_id : false;
+		if ( $result ) {
+			return (int) $wpdb->insert_id;
+		}
+
+		$existing = self::find_by_identity(
+			$record['calendar_id'],
+			$record['event_id'],
+			$record['attendee_email'],
+			$record['reminder_date']
+		);
+
+		return null === $existing ? false : self::update_existing_record( (int) $existing['id'], $record, $now );
+	}
+
+	/**
+	 * Update an existing reminder record while preserving optional metadata unless new values are supplied.
+	 *
+	 * @param int                  $id     Reminder record ID.
+	 * @param array<string, mixed> $record Sanitized reminder record.
+	 * @param string               $now    Current MySQL datetime.
+	 */
+	private static function update_existing_record( int $id, array $record, string $now ): int|false {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$update = $record;
+		unset( $update['calendar_id'], $update['event_id'], $update['event_start_at'], $update['reminder_date'], $update['attendee_email'], $update['created_at'] );
+
+		foreach ( [ 'phone_hash', 'skip_reason', 'provider', 'provider_message_id', 'approval_request_id', 'sent_at' ] as $optional_field ) {
+			if ( empty( $update[ $optional_field ] ) ) {
+				unset( $update[ $optional_field ] );
+			}
+		}
+
+		$update['updated_at'] = $now;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
+		$updated = $wpdb->update(
+			self::table_name(),
+			$update,
+			[ 'id' => $id ]
+		);
+
+		return false === $updated ? false : $id;
 	}
 
 	/**

--- a/includes/Core/Database.php
+++ b/includes/Core/Database.php
@@ -36,7 +36,7 @@ use SdAiAgent\Tools\CustomTools;
 class Database {
 
 	const DB_VERSION_OPTION = 'sd_ai_agent_db_version';
-	const DB_VERSION        = '19.5.5';
+	const DB_VERSION        = '19.5.6';
 
 	// ─── Table Name Registry ──────────────────────────────────────────────────
 
@@ -469,7 +469,7 @@ class Database {
 			created_at datetime NOT NULL,
 			updated_at datetime NOT NULL,
 			PRIMARY KEY  (id),
-			UNIQUE KEY reminder_dedupe (calendar_id(80), event_id(120), attendee_email(120), reminder_date),
+			UNIQUE KEY reminder_dedupe (calendar_id, event_id, attendee_email, reminder_date),
 			KEY status (status),
 			KEY reminder_date (reminder_date),
 			KEY approval_request_id (approval_request_id),
@@ -747,6 +747,8 @@ class Database {
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 		dbDelta( $sql );
 
+		self::ensure_calendar_reminder_dedupe_index( $calendar_reminders_table );
+
 		// Add FULLTEXT index on memories table if not present.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Custom table query; table name from internal method.
 		$ft_exists = $wpdb->get_var( "SHOW INDEX FROM {$memories_table} WHERE Key_name = 'ft_content'" );
@@ -768,6 +770,27 @@ class Database {
 		Agent::seed_defaults();
 
 		update_option( self::DB_VERSION_OPTION, self::DB_VERSION );
+	}
+
+	/**
+	 * Ensure the calendar reminder dedupe key uses the full reminder identity.
+	 */
+	private static function ensure_calendar_reminder_dedupe_index( string $table ): void {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Schema introspection for an internal table name.
+		$prefixed_parts = $wpdb->get_col( "SHOW INDEX FROM {$table} WHERE Key_name = 'reminder_dedupe' AND Sub_part IS NOT NULL" );
+
+		if ( [] === $prefixed_parts ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Required schema repair for the calendar reminder dedupe index.
+		$wpdb->query( "ALTER TABLE {$table} DROP INDEX reminder_dedupe" );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Required schema repair for the calendar reminder dedupe index.
+		$wpdb->query( "ALTER TABLE {$table} ADD UNIQUE KEY reminder_dedupe (calendar_id, event_id, attendee_email, reminder_date)" );
 	}
 
 	// ─── Session Delegates ────────────────────────────────────────────────────

--- a/tests/SdAiAgent/Automations/CalendarReminderRecordsTest.php
+++ b/tests/SdAiAgent/Automations/CalendarReminderRecordsTest.php
@@ -69,7 +69,7 @@ class CalendarReminderRecordsTest extends WP_UnitTestCase {
 		$this->assertNotNull( $record );
 		$this->assertSame( CalendarReminderRecords::STATUS_SENT, $record['status'] );
 		$this->assertSame( 'person@example.com', $record['attendee_email'] );
-		$this->assertSame( hash( 'sha256', '15551234567' ), $record['phone_hash'] );
+		$this->assertSame( hash_hmac( 'sha256', '15551234567', wp_salt( 'auth' ) ), $record['phone_hash'] );
 		$this->assertStringNotContainsString( '555', implode( ' ', array_map( 'strval', $record ) ) );
 		$this->assertNotEmpty( $record['sent_at'] );
 	}
@@ -86,6 +86,8 @@ class CalendarReminderRecordsTest extends WP_UnitTestCase {
 
 		$this->assertSame( CalendarReminderRecords::STATUS_SENT, $record['status'] );
 		$this->assertSame( 'msg-456', $record['provider_message_id'] );
+		$this->assertSame( 'approval-1', $record['approval_request_id'] );
+		$this->assertNotEmpty( $record['phone_hash'] );
 
 		global $wpdb;
 		/** @var \wpdb $wpdb */

--- a/tests/SdAiAgent/Core/DatabaseSchemaTest.php
+++ b/tests/SdAiAgent/Core/DatabaseSchemaTest.php
@@ -291,6 +291,10 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test-only introspection query.
 		$unique_exists = $wpdb->get_var( "SHOW INDEX FROM {$table} WHERE Key_name = 'reminder_dedupe' AND Non_unique = 0" );
 		$this->assertNotNull( $unique_exists, "Calendar reminders table should have UNIQUE KEY 'reminder_dedupe'." );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test-only introspection query.
+		$sub_parts = $wpdb->get_col( "SHOW INDEX FROM {$table} WHERE Key_name = 'reminder_dedupe' AND Sub_part IS NOT NULL" );
+		$this->assertSame( [], $sub_parts, "Calendar reminders table should use full columns for UNIQUE KEY 'reminder_dedupe'." );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Hardened calendar reminder idempotency records by switching phone hashing to a site-keyed HMAC, preserving existing optional metadata on duplicate updates, retrying insert collisions through the existing-record update path, and repairing the calendar reminder dedupe index to cover the full identity.

## Files Changed

includes/Automations/CalendarReminderRecords.php,includes/Core/Database.php,tests/SdAiAgent/Automations/CalendarReminderRecordsTest.php,tests/SdAiAgent/Core/DatabaseSchemaTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify (lint PHP/JS/CSS clean; PHPStan 0 errors; PHPUnit Tests: 3668, Assertions: 15283, Errors: 0, Failures: 0, Skipped: 120, Incomplete: 4; build succeeded; bundle check passed)

Resolves #2141


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.31 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 15m and 71,431 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar reminder record handling so duplicate or partially saved reminders are updated more reliably instead of failing.
  * Strengthened phone-number matching to use a more secure, consistent hash, helping prevent duplicate reminder records.
  * Fixed reminder deduplication so records are matched using full values, reducing false duplicates and missed updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->