### PR TITLE
fix: improve public docs chat behavior

### DIFF
--- a/includes/Abilities/KnowledgeAbilities.php
+++ b/includes/Abilities/KnowledgeAbilities.php
@@ -83,13 +83,6 @@ class KnowledgeAbilities {
 			$args['query'] = self::$public_default_query;
 		}
 
-		if ( empty( $args['collection'] ) ) {
-			$collection = array_key_first( self::$public_collection_allowlist );
-			if ( is_string( $collection ) ) {
-				$args['collection'] = $collection;
-			}
-		}
-
 		return $args;
 	}
 
@@ -171,13 +164,75 @@ class KnowledgeAbilities {
 				return new \WP_Error( 'sd_ai_agent_public_collection_forbidden', 'This public chat session cannot search that collection.' );
 			}
 
-			$options['collection'] = '' !== $requested ? $requested : (string) array_key_first( self::$public_collection_allowlist );
+			if ( '' !== $requested ) {
+				$options['collection'] = $requested;
+			} else {
+				$results = self::search_public_collections( (string) $query, $options );
+				return self::format_knowledge_search_results( $results );
+			}
 		} elseif ( ! empty( $input['collection'] ) ) {
 			$options['collection'] = $input['collection'];
 		}
 
 		// @phpstan-ignore-next-line
 		$results = Knowledge::search( $query, $options );
+
+		return self::format_knowledge_search_results( $results );
+	}
+
+	/**
+	 * Search every allowlisted public collection and merge the highest scoring hits.
+	 *
+	 * @param string               $query   Search query.
+	 * @param array<string, mixed> $options Search options.
+	 * @return list<array<string, mixed>>
+	 */
+	private static function search_public_collections( string $query, array $options ): array {
+		$merged = [];
+		foreach ( array_keys( self::$public_collection_allowlist ) as $collection ) {
+			$options['collection'] = $collection;
+			$results               = Knowledge::search( $query, $options );
+			foreach ( $results as $result ) {
+				$merged[] = $result;
+			}
+		}
+
+		if ( empty( $merged ) && self::query_needs_overview_fallback( $query ) ) {
+			foreach ( array_keys( self::$public_collection_allowlist ) as $collection ) {
+				$options['collection'] = $collection;
+				$results               = Knowledge::search( 'overview getting started introduction documentation guide', $options );
+				foreach ( $results as $result ) {
+					$merged[] = $result;
+				}
+			}
+		}
+
+		usort(
+			$merged,
+			static fn( array $a, array $b ): int => ( $b['score'] ?? 0 ) <=> ( $a['score'] ?? 0 )
+		);
+
+		return array_slice( $merged, 0, (int) ( $options['limit'] ?? 8 ) );
+	}
+
+	/**
+	 * Whether a public query is too contextual to search literally.
+	 *
+	 * @param string $query Customer query.
+	 * @return bool
+	 */
+	private static function query_needs_overview_fallback( string $query ): bool {
+		$normalized = strtolower( trim( preg_replace( '/\s+/', ' ', $query ) ?? $query ) );
+		return (bool) preg_match( '/\b(?:what\s+(?:is|are)\s+(?:this|that|it|these|those|thing|things)|tell\s+me\s+about\s+(?:this|that|it)|how\s+does\s+(?:this|that|it)\s+work)\b/', $normalized );
+	}
+
+	/**
+	 * Format raw knowledge search rows for tool output.
+	 *
+	 * @param list<array<string, mixed>> $results Raw search results.
+	 * @return array<string, mixed>
+	 */
+	private static function format_knowledge_search_results( array $results ): array {
 
 		if ( empty( $results ) ) {
 			return [

--- a/includes/Knowledge/KnowledgeDatabase.php
+++ b/includes/Knowledge/KnowledgeDatabase.php
@@ -557,21 +557,125 @@ class KnowledgeDatabase {
 		$sources_table     = self::sources_table();
 		$collections_table = self::collections_table();
 
-		// Build boolean mode search terms: prefix each word with +.
-		$words         = preg_split( '/\s+/', trim( $query ) );
-		$boolean_terms = [];
-		foreach ( $words ?: [] as $word ) {
-			$word = (string) preg_replace( '/[^\w]/', '', $word );
-			if ( strlen( $word ) > 1 ) {
-				$boolean_terms[] = '+' . $word . '*';
-			}
-		}
-
-		if ( empty( $boolean_terms ) ) {
+		$search_expr = self::build_boolean_search_expression( $query, true );
+		if ( '' === $search_expr ) {
 			return [];
 		}
 
-		$search_expr = implode( ' ', $boolean_terms );
+		$results = self::run_chunk_search_query( $search_expr, $collection_id, $limit, $chunks_table, $sources_table, $collections_table );
+
+		if ( empty( $results ) ) {
+			$fallback_expr = self::build_boolean_search_expression( $query, false );
+			if ( '' !== $fallback_expr && $fallback_expr !== $search_expr ) {
+				$results = self::run_chunk_search_query( $fallback_expr, $collection_id, $limit, $chunks_table, $sources_table, $collections_table );
+			}
+		}
+
+		if ( empty( $results ) ) {
+			$results = self::run_chunk_like_search_query( self::extract_search_terms( $query ), $collection_id, $limit, $chunks_table, $sources_table, $collections_table );
+		}
+
+		return $results ?: [];
+	}
+
+	/**
+	 * Build a MySQL boolean fulltext expression from a natural-language query.
+	 *
+	 * @param string $query    User query.
+	 * @param bool   $required Whether every term should be required.
+	 * @return string
+	 */
+	private static function build_boolean_search_expression( string $query, bool $required ): string {
+		$terms = self::extract_search_terms( $query );
+		if ( empty( $terms ) ) {
+			return '';
+		}
+
+		$prefix = $required ? '+' : '';
+		return implode(
+			' ',
+			array_map(
+				static fn( string $term ): string => $prefix . $term . '*',
+				$terms
+			)
+		);
+	}
+
+	/**
+	 * Extract useful fulltext terms from a natural-language query.
+	 *
+	 * @param string $query User query.
+	 * @return list<string>
+	 */
+	private static function extract_search_terms( string $query ): array {
+		$stopwords = array_fill_keys(
+			[
+				'a',
+				'an',
+				'and',
+				'are',
+				'as',
+				'at',
+				'be',
+				'by',
+				'can',
+				'do',
+				'does',
+				'for',
+				'from',
+				'how',
+				'i',
+				'in',
+				'is',
+				'it',
+				'of',
+				'on',
+				'or',
+				'so',
+				'that',
+				'the',
+				'this',
+				'to',
+				'what',
+				'when',
+				'where',
+				'which',
+				'who',
+				'why',
+				'with',
+				'you',
+				'your',
+			],
+			true
+		);
+		$terms     = [];
+
+		foreach ( preg_split( '/\s+/', strtolower( trim( $query ) ) ) ?: [] as $word ) {
+			$word = (string) preg_replace( '/[^a-z0-9_]/', '', (string) $word );
+			if ( strlen( $word ) < 4 || isset( $stopwords[ $word ] ) ) {
+				continue;
+			}
+
+			$terms[] = $word;
+		}
+
+		return array_values( array_unique( $terms ) );
+	}
+
+	/**
+	 * Execute a chunk search query.
+	 *
+	 * @param string $search_expr       Boolean fulltext search expression.
+	 * @param ?int   $collection_id     Optional collection ID.
+	 * @param int    $limit             Max results.
+	 * @param string $chunks_table      Chunks table name.
+	 * @param string $sources_table     Sources table name.
+	 * @param string $collections_table Collections table name.
+	 * @return list<object>
+	 */
+	private static function run_chunk_search_query( string $search_expr, ?int $collection_id, int $limit, string $chunks_table, string $sources_table, string $collections_table ): array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
 
 		if ( $collection_id ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Custom table query; caching not applicable.
@@ -620,6 +724,60 @@ class KnowledgeDatabase {
 				)
 			);
 		}
+
+		return $results ?: [];
+	}
+
+	/**
+	 * Execute a LIKE fallback query when FULLTEXT returns no hits.
+	 *
+	 * @param string[] $terms Query terms.
+	 * @param ?int     $collection_id Optional collection ID.
+	 * @param int      $limit         Max results.
+	 * @param string   $chunks_table  Chunks table name.
+	 * @param string   $sources_table Sources table name.
+	 * @param string   $collections_table Collections table name.
+	 * @return list<object>
+	 */
+	private static function run_chunk_like_search_query( array $terms, ?int $collection_id, int $limit, string $chunks_table, string $sources_table, string $collections_table ): array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		if ( empty( $terms ) ) {
+			return [];
+		}
+
+		$where_parts     = [];
+		$relevance_parts = [];
+		$values          = [];
+
+		foreach ( $terms as $term ) {
+			$like              = '%' . $wpdb->esc_like( $term ) . '%';
+			$where_parts[]     = 'c.chunk_text LIKE %s';
+			$relevance_parts[] = 'CASE WHEN c.chunk_text LIKE %s THEN 1 ELSE 0 END';
+			$values[]          = $like;
+		}
+
+		$sql = 'SELECT c.id, c.chunk_text, c.chunk_index, c.metadata,
+				s.title AS source_title, s.source_type, s.source_id, s.source_url,
+				col.name AS collection_name, col.slug AS collection_slug,
+				(' . implode( ' + ', $relevance_parts ) . ') AS relevance
+			FROM %i c
+			INNER JOIN %i s ON c.source_id = s.id
+			INNER JOIN %i col ON c.collection_id = col.id
+			WHERE (' . implode( ' OR ', $where_parts ) . ')';
+
+		$query_values = array_merge( $values, [ $chunks_table, $sources_table, $collections_table ], $values );
+		if ( $collection_id ) {
+			$sql           .= ' AND c.collection_id = %d';
+			$query_values[] = $collection_id;
+		}
+
+		$sql           .= ' ORDER BY relevance DESC LIMIT %d';
+		$query_values[] = $limit;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Custom table query; caching not applicable.
+		$results = $wpdb->get_results( $wpdb->prepare( $sql, $query_values ) );
 
 		return $results ?: [];
 	}

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -1791,7 +1791,9 @@ final class SessionController {
 		$example_collection = $config['collections'][0] ?? 'docs';
 
 		return 'You are a public documentation assistant. Answer only from retrieved documentation, code, or documentation-index context whenever possible. '
-			. 'Your only public tool is knowledge-search. When you need documentation context, call knowledge-search with a non-empty JSON query argument copied from or summarized from the customer question, '
+			. 'Your only public tool is knowledge-search. Before answering any substantive product or documentation question, call knowledge-search at least once. '
+			. 'When the customer asks a vague contextual question such as "what is this?" or uses pronouns, rewrite it into a concrete overview/getting-started documentation query instead of searching only the vague words. '
+			. 'When you need documentation context, call knowledge-search with a non-empty JSON query argument copied from or summarized from the customer question, '
 			. 'and when selecting a collection use only one of these configured collections: ' . $collections . '. '
 			. 'Example valid arguments: {"query":"customer docs question","collection":"' . $example_collection . '"}. '
 			. 'Never call knowledge-search with empty arguments. Cite source titles and URLs from knowledge-search results when using facts. '

--- a/src/embed-widget/__tests__/index.test.js
+++ b/src/embed-widget/__tests__/index.test.js
@@ -49,4 +49,26 @@ describe( 'embed widget', () => {
 			expect.objectContaining( { credentials: 'omit' } )
 		);
 	} );
+
+	test( 'starts collapsed and close button collapses the panel', () => {
+		const root = module.mountEmbed( {
+			...module.resolveConfig( null, {} ),
+			apiBase: 'https://example.test/wp-json/sd-ai-agent/v1',
+			mount: '#mount',
+		} );
+		const launcher = root.querySelector( '.sdaa-embed__launcher' );
+		const panel = root.querySelector( '.sdaa-embed__panel' );
+		const close = root.querySelector( '.sdaa-embed__close' );
+
+		expect( panel.hidden ).toBe( true );
+		expect( launcher.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
+
+		launcher.click();
+		expect( panel.hidden ).toBe( false );
+		expect( launcher.getAttribute( 'aria-expanded' ) ).toBe( 'true' );
+
+		close.click();
+		expect( panel.hidden ).toBe( true );
+		expect( launcher.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
+	} );
 } );

--- a/src/embed-widget/style.css
+++ b/src/embed-widget/style.css
@@ -51,6 +51,10 @@
 	color: var(--sdaa-embed-text);
 }
 
+.sdaa-embed__panel[hidden] {
+	display: none !important;
+}
+
 .sdaa-embed__header,
 .sdaa-embed__form {
 	display: flex;

--- a/tests/SdAiAgent/Abilities/KnowledgeAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/KnowledgeAbilitiesTest.php
@@ -10,12 +10,38 @@
 namespace SdAiAgent\Tests\Abilities;
 
 use SdAiAgent\Abilities\KnowledgeAbilities;
+use SdAiAgent\Core\Database;
+use SdAiAgent\Knowledge\KnowledgeDatabase;
 use WP_UnitTestCase;
 
 /**
  * Test KnowledgeAbilities handler methods.
  */
 class KnowledgeAbilitiesTest extends WP_UnitTestCase {
+
+	/**
+	 * Ensure custom tables exist before tests run.
+	 */
+	public static function set_up_before_class(): void {
+		parent::set_up_before_class();
+		Database::install();
+	}
+
+	/**
+	 * Clean up knowledge data and public mode after each test.
+	 */
+	public function tear_down(): void {
+		KnowledgeAbilities::clear_public_collection_allowlist();
+		parent::tear_down();
+
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test cleanup.
+		$wpdb->query( $wpdb->prepare( 'DELETE FROM %i WHERE 1=1', KnowledgeDatabase::chunks_table() ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test cleanup.
+		$wpdb->query( $wpdb->prepare( 'DELETE FROM %i WHERE 1=1', KnowledgeDatabase::sources_table() ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test cleanup.
+		$wpdb->query( $wpdb->prepare( 'DELETE FROM %i WHERE 1=1', KnowledgeDatabase::collections_table() ) );
+	}
 
 	/**
 	 * Test handle_knowledge_search with empty query returns WP_Error.
@@ -81,10 +107,73 @@ class KnowledgeAbilitiesTest extends WP_UnitTestCase {
 
 		$args = KnowledgeAbilities::hydrate_public_search_args( [] );
 
-		KnowledgeAbilities::clear_public_collection_allowlist();
-
 		$this->assertSame( 'How do I embed the widget?', $args['query'] );
-		$this->assertSame( 'docs', $args['collection'] );
+		$this->assertArrayNotHasKey( 'collection', $args );
+	}
+
+	/**
+	 * Test public chat searches every allowlisted collection when no collection is requested.
+	 */
+	public function test_public_search_without_collection_searches_allowlist() {
+		$docs_id = KnowledgeDatabase::create_collection( [ 'name' => 'Docs', 'slug' => 'docs' ] );
+		$code_id = KnowledgeDatabase::create_collection( [ 'name' => 'Code Reference', 'slug' => 'code-reference' ] );
+
+		$docs_source = KnowledgeDatabase::create_source( [
+			'collection_id' => $docs_id,
+			'source_type'   => 'static_file',
+			'source_id'     => 1,
+			'title'         => 'General Docs',
+		] );
+		$code_source = KnowledgeDatabase::create_source( [
+			'collection_id' => $code_id,
+			'source_type'   => 'static_file',
+			'source_id'     => 2,
+			'title'         => 'Site Creation Reference',
+		] );
+
+		KnowledgeDatabase::insert_chunks( $docs_id, $docs_source, [
+			[ 'text' => 'Ultimate Multisite overview and installation notes.', 'index' => 0 ],
+		] );
+		KnowledgeDatabase::insert_chunks( $code_id, $code_source, [
+			[ 'text' => 'Ultimate Multisite creates new sites from templates during checkout.', 'index' => 0 ],
+		] );
+
+		KnowledgeAbilities::set_public_collection_allowlist( [ 'docs', 'code-reference' ], 'How are sites created?' );
+
+		$result = KnowledgeAbilities::handle_knowledge_search( [
+			'query' => 'how does Ultimate Multisite create new sites?',
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertGreaterThan( 0, $result['count'] );
+		$this->assertContains( 'Site Creation Reference', wp_list_pluck( $result['results'], 'source' ) );
+	}
+
+	/**
+	 * Test public chat uses overview fallback for contextual/vague questions.
+	 */
+	public function test_public_search_uses_overview_fallback_for_vague_question() {
+		$docs_id = KnowledgeDatabase::create_collection( [ 'name' => 'Docs', 'slug' => 'docs' ] );
+		$source_id = KnowledgeDatabase::create_source( [
+			'collection_id' => $docs_id,
+			'source_type'   => 'static_file',
+			'source_id'     => 3,
+			'title'         => 'Ultimate Multisite Overview',
+		] );
+
+		KnowledgeDatabase::insert_chunks( $docs_id, $source_id, [
+			[ 'text' => 'Overview: Ultimate Multisite is a platform for creating hosted WordPress multisite networks.', 'index' => 0 ],
+		] );
+
+		KnowledgeAbilities::set_public_collection_allowlist( [ 'docs' ], 'What is this thing?' );
+
+		$result = KnowledgeAbilities::handle_knowledge_search( [
+			'query' => 'what is this thing?',
+		] );
+
+		$this->assertIsArray( $result );
+		$this->assertGreaterThan( 0, $result['count'] );
+		$this->assertSame( 'Ultimate Multisite Overview', $result['results'][0]['source'] );
 	}
 
 	/**

--- a/tests/SdAiAgent/Knowledge/KnowledgeDatabaseTest.php
+++ b/tests/SdAiAgent/Knowledge/KnowledgeDatabaseTest.php
@@ -609,4 +609,29 @@ class KnowledgeDatabaseTest extends WP_UnitTestCase {
 		$this->assertIsArray( $results );
 		$this->assertEmpty( $results );
 	}
+
+	/**
+	 * Test search_chunks handles natural-language questions with stopwords.
+	 */
+	public function test_search_chunks_handles_natural_language_question(): void {
+		$col_id    = KnowledgeDatabase::create_collection( [ 'name' => 'Docs', 'slug' => 'docs' ] );
+		$source_id = KnowledgeDatabase::create_source( [
+			'collection_id' => $col_id,
+			'source_type'   => 'static_file',
+			'source_id'     => 101,
+			'title'         => 'Managing Sites',
+		] );
+
+		KnowledgeDatabase::insert_chunks( $col_id, $source_id, [
+			[
+				'text'  => 'Sites are the core of your WaaS business. Ultimate Multisite can create new customer sites from templates.',
+				'index' => 0,
+			],
+		] );
+
+		$results = KnowledgeDatabase::search_chunks( 'how does Ultimate Multisite create new sites?', $col_id, 3 );
+
+		$this->assertNotEmpty( $results );
+		$this->assertSame( 'Managing Sites', $results[0]->source_title );
+	}
 }

--- a/tests/SdAiAgent/REST/PublicChatControllerTest.php
+++ b/tests/SdAiAgent/REST/PublicChatControllerTest.php
@@ -161,6 +161,8 @@ class PublicChatControllerTest extends WP_UnitTestCase {
 		$this->assertSame( 0, $job['user_id'] );
 		$this->assertSame( array( 'sd-ai-agent/knowledge-search' ), $job['params']['abilities'] );
 		$this->assertStringContainsString( 'Never call knowledge-search with empty arguments', $job['params']['system_instruction'] );
+		$this->assertStringContainsString( 'Before answering any substantive product or documentation question', $job['params']['system_instruction'] );
+		$this->assertStringContainsString( 'rewrite it into a concrete overview/getting-started documentation query', $job['params']['system_instruction'] );
 		$this->assertStringContainsString( '"query":"customer docs question"', $job['params']['system_instruction'] );
 		$this->assertStringContainsString( 'docs', $job['params']['system_instruction'] );
 


### PR DESCRIPTION
## Summary
- Improve public knowledge search for natural-language docs questions by filtering stopwords, retrying broad boolean searches, and falling back to LIKE matches.
- Search all allowlisted public collections by default, with an overview fallback for vague questions like “what is this?”.
- Keep the static embed widget collapsed by honoring the panel `hidden` state, and cover close-button behavior with a Jest test.

## Worker self-verification
- PHPUnit: Tests: 3713, Assertions: 15556, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded (`npm run verify`; webpack reported existing asset-size warnings, bundle budget check passed)
- JS:      `npm run test:js -- src/embed-widget/__tests__/index.test.js --runInBand` passed, 3 tests

## Notes
- No production deploy included. This is ready for dev-first review/testing.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.76 plugin for [OpenCode](https://opencode.ai) v1.17.13
