### PR TITLE
GH#2205: docs: clarify release deployment channels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,9 +136,27 @@ jobs:
             ## WordPress.org
 
             Stable `v*.*.*` releases publish only the core `superdav-ai-agent` package to the WordPress.org SVN trunk and tag. Pre-release tags create GitHub release assets but skip SVN deployment.
+
+            ## WooCommerce Marketplace
+
+            This repository does not publish either package to the WooCommerce Marketplace. The advanced companion ZIP remains a GitHub release asset only unless a separate marketplace deployment workflow is added later with explicit product targets and credentials.
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+      - name: Summarize release channels
+        run: |
+          {
+            echo "## Release channels"
+            echo ""
+            echo "- GitHub release: core and advanced ZIP assets uploaded."
+            if [ "${IS_PRERELEASE}" = "true" ]; then
+              echo "- WordPress.org SVN: skipped for pre-release tag."
+            else
+              echo "- WordPress.org SVN: core package deploy runs in the dependent job."
+            fi
+            echo "- WooCommerce Marketplace: not configured for this repository; no marketplace upload is attempted."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   deploy-to-wporg:
     name: Deploy core plugin to WordPress.org
@@ -267,3 +285,15 @@ jobs:
             -m "Tag Superdav AI Agent v${VERSION}"
 
           echo "Successfully tagged ${VERSION} on WordPress.org."
+
+      - name: Summarize WordPress.org deployment
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          {
+            echo "## WordPress.org deployment"
+            echo ""
+            echo "- Core package: deployed to WordPress.org SVN trunk and tag ${VERSION}."
+            echo "- Advanced companion package: not deployed to WordPress.org SVN."
+            echo "- WooCommerce Marketplace: not configured for this repository; no marketplace upload is attempted."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,16 @@ professional, issue-by-issue format:
   exact file/pattern evidence that proves the submitted code is safe.
 - Close with the resubmission status and any specific reviewer action requested.
 
+### Release Channel Policy
+
+For `/wp-release` work in this repository, do not claim WooCommerce Marketplace
+publication. Stable tags create GitHub release assets for the core and advanced
+ZIPs, then deploy only the core `superdav-ai-agent` package to WordPress.org SVN;
+the advanced companion ZIP remains a GitHub release asset only. WooCommerce
+Marketplace deployment is out of scope unless a future workflow adds explicit
+marketplace product targets, repository secrets, and a verified upload/update
+job.
+
 ### Contributor Insight Triage
 
 When recurring maintainer feedback suggests that automation is missing context,

--- a/docs/wordpress-org-submission.md
+++ b/docs/wordpress-org-submission.md
@@ -368,6 +368,12 @@ secrets named `SVN_USERNAME` and `SVN_PASSWORD`; stable tags deploy only the cor
 ZIP to WordPress.org SVN, while the advanced companion ZIP remains a GitHub
 release asset only.
 
+This repository does not publish either ZIP to the WooCommerce Marketplace. The
+`/wp-release` expectation for this repo is GitHub release asset creation plus
+WordPress.org SVN deployment for stable core releases only. Do not claim a
+WooCommerce Marketplace deployment unless a future workflow adds explicit
+marketplace product targets, credentials, and a successful upload/update step.
+
 `bin/deploy-wporg.sh` remains available for local/manual trunk updates and
 tagging of the core package.
 


### PR DESCRIPTION
## Summary

Documented that this repository releases GitHub assets and deploys only the core package to WordPress.org SVN, explicitly excluding WooCommerce Marketplace publication unless a future workflow adds credentials and product targets. Updated the GitHub release body and workflow summaries to report channel status separately.

## Files Changed

.github/workflows/release.yml, AGENTS.md, docs/wordpress-org-submission.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify; python3 YAML parse for .github/workflows/release.yml; rg -n "WooCommerce|woocommerce|marketplace|WC_CONSUMER|WP_APP_PASSWORD|SVN_USERNAME" .github/workflows AGENTS.md .agents/AGENTS.md docs/wordpress-org-submission.md

Resolves #2205


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.4 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 7m and 85,366 tokens on this as a headless worker.