### PR TITLE
fix: render embed assistant markdown

### DIFF
--- a/src/embed-widget/__tests__/index.test.js
+++ b/src/embed-widget/__tests__/index.test.js
@@ -118,4 +118,21 @@ describe( 'embed widget', () => {
 			'<img src=x onerror=alert(1)>'
 		);
 	} );
+
+	test( 'keeps underscores and asterisks inside identifiers literal', () => {
+		const container = document.createElement( 'div' );
+		container.appendChild(
+			module.renderMarkdown(
+				'Keep wp_config_value, some_snake_case, and word*star*word literal; render _emphasis_.'
+			)
+		);
+
+		expect( container.querySelectorAll( 'em' ) ).toHaveLength( 1 );
+		expect( container.querySelector( 'em' ).textContent ).toBe(
+			'emphasis'
+		);
+		expect( container.textContent ).toContain( 'wp_config_value' );
+		expect( container.textContent ).toContain( 'some_snake_case' );
+		expect( container.textContent ).toContain( 'word*star*word' );
+	} );
 } );

--- a/src/embed-widget/__tests__/index.test.js
+++ b/src/embed-widget/__tests__/index.test.js
@@ -71,4 +71,51 @@ describe( 'embed widget', () => {
 		expect( panel.hidden ).toBe( true );
 		expect( launcher.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
 	} );
+
+	test( 'renders assistant markdown and makes source URLs clickable', () => {
+		const root = module.mountEmbed( {
+			...module.resolveConfig( null, {} ),
+			apiBase: 'https://example.test/wp-json/sd-ai-agent/v1',
+			greeting:
+				'Read **Setup Wizard**. Source: https://example.test/docs/setup.',
+			mount: '#mount',
+		} );
+
+		const message = root.querySelector( '.sdaa-embed__message--assistant' );
+		const sourceLink = message.querySelector( 'a' );
+
+		expect( message.querySelector( 'strong' ).textContent ).toBe(
+			'Setup Wizard'
+		);
+		expect( sourceLink.textContent ).toBe(
+			'https://example.test/docs/setup'
+		);
+		expect( sourceLink.getAttribute( 'href' ) ).toBe(
+			'https://example.test/docs/setup'
+		);
+		expect( sourceLink.getAttribute( 'target' ) ).toBe( '_blank' );
+		expect( sourceLink.getAttribute( 'rel' ) ).toBe(
+			'noopener noreferrer'
+		);
+		expect( message.textContent ).toBe(
+			'Read Setup Wizard. Source: https://example.test/docs/setup.'
+		);
+	} );
+
+	test( 'escapes raw HTML while rendering inline code', () => {
+		const container = document.createElement( 'div' );
+		container.appendChild(
+			module.renderMarkdown(
+				'Use <img src=x onerror=alert(1)> and `wp config`.'
+			)
+		);
+
+		expect( container.querySelector( 'img' ) ).toBeNull();
+		expect( container.querySelector( 'code' ).textContent ).toBe(
+			'wp config'
+		);
+		expect( container.textContent ).toContain(
+			'<img src=x onerror=alert(1)>'
+		);
+	} );
 } );

--- a/src/embed-widget/index.js
+++ b/src/embed-widget/index.js
@@ -30,6 +30,282 @@ const STRINGS = {
 	thinking: 'Thinking…',
 };
 
+const TRAILING_URL_PUNCTUATION = /[.,;:!?'")\]]+$/;
+
+/**
+ * Create a fresh inline markdown matcher.
+ *
+ * The embeddable widget cannot rely on WordPress globals or React, so this
+ * handles the small subset of assistant markdown we render in the static DOM:
+ * links, raw URLs, strong/emphasis, and inline code.
+ *
+ * @return {RegExp} Stateful inline markdown matcher.
+ */
+function createInlineMarkdownRegex() {
+	return /\[([^\]\n]+)\]\((https?:\/\/[^\s)]+)\)|`([^`\n]+)`|\*\*([^*\n]+)\*\*|__([^_\n]+)__|\*([^*\n]+)\*|_([^_\n]+)_|https?:\/\/[^\s<>"']+/g;
+}
+
+/**
+ * Validate and normalize absolute HTTP(S) URLs before creating anchors.
+ *
+ * @param {string} url Candidate URL.
+ * @return {string} Safe URL, or an empty string when unsafe/invalid.
+ */
+function normalizeHttpUrl( url ) {
+	try {
+		const parsed = new URL( url );
+		return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+			? parsed.href
+			: '';
+	} catch {
+		return '';
+	}
+}
+
+/**
+ * Split punctuation that usually belongs to prose, not the URL itself.
+ *
+ * @param {string} rawUrl URL token from the markdown source.
+ * @return {{url: string, suffix: string}} Trimmed URL and trailing suffix.
+ */
+function splitTrailingUrlPunctuation( rawUrl ) {
+	const url = rawUrl.replace( TRAILING_URL_PUNCTUATION, '' );
+	return {
+		url,
+		suffix: rawUrl.slice( url.length ),
+	};
+}
+
+/**
+ * Append a safe external link, falling back to text if the URL is invalid.
+ *
+ * @param {HTMLElement|DocumentFragment} parent     Node to append to.
+ * @param {string}                       href       Link destination.
+ * @param {string}                       label      Link text.
+ * @param {boolean}                      parseLabel Whether label markdown should be parsed.
+ * @return {void}
+ */
+function appendLink( parent, href, label, parseLabel = true ) {
+	const safeHref = normalizeHttpUrl( href );
+	if ( ! safeHref ) {
+		parent.appendChild( document.createTextNode( label ) );
+		return;
+	}
+
+	const anchor = document.createElement( 'a' );
+	anchor.href = safeHref;
+	anchor.target = '_blank';
+	anchor.rel = 'noopener noreferrer';
+	if ( parseLabel ) {
+		appendInlineMarkdown( anchor, label );
+	} else {
+		anchor.textContent = label;
+	}
+	parent.appendChild( anchor );
+}
+
+/**
+ * Append inline markdown to a DOM node without using innerHTML.
+ *
+ * @param {HTMLElement|DocumentFragment} parent Node to append to.
+ * @param {string}                       text   Inline markdown text.
+ * @return {void}
+ */
+function appendInlineMarkdown( parent, text ) {
+	const source = String( text || '' );
+	const regex = createInlineMarkdownRegex();
+	let lastIndex = 0;
+	let match;
+
+	while ( ( match = regex.exec( source ) ) !== null ) {
+		if ( match.index > lastIndex ) {
+			parent.appendChild(
+				document.createTextNode(
+					source.slice( lastIndex, match.index )
+				)
+			);
+		}
+
+		if ( match[ 1 ] && match[ 2 ] ) {
+			appendLink( parent, match[ 2 ], match[ 1 ] );
+		} else if ( match[ 3 ] ) {
+			const code = document.createElement( 'code' );
+			code.textContent = match[ 3 ];
+			parent.appendChild( code );
+		} else if ( match[ 4 ] || match[ 5 ] ) {
+			const strong = document.createElement( 'strong' );
+			appendInlineMarkdown( strong, match[ 4 ] || match[ 5 ] );
+			parent.appendChild( strong );
+		} else if ( match[ 6 ] || match[ 7 ] ) {
+			const emphasis = document.createElement( 'em' );
+			appendInlineMarkdown( emphasis, match[ 6 ] || match[ 7 ] );
+			parent.appendChild( emphasis );
+		} else {
+			const { url, suffix } = splitTrailingUrlPunctuation( match[ 0 ] );
+			appendLink( parent, url, url, false );
+			if ( suffix ) {
+				parent.appendChild( document.createTextNode( suffix ) );
+			}
+		}
+
+		lastIndex = match.index + match[ 0 ].length;
+	}
+
+	if ( lastIndex < source.length ) {
+		parent.appendChild(
+			document.createTextNode( source.slice( lastIndex ) )
+		);
+	}
+}
+
+/**
+ * Append multiple inline markdown lines with explicit line breaks.
+ *
+ * @param {HTMLElement} parent Node to append to.
+ * @param {string[]}    lines  Lines to append.
+ * @return {void}
+ */
+function appendInlineLines( parent, lines ) {
+	lines.forEach( ( line, index ) => {
+		if ( index > 0 ) {
+			parent.appendChild( document.createElement( 'br' ) );
+		}
+		appendInlineMarkdown( parent, line );
+	} );
+}
+
+/**
+ * Detect whether a line starts a markdown block.
+ *
+ * @param {string} line Markdown source line.
+ * @return {boolean} True when the line starts a block.
+ */
+function isBlockStart( line ) {
+	return (
+		/^```/.test( line ) ||
+		/^#{1,6}\s+/.test( line ) ||
+		/^>\s?/.test( line ) ||
+		/^\s*[-*+]\s+/.test( line ) ||
+		/^\s*\d+\.\s+/.test( line )
+	);
+}
+
+/**
+ * Render assistant markdown into safe DOM nodes for the dependency-free embed.
+ *
+ * This intentionally supports a compact markdown subset instead of raw HTML so
+ * source links are clickable without exposing the host site to injected markup.
+ *
+ * @param {string} markdown Markdown response text.
+ * @return {DocumentFragment} Rendered DOM fragment.
+ */
+export function renderMarkdown( markdown ) {
+	const fragment = document.createDocumentFragment();
+	const lines = String( markdown || '' )
+		.replace( /\r\n?/g, '\n' )
+		.split( '\n' );
+	let index = 0;
+
+	while ( index < lines.length ) {
+		const line = lines[ index ];
+
+		if ( ! line.trim() ) {
+			index += 1;
+			continue;
+		}
+
+		const fence = line.match( /^```\s*([\w-]+)?\s*$/ );
+		if ( fence ) {
+			const codeLines = [];
+			index += 1;
+			while (
+				index < lines.length &&
+				! /^```\s*$/.test( lines[ index ] )
+			) {
+				codeLines.push( lines[ index ] );
+				index += 1;
+			}
+			if ( index < lines.length ) {
+				index += 1;
+			}
+
+			const pre = document.createElement( 'pre' );
+			const code = document.createElement( 'code' );
+			if ( fence[ 1 ] ) {
+				code.className = `language-${ fence[ 1 ] }`;
+			}
+			code.textContent = codeLines.join( '\n' );
+			pre.appendChild( code );
+			fragment.appendChild( pre );
+			continue;
+		}
+
+		const heading = line.match( /^(#{1,6})\s+(.+)$/ );
+		if ( heading ) {
+			const headingNode = document.createElement(
+				`h${ heading[ 1 ].length }`
+			);
+			appendInlineMarkdown( headingNode, heading[ 2 ].trim() );
+			fragment.appendChild( headingNode );
+			index += 1;
+			continue;
+		}
+
+		if ( /^>\s?/.test( line ) ) {
+			const quoteLines = [];
+			while ( index < lines.length && /^>\s?/.test( lines[ index ] ) ) {
+				quoteLines.push( lines[ index ].replace( /^>\s?/, '' ) );
+				index += 1;
+			}
+
+			const blockquote = document.createElement( 'blockquote' );
+			appendInlineLines( blockquote, quoteLines );
+			fragment.appendChild( blockquote );
+			continue;
+		}
+
+		const unorderedList = line.match( /^\s*[-*+]\s+(.+)$/ );
+		const orderedList = line.match( /^\s*\d+\.\s+(.+)$/ );
+		if ( unorderedList || orderedList ) {
+			const list = document.createElement( unorderedList ? 'ul' : 'ol' );
+			const lineRegex = unorderedList
+				? /^\s*[-*+]\s+(.+)$/
+				: /^\s*\d+\.\s+(.+)$/;
+
+			while ( index < lines.length ) {
+				const itemMatch = lines[ index ].match( lineRegex );
+				if ( ! itemMatch ) {
+					break;
+				}
+
+				const item = document.createElement( 'li' );
+				appendInlineMarkdown( item, itemMatch[ 1 ].trim() );
+				list.appendChild( item );
+				index += 1;
+			}
+
+			fragment.appendChild( list );
+			continue;
+		}
+
+		const paragraphLines = [];
+		while (
+			index < lines.length &&
+			lines[ index ].trim() &&
+			( paragraphLines.length === 0 || ! isBlockStart( lines[ index ] ) )
+		) {
+			paragraphLines.push( lines[ index ].trim() );
+			index += 1;
+		}
+
+		const paragraph = document.createElement( 'p' );
+		appendInlineLines( paragraph, paragraphLines );
+		fragment.appendChild( paragraph );
+	}
+
+	return fragment;
+}
+
 /**
  * Resolve configuration from script attributes and the optional global object.
  *
@@ -158,10 +434,20 @@ export function mountEmbed( config ) {
 	const input = root.querySelector( '.sdaa-embed__input' );
 	let sessionToken = '';
 
+	const setMessageContent = ( item, role, text ) => {
+		item.textContent = '';
+		if ( role === 'assistant' ) {
+			item.appendChild( renderMarkdown( text ) );
+			return;
+		}
+
+		item.textContent = text;
+	};
+
 	const addMessage = ( role, text ) => {
 		const item = document.createElement( 'div' );
 		item.className = `sdaa-embed__message sdaa-embed__message--${ role }`;
-		item.textContent = text;
+		setMessageContent( item, role, text );
 		messages.appendChild( item );
 		messages.scrollTop = messages.scrollHeight;
 		return item;
@@ -232,9 +518,17 @@ export function mountEmbed( config ) {
 			if ( status.status !== 'complete' ) {
 				throw new Error( status.error || STRINGS.unavailable );
 			}
-			pending.textContent = status.reply || STRINGS.unavailable;
+			setMessageContent(
+				pending,
+				'assistant',
+				status.reply || STRINGS.unavailable
+			);
 		} catch ( error ) {
-			pending.textContent = error.message || STRINGS.unavailable;
+			setMessageContent(
+				pending,
+				'assistant',
+				error.message || STRINGS.unavailable
+			);
 		}
 	} );
 

--- a/src/embed-widget/index.js
+++ b/src/embed-widget/index.js
@@ -31,6 +31,7 @@ const STRINGS = {
 };
 
 const TRAILING_URL_PUNCTUATION = /[.,;:!?'")\]]+$/;
+const INLINE_MARKDOWN_WORD_BOUNDARY = /[A-Za-z0-9_]/;
 
 /**
  * Create a fresh inline markdown matcher.
@@ -43,6 +44,40 @@ const TRAILING_URL_PUNCTUATION = /[.,;:!?'")\]]+$/;
  */
 function createInlineMarkdownRegex() {
 	return /\[([^\]\n]+)\]\((https?:\/\/[^\s)]+)\)|`([^`\n]+)`|\*\*([^*\n]+)\*\*|__([^_\n]+)__|\*([^*\n]+)\*|_([^_\n]+)_|https?:\/\/[^\s<>"']+/g;
+}
+
+/**
+ * Check whether emphasis delimiters are outside identifier words.
+ *
+ * This avoids lookbehind so the embeddable widget remains compatible with older
+ * Safari versions while keeping snake_case and word*star*word text literal.
+ *
+ * @param {string} source          Full markdown source.
+ * @param {number} matchIndex      Matched delimiter start.
+ * @param {number} matchLength     Full matched delimiter span.
+ * @param {number} delimiterLength Number of delimiter characters.
+ * @return {boolean} True when the match is boundary-safe.
+ */
+function isEmphasisBoundarySafe(
+	source,
+	matchIndex,
+	matchLength,
+	delimiterLength
+) {
+	const before = matchIndex > 0 ? source.charAt( matchIndex - 1 ) : '';
+	const after = source.charAt( matchIndex + matchLength );
+
+	return (
+		! INLINE_MARKDOWN_WORD_BOUNDARY.test( before ) &&
+		! INLINE_MARKDOWN_WORD_BOUNDARY.test( after ) &&
+		! /^\s/.test( source.charAt( matchIndex + delimiterLength ) ) &&
+		! /\s$/.test(
+			source.slice(
+				matchIndex + delimiterLength,
+				matchIndex + matchLength - delimiterLength
+			)
+		)
+	);
 }
 
 /**
@@ -118,6 +153,21 @@ function appendInlineMarkdown( parent, text ) {
 	let match;
 
 	while ( ( match = regex.exec( source ) ) !== null ) {
+		const isStrong = Boolean( match[ 4 ] || match[ 5 ] );
+		const isEmphasis = Boolean( match[ 6 ] || match[ 7 ] );
+
+		if (
+			( isStrong || isEmphasis ) &&
+			! isEmphasisBoundarySafe(
+				source,
+				match.index,
+				match[ 0 ].length,
+				isStrong ? 2 : 1
+			)
+		) {
+			continue;
+		}
+
 		if ( match.index > lastIndex ) {
 			parent.appendChild(
 				document.createTextNode(

--- a/src/embed-widget/style.css
+++ b/src/embed-widget/style.css
@@ -98,13 +98,15 @@
 	background: var(--sdaa-embed-surface);
 	box-shadow: 0 1px 2px rgb(0 0 0 / 8%);
 	line-height: 1.45;
-	white-space: pre-wrap;
+	overflow-wrap: anywhere;
+	white-space: normal;
 }
 
 .sdaa-embed__message--user {
 	margin-left: auto;
 	background: var(--sdaa-embed-primary);
 	color: #fff;
+	white-space: pre-wrap;
 }
 
 .sdaa-embed__message--system {
@@ -113,6 +115,63 @@
 	box-shadow: none;
 	color: var(--sdaa-embed-muted);
 	font-size: 12px;
+	white-space: pre-wrap;
+}
+
+.sdaa-embed__message--assistant p,
+.sdaa-embed__message--assistant ul,
+.sdaa-embed__message--assistant ol,
+.sdaa-embed__message--assistant blockquote,
+.sdaa-embed__message--assistant pre,
+.sdaa-embed__message--assistant h1,
+.sdaa-embed__message--assistant h2,
+.sdaa-embed__message--assistant h3,
+.sdaa-embed__message--assistant h4,
+.sdaa-embed__message--assistant h5,
+.sdaa-embed__message--assistant h6 {
+	margin: 0 0 0.75em;
+}
+
+.sdaa-embed__message--assistant > :last-child {
+	margin-bottom: 0;
+}
+
+.sdaa-embed__message--assistant ul,
+.sdaa-embed__message--assistant ol {
+	padding-left: 1.25em;
+}
+
+.sdaa-embed__message--assistant blockquote {
+	padding-left: 0.75em;
+	border-left: 3px solid var(--sdaa-embed-border);
+	color: var(--sdaa-embed-muted);
+}
+
+.sdaa-embed__message--assistant pre {
+	overflow: auto;
+	padding: 8px;
+	border: 1px solid var(--sdaa-embed-border);
+	border-radius: 8px;
+	background: color-mix(in srgb, var(--sdaa-embed-surface) 86%, #000);
+}
+
+.sdaa-embed__message--assistant code {
+	padding: 0.1em 0.3em;
+	border-radius: 4px;
+	background: color-mix(in srgb, var(--sdaa-embed-surface) 82%, #000);
+	font-family: ui-monospace, sfmono-regular, Consolas, "Liberation Mono", monospace;
+	font-size: 0.92em;
+}
+
+.sdaa-embed__message--assistant pre code {
+	padding: 0;
+	background: transparent;
+}
+
+.sdaa-embed__message--assistant a {
+	color: var(--sdaa-embed-primary);
+	text-decoration: underline;
+	text-underline-offset: 2px;
 }
 
 .sdaa-embed__input {


### PR DESCRIPTION
## Summary
- Render assistant responses in the dependency-free embedded docs widget as a safe markdown subset instead of raw text.
- Convert raw HTTP(S) source URLs into clickable external links with `target="_blank"` and `rel="noopener noreferrer"`.
- Add markdown-specific widget styles and regression coverage for clickable source URLs plus raw HTML escaping.

## Files changed
- `src/embed-widget/index.js` — safe markdown renderer and assistant message rendering path.
- `src/embed-widget/style.css` — assistant markdown/link/code/list styling.
- `src/embed-widget/__tests__/index.test.js` — regression tests for source links and HTML escaping.

## Worker self-verification
- PHPUnit: Tests: 3716, Assertions: 15567, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Additional checks:
- `npm run test:js -- src/embed-widget/__tests__/index.test.js --runInBand`
- `npm run check:bundle`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.2 plugin for [OpenCode](https://opencode.ai) v1.17.13


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assistant messages can now render basic markdown, including links, bold text, headings, quotes, lists, and code formatting.
  * Links in assistant replies open safely in a new tab.
  * Message bubbles now wrap rich text more naturally, with improved styling for code blocks and inline code.

* **Bug Fixes**
  * Markdown content is now displayed more safely, preventing unwanted HTML from being rendered.
  * User message formatting remains preserved as plain text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->