### PR TITLE
fix: ignore saved providers without models

### DIFF
--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -336,6 +336,32 @@ describe( 'resolveProviderSelection', () => {
 			modelId: 'superdav-chat-fast',
 		} );
 	} );
+
+	test( 'moves away from a saved provider that has no advertised models', () => {
+		const selection = resolveProviderSelection(
+			[
+				{
+					id: 'ollama',
+					models: [],
+				},
+				{
+					id: 'sd-ai-agent-cloud',
+					default_model: 'superdav-chat-pro',
+					models: [
+						{ id: 'superdav-chat-fast' },
+						{ id: 'superdav-chat-pro' },
+					],
+				},
+			],
+			'ollama',
+			''
+		);
+
+		expect( selection ).toEqual( {
+			providerId: 'sd-ai-agent-cloud',
+			modelId: 'superdav-chat-pro',
+		} );
+	} );
 } );
 
 // ─── Reducer ──────────────────────────────────────────────────────────────────

--- a/src/store/slices/providersSlice.js
+++ b/src/store/slices/providersSlice.js
@@ -22,9 +22,18 @@ export function resolveProviderSelection(
 	savedProviderId,
 	savedModelId
 ) {
+	const providerHasModels = ( candidate ) =>
+		Array.isArray( candidate?.models ) && candidate.models.length > 0;
+	const savedProvider = providers.find(
+		( candidate ) => candidate.id === savedProviderId
+	);
+	const firstProviderWithModels = providers.find( providerHasModels );
 	const provider =
-		providers.find( ( candidate ) => candidate.id === savedProviderId ) ||
-		providers.find( ( candidate ) => candidate.models?.length ) ||
+		( savedProvider && providerHasModels( savedProvider )
+			? savedProvider
+			: null ) ||
+		firstProviderWithModels ||
+		savedProvider ||
 		providers[ 0 ];
 
 	if ( ! provider ) {


### PR DESCRIPTION
## Summary
- Prefer a saved provider only when it still advertises at least one model.
- Fall back to the first provider with advertised models so a stale no-model provider does not keep the picker empty.
- Add Jest coverage for the saved empty-provider selection path.

## Worker self-verification
- PHPUnit: Tests: 3716, Assertions: 15567, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded
- Bundle check: passed
- Targeted Jest: `npm run test:js -- --runTestsByPath src/store/__tests__/index.test.js --runInBand` — 100 passed

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.4 plugin for [OpenCode](https://opencode.ai) v1.17.13


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider selection so saved choices without available models now fall back to a provider that can actually be used.
  * When this happens, the app now picks the selected provider’s default model automatically.
  * Added coverage for this fallback behavior to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->