### PR TITLE
GH#2160: test: cover calendar sms raw-array mappings

### DIFF
--- a/src/settings-page/__tests__/calendar-sms-manager.test.js
+++ b/src/settings-page/__tests__/calendar-sms-manager.test.js
@@ -110,4 +110,45 @@ describe( 'CalendarSmsManager', () => {
 		expect( container.textContent ).toContain( 'attendee@example.com' );
 		expect( container.textContent ).toContain( '2026-06-29 08:05:00' );
 	} );
+
+	test( 'renders legacy raw-array contact mappings', async () => {
+		apiFetch.mockImplementation( ( options ) => {
+			if (
+				options.path === '/sd-ai-agent/v1/settings/contact-mappings'
+			) {
+				return Promise.resolve( [
+					{
+						id: 8,
+						attendee_email: 'legacy@example.com',
+						phone_e164: '+15557654321',
+						sms_consent: true,
+						display_name: 'Legacy Example',
+					},
+				] );
+			}
+
+			if (
+				Object.prototype.hasOwnProperty.call(
+					routeResponses,
+					options.path
+				)
+			) {
+				return Promise.resolve( routeResponses[ options.path ] );
+			}
+
+			return Promise.reject(
+				new Error( `Unexpected path: ${ options.path }` )
+			);
+		} );
+
+		await act( async () => {
+			root.render( createElement( CalendarSmsManager, {} ) );
+		} );
+		await act( async () => {
+			await Promise.resolve();
+		} );
+
+		expect( container.textContent ).toContain( 'legacy@example.com' );
+		expect( container.textContent ).toContain( '+15557654321' );
+	} );
 } );


### PR DESCRIPTION
## Summary

Added a regression test proving CalendarSmsManager still renders legacy raw-array contact mapping responses from `/settings/contact-mappings`.

## Files Changed

- `src/settings-page/__tests__/calendar-sms-manager.test.js`

## Worker self-verification

- PHPUnit: Tests: 3682, Assertions: 15363, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

## Additional verification

- `npm run verify`
- `npm run test:js -- src/settings-page/__tests__/calendar-sms-manager.test.js` — 2 tests passed

Resolves #2160

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 8m and 80,247 tokens on this as a headless worker.
