### PR TITLE
fix: install blueprint plugin from wporg

### DIFF
--- a/.wordpress-org/blueprints/blueprint.json
+++ b/.wordpress-org/blueprints/blueprint.json
@@ -22,9 +22,8 @@
     {
       "step": "installPlugin",
       "pluginData": {
-        "resource": "url",
-        "url": "https://github.com/Ultimate-Multisite/superdav-ai-agent/releases/latest/download/superdav-ai-agent.zip",
-        "caption": "Downloading AI Agent..."
+        "resource": "wordpress.org/plugins",
+        "slug": "superdav-ai-agent"
       },
       "options": {
         "activate": true

--- a/playground/blueprint-dev.json
+++ b/playground/blueprint-dev.json
@@ -31,9 +31,8 @@
     {
       "step": "installPlugin",
       "pluginData": {
-        "resource": "url",
-        "url": "https://github.com/Ultimate-Multisite/superdav-ai-agent/releases/latest/download/superdav-ai-agent.zip",
-        "caption": "Downloading AI Agent..."
+        "resource": "wordpress.org/plugins",
+        "slug": "superdav-ai-agent"
       },
       "options": {
         "activate": true

--- a/playground/blueprint.json
+++ b/playground/blueprint.json
@@ -31,9 +31,8 @@
     {
       "step": "installPlugin",
       "pluginData": {
-        "resource": "url",
-        "url": "https://github.com/Ultimate-Multisite/superdav-ai-agent/releases/latest/download/superdav-ai-agent.zip",
-        "caption": "Downloading AI Agent..."
+        "resource": "wordpress.org/plugins",
+        "slug": "superdav-ai-agent"
       },
       "options": {
         "activate": true


### PR DESCRIPTION
## Summary
- Update `.wordpress-org/blueprints/blueprint.json`, `playground/blueprint.json`, and `playground/blueprint-dev.json` so the primary plugin install uses the WordPress.org plugin resource.
- Replace the GitHub release ZIP source for this plugin with the WordPress.org slug `superdav-ai-agent`.
- Leave the provider plugin install sources unchanged.

## Verification
- `python3 -m json.tool .wordpress-org/blueprints/blueprint.json >/dev/null`
- `python3 -m json.tool playground/blueprint.json >/dev/null`
- `python3 -m json.tool playground/blueprint-dev.json >/dev/null`
- `npm run verify`

## Worker self-verification
- PHPUnit: Tests: 3688, Assertions: 15408, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  succeeded

Note: `npm run verify` completed successfully; webpack emitted the existing asset-size warnings during the build step.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.16 plugin for [OpenCode](https://opencode.ai) v1.17.13
