### PR TITLE
GH#2161: fix: harden calendar SMS reminders

### DIFF
--- a/includes/Abilities/CalendarReminderAbilities.php
+++ b/includes/Abilities/CalendarReminderAbilities.php
@@ -143,12 +143,22 @@ class CalendarReminderAbilities {
 	 * @return array<string, mixed>|WP_Error
 	 */
 	public static function handle_approved_reminder( array $payload, array $request = [] ): array|WP_Error {
-		unset( $request );
 		$contact = ContactMapping::get_by_email( (string) ( $payload['attendee_email'] ?? '' ) );
 		if ( ! is_array( $contact ) || true !== $contact['sms_consent'] ) {
 			$error = new WP_Error( 'calendar_reminder_contact_unavailable', __( 'Consented attendee phone mapping is no longer available.', 'superdav-ai-agent' ), [ 'status' => 409 ] );
 			self::record_failed_from_payload( $payload, $error );
 			return $error;
+		}
+
+		$record_data = self::record_data_from_payload(
+			$payload,
+			[
+				'approval_request_id' => (string) ( $request['id'] ?? $payload['approval_request_id'] ?? '' ),
+				'phone'               => (string) $contact['phone_e164'],
+			]
+		);
+		if ( false === CalendarReminderRecords::claim_for_delivery( $record_data ) ) {
+			return new WP_Error( 'calendar_reminder_already_processed', __( 'Reminder was already processed or claimed.', 'superdav-ai-agent' ), [ 'status' => 409 ] );
 		}
 
 		$result = self::send_sms( (string) $contact['phone_e164'], (string) ( $payload['message'] ?? '' ) );
@@ -158,10 +168,9 @@ class CalendarReminderAbilities {
 		}
 
 		CalendarReminderRecords::record_sent(
-			self::record_data_from_payload(
-				$payload,
+			array_merge(
+				$record_data,
 				[
-					'phone'    => (string) $contact['phone_e164'],
 					'provider' => 'textbee',
 				]
 			)
@@ -274,7 +283,7 @@ class CalendarReminderAbilities {
 			++$processed;
 			$record_data = self::record_data( $calendar_id, $event, $email, $event_start, $date, (string) ( $contact['phone_e164'] ?? '' ) );
 			if ( 'dry_run' === $args['approval_mode'] ) {
-				$result['skipped'][] = self::skip_item( $event, $email, 'dry_run', [ 'message' => $message ] );
+				$result['skipped'][] = self::skip_item( $event, $email, 'dry_run' );
 				continue;
 			}
 
@@ -289,17 +298,22 @@ class CalendarReminderAbilities {
 				continue;
 			}
 
+			if ( false === CalendarReminderRecords::claim_for_delivery( $record_data ) ) {
+				$result['skipped'][] = self::skip_item( $event, $email, 'already_processed' );
+				continue;
+			}
+
 			$sent = self::send_sms( (string) ( $contact['phone_e164'] ?? '' ), $message );
 			if ( is_wp_error( $sent ) ) {
 				CalendarReminderRecords::record_failed(
 					array_merge(
-					$record_data,
-					[
-						'provider'      => 'textbee',
-						'error_message' => $sent->get_error_message(),
-					]
+						$record_data,
+						[
+							'provider'      => 'textbee',
+							'error_message' => $sent->get_error_message(),
+						]
 					)
-					);
+				);
 				$result['failed'][] = self::failure_item( $event, $email, $sent );
 				continue;
 			}
@@ -402,7 +416,16 @@ class CalendarReminderAbilities {
 	private static function safe_text( string $text, int $max_length ): string {
 		$text = wp_strip_all_tags( preg_replace( '/\s+/', ' ', $text ) ?: '' );
 		$text = trim( str_replace( [ "\r", "\n" ], ' ', $text ) );
-		return strlen( $text ) > $max_length ? substr( $text, 0, max( 0, $max_length - 1 ) ) . '…' : $text;
+		if ( strlen( $text ) <= $max_length ) {
+			return $text;
+		}
+
+		$ellipsis = '…';
+		if ( $max_length <= strlen( $ellipsis ) ) {
+			return substr( $text, 0, max( 0, $max_length ) );
+		}
+
+		return substr( $text, 0, max( 0, $max_length - strlen( $ellipsis ) ) ) . $ellipsis;
 	}
 
 	/**

--- a/includes/Abilities/ToolCapabilities.php
+++ b/includes/Abilities/ToolCapabilities.php
@@ -494,7 +494,11 @@ class ToolCapabilities {
 	 * @return string[]
 	 */
 	public static function all_ability_ids(): array {
-		$ids = array_merge( array_keys( self::CORE_CAP_MAP ), self::CORE_CAP_OPTOUT );
+		$ids = array_merge(
+			array_keys( self::CORE_CAP_MAP ),
+			array_keys( self::GOOGLE_CALENDAR_CORE_CAP_MAP ),
+			self::CORE_CAP_OPTOUT
+		);
 		sort( $ids );
 		return array_values( array_unique( $ids ) );
 	}

--- a/includes/Automations/CalendarReminderRecords.php
+++ b/includes/Automations/CalendarReminderRecords.php
@@ -17,6 +17,7 @@ class CalendarReminderRecords {
 	public const STATUS_SENT             = 'sent';
 	public const STATUS_SKIPPED          = 'skipped';
 	public const STATUS_PENDING_APPROVAL = 'pending_approval';
+	public const STATUS_CLAIMED          = 'claimed';
 	public const STATUS_FAILED           = 'failed';
 
 	/**
@@ -95,6 +96,52 @@ class CalendarReminderRecords {
 				'skip_reason'         => sanitize_textarea_field( (string) ( $data['error_message'] ?? $data['skip_reason'] ?? '' ) ),
 			]
 		);
+	}
+
+	/**
+	 * Atomically claim a reminder identity before non-idempotent delivery.
+	 *
+	 * @param array<string, mixed> $data Reminder data.
+	 */
+	public static function claim_for_delivery( array $data ): int|false {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$now                 = current_time( 'mysql', true );
+		$approval_request_id = sanitize_text_field( (string) ( $data['approval_request_id'] ?? '' ) );
+		$record              = self::prepare_record(
+			$data,
+			self::STATUS_CLAIMED,
+			[
+				'approval_request_id' => $approval_request_id,
+			]
+		);
+
+		$previous_suppression = $wpdb->suppress_errors( true );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Custom table write; claim must be durable before SMS delivery.
+		$result = $wpdb->insert( self::table_name(), $record );
+		$wpdb->suppress_errors( $previous_suppression );
+		if ( $result ) {
+			return (int) $wpdb->insert_id;
+		}
+
+		$existing = self::find_by_identity(
+			$record['calendar_id'],
+			$record['event_id'],
+			$record['attendee_email'],
+			$record['reminder_date']
+		);
+
+		if (
+			null !== $existing
+			&& '' !== $approval_request_id
+			&& self::STATUS_PENDING_APPROVAL === $existing['status']
+			&& $approval_request_id === (string) $existing['approval_request_id']
+		) {
+			return self::update_existing_record( (int) $existing['id'], $record, $now );
+		}
+
+		return false;
 	}
 
 	/**
@@ -189,26 +236,8 @@ class CalendarReminderRecords {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 
-		$now           = current_time( 'mysql', true );
-		$reminder_date = self::sanitize_date( (string) ( $data['reminder_date'] ?? $data['event_start_at'] ?? $now ) );
-		$base          = [
-			'calendar_id'         => self::sanitize_identifier( (string) ( $data['calendar_id'] ?? '' ) ),
-			'event_id'            => self::sanitize_identifier( (string) ( $data['event_id'] ?? '' ) ),
-			'event_start_at'      => self::sanitize_datetime( (string) ( $data['event_start_at'] ?? $now ) ),
-			'reminder_date'       => $reminder_date,
-			'attendee_email'      => self::sanitize_email( (string) ( $data['attendee_email'] ?? '' ) ),
-			'phone_hash'          => self::phone_hash_from_data( $data ),
-			'status'              => self::sanitize_status( $status ),
-			'skip_reason'         => '',
-			'provider'            => '',
-			'provider_message_id' => '',
-			'approval_request_id' => '',
-			'sent_at'             => null,
-			'created_at'          => $now,
-			'updated_at'          => $now,
-		];
-
-		$record = array_merge( $base, $fields );
+		$now    = current_time( 'mysql', true );
+		$record = self::prepare_record( $data, $status, $fields );
 
 		$existing = self::find_by_identity(
 			$record['calendar_id'],
@@ -236,6 +265,37 @@ class CalendarReminderRecords {
 		);
 
 		return null === $existing ? false : self::update_existing_record( (int) $existing['id'], $record, $now );
+	}
+
+	/**
+	 * Build a sanitized reminder record for insert/update operations.
+	 *
+	 * @param array<string, mixed> $data   Reminder data.
+	 * @param string               $status Reminder status.
+	 * @param array<string, mixed> $fields Additional fields.
+	 * @return array<string, mixed>
+	 */
+	private static function prepare_record( array $data, string $status, array $fields = [] ): array {
+		$now           = current_time( 'mysql', true );
+		$reminder_date = self::sanitize_date( (string) ( $data['reminder_date'] ?? $data['event_start_at'] ?? $now ) );
+		$base          = [
+			'calendar_id'         => self::sanitize_identifier( (string) ( $data['calendar_id'] ?? '' ) ),
+			'event_id'            => self::sanitize_identifier( (string) ( $data['event_id'] ?? '' ) ),
+			'event_start_at'      => self::sanitize_datetime( (string) ( $data['event_start_at'] ?? $now ) ),
+			'reminder_date'       => $reminder_date,
+			'attendee_email'      => self::sanitize_email( (string) ( $data['attendee_email'] ?? '' ) ),
+			'phone_hash'          => self::phone_hash_from_data( $data ),
+			'status'              => self::sanitize_status( $status ),
+			'skip_reason'         => '',
+			'provider'            => '',
+			'provider_message_id' => '',
+			'approval_request_id' => '',
+			'sent_at'             => null,
+			'created_at'          => $now,
+			'updated_at'          => $now,
+		];
+
+		return array_merge( $base, $fields );
 	}
 
 	/**
@@ -328,7 +388,7 @@ class CalendarReminderRecords {
 	 * Sanitize a supported status.
 	 */
 	private static function sanitize_status( string $status ): string {
-		$allowed = [ self::STATUS_SENT, self::STATUS_SKIPPED, self::STATUS_PENDING_APPROVAL, self::STATUS_FAILED ];
+		$allowed = [ self::STATUS_SENT, self::STATUS_SKIPPED, self::STATUS_PENDING_APPROVAL, self::STATUS_CLAIMED, self::STATUS_FAILED ];
 
 		return in_array( $status, $allowed, true ) ? $status : self::STATUS_FAILED;
 	}

--- a/tests/SdAiAgent/Abilities/CalendarReminderAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/CalendarReminderAbilitiesTest.php
@@ -80,6 +80,9 @@ final class CalendarReminderAbilitiesTest extends WP_UnitTestCase {
 		$this->assertContains( 'event_cancelled', array_column( $result['skipped'], 'reason' ) );
 		$this->assertContains( 'attendee_declined', array_column( $result['skipped'], 'reason' ) );
 		$this->assertContains( 'sms_consent_missing', array_column( $result['skipped'], 'reason' ) );
+		foreach ( $result['skipped'] as $item ) {
+			$this->assertArrayNotHasKey( 'message', $item );
+		}
 	}
 
 	/** Missing Google Calendar credentials surface setup-required status. */
@@ -149,6 +152,16 @@ final class CalendarReminderAbilitiesTest extends WP_UnitTestCase {
 		$record = CalendarReminderRecords::find_by_identity( 'primary', 'evt-accepted', 'accepted@example.com', '2026-07-01' );
 		$this->assertIsArray( $record );
 		$this->assertSame( CalendarReminderRecords::STATUS_SENT, $record['status'] );
+	}
+
+	/** Safe text truncation keeps the returned byte length within the configured limit. */
+	public function test_safe_text_truncation_includes_ellipsis_within_limit(): void {
+		$method = new \ReflectionMethod( CalendarReminderAbilities::class, 'safe_text' );
+		$result = $method->invoke( null, str_repeat( 'A', 20 ), 10 );
+
+		$this->assertIsString( $result );
+		$this->assertLessThanOrEqual( 10, strlen( $result ) );
+		$this->assertStringEndsWith( '…', $result );
 	}
 
 	/** @param int $sms_requests Counter passed by reference. */

--- a/tests/SdAiAgent/Automations/CalendarReminderRecordsTest.php
+++ b/tests/SdAiAgent/Automations/CalendarReminderRecordsTest.php
@@ -109,6 +109,37 @@ class CalendarReminderRecordsTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Delivery claims reserve an unprocessed identity before non-idempotent sends.
+	 */
+	public function test_claim_for_delivery_reserves_identity_once(): void {
+		$first_id  = CalendarReminderRecords::claim_for_delivery( $this->make_reminder() );
+		$second_id = CalendarReminderRecords::claim_for_delivery( $this->make_reminder() );
+
+		$this->assertIsInt( $first_id );
+		$this->assertFalse( $second_id );
+
+		$record = CalendarReminderRecords::get( (int) $first_id );
+		$this->assertSame( CalendarReminderRecords::STATUS_CLAIMED, $record['status'] );
+		$this->assertTrue( CalendarReminderRecords::already_processed( 'primary', 'event-123', 'person@example.com', '2026-07-01' ) );
+	}
+
+	/**
+	 * Approved reminders may claim the exact pending approval once before sending.
+	 */
+	public function test_claim_for_delivery_claims_pending_approval_once(): void {
+		$pending_id = CalendarReminderRecords::record_pending_approval( $this->make_reminder( [ 'approval_request_id' => 'approval-1' ] ) );
+		$claim_id   = CalendarReminderRecords::claim_for_delivery( $this->make_reminder( [ 'approval_request_id' => 'approval-1' ] ) );
+		$retry_id   = CalendarReminderRecords::claim_for_delivery( $this->make_reminder( [ 'approval_request_id' => 'approval-1' ] ) );
+
+		$this->assertSame( $pending_id, $claim_id );
+		$this->assertFalse( $retry_id );
+
+		$record = CalendarReminderRecords::get( (int) $pending_id );
+		$this->assertSame( CalendarReminderRecords::STATUS_CLAIMED, $record['status'] );
+		$this->assertSame( 'approval-1', $record['approval_request_id'] );
+	}
+
+	/**
 	 * Reminder state can represent skipped, pending approval, failed, and sent outcomes.
 	 */
 	public function test_status_helpers_record_supported_states(): void {


### PR DESCRIPTION
## Summary

Added atomic reminder delivery claims before TextBee sends, removed dry-run SMS preview content, kept SMS truncation within the byte limit, and registered Google Calendar companion ability IDs for tool capability setup.

## Files Changed

includes/Abilities/CalendarReminderAbilities.php,includes/Abilities/ToolCapabilities.php,includes/Automations/CalendarReminderRecords.php,tests/SdAiAgent/Abilities/CalendarReminderAbilitiesTest.php,tests/SdAiAgent/Automations/CalendarReminderRecordsTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify — lint passed; PHPStan: 0 errors; PHPUnit: Tests: 3685, Assertions: 15392, Skipped: 121, Incomplete: 4; build succeeded; bundle-size check passed

Resolves #2161


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 17m and 114,495 tokens on this as a headless worker.