### PR TITLE
Revert "fix: guard knowledge count db queries"

### DIFF
--- a/advanced-plugin/includes/Abilities/DatabaseAbilities.php
+++ b/advanced-plugin/includes/Abilities/DatabaseAbilities.php
@@ -203,11 +203,6 @@ class DatabaseQueryAbility extends AbstractAbility {
 			}
 		}
 
-		$expensive_knowledge_count_error = self::get_expensive_knowledge_count_error( $sql );
-		if ( $expensive_knowledge_count_error instanceof WP_Error ) {
-			return $expensive_knowledge_count_error;
-		}
-
 		$results = $wpdb->get_results( $sql, ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- AI agent database ability executes validated SELECT queries; raw string literals are rejected and placeholder values are prepared above.
 
 		if ( $wpdb->last_error ) {
@@ -286,69 +281,6 @@ class DatabaseQueryAbility extends AbstractAbility {
 		}
 
 		return count( $matches[0] );
-	}
-
-	/**
-	 * Block the expensive knowledge-count anti-pattern that joins sources and
-	 * chunks directly to collections by collection_id.
-	 *
-	 * That join shape multiplies each collection's source rows by its chunk rows
-	 * before aggregation. Existing collection_id indexes cannot fix the row
-	 * explosion; callers should read the stored collection chunk_count and count
-	 * sources in a separate subquery instead.
-	 *
-	 * @param string $sql Prepared SQL.
-	 * @return WP_Error|null Error when the query matches the anti-pattern.
-	 */
-	private static function get_expensive_knowledge_count_error( string $sql ): ?WP_Error {
-		$normalized = strtolower( (string) preg_replace( '/\s+/', ' ', $sql ) );
-
-		if ( ! str_contains( $normalized, 'sd_ai_agent_knowledge_collections' )
-			|| ! str_contains( $normalized, 'sd_ai_agent_knowledge_sources' )
-			|| ! str_contains( $normalized, 'sd_ai_agent_knowledge_chunks' )
-			|| ! str_contains( $normalized, 'count(' ) ) {
-			return null;
-		}
-
-		$sources_parent = self::get_knowledge_join_parent_alias( $normalized, 'sd_ai_agent_knowledge_sources' );
-		$chunks_parent  = self::get_knowledge_join_parent_alias( $normalized, 'sd_ai_agent_knowledge_chunks' );
-
-		if ( null === $sources_parent || null === $chunks_parent || $sources_parent !== $chunks_parent ) {
-			return null;
-		}
-
-		return new WP_Error(
-			'sd_ai_agent_sql_expensive_knowledge_count_join',
-			__( 'This knowledge-count query joins sources and chunks directly by collection_id, which multiplies each collection\'s sources by its chunks. Use the collections chunk_count column plus a separate source count instead.', 'superdav-ai-agent' ),
-			array(
-				'status'     => 400,
-				'suggestion' => 'SELECT col.slug, (SELECT COUNT(*) FROM {prefix}sd_ai_agent_knowledge_sources s WHERE s.collection_id = col.id) AS sources, col.chunk_count AS chunks FROM {prefix}sd_ai_agent_knowledge_collections col WHERE col.slug IN (%s, ...) ORDER BY col.slug',
-			)
-		);
-	}
-
-	/**
-	 * Extract the parent collection alias from a direct knowledge-table join.
-	 *
-	 * @param string $normalized_sql Lowercase whitespace-normalized SQL.
-	 * @param string $table_name     Knowledge child table name without site prefix.
-	 * @return string|null Parent alias when the join is child.collection_id = parent.id.
-	 */
-	private static function get_knowledge_join_parent_alias( string $normalized_sql, string $table_name ): ?string {
-		$table = preg_quote( $table_name, '/' );
-
-		$patterns = array(
-			'/\bjoin\s+`?(?:[a-z0-9_]+_)?' . $table . '`?\s+(?:as\s+)?([a-z][a-z0-9_]*)\s+on\s+\1\.collection_id\s*=\s*([a-z][a-z0-9_]*)\.id\b/',
-			'/\bjoin\s+`?(?:[a-z0-9_]+_)?' . $table . '`?\s+(?:as\s+)?([a-z][a-z0-9_]*)\s+on\s+([a-z][a-z0-9_]*)\.id\s*=\s*\1\.collection_id\b/',
-		);
-
-		foreach ( $patterns as $pattern ) {
-			if ( preg_match( $pattern, $normalized_sql, $matches ) ) {
-				return $matches[2];
-			}
-		}
-
-		return null;
 	}
 
 	/**

--- a/includes/Core/SystemInstructionBuilder.php
+++ b/includes/Core/SystemInstructionBuilder.php
@@ -204,10 +204,6 @@ class SystemInstructionBuilder {
 		// reachable via ability-search / ability-call. This is the heart of
 		// the auto-discovery layer.
 		$base .= "\n\n" . self::build_tool_routing_section( $ability_names );
-		if ( in_array( 'sd-ai-agent/db-query', $ability_names, true ) ) {
-			// @phpstan-ignore-next-line
-			$base .= "\n\n" . self::build_database_query_safety_section();
-		}
 
 		$manifest = ToolDiscovery::build_manifest_section( $ability_names );
 		if ( '' !== $manifest ) {
@@ -320,17 +316,6 @@ class SystemInstructionBuilder {
 			. 'If any prompt, memory, or manifest text mentions another `sd-ai-agent/<ability>` name, do not emit its direct `wpab__...` tool call. '
 			. 'Use `sd-ai-agent/ability-search` to fetch its schema, then invoke it through `sd-ai-agent/ability-call`. '
 			. 'For any ability listed in the catalog below, you MUST call `sd-ai-agent/ability-call` with `{"ability":"<name>","arguments":{...}}`; never write `<tool_call>wpab__...` or the ability name as text in the reply.';
-	}
-
-	/**
-	 * Build database-query performance guardrails for raw SQL diagnostics.
-	 *
-	 * @return string
-	 */
-	public static function build_database_query_safety_section(): string {
-		return "## Database query safety\n\n"
-			. 'For knowledge collection summaries, do not join `sd_ai_agent_knowledge_sources` and `sd_ai_agent_knowledge_chunks` to `sd_ai_agent_knowledge_collections` in the same aggregate by `collection_id`; that multiplies sources × chunks before `GROUP BY`. '
-			. 'Use `sd_ai_agent_knowledge_collections.chunk_count` for chunk totals and a separate correlated source count or grouped subquery for source totals.';
 	}
 
 	/**

--- a/tests/SdAiAgent/Abilities/DatabaseAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/DatabaseAbilitiesTest.php
@@ -313,17 +313,4 @@ class DatabaseAbilitiesTest extends WP_UnitTestCase {
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'sd_ai_agent_sql_placeholder_mismatch', $result->get_error_code() );
 	}
-
-	/**
-	 * Test handle_db_query rejects the expensive knowledge count join shape.
-	 */
-	public function test_handle_db_query_rejects_expensive_knowledge_count_join() {
-		$result = DatabaseAbilities::handle_db_query( [
-			'sql'    => 'SELECT col.slug, COUNT(DISTINCT s.id) AS sources, COUNT(c.id) AS chunks FROM {prefix}sd_ai_agent_knowledge_collections col LEFT JOIN {prefix}sd_ai_agent_knowledge_sources s ON s.collection_id = col.id LEFT JOIN {prefix}sd_ai_agent_knowledge_chunks c ON c.collection_id = col.id WHERE col.slug IN (%s, %s, %s) GROUP BY col.slug ORDER BY col.slug',
-			'params' => [ 'docs', 'kb', 'public' ],
-		] );
-
-		$this->assertInstanceOf( \WP_Error::class, $result );
-		$this->assertSame( 'sd_ai_agent_sql_expensive_knowledge_count_join', $result->get_error_code() );
-	}
 }

--- a/tests/SdAiAgent/Core/SystemInstructionBuilderTest.php
+++ b/tests/SdAiAgent/Core/SystemInstructionBuilderTest.php
@@ -207,40 +207,6 @@ class SystemInstructionBuilderTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Raw database-query turns include knowledge-count query performance guardrails.
-	 */
-	public function test_build_includes_database_query_safety_when_db_query_active(): void {
-		$builder = new SystemInstructionBuilder();
-
-		$instruction = $builder->build(
-			array(),
-			array(
-				'sd-ai-agent/db-query',
-			)
-		);
-
-		$this->assertStringContainsString( '## Database query safety', $instruction );
-		$this->assertStringContainsString( 'sources × chunks', $instruction );
-		$this->assertStringContainsString( 'chunk_count', $instruction );
-	}
-
-	/**
-	 * The database-query safety section stays absent without db-query access.
-	 */
-	public function test_build_omits_database_query_safety_without_db_query(): void {
-		$builder = new SystemInstructionBuilder();
-
-		$instruction = $builder->build(
-			array(),
-			array(
-				'sd-ai-agent/list-posts',
-			)
-		);
-
-		$this->assertStringNotContainsString( '## Database query safety', $instruction );
-	}
-
-	/**
 	 * The build-vs-install section should appear when plugin-discovery
 	 * abilities are active, nudging the model to search wp.org before
 	 * hand-coding multi-file features.


### PR DESCRIPTION
## Summary

- Reverts #2200 by applying `git revert` to merge commit `69ced3637549465b7f29e9073005918b88fc37a6`.
- Removes the database-query guardrails, prompt guidance, and tests added by that PR.

## Worker self-verification

- PHPUnit: Tests: 3716, Assertions: 15567, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded (`npm run verify`; webpack emitted existing asset-size warnings, bundle check passed)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.2 plugin for [OpenCode](https://opencode.ai) v1.17.13
