### PR TITLE
GH#2186: fix: harden static docs import followups

### DIFF
--- a/includes/Knowledge/Knowledge.php
+++ b/includes/Knowledge/Knowledge.php
@@ -238,13 +238,17 @@ class Knowledge {
 		$seen  = [];
 
 		foreach ( $records as $record ) {
+			$identity = self::get_static_doc_identity( $record );
+			if ( '' !== $identity ) {
+				$seen[] = self::stable_static_doc_source_key( $identity );
+			}
+
 			$result = self::index_static_doc_record( $collection_id, $record );
 			if ( is_wp_error( $result ) ) {
 				++$stats['errors'];
 				continue;
 			}
 
-			$seen[] = $result['source_key'];
 			++$stats[ $result['action'] ];
 		}
 
@@ -591,7 +595,10 @@ class Knowledge {
 	 * Build stable numeric key for static docs source identity.
 	 */
 	private static function stable_static_doc_source_key( string $identity ): int {
-		return (int) sprintf( '%u', crc32( $identity ) );
+		// Use 60 bits of sha1 for a far larger keyspace than crc32's 32 bits,
+		// while still fitting comfortably in PHP's signed 64-bit int and the
+		// bigint(20) unsigned source_id column.
+		return (int) hexdec( substr( sha1( $identity ), 0, 15 ) );
 	}
 
 	/**

--- a/includes/Models/DocumentParser.php
+++ b/includes/Models/DocumentParser.php
@@ -52,7 +52,7 @@ class DocumentParser {
 				continue;
 			}
 
-			if ( ! $in_fence && preg_match( '/^(import|export)\s+/i', $trimmed ) ) {
+			if ( ! $in_fence && preg_match( '/^(import|export)\s+/', $trimmed ) ) {
 				continue;
 			}
 

--- a/tests/SdAiAgent/Knowledge/KnowledgeTest.php
+++ b/tests/SdAiAgent/Knowledge/KnowledgeTest.php
@@ -414,6 +414,40 @@ class KnowledgeTest extends WP_UnitTestCase {
 		$this->assertCount( 1, KnowledgeDatabase::get_sources_for_collection( $col_id ) );
 	}
 
+	/**
+	 * Test static documentation manifest prune preserves present records that fail re-indexing.
+	 */
+	public function test_import_static_docs_manifest_prune_preserves_errored_present_records(): void {
+		$col_id = KnowledgeDatabase::create_collection( [
+			'name' => 'Docs Error Prune Collection',
+			'slug' => 'docs-error-prune-collection',
+		] );
+
+		Knowledge::import_static_docs_manifest(
+			$col_id,
+			[
+				[ 'id' => 'docs/a.md', 'title' => 'A', 'content' => '# A\n\nAlpha.' ],
+				[ 'id' => 'docs/b.md', 'title' => 'B', 'content' => '# B\n\nBravo.' ],
+			]
+		);
+
+		$stats = Knowledge::import_static_docs_manifest(
+			$col_id,
+			[
+				[ 'id' => 'docs/b.md', 'title' => 'B', 'content' => '' ],
+			],
+			[ 'prune' => true ]
+		);
+
+		$this->assertIsArray( $stats );
+		$this->assertSame( 1, $stats['errors'] );
+		$this->assertSame( 1, $stats['pruned'] );
+
+		$sources = KnowledgeDatabase::get_sources_for_collection( $col_id );
+		$this->assertCount( 1, $sources );
+		$this->assertSame( 'B', $sources[0]->title );
+	}
+
 	// ── get_context_for_query ─────────────────────────────────────────────
 
 	/**

--- a/tests/SdAiAgent/Models/DocumentParserTest.php
+++ b/tests/SdAiAgent/Models/DocumentParserTest.php
@@ -128,6 +128,17 @@ class DocumentParserTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Markdown content', $result );
 	}
 
+	/**
+	 * extract_markdown_content() preserves prose that starts with capitalized import/export words.
+	 */
+	public function test_extract_markdown_content_preserves_capitalized_import_export_prose(): void {
+		$result = DocumentParser::extract_markdown_content( "import Widget from './Widget';\nImport the file before continuing.\nExport your settings after setup." );
+
+		$this->assertStringNotContainsString( 'import Widget', $result['text'] );
+		$this->assertStringContainsString( 'Import the file before continuing.', $result['text'] );
+		$this->assertStringContainsString( 'Export your settings after setup.', $result['text'] );
+	}
+
 	// ─── extract_from_file() — text/html ─────────────────────────────────────
 
 	/**


### PR DESCRIPTION
## Summary

Marked identifiable static-doc manifest records as seen before indexing so errored-but-present records are not pruned, widened static-doc source keys from crc32 to 60-bit sha1-derived integers, and made MDX import/export stripping case-sensitive to preserve visible prose. Added regressions for errored present records during prune and capitalized import/export prose.

## Files Changed

includes/Knowledge/Knowledge.php, includes/Models/DocumentParser.php, tests/SdAiAgent/Knowledge/KnowledgeTest.php, tests/SdAiAgent/Models/DocumentParserTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run test:php -- --filter='KnowledgeTest|DocumentParserTest' => OK (36 tests, 98 assertions); npm run verify => lint clean, PHPStan 0 errors, PHPUnit Tests: 3703, Assertions: 15492, Skipped: 121, Incomplete: 4, build succeeded, bundle check passed

Resolves #2186


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.70 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 8m and 67,437 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of static documentation imports so previously indexed items are retained when a re-import fails, while missing items are still pruned correctly.
  * Made markdown text extraction more precise, so prose that starts with capitalized “Import” or “Export” is no longer removed unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->