### PR TITLE
fix: enforce tool permission defaults

### DIFF
--- a/includes/Abilities/ImageAbilities/StockImageAbility.php
+++ b/includes/Abilities/ImageAbilities/StockImageAbility.php
@@ -173,6 +173,20 @@ class StockImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 	/**
 	 * {@inheritdoc}
 	 */
+	protected function meta(): array {
+		$meta                = parent::meta();
+		$meta['annotations'] = [
+			'readonly'    => false,
+			'destructive' => false,
+			'idempotent'  => false,
+		];
+
+		return $meta;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
 	protected function permission_callback( mixed $input = null ): bool {
 		// Dual gate: per-tool cap (sd_ai_agent_tool_stock_image) AND core cap
 		// (`upload_files`) from CORE_CAP_MAP. On multisite with an explicit

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -644,12 +644,14 @@ class AgentLoop {
 				// The last message in history is the model's tool call message.
 				$assistant_message     = end( $this->history );
 				$this->last_loop_phase = 'executing_confirmed_abilities';
+				ToolPermissionResolver::set_one_turn_approved_abilities( $this->approved_once_abilities );
 				ChangeLogger::begin( $this->session_id, 'confirmed-tool' );
 				try {
 					$response_message = $this->get_ability_resolver()->execute_abilities( $assistant_message );
 					/** @var \WordPress\AiClient\Messages\DTO\Message $response_message */
 				} finally {
 					ChangeLogger::end();
+					ToolPermissionResolver::clear_one_turn_approved_abilities();
 				}
 				$this->last_loop_phase = 'confirmed_ability_response_received';
 				// Truncate then split for OpenAI-compatible providers.

--- a/includes/Core/ToolPermissionResolver.php
+++ b/includes/Core/ToolPermissionResolver.php
@@ -18,6 +18,13 @@ use WordPress\AiClient\Messages\DTO\Message;
 class ToolPermissionResolver {
 
 	/**
+	 * Ability IDs approved for exactly this confirmed tool-resume request.
+	 *
+	 * @var array<string, true>
+	 */
+	private static array $one_turn_approved_abilities = array();
+
+	/**
 	 * @param bool                     $yolo_mode        When true, skip all confirmations.
 	 * @param array<int|string, mixed> $tool_permissions Tool permission levels from settings.
 	 */
@@ -31,10 +38,16 @@ class ToolPermissionResolver {
 	 *
 	 * Permission resolution order (first match wins):
 	 * 1. YOLO mode → skip all confirmations.
-	 * 2. Explicit tool_permissions setting ('auto'|'confirm'|'disabled'|'always_allow') → use it.
+	 * 2. Explicit tool_permissions setting:
+	 *    - confirm → require confirmation.
+	 *    - always_allow/disabled → do not pause here (disabled is enforced before execution).
+	 *    - auto or unset → continue to the default annotation policy.
 	 * 3. Annotation-based classification:
-	 *    - readonly=true  → auto-execute (read-only, safe).
-	 *    - readonly=false or null → require confirmation (write operation).
+	 *    - readonly=true      → auto-execute (read-only, safe).
+	 *    - destructive=false  → auto-execute (non-destructive write).
+	 *    - destructive=true or unknown → require confirmation.
+	 * 4. For sd-ai-agent/ability-call, classify the nested target ability so the
+	 *    meta-tool cannot bypass a target tool's confirmation policy.
 	 *
 	 * @param Message $message The assistant's tool-call message.
 	 * @return list<array<string, mixed>> Array of tool details needing confirmation (empty if none).
@@ -70,47 +83,16 @@ class ToolPermissionResolver {
 				$ability_name = \WP_AI_Client_Ability_Function_Resolver::function_name_to_ability_name( $fn_name );
 			}
 
-			// 1. Check explicit tool_permissions setting first.
-			if ( ! empty( $this->tool_permissions ) ) {
-				$permission = $this->tool_permissions[ $ability_name ] ?? null;
+			$args                    = self::normalize_function_call_args( $call->getArgs() );
+			$confirmation_ability_id = self::get_confirmation_ability_id( $ability_name, $args, $all_abilities );
+			$ability                 = $all_abilities[ $confirmation_ability_id ] ?? null;
+			$ability                 = $ability instanceof \WP_Ability ? $ability : null;
 
-				if ( null !== $permission ) {
-					// Explicit permission set for this tool.
-					if ( 'confirm' === $permission ) {
-						$confirm[] = array(
-							'id'      => $call->getId(),
-							'name'    => $fn_name,
-							'ability' => $ability_name,
-							'args'    => $call->getArgs(),
-						);
-					}
-					// 'auto', 'always_allow', 'disabled' → no confirmation needed.
-					continue;
-				}
-			}
-
-			// 2. No explicit permission — use annotation-based classification.
-			$ability = $all_abilities[ $ability_name ] ?? null;
-
-			if ( null !== $ability ) {
-				$classification = self::classify_ability( $ability );
-
-				if ( 'destructive' === $classification ) {
-					$confirm[] = array(
-						'id'      => $call->getId(),
-						'name'    => $fn_name,
-						'ability' => $ability_name,
-						'args'    => $call->getArgs(),
-					);
-				}
-				// 'read' and 'write' → auto-execute.
-			} else {
-				// Ability not found in registry (e.g. custom tool) — default
-				// to requiring confirmation for safety.
+			if ( self::ability_needs_confirmation( $confirmation_ability_id, $ability, $this->tool_permissions ) ) {
 				$confirm[] = array(
 					'id'      => $call->getId(),
 					'name'    => $fn_name,
-					'ability' => $ability_name,
+					'ability' => $confirmation_ability_id,
 					'args'    => $call->getArgs(),
 				);
 			}
@@ -156,6 +138,60 @@ class ToolPermissionResolver {
 	}
 
 	/**
+	 * Whether an ability should pause for user confirmation.
+	 *
+	 * @param string                   $ability_name     Ability ID.
+	 * @param \WP_Ability|null         $ability          Registered ability, if known.
+	 * @param array<int|string, mixed> $tool_permissions Per-tool permission map.
+	 */
+	public static function ability_needs_confirmation( string $ability_name, ?\WP_Ability $ability, array $tool_permissions ): bool {
+		$permission = $tool_permissions[ $ability_name ] ?? null;
+
+		if ( 'confirm' === $permission ) {
+			return true;
+		}
+
+		if ( 'always_allow' === $permission || 'disabled' === $permission ) {
+			return false;
+		}
+
+		if ( ! $ability instanceof \WP_Ability ) {
+			return true;
+		}
+
+		return 'destructive' === self::classify_ability( $ability );
+	}
+
+	/**
+	 * Store one-turn approvals for the current confirmed resume request.
+	 *
+	 * @param array<int, mixed> $ability_names Ability IDs.
+	 */
+	public static function set_one_turn_approved_abilities( array $ability_names ): void {
+		self::$one_turn_approved_abilities = array();
+
+		foreach ( $ability_names as $ability_name ) {
+			if ( is_string( $ability_name ) && '' !== $ability_name ) {
+				self::$one_turn_approved_abilities[ $ability_name ] = true;
+			}
+		}
+	}
+
+	/**
+	 * Clear request-scoped one-turn approvals.
+	 */
+	public static function clear_one_turn_approved_abilities(): void {
+		self::$one_turn_approved_abilities = array();
+	}
+
+	/**
+	 * Whether an ability was approved for this confirmed resume request.
+	 */
+	public static function is_one_turn_approved( string $ability_name ): bool {
+		return isset( self::$one_turn_approved_abilities[ $ability_name ] );
+	}
+
+	/**
 	 * Persist an "always allow" permission for a specific ability.
 	 *
 	 * @param string $ability_name The ability name (e.g. 'sd-ai-agent/memory-save').
@@ -190,5 +226,75 @@ class ToolPermissionResolver {
 		}
 
 		return $always;
+	}
+
+	/**
+	 * Return the ability ID whose policy should govern a tool call.
+	 *
+	 * For direct tools this is the tool itself. For sd-ai-agent/ability-call it is
+	 * the nested registered target ability, when present, so the meta-tool cannot
+	 * bypass the target's confirmation policy.
+	 *
+	 * @param string                         $ability_name  Direct ability ID.
+	 * @param array<string, mixed>           $args          Normalized tool-call args.
+	 * @param array<int|string, \WP_Ability> $all_abilities Registered abilities.
+	 */
+	private static function get_confirmation_ability_id( string $ability_name, array $args, array $all_abilities ): string {
+		if ( 'sd-ai-agent/ability-call' !== $ability_name ) {
+			return $ability_name;
+		}
+
+		$target = isset( $args['ability'] ) && is_string( $args['ability'] ) ? trim( $args['ability'] ) : '';
+		if ( '' === $target ) {
+			return $ability_name;
+		}
+
+		if ( class_exists( \SdAiAgent\Tools\ToolDiscovery::class ) ) {
+			$target = \SdAiAgent\Tools\ToolDiscovery::canonicalise_ability_id( $target );
+		}
+
+		return isset( $all_abilities[ $target ] ) ? $target : $ability_name;
+	}
+
+	/**
+	 * Normalize function-call args to a string-keyed array.
+	 *
+	 * @param mixed $args Raw function-call arguments.
+	 * @return array<string, mixed>
+	 */
+	private static function normalize_function_call_args( $args ): array {
+		if ( is_string( $args ) && '' !== $args ) {
+			$decoded = json_decode( $args, true );
+			return is_array( $decoded ) ? self::string_keyed_array( $decoded ) : array();
+		}
+
+		if ( is_array( $args ) ) {
+			return self::string_keyed_array( $args );
+		}
+
+		if ( is_object( $args ) ) {
+			$encoded = wp_json_encode( $args );
+			$decoded = is_string( $encoded ) ? json_decode( $encoded, true ) : null;
+			return is_array( $decoded ) ? self::string_keyed_array( $decoded ) : array();
+		}
+
+		return array();
+	}
+
+	/**
+	 * Keep only string-keyed values from a decoded JSON object.
+	 *
+	 * @param array<mixed> $value Decoded function-call args.
+	 * @return array<string, mixed>
+	 */
+	private static function string_keyed_array( array $value ): array {
+		$result = array();
+		foreach ( $value as $key => $item ) {
+			if ( is_string( $key ) ) {
+				$result[ $key ] = $item;
+			}
+		}
+
+		return $result;
 	}
 }

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -1316,11 +1316,14 @@ final class SessionController {
 		}
 
 		// "Always allow" — persist permission so this tool auto-executes in future.
+		// For sd-ai-agent/ability-call confirmations, `ability` is the nested
+		// target ability whose policy triggered the pause; `name` remains the
+		// executable meta-tool function name so the confirmed resume can run.
 		if ( $request->get_param( 'always_allow' ) && ! empty( $job['pending_tools'] ) ) {
 			// @phpstan-ignore-next-line
 			foreach ( $job['pending_tools'] as $tool ) {
 				/** @var array<string, mixed> $tool */
-				$tool_name = (string) ( $tool['name'] ?? '' );
+				$tool_name = (string) ( $tool['ability'] ?? ( $tool['name'] ?? '' ) );
 				// Convert function name (wpab__...) to ability name for storage.
 				if ( str_starts_with( $tool_name, 'wpab__' ) && class_exists( 'WP_AI_Client_Ability_Function_Resolver' ) ) {
 					$tool_name = \WP_AI_Client_Ability_Function_Resolver::function_name_to_ability_name( $tool_name );

--- a/includes/Tools/ToolDiscovery.php
+++ b/includes/Tools/ToolDiscovery.php
@@ -36,7 +36,9 @@ namespace SdAiAgent\Tools;
 use SdAiAgent\Abilities\Js\JsAbilityCatalog;
 use SdAiAgent\Core\AbilityRegistry;
 use SdAiAgent\Core\AbilityVisibility;
+use SdAiAgent\Core\RolePermissions;
 use SdAiAgent\Core\Settings;
+use SdAiAgent\Core\ToolPermissionResolver;
 use WP_Error;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -430,6 +432,10 @@ class ToolDiscovery {
 			}
 
 			if ( 'disabled' === ( $perms[ $name ] ?? 'auto' ) ) {
+				continue;
+			}
+
+			if ( ! RolePermissions::current_user_can_use_ability( $name ) ) {
 				continue;
 			}
 
@@ -894,6 +900,33 @@ class ToolDiscovery {
 			);
 		}
 
+		if ( ! RolePermissions::current_user_can_use_ability( $ability_id ) ) {
+			return new WP_Error(
+				'ability_forbidden',
+				sprintf(
+					/* translators: %s: ability id */
+					__( 'Your role is not allowed to use ability "%s".', 'superdav-ai-agent' ),
+					$ability_id
+				),
+				array( 'status' => 403 )
+			);
+		}
+
+		if (
+			ToolPermissionResolver::ability_needs_confirmation( $ability_id, $ability, $perms )
+			&& ! ToolPermissionResolver::is_one_turn_approved( $ability_id )
+		) {
+			return new WP_Error(
+				'ability_requires_confirmation',
+				sprintf(
+					/* translators: %s: ability id */
+					__( 'Ability "%s" requires user confirmation before it can run through sd-ai-agent/ability-call.', 'superdav-ai-agent' ),
+					$ability_id
+				),
+				array( 'status' => 403 )
+			);
+		}
+
 		// Normalize the arguments to a plain PHP associative array.
 		//
 		// Three cases handled:
@@ -1204,6 +1237,9 @@ class ToolDiscovery {
 				continue;
 			}
 			if ( 'disabled' === ( $perms[ $ability->get_name() ] ?? 'auto' ) ) {
+				continue;
+			}
+			if ( ! RolePermissions::current_user_can_use_ability( $ability->get_name() ) ) {
 				continue;
 			}
 			$out[] = $ability;

--- a/tests/SdAiAgent/Abilities/StockImageAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/StockImageAbilityTest.php
@@ -21,6 +21,7 @@ namespace SdAiAgent\Tests\Abilities;
 use SdAiAgent\Abilities\ImageAbilities\StockImageAbility;
 use SdAiAgent\Abilities\ImageSources\ImageSourceFactory;
 use SdAiAgent\Abilities\ImageSources\ImageSourceInterface;
+use SdAiAgent\Core\ToolPermissionResolver;
 use WP_Error;
 use WP_UnitTestCase;
 
@@ -100,6 +101,19 @@ class StockImageAbilityTest extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'required', $schema );
 		$this->assertNotContains( 'keyword', $schema['required'] );
+	}
+
+	/**
+	 * Stock-image imports are safe writes, not destructive operations, so the
+	 * default tool policy should not pause for user confirmation.
+	 */
+	public function test_stock_image_is_non_destructive_for_default_tool_policy(): void {
+		$meta = $this->ability->get_meta();
+
+		$this->assertIsArray( $meta['annotations'] ?? null );
+		$this->assertFalse( $meta['annotations']['readonly'] );
+		$this->assertFalse( $meta['annotations']['destructive'] );
+		$this->assertSame( 'write', ToolPermissionResolver::classify_ability( $this->ability ) );
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -2573,6 +2573,42 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertSame( 'destructive', ToolPermissionResolver::classify_ability( $ability ) );
 	}
 
+	/**
+	 * Explicit stored "auto" means use the default annotation policy, not force
+	 * execution without confirmation.
+	 */
+	public function test_auto_permission_uses_default_destructive_policy(): void {
+		if ( ! class_exists( 'WP_Ability' ) ) {
+			$this->markTestSkipped( 'WP_Ability not available.' );
+		}
+
+		$ability = new \WP_Ability(
+			'test/auto-default-destructive',
+			[
+				'label'               => 'Auto Default Destructive',
+				'description'         => 'A destructive ability with an explicit auto setting.',
+				'category'            => 'sd-ai-agent',
+				'execute_callback'    => '__return_true',
+				'permission_callback' => '__return_true',
+				'meta'                => [
+					'annotations' => [
+						'readonly'    => false,
+						'destructive' => true,
+						'idempotent'  => false,
+					],
+				],
+			]
+		);
+
+		$this->assertTrue(
+			ToolPermissionResolver::ability_needs_confirmation(
+				'test/auto-default-destructive',
+				$ability,
+				[ 'test/auto-default-destructive' => 'auto' ]
+			)
+		);
+	}
+
 	// -------------------------------------------------------------------------
 	// Always-allow persistence
 	// -------------------------------------------------------------------------
@@ -2688,6 +2724,84 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'awaiting_confirmation', $result );
 		$this->assertTrue( $result['awaiting_confirmation'] );
+	}
+
+	/**
+	 * sd-ai-agent/ability-call must inherit the nested target ability's
+	 * confirmation policy instead of auto-executing the meta-tool wrapper.
+	 */
+	public function test_ability_call_target_requires_confirmation_by_default(): void {
+		$this->skip_if_sdk_unavailable();
+		if ( ! class_exists( 'WP_AI_Client_Ability_Function_Resolver' ) ) {
+			$this->markTestSkipped( 'WP_AI_Client_Ability_Function_Resolver not available.' );
+		}
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			$this->markTestSkipped( 'wp_register_ability() not available.' );
+		}
+
+		delete_option( Settings::OPTION_NAME );
+
+		$target = 'sd-ai-agent/test-ability-call-destructive-target';
+
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Standard WordPress hook stack global.
+		global $wp_current_filter;
+		$wp_current_filter[] = 'wp_abilities_api_init';
+
+		try {
+			wp_register_ability(
+				$target,
+				[
+					'label'               => 'Test Ability Call Destructive Target',
+					'description'         => 'A destructive target called through ability-call.',
+					'category'            => 'sd-ai-agent',
+					'execute_callback'    => '__return_true',
+					'permission_callback' => '__return_true',
+					'meta'                => [
+						'annotations' => [
+							'readonly'    => false,
+							'destructive' => true,
+							'idempotent'  => false,
+						],
+					],
+				]
+			);
+		} finally {
+			array_pop( $wp_current_filter );
+		}
+
+		try {
+			$this->mock_ai_response(
+				'',
+				[
+					[
+						'id'       => 'call_ability_call_target',
+						'type'     => 'function',
+						'function' => [
+							'name'      => 'wpab__sd-ai-agent__ability-call',
+							'arguments' => wp_json_encode(
+								[
+									'ability'   => $target,
+									'arguments' => [],
+								]
+							),
+						],
+					],
+				]
+			);
+
+			$loop   = new AgentLoop( 'Call a destructive target through ability-call' );
+			$result = $loop->run();
+
+			$this->assertIsArray( $result );
+			$this->assertArrayHasKey( 'awaiting_confirmation', $result );
+			$this->assertTrue( $result['awaiting_confirmation'] );
+			$this->assertSame( $target, $result['pending_tools'][0]['ability'] ?? '' );
+			$this->assertSame( 'wpab__sd-ai-agent__ability-call', $result['pending_tools'][0]['name'] ?? '' );
+		} finally {
+			if ( function_exists( 'wp_unregister_ability' ) ) {
+				wp_unregister_ability( $target );
+			}
+		}
 	}
 
 	/**

--- a/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
+++ b/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
@@ -10,6 +10,7 @@
 namespace SdAiAgent\Tests\Tools;
 
 use SdAiAgent\Core\IdenticalFailureTracker;
+use SdAiAgent\Core\RolePermissions;
 use SdAiAgent\Tools\AbilityUsageTracker;
 use SdAiAgent\Tools\ToolDiscovery;
 use WP_UnitTestCase;
@@ -73,6 +74,7 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 		ToolDiscovery::reset_schema_cache();
 		ToolDiscovery::reset_keyword_search_state();
 		IdenticalFailureTracker::reset();
+		delete_option( RolePermissions::OPTION_NAME );
 	}
 
 	/**
@@ -518,6 +520,107 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'invalid_ability_arguments', $result->get_error_code() );
+	}
+
+	public function test_ability_call_rejects_role_restricted_target(): void {
+		$executed = false;
+		$target   = 'sd-ai-agent/role-restricted-tool';
+
+		$this->register_test_ability(
+			$target,
+			[
+				'label'               => 'Role Restricted Tool',
+				'description'         => 'Role restricted execution target.',
+				'category'            => 'sd-ai-agent',
+				'input_schema'        => [ 'type' => 'object' ],
+				'output_schema'       => [ 'type' => 'object' ],
+				'execute_callback'    => static function () use ( &$executed ): array {
+					$executed = true;
+					return [ 'ok' => true ];
+				},
+				'permission_callback' => '__return_true',
+				'meta'                => [
+					'annotations' => [
+						'readonly'    => false,
+						'destructive' => false,
+					],
+				],
+			]
+		);
+
+		update_option(
+			RolePermissions::OPTION_NAME,
+			[
+				'author' => [
+					'chat_access'       => true,
+					'allowed_abilities' => [ 'sd-ai-agent/get-plugins' ],
+				],
+			]
+		);
+		$author_id = self::factory()->user->create( [ 'role' => 'author' ] );
+		wp_set_current_user( $author_id );
+
+		$result = ToolDiscovery::handle_ability_call(
+			[
+				'ability'   => $target,
+				'arguments' => [],
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ability_forbidden', $result->get_error_code() );
+		$this->assertFalse( $executed );
+	}
+
+	public function test_ability_search_hides_role_restricted_targets(): void {
+		$target = 'sd-ai-agent/hidden-role-search-tool';
+
+		$this->register_test_ability(
+			$target,
+			[
+				'label'               => 'Hidden Role Search Tool',
+				'description'         => 'needle-role-hidden-search unique marker.',
+				'category'            => 'sd-ai-agent',
+				'input_schema'        => [ 'type' => 'object' ],
+				'output_schema'       => [ 'type' => 'object' ],
+				'execute_callback'    => '__return_true',
+				'permission_callback' => '__return_true',
+				'meta'                => [
+					'annotations' => [
+						'readonly'    => false,
+						'destructive' => false,
+					],
+				],
+			]
+		);
+
+		update_option(
+			RolePermissions::OPTION_NAME,
+			[
+				'author' => [
+					'chat_access'       => true,
+					'allowed_abilities' => [ 'sd-ai-agent/get-plugins' ],
+				],
+			]
+		);
+		$author_id = self::factory()->user->create( [ 'role' => 'author' ] );
+		wp_set_current_user( $author_id );
+
+		$result = ToolDiscovery::handle_ability_search(
+			[
+				'query'       => 'needle-role-hidden-search',
+				'max_results' => 10,
+			]
+		);
+
+		$ids = array_map(
+			static function ( array $row ): string {
+				return (string) $row['id'];
+			},
+			$result['results'] ?? []
+		);
+
+		$this->assertNotContains( $target, $ids );
 	}
 
 	// ── manifest ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Treat explicit `auto` tool permissions as the default annotation policy instead of force-allowing execution.
- Mark `sd-ai-agent/stock-image` as a safe, non-destructive write so default policy can run it without confirmation.
- Enforce nested target permissions for `sd-ai-agent/ability-call`, including confirmation, disabled/role restrictions, one-turn approvals, and persisting "always allow" on the target ability.
- Hide role-restricted abilities from ability discovery/search surfaces.

## Worker self-verification
- PHPUnit: Tests: 3674, Assertions: 15296, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

## Commands run
- `git diff --check`
- `php -l` on changed PHP files
- `composer phpcs`
- `composer phpstan`
- `npm run test:php -- --filter='AgentLoopTest|ToolDiscoveryTest|StockImageAbilityTest'`
- `npm run test:php`
- `npm run lint:php`
- `npm run lint:js`
- `npm run lint:css`
- `npm run build`

## Notes
- Full PHPUnit passed with existing deprecation noise for `mb_convert_encoding()` in `includes/Abilities/SeoAbilities.php`.
- `npm run build` succeeded with existing webpack asset-size warnings for `admin-page` assets.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.36 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5
