### PR TITLE
Fix chat error recovery state preservation

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -925,6 +925,35 @@ class AgentLoop {
 			// corruption from session storage could leave orphaned tool
 			// calls that cause API 400 errors.
 			$this->history = ConversationTrimmer::validate_tool_pairs( $this->history );
+
+			if ( $this->history_ends_with_model_message() ) {
+				$result = $this->with_error_recovery_data(
+					new WP_Error(
+						'sd_ai_agent_history_needs_user_turn',
+						__(
+							'The previous agent run stopped after an assistant message. Send a new message to continue from the saved chat history.',
+							'superdav-ai-agent'
+						)
+					)
+				);
+
+				AgentEventLog::log(
+					'agent_loop_aborted',
+					AgentEventLog::SEVERITY_ERROR,
+					array(
+						'session_id'      => $this->session_id,
+						'reason'          => (string) $result->get_error_code(),
+						'iterations_used' => $this->iterations_used,
+						'iterations_max'  => (int) $this->max_iterations,
+						'model_id'        => (string) $this->model_id,
+						'provider_id'     => (string) $this->provider_id,
+						'message'         => (string) $result->get_error_message(),
+					)
+				);
+
+				return $result;
+			}
+
 			$this->save_active_job_checkpoint( self::CHECKPOINT_BEFORE_PROVIDER_CALL, $iterations + 1 );
 
 			$this->last_loop_phase = 'provider_call';
@@ -933,6 +962,7 @@ class AgentLoop {
 
 			if ( is_wp_error( $result ) ) {
 				/** @var WP_Error $result */
+				$result = $this->with_error_recovery_data( $result );
 				AgentEventLog::log(
 					'agent_loop_aborted',
 					AgentEventLog::SEVERITY_ERROR,
@@ -1922,6 +1952,91 @@ class AgentLoop {
 	 */
 	private function serialize_history(): array {
 		return ConversationSerializer::serialize( $this->history );
+	}
+
+	/**
+	 * Whether the prompt history currently ends with an assistant/model turn.
+	 *
+	 * Provider SDKs require a resumed request to continue from a user/tool result
+	 * boundary. If a crashed checkpoint or stale paused state ends with a plain
+	 * model response, sending it again produces provider validation errors such as
+	 * "The last message must be from a user role, not from model". Surface a
+	 * recoverable local error instead so the browser can keep the saved history and
+	 * the user can send a fresh continuation message.
+	 */
+	private function history_ends_with_model_message(): bool {
+		$last = end( $this->history );
+		reset( $this->history );
+
+		if ( ! $last instanceof Message ) {
+			return false;
+		}
+
+		return in_array( $this->message_role_string( $last ), array( 'model', 'assistant' ), true );
+	}
+
+	/**
+	 * Return a stable role string for SDK message objects.
+	 *
+	 * @param Message $message Message to inspect.
+	 */
+	private function message_role_string( Message $message ): string {
+		try {
+			$data = $message->toArray();
+			$role = $data['role'] ?? '';
+
+			if ( is_scalar( $role ) ) {
+				return (string) $role;
+			}
+
+			if ( $role instanceof \BackedEnum ) {
+				return (string) $role->value;
+			}
+
+			if ( is_object( $role ) && method_exists( $role, 'getValue' ) ) {
+				return (string) $role->getValue();
+			}
+
+			return '';
+		} catch ( \Throwable $e ) {
+			return '';
+		}
+	}
+
+	/**
+	 * Attach resumable conversation context to a loop error.
+	 *
+	 * Job/session persistence layers use this data to keep the user's failed turn
+	 * and the latest safe history instead of dropping the prompt when the provider
+	 * or SDK rejects a request.
+	 *
+	 * @param WP_Error $error Error returned from a provider/loop boundary.
+	 */
+	private function with_error_recovery_data( WP_Error $error ): WP_Error {
+		$error_data = $error->get_error_data();
+		$data       = is_array( $error_data ) ? $error_data : array();
+
+		$defaults = array(
+			'tool_calls'       => $this->tool_call_log,
+			'token_usage'      => $this->token_usage,
+			'iterations_used'  => $this->iterations_used,
+			'model_id'         => $this->model_id,
+			'provider_id'      => $this->provider_id,
+			'history'          => $this->serialize_history(),
+			'client_abilities' => $this->client_abilities,
+			'recoverable'      => true,
+		);
+
+		foreach ( $defaults as $key => $value ) {
+			if ( ! array_key_exists( $key, $data ) ) {
+				$data[ $key ] = $value;
+			}
+		}
+
+		$data = $this->with_result_logs( $data );
+		$error->add_data( $data );
+
+		return $error;
 	}
 
 	/**

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -1042,11 +1042,19 @@ final class SessionController {
 		}
 
 		if ( 'error' === $job['status'] && isset( $job['error'] ) ) {
-			$error_context = array(
+			$job_session_id = $this->get_job_session_id( $job );
+			$error_context  = array(
 				'job_id'        => $job_id,
-				'session_id'    => isset( $job['session_id'] ) ? (int) $job['session_id'] : 0,
+				'session_id'    => $job_session_id,
 				'error_context' => $job['error_context'] ?? null,
 			);
+
+			if ( $job_session_id > 0 ) {
+				$response['session_id'] = $job_session_id;
+			}
+			if ( ! empty( $job['recoverable'] ) ) {
+				$response['recoverable'] = true;
+			}
 
 			/**
 			 * Filter the error message returned to the chat client.
@@ -1290,6 +1298,192 @@ final class SessionController {
 		}
 
 		return $detail;
+	}
+
+	/**
+	 * Resolve a session ID from a transient-backed job array.
+	 *
+	 * @param array<string, mixed> $job Job transient payload.
+	 * @return int Session ID, or 0 when none is known.
+	 */
+	private function get_job_session_id( array $job ): int {
+		if ( ! empty( $job['session_id'] ) ) {
+			return absint( $job['session_id'] );
+		}
+
+		$params = $job['params'] ?? array();
+		if ( is_array( $params ) && ! empty( $params['session_id'] ) ) {
+			return absint( $params['session_id'] );
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Build a best-effort history payload when an exception prevents AgentLoop
+	 * from returning structured recovery data.
+	 *
+	 * @param array $history Existing deserialized session history.
+	 * @param array $params  Job params.
+	 * @return list<array<string, mixed>> Serialized history.
+	 *
+	 * @phpstan-param list<\WordPress\AiClient\Messages\DTO\Message> $history
+	 * @phpstan-param array<string, mixed> $params
+	 */
+	private function build_exception_recovery_history( array $history, array $params ): array {
+		$serialized = ConversationSerializer::serialize( $history );
+		$message    = isset( $params['message'] ) ? (string) $params['message'] : '';
+
+		if ( '' === trim( $message ) ) {
+			return $serialized;
+		}
+
+		try {
+			$user_turn = new \WordPress\AiClient\Messages\DTO\UserMessage(
+				array(
+					new \WordPress\AiClient\Messages\DTO\MessagePart( $message ),
+				)
+			);
+
+			return array_merge( $serialized, ConversationSerializer::serialize( array( $user_turn ) ) );
+		} catch ( \Throwable $e ) {
+			return $serialized;
+		}
+	}
+
+	/**
+	 * Persist enough failed-job state for the chat UI to reload and continue.
+	 *
+	 * Provider and SDK errors often occur after the new user turn has been added
+	 * to AgentLoop history but before a final assistant response exists. Append the
+	 * history delta to the session and save the latest safe state so a refresh or
+	 * retry does not make the user's prompt disappear.
+	 *
+	 * @param int                  $session_id Session ID.
+	 * @param WP_Error             $error      Loop/provider error.
+	 * @param array<string, mixed> $error_data Structured recovery data.
+	 * @param array<string, mixed> $params     Job params.
+	 * @param array<string, mixed> $options    Loop options.
+	 * @param array<string, mixed> $job        Job payload, updated by reference.
+	 */
+	private function persist_error_recovery_to_session(
+		int $session_id,
+		WP_Error $error,
+		array $error_data,
+		array $params,
+		array $options,
+		array &$job
+	): void {
+		$history = $this->normalize_serialized_rows( $error_data['history'] ?? array() );
+		if ( empty( $history ) ) {
+			$history = $this->build_exception_recovery_history( array(), $params );
+		}
+
+		if ( empty( $history ) ) {
+			return;
+		}
+
+		$tool_calls = $this->normalize_serialized_rows( $error_data['tool_calls'] ?? array() );
+		$this->append_history_delta_to_session(
+			$session_id,
+			$history,
+			$tool_calls
+		);
+
+		$message_log = $error_data['messages'] ?? array();
+		$message_log = is_array( $message_log ) ? $message_log : array();
+		$token_usage = $error_data['token_usage'] ?? array();
+		$token_usage = is_array( $token_usage ) ? $token_usage : array();
+
+		$client_abilities = $error_data['client_abilities'] ?? ( $params['client_abilities'] ?? array() );
+		$client_abilities = is_array( $client_abilities ) ? $client_abilities : array();
+
+		$this->database->save_paused_state(
+			$session_id,
+			array(
+				'history'          => array_values( $history ),
+				'tool_call_log'    => array_values( $tool_calls ),
+				'message_log'      => array_values( $message_log ),
+				'token_usage'      => $token_usage,
+				'model_id'         => (string) ( $error_data['model_id']
+					?? $options['model_id']
+					?? $params['model_id']
+					?? '' ),
+				'provider_id'      => (string) ( $error_data['provider_id']
+					?? $options['provider_id']
+					?? $params['provider_id']
+					?? '' ),
+				'client_abilities' => $client_abilities,
+				'exit_reason'      => (string) $error->get_error_code(),
+			)
+		);
+
+		$job['session_id']  = $session_id;
+		$job['recoverable'] = true;
+	}
+
+	/**
+	 * Normalize a mixed serialized payload into a list of string-keyed rows.
+	 *
+	 * @param mixed $value Serialized rows candidate.
+	 * @return list<array<string, mixed>>
+	 */
+	private function normalize_serialized_rows( mixed $value ): array {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$rows = array();
+		foreach ( $value as $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+
+			$row = array();
+			foreach ( $item as $key => $entry ) {
+				if ( is_string( $key ) ) {
+					$row[ $key ] = $entry;
+				}
+			}
+
+			$rows[] = $row;
+		}
+
+		return $rows;
+	}
+
+	/**
+	 * Append only messages that are newer than the currently persisted session.
+	 *
+	 * @param int   $session_id   Session ID.
+	 * @param array $full_history Full serialized loop history.
+	 * @param array $tool_calls   Tool-call log entries.
+	 * @return bool Whether persistence succeeded.
+	 *
+	 * @phpstan-param list<array<string, mixed>> $full_history
+	 * @phpstan-param list<array<string, mixed>> $tool_calls
+	 */
+	private function append_history_delta_to_session(
+		int $session_id,
+		array $full_history,
+		array $tool_calls
+	): bool {
+		$session = $this->database->get_session( $session_id );
+		if ( ! $session ) {
+			return false;
+		}
+
+		$existing_messages = json_decode( (string) $session->messages, true );
+		if ( ! is_array( $existing_messages ) ) {
+			$existing_messages = array();
+		}
+
+		$appended = array_slice( $full_history, count( $existing_messages ) );
+		if ( empty( $appended ) && empty( $tool_calls ) ) {
+			return true;
+		}
+
+		return $this->database->append_to_session( $session_id, array_values( $appended ), $tool_calls );
 	}
 
 	/**
@@ -1554,24 +1748,6 @@ final class SessionController {
 			return new WP_REST_Response( array( 'ok' => false ), 200 );
 		}
 
-		// Send the HTTP response immediately so the calling process (the
-		// non-blocking loopback from /run or /confirm) can close its
-		// connection while PHP continues the job. PHP-FPM exposes
-		// fastcgi_finish_request(); LiteSpeed exposes litespeed_finish_request().
-		// Without a SAPI-specific detach call, some hosts terminate the worker
-		// when the non-blocking client disconnects.
-		if ( function_exists( 'fastcgi_finish_request' ) || function_exists( 'litespeed_finish_request' ) ) {
-			// Send a minimal JSON response before detaching.
-			header( 'Content-Type: application/json' );
-			echo '{"ok":true}';
-
-			if ( function_exists( 'fastcgi_finish_request' ) ) {
-				fastcgi_finish_request();
-			} else {
-				litespeed_finish_request();
-			}
-		}
-
 		/** @var array<string, mixed> $job */
 
 		// Restore the user context — the loopback request has no cookies,
@@ -1812,6 +1988,34 @@ final class SessionController {
 				'trace' => $trace_frames,
 			);
 
+			if ( $session_id ) {
+				$recovery_error = new WP_Error(
+					'sd_ai_agent_loop_exception',
+					$e->getMessage(),
+					array(
+						'history'     => $this->build_exception_recovery_history( array_values( $history ), $params ),
+						'tool_calls'  => is_array( $job['tool_calls'] ?? null )
+							? $job['tool_calls']
+							: array(),
+						'messages'    => is_array( $job['messages'] ?? null )
+							? $job['messages']
+							: array(),
+						'token_usage' => array(
+							'prompt'     => 0,
+							'completion' => 0,
+						),
+					)
+				);
+				$this->persist_error_recovery_to_session(
+					$session_id,
+					$recovery_error,
+					(array) $recovery_error->get_error_data(),
+					$params,
+					$options,
+					$job
+				);
+			}
+
 			unset( $job['token'] );
 			set_transient( RestController::JOB_PREFIX . $job_id, $job, RestController::JOB_TTL );
 
@@ -1828,6 +2032,16 @@ final class SessionController {
 			if ( is_array( $error_data ) ) {
 				$job['tool_calls'] = $error_data['tool_calls'] ?? ( $job['tool_calls'] ?? array() );
 				$job['messages']   = $error_data['messages'] ?? ( $job['messages'] ?? array() );
+				if ( $session_id ) {
+					$this->persist_error_recovery_to_session(
+						$session_id,
+						$result,
+						$error_data,
+						$params,
+						$options,
+						$job
+					);
+				}
 			}
 
 			// Log webhook execution failure.
@@ -2034,7 +2248,11 @@ final class SessionController {
 		// @phpstan-ignore-next-line -- status is set above in all paths (error or complete).
 		$db_status = (string) $job['status'];
 		if ( 'error' === $db_status ) {
-			ActiveJobRepository::update_status( $job_id, 'error', [ 'error' => (string) ( $job['error'] ?? '' ) ] );
+			$error_extra = [ 'error' => (string) ( $job['error'] ?? '' ) ];
+			if ( ! empty( $job['tool_calls'] ) && is_array( $job['tool_calls'] ) ) {
+				$error_extra['tool_calls'] = wp_json_encode( $job['tool_calls'] );
+			}
+			ActiveJobRepository::update_status( $job_id, 'error', $error_extra );
 		} elseif ( 'complete' === $db_status ) {
 			/** @var array<string, mixed> $complete_result */
 			$complete_result = $job['result'] ?? array();

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -810,6 +810,39 @@ class AgentLoopTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A crashed checkpoint ending in a model turn must not be sent back to the provider.
+	 */
+	public function test_resume_from_checkpoint_rejects_model_ended_history_before_provider_call(): void {
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			$this->markTestSkipped( 'wp_ai_client_prompt() is not available.' );
+		}
+		if ( ! class_exists( 'WordPress\AiClient\Messages\DTO\UserMessage' ) ) {
+			$this->markTestSkipped( 'AI Client SDK message classes are not available.' );
+		}
+
+		$history = [
+			new \WordPress\AiClient\Messages\DTO\UserMessage(
+				[ new \WordPress\AiClient\Messages\DTO\MessagePart( 'Build the page.' ) ]
+			),
+			new \WordPress\AiClient\Messages\DTO\ModelMessage(
+				[ new \WordPress\AiClient\Messages\DTO\MessagePart( 'I found the theme details.' ) ]
+			),
+		];
+
+		$loop   = new AgentLoop( '', [], $history );
+		$result = $loop->resume_from_checkpoint( 1 );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_history_needs_user_turn', $result->get_error_code() );
+
+		$data = $result->get_error_data();
+		$this->assertIsArray( $data );
+		$this->assertTrue( $data['recoverable'] );
+		$this->assertCount( 2, $data['history'] );
+		$this->assertSame( 'model', $data['history'][1]['role'] );
+	}
+
+	/**
 	 * Test run() returns WP_Error with 401 Unauthorized response.
 	 */
 	public function test_run_returns_wp_error_on_unauthorized(): void {

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -1020,6 +1020,81 @@ class RestControllerTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test failed agent jobs persist the current user turn for recovery.
+	 */
+	public function test_error_recovery_persists_failed_turn_to_session(): void {
+		if ( ! class_exists( 'WordPress\AiClient\Messages\DTO\UserMessage' ) ) {
+			$this->markTestSkipped( 'AI Client SDK message classes are not available.' );
+		}
+
+		wp_set_current_user( $this->admin_id );
+
+		$session_id = Database::create_session( [
+			'user_id' => $this->admin_id,
+			'title'   => 'Recover failed turn',
+		] );
+
+		$existing = \SdAiAgent\Core\ConversationSerializer::serialize(
+			[
+				new \WordPress\AiClient\Messages\DTO\UserMessage(
+					[ new \WordPress\AiClient\Messages\DTO\MessagePart( 'Start the site.' ) ]
+				),
+				new \WordPress\AiClient\Messages\DTO\ModelMessage(
+					[ new \WordPress\AiClient\Messages\DTO\MessagePart( 'I checked the site.' ) ]
+				),
+			]
+		);
+		Database::append_to_session( $session_id, $existing );
+
+		$failed_turn = \SdAiAgent\Core\ConversationSerializer::serialize(
+			[
+				new \WordPress\AiClient\Messages\DTO\UserMessage(
+					[ new \WordPress\AiClient\Messages\DTO\MessagePart( 'Please continue after the error.' ) ]
+				),
+			]
+		);
+		$history     = array_merge( $existing, $failed_turn );
+		$error       = new \WP_Error(
+			'prompt_invalid_argument',
+			'The last message must be from a user role, not from model',
+			[
+				'history'          => $history,
+				'tool_calls'       => [ [ 'type' => 'call', 'id' => 'call_1', 'name' => 'wpab__sd-ai-agent__site-info' ] ],
+				'messages'         => [ [ 'type' => 'provider_error', 'message' => 'Provider rejected history.' ] ],
+				'token_usage'      => [ 'prompt' => 12, 'completion' => 0 ],
+				'model_id'         => 'superdav-chat-pro',
+				'provider_id'      => 'sd-ai-agent-cloud',
+				'client_abilities' => [],
+			]
+		);
+
+		$controller = new \SdAiAgent\REST\SessionController( new Database() );
+		$method     = new \ReflectionMethod( \SdAiAgent\REST\SessionController::class, 'persist_error_recovery_to_session' );
+		$method->setAccessible( true );
+
+		$params     = [ 'message' => 'Please continue after the error.', 'session_id' => $session_id ];
+		$options    = [ 'provider_id' => 'sd-ai-agent-cloud', 'model_id' => 'superdav-chat-pro' ];
+		$job        = [ 'status' => 'error', 'error' => $error->get_error_message(), 'params' => $params ];
+		$error_data = $error->get_error_data();
+		$this->assertIsArray( $error_data );
+
+		$method->invokeArgs( $controller, [ $session_id, $error, $error_data, $params, $options, &$job ] );
+
+		$session  = Database::get_session( $session_id );
+		$messages = json_decode( (string) $session->messages, true );
+		$paused   = json_decode( (string) $session->paused_state, true );
+
+		$this->assertCount( 3, $messages );
+		$this->assertSame( 'user', $messages[2]['role'] );
+		$this->assertStringContainsString( 'Please continue', wp_json_encode( $messages[2] ) );
+		$this->assertIsArray( $paused );
+		$this->assertSame( 'prompt_invalid_argument', $paused['exit_reason'] );
+		$this->assertCount( 3, $paused['history'] );
+		$this->assertSame( $session_id, $job['session_id'] );
+		$this->assertTrue( $job['recoverable'] );
+	}
+
+	/**
 	 * Test GET /job/{id} requires authentication.
 	 */
 	public function test_job_status_requires_auth(): void {


### PR DESCRIPTION
## Summary
- Prevent resumed agent checkpoints from sending histories that end with an assistant/model turn back to the provider.
- Preserve failed job recovery state by appending the failed user turn, tool log, message log, and paused state to the session.
- Return `session_id`/`recoverable` metadata from failed job polling so the chat UI can reload and continue.
- Remove direct `header()`/`echo` response output from `/process` to avoid header warnings in loopback execution.
- Add regressions for model-ended checkpoint recovery and failed-turn session persistence.

## Worker self-verification
- PHPUnit: Tests: 3671, Assertions: 15302, Errors: 0, Failures: 0, Skipped: 120, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Additional checks:
- Bundle size check: passed
- `git diff --check`: passed

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.36 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when a conversation can’t continue, so users are prompted to send a new message instead of hitting a dead end.
  * Added better error details for failed background jobs, including recovery state and session context when available.
  * Preserved more conversation state after processing failures, helping paused sessions resume more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->