### PR TITLE
GH#2171: build: anchor distignore vendor excludes

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -182,23 +182,23 @@ src/**/__snapshots__
 # These are require-dev packages that should not ship in a production zip.
 /vendor/pondermatic
 /vendor/**/composer.lock
-vendor/dealerdirect
-vendor/doctrine
-vendor/myclabs
-vendor/nikic
-vendor/phar-io
-vendor/phpcompatibility
-vendor/phpcsstandards
-vendor/phpstan
-vendor/php-stubs
-vendor/phpunit
-vendor/sebastian
-vendor/squizlabs
-vendor/szepeviktor
-vendor/theseer
-vendor/wp-coding-standards
-vendor/yoast
-vendor/bin
+/vendor/dealerdirect
+/vendor/doctrine
+/vendor/myclabs
+/vendor/nikic
+/vendor/phar-io
+/vendor/phpcompatibility
+/vendor/phpcsstandards
+/vendor/phpstan
+/vendor/php-stubs
+/vendor/phpunit
+/vendor/sebastian
+/vendor/squizlabs
+/vendor/szepeviktor
+/vendor/theseer
+/vendor/wp-coding-standards
+/vendor/yoast
+/vendor/bin
 
 # Build artefacts that should not be re-packaged (tree-wide is intentional)
 *.zip


### PR DESCRIPTION
## Summary

Anchored the remaining top-level vendor dev-only .distignore excludes so the section only removes root vendor dependencies and does not match nested third-party package paths.

## Files Changed

.distignore

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify (lint, PHPStan, PHPUnit: Tests: 3687, Assertions: 15403, Skipped: 121, Incomplete: 4; build; bundle-size checks)

Resolves #2171


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11 with gpt-5.5 spent 7m and 43,260 tokens on this as a headless worker.