### PR TITLE
GH#2162: fix: preserve chat error recovery state

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -915,6 +915,11 @@ class AgentLoop {
 			// aware of the new context on this iteration.
 			$this->check_and_inject_interrupts();
 
+			// Preserve the full pre-trim history for recovery payloads. The provider
+			// call may need a trimmed prompt, but error recovery must append against
+			// the untrimmed session prefix so the failed user turn is not skipped.
+			$recovery_history = $this->history;
+
 			// Smart conversation trimming before each LLM call.
 			// @phpstan-ignore-next-line
 			$max_turns = (int) $this->settings_service->get( 'max_history_turns' );
@@ -936,7 +941,8 @@ class AgentLoop {
 							'The previous agent run stopped after an assistant message. Send a new message to continue from the saved chat history.',
 							'superdav-ai-agent'
 						)
-					)
+					),
+					$recovery_history
 				);
 
 				AgentEventLog::log(
@@ -964,7 +970,7 @@ class AgentLoop {
 
 			if ( is_wp_error( $result ) ) {
 				/** @var WP_Error $result */
-				$result = $this->with_error_recovery_data( $result );
+				$result = $this->with_error_recovery_data( $result, $recovery_history );
 				AgentEventLog::log(
 					'agent_loop_aborted',
 					AgentEventLog::SEVERITY_ERROR,
@@ -2012,11 +2018,15 @@ class AgentLoop {
 	 * and the latest safe history instead of dropping the prompt when the provider
 	 * or SDK rejects a request.
 	 *
-	 * @param WP_Error $error Error returned from a provider/loop boundary.
+	 * @param WP_Error $error           Error returned from a provider/loop boundary.
+	 * @param array    $recovery_history Optional pre-trim history to serialize for recovery.
+	 *
+	 * @phpstan-param array<int|string, Message>|null $recovery_history
 	 */
-	private function with_error_recovery_data( WP_Error $error ): WP_Error {
+	private function with_error_recovery_data( WP_Error $error, ?array $recovery_history = null ): WP_Error {
 		$error_data = $error->get_error_data();
 		$data       = is_array( $error_data ) ? $error_data : array();
+		$history    = $recovery_history ?? $this->history;
 
 		$defaults = array(
 			'tool_calls'       => $this->tool_call_log,
@@ -2024,7 +2034,7 @@ class AgentLoop {
 			'iterations_used'  => $this->iterations_used,
 			'model_id'         => $this->model_id,
 			'provider_id'      => $this->provider_id,
-			'history'          => $this->serialize_history(),
+			'history'          => ConversationSerializer::serialize( $history ),
 			'client_abilities' => $this->client_abilities,
 			'recoverable'      => true,
 		);

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -1151,6 +1151,10 @@ final class SessionController {
 			$response['message'] = '' !== $error_detail
 				? $error_detail
 				: __( 'The background agent job failed before it could finish. Please retry the request.', 'superdav-ai-agent' );
+
+			if ( $this->session_has_recoverable_paused_state( $row->session_id ) ) {
+				$response['recoverable'] = true;
+			}
 		}
 
 		if ( in_array( $status, array( 'interrupted', 'abandoned' ), true ) ) {
@@ -1331,8 +1335,12 @@ final class SessionController {
 	 * @phpstan-param array<string, mixed> $params
 	 */
 	private function build_exception_recovery_history( array $history, array $params ): array {
-		$serialized = ConversationSerializer::serialize( $history );
-		$message    = isset( $params['message'] ) ? (string) $params['message'] : '';
+		try {
+			$serialized = ConversationSerializer::serialize( $history );
+		} catch ( \Throwable $e ) {
+			$serialized = array();
+		}
+		$message = isset( $params['message'] ) ? (string) $params['message'] : '';
 
 		if ( '' === trim( $message ) ) {
 			return $serialized;
@@ -1384,7 +1392,7 @@ final class SessionController {
 		}
 
 		$tool_calls = $this->normalize_serialized_rows( $error_data['tool_calls'] ?? array() );
-		$this->append_history_delta_to_session(
+		$appended   = $this->append_history_delta_to_session(
 			$session_id,
 			$history,
 			$tool_calls
@@ -1398,7 +1406,7 @@ final class SessionController {
 		$client_abilities = $error_data['client_abilities'] ?? ( $params['client_abilities'] ?? array() );
 		$client_abilities = is_array( $client_abilities ) ? $client_abilities : array();
 
-		$this->database->save_paused_state(
+		$paused_saved = $this->database->save_paused_state(
 			$session_id,
 			array(
 				'history'          => array_values( $history ),
@@ -1417,6 +1425,10 @@ final class SessionController {
 				'exit_reason'      => (string) $error->get_error_code(),
 			)
 		);
+
+		if ( ! $appended || ! $paused_saved ) {
+			return;
+		}
 
 		$job['session_id']  = $session_id;
 		$job['recoverable'] = true;
@@ -1478,12 +1490,70 @@ final class SessionController {
 			$existing_messages = array();
 		}
 
-		$appended = array_slice( $full_history, count( $existing_messages ) );
+		$append_offset = $this->get_history_append_offset( $full_history, $existing_messages );
+		$appended      = array_slice( $full_history, $append_offset );
 		if ( empty( $appended ) && empty( $tool_calls ) ) {
 			return true;
 		}
 
 		return $this->database->append_to_session( $session_id, array_values( $appended ), $tool_calls );
+	}
+
+	/**
+	 * Find the first recovery-history row not already persisted in the session.
+	 *
+	 * Recovery payloads can be full histories or best-effort suffixes. Prefer the
+	 * longest identity prefix; when the persisted session is not a prefix of the
+	 * payload, treat the payload as a suffix so a failed user turn is not dropped.
+	 *
+	 * @param array $full_history      Serialized recovery history.
+	 * @param array $existing_messages Serialized messages already persisted.
+	 * @return int Offset in $full_history from which rows should be appended.
+	 *
+	 * @phpstan-param list<array<string, mixed>> $full_history
+	 * @phpstan-param array<mixed> $existing_messages
+	 */
+	private function get_history_append_offset( array $full_history, array $existing_messages ): int {
+		$common_prefix = 0;
+		foreach ( $full_history as $index => $row ) {
+			if ( ! isset( $existing_messages[ $index ] ) || $existing_messages[ $index ] !== $row ) {
+				break;
+			}
+
+			++$common_prefix;
+		}
+
+		if ( $common_prefix > 0 || empty( $existing_messages ) ) {
+			return $common_prefix;
+		}
+
+		foreach ( $full_history as $index => $row ) {
+			if ( ! in_array( $row, $existing_messages, true ) ) {
+				return $index;
+			}
+		}
+
+		return count( $full_history );
+	}
+
+	/**
+	 * Determine whether a session has durable paused state for an error job.
+	 *
+	 * @param int $session_id Session ID.
+	 * @return bool Whether recovery state exists.
+	 */
+	private function session_has_recoverable_paused_state( int $session_id ): bool {
+		if ( $session_id <= 0 ) {
+			return false;
+		}
+
+		$session = $this->database->get_session( $session_id );
+		if ( ! $session || empty( $session->paused_state ) ) {
+			return false;
+		}
+
+		$paused_state = json_decode( (string) $session->paused_state, true );
+		return is_array( $paused_state ) && ! empty( $paused_state['history'] );
 	}
 
 	/**

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -978,6 +978,45 @@ class RestControllerTest extends WP_UnitTestCase {
 		$this->assertSame( 'error', $data['status'] );
 		$this->assertTrue( $data['from_db'] );
 		$this->assertSame( $error_text, $data['message'] );
+		$this->assertArrayNotHasKey( 'recoverable', $data );
+		$this->assertNull( ActiveJobRepository::get_by_job_id( $job_id ) );
+	}
+
+	/**
+	 * Test terminal DB error rows keep recoverable metadata when paused state exists.
+	 */
+	public function test_job_status_from_db_error_row_includes_recoverable_when_paused_state_exists(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$session_id = Database::create_session( [
+			'user_id' => $this->admin_id,
+			'title'   => 'DB recoverable fallback',
+		] );
+		$job_id     = '44444444-5555-6666-7777-888888888888';
+		$error_text = 'Provider rejected the recovery prompt.';
+
+		Database::save_paused_state(
+			$session_id,
+			[
+				'history'       => [ [ 'role' => 'user', 'parts' => [ [ 'text' => 'Recover this turn.' ] ] ] ],
+				'tool_call_log' => [],
+				'message_log'   => [],
+				'token_usage'   => [ 'prompt' => 0, 'completion' => 0 ],
+			]
+		);
+		ActiveJobRepository::create( $session_id, $job_id, $this->admin_id, 'processing' );
+		ActiveJobRepository::update_status( $job_id, 'error', [ 'error' => $error_text ] );
+		delete_transient( RestController::JOB_PREFIX . $job_id );
+
+		$status_response = $this->dispatch( 'GET', "/sd-ai-agent/v1/job/{$job_id}" );
+
+		$this->assertStatus( 200, $status_response );
+		$data = $status_response->get_data();
+
+		$this->assertSame( 'error', $data['status'] );
+		$this->assertTrue( $data['from_db'] );
+		$this->assertSame( $error_text, $data['message'] );
+		$this->assertTrue( $data['recoverable'] );
 		$this->assertNull( ActiveJobRepository::get_by_job_id( $job_id ) );
 	}
 
@@ -1090,6 +1129,68 @@ class RestControllerTest extends WP_UnitTestCase {
 		$this->assertIsArray( $paused );
 		$this->assertSame( 'prompt_invalid_argument', $paused['exit_reason'] );
 		$this->assertCount( 3, $paused['history'] );
+		$this->assertSame( $session_id, $job['session_id'] );
+		$this->assertTrue( $job['recoverable'] );
+	}
+
+	/**
+	 * Test recovery persistence appends a suffix payload instead of dropping it by count.
+	 */
+	public function test_persist_error_recovery_appends_shorter_failed_turn_suffix(): void {
+		$session_id = Database::create_session( [
+			'user_id' => $this->admin_id,
+			'title'   => 'Recover shorter history suffix',
+		] );
+
+		$existing = \SdAiAgent\Core\ConversationSerializer::serialize(
+			[
+				new \WordPress\AiClient\Messages\DTO\UserMessage(
+					[ new \WordPress\AiClient\Messages\DTO\MessagePart( 'Start the site.' ) ]
+				),
+				new \WordPress\AiClient\Messages\DTO\ModelMessage(
+					[ new \WordPress\AiClient\Messages\DTO\MessagePart( 'I checked the site.' ) ]
+				),
+			]
+		);
+		Database::append_to_session( $session_id, $existing );
+
+		$failed_turn = \SdAiAgent\Core\ConversationSerializer::serialize(
+			[
+				new \WordPress\AiClient\Messages\DTO\UserMessage(
+					[ new \WordPress\AiClient\Messages\DTO\MessagePart( 'Please keep this shorter payload.' ) ]
+				),
+			]
+		);
+		$error       = new \WP_Error(
+			'prompt_invalid_argument',
+			'The provider rejected the prompt.',
+			[
+				'history'          => $failed_turn,
+				'tool_calls'       => [],
+				'messages'         => [],
+				'token_usage'      => [ 'prompt' => 1, 'completion' => 0 ],
+				'client_abilities' => [],
+			]
+		);
+
+		$controller = new \SdAiAgent\REST\SessionController( new Database() );
+		$method     = new \ReflectionMethod( \SdAiAgent\REST\SessionController::class, 'persist_error_recovery_to_session' );
+		$method->setAccessible( true );
+
+		$params     = [ 'message' => 'Please keep this shorter payload.', 'session_id' => $session_id ];
+		$options    = [];
+		$job        = [ 'status' => 'error', 'error' => $error->get_error_message(), 'params' => $params ];
+		$error_data = $error->get_error_data();
+		$this->assertIsArray( $error_data );
+
+		$method->invokeArgs( $controller, [ $session_id, $error, $error_data, $params, $options, &$job ] );
+
+		$session  = Database::get_session( $session_id );
+		$messages = json_decode( (string) $session->messages, true );
+
+		$this->assertCount( 3, $messages );
+		$this->assertSame( 'user', $messages[2]['role'] );
+		$this->assertStringContainsString( 'shorter payload', wp_json_encode( $messages[2] ) );
 		$this->assertSame( $session_id, $job['session_id'] );
 		$this->assertTrue( $job['recoverable'] );
 	}


### PR DESCRIPTION
## Summary

Preserved pre-trim AgentLoop history for recoverable errors, mirrored recoverable metadata in DB-backed job polling, hardened exception recovery serialization, appended recovery deltas by message identity instead of count, and covered DB fallback plus shorter recovery suffix cases.

## Files Changed

includes/Core/AgentLoop.php,includes/REST/SessionController.php,tests/SdAiAgent/REST/RestControllerTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify (lint clean; PHPStan 0 errors; PHPUnit: Tests: 3684, Assertions: 15377, Skipped: 121, Incomplete: 4; build succeeded; bundle budgets passed)

Resolves #2162


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 19m and 120,188 tokens on this as a headless worker.