### PR TITLE
GH#2193: fix: preserve lowercase import export prose

### DIFF
--- a/includes/Models/DocumentParser.php
+++ b/includes/Models/DocumentParser.php
@@ -52,7 +52,7 @@ class DocumentParser {
 				continue;
 			}
 
-			if ( ! $in_fence && preg_match( '/^(import|export)\s+/', $trimmed ) ) {
+			if ( ! $in_fence && self::is_mdx_module_statement( $trimmed ) ) {
 				continue;
 			}
 
@@ -287,6 +287,29 @@ class DocumentParser {
 		];
 
 		return $map[ $ext ] ?? 'application/octet-stream';
+	}
+
+	/**
+	 * Determine whether a line is MDX module syntax that should be hidden.
+	 *
+	 * @param string $line Trimmed markdown line.
+	 * @return bool True when the line is import/export module plumbing.
+	 */
+	private static function is_mdx_module_statement( string $line ): bool {
+		$patterns = [
+			'/^import\s+(?:[\w*{}\s,]+\s+from\s+)?[\'\"][^\'\"]+[\'\"]\s*;?$/',
+			'/^export\s+(?:default\s+)?(?:const|let|var|function|class)\b/',
+			'/^export\s+(?:\*|\{[^}]+\})\s+from\s+[\'\"][^\'\"]+[\'\"]\s*;?$/',
+			'/^export\s+\{[^}]+\}\s*;?$/',
+		];
+
+		foreach ( $patterns as $pattern ) {
+			if ( preg_match( $pattern, $line ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/SdAiAgent/Models/DocumentParserTest.php
+++ b/tests/SdAiAgent/Models/DocumentParserTest.php
@@ -139,6 +139,18 @@ class DocumentParserTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Export your settings after setup.', $result['text'] );
 	}
 
+	/**
+	 * extract_markdown_content() preserves lowercase prose that starts with import/export words.
+	 */
+	public function test_extract_markdown_content_preserves_lowercase_import_export_prose(): void {
+		$result = DocumentParser::extract_markdown_content( "import Widget from './Widget';\nexport your settings before continuing.\nimport the file after setup.\nexport const value = 1;" );
+
+		$this->assertStringNotContainsString( 'import Widget', $result['text'] );
+		$this->assertStringNotContainsString( 'export const value', $result['text'] );
+		$this->assertStringContainsString( 'export your settings before continuing.', $result['text'] );
+		$this->assertStringContainsString( 'import the file after setup.', $result['text'] );
+	}
+
 	// ─── extract_from_file() — text/html ─────────────────────────────────────
 
 	/**


### PR DESCRIPTION
## Summary

Tightened DocumentParser's MDX import/export stripping so only module syntax is hidden while lowercase prose beginning with import/export remains searchable; added regression coverage for lowercase prose alongside actual MDX statements.

## Files Changed

includes/Models/DocumentParser.php, tests/SdAiAgent/Models/DocumentParserTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run lint; COMPOSER_PROCESS_TIMEOUT=1200 composer phpstan; npm run test:php -- --filter=DocumentParserTest (OK: 15 tests, 40 assertions); npm run build; npm run check:bundle. npm run verify was attempted after npm run test:php:setup but the full suite failed because the local PHPUnit database is missing core wptests_* tables, producing unrelated WP_Error insert failures outside DocumentParser.

Resolves #2193


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.80 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 11m and 101,393 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved markdown extraction so import/export-like lines are removed more reliably from visible content.
  * Preserved normal prose that happens to start with words like “import” or “export,” preventing unintended text loss.
  * Added test coverage to confirm the cleaner behavior across code-like lines and lowercase sentence text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->