### PR TITLE
GH#2196: fix: hide mdx module export statements

### DIFF
--- a/includes/Models/DocumentParser.php
+++ b/includes/Models/DocumentParser.php
@@ -299,6 +299,8 @@ class DocumentParser {
 		$patterns = [
 			'/^import\s+(?:[\w*{}\s,]+\s+from\s+)?[\'\"][^\'\"]+[\'\"]\s*;?$/',
 			'/^export\s+(?:default\s+)?(?:const|let|var|function|class)\b/',
+			'/^export\s+default\s+[A-Za-z_$][\w$]*\s*;?$/',
+			'/^export\s+\*\s+as\s+[A-Za-z_$][\w$]*\s+from\s+[\'\"][^\'\"]+[\'\"]\s*;?$/',
 			'/^export\s+(?:\*|\{[^}]+\})\s+from\s+[\'\"][^\'\"]+[\'\"]\s*;?$/',
 			'/^export\s+\{[^}]+\}\s*;?$/',
 		];

--- a/tests/SdAiAgent/Models/DocumentParserTest.php
+++ b/tests/SdAiAgent/Models/DocumentParserTest.php
@@ -151,6 +151,18 @@ class DocumentParserTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'import the file after setup.', $result['text'] );
 	}
 
+	/**
+	 * extract_markdown_content() hides bare default and namespace re-export MDX statements.
+	 */
+	public function test_extract_markdown_content_hides_bare_default_and_namespace_exports(): void {
+		$result = DocumentParser::extract_markdown_content( "export default Layout;\nexport * as components from './components';\n# Visible heading\nVisible copy remains." );
+
+		$this->assertStringNotContainsString( 'export default Layout', $result['text'] );
+		$this->assertStringNotContainsString( 'export * as components', $result['text'] );
+		$this->assertStringContainsString( 'Visible heading', $result['text'] );
+		$this->assertStringContainsString( 'Visible copy remains.', $result['text'] );
+	}
+
 	// ─── extract_from_file() — text/html ─────────────────────────────────────
 
 	/**


### PR DESCRIPTION
## Summary

Extended MDX module statement filtering to hide bare default exports and namespace re-exports, with DocumentParser regression coverage.

## Files Changed

includes/Models/DocumentParser.php, tests/SdAiAgent/Models/DocumentParserTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run test:php -- --filter=DocumentParserTest; npm run verify

Resolves #2196


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.80 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 5m and 54,714 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved extracted text so MDX module export lines no longer appear in visible content.
  * Hidden additional export patterns, including default and namespace re-exports, when they’re outside code blocks.

* **Tests**
  * Added coverage to confirm export statements are omitted while normal markdown content still appears.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->