### PR TITLE
fix: add safe retry banner for failed chat sends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ blob-report/
 tests/benchmark/results/
 # Local AI tooling artifacts
 .claude/
+.opencode/opencode-loop/
 .agents/skills/
 skills-lock.json
 # Local wp-env port overrides

--- a/src/components/chat-redesign/MessageList.js
+++ b/src/components/chat-redesign/MessageList.js
@@ -47,6 +47,7 @@ export default function MessageList() {
 		ttsVoiceURI,
 		ttsRate,
 		ttsPitch,
+		hasStreamError,
 	} = useSelect( ( sel ) => {
 		const store = sel( STORE_NAME );
 		return {
@@ -65,10 +66,11 @@ export default function MessageList() {
 			ttsVoiceURI: store.getTtsVoiceURI(),
 			ttsRate: store.getTtsRate(),
 			ttsPitch: store.getTtsPitch(),
+			hasStreamError: store.hasStreamError(),
 		};
 	}, [] );
 
-	const { sendMessage } = useDispatch( STORE_NAME );
+	const { sendMessage, retryLastMessage } = useDispatch( STORE_NAME );
 	const ref = useRef( null );
 
 	/** True when the scroll container is within SCROLL_THRESHOLD px of the bottom. */
@@ -290,6 +292,24 @@ export default function MessageList() {
 							step={ runningStep }
 							liveToolCalls={ runningToolCalls }
 						/>
+					) }
+
+					{ hasStreamError && currentSessionId && ! sending && (
+						<div className="sdaa-cr-error-banner" role="status">
+							<span className="sdaa-cr-error-banner__message">
+								{ __(
+									'Something went wrong while sending your message.',
+									'superdav-ai-agent'
+								) }
+							</span>
+							<button
+								type="button"
+								className="sdaa-cr-error-banner__retry"
+								onClick={ retryLastMessage }
+							>
+								{ __( 'Try again', 'superdav-ai-agent' ) }
+							</button>
+						</div>
 					) }
 				</div>
 			</div>

--- a/src/components/chat-redesign/__tests__/MessageList.test.js
+++ b/src/components/chat-redesign/__tests__/MessageList.test.js
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for the redesigned chat MessageList.
+ */
+
+import { createElement } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+
+import MessageList from '../MessageList';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( str ) => str,
+} ) );
+
+jest.mock( '../../../store', () => 'sd-ai-agent' );
+
+jest.mock( '../../feedback-consent-modal', () => () => null );
+
+jest.mock( '../../use-text-to-speech', () => () => ( {
+	speak: jest.fn(),
+	cancel: jest.fn(),
+} ) );
+
+jest.mock( '../message-items', () => ( {
+	AssistantMessage: () => null,
+	RunningMessage: () => null,
+	SystemMessage: () => null,
+	UserMessage: () => null,
+} ) );
+
+/**
+ * Build the selector map needed by MessageList.
+ *
+ * @param {Object}  root0                 Options.
+ * @param {boolean} root0.hasStreamError  Whether the active session has a send error.
+ * @param {boolean} [root0.sending=false] Whether a send is currently in progress.
+ * @param {number}  [root0.sessionId=123] Current session ID.
+ * @return {Object} Selector map.
+ */
+function buildSelectors( {
+	hasStreamError,
+	sending = false,
+	sessionId = 123,
+} ) {
+	return {
+		getCurrentSessionMessages: () => [],
+		isSending: () => sending,
+		getCurrentSessionId: () => sessionId,
+		getLiveToolCalls: () => [],
+		getSessionJobs: () => ( {} ),
+		getSettings: () => null,
+		isTtsEnabled: () => false,
+		getTtsVoiceURI: () => '',
+		getTtsRate: () => 1,
+		getTtsPitch: () => 1,
+		hasStreamError: () => hasStreamError,
+	};
+}
+
+/**
+ * Render MessageList with mocked store hooks.
+ *
+ * @param {Object} root0             Options.
+ * @param {Object} root0.selectors   Mock selector map.
+ * @param {Object} root0.dispatchMap Mock dispatch action map.
+ * @return {Promise<{container: HTMLElement, root: import('react-dom/client').Root}>}
+ *   Rendered container and root.
+ */
+async function renderMessageList( { selectors, dispatchMap } ) {
+	useSelect.mockImplementation( ( fn ) => fn( () => selectors ) );
+	useDispatch.mockReturnValue( dispatchMap );
+
+	const container = document.createElement( 'div' );
+	document.body.appendChild( container );
+	const root = createRoot( container );
+	await act( async () => {
+		root.render( createElement( MessageList ) );
+	} );
+	return { container, root };
+}
+
+describe( 'MessageList stream error banner', () => {
+	let container;
+	let root;
+	let retryLastMessage;
+
+	beforeEach( () => {
+		retryLastMessage = jest.fn();
+	} );
+
+	afterEach( async () => {
+		if ( root ) {
+			await act( async () => {
+				root.unmount();
+			} );
+			document.body.removeChild( container );
+		}
+		container = undefined;
+		root = undefined;
+		jest.clearAllMocks();
+	} );
+
+	test( 'shows retry banner for the active failed session', async () => {
+		( { container, root } = await renderMessageList( {
+			selectors: buildSelectors( { hasStreamError: true } ),
+			dispatchMap: { sendMessage: jest.fn(), retryLastMessage },
+		} ) );
+
+		const banner = container.querySelector( '.sdaa-cr-error-banner' );
+		expect( banner ).not.toBeNull();
+		expect( banner.textContent ).toContain(
+			'Something went wrong while sending your message.'
+		);
+
+		await act( async () => {
+			banner
+				.querySelector( '.sdaa-cr-error-banner__retry' )
+				.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+		} );
+
+		expect( retryLastMessage ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'hides retry banner while sending or when no stream error exists', async () => {
+		( { container, root } = await renderMessageList( {
+			selectors: buildSelectors( {
+				hasStreamError: true,
+				sending: true,
+			} ),
+			dispatchMap: { sendMessage: jest.fn(), retryLastMessage },
+		} ) );
+
+		expect( container.querySelector( '.sdaa-cr-error-banner' ) ).toBeNull();
+
+		await act( async () => {
+			root.unmount();
+		} );
+		document.body.removeChild( container );
+		container = undefined;
+		root = undefined;
+
+		( { container, root } = await renderMessageList( {
+			selectors: buildSelectors( { hasStreamError: false } ),
+			dispatchMap: { sendMessage: jest.fn(), retryLastMessage },
+		} ) );
+
+		expect( container.querySelector( '.sdaa-cr-error-banner' ) ).toBeNull();
+	} );
+} );

--- a/src/components/chat-redesign/chat-redesign.css
+++ b/src/components/chat-redesign/chat-redesign.css
@@ -1876,6 +1876,46 @@ textarea.sdaa-cr-input-textarea {
 	font-weight: 700;
 }
 
+/* ─── Error Banner (send failure retry) ─────────────────────────────── */
+
+.sdaa-cr-error-banner {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 12px;
+	margin: 8px 0;
+	padding: 10px 14px;
+	border: 1px solid #fecaca;
+	border-radius: var(--sdaa-radius-md);
+	background: #fef2f2;
+	color: #991b1b;
+	font-size: 13px;
+}
+
+.sdaa-cr-error-banner__message {
+	flex: 1;
+	min-width: 0;
+	line-height: 1.4;
+}
+
+.sdaa-cr-error-banner__retry {
+	flex-shrink: 0;
+	padding: 4px 12px;
+	border: 0;
+	border-radius: var(--sdaa-radius-sm);
+	background: #dc2626;
+	color: #fff;
+	font-size: 12.5px;
+	font-weight: 600;
+	cursor: pointer;
+	transition: background var(--sdaa-duration);
+}
+
+.sdaa-cr-error-banner__retry:hover,
+.sdaa-cr-error-banner__retry:focus-visible {
+	background: #b91c1c;
+}
+
 /* ─── Design Preview Gallery (issue #1532) ──────────────────────────── */
 
 .sd-ai-agent-design-preview-gallery {

--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -68,6 +68,9 @@ const DEFAULT_STATE = {
 	currentSessionMessages: [],
 	currentSessionToolCalls: [],
 	sending: false,
+	streamError: false,
+	streamErrorSessionId: null,
+	lastUserMessage: '',
 	currentJobId: null,
 	selectedProviderId: '',
 	selectedModelId: '',
@@ -271,6 +274,21 @@ describe( 'actions', () => {
 		} );
 	} );
 
+	test( 'setStreamError scopes the error to a session', () => {
+		expect( actions.setStreamError( true, 42 ) ).toEqual( {
+			type: 'SET_STREAM_ERROR',
+			error: true,
+			sessionId: 42,
+		} );
+	} );
+
+	test( 'setLastUserMessage stores retry text', () => {
+		expect( actions.setLastUserMessage( 'retry me' ) ).toEqual( {
+			type: 'SET_LAST_USER_MESSAGE',
+			message: 'retry me',
+		} );
+	} );
+
 	test( 'setPageContext returns correct action', () => {
 		expect( actions.setPageContext( 'page-ctx' ) ).toEqual( {
 			type: 'SET_PAGE_CONTEXT',
@@ -289,6 +307,54 @@ describe( 'actions', () => {
 
 	test( 'sendMessage returns a thunk function', () => {
 		expect( typeof actions.sendMessage( 'hello' ) ).toBe( 'function' );
+	} );
+
+	test( 'retryLastMessage rewinds to the last user message and resends it', async () => {
+		const dispatch = {
+			truncateMessagesTo: jest.fn(),
+			setStreamError: jest.fn(),
+			streamMessage: jest.fn(),
+		};
+		const select = {
+			getCurrentSessionMessages: jest.fn( () => [
+				{ role: 'model', parts: [ { text: 'Previous reply' } ] },
+				{
+					role: 'user',
+					parts: [ { text: 'Retry this' } ],
+					attachments: [ { name: 'image.png', isImage: true } ],
+				},
+				{ role: 'system', parts: [ { text: 'Error: failed' } ] },
+			] ),
+			getLastUserMessage: jest.fn( () => 'fallback' ),
+		};
+
+		await actions.retryLastMessage()( { dispatch, select } );
+
+		expect( dispatch.truncateMessagesTo ).toHaveBeenCalledWith( 1 );
+		expect( dispatch.setStreamError ).toHaveBeenCalledWith( false );
+		expect( dispatch.streamMessage ).toHaveBeenCalledWith( 'Retry this', [
+			{ name: 'image.png', isImage: true },
+		] );
+	} );
+
+	test( 'retryLastMessage does not delete messages when no user message exists', async () => {
+		const dispatch = {
+			truncateMessagesTo: jest.fn(),
+			setStreamError: jest.fn(),
+			streamMessage: jest.fn(),
+		};
+		const select = {
+			getCurrentSessionMessages: jest.fn( () => [
+				{ role: 'system', parts: [ { text: 'Error only' } ] },
+			] ),
+			getLastUserMessage: jest.fn( () => '' ),
+		};
+
+		await actions.retryLastMessage()( { dispatch, select } );
+
+		expect( dispatch.truncateMessagesTo ).not.toHaveBeenCalled();
+		expect( dispatch.setStreamError ).not.toHaveBeenCalled();
+		expect( dispatch.streamMessage ).not.toHaveBeenCalled();
 	} );
 } );
 
@@ -463,12 +529,18 @@ describe( 'reducer', () => {
 			currentSessionMessages: [ { role: 'user' } ],
 			currentSessionToolCalls: [ {} ],
 			tokenUsage: { prompt: 100, completion: 50 },
+			streamError: true,
+			streamErrorSessionId: 5,
+			lastUserMessage: 'hello',
 		};
 		const state = reducer( populated, { type: 'CLEAR_CURRENT_SESSION' } );
 		expect( state.currentSessionId ).toBeNull();
 		expect( state.currentSessionMessages ).toEqual( [] );
 		expect( state.currentSessionToolCalls ).toEqual( [] );
 		expect( state.tokenUsage ).toEqual( { prompt: 0, completion: 0 } );
+		expect( state.streamError ).toBe( false );
+		expect( state.streamErrorSessionId ).toBeNull();
+		expect( state.lastUserMessage ).toBe( '' );
 	} );
 
 	test( 'SET_SENDING updates sending flag', () => {
@@ -477,6 +549,39 @@ describe( 'reducer', () => {
 			sending: true,
 		} );
 		expect( state.sending ).toBe( true );
+	} );
+
+	test( 'SET_STREAM_ERROR records the current session when no session is provided', () => {
+		const state = reducer(
+			{ ...DEFAULT_STATE, currentSessionId: 42 },
+			{ type: 'SET_STREAM_ERROR', error: true, sessionId: null }
+		);
+
+		expect( state.streamError ).toBe( true );
+		expect( state.streamErrorSessionId ).toBe( 42 );
+	} );
+
+	test( 'SET_STREAM_ERROR clears the error session when dismissed', () => {
+		const state = reducer(
+			{
+				...DEFAULT_STATE,
+				streamError: true,
+				streamErrorSessionId: 42,
+			},
+			{ type: 'SET_STREAM_ERROR', error: false, sessionId: null }
+		);
+
+		expect( state.streamError ).toBe( false );
+		expect( state.streamErrorSessionId ).toBeNull();
+	} );
+
+	test( 'SET_LAST_USER_MESSAGE stores retry text', () => {
+		const state = reducer( DEFAULT_STATE, {
+			type: 'SET_LAST_USER_MESSAGE',
+			message: 'retry text',
+		} );
+
+		expect( state.lastUserMessage ).toBe( 'retry text' );
 	} );
 
 	test( 'SET_CURRENT_JOB_ID updates jobId', () => {
@@ -726,6 +831,9 @@ describe( 'selectors', () => {
 		foldersLoaded: true,
 		pendingConfirmation: { jobId: 'j1' },
 		sendTimestamp: 12345,
+		streamError: true,
+		streamErrorSessionId: 42,
+		lastUserMessage: 'retry text',
 	};
 
 	test( 'getProviders returns providers array', () => {
@@ -868,6 +976,17 @@ describe( 'selectors', () => {
 
 	test( 'getSendTimestamp returns sendTimestamp', () => {
 		expect( selectors.getSendTimestamp( state ) ).toBe( 12345 );
+	} );
+
+	test( 'hasStreamError returns true only for the active session', () => {
+		expect( selectors.hasStreamError( state ) ).toBe( true );
+		expect(
+			selectors.hasStreamError( { ...state, currentSessionId: 7 } )
+		).toBe( false );
+	} );
+
+	test( 'getLastUserMessage returns retry text', () => {
+		expect( selectors.getLastUserMessage( state ) ).toBe( 'retry text' );
 	} );
 
 	test( 'getContextPercentage calculates percentage from known model', () => {

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -726,6 +726,7 @@ export const actions = {
 								role: 'system',
 								parts: [ { text: errorText } ],
 							} );
+							dispatch.setStreamError( true, sessionId );
 							// WP_Error max_iterations — show feedback banner (t183).
 							const errMsg = result.message || '';
 							if ( /max.?iteration/i.test( errMsg ) ) {
@@ -976,6 +977,7 @@ export const actions = {
 									},
 								],
 							} );
+							dispatch.setStreamError( true, sessionId );
 							dispatch.setSending( false );
 							dispatch.setLiveToolCalls( [] );
 						}

--- a/src/store/slices/sessionsSlice.js
+++ b/src/store/slices/sessionsSlice.js
@@ -165,6 +165,7 @@ export const initialState = {
 	// Stream error state — true when the last send attempt failed.
 	// Used to show a "Try again" button in the message list.
 	streamError: false,
+	streamErrorSessionId: null,
 
 	// Last user message text — stored so retryLastMessage can resend it.
 	lastUserMessage: '',
@@ -371,11 +372,12 @@ export const actions = {
 	/**
 	 * Set or clear the stream error flag.
 	 *
-	 * @param {boolean} error - Whether the last stream attempt failed.
+	 * @param {boolean}     error     - Whether the last stream attempt failed.
+	 * @param {number|null} sessionId - Session the error belongs to.
 	 * @return {Object} Redux action.
 	 */
-	setStreamError( error ) {
-		return { type: 'SET_STREAM_ERROR', error };
+	setStreamError( error, sessionId = null ) {
+		return { type: 'SET_STREAM_ERROR', error, sessionId };
 	},
 
 	/**
@@ -888,25 +890,46 @@ export const actions = {
 	},
 
 	/**
-	 * Retry the last failed stream by removing the error message and
-	 * resending the last user message via streamMessage.
+	 * Retry the last failed send by rewinding to the last user message and
+	 * resending it. This avoids blindly removing the last two messages, which can
+	 * delete unrelated messages if the session was reloaded or the failure shape
+	 * differs from the expected user+system pair.
 	 *
 	 * @return {Function} Redux thunk.
 	 */
 	retryLastMessage() {
 		return async ( { dispatch, select } ) => {
-			const lastMessage = select.getLastUserMessage();
-			if ( ! lastMessage ) {
+			const messages = select.getCurrentSessionMessages() || [];
+			let userIndex = -1;
+			for ( let i = messages.length - 1; i >= 0; i-- ) {
+				if ( messages[ i ]?.role === 'user' ) {
+					userIndex = i;
+					break;
+				}
+			}
+
+			if ( userIndex < 0 ) {
 				return;
 			}
-			// Remove the error system message appended on failure.
-			dispatch.removeLastMessage();
-			// Remove the user message that was appended before the failure.
-			dispatch.removeLastMessage();
-			// Clear the error flag.
+
+			const lastUserMessage = messages[ userIndex ];
+			const messageText =
+				extractMessageText( lastUserMessage ) ||
+				select.getLastUserMessage();
+			const attachments = Array.isArray( lastUserMessage.attachments )
+				? lastUserMessage.attachments
+				: [];
+
+			if ( ! messageText && attachments.length === 0 ) {
+				return;
+			}
+
+			// Remove the failed user message and any local error messages after it,
+			// then resend through the normal stream path so provider/model selection is
+			// read fresh and UI state is rebuilt consistently.
+			dispatch.truncateMessagesTo( userIndex );
 			dispatch.setStreamError( false );
-			// Resend.
-			dispatch.streamMessage( lastMessage );
+			dispatch.streamMessage( messageText, attachments );
 		};
 	},
 
@@ -1125,7 +1148,7 @@ export const actions = {
 						},
 					],
 				} );
-				dispatch.setStreamError( true );
+				dispatch.setStreamError( true, sessionId );
 				dispatch.setSending( false );
 				return;
 			}
@@ -1156,6 +1179,7 @@ export const actions = {
 						},
 					],
 				} );
+				dispatch.setStreamError( true, sessionId );
 				dispatch.setSending( false );
 			}
 		};
@@ -1536,7 +1560,10 @@ export const selectors = {
 	 * @return {boolean} Whether the last stream attempt failed with an error.
 	 */
 	hasStreamError( state ) {
-		return state.streamError;
+		return Boolean(
+			state.streamError &&
+				state.streamErrorSessionId === state.currentSessionId
+		);
 	},
 
 	/**
@@ -1689,6 +1716,9 @@ export function reducer( state, action ) {
 				sessionTokens: 0,
 				sessionCost: 0,
 				messageTokens: [],
+				streamError: false,
+				streamErrorSessionId: null,
+				lastUserMessage: '',
 				feedbackBanner: null,
 				messageQueue: [],
 			};
@@ -1741,8 +1771,17 @@ export function reducer( state, action ) {
 			};
 		case 'SET_SEND_TIMESTAMP':
 			return { ...state, sendTimestamp: action.ts };
-		case 'SET_STREAM_ERROR':
-			return { ...state, streamError: action.error };
+		case 'SET_STREAM_ERROR': {
+			let errorSessionId = action.sessionId ?? state.currentSessionId;
+			if ( typeof errorSessionId === 'string' ) {
+				errorSessionId = parseInt( errorSessionId, 10 );
+			}
+			return {
+				...state,
+				streamError: Boolean( action.error ),
+				streamErrorSessionId: action.error ? errorSessionId : null,
+			};
+		}
 		case 'SET_LAST_USER_MESSAGE':
 			return { ...state, lastUserMessage: action.message };
 		case 'SET_EDITING_MESSAGE_INDEX':

--- a/src/types.js
+++ b/src/types.js
@@ -151,6 +151,9 @@
  * @property {Message[]}                                                 currentSessionMessages  - Messages in the active session.
  * @property {ToolCall[]}                                                currentSessionToolCalls - Tool calls in the active session.
  * @property {boolean}                                                   sending                 - Whether a message is in-flight.
+ * @property {boolean}                                                   streamError             - Whether the last send failed.
+ * @property {number|null}                                               streamErrorSessionId    - Session ID associated with the current send error.
+ * @property {string}                                                    lastUserMessage         - Last user message text for retry fallback.
  * @property {string|null}                                               currentJobId            - Active polling job ID.
  * @property {string}                                                    selectedProviderId      - Currently selected provider ID.
  * @property {string}                                                    selectedModelId         - Currently selected model ID.

--- a/tests/SdAiAgent/Automations/CalendarReminderRecordsTest.php
+++ b/tests/SdAiAgent/Automations/CalendarReminderRecordsTest.php
@@ -69,8 +69,12 @@ class CalendarReminderRecordsTest extends WP_UnitTestCase {
 		$this->assertNotNull( $record );
 		$this->assertSame( CalendarReminderRecords::STATUS_SENT, $record['status'] );
 		$this->assertSame( 'person@example.com', $record['attendee_email'] );
-		$this->assertSame( hash_hmac( 'sha256', '15551234567', wp_salt( 'auth' ) ), $record['phone_hash'] );
-		$this->assertStringNotContainsString( '555', implode( ' ', array_map( 'strval', $record ) ) );
+		$normalized_phone = '15551234567';
+		$record_values    = array_map( 'strval', $record );
+		$this->assertSame( hash_hmac( 'sha256', $normalized_phone, wp_salt( 'auth' ) ), $record['phone_hash'] );
+		$this->assertNotSame( $normalized_phone, $record['phone_hash'] );
+		$this->assertNotContains( '+1 (555) 123-4567', $record_values );
+		$this->assertNotContains( $normalized_phone, $record_values );
 		$this->assertNotEmpty( $record['sent_at'] );
 	}
 


### PR DESCRIPTION
## Summary

- Add a visible, session-scoped retry banner when chat sends or job polling fails.
- Make retry safe by rewinding to the last user message instead of blindly deleting the last two messages.
- Cover the retry reducer/thunk behavior and MessageList banner with JS unit tests.
- Replace the brittle calendar reminder phone substring assertion with exact hash and exact raw-value absence checks.
- Ignore local `.opencode/opencode-loop/` artifacts so loop checkpoint files are not accidentally committed.

## Worker self-verification
- PHPUnit: Tests: 3716, Assertions: 15569, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Additional checks:
- `npm run test:js -- src/store/__tests__/index.test.js src/components/chat-redesign/__tests__/MessageList.test.js --runInBand` — 2 suites, 110 tests passed
- `npm run verify` — passed; webpack reported existing asset-size warnings only

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.4 plugin for [OpenCode](https://opencode.ai) v1.17.13
