### PR TITLE
GH#2146: fix: harden google calendar token cache

### DIFF
--- a/includes/Abilities/GoogleCalendarAbilities.php
+++ b/includes/Abilities/GoogleCalendarAbilities.php
@@ -138,7 +138,7 @@ class GoogleCalendarAbilities {
 	 * @param array<string, mixed> $input Input arguments.
 	 * @return array<string, mixed>|WP_Error
 	 */
-	public static function handle_list_events( array $input = [] ) {
+	public static function handle_list_events( array $input = [] ): array|WP_Error {
 		$token = self::get_access_token();
 		if ( is_wp_error( $token ) ) {
 			return $token;
@@ -181,7 +181,7 @@ class GoogleCalendarAbilities {
 	 * @param array<string, mixed> $input Input arguments.
 	 * @return array<string, mixed>|WP_Error
 	 */
-	public static function handle_get_event( array $input = [] ) {
+	public static function handle_get_event( array $input = [] ): array|WP_Error {
 		$event_id = sanitize_text_field( (string) ( $input['event_id'] ?? '' ) );
 		if ( '' === $event_id ) {
 			return new WP_Error( 'google_calendar_missing_event_id', __( 'event_id is required.', 'superdav-ai-agent' ) );
@@ -207,7 +207,7 @@ class GoogleCalendarAbilities {
 	 * @param array<string, mixed> $input Input arguments.
 	 * @return array<string, mixed>|WP_Error
 	 */
-	public static function handle_list_calendars( array $input = [] ) {
+	public static function handle_list_calendars( array $input = [] ): array|WP_Error {
 		unset( $input );
 		$token = self::get_access_token();
 		if ( is_wp_error( $token ) ) {
@@ -260,7 +260,11 @@ class GoogleCalendarAbilities {
 			return new WP_Error( 'google_calendar_invalid_credentials', __( 'Google Calendar OAuth2 credentials are incomplete.', 'superdav-ai-agent' ) );
 		}
 
-		$cache_key = 'sd_google_calendar_token_' . substr( md5( $client_id . ':' . $refresh_token ), 0, 12 );
+		$cache_key = 'sd_google_calendar_token_' . substr(
+			hash_hmac( 'sha256', $client_id . ':' . $refresh_token, wp_salt( 'auth' ) ),
+			0,
+			24
+		);
 		$cached    = get_transient( $cache_key );
 		if ( is_string( $cached ) && '' !== $cached ) {
 			return $cached;

--- a/tests/SdAiAgent/Abilities/GoogleCalendarAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/GoogleCalendarAbilitiesTest.php
@@ -144,6 +144,52 @@ final class GoogleCalendarAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 'a@example.com', $result['events'][0]['attendees'][0]['email'] );
 	}
 
+	/** Token cache keys use a salted HMAC fingerprint rather than unsalted MD5. */
+	public function test_token_cache_key_uses_salted_hmac_fingerprint(): void {
+		$credentials = $this->credentials( 'cache-test@example.com' );
+		Settings::instance()->set_google_calendar_credentials( $credentials );
+
+		$token_requests = 0;
+		add_filter(
+			'pre_http_request',
+			static function ( mixed $preempt, array $parsed_args, string $url ) use ( &$token_requests ): mixed {
+				unset( $parsed_args );
+				if ( 'https://oauth2.googleapis.com/token' === $url ) {
+					++$token_requests;
+					return array(
+						'response' => array( 'code' => 200, 'message' => 'OK' ),
+						'body'     => wp_json_encode( array( 'access_token' => 'cached-calendar-token', 'expires_in' => 3600 ) ),
+					);
+				}
+
+				if ( str_starts_with( $url, 'https://www.googleapis.com/calendar/v3/users/me/calendarList' ) ) {
+					return array(
+						'response' => array( 'code' => 200, 'message' => 'OK' ),
+						'body'     => wp_json_encode( array( 'items' => array() ) ),
+					);
+				}
+
+				return $preempt;
+			},
+			10,
+			3
+		);
+
+		$result = GoogleCalendarAbilities::handle_list_calendars();
+
+		$hmac_key = 'sd_google_calendar_token_' . substr(
+			hash_hmac( 'sha256', $credentials['client_id'] . ':' . $credentials['refresh_token'], wp_salt( 'auth' ) ),
+			0,
+			24
+		);
+		$md5_key  = 'sd_google_calendar_token_' . substr( md5( $credentials['client_id'] . ':' . $credentials['refresh_token'] ), 0, 12 );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 1, $token_requests );
+		$this->assertSame( 'cached-calendar-token', get_transient( $hmac_key ) );
+		$this->assertFalse( get_transient( $md5_key ) );
+	}
+
 	/** Get event requires event_id. */
 	public function test_get_event_requires_event_id(): void {
 		$result = GoogleCalendarAbilities::handle_get_event( array() );


### PR DESCRIPTION
## Summary

Added native array|WP_Error return types to the Google Calendar public handlers and replaced the OAuth credential-derived token cache key with a salted HMAC fingerprint. Added PHPUnit coverage proving the HMAC transient key is used and the legacy unsalted MD5 key is not populated.

## Files Changed

includes/Abilities/GoogleCalendarAbilities.php,tests/SdAiAgent/Abilities/GoogleCalendarAbilitiesTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify (lint:js, lint:css, lint:php, PHPStan 0 errors, PHPUnit: Tests: 3669, Assertions: 15287, Skipped: 120, Incomplete: 4, build succeeded, bundle size checks passed)

Resolves #2146


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.31 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 12m and 95,867 tokens on this as a headless worker.