### PR TITLE
GH#2156: fix: render calendar SMS contact mappings

### DIFF
--- a/src/settings-page/__tests__/calendar-sms-manager.test.js
+++ b/src/settings-page/__tests__/calendar-sms-manager.test.js
@@ -22,15 +22,17 @@ const routeResponses = {
 		api_base_url: 'https://api.textbee.dev',
 		device_id_redacted: '********1234',
 	},
-	'/sd-ai-agent/v1/settings/contact-mappings': [
-		{
-			id: 7,
-			attendee_email: 'attendee@example.com',
-			phone_e164: '+15551234567',
-			sms_consent: true,
-			display_name: 'Attendee Example',
-		},
-	],
+	'/sd-ai-agent/v1/settings/contact-mappings': {
+		contacts: [
+			{
+				id: 7,
+				attendee_email: 'attendee@example.com',
+				phone_e164: '+15551234567',
+				sms_consent: true,
+				display_name: 'Attendee Example',
+			},
+		],
+	},
 	'/sd-ai-agent/v1/automations': [
 		{
 			id: 11,

--- a/src/settings-page/calendar-sms-manager.js
+++ b/src/settings-page/calendar-sms-manager.js
@@ -33,6 +33,14 @@ const statusLabel = ( configured ) =>
 		? __( 'Configured', 'superdav-ai-agent' )
 		: __( 'Needs setup', 'superdav-ai-agent' );
 
+const normalizeContactMappings = ( mappingRows ) => {
+	if ( Array.isArray( mappingRows?.contacts ) ) {
+		return mappingRows.contacts;
+	}
+
+	return Array.isArray( mappingRows ) ? mappingRows : [];
+};
+
 /**
  * Calendar SMS reminder setup surface.
  *
@@ -120,7 +128,7 @@ export default function CalendarSmsManager() {
 
 			setCalendarStatus( calendar );
 			setSmsStatus( sms );
-			setContacts( Array.isArray( mappingRows ) ? mappingRows : [] );
+			setContacts( normalizeContactMappings( mappingRows ) );
 			setAutomations(
 				Array.isArray( automationRows ) ? automationRows : []
 			);


### PR DESCRIPTION
## Summary

Normalized Calendar SMS contact mapping REST responses so the settings UI reads the deployed { contacts: [...] } shape while retaining raw-array fallback, and updated the unit test mock to cover the real response shape.

## Files Changed

src/settings-page/__tests__/calendar-sms-manager.test.js,src/settings-page/calendar-sms-manager.js

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run test:js -- --runInBand src/settings-page/__tests__/calendar-sms-manager.test.js; npm run lint:js; npm run build; npm run verify (PHPUnit: Tests: 3680, Assertions: 15355, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4; PHPStan: 0 errors; bundle check passed)

Resolves #2156


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 9m and 57,244 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar SMS settings to handle contact-mapping responses in the expected format, so contacts load correctly when the data comes back wrapped in a contacts list.
  * Updated the related test coverage to match the revised response shape.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->