### PR TITLE
GH#2177: feat: add static docs knowledge import

### DIFF
--- a/includes/Bootstrap/CliHandler.php
+++ b/includes/Bootstrap/CliHandler.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Bootstrap;
 
 use SdAiAgent\CLI\CliCommand;
+use SdAiAgent\CLI\KnowledgeCommand;
 use SdAiAgent\CLI\ModelsCommand;
 use SdAiAgent\CLI\SkillsCommand;
 use SdAiAgent\CLI\TraceCommand;
@@ -55,9 +56,10 @@ final class CliHandler {
 	 * @var array<string,class-string>
 	 */
 	private const COMMANDS = array(
-		'prompt' => CliCommand::class,
-		'models' => ModelsCommand::class,
-		'skills' => SkillsCommand::class,
+		'prompt'    => CliCommand::class,
+		'knowledge' => KnowledgeCommand::class,
+		'models'    => ModelsCommand::class,
+		'skills'    => SkillsCommand::class,
 	);
 
 	/**

--- a/includes/CLI/KnowledgeCommand.php
+++ b/includes/CLI/KnowledgeCommand.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * WP-CLI command for knowledge base maintenance.
+ *
+ * @package SdAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\CLI;
+
+use SdAiAgent\Knowledge\Knowledge;
+use SdAiAgent\Knowledge\KnowledgeDatabase;
+use WP_CLI;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Import and maintain knowledge base sources.
+ */
+class KnowledgeCommand extends \WP_CLI_Command {
+
+	/**
+	 * Import a static documentation JSON/JSONL manifest.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <manifest>
+	 * : Path to a trusted JSON or JSONL manifest file. Each record should include
+	 *   id/path/url, title, route/url, metadata, and content.
+	 *
+	 * [--collection-id=<id>]
+	 * : Existing knowledge collection ID.
+	 *
+	 * [--collection=<slug>]
+	 * : Existing knowledge collection slug. Used when --collection-id is omitted.
+	 *
+	 * [--prune]
+	 * : Delete static_file sources no longer present in the manifest.
+	 *
+	 * [--stale-removed]
+	 * : Mark static_file sources no longer present in the manifest as stale.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp sd-ai-agent knowledge import-static-docs build/docs-manifest.jsonl --collection=docs --prune
+	 *
+	 * @when after_wp_load
+	 *
+	 * @param array<int, string>   $args       Positional arguments.
+	 * @param array<string, mixed> $assoc_args Associative arguments.
+	 */
+	public function import_static_docs( array $args, array $assoc_args ): void {
+		$manifest_path = $args[0] ?? '';
+		if ( '' === $manifest_path ) {
+			WP_CLI::error( 'Manifest path is required.' );
+			return;
+		}
+
+		$collection_id = $this->resolve_collection_id( $assoc_args );
+		if ( $collection_id <= 0 ) {
+			WP_CLI::error( 'Provide a valid --collection-id or --collection slug.' );
+			return;
+		}
+
+		$result = Knowledge::import_static_docs_manifest_file(
+			$collection_id,
+			$manifest_path,
+			[
+				'prune'         => \WP_CLI\Utils\get_flag_value( $assoc_args, 'prune', false ),
+				'stale_removed' => \WP_CLI\Utils\get_flag_value( $assoc_args, 'stale-removed', false ),
+			]
+		);
+
+		if ( is_wp_error( $result ) ) {
+			WP_CLI::error( $result->get_error_message() );
+			return;
+		}
+
+		WP_CLI::success(
+			sprintf(
+				'Imported static docs: imported=%d updated=%d skipped=%d pruned=%d stale=%d errors=%d',
+				$result['imported'],
+				$result['updated'],
+				$result['skipped'],
+				$result['pruned'],
+				$result['stale'],
+				$result['errors']
+			)
+		);
+	}
+
+	/**
+	 * Resolve a collection ID from CLI flags.
+	 *
+	 * @param array<string, mixed> $assoc_args Associative arguments.
+	 * @return int Collection ID, or 0 when unresolved.
+	 */
+	private function resolve_collection_id( array $assoc_args ): int {
+		$collection_id = (int) \WP_CLI\Utils\get_flag_value( $assoc_args, 'collection-id', 0 );
+		if ( $collection_id > 0 ) {
+			return $collection_id;
+		}
+
+		$slug = (string) \WP_CLI\Utils\get_flag_value( $assoc_args, 'collection', '' );
+		if ( '' === $slug ) {
+			return 0;
+		}
+
+		$collection = KnowledgeDatabase::get_collection_by_slug( $slug );
+		return $collection ? (int) $collection->id : 0;
+	}
+}

--- a/includes/Knowledge/Knowledge.php
+++ b/includes/Knowledge/Knowledge.php
@@ -18,6 +18,8 @@ use WP_Error;
 
 class Knowledge {
 
+	private const STATIC_FILE_SOURCE_TYPE = 'static_file';
+
 	/**
 	 * Index a WordPress post into a collection.
 	 *
@@ -212,6 +214,89 @@ class Knowledge {
 	}
 
 	/**
+	 * Import static documentation records from a manifest.
+	 *
+	 * @param int                        $collection_id Collection ID.
+	 * @param list<array<string, mixed>> $records       Manifest records.
+	 * @param array<string, bool|int>    $options       Import options. Supports prune/stale_removed.
+	 * @return array{imported: int, updated: int, skipped: int, pruned: int, stale: int, errors: int}|WP_Error
+	 */
+	public static function import_static_docs_manifest( int $collection_id, array $records, array $options = [] ) {
+		$collection = KnowledgeDatabase::get_collection( $collection_id );
+		if ( ! $collection ) {
+			return new WP_Error( 'not_found', __( 'Collection not found.', 'superdav-ai-agent' ) );
+		}
+
+		$stats = [
+			'imported' => 0,
+			'updated'  => 0,
+			'skipped'  => 0,
+			'pruned'   => 0,
+			'stale'    => 0,
+			'errors'   => 0,
+		];
+		$seen  = [];
+
+		foreach ( $records as $record ) {
+			$result = self::index_static_doc_record( $collection_id, $record );
+			if ( is_wp_error( $result ) ) {
+				++$stats['errors'];
+				continue;
+			}
+
+			$seen[] = $result['source_key'];
+			++$stats[ $result['action'] ];
+		}
+
+		if ( ! empty( $options['prune'] ) || ! empty( $options['stale_removed'] ) ) {
+			$removed = self::handle_removed_static_docs( $collection_id, $seen, ! empty( $options['prune'] ) );
+			if ( ! empty( $options['prune'] ) ) {
+				$stats['pruned'] = $removed;
+			} else {
+				$stats['stale'] = $removed;
+			}
+		}
+
+		KnowledgeDatabase::recalculate_collection_chunk_count( $collection_id );
+		KnowledgeDatabase::update_collection( $collection_id, [ 'last_indexed_at' => current_time( 'mysql', true ) ] );
+
+		return $stats;
+	}
+
+	/**
+	 * Import static documentation records from a JSON or JSONL manifest file.
+	 *
+	 * @param int                     $collection_id Collection ID.
+	 * @param string                  $manifest_path Manifest path for trusted CLI/admin workflows.
+	 * @param array<string, bool|int> $options       Import options.
+	 * @return array{imported: int, updated: int, skipped: int, pruned: int, stale: int, errors: int}|WP_Error
+	 */
+	public static function import_static_docs_manifest_file( int $collection_id, string $manifest_path, array $options = [] ) {
+		if ( ! is_readable( $manifest_path ) ) {
+			return new WP_Error( 'file_not_found', __( 'Manifest file not found or not readable.', 'superdav-ai-agent' ) );
+		}
+
+		$max_bytes = (int) ( $options['max_bytes'] ?? 25 * 1024 * 1024 );
+		$size      = filesize( $manifest_path );
+		if ( false !== $size && $size > $max_bytes ) {
+			return new WP_Error( 'manifest_too_large', __( 'Manifest file exceeds the allowed size.', 'superdav-ai-agent' ) );
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Trusted CLI/admin manifest import path.
+		$raw = file_get_contents( $manifest_path );
+		if ( false === $raw ) {
+			return new WP_Error( 'read_error', __( 'Could not read manifest file.', 'superdav-ai-agent' ) );
+		}
+
+		$records = self::decode_static_docs_manifest( $raw );
+		if ( is_wp_error( $records ) ) {
+			return $records;
+		}
+
+		return self::import_static_docs_manifest( $collection_id, $records, $options );
+	}
+
+	/**
 	 * Re-index all posts matching a collection's source_config.
 	 *
 	 * @param int $collection_id Collection ID.
@@ -317,6 +402,275 @@ class Knowledge {
 		}
 
 		return $results;
+	}
+
+	/**
+	 * Index one static docs manifest record.
+	 *
+	 * @param int                  $collection_id Collection ID.
+	 * @param array<string, mixed> $record        Manifest record.
+	 * @return array{action: 'imported'|'updated'|'skipped', source_key: int}|WP_Error
+	 */
+	private static function index_static_doc_record( int $collection_id, array $record ) {
+		$content = isset( $record['content'] ) ? (string) $record['content'] : '';
+		if ( '' === trim( $content ) ) {
+			return new WP_Error( 'empty_content', __( 'Static documentation record has no content.', 'superdav-ai-agent' ) );
+		}
+
+		$identity = self::get_static_doc_identity( $record );
+		if ( '' === $identity ) {
+			return new WP_Error( 'missing_identity', __( 'Static documentation record requires an id, path, or URL.', 'superdav-ai-agent' ) );
+		}
+
+		$parsed   = DocumentParser::extract_markdown_content( $content );
+		$text     = trim( $parsed['text'] );
+		$metadata = self::build_static_doc_metadata( $record, $parsed['metadata'], $parsed['headings'], $identity );
+		$title    = self::get_static_doc_title( $record, $metadata, $parsed['headings'] );
+		$url      = self::get_static_doc_public_url( $record );
+
+		if ( '' === $text ) {
+			return new WP_Error( 'empty_content', __( 'Static documentation record has no visible text content.', 'superdav-ai-agent' ) );
+		}
+
+		$source_key = self::stable_static_doc_source_key( $identity );
+		$hash       = md5( wp_json_encode( [ $text, $title, $url, $metadata ] ) ?: $text );
+		$existing   = KnowledgeDatabase::find_source( $collection_id, self::STATIC_FILE_SOURCE_TYPE, $source_key );
+
+		if ( $existing && $existing->content_hash === $hash ) {
+			return [
+				'action'     => 'skipped',
+				'source_key' => $source_key,
+			];
+		}
+
+		$action = $existing ? 'updated' : 'imported';
+		if ( $existing ) {
+			$source_id = (int) $existing->id;
+			KnowledgeDatabase::delete_chunks_for_source( $source_id );
+			KnowledgeDatabase::update_source(
+				$source_id,
+				[
+					'title'        => $title,
+					'source_url'   => $url,
+					'content_hash' => $hash,
+					'status'       => 'pending',
+				]
+			);
+		} else {
+			$source_id = KnowledgeDatabase::create_source(
+				[
+					'collection_id' => $collection_id,
+					'source_type'   => self::STATIC_FILE_SOURCE_TYPE,
+					'source_id'     => $source_key,
+					'source_url'    => $url,
+					'title'         => $title,
+					'content_hash'  => $hash,
+				]
+			);
+
+			if ( ! $source_id ) {
+				return new WP_Error( 'db_error', __( 'Failed to create source record.', 'superdav-ai-agent' ) );
+			}
+		}
+
+		$chunks = Chunker::chunk( $text );
+		foreach ( $chunks as &$chunk ) {
+			$chunk['metadata'] = $metadata;
+		}
+		unset( $chunk );
+
+		$inserted = KnowledgeDatabase::insert_chunks( $collection_id, (int) $source_id, $chunks );
+		KnowledgeDatabase::update_source(
+			(int) $source_id,
+			[
+				'chunk_count' => $inserted,
+				'status'      => 'indexed',
+			]
+		);
+
+		return [
+			'action'     => $action,
+			'source_key' => $source_key,
+		];
+	}
+
+	/**
+	 * Decode JSON array/object or JSONL static docs manifest data.
+	 *
+	 * @param string $raw Raw manifest data.
+	 * @return list<array<string, mixed>>|WP_Error
+	 */
+	private static function decode_static_docs_manifest( string $raw ) {
+		$trimmed = trim( $raw );
+		if ( '' === $trimmed ) {
+			return new WP_Error( 'empty_manifest', __( 'Manifest is empty.', 'superdav-ai-agent' ) );
+		}
+
+		$decoded = json_decode( $trimmed, true );
+		if ( is_array( $decoded ) ) {
+			$records = isset( $decoded['records'] ) && is_array( $decoded['records'] ) ? $decoded['records'] : $decoded;
+			return self::normalize_static_docs_records( $records );
+		}
+
+		$records = [];
+		foreach ( preg_split( '/\n+/', $trimmed ) ?: [] as $line ) {
+			$record = json_decode( trim( $line ), true );
+			if ( ! is_array( $record ) ) {
+				return new WP_Error( 'invalid_manifest', __( 'Manifest contains invalid JSON.', 'superdav-ai-agent' ) );
+			}
+			$normalized = self::normalize_static_docs_records( [ $record ] );
+			if ( ! empty( $normalized ) ) {
+				$records[] = $normalized[0];
+			}
+		}
+
+		return $records;
+	}
+
+	/**
+	 * Normalize decoded manifest records to string-keyed arrays.
+	 *
+	 * @param array<mixed> $records Raw decoded records.
+	 * @return list<array<string, mixed>>
+	 */
+	private static function normalize_static_docs_records( array $records ): array {
+		$normalized = [];
+		foreach ( $records as $record ) {
+			if ( ! is_array( $record ) ) {
+				continue;
+			}
+
+			$item = [];
+			foreach ( $record as $key => $value ) {
+				if ( is_string( $key ) ) {
+					$item[ $key ] = $value;
+				}
+			}
+
+			$normalized[] = $item;
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Handle static docs records no longer present in an imported manifest.
+	 *
+	 * @param int             $collection_id Collection ID.
+	 * @param array<int, int> $seen          Source keys present in the import.
+	 * @param bool            $prune         Whether to delete instead of stale-mark.
+	 * @return int Number of removed records handled.
+	 */
+	private static function handle_removed_static_docs( int $collection_id, array $seen, bool $prune ): int {
+		$sources = KnowledgeDatabase::get_sources_for_collection( $collection_id ) ?: [];
+		$count   = 0;
+		foreach ( $sources as $source ) {
+			if ( self::STATIC_FILE_SOURCE_TYPE !== $source->source_type || in_array( (int) $source->source_id, $seen, true ) ) {
+				continue;
+			}
+
+			if ( $prune ) {
+				KnowledgeDatabase::delete_source( (int) $source->id );
+			} else {
+				KnowledgeDatabase::delete_chunks_for_source( (int) $source->id );
+				KnowledgeDatabase::update_source(
+					(int) $source->id,
+					[
+						'status'      => 'stale',
+						'chunk_count' => 0,
+					]
+				);
+			}
+			++$count;
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Build stable numeric key for static docs source identity.
+	 */
+	private static function stable_static_doc_source_key( string $identity ): int {
+		return (int) sprintf( '%u', crc32( $identity ) );
+	}
+
+	/**
+	 * Get static docs source identity.
+	 *
+	 * @param array<string, mixed> $record Manifest record.
+	 */
+	private static function get_static_doc_identity( array $record ): string {
+		foreach ( [ 'id', 'path', 'url', 'route' ] as $key ) {
+			if ( ! empty( $record[ $key ] ) && is_scalar( $record[ $key ] ) ) {
+				return sanitize_text_field( (string) $record[ $key ] );
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Get public source URL/route without exposing local filesystem paths.
+	 *
+	 * @param array<string, mixed> $record Manifest record.
+	 */
+	private static function get_static_doc_public_url( array $record ): string {
+		foreach ( [ 'url', 'route', 'docs_route' ] as $key ) {
+			if ( ! empty( $record[ $key ] ) && is_scalar( $record[ $key ] ) ) {
+				return esc_url_raw( (string) $record[ $key ] );
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Build searchable metadata for static docs chunks.
+	 *
+	 * @param array<string, mixed> $record           Manifest record.
+	 * @param array<string, mixed> $frontmatter      Parsed frontmatter.
+	 * @param array<int, string>   $headings         Parsed headings.
+	 * @param string               $source_identity Source identity.
+	 * @return array<string, mixed>
+	 */
+	private static function build_static_doc_metadata( array $record, array $frontmatter, array $headings, string $source_identity ): array {
+		$metadata = [];
+		if ( is_array( $record['metadata'] ?? null ) ) {
+			foreach ( $record['metadata'] as $key => $value ) {
+				if ( is_string( $key ) ) {
+					$metadata[ $key ] = $value;
+				}
+			}
+		}
+		foreach ( [ 'locale', 'addon', 'product', 'section', 'version', 'path', 'route', 'docs_route' ] as $key ) {
+			if ( isset( $record[ $key ] ) && is_scalar( $record[ $key ] ) ) {
+				$metadata[ $key ] = sanitize_text_field( (string) $record[ $key ] );
+			}
+		}
+
+		$metadata['source_type'] = self::STATIC_FILE_SOURCE_TYPE;
+		$metadata['source_id']   = $source_identity;
+		$metadata['frontmatter'] = $frontmatter;
+		$metadata['headings']    = $headings;
+
+		return $metadata;
+	}
+
+	/**
+	 * Resolve title from manifest, frontmatter, or first heading.
+	 *
+	 * @param array<string, mixed> $record   Manifest record.
+	 * @param array<string, mixed> $metadata Built metadata.
+	 * @param array<int, string>   $headings Parsed headings.
+	 */
+	private static function get_static_doc_title( array $record, array $metadata, array $headings ): string {
+		foreach ( [ $record['title'] ?? null, $metadata['title'] ?? null, $metadata['frontmatter']['title'] ?? null, $headings[0] ?? null ] as $title ) {
+			if ( is_scalar( $title ) && '' !== trim( (string) $title ) ) {
+				return sanitize_text_field( (string) $title );
+			}
+		}
+
+		return __( 'Untitled documentation file', 'superdav-ai-agent' );
 	}
 
 	/**

--- a/includes/Knowledge/KnowledgeDatabase.php
+++ b/includes/Knowledge/KnowledgeDatabase.php
@@ -397,7 +397,7 @@ class KnowledgeDatabase {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 
-		$allowed = [ 'title', 'status', 'chunk_count', 'content_hash', 'error_message' ];
+		$allowed = [ 'title', 'source_url', 'status', 'chunk_count', 'content_hash', 'error_message' ];
 		$update  = [];
 		$formats = [];
 

--- a/includes/Models/DocumentParser.php
+++ b/includes/Models/DocumentParser.php
@@ -17,6 +17,67 @@ use WP_Error;
 class DocumentParser {
 
 	/**
+	 * Extract visible text and metadata from Markdown/MDX content.
+	 *
+	 * Keeps fenced code blocks intact, strips YAML frontmatter into metadata,
+	 * removes MDX import/export plumbing, and unwraps simple JSX tags so visible
+	 * copy remains searchable.
+	 *
+	 * @param string $content Markdown or MDX content.
+	 * @return array{text: string, metadata: array<string, mixed>, headings: list<string>}
+	 */
+	public static function extract_markdown_content( string $content ): array {
+		$metadata = [];
+		$content  = str_replace( [ "\r\n", "\r" ], "\n", $content );
+
+		if ( str_starts_with( $content, "---\n" ) ) {
+			$end = strpos( $content, "\n---\n", 4 );
+			if ( false !== $end ) {
+				$frontmatter = substr( $content, 4, $end - 4 );
+				$metadata    = self::parse_simple_yaml_frontmatter( $frontmatter );
+				$content     = substr( $content, $end + 5 );
+			}
+		}
+
+		$lines         = explode( "\n", $content );
+		$visible_lines = [];
+		$headings      = [];
+		$in_fence      = false;
+
+		foreach ( $lines as $line ) {
+			$trimmed = trim( $line );
+			if ( str_starts_with( $trimmed, '```' ) || str_starts_with( $trimmed, '~~~' ) ) {
+				$in_fence        = ! $in_fence;
+				$visible_lines[] = $line;
+				continue;
+			}
+
+			if ( ! $in_fence && preg_match( '/^(import|export)\s+/i', $trimmed ) ) {
+				continue;
+			}
+
+			if ( ! $in_fence && preg_match( '/^#{1,6}\s+(.+)$/', $trimmed, $matches ) ) {
+				$headings[] = trim( wp_strip_all_tags( $matches[1] ) );
+			}
+
+			if ( ! $in_fence ) {
+				$line = (string) preg_replace( '/<([A-Z][A-Za-z0-9_:.]*)(\s[^>]*)?>/', '', $line );
+				$line = (string) preg_replace( '/<\/([A-Z][A-Za-z0-9_:.]*)>/', '', $line );
+				$line = (string) preg_replace( '/<([A-Z][A-Za-z0-9_:.]*)(\s[^>]*)?\/>/', '', $line );
+				$line = (string) preg_replace( '/\{\/\*.*?\*\/\}/', '', $line );
+			}
+
+			$visible_lines[] = $line;
+		}
+
+		return [
+			'text'     => self::clean_text( implode( "\n", $visible_lines ) ),
+			'metadata' => $metadata,
+			'headings' => $headings,
+		];
+	}
+
+	/**
 	 * Extract text from a WordPress attachment.
 	 *
 	 * @param int $attachment_id The attachment post ID.
@@ -245,5 +306,28 @@ class DocumentParser {
 		$text = (string) preg_replace( '/[\x00-\x08\x0B\x0C\x0E-\x1F]/', '', $text );
 
 		return trim( $text );
+	}
+
+	/**
+	 * Parse simple YAML frontmatter key/value pairs.
+	 *
+	 * @param string $frontmatter Raw frontmatter block.
+	 * @return array<string, mixed>
+	 */
+	private static function parse_simple_yaml_frontmatter( string $frontmatter ): array {
+		$metadata = [];
+		foreach ( explode( "\n", $frontmatter ) as $line ) {
+			if ( ! str_contains( $line, ':' ) ) {
+				continue;
+			}
+			list( $key, $value ) = array_map( 'trim', explode( ':', $line, 2 ) );
+			if ( '' === $key ) {
+				continue;
+			}
+			$value            = trim( $value, " \t\n\r\0\x0B\"'" );
+			$metadata[ $key ] = $value;
+		}
+
+		return $metadata;
 	}
 }

--- a/tests/SdAiAgent/Knowledge/KnowledgeTest.php
+++ b/tests/SdAiAgent/Knowledge/KnowledgeTest.php
@@ -260,6 +260,160 @@ class KnowledgeTest extends WP_UnitTestCase {
 		$this->assertIsArray( $results );
 	}
 
+	// ── static docs manifest import ────────────────────────────────────────
+
+	/**
+	 * Test static documentation manifest import creates searchable file sources.
+	 */
+	public function test_import_static_docs_manifest_creates_sources_and_chunks(): void {
+		$col_id = KnowledgeDatabase::create_collection( [
+			'name' => 'Docs Collection',
+			'slug' => 'docs-collection',
+		] );
+
+		$stats = Knowledge::import_static_docs_manifest(
+			$col_id,
+			[
+				[
+					'id'       => 'docs/addons/example/setup.mdx',
+					'path'     => 'docs/addons/example/setup.mdx',
+					'title'    => 'Addon setup',
+					'url'      => '/addons/example/setup',
+					'locale'   => 'en',
+					'product'  => 'Ultimate Multisite',
+					'addon'    => 'example',
+					'metadata' => [ 'section' => 'addons' ],
+					'content'  => "---\ntitle: Frontmatter title\n---\nimport Tabs from '@theme/Tabs';\n\n# Addon setup\n\n<Note>Visible docs copy.</Note>\n\n```php\nwp option get blogname\n```",
+				],
+			]
+		);
+
+		$this->assertIsArray( $stats );
+		$this->assertSame( 1, $stats['imported'] );
+		$this->assertSame( 0, $stats['errors'] );
+
+		$sources = KnowledgeDatabase::get_sources_for_collection( $col_id );
+		$this->assertCount( 1, $sources );
+		$this->assertSame( 'static_file', $sources[0]->source_type );
+		$this->assertSame( '/addons/example/setup', $sources[0]->source_url );
+		$this->assertSame( 'Addon setup', $sources[0]->title );
+
+		global $wpdb;
+		$chunk = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT chunk_text, metadata FROM %i WHERE source_id = %d',
+				KnowledgeDatabase::chunks_table(),
+				$sources[0]->id
+			)
+		);
+
+		$this->assertNotNull( $chunk );
+		$this->assertStringContainsString( 'Visible docs copy.', $chunk->chunk_text );
+		$this->assertStringContainsString( 'wp option get blogname', $chunk->chunk_text );
+		$this->assertStringNotContainsString( 'import Tabs', $chunk->chunk_text );
+
+		$metadata = json_decode( $chunk->metadata, true );
+		$this->assertSame( 'en', $metadata['locale'] );
+		$this->assertSame( 'example', $metadata['addon'] );
+		$this->assertSame( 'addons', $metadata['section'] );
+		$this->assertSame( [ 'Addon setup' ], $metadata['headings'] );
+	}
+
+	/**
+	 * Test static documentation manifest imports skip unchanged records.
+	 */
+	public function test_import_static_docs_manifest_skips_unchanged_records(): void {
+		$col_id = KnowledgeDatabase::create_collection( [
+			'name' => 'Docs Skip Collection',
+			'slug' => 'docs-skip-collection',
+		] );
+		$record = [
+			'id'      => 'docs/setup.md',
+			'title'   => 'Setup',
+			'url'     => '/setup',
+			'content' => '# Setup\n\nInstall the addon.',
+		];
+
+		Knowledge::import_static_docs_manifest( $col_id, [ $record ] );
+		$stats = Knowledge::import_static_docs_manifest( $col_id, [ $record ] );
+
+		$this->assertIsArray( $stats );
+		$this->assertSame( 1, $stats['skipped'] );
+		$this->assertSame( 0, $stats['updated'] );
+	}
+
+	/**
+	 * Test static documentation manifest imports update changed records.
+	 */
+	public function test_import_static_docs_manifest_updates_changed_records(): void {
+		$col_id = KnowledgeDatabase::create_collection( [
+			'name' => 'Docs Update Collection',
+			'slug' => 'docs-update-collection',
+		] );
+
+		Knowledge::import_static_docs_manifest(
+			$col_id,
+			[
+				[
+					'id'      => 'docs/setup.md',
+					'title'   => 'Setup',
+					'url'     => '/setup',
+					'content' => '# Setup\n\nOriginal copy.',
+				],
+			]
+		);
+
+		$stats = Knowledge::import_static_docs_manifest(
+			$col_id,
+			[
+				[
+					'id'      => 'docs/setup.md',
+					'title'   => 'Setup updated',
+					'url'     => '/setup-updated',
+					'content' => '# Setup\n\nUpdated copy.',
+				],
+			]
+		);
+
+		$this->assertIsArray( $stats );
+		$this->assertSame( 1, $stats['updated'] );
+
+		$sources = KnowledgeDatabase::get_sources_for_collection( $col_id );
+		$this->assertCount( 1, $sources );
+		$this->assertSame( 'Setup updated', $sources[0]->title );
+		$this->assertSame( '/setup-updated', $sources[0]->source_url );
+	}
+
+	/**
+	 * Test static documentation manifest prune removes missing records.
+	 */
+	public function test_import_static_docs_manifest_prunes_removed_records(): void {
+		$col_id = KnowledgeDatabase::create_collection( [
+			'name' => 'Docs Prune Collection',
+			'slug' => 'docs-prune-collection',
+		] );
+
+		Knowledge::import_static_docs_manifest(
+			$col_id,
+			[
+				[ 'id' => 'docs/a.md', 'title' => 'A', 'content' => '# A\n\nAlpha.' ],
+				[ 'id' => 'docs/b.md', 'title' => 'B', 'content' => '# B\n\nBravo.' ],
+			]
+		);
+
+		$stats = Knowledge::import_static_docs_manifest(
+			$col_id,
+			[
+				[ 'id' => 'docs/a.md', 'title' => 'A', 'content' => '# A\n\nAlpha.' ],
+			],
+			[ 'prune' => true ]
+		);
+
+		$this->assertIsArray( $stats );
+		$this->assertSame( 1, $stats['pruned'] );
+		$this->assertCount( 1, KnowledgeDatabase::get_sources_for_collection( $col_id ) );
+	}
+
 	// ── get_context_for_query ─────────────────────────────────────────────
 
 	/**


### PR DESCRIPTION
## Summary

Added a static_file knowledge source importer for JSON/JSONL docs manifests, Markdown/MDX extraction with frontmatter/headings/code fences, incremental update/skip/prune handling, and a WP-CLI import command.

## Files Changed

includes/Bootstrap/CliHandler.php, includes/CLI/KnowledgeCommand.php, includes/Knowledge/Knowledge.php, includes/Knowledge/KnowledgeDatabase.php, includes/Models/DocumentParser.php, tests/SdAiAgent/Knowledge/KnowledgeTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify — PHPUnit: Tests: 3692, Assertions: 15434, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4; Lint: PHP/JS/CSS all clean; PHPStan: 0 errors; Build: succeeded; Bundle check: succeeded

Resolves #2177


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.64 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 18m and 125,635 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new CLI command for importing static documentation manifests into the knowledge base.
  * Markdown content is now parsed more accurately, including headings, frontmatter metadata, and cleaned readable text.

* **Bug Fixes**
  * Static documentation imports now update changed entries, skip unchanged ones, and can prune removed entries.
  * Source URLs are now preserved during knowledge source updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->