### PR TITLE
build: package compiled DI cache

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -203,7 +203,9 @@ src/**/__snapshots__
 # Build artefacts that should not be re-packaged (tree-wide is intentional)
 *.zip
 *.map
-build/di-cache
+# build/di-cache is intentionally packaged: bin/build.sh refreshes the
+# versioned CompiledContainerSdAiAgent.php during the core release build so
+# WordPress installs do not generate checksum-drifting cache files at runtime.
 # Pre-submission AI review reports written by bin/wporg-review.sh —
 # never include these in either the GitHub or WP.org zip.
 build/wporg-review

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -236,6 +236,16 @@ prune_dev_metadata() {
 	return 0
 }
 
+compile_di_cache() {
+	local dest="$1"
+
+	echo "==> [core] Compiling DI cache for release..."
+	php "${PLUGIN_DIR}/bin/compile-di-cache.php" "$dest" "$VERSION"
+	echo "    DI cache compiled."
+
+	return 0
+}
+
 zip_dir() {
 	local build_dir="$1"
 	local top_dir="$2"
@@ -250,6 +260,30 @@ zip_dir() {
 
 	echo "    File: ${zip_path}"
 	echo "    Size: ${zip_size}"
+	return 0
+}
+
+validate_core_di_cache_in_zip() {
+	local zip_path="$1"
+	local top_dir="$2"
+	local listing_file=""
+	local cache_entry="${top_dir}/build/di-cache/${VERSION}/CompiledContainerSdAiAgent.php"
+
+	listing_file="$(mktemp)"
+	if ! unzip -Z1 "$zip_path" >"$listing_file"; then
+		echo "ERROR: Could not inspect ${zip_path}." >&2
+		rm -f "$listing_file"
+		return 1
+	fi
+
+	if ! grep -Fxq "$cache_entry" "$listing_file"; then
+		echo "ERROR: core zip is missing the compiled DI cache: ${cache_entry}" >&2
+		rm -f "$listing_file"
+		return 1
+	fi
+
+	rm -f "$listing_file"
+	echo "    DI cache validated: ${cache_entry} is packaged."
 	return 0
 }
 
@@ -355,8 +389,10 @@ build_core() {
 
 	prune_dev_metadata "$dest"
 	composer --working-dir="$dest" dump-autoload --no-dev --optimize --quiet
+	compile_di_cache "$dest"
 	zip_dir "$build_dir" "superdav-ai-agent" "superdav-ai-agent-${VERSION}.zip"
 	validate_zip_contents "${PLUGIN_DIR}/superdav-ai-agent-${VERSION}.zip" "superdav-ai-agent" "core" "superdav-ai-agent.php" "no"
+	validate_core_di_cache_in_zip "${PLUGIN_DIR}/superdav-ai-agent-${VERSION}.zip" "superdav-ai-agent"
 	return 0
 }
 

--- a/bin/compile-di-cache.php
+++ b/bin/compile-di-cache.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Compile the production DI container cache for a staged plugin directory.
+ *
+ * This build-time helper intentionally does not bootstrap WordPress. The
+ * compiled container only needs the plugin's PHP-DI definitions, and all
+ * install-specific values are runtime-resolved by factories in Plugin::configure().
+ *
+ * @package SdAiAgent
+ */
+
+if ( PHP_SAPI !== 'cli' ) {
+	fwrite( STDERR, "This script must be run from the command line.\n" );
+	exit( 1 );
+}
+
+/**
+ * Recursively remove a directory if it exists.
+ *
+ * @param string $path Directory path.
+ */
+function sd_ai_agent_build_remove_dir( string $path ): void {
+	if ( ! is_dir( $path ) ) {
+		return;
+	}
+
+	$iterator = new RecursiveIteratorIterator(
+		new RecursiveDirectoryIterator( $path, FilesystemIterator::SKIP_DOTS ),
+		RecursiveIteratorIterator::CHILD_FIRST
+	);
+
+	foreach ( $iterator as $item ) {
+		if ( $item->isDir() ) {
+			rmdir( $item->getPathname() );
+			continue;
+		}
+
+		unlink( $item->getPathname() );
+	}
+
+	rmdir( $path );
+}
+
+/**
+ * Write an error message and stop the build.
+ *
+ * @param string $message Error message.
+ */
+function sd_ai_agent_build_fail( string $message ): never {
+	fwrite( STDERR, $message . "\n" );
+	exit( 1 );
+}
+
+$plugin_dir_arg = $argv[1] ?? '';
+$version        = $argv[2] ?? '';
+
+if ( '' === $plugin_dir_arg || '' === $version ) {
+	sd_ai_agent_build_fail( 'Usage: php bin/compile-di-cache.php <plugin-dir> <version>' );
+}
+
+$plugin_dir = realpath( $plugin_dir_arg );
+
+if ( false === $plugin_dir || ! is_dir( $plugin_dir ) ) {
+	sd_ai_agent_build_fail( 'Plugin directory does not exist: ' . $plugin_dir_arg );
+}
+
+$autoload = $plugin_dir . '/vendor/autoload.php';
+if ( ! is_file( $autoload ) ) {
+	sd_ai_agent_build_fail( 'Composer autoload file is missing: ' . $autoload );
+}
+
+defined( 'ABSPATH' ) || define( 'ABSPATH', $plugin_dir . '/' );
+defined( 'SD_AI_AGENT_VERSION' ) || define( 'SD_AI_AGENT_VERSION', $version );
+defined( 'SD_AI_AGENT_DIR' ) || define( 'SD_AI_AGENT_DIR', $plugin_dir );
+defined( 'SD_AI_AGENT_URL' ) || define( 'SD_AI_AGENT_URL', '' );
+
+require_once $autoload;
+
+$cache_root   = $plugin_dir . '/build/di-cache';
+$compile_dir  = $cache_root . '/' . $version;
+$compile_file = $compile_dir . '/CompiledContainerSdAiAgent.php';
+
+sd_ai_agent_build_remove_dir( $cache_root );
+
+if ( ! mkdir( $compile_dir, 0775, true ) && ! is_dir( $compile_dir ) ) {
+	sd_ai_agent_build_fail( 'Could not create DI cache directory: ' . $compile_dir );
+}
+
+$builder = new DI\ContainerBuilder();
+$builder->useAttributes( true );
+$builder->useAutowiring( true );
+$builder->enableCompilation( $compile_dir, 'CompiledContainerSdAiAgent' );
+$builder->addDefinitions( SdAiAgent\Plugin::configure() );
+$builder->build();
+
+if ( ! is_file( $compile_file ) ) {
+	sd_ai_agent_build_fail( 'Compiled DI cache file was not created: ' . $compile_file );
+}
+
+$compiled_contents = file_get_contents( $compile_file );
+if ( false === $compiled_contents ) {
+	sd_ai_agent_build_fail( 'Could not read compiled DI cache file: ' . $compile_file );
+}
+
+if ( str_contains( $compiled_contents, $plugin_dir ) ) {
+	sd_ai_agent_build_fail( 'Compiled DI cache contains the staging path and is not install-portable.' );
+}
+
+$compiled_contents = preg_replace(
+	'/^<\?php\s*/',
+	"<?php\ndeclare(strict_types=1);\n\nif ( ! defined( 'ABSPATH' ) ) {\n\texit;\n}\n\n",
+	$compiled_contents,
+	1
+);
+
+if ( ! is_string( $compiled_contents ) ) {
+	sd_ai_agent_build_fail( 'Could not add the WordPress direct-access guard to the compiled DI cache.' );
+}
+
+if ( false === file_put_contents( $compile_file, $compiled_contents ) ) {
+	sd_ai_agent_build_fail( 'Could not write guarded compiled DI cache file: ' . $compile_file );
+}
+
+fwrite( STDOUT, 'Compiled DI cache: ' . $compile_file . "\n" );

--- a/docs/x-wp-di.md
+++ b/docs/x-wp-di.md
@@ -338,7 +338,7 @@ protected function get4() {
 }
 ```
 
-**`compile_dir` can stay absolute** — it's only used during compilation on the development machine, not at runtime.
+`bin/build.sh` compiles `build/di-cache/{SD_AI_AGENT_VERSION}/CompiledContainerSdAiAgent.php` inside the staged release directory and packages it in the WordPress.org ZIP. That keeps installs checksum-stable because PHP-DI sees the versioned compiled file on first load instead of creating it after activation. The build helper validates that the compiled file does not contain the staging path; keep install-specific definitions as `\DI\factory()` values so the packaged cache remains portable.
 
 ### 11. Pre-commit vendor dance
 


### PR DESCRIPTION
## Summary

- Compile the versioned PHP-DI container during the core release build.
- Package `build/di-cache/{version}/CompiledContainerSdAiAgent.php` in the WordPress.org ZIP so installs do not create it at runtime.
- Validate the ZIP contains the compiled cache and document the build-time requirement.

## Context

WordPress checksum verification reported an added runtime-generated DI cache file after installing the official ZIP. The plugin enables PHP-DI compilation, but the release package excluded `build/di-cache`, so PHP-DI generated the missing file on first load.

## Worker self-verification
- PHPUnit: Tests: 3688, Assertions: 15408, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Additional targeted checks: `bin/build.sh --target=core`, `shellcheck bin/build.sh`, `php -l bin/compile-di-cache.php`, and ZIP inspection of the packaged compiled cache.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.24 plugin for [OpenCode](https://opencode.ai) v1.17.13
