### PR TITLE
GH#2192: fix: address customer chat setup review feedback

### DIFF
--- a/includes/Abilities/PublicChatSetupAbilities.php
+++ b/includes/Abilities/PublicChatSetupAbilities.php
@@ -49,7 +49,7 @@ class PublicChatSetupAbilities {
 						),
 						'enabled'            => array(
 							'type'        => 'boolean',
-							'description' => 'Whether public chat should be enabled during configure. Defaults to true for configure.',
+							'description' => 'Whether public chat should be enabled during configure. Defaults to the currently saved state when omitted.',
 						),
 						'origins'            => array(
 							'type'        => 'array',
@@ -165,8 +165,9 @@ class PublicChatSetupAbilities {
 	 */
 	private static function configure_public_chat( Settings $settings, array $input ): true|WP_Error {
 		$current = self::public_chat_settings( $settings );
+		$enabled = array_key_exists( 'enabled', $input ) ? (bool) $input['enabled'] : (bool) $current['public_chat_enabled'];
 		$updates = array(
-			'public_chat_enabled'           => array_key_exists( 'enabled', $input ) ? (bool) $input['enabled'] : true,
+			'public_chat_enabled'           => $enabled,
 			'public_chat_allowed_abilities' => self::SAFE_PUBLIC_ABILITIES,
 		);
 

--- a/includes/Models/skills/customer-chat-setup.md
+++ b/includes/Models/skills/customer-chat-setup.md
@@ -18,7 +18,8 @@ support chat.
    manifest with WP-CLI:
 
    ```bash
-   wp sd-ai-agent knowledge import_static_docs build/docs-manifest.jsonl --collection=docs --prune
+   wp sd-ai-agent knowledge import-static-docs build/docs-manifest.jsonl \
+     --collection=docs --prune
    ```
 
    Do not ask public/browser input to read arbitrary server paths. The importer

--- a/tests/SdAiAgent/Abilities/PublicChatSetupAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/PublicChatSetupAbilitiesTest.php
@@ -79,6 +79,7 @@ class PublicChatSetupAbilitiesTest extends WP_UnitTestCase {
 		$result = PublicChatSetupAbilities::handle_public_chat_setup(
 			array(
 				'action'             => 'configure',
+				'enabled'            => true,
 				'origins'            => array( 'HTTPS://Docs.Example.com/path' ),
 				'collection_slugs'   => array( $this->collection_slug ),
 				'provider_id'        => 'sd-ai-agent-cloud',
@@ -137,5 +138,35 @@ class PublicChatSetupAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 'disabled', $result['status'] );
 		$this->assertFalse( $result['settings']['public_chat_enabled'] );
 		$this->assertSame( array( $this->collection_slug ), $result['settings']['public_chat_collection_ids'] );
+	}
+
+	/** Configure preserves a disabled public chat state when enabled is omitted. */
+	public function test_configure_preserves_disabled_state_when_enabled_is_omitted(): void {
+		PublicChatSetupAbilities::handle_public_chat_setup(
+			array(
+				'action'           => 'configure',
+				'enabled'          => true,
+				'collection_slugs' => array( $this->collection_slug ),
+				'provider_id'      => 'sd-ai-agent-cloud',
+				'model_id'         => 'superdav-chat-pro',
+			)
+		);
+
+		PublicChatSetupAbilities::handle_public_chat_setup(
+			array(
+				'action' => 'disable',
+			)
+		);
+
+		$result = PublicChatSetupAbilities::handle_public_chat_setup(
+			array(
+				'action'             => 'configure',
+				'rate_limit_per_min' => 12,
+			)
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertFalse( $result['settings']['public_chat_enabled'] );
+		$this->assertSame( 12, $result['settings']['public_chat_rate_limit_per_min'] );
 	}
 }


### PR DESCRIPTION
## Summary

Preserved the saved public chat enabled state when configure omits enabled, updated the ability schema description, corrected the customer chat setup WP-CLI example to import-static-docs, and added regression coverage for disabled-state preservation.

## Files Changed

includes/Abilities/PublicChatSetupAbilities.php, includes/Models/skills/customer-chat-setup.md, tests/SdAiAgent/Abilities/PublicChatSetupAbilitiesTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Targeted: npm run test:php -- --filter=PublicChatSetupAbilitiesTest (OK: 6 tests, 27 assertions); composer phpcs on changed PHP files (pass); npx markdownlint-cli2 includes/Models/skills/customer-chat-setup.md (pass); npm run build (pass with existing webpack size warnings); npm run check:bundle (pass). Full npm run verify reached PHPUnit and failed due local shared PHPUnit database instability/unrelated failures after test tables disappeared mid-suite; retry after npm run test:php:setup reduced to one unrelated ContactMappingController admin-only assertion with missing test DB table errors.

Resolves #2192


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.80 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 11m and 153,575 tokens on this as a headless worker.