### PR TITLE
GH#2157: fix: return setup status for calendar dry run

### DIFF
--- a/includes/Abilities/GoogleCalendarAbilities.php
+++ b/includes/Abilities/GoogleCalendarAbilities.php
@@ -22,8 +22,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class GoogleCalendarAbilities {
 
-	private const TOKEN_URL = 'https://oauth2.googleapis.com/token';
-	private const API_BASE  = 'https://www.googleapis.com/calendar/v3';
+	private const TOKEN_URL             = 'https://oauth2.googleapis.com/token';
+	private const API_BASE              = 'https://www.googleapis.com/calendar/v3';
+	private const SETUP_REQUIRED_STATUS = 412;
 
 	/**
 	 * Register Google Calendar abilities.
@@ -246,7 +247,7 @@ class GoogleCalendarAbilities {
 	private static function get_access_token(): string|WP_Error {
 		$creds = Settings::instance()->get_google_calendar_credentials();
 		if ( empty( $creds ) || empty( $creds['type'] ) ) {
-			return new WP_Error( 'google_calendar_not_configured', __( 'Google Calendar credentials are not configured.', 'superdav-ai-agent' ) );
+			return new WP_Error( 'google_calendar_not_configured', __( 'Google Calendar credentials are not configured.', 'superdav-ai-agent' ), [ 'status' => self::SETUP_REQUIRED_STATUS ] );
 		}
 
 		if ( 'oauth2_refresh_token' !== $creds['type'] ) {

--- a/tests/SdAiAgent/Abilities/CalendarReminderAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/CalendarReminderAbilitiesTest.php
@@ -82,6 +82,17 @@ final class CalendarReminderAbilitiesTest extends WP_UnitTestCase {
 		$this->assertContains( 'sms_consent_missing', array_column( $result['skipped'], 'reason' ) );
 	}
 
+	/** Missing Google Calendar credentials surface setup-required status. */
+	public function test_dry_run_missing_google_calendar_credentials_returns_setup_status(): void {
+		Settings::instance()->set_google_calendar_credentials( [] );
+
+		$result = CalendarReminderAbilities::handle_send_sms_reminders( [ 'approval_mode' => 'dry_run' ] );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'google_calendar_not_configured', $result->get_error_code() );
+		$this->assertSame( 412, $result->get_error_data()['status'] ?? null );
+	}
+
 	/** Approval mode queues a human request and prevents duplicate queueing on retry. */
 	public function test_approval_mode_queues_without_sending_and_prevents_duplicates(): void {
 		$sms_requests = 0;

--- a/tests/SdAiAgent/Abilities/GoogleCalendarAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/GoogleCalendarAbilitiesTest.php
@@ -39,6 +39,7 @@ final class GoogleCalendarAbilitiesTest extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'google_calendar_not_configured', $result->get_error_code() );
+		$this->assertSame( 412, $result->get_error_data()['status'] ?? null );
 	}
 
 	/** Unknown credential types fail closed. */

--- a/tests/SdAiAgent/REST/SettingsControllerTest.php
+++ b/tests/SdAiAgent/REST/SettingsControllerTest.php
@@ -92,6 +92,20 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		$this->assertSame( 400, $response->get_status() );
 	}
 
+	/** Calendar reminder dry-run returns setup status when Google Calendar is not connected. */
+	public function test_calendar_reminders_dry_run_missing_google_calendar_credentials_returns_setup_status(): void {
+		$controller = new SettingsController( new Settings(), new Database() );
+		$request    = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/settings/calendar-reminders/dry-run' );
+		$request->set_body( (string) wp_json_encode( array() ) );
+		$request->set_header( 'Content-Type', 'application/json' );
+
+		$response = $controller->handle_calendar_reminders_dry_run( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'google_calendar_not_configured', $response->get_error_code() );
+		$this->assertSame( 412, $response->get_error_data()['status'] ?? null );
+	}
+
 	/**
 	 * /providers auto-provisions the managed Superdav token before listing providers.
 	 */


### PR DESCRIPTION
## Summary

Added REST status metadata to the Google Calendar not-configured error so Calendar SMS dry-run surfaces a setup-required response instead of REST 500. Added regression coverage for Google Calendar abilities, CalendarReminder dry-run orchestration, and the SettingsController dry-run endpoint.

## Files Changed

includes/Abilities/GoogleCalendarAbilities.php,tests/SdAiAgent/Abilities/CalendarReminderAbilitiesTest.php,tests/SdAiAgent/Abilities/GoogleCalendarAbilitiesTest.php,tests/SdAiAgent/REST/SettingsControllerTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify; npm run test:php -- --filter='GoogleCalendarAbilitiesTest|CalendarReminderAbilitiesTest|SettingsControllerTest'; npm run lint:php

Resolves #2157


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 11m and 117,316 tokens on this as a headless worker.