### PR TITLE
feat: add customer simple chat mode

### DIFF
--- a/src/components/chat-redesign/ConvoHeader.js
+++ b/src/components/chat-redesign/ConvoHeader.js
@@ -9,23 +9,26 @@ import { __ } from '@wordpress/i18n';
 import { Icon, moreHorizontal, sidebar as sidebarIcon } from '@wordpress/icons';
 
 import STORE_NAME from '../../store';
+import { getBranding } from '../../utils/branding';
 import { isTTSSupported } from '../use-text-to-speech';
 import SessionContextMenu from '../session-context-menu';
 import { AiIcon, Speaker, SpeakerMuted } from './icons';
 
 /**
  *
- * @param {Object} root0
- * @param {*}      root0.sidebarCollapsed
- * @param {*}      root0.onExpandSidebar
- * @param {*}      root0.changesCount
- * @param {*}      root0.onShowChanges
+ * @param {Object}  root0
+ * @param {*}       root0.sidebarCollapsed
+ * @param {*}       root0.onExpandSidebar
+ * @param {*}       root0.changesCount
+ * @param {*}       root0.onShowChanges
+ * @param {boolean} root0.isSimpleMode
  */
 export default function ConvoHeader( {
 	sidebarCollapsed,
 	onExpandSidebar,
 	changesCount,
 	onShowChanges,
+	isSimpleMode = false,
 } ) {
 	const { renameSession, setTtsEnabled } = useDispatch( STORE_NAME );
 	const { session, isRunning, ttsEnabled } = useSelect( ( sel ) => {
@@ -53,7 +56,10 @@ export default function ConvoHeader( {
 		}
 	}, [ editing ] );
 
-	const title = session?.title || __( 'New conversation', 'sd-ai-agent' );
+	const branding = getBranding();
+	const title = isSimpleMode
+		? branding.agentName || __( 'AI Agent', 'sd-ai-agent' )
+		: session?.title || __( 'New conversation', 'sd-ai-agent' );
 
 	const startRename = useCallback( () => {
 		if ( ! session ) {
@@ -72,7 +78,7 @@ export default function ConvoHeader( {
 
 	return (
 		<div className="sdaa-cr-convo-head">
-			{ sidebarCollapsed && (
+			{ sidebarCollapsed && ! isSimpleMode && (
 				<button
 					type="button"
 					className="sdaa-cr-icon-btn"
@@ -103,8 +109,10 @@ export default function ConvoHeader( {
 				<button
 					type="button"
 					className="sdaa-cr-convo-head-title"
-					onClick={ session ? startRename : undefined }
-					disabled={ ! session }
+					onClick={
+						session && ! isSimpleMode ? startRename : undefined
+					}
+					disabled={ ! session || isSimpleMode }
 					title={ title }
 				>
 					<span className="sdaa-cr-convo-head-title-text">
@@ -116,7 +124,7 @@ export default function ConvoHeader( {
 							title={ __( 'Agent running', 'sd-ai-agent' ) }
 						/>
 					) }
-					{ session && (
+					{ session && ! isSimpleMode && (
 						<span className="sdaa-cr-convo-head-rename-hint">
 							{ __( 'Click to rename', 'sd-ai-agent' ) }
 						</span>
@@ -131,7 +139,7 @@ export default function ConvoHeader( {
 				>
 					<AiIcon thinking={ isRunning } size={ 16 } />
 				</span>
-				{ changesCount > 0 && (
+				{ ! isSimpleMode && changesCount > 0 && (
 					<span
 						className="sdaa-cr-changes-pill"
 						title={ __(
@@ -169,28 +177,30 @@ export default function ConvoHeader( {
 						{ ttsEnabled ? <Speaker /> : <SpeakerMuted /> }
 					</button>
 				) }
-				<div className="sdaa-cr-convo-head-menu-wrap">
-					<button
-						type="button"
-						className="sdaa-cr-icon-btn"
-						aria-label={ __( 'More options', 'sd-ai-agent' ) }
-						aria-haspopup="menu"
-						aria-expanded={ showMenu }
-						disabled={ ! session }
-						onClick={ () => setShowMenu( ( v ) => ! v ) }
-					>
-						<Icon icon={ moreHorizontal } size={ 16 } />
-					</button>
-					{ showMenu && session && (
-						<div className="sdaa-cr-context-menu sdaa-cr-context-menu--header">
-							<SessionContextMenu
-								session={ session }
-								onClose={ () => setShowMenu( false ) }
-								isOwner={ true }
-							/>
-						</div>
-					) }
-				</div>
+				{ ! isSimpleMode && (
+					<div className="sdaa-cr-convo-head-menu-wrap">
+						<button
+							type="button"
+							className="sdaa-cr-icon-btn"
+							aria-label={ __( 'More options', 'sd-ai-agent' ) }
+							aria-haspopup="menu"
+							aria-expanded={ showMenu }
+							disabled={ ! session }
+							onClick={ () => setShowMenu( ( v ) => ! v ) }
+						>
+							<Icon icon={ moreHorizontal } size={ 16 } />
+						</button>
+						{ showMenu && session && (
+							<div className="sdaa-cr-context-menu sdaa-cr-context-menu--header">
+								<SessionContextMenu
+									session={ session }
+									onClose={ () => setShowMenu( false ) }
+									isOwner={ true }
+								/>
+							</div>
+						) }
+					</div>
+				) }
 			</div>
 		</div>
 	);

--- a/src/components/chat-redesign/InputArea.js
+++ b/src/components/chat-redesign/InputArea.js
@@ -44,10 +44,13 @@ function readAsDataUrl( file ) {
 }
 
 /**
- * Input area with slash-command autocomplete, file upload, voice input,
+ * Input area with optional slash-command autocomplete, file upload, voice input,
  * and send/stop controls.
+ *
+ * @param {Object}  root0
+ * @param {boolean} root0.isSimpleMode Whether customer/simple UI mode is active.
  */
-export default function InputArea() {
+export default function InputArea( { isSimpleMode = false } = {} ) {
 	const {
 		sendMessage,
 		stopGeneration,
@@ -103,8 +106,10 @@ export default function InputArea() {
 	// Show slash menu while the user is still typing the command name
 	// (starts with / and has no space yet). Hide once they start arguments.
 	useEffect( () => {
-		setShowSlash( text.startsWith( '/' ) && ! text.includes( ' ' ) );
-	}, [ text ] );
+		setShowSlash(
+			! isSimpleMode && text.startsWith( '/' ) && ! text.includes( ' ' )
+		);
+	}, [ text, isSimpleMode ] );
 
 	const processFiles = useCallback( async ( files ) => {
 		const next = [];
@@ -141,7 +146,7 @@ export default function InputArea() {
 		}
 
 		// /remember <fact>
-		if ( trimmed.startsWith( '/remember ' ) ) {
+		if ( ! isSimpleMode && trimmed.startsWith( '/remember ' ) ) {
 			const fact = trimmed.slice( 10 ).trim();
 			if ( fact ) {
 				apiFetch( {
@@ -155,7 +160,7 @@ export default function InputArea() {
 		}
 
 		// /forget <topic>
-		if ( trimmed.startsWith( '/forget ' ) ) {
+		if ( ! isSimpleMode && trimmed.startsWith( '/forget ' ) ) {
 			const topic = trimmed.slice( 8 ).trim();
 			if ( topic ) {
 				apiFetch( {
@@ -189,7 +194,7 @@ export default function InputArea() {
 		setText( '' );
 		setAttachments( [] );
 		setTimeout( () => taRef.current?.focus( { preventScroll: true } ), 0 );
-	}, [ text, attachments, sendMessage ] );
+	}, [ text, attachments, sendMessage, isSimpleMode ] );
 
 	const handleSlashSelect = useCallback(
 		( cmd ) => {
@@ -322,10 +327,20 @@ export default function InputArea() {
 		e.preventDefault();
 		taRef.current?.focus( { preventScroll: true } );
 	}, [] );
+	let placeholder = __(
+		'Ask the agent to do something, or type / for commands…',
+		'sd-ai-agent'
+	);
+	if ( isSimpleMode ) {
+		placeholder = __( 'Ask a question…', 'sd-ai-agent' );
+	}
+	if ( sending ) {
+		placeholder = __( 'Type to queue a message…', 'sd-ai-agent' );
+	}
 
 	return (
 		<div className="sdaa-cr-input-area">
-			{ showSlash && (
+			{ ! isSimpleMode && showSlash && (
 				<SlashCommandMenu
 					filter={ text }
 					onSelect={ handleSlashSelect }
@@ -417,17 +432,7 @@ export default function InputArea() {
 					<textarea
 						ref={ taRef }
 						className="sdaa-cr-input-textarea"
-						placeholder={
-							sending
-								? __(
-										'Type to queue a message…',
-										'sd-ai-agent'
-								  )
-								: __(
-										'Ask the agent to do something, or type / for commands…',
-										'sd-ai-agent'
-								  )
-						}
+						placeholder={ placeholder }
 						value={ text }
 						onChange={ ( e ) => setText( e.target.value ) }
 						onKeyDown={ handleKey }
@@ -460,8 +465,8 @@ export default function InputArea() {
 							>
 								<Paperclip />
 							</button>
-							<ModelPicker />
-							<AgentPicker />
+							{ ! isSimpleMode && <ModelPicker /> }
+							{ ! isSimpleMode && <AgentPicker /> }
 						</div>
 						<div className="sdaa-cr-input-toolbar-right">
 							{ micSupported && (

--- a/src/components/chat-redesign/__tests__/customer-simple-mode.test.js
+++ b/src/components/chat-redesign/__tests__/customer-simple-mode.test.js
@@ -1,0 +1,327 @@
+/**
+ * Unit tests for customer/simple chat UI mode.
+ */
+
+import { createElement } from '@wordpress/element';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+import ChatRedesign from '../index';
+import InputArea from '../InputArea';
+import WidgetHeader from '../../chat-widget/widget-header';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( str ) => str,
+	_n: ( single, plural, count ) => ( count === 1 ? single : plural ),
+	sprintf: ( format, value ) => format.replace( '%d', value ),
+} ) );
+
+jest.mock( '@wordpress/icons', () => ( {
+	Icon: () => null,
+	arrowUp: 'arrow-up',
+	close: 'close',
+	chevronDown: 'chevron-down',
+	commentContent: 'comment-content',
+	moreHorizontal: 'more-horizontal',
+	plus: 'plus',
+	sidebar: 'sidebar',
+} ) );
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+jest.mock( '../../../store', () => 'sd-ai-agent' );
+jest.mock( '../../../utils/branding', () => ( {
+	getBranding: () => ( { agentName: 'Docs Assistant' } ),
+} ) );
+jest.mock( '../../use-speech-recognition', () => () => ( {
+	isListening: false,
+	isSupported: false,
+	toggleListening: jest.fn(),
+} ) );
+jest.mock( '../../use-text-to-speech', () => ( {
+	isTTSSupported: false,
+} ) );
+jest.mock(
+	'../../slash-command-menu',
+	() => () =>
+		require( '@wordpress/element' ).createElement( 'div', {
+			className: 'mock-slash-command-menu',
+		} )
+);
+jest.mock( '../../feedback-consent-modal', () => () => null );
+jest.mock(
+	'../ModelPicker',
+	() => () =>
+		require( '@wordpress/element' ).createElement( 'div', {
+			className: 'mock-model-picker',
+		} )
+);
+jest.mock(
+	'../AgentPicker',
+	() => () =>
+		require( '@wordpress/element' ).createElement( 'div', {
+			className: 'mock-agent-picker',
+		} )
+);
+jest.mock( '../../chat-banners', () => () => null );
+jest.mock(
+	'../../error-boundary',
+	() =>
+		( { children } ) =>
+			children
+);
+jest.mock(
+	'../../tool-confirmation-dialog',
+	() => () =>
+		require( '@wordpress/element' ).createElement( 'div', {
+			className: 'mock-tool-confirmation',
+		} )
+);
+jest.mock(
+	'../MessageList',
+	() => () =>
+		require( '@wordpress/element' ).createElement( 'div', {
+			className: 'mock-message-list',
+		} )
+);
+jest.mock(
+	'../ChangesDrawer',
+	() => () =>
+		require( '@wordpress/element' ).createElement( 'div', {
+			className: 'mock-changes',
+		} )
+);
+jest.mock(
+	'../../session-context-menu',
+	() => () =>
+		require( '@wordpress/element' ).createElement( 'div', {
+			className: 'mock-session-context-menu',
+		} )
+);
+jest.mock( '../icons', () => ( {
+	AiIcon: () => null,
+	Microphone: () => null,
+	Paperclip: () => null,
+	Speaker: () => null,
+	SpeakerMuted: () => null,
+	Stop: () => null,
+} ) );
+
+/**
+ *
+ */
+function buildSelectors() {
+	return {
+		getCurrentSessionId: () => 7,
+		getPendingConfirmation: () => null,
+		getPendingProposal: () => null,
+		isYoloMode: () => false,
+		isSending: () => false,
+		isFloatingMinimized: () => false,
+		getCurrentSessionMessages: () => [],
+		getMessageQueue: () => [],
+		getSessions: () => [
+			{
+				id: 7,
+				title: 'Admin session',
+				updated_at: '2026-01-01 00:00:00',
+			},
+		],
+		getSessionJobs: () => ( {} ),
+		getProviders: () => [
+			{
+				id: 'openai',
+				models: [ { id: 'gpt-4o', name: 'GPT-4o' } ],
+			},
+		],
+		getSelectedProviderId: () => 'openai',
+		getSelectedModelId: () => 'gpt-4o',
+		isTtsEnabled: () => false,
+	};
+}
+
+/**
+ *
+ */
+function buildActions() {
+	return {
+		clearCurrentSession: jest.fn(),
+		compactConversation: jest.fn(),
+		confirmToolCall: jest.fn(),
+		exportSession: jest.fn(),
+		fetchSessions: jest.fn(),
+		openSession: jest.fn(),
+		rejectToolCall: jest.fn(),
+		renameSession: jest.fn(),
+		sendMessage: jest.fn(),
+		setFloatingOpen: jest.fn(),
+		setFloatingMinimized: jest.fn(),
+		setShowShortcutsHelp: jest.fn(),
+		setTtsEnabled: jest.fn(),
+		stopGeneration: jest.fn(),
+	};
+}
+
+let actions;
+
+/**
+ *
+ */
+function setupStore() {
+	useSelect.mockImplementation( ( fn ) => fn( () => buildSelectors() ) );
+	actions = buildActions();
+	useDispatch.mockReturnValue( actions );
+}
+
+/**
+ *
+ * @param {JSX.Element} component Component to render.
+ */
+async function renderComponent( component ) {
+	const container = document.createElement( 'div' );
+	document.body.appendChild( container );
+	const root = createRoot( container );
+
+	await act( async () => {
+		root.render( component );
+	} );
+
+	return { container, root };
+}
+
+/**
+ *
+ * @param {HTMLElement} container Rendered component container.
+ * @param {string}      value     Textarea value.
+ */
+async function setTextareaValue( container, value ) {
+	const textarea = container.querySelector( 'textarea' );
+	const setter = Object.getOwnPropertyDescriptor(
+		window.HTMLTextAreaElement.prototype,
+		'value'
+	).set;
+
+	await act( async () => {
+		setter.call( textarea, value );
+		textarea.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+	} );
+}
+
+describe( 'customer/simple chat UI mode', () => {
+	let mounted;
+
+	beforeEach( () => {
+		setupStore();
+	} );
+
+	afterEach( async () => {
+		if ( mounted ) {
+			await act( async () => {
+				mounted.root.unmount();
+			} );
+			document.body.removeChild( mounted.container );
+			mounted = undefined;
+		}
+	} );
+
+	test( 'InputArea hides model picker, agent picker, and slash menu in simple mode', async () => {
+		mounted = await renderComponent(
+			createElement( InputArea, { isSimpleMode: true } )
+		);
+
+		expect(
+			mounted.container.querySelector( '.mock-model-picker' )
+		).toBeNull();
+		expect(
+			mounted.container.querySelector( '.mock-agent-picker' )
+		).toBeNull();
+
+		await setTextareaValue( mounted.container, '/' );
+
+		expect(
+			mounted.container.querySelector( '.mock-slash-command-menu' )
+		).toBeNull();
+
+		await setTextareaValue( mounted.container, 'How do I set up docs?' );
+		await act( async () => {
+			mounted.container
+				.querySelector( 'button[aria-label="Send message"]' )
+				.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+		} );
+
+		expect( actions.sendMessage ).toHaveBeenCalledWith(
+			'How do I set up docs?',
+			[]
+		);
+	} );
+
+	test( 'InputArea keeps admin selectors outside simple mode', async () => {
+		mounted = await renderComponent( createElement( InputArea ) );
+
+		expect(
+			mounted.container.querySelector( '.mock-model-picker' )
+		).not.toBeNull();
+		expect(
+			mounted.container.querySelector( '.mock-agent-picker' )
+		).not.toBeNull();
+	} );
+
+	test( 'WidgetHeader hides session drawer affordance and new-chat button in simple mode', async () => {
+		mounted = await renderComponent(
+			createElement( WidgetHeader, {
+				isMinimized: false,
+				onToggleMinimize: jest.fn(),
+				isSimpleMode: true,
+			} )
+		);
+
+		expect(
+			mounted.container.querySelector( '.sdaa-w-new-btn' )
+		).toBeNull();
+		expect(
+			mounted.container.querySelector( '.sdaa-w-head-caret' )
+		).toBeNull();
+		expect( mounted.container.textContent ).not.toContain( 'GPT-4o' );
+		expect( mounted.container.textContent ).toContain( 'Docs Assistant' );
+
+		await act( async () => {
+			mounted.container
+				.querySelector( '.sdaa-w-head-session' )
+				.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+		} );
+
+		expect(
+			mounted.container.querySelector( '.sdaa-w-session-drawer' )
+		).toBeNull();
+		expect( actions.fetchSessions ).not.toHaveBeenCalled();
+	} );
+
+	test( 'ChatRedesign suppresses sidebar, selectors, and conversation menu in simple mode', async () => {
+		mounted = await renderComponent(
+			createElement( ChatRedesign, { uiMode: 'customer_simple' } )
+		);
+
+		expect(
+			mounted.container.querySelector( '.sdaa-cr-sidebar' )
+		).toBeNull();
+		expect(
+			mounted.container.querySelector( '.mock-model-picker' )
+		).toBeNull();
+		expect(
+			mounted.container.querySelector( '.mock-agent-picker' )
+		).toBeNull();
+		expect(
+			mounted.container.querySelector( '.sdaa-cr-convo-head-menu-wrap' )
+		).toBeNull();
+		expect( mounted.container.textContent ).not.toContain(
+			'Click to rename'
+		);
+	} );
+} );

--- a/src/components/chat-redesign/index.js
+++ b/src/components/chat-redesign/index.js
@@ -14,6 +14,7 @@ import STORE_NAME from '../../store';
 import ChatBanners from '../chat-banners';
 import ErrorBoundary from '../error-boundary';
 import ToolConfirmationDialog from '../tool-confirmation-dialog';
+import { getChatUiMode, isCustomerSimpleMode } from '../../utils/chat-ui-mode';
 import Sidebar from './Sidebar';
 import ConvoHeader from './ConvoHeader';
 import ChangesDrawer from './ChangesDrawer';
@@ -26,8 +27,11 @@ const DENSITY_STORAGE_KEY = 'sdAiAgentChatDensity';
 
 /**
  *
+ * @param {Object} [root0]
+ * @param {string} [root0.uiMode] Chat UI mode.
  */
-export default function ChatRedesign() {
+export default function ChatRedesign( { uiMode = getChatUiMode() } = {} ) {
+	const isSimpleMode = isCustomerSimpleMode( uiMode );
 	const [ sidebarCollapsed, setSidebarCollapsed ] = useState( () => {
 		// On medium or larger screens (≥782px — wp-admin's tablet breakpoint)
 		// the sidebar should always start open. Saved collapse preference
@@ -89,6 +93,10 @@ export default function ChatRedesign() {
 
 	// Refresh the changes count when the session changes or a turn finishes.
 	const refreshChangesCount = useCallback( async () => {
+		if ( isSimpleMode ) {
+			setChangesCount( 0 );
+			return;
+		}
 		if ( ! currentSessionId ) {
 			setChangesCount( 0 );
 			return;
@@ -101,7 +109,7 @@ export default function ChatRedesign() {
 		} catch {
 			setChangesCount( 0 );
 		}
-	}, [ currentSessionId ] );
+	}, [ currentSessionId, isSimpleMode ] );
 
 	useEffect( () => {
 		refreshChangesCount();
@@ -114,18 +122,28 @@ export default function ChatRedesign() {
 	}, [ sending, currentSessionId, refreshChangesCount ] );
 
 	return (
-		<div className={ `sdaa-cr is-density-${ density }` }>
+		<div
+			className={ `sdaa-cr is-density-${ density }${
+				isSimpleMode ? ' is-customer-simple' : ''
+			}` }
+		>
 			<div
 				className={ `sdaa-cr-shell${
-					sidebarCollapsed ? ' is-sidebar-collapsed' : ''
+					sidebarCollapsed || isSimpleMode
+						? ' is-sidebar-collapsed'
+						: ''
 				}` }
 			>
-				<ErrorBoundary label={ __( 'Sidebar', 'superdav-ai-agent' ) }>
-					<Sidebar
-						collapsed={ sidebarCollapsed }
-						onToggleCollapse={ toggleSidebar }
-					/>
-				</ErrorBoundary>
+				{ ! isSimpleMode && (
+					<ErrorBoundary
+						label={ __( 'Sidebar', 'superdav-ai-agent' ) }
+					>
+						<Sidebar
+							collapsed={ sidebarCollapsed }
+							onToggleCollapse={ toggleSidebar }
+						/>
+					</ErrorBoundary>
+				) }
 
 				<section className="sdaa-cr-convo">
 					<ConvoHeader
@@ -133,6 +151,7 @@ export default function ChatRedesign() {
 						onExpandSidebar={ () => setSidebarCollapsed( false ) }
 						changesCount={ changesCount }
 						onShowChanges={ () => setShowChanges( true ) }
+						isSimpleMode={ isSimpleMode }
 					/>
 
 					<ErrorBoundary
@@ -141,7 +160,7 @@ export default function ChatRedesign() {
 						<ChatBanners />
 					</ErrorBoundary>
 
-					{ showChanges && (
+					{ ! isSimpleMode && showChanges && (
 						<ChangesDrawer
 							sessionId={ currentSessionId }
 							onClose={ () => setShowChanges( false ) }
@@ -158,12 +177,12 @@ export default function ChatRedesign() {
 					<ErrorBoundary
 						label={ __( 'Message input', 'superdav-ai-agent' ) }
 					>
-						<InputArea />
+						<InputArea isSimpleMode={ isSimpleMode } />
 					</ErrorBoundary>
 				</section>
 			</div>
 
-			{ pendingConfirmation && ! yoloMode && (
+			{ pendingConfirmation && ! yoloMode && ! isSimpleMode && (
 				<ToolConfirmationDialog
 					confirmation={ pendingConfirmation }
 					onConfirm={ ( alwaysAllow ) =>

--- a/src/components/chat-widget/index.js
+++ b/src/components/chat-widget/index.js
@@ -19,6 +19,7 @@ import { lazy, Suspense } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 
 import STORE_NAME from '../../store';
+import { getChatUiMode } from '../../utils/chat-ui-mode';
 import WidgetLauncher from './widget-launcher';
 // widget.css contains the launcher (FAB) styles and is required in the
 // initial bundle so the FAB is styled immediately on every page load.
@@ -38,6 +39,7 @@ const WidgetPanel = lazy( () =>
  * @param {string|null} root0.frontendOnboardingMode Frontend onboarding layout mode.
  */
 export default function ChatWidget( { frontendOnboardingMode = null } ) {
+	const uiMode = getChatUiMode();
 	const isOpen = useSelect(
 		( sel ) => sel( STORE_NAME ).isFloatingOpen(),
 		[]
@@ -51,7 +53,10 @@ export default function ChatWidget( { frontendOnboardingMode = null } ) {
 	// On a cache hit (prefetch or repeat visit) this is imperceptible.
 	return (
 		<Suspense fallback={ null }>
-			<WidgetPanel frontendOnboardingMode={ frontendOnboardingMode } />
+			<WidgetPanel
+				frontendOnboardingMode={ frontendOnboardingMode }
+				uiMode={ uiMode }
+			/>
 		</Suspense>
 	);
 }

--- a/src/components/chat-widget/widget-header.js
+++ b/src/components/chat-widget/widget-header.js
@@ -71,15 +71,17 @@ function relativeTime( dateStr ) {
 
 /**
  *
- * @param {Object} root0
- * @param {*}      root0.isMinimized
- * @param {*}      root0.onToggleMinimize
- * @param {*}      root0.onDragHandleMouseDown
+ * @param {Object}  root0
+ * @param {*}       root0.isMinimized
+ * @param {*}       root0.onToggleMinimize
+ * @param {*}       root0.onDragHandleMouseDown
+ * @param {boolean} root0.isSimpleMode
  */
 export default function WidgetHeader( {
 	isMinimized,
 	onToggleMinimize,
 	onDragHandleMouseDown,
+	isSimpleMode = false,
 } ) {
 	const { setFloatingOpen, clearCurrentSession, openSession, fetchSessions } =
 		useDispatch( STORE_NAME );
@@ -132,7 +134,7 @@ export default function WidgetHeader( {
 	const session = sessions.find( ( s ) => s.id === currentSessionId ) || null;
 	const branding = getBranding();
 	const agentName = branding.agentName || __( 'AI Agent', 'sd-ai-agent' );
-	const title = session?.title || agentName;
+	const title = isSimpleMode ? agentName : session?.title || agentName;
 	const runningJob = currentSessionId
 		? sessionJobs[ currentSessionId ]
 		: null;
@@ -147,6 +149,9 @@ export default function WidgetHeader( {
 				return __( 'Working…', 'sd-ai-agent' );
 			}
 			return __( 'Working…', 'sd-ai-agent' );
+		}
+		if ( isSimpleMode ) {
+			return __( 'Ready', 'sd-ai-agent' );
 		}
 		return activeModelName
 			? `${ __( 'Ready', 'sd-ai-agent' ) } · ${ activeModelName }`
@@ -175,15 +180,34 @@ export default function WidgetHeader( {
 			onMouseDown={ onDragHandleMouseDown }
 		>
 			<div className="sdaa-w-head-title-wrap" ref={ drawerRef }>
-				<button
-					type="button"
+				<div
 					className={ `sdaa-w-head-session${
-						drawerOpen ? ' is-open' : ''
+						drawerOpen && ! isSimpleMode ? ' is-open' : ''
 					}` }
-					onClick={ () => setDrawerOpen( ( v ) => ! v ) }
-					title={ __( 'Switch session', 'sd-ai-agent' ) }
-					aria-haspopup="menu"
-					aria-expanded={ drawerOpen }
+					role={ isSimpleMode ? undefined : 'button' }
+					tabIndex={ isSimpleMode ? undefined : 0 }
+					onClick={
+						isSimpleMode
+							? undefined
+							: () => setDrawerOpen( ( v ) => ! v )
+					}
+					onKeyDown={
+						isSimpleMode
+							? undefined
+							: ( e ) => {
+									if ( e.key === 'Enter' || e.key === ' ' ) {
+										e.preventDefault();
+										setDrawerOpen( ( v ) => ! v );
+									}
+							  }
+					}
+					title={
+						isSimpleMode
+							? title
+							: __( 'Switch session', 'sd-ai-agent' )
+					}
+					aria-haspopup={ isSimpleMode ? undefined : 'menu' }
+					aria-expanded={ isSimpleMode ? undefined : drawerOpen }
 				>
 					<span className="sdaa-w-avatar" aria-hidden="true">
 						{ branding.logoUrl ? (
@@ -201,9 +225,11 @@ export default function WidgetHeader( {
 							<span className="sdaa-w-head-name-text">
 								{ title }
 							</span>
-							<span className="sdaa-w-head-caret">
-								<Icon icon={ chevronDown } size={ 14 } />
-							</span>
+							{ ! isSimpleMode && (
+								<span className="sdaa-w-head-caret">
+									<Icon icon={ chevronDown } size={ 14 } />
+								</span>
+							) }
 						</span>
 						<span
 							className={ `sdaa-w-head-status${
@@ -216,9 +242,9 @@ export default function WidgetHeader( {
 							</span>
 						</span>
 					</span>
-				</button>
+				</div>
 
-				{ drawerOpen && (
+				{ ! isSimpleMode && drawerOpen && (
 					<div className="sdaa-w-session-drawer" role="menu">
 						<div className="sdaa-w-session-drawer-head">
 							<span>
@@ -286,15 +312,17 @@ export default function WidgetHeader( {
 				) }
 			</div>
 
-			<button
-				type="button"
-				className="sdaa-w-new-btn"
-				onClick={ handleNewChat }
-				aria-label={ __( 'Start new chat', 'sd-ai-agent' ) }
-				title={ __( 'Start new chat', 'sd-ai-agent' ) }
-			>
-				<Icon icon={ plus } size={ 18 } />
-			</button>
+			{ ! isSimpleMode && (
+				<button
+					type="button"
+					className="sdaa-w-new-btn"
+					onClick={ handleNewChat }
+					aria-label={ __( 'Start new chat', 'sd-ai-agent' ) }
+					title={ __( 'Start new chat', 'sd-ai-agent' ) }
+				>
+					<Icon icon={ plus } size={ 18 } />
+				</button>
+			) }
 
 			<div className="sdaa-w-head-actions">
 				<button

--- a/src/components/chat-widget/widget-input.js
+++ b/src/components/chat-widget/widget-input.js
@@ -1,7 +1,7 @@
 /**
  * Compact input row for the widget — same wiring as the chat-redesign
  * InputArea (sendMessage / stopGeneration / speech / attachments) but
- * rendered as a tight 1-line textarea with paperclip, model chip, mic
+ * rendered as a tight 1-line textarea with paperclip, optional model chip, mic
  * and send/stop in a single toolbar.
  */
 
@@ -44,8 +44,10 @@ function readAsDataUrl( file ) {
 
 /**
  *
+ * @param {Object}  root0
+ * @param {boolean} root0.isSimpleMode Whether customer/simple UI mode is active.
  */
-export default function WidgetInput() {
+export default function WidgetInput( { isSimpleMode = false } = {} ) {
 	const {
 		sendMessage,
 		stopGeneration,
@@ -95,8 +97,10 @@ export default function WidgetInput() {
 	}, [ text ] );
 
 	useEffect( () => {
-		setShowSlash( text.startsWith( '/' ) && ! text.includes( ' ' ) );
-	}, [ text ] );
+		setShowSlash(
+			! isSimpleMode && text.startsWith( '/' ) && ! text.includes( ' ' )
+		);
+	}, [ text, isSimpleMode ] );
 
 	const processFiles = useCallback( async ( files ) => {
 		const next = [];
@@ -132,7 +136,7 @@ export default function WidgetInput() {
 			return;
 		}
 
-		if ( trimmed.startsWith( '/remember ' ) ) {
+		if ( ! isSimpleMode && trimmed.startsWith( '/remember ' ) ) {
 			const fact = trimmed.slice( 10 ).trim();
 			if ( fact ) {
 				apiFetch( {
@@ -149,7 +153,7 @@ export default function WidgetInput() {
 			return;
 		}
 
-		if ( trimmed.startsWith( '/forget ' ) ) {
+		if ( ! isSimpleMode && trimmed.startsWith( '/forget ' ) ) {
 			const topic = trimmed.slice( 8 ).trim();
 			if ( topic ) {
 				apiFetch( {
@@ -187,7 +191,7 @@ export default function WidgetInput() {
 		setText( '' );
 		setAttachments( [] );
 		setTimeout( () => taRef.current?.focus( { preventScroll: true } ), 0 );
-	}, [ text, attachments, sendMessage ] );
+	}, [ text, attachments, sendMessage, isSimpleMode ] );
 
 	const handleSlashSelect = useCallback(
 		( cmd ) => {
@@ -301,10 +305,20 @@ export default function WidgetInput() {
 		e.preventDefault();
 		taRef.current?.focus( { preventScroll: true } );
 	}, [] );
+	let placeholder = __(
+		'Ask the agent or type / for commands…',
+		'sd-ai-agent'
+	);
+	if ( isSimpleMode ) {
+		placeholder = __( 'Ask a question…', 'sd-ai-agent' );
+	}
+	if ( sending ) {
+		placeholder = __( 'Type to queue a message…', 'sd-ai-agent' );
+	}
 
 	return (
 		<div className="sdaa-w-input">
-			{ showSlash && (
+			{ ! isSimpleMode && showSlash && (
 				<SlashCommandMenu
 					filter={ text }
 					onSelect={ handleSlashSelect }
@@ -376,14 +390,7 @@ export default function WidgetInput() {
 				<textarea
 					ref={ taRef }
 					className="sdaa-w-input-textarea"
-					placeholder={
-						sending
-							? __( 'Type to queue a message…', 'sd-ai-agent' )
-							: __(
-									'Ask the agent or type / for commands…',
-									'sd-ai-agent'
-							  )
-					}
+					placeholder={ placeholder }
 					value={ text }
 					onChange={ ( e ) => setText( e.target.value ) }
 					onKeyDown={ handleKey }
@@ -414,8 +421,8 @@ export default function WidgetInput() {
 						>
 							<Paperclip />
 						</button>
-						<ModelPicker />
-						<AgentPicker />
+						{ ! isSimpleMode && <ModelPicker /> }
+						{ ! isSimpleMode && <AgentPicker /> }
 					</div>
 					<div className="sdaa-w-input-toolbar-right">
 						{ micSupported && (

--- a/src/components/chat-widget/widget-panel.js
+++ b/src/components/chat-widget/widget-panel.js
@@ -15,6 +15,7 @@ import ErrorBoundary from '../error-boundary';
 import ToolConfirmationDialog from '../tool-confirmation-dialog';
 import ProposalPanel from '../proposal-panel';
 import ChangesDrawer from '../chat-redesign/ChangesDrawer';
+import { isCustomerSimpleMode } from '../../utils/chat-ui-mode';
 // chat-redesign base styles (.sdaa-cr-*) are only needed by panel
 // sub-components, so the import lives here rather than in index.js.
 // This keeps the CSS in the async panel chunk and out of the initial bundle.
@@ -32,8 +33,13 @@ const PANEL_SIZE_STORAGE_KEY = 'aiAgentWidgetPanelSize';
 /**
  * @param {Object}      root0                        Component props.
  * @param {string|null} root0.frontendOnboardingMode Frontend onboarding layout mode.
+ * @param {string}      root0.uiMode                 Chat UI mode.
  */
-export default function WidgetPanel( { frontendOnboardingMode = null } ) {
+export default function WidgetPanel( {
+	frontendOnboardingMode = null,
+	uiMode = 'admin',
+} ) {
+	const isSimpleMode = isCustomerSimpleMode( uiMode );
 	const { confirmToolCall, rejectToolCall, setFloatingMinimized } =
 		useDispatch( STORE_NAME );
 
@@ -69,6 +75,10 @@ export default function WidgetPanel( { frontendOnboardingMode = null } ) {
 	}, [ yoloMode, pendingConfirmation, confirmToolCall ] );
 
 	const refreshChangesCount = useCallback( async () => {
+		if ( isSimpleMode ) {
+			setChangesCount( 0 );
+			return;
+		}
 		if ( ! currentSessionId ) {
 			setChangesCount( 0 );
 			return;
@@ -81,7 +91,7 @@ export default function WidgetPanel( { frontendOnboardingMode = null } ) {
 		} catch {
 			setChangesCount( 0 );
 		}
-	}, [ currentSessionId ] );
+	}, [ currentSessionId, isSimpleMode ] );
 
 	useEffect( () => {
 		refreshChangesCount();
@@ -188,7 +198,9 @@ export default function WidgetPanel( { frontendOnboardingMode = null } ) {
 					isMinimized ? ' is-minimized' : ''
 				}${ isDragging ? ' is-dragging' : '' }${
 					isResizing ? ' is-resizing' : ''
-				}${ onboardingClass }` }
+				}${ onboardingClass }${
+					isSimpleMode ? ' is-customer-simple' : ''
+				}` }
 				style={ panelStyle }
 				role="presentation"
 				data-drag-target="true"
@@ -200,6 +212,7 @@ export default function WidgetPanel( { frontendOnboardingMode = null } ) {
 				<WidgetHeader
 					isMinimized={ isMinimized }
 					onToggleMinimize={ toggleMinimize }
+					isSimpleMode={ isSimpleMode }
 					onDragHandleMouseDown={
 						frontendOnboardingMode
 							? undefined
@@ -219,7 +232,7 @@ export default function WidgetPanel( { frontendOnboardingMode = null } ) {
 					</div>
 				) }
 
-				{ ! isMinimized && changesCount > 0 && (
+				{ ! isMinimized && ! isSimpleMode && changesCount > 0 && (
 					<div className="sdaa-w-changes-strip">
 						<span className="sdaa-w-changes-strip-text">
 							<span className="sdaa-w-changes-count">
@@ -259,7 +272,7 @@ export default function WidgetPanel( { frontendOnboardingMode = null } ) {
 								<WidgetMessageList />
 							) }
 						</ErrorBoundary>
-						{ showChanges && (
+						{ ! isSimpleMode && showChanges && (
 							<div className="sdaa-w-changes-drawer-wrap sdaa-cr">
 								<ChangesDrawer
 									sessionId={ currentSessionId }
@@ -275,7 +288,7 @@ export default function WidgetPanel( { frontendOnboardingMode = null } ) {
 					<ErrorBoundary
 						label={ __( 'Message input', 'sd-ai-agent' ) }
 					>
-						<WidgetInput />
+						<WidgetInput isSimpleMode={ isSimpleMode } />
 					</ErrorBoundary>
 				) }
 
@@ -306,7 +319,7 @@ export default function WidgetPanel( { frontendOnboardingMode = null } ) {
 				) }
 			</div>
 
-			{ pendingConfirmation && ! yoloMode && (
+			{ pendingConfirmation && ! yoloMode && ! isSimpleMode && (
 				<ToolConfirmationDialog
 					confirmation={ pendingConfirmation }
 					onConfirm={ ( alwaysAllow ) =>
@@ -321,7 +334,7 @@ export default function WidgetPanel( { frontendOnboardingMode = null } ) {
 				/>
 			) }
 
-			{ pendingProposal && (
+			{ ! isSimpleMode && pendingProposal && (
 				<ProposalPanel
 					proposal={ pendingProposal }
 					onClose={ () => {

--- a/src/components/chat-widget/widget.css
+++ b/src/components/chat-widget/widget.css
@@ -335,6 +335,14 @@
 	background: var(--sdaa-w-surface-hover);
 }
 
+.sdaa-w-panel.is-customer-simple .sdaa-w-head-session {
+	cursor: default;
+}
+
+.sdaa-w-panel.is-customer-simple .sdaa-w-head-session:hover {
+	background: transparent;
+}
+
 .sdaa-w-avatar {
 	display: inline-flex;
 	width: 26px;

--- a/src/types.js
+++ b/src/types.js
@@ -142,40 +142,41 @@
  * The Redux store state shape.
  *
  * @typedef {Object} StoreState
- * @property {Provider[]}               providers               - Available AI providers.
- * @property {boolean}                  providersLoaded         - Whether providers have been fetched.
- * @property {boolean}                  providersLoading        - Whether a providers fetch is in-flight.
- * @property {Session[]}                sessions                - Session list.
- * @property {boolean}                  sessionsLoaded          - Whether sessions have been fetched.
- * @property {number|null}              currentSessionId        - Active session ID.
- * @property {Message[]}                currentSessionMessages  - Messages in the active session.
- * @property {ToolCall[]}               currentSessionToolCalls - Tool calls in the active session.
- * @property {boolean}                  sending                 - Whether a message is in-flight.
- * @property {string|null}              currentJobId            - Active polling job ID.
- * @property {string}                   selectedProviderId      - Currently selected provider ID.
- * @property {string}                   selectedModelId         - Currently selected model ID.
- * @property {boolean}                  floatingOpen            - Whether the floating panel is open.
- * @property {boolean}                  floatingMinimized       - Whether the floating panel is minimized.
- * @property {string|Object}            pageContext             - Structured page context for the AI.
- * @property {string}                   sessionFilter           - Active session filter tab.
- * @property {string}                   sessionFolder           - Active folder filter.
- * @property {string}                   sessionSearch           - Active search query.
- * @property {string[]}                 folders                 - Available folder names.
- * @property {boolean}                  foldersLoaded           - Whether folders have been fetched.
- * @property {Settings|null}            settings                - Plugin settings.
- * @property {boolean}                  settingsLoaded          - Whether settings have been fetched.
- * @property {boolean}                  settingsLoading         - Whether a settings fetch is in-flight.
- * @property {Memory[]}                 memories                - Memory entries.
- * @property {boolean}                  memoriesLoaded          - Whether memories have been fetched.
- * @property {Skill[]}                  skills                  - Skill entries.
- * @property {boolean}                  skillsLoaded            - Whether skills have been fetched.
- * @property {Object}                   skillStats              - Aggregated usage stats indexed by skill_id.
- * @property {boolean}                  skillStatsLoaded        - Whether skill stats have been fetched.
- * @property {Object}                   skillUpdates            - Update availability map from check-updates, indexed by skill_id.
- * @property {boolean}                  skillUpdatesChecking    - Whether a check-updates request is in flight.
- * @property {TokenUsage}               tokenUsage              - Cumulative token usage for the session.
- * @property {PendingConfirmation|null} pendingConfirmation     - Pending tool confirmation.
- * @property {number}                   sendTimestamp           - Timestamp of the last send (ms since epoch).
+ * @property {Provider[]}                                                providers               - Available AI providers.
+ * @property {boolean}                                                   providersLoaded         - Whether providers have been fetched.
+ * @property {boolean}                                                   providersLoading        - Whether a providers fetch is in-flight.
+ * @property {Session[]}                                                 sessions                - Session list.
+ * @property {boolean}                                                   sessionsLoaded          - Whether sessions have been fetched.
+ * @property {number|null}                                               currentSessionId        - Active session ID.
+ * @property {Message[]}                                                 currentSessionMessages  - Messages in the active session.
+ * @property {ToolCall[]}                                                currentSessionToolCalls - Tool calls in the active session.
+ * @property {boolean}                                                   sending                 - Whether a message is in-flight.
+ * @property {string|null}                                               currentJobId            - Active polling job ID.
+ * @property {string}                                                    selectedProviderId      - Currently selected provider ID.
+ * @property {string}                                                    selectedModelId         - Currently selected model ID.
+ * @property {'admin'|'frontend'|'customer_simple'|'public_docs'|string} [chatUiMode]            - Active chat UI mode.
+ * @property {boolean}                                                   floatingOpen            - Whether the floating panel is open.
+ * @property {boolean}                                                   floatingMinimized       - Whether the floating panel is minimized.
+ * @property {string|Object}                                             pageContext             - Structured page context for the AI.
+ * @property {string}                                                    sessionFilter           - Active session filter tab.
+ * @property {string}                                                    sessionFolder           - Active folder filter.
+ * @property {string}                                                    sessionSearch           - Active search query.
+ * @property {string[]}                                                  folders                 - Available folder names.
+ * @property {boolean}                                                   foldersLoaded           - Whether folders have been fetched.
+ * @property {Settings|null}                                             settings                - Plugin settings.
+ * @property {boolean}                                                   settingsLoaded          - Whether settings have been fetched.
+ * @property {boolean}                                                   settingsLoading         - Whether a settings fetch is in-flight.
+ * @property {Memory[]}                                                  memories                - Memory entries.
+ * @property {boolean}                                                   memoriesLoaded          - Whether memories have been fetched.
+ * @property {Skill[]}                                                   skills                  - Skill entries.
+ * @property {boolean}                                                   skillsLoaded            - Whether skills have been fetched.
+ * @property {Object}                                                    skillStats              - Aggregated usage stats indexed by skill_id.
+ * @property {boolean}                                                   skillStatsLoaded        - Whether skill stats have been fetched.
+ * @property {Object}                                                    skillUpdates            - Update availability map from check-updates, indexed by skill_id.
+ * @property {boolean}                                                   skillUpdatesChecking    - Whether a check-updates request is in flight.
+ * @property {TokenUsage}                                                tokenUsage              - Cumulative token usage for the session.
+ * @property {PendingConfirmation|null}                                  pendingConfirmation     - Pending tool confirmation.
+ * @property {number}                                                    sendTimestamp           - Timestamp of the last send (ms since epoch).
  */
 
 /**

--- a/src/utils/__tests__/chat-ui-mode.test.js
+++ b/src/utils/__tests__/chat-ui-mode.test.js
@@ -1,0 +1,31 @@
+import { getChatUiMode, isCustomerSimpleMode } from '../chat-ui-mode';
+
+describe( 'chat UI mode helpers', () => {
+	afterEach( () => {
+		delete window.sdAiAgentData;
+	} );
+
+	test( 'defaults to admin mode', () => {
+		expect( getChatUiMode( {} ) ).toBe( 'admin' );
+		expect( isCustomerSimpleMode( 'admin' ) ).toBe( false );
+	} );
+
+	test( 'normalizes explicit customer/public simple modes', () => {
+		expect( getChatUiMode( { uiMode: 'customer-simple' } ) ).toBe(
+			'customer_simple'
+		);
+		expect( isCustomerSimpleMode( { chat_ui_mode: 'public_docs' } ) ).toBe(
+			true
+		);
+		expect( isCustomerSimpleMode( { embed: { uiMode: 'simple' } } ) ).toBe(
+			true
+		);
+	} );
+
+	test( 'supports localized window data and public chat boolean flags', () => {
+		window.sdAiAgentData = { publicChat: true };
+
+		expect( getChatUiMode() ).toBe( 'public_chat' );
+		expect( isCustomerSimpleMode( window.sdAiAgentData ) ).toBe( true );
+	} );
+} );

--- a/src/utils/chat-ui-mode.js
+++ b/src/utils/chat-ui-mode.js
@@ -1,0 +1,76 @@
+/**
+ * Chat UI mode helpers.
+ *
+ * Customer/public docs embeds need the ask/answer chat surface without the
+ * admin controls for switching sessions, agents, models, or tool profiles.
+ */
+
+const DEFAULT_CHAT_UI_MODE = 'admin';
+
+const SIMPLE_MODE_ALIASES = new Set( [
+	'customer_simple',
+	'public_docs',
+	'public_simple',
+	'public_chat',
+	'customer',
+	'simple',
+] );
+
+/**
+ * Normalize a chat UI mode value.
+ *
+ * @param {*} value Candidate mode value.
+ * @return {string} Normalized mode string.
+ */
+function normalizeMode( value ) {
+	return String( value || '' )
+		.trim()
+		.toLowerCase()
+		.replace( /-/g, '_' );
+}
+
+/**
+ * Resolve the configured chat UI mode from localized/embed data.
+ *
+ * @param {Object} [data] Localized/embed configuration. Defaults to window.sdAiAgentData.
+ * @return {string} Normalized chat UI mode.
+ */
+export function getChatUiMode( data = undefined ) {
+	const source =
+		data ||
+		( typeof window !== 'undefined' ? window.sdAiAgentData || {} : {} );
+	const mode = normalizeMode(
+		source.chatUiMode ||
+			source.chat_ui_mode ||
+			source.uiMode ||
+			source.ui_mode ||
+			source.mode ||
+			source.embed?.chatUiMode ||
+			source.embed?.uiMode
+	);
+
+	if ( mode ) {
+		return mode;
+	}
+
+	if ( source.publicChat === true || source.public_chat === true ) {
+		return 'public_chat';
+	}
+
+	return DEFAULT_CHAT_UI_MODE;
+}
+
+/**
+ * Check whether a resolved UI mode should render the simplified customer UI.
+ *
+ * @param {string|Object} modeOrData Normalized mode string or localized/embed data object.
+ * @return {boolean} True when admin controls should be hidden.
+ */
+export function isCustomerSimpleMode( modeOrData ) {
+	const mode =
+		typeof modeOrData === 'string'
+			? normalizeMode( modeOrData )
+			: getChatUiMode( modeOrData );
+
+	return SIMPLE_MODE_ALIASES.has( mode );
+}


### PR DESCRIPTION
Resolves #2178

## Summary
- Added a `chatUiMode` resolver for `window.sdAiAgentData`/embed config values including `customer_simple` and `public_docs`.
- Hid model/agent selectors, slash-command menu, session drawer, new-chat controls, sidebar, rename/menu actions, changes drawer, proposals, and tool confirmations in customer/simple mode.
- Kept admin mode unchanged by default and passed the simple-mode flag only when configured.
- Added React unit tests for simple-mode suppression and message sending, plus utility tests for mode normalization.

## Worker self-verification
- PHPUnit: Tests: 3696, Assertions: 15453, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- JS tests: Test Suites: 26 passed, 26 total; Tests: 330 passed, 330 total; Snapshots: 6 passed, 6 total
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded (`npm run verify`, including bundle check)

Notes: `npm run verify` reported existing webpack asset-size warnings for admin chunks and a PHPUnit deprecation notice in `SeoAbilities.php`; the command exited successfully.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.67 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 16m and 208,243 tokens on this as a headless worker.
