### PR TITLE
Add OpenAI Responses tool search support

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -1486,9 +1486,11 @@ class AgentLoop {
 		$builder = wp_ai_client_prompt();
 		/** @var \WP_AI_Client_Prompt_Builder $builder */
 
-		// Resolve abilities once here so they are available for both the
-		// system-instruction rebuild (cadence injection) and the prompt
-		// builder's using_abilities() call below.
+		// Resolve abilities once here so they are available for both the prompt
+		// builder's using_abilities() call and the system-instruction rebuild.
+		// When native Responses tool search is active this may include the full
+		// visible catalog, while the system prompt still uses the compact Tier-1
+		// names so it does not re-inline every searchable tool in prose.
 		$abilities = $this->resolve_abilities();
 
 		// Rebuild the system instruction unless the caller pinned a static
@@ -1497,10 +1499,7 @@ class AgentLoop {
 		// Pass active ability names so the cadence section is injected
 		// when content-generation or theme-modification tools are in scope.
 		if ( ! $this->system_instruction_locked ) {
-			$ability_names            = array_map(
-				static fn( \WP_Ability $a ): string => $a->get_name(),
-				$abilities
-			);
+			$ability_names            = $this->system_prompt_ability_names( $abilities );
 			$this->system_instruction = $this->instruction_builder->build( $this->settings_for_prompt, $ability_names );
 		}
 		$builder->using_system_instruction( $this->system_instruction );
@@ -2485,6 +2484,15 @@ class AgentLoop {
 			);
 		}
 
+		if ( $this->should_use_native_tool_search() ) {
+			return $this->deduplicate_by_function_name(
+				array_merge(
+					ToolDiscovery::visible_ai_chat_abilities(),
+					$this->client_router->build_stubs()
+				)
+			);
+		}
+
 		$tier_1 = ToolDiscovery::tier_1_for_run( $this->agent_tier_1_tools );
 
 		$role_allowed = ToolDiscovery::is_anonymous_ability_mode() ? null : RolePermissions::get_allowed_abilities_for_current_user();
@@ -2515,6 +2523,47 @@ class AgentLoop {
 		return $this->deduplicate_by_function_name(
 			array_merge( $resolved, $this->client_router->build_stubs() )
 		);
+	}
+
+	/**
+	 * Return compact ability names for the system prompt.
+	 *
+	 * Native OpenAI tool search receives the full visible catalog as deferred
+	 * function tools. Keeping the prose prompt on Tier 1 preserves the existing
+	 * ability-search guidance and avoids paying for a duplicate direct-tool list.
+	 *
+	 * @param \WP_Ability[] $resolved_abilities Abilities passed to the provider.
+	 * @return list<string>
+	 */
+	private function system_prompt_ability_names( array $resolved_abilities ): array {
+		if ( ! $this->should_use_native_tool_search() ) {
+			return array_values(
+				array_map(
+					static fn( \WP_Ability $a ): string => $a->get_name(),
+					$resolved_abilities
+				)
+			);
+		}
+
+		$names = array_merge( ToolDiscovery::tier_1_for_run( $this->agent_tier_1_tools ), $this->approved_once_abilities );
+		return array_values(
+			array_unique(
+				array_filter(
+					$names,
+					static fn( string $name ): bool => '' !== $name
+				)
+			)
+		);
+	}
+
+	/** Whether the active Superdav provider/model should use Responses tool search. */
+	private function should_use_native_tool_search(): bool {
+		$model_id = (string) $this->model_id;
+		if ( '' === $model_id && function_exists( 'OpenAiCompatibleConnector\\get_default_model' ) ) {
+			$model_id = (string) \OpenAiCompatibleConnector\get_default_model();
+		}
+
+		return SuperdavAiProvider::responses_tool_search_enabled( $this->resolve_provider_id(), $model_id );
 	}
 
 	/**
@@ -3287,7 +3336,10 @@ class AgentLoop {
 		foreach ( $message->getParts() as $part ) {
 			$call = $part->getFunctionCall();
 			if ( $call ) {
-				return $call->getName();
+				$name = $call->getName();
+				if ( is_string( $name ) && '' !== $name ) {
+					return $name;
+				}
 			}
 		}
 

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php
@@ -95,7 +95,62 @@ final class SuperdavAiProvider extends AbstractApiProvider {
 	 * @return ModelInterface
 	 */
 	protected static function createModel( ModelMetadata $model_metadata, ProviderMetadata $provider_metadata ): ModelInterface {
+		if ( self::responses_tool_search_enabled( $provider_metadata->getId(), $model_metadata->getId() ) ) {
+			return new SuperdavAiResponsesToolSearchTextGenerationModel( $model_metadata, $provider_metadata );
+		}
+
 		return new SuperdavAiTextGenerationModel( $model_metadata, $provider_metadata );
+	}
+
+	/**
+	 * Whether the Responses API tool-search experiment should handle a model.
+	 *
+	 * Tool search is an OpenAI Responses API feature (not Chat Completions) and
+	 * is documented for GPT-5.4+ models. Keep the switch filterable so managed
+	 * aliases can opt in once the service confirms the underlying model/endpoint
+	 * supports `/responses` with `tool_search`.
+	 */
+	public static function responses_tool_search_enabled( string $provider_id, string $model_id ): bool {
+		if ( self::PROVIDER_ID !== $provider_id ) {
+			return false;
+		}
+
+		$supported = self::model_supports_responses_tool_search( $model_id );
+
+		/**
+		 * Filter whether the Superdav provider should use OpenAI Responses tool search.
+		 *
+		 * Return true to opt a managed alias into the experiment after verifying the
+		 * endpoint supports `/responses` and the backing model is GPT-5.4 or later.
+		 *
+		 * @param bool   $enabled     Default true only for explicit GPT-5.4+ IDs.
+		 * @param string $provider_id AI Client provider ID.
+		 * @param string $model_id    Provider model ID.
+		 * @param bool   $supported   Whether the model ID itself matches GPT-5.4+.
+		 */
+		$enabled = apply_filters( 'sd_ai_agent_openai_tool_search_enabled', $supported, $provider_id, $model_id, $supported );
+
+		return (bool) $enabled;
+	}
+
+	/**
+	 * Whether a model ID is in the documented OpenAI tool-search support range.
+	 */
+	public static function model_supports_responses_tool_search( string $model_id ): bool {
+		$normalised = strtolower( trim( $model_id ) );
+		if ( '' === $normalised ) {
+			return false;
+		}
+
+		if ( preg_match( '/^gpt-5\.(\d+)(?:[^0-9]|$)/', $normalised, $matches ) ) {
+			return (int) $matches[1] >= 4;
+		}
+
+		if ( preg_match( '/^gpt-(\d+)(?:[.\-]|$)/', $normalised, $matches ) ) {
+			return (int) $matches[1] >= 6;
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiResponsesToolSearchTextGenerationModel.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiResponsesToolSearchTextGenerationModel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Infrastructure\AiClient\Superdav;
 
+use SdAiAgent\Tools\ToolDiscovery;
 use WordPress\AiClient\Common\Exception\InvalidArgumentException;
 use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
@@ -236,14 +237,16 @@ final class SuperdavAiResponsesToolSearchTextGenerationModel extends AbstractApi
 			return array();
 		}
 
-		$groups = array();
+		$immediate_function_names = $this->immediate_tool_function_names();
+		$groups                   = array();
 		foreach ( $declarations as $declaration ) {
 			if ( ! $declaration instanceof FunctionDeclaration ) {
 				continue;
 			}
 
-			$key              = $this->namespace_key_for_function( $declaration->getName() );
-			$groups[ $key ][] = $this->function_declaration_to_tool( $declaration );
+			$function_name    = $declaration->getName();
+			$key              = $this->namespace_key_for_function( $function_name );
+			$groups[ $key ][] = $this->function_declaration_to_tool( $declaration, ! isset( $immediate_function_names[ $function_name ] ) );
 		}
 
 		$tools = array();
@@ -267,14 +270,16 @@ final class SuperdavAiResponsesToolSearchTextGenerationModel extends AbstractApi
 		return $tools;
 	}
 
-	/** Convert a FunctionDeclaration DTO to a deferred Responses function tool. */
-	private function function_declaration_to_tool( FunctionDeclaration $declaration ): array {
+	/** Convert a FunctionDeclaration DTO to a Responses function tool. */
+	private function function_declaration_to_tool( FunctionDeclaration $declaration, bool $defer_loading ): array {
 		$tool = array(
-			'type'          => 'function',
-			'name'          => $declaration->getName(),
-			'description'   => $declaration->getDescription(),
-			'defer_loading' => true,
+			'type'        => 'function',
+			'name'        => $declaration->getName(),
+			'description' => $declaration->getDescription(),
 		);
+		if ( $defer_loading ) {
+			$tool['defer_loading'] = true;
+		}
 
 		$parameters = $declaration->getParameters();
 		if ( is_array( $parameters ) && ! empty( $parameters ) ) {
@@ -282,6 +287,34 @@ final class SuperdavAiResponsesToolSearchTextGenerationModel extends AbstractApi
 		}
 
 		return $tool;
+	}
+
+	/**
+	 * Return function names that should remain immediately visible to the model.
+	 *
+	 * Native Responses tool search receives the whole visible catalog. Keeping the
+	 * established Tier-1 abilities non-deferred preserves the cold-start direct
+	 * tool path while the long tail stays searchable behind `tool_search`.
+	 *
+	 * @return array<string, true>
+	 */
+	private function immediate_tool_function_names(): array {
+		$ability_names = ToolDiscovery::DEFAULT_TIER_1;
+		foreach ( ToolDiscovery::tier_1_for_run() as $ability_name ) {
+			$ability_names[] = $ability_name;
+		}
+
+		$function_names = array();
+		foreach ( array_unique( $ability_names ) as $ability_name ) {
+			if ( class_exists( '\\WP_AI_Client_Ability_Function_Resolver' ) ) {
+				$function_names[ \WP_AI_Client_Ability_Function_Resolver::ability_name_to_function_name( $ability_name ) ] = true;
+				continue;
+			}
+
+			$function_names[ 'wpab__' . str_replace( '/', '__', $ability_name ) ] = true;
+		}
+
+		return $function_names;
 	}
 
 	/** Return a stable namespace key for a WordPress ability function name. */
@@ -356,7 +389,7 @@ final class SuperdavAiResponsesToolSearchTextGenerationModel extends AbstractApi
 			$parts[] = new MessagePart( '' );
 		}
 
-		$finish_reason = $has_function_call ? FinishReasonEnum::toolCalls() : FinishReasonEnum::stop();
+		$finish_reason = $this->finish_reason_for_response_data( $data, $has_function_call );
 		$candidate     = new Candidate( new ModelMessage( $parts ), $finish_reason );
 		$usage         = $this->parse_token_usage( is_array( $data['usage'] ?? null ) ? $data['usage'] : array() );
 
@@ -368,6 +401,25 @@ final class SuperdavAiResponsesToolSearchTextGenerationModel extends AbstractApi
 			$this->metadata(),
 			array( 'responses_output' => $output )
 		);
+	}
+
+	/**
+	 * Return the SDK finish reason for a Responses API payload.
+	 *
+	 * @param array<string, mixed> $data              Decoded Responses payload.
+	 * @param bool                 $has_function_call Whether the output included a function call.
+	 */
+	private function finish_reason_for_response_data( array $data, bool $has_function_call ): FinishReasonEnum {
+		$incomplete_details = $data['incomplete_details'] ?? null;
+		$incomplete_reason  = is_array( $incomplete_details ) && isset( $incomplete_details['reason'] )
+			? (string) $incomplete_details['reason']
+			: '';
+
+		if ( 'incomplete' === (string) ( $data['status'] ?? '' ) && 'max_output_tokens' === $incomplete_reason ) {
+			return FinishReasonEnum::length();
+		}
+
+		return $has_function_call ? FinishReasonEnum::toolCalls() : FinishReasonEnum::stop();
 	}
 
 	/**

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiResponsesToolSearchTextGenerationModel.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiResponsesToolSearchTextGenerationModel.php
@@ -1,0 +1,471 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Infrastructure\AiClient\Superdav;
+
+use WordPress\AiClient\Common\Exception\InvalidArgumentException;
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\DTO\ModelMessage;
+use WordPress\AiClient\Providers\ApiBasedImplementation\AbstractApiBasedModel;
+use WordPress\AiClient\Providers\Http\DTO\Request;
+use WordPress\AiClient\Providers\Http\DTO\Response;
+use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
+use WordPress\AiClient\Providers\Http\Exception\ClientException;
+use WordPress\AiClient\Providers\Http\Exception\ResponseException;
+use WordPress\AiClient\Providers\Http\Util\ResponseUtil;
+use WordPress\AiClient\Providers\Models\TextGeneration\Contracts\TextGenerationModelInterface;
+use WordPress\AiClient\Results\DTO\Candidate;
+use WordPress\AiClient\Results\DTO\GenerativeAiResult;
+use WordPress\AiClient\Results\DTO\TokenUsage;
+use WordPress\AiClient\Results\Enums\FinishReasonEnum;
+use WordPress\AiClient\Tools\DTO\FunctionCall;
+use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Experimental OpenAI Responses API text model with hosted tool search.
+ *
+ * OpenAI documents `tool_search` as a Responses API feature for GPT-5.4+
+ * models. The WordPress AI Client OpenAI-compatible base class targets Chat
+ * Completions, so this model performs the small request/response translation
+ * needed for the Superdav provider while returning the same SDK result DTOs
+ * AgentLoop already consumes.
+ */
+final class SuperdavAiResponsesToolSearchTextGenerationModel extends AbstractApiBasedModel implements TextGenerationModelInterface {
+
+	/** Keep namespaces small as recommended by the OpenAI tool-search guide. */
+	private const NAMESPACE_TOOL_LIMIT = 10;
+
+	/**
+	 * Generate text through `/responses`, falling back to Chat Completions if the
+	 * experimental endpoint/tool is unavailable.
+	 *
+	 * @param Message[] $prompt Prompt messages.
+	 * @phpstan-param list<Message> $prompt
+	 * @return GenerativeAiResult
+	 */
+	public function generateTextResult( array $prompt ): GenerativeAiResult {
+		try {
+			$params  = $this->prepare_responses_params( $prompt );
+			$request = $this->createRequest(
+				HttpMethodEnum::POST(),
+				'responses',
+				array( 'Content-Type' => 'application/json' ),
+				$params
+			);
+			$request = $this->getRequestAuthentication()->authenticateRequest( $request );
+
+			$response = $this->getHttpTransporter()->send( $request );
+			ResponseUtil::throwIfNotSuccessful( $response );
+
+			return $this->parse_response_to_generative_ai_result( $response );
+		} catch ( ClientException $e ) {
+			if ( $this->should_fallback_to_chat_completions( $e ) ) {
+				return $this->generate_chat_completions_fallback( $prompt );
+			}
+
+			throw $e;
+		}
+	}
+
+	/**
+	 * Create an API request.
+	 *
+	 * @param HttpMethodEnum                     $method  HTTP method.
+	 * @param string                             $path    Endpoint path.
+	 * @param array<string, string|list<string>> $headers Request headers.
+	 * @param string|array<string, mixed>|null   $data    Request body/query data.
+	 * @return Request
+	 */
+	protected function createRequest( HttpMethodEnum $method, string $path, array $headers = array(), mixed $data = null ): Request {
+		return new Request( $method, SuperdavAiProvider::url( $path ), $headers, $data, $this->getRequestOptions() );
+	}
+
+	/**
+	 * Prepare OpenAI Responses API parameters from SDK prompt/config DTOs.
+	 *
+	 * @param Message[] $prompt Prompt messages.
+	 * @phpstan-param list<Message> $prompt
+	 * @return array<string, mixed>
+	 */
+	protected function prepare_responses_params( array $prompt ): array {
+		$config = $this->getConfig();
+		$params = array(
+			'model' => $this->metadata()->getId(),
+			'input' => $this->prepare_input_param( $prompt ),
+		);
+
+		$system_instruction = $config->getSystemInstruction();
+		if ( is_string( $system_instruction ) && '' !== $system_instruction ) {
+			$params['instructions'] = $system_instruction;
+		}
+
+		$max_tokens = $config->getMaxTokens();
+		if ( null !== $max_tokens ) {
+			$params['max_output_tokens'] = $max_tokens;
+		}
+
+		$temperature = $config->getTemperature();
+		if ( null !== $temperature ) {
+			$params['temperature'] = $temperature;
+		}
+
+		$top_p = $config->getTopP();
+		if ( null !== $top_p ) {
+			$params['top_p'] = $top_p;
+		}
+
+		$effort = SuperdavAiProvider::reasoning_effort_for_model( $this->metadata()->getId() );
+		if ( '' !== $effort ) {
+			$params['reasoning'] = array( 'effort' => $effort );
+		}
+
+		$tools = $this->prepare_tool_search_tools_param();
+		if ( ! empty( $tools ) ) {
+			$params['tools']               = $tools;
+			$params['parallel_tool_calls'] = false;
+		}
+
+		foreach ( $config->getCustomOptions() as $key => $value ) {
+			if ( isset( $params[ $key ] ) ) {
+				throw new InvalidArgumentException( sprintf( 'The custom option "%s" conflicts with an existing Responses parameter.', esc_html( (string) $key ) ) );
+			}
+			$params[ $key ] = $value;
+		}
+
+		return $params;
+	}
+
+	/**
+	 * Convert SDK messages to Responses `input` items.
+	 *
+	 * @param Message[] $messages Prompt messages.
+	 * @phpstan-param list<Message> $messages
+	 * @return list<array<string, mixed>>
+	 */
+	private function prepare_input_param( array $messages ): array {
+		$input = array();
+
+		foreach ( $messages as $message ) {
+			if ( ! $message instanceof Message ) {
+				continue;
+			}
+			array_push( $input, ...$this->prepare_message_input_items( $message ) );
+		}
+
+		return $input;
+	}
+
+	/**
+	 * Convert one SDK message into one or more Responses input items.
+	 *
+	 * @return list<array<string, mixed>>
+	 */
+	private function prepare_message_input_items( Message $message ): array {
+		$items = array();
+		$text  = array();
+
+		foreach ( $message->getParts() as $part ) {
+			$part_text = $part->getText();
+			if ( is_string( $part_text ) && '' !== $part_text ) {
+				$text[] = $part_text;
+			}
+		}
+
+		if ( ! empty( $text ) ) {
+			$items[] = array(
+				'role'    => $this->responses_role_for_message( $message ),
+				'content' => implode( "\n", $text ),
+			);
+		}
+
+		foreach ( $message->getParts() as $part ) {
+			$call = $part->getFunctionCall();
+			if ( $call instanceof FunctionCall ) {
+				$items[] = $this->function_call_to_input_item( $call );
+				continue;
+			}
+
+			$response = $part->getFunctionResponse();
+			if ( null !== $response ) {
+				$items[] = array(
+					'type'    => 'function_call_output',
+					'call_id' => $response->getId() ?? $response->getName() ?? 'unknown',
+					'output'  => $this->json_encode_for_api( $response->getResponse() ),
+				);
+			}
+		}
+
+		return $items;
+	}
+
+	/** Return the Responses role for an SDK message. */
+	private function responses_role_for_message( Message $message ): string {
+		$role = $message->getRole();
+
+		return $role->isModel() ? 'assistant' : 'user';
+	}
+
+	/**
+	 * Convert a FunctionCall DTO into a Responses input item.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function function_call_to_input_item( FunctionCall $call ): array {
+		return array(
+			'type'      => 'function_call',
+			'call_id'   => $call->getId() ?? 'unknown',
+			'name'      => $call->getName() ?? 'unknown',
+			'arguments' => $this->json_encode_for_api( $call->getArgs() ?? new \stdClass() ),
+		);
+	}
+
+	/**
+	 * Convert configured functions into OpenAI namespace + tool_search tools.
+	 *
+	 * @return list<array<string, mixed>>
+	 */
+	private function prepare_tool_search_tools_param(): array {
+		$declarations = $this->getConfig()->getFunctionDeclarations();
+		if ( ! is_array( $declarations ) || empty( $declarations ) ) {
+			return array();
+		}
+
+		$groups = array();
+		foreach ( $declarations as $declaration ) {
+			if ( ! $declaration instanceof FunctionDeclaration ) {
+				continue;
+			}
+
+			$key              = $this->namespace_key_for_function( $declaration->getName() );
+			$groups[ $key ][] = $this->function_declaration_to_tool( $declaration );
+		}
+
+		$tools = array();
+		foreach ( $groups as $namespace => $functions ) {
+			$chunks = array_chunk( $functions, self::NAMESPACE_TOOL_LIMIT );
+			foreach ( $chunks as $index => $chunk ) {
+				$name    = 0 === $index ? $namespace : $namespace . '_' . ( $index + 1 );
+				$tools[] = array(
+					'type'        => 'namespace',
+					'name'        => $name,
+					'description' => $this->namespace_description( $name ),
+					'tools'       => $chunk,
+				);
+			}
+		}
+
+		if ( ! empty( $tools ) ) {
+			$tools[] = array( 'type' => 'tool_search' );
+		}
+
+		return $tools;
+	}
+
+	/** Convert a FunctionDeclaration DTO to a deferred Responses function tool. */
+	private function function_declaration_to_tool( FunctionDeclaration $declaration ): array {
+		$tool = array(
+			'type'          => 'function',
+			'name'          => $declaration->getName(),
+			'description'   => $declaration->getDescription(),
+			'defer_loading' => true,
+		);
+
+		$parameters = $declaration->getParameters();
+		if ( is_array( $parameters ) && ! empty( $parameters ) ) {
+			$tool['parameters'] = $parameters;
+		}
+
+		return $tool;
+	}
+
+	/** Return a stable namespace key for a WordPress ability function name. */
+	private function namespace_key_for_function( string $function_name ): string {
+		$raw = 'general';
+		if ( str_starts_with( $function_name, 'wpab__' ) ) {
+			$without_prefix = substr( $function_name, strlen( 'wpab__' ) );
+			$parts          = explode( '__', $without_prefix );
+			$raw            = (string) ( $parts[0] ?? 'general' );
+		}
+
+		$slug = strtolower( (string) preg_replace( '/[^A-Za-z0-9_]+/', '_', $raw ) );
+		$slug = trim( $slug, '_' );
+
+		return 'wp_abilities_' . ( '' !== $slug ? $slug : 'general' );
+	}
+
+	/** Return a concise namespace description for the model-visible search surface. */
+	private function namespace_description( string $namespace_name ): string {
+		$label = str_replace( '_', ' ', preg_replace( '/^wp_abilities_/', '', $namespace_name ) ?? $namespace_name );
+
+		return sprintf( 'Searchable WordPress abilities for %s tasks on the current site.', $label );
+	}
+
+	/** Parse a Responses API response into the SDK result DTO shape. */
+	protected function parse_response_to_generative_ai_result( Response $response ): GenerativeAiResult {
+		$data = $response->getData();
+		if ( ! is_array( $data ) ) {
+			throw ResponseException::fromMissingData( 'OpenAI Responses', 'response body' );
+		}
+
+		$output = $data['output'] ?? null;
+		if ( ! is_array( $output ) ) {
+			throw ResponseException::fromMissingData( 'OpenAI Responses', 'output' );
+		}
+
+		$parts             = array();
+		$has_function_call = false;
+
+		foreach ( $output as $item ) {
+			if ( ! is_array( $item ) ) {
+				continue;
+			}
+
+			$type = isset( $item['type'] ) ? (string) $item['type'] : '';
+			if ( 'message' === $type ) {
+				$text = $this->extract_message_output_text( $item );
+				if ( '' !== $text ) {
+					$parts[] = new MessagePart( $text );
+				}
+				continue;
+			}
+
+			if ( 'function_call' === $type ) {
+				$name = isset( $item['name'] ) && is_string( $item['name'] ) ? $item['name'] : '';
+				if ( '' === $name ) {
+					continue;
+				}
+
+				$parts[]           = new MessagePart(
+					new FunctionCall(
+						isset( $item['call_id'] ) && is_string( $item['call_id'] ) ? $item['call_id'] : null,
+						$name,
+						$this->decode_function_arguments( $item['arguments'] ?? null )
+					)
+				);
+				$has_function_call = true;
+			}
+		}
+
+		if ( empty( $parts ) ) {
+			$parts[] = new MessagePart( '' );
+		}
+
+		$finish_reason = $has_function_call ? FinishReasonEnum::toolCalls() : FinishReasonEnum::stop();
+		$candidate     = new Candidate( new ModelMessage( $parts ), $finish_reason );
+		$usage         = $this->parse_token_usage( is_array( $data['usage'] ?? null ) ? $data['usage'] : array() );
+
+		return new GenerativeAiResult(
+			isset( $data['id'] ) && is_string( $data['id'] ) ? $data['id'] : '',
+			array( $candidate ),
+			$usage,
+			$this->providerMetadata(),
+			$this->metadata(),
+			array( 'responses_output' => $output )
+		);
+	}
+
+	/**
+	 * Extract assistant text from a Responses `message` output item.
+	 *
+	 * @param array<string, mixed> $item Responses message output item.
+	 */
+	private function extract_message_output_text( array $item ): string {
+		$content = $item['content'] ?? '';
+		if ( is_string( $content ) ) {
+			return $content;
+		}
+
+		if ( ! is_array( $content ) ) {
+			return '';
+		}
+
+		$text = array();
+		foreach ( $content as $part ) {
+			if ( ! is_array( $part ) ) {
+				continue;
+			}
+			$type = isset( $part['type'] ) ? (string) $part['type'] : '';
+			if ( in_array( $type, array( 'output_text', 'text' ), true ) && isset( $part['text'] ) && is_string( $part['text'] ) ) {
+				$text[] = $part['text'];
+			}
+		}
+
+		return implode( "\n", $text );
+	}
+
+	/** Decode a Responses function-call arguments payload. */
+	private function decode_function_arguments( mixed $arguments ): mixed {
+		if ( ! is_string( $arguments ) ) {
+			return $arguments;
+		}
+
+		if ( '' === trim( $arguments ) ) {
+			return null;
+		}
+
+		$decoded = json_decode( $arguments, true );
+		return JSON_ERROR_NONE === json_last_error() ? $decoded : $arguments;
+	}
+
+	/**
+	 * Parse Responses token usage into the SDK token DTO.
+	 *
+	 * @param array<string, mixed> $usage Responses usage payload.
+	 */
+	private function parse_token_usage( array $usage ): TokenUsage {
+		$prompt_tokens     = isset( $usage['input_tokens'] ) && is_numeric( $usage['input_tokens'] ) ? (int) $usage['input_tokens'] : 0;
+		$completion_tokens = isset( $usage['output_tokens'] ) && is_numeric( $usage['output_tokens'] ) ? (int) $usage['output_tokens'] : 0;
+		$total_tokens      = isset( $usage['total_tokens'] ) && is_numeric( $usage['total_tokens'] ) ? (int) $usage['total_tokens'] : $prompt_tokens + $completion_tokens;
+		$details           = is_array( $usage['output_tokens_details'] ?? null ) ? $usage['output_tokens_details'] : array();
+		$thought_tokens    = isset( $details['reasoning_tokens'] ) && is_numeric( $details['reasoning_tokens'] ) ? (int) $details['reasoning_tokens'] : null;
+
+		return new TokenUsage( $prompt_tokens, $completion_tokens, $total_tokens, $thought_tokens );
+	}
+
+	/** Return whether a Responses failure should fall back to Chat Completions. */
+	private function should_fallback_to_chat_completions( ClientException $e ): bool {
+		$status = (int) $e->getCode();
+		if ( 404 === $status ) {
+			return true;
+		}
+
+		if ( ! in_array( $status, array( 400, 422 ), true ) ) {
+			return false;
+		}
+
+		return (bool) preg_match( '/\b(tool_search|defer_loading|responses|unsupported|unknown parameter)\b/i', $e->getMessage() );
+	}
+
+	/**
+	 * Generate through the existing Chat Completions model as a compatibility fallback.
+	 *
+	 * @param Message[] $prompt Prompt messages.
+	 * @phpstan-param list<Message> $prompt
+	 */
+	private function generate_chat_completions_fallback( array $prompt ): GenerativeAiResult {
+		$fallback = new SuperdavAiTextGenerationModel( $this->metadata(), $this->providerMetadata() );
+		$fallback->setConfig( $this->getConfig() );
+		$fallback->setHttpTransporter( $this->getHttpTransporter() );
+		$fallback->setRequestAuthentication( $this->getRequestAuthentication() );
+
+		$options = $this->getRequestOptions();
+		if ( null !== $options ) {
+			$fallback->setRequestOptions( $options );
+		}
+
+		return $fallback->generateTextResult( $prompt );
+	}
+
+	/** JSON encode a value for OpenAI string fields. */
+	private function json_encode_for_api( mixed $value ): string {
+		$encoded = wp_json_encode( $value );
+
+		return is_string( $encoded ) ? $encoded : 'null';
+	}
+}

--- a/includes/Tools/ToolDiscovery.php
+++ b/includes/Tools/ToolDiscovery.php
@@ -1284,6 +1284,19 @@ class ToolDiscovery {
 	}
 
 	/**
+	 * Return all currently visible AI-chat abilities for native provider tool search.
+	 *
+	 * This intentionally applies the same visibility, permission, role, and
+	 * anonymous-chat gates as `ability-search` so provider-native discovery never
+	 * exposes a broader tool catalog than the plugin's existing meta-tool path.
+	 *
+	 * @return \WP_Ability[]
+	 */
+	public static function visible_ai_chat_abilities(): array {
+		return self::visible_abilities();
+	}
+
+	/**
 	 * All registered abilities the current user can see — `ai_hidden` and
 	 * `disabled` entries removed.
 	 *

--- a/stubs/wordpress-7-runtime.php
+++ b/stubs/wordpress-7-runtime.php
@@ -39,6 +39,12 @@ namespace WordPress\AiClient\Messages\Enums {
 			return $this->value;
 		}
 
+		/** @return bool */
+		public function isModel(): bool { return false; }
+
+		/** @return bool */
+		public function isUser(): bool { return false; }
+
 		/**
 		 * Allow casting to string.
 		 *
@@ -59,17 +65,17 @@ namespace WordPress\AiClient\Tools\DTO {
 		/**
 		 * Constructor.
 		 *
-		 * @param string               $id   Function call ID.
-		 * @param string               $name Function name.
-		 * @param array<string, mixed> $args Function arguments.
+		 * @param string|null $id   Function call ID.
+		 * @param string|null $name Function name.
+		 * @param mixed       $args Function arguments.
 		 */
-		public function __construct( string $id, string $name, array $args = array() ) {}
+		public function __construct( ?string $id = null, ?string $name = null, mixed $args = null ) {}
 
-		/** @return string */
-		public function getId(): string { return ''; }
+		/** @return string|null */
+		public function getId(): ?string { return ''; }
 
-		/** @return string */
-		public function getName(): string { return ''; }
+		/** @return string|null */
+		public function getName(): ?string { return ''; }
 
 		/**
 		 * Provider JSON decoders may return a top-level stdClass for
@@ -87,20 +93,43 @@ namespace WordPress\AiClient\Tools\DTO {
 		/**
 		 * Constructor.
 		 *
-		 * @param string $id       Function call ID.
-		 * @param string $name     Function name.
+		 * @param string|null $id       Function call ID.
+		 * @param string|null $name     Function name.
 		 * @param mixed  $response Response data.
 		 */
-		public function __construct( string $id, string $name, mixed $response = null ) {}
+		public function __construct( ?string $id = null, ?string $name = null, mixed $response = null ) {}
 
-		/** @return string */
-		public function getId(): string { return ''; }
+		/** @return string|null */
+		public function getId(): ?string { return ''; }
+
+		/** @return string|null */
+		public function getName(): ?string { return ''; }
+
+		/** @return mixed */
+		public function getResponse(): mixed { return null; }
+
+	}
+
+	/**
+	 * Represents an AI function declaration (stub).
+	 */
+	class FunctionDeclaration {
+		/**
+		 * @param string                    $name        Function name.
+		 * @param string                    $description Function description.
+		 * @param array<string, mixed>|null $parameters  JSON schema parameters.
+		 */
+		public function __construct( string $name, string $description, ?array $parameters = null ) {}
 
 		/** @return string */
 		public function getName(): string { return ''; }
 
-		/** @return mixed */
-		public function getResponse(): mixed { return null; }
+		/** @return string */
+		public function getDescription(): string { return ''; }
+
+		/** @return array<string, mixed>|null */
+		public function getParameters(): ?array { return null; }
+
 	}
 }
 
@@ -276,6 +305,12 @@ namespace WordPress\AiClient\Results\Enums {
 			return $this->value;
 		}
 
+		/** @return self */
+		public static function stop(): self { return new self(); }
+
+		/** @return self */
+		public static function toolCalls(): self { return new self(); }
+
 		/** @return string */
 		public function __toString(): string {
 			return $this->value;
@@ -293,6 +328,14 @@ namespace WordPress\AiClient\Results\DTO {
 	 * Token usage data from a generative AI request (stub).
 	 */
 	class TokenUsage {
+		/**
+		 * @param int      $promptTokens     Prompt tokens.
+		 * @param int      $completionTokens Completion tokens.
+		 * @param int      $totalTokens      Total tokens.
+		 * @param int|null $thoughtTokens    Thought tokens.
+		 */
+		public function __construct( int $promptTokens = 0, int $completionTokens = 0, int $totalTokens = 0, ?int $thoughtTokens = null ) {}
+
 		/**
 		 * Get the number of prompt/input tokens used.
 		 *
@@ -332,6 +375,12 @@ namespace WordPress\AiClient\Results\DTO {
 	 * (why the candidate stopped generating).
 	 */
 	class Candidate {
+		/**
+		 * @param Message          $message      Model message.
+		 * @param FinishReasonEnum $finishReason Finish reason.
+		 */
+		public function __construct( ?Message $message = null, ?FinishReasonEnum $finishReason = null ) {}
+
 		/** @return Message */
 		public function getMessage(): Message { return new Message(); }
 
@@ -343,6 +392,16 @@ namespace WordPress\AiClient\Results\DTO {
 	 * Result from a generative AI request (stub).
 	 */
 	class GenerativeAiResult {
+		/**
+		 * @param string               $id                 Result id.
+		 * @param Candidate[]          $candidates         Candidates.
+		 * @param TokenUsage|null      $tokenUsage         Token usage.
+		 * @param mixed                $providerMetadata   Provider metadata.
+		 * @param ModelMetadata|null   $modelMetadata      Model metadata.
+		 * @param array<string, mixed> $additionalData     Additional data.
+		 */
+		public function __construct( string $id = '', array $candidates = array(), ?TokenUsage $tokenUsage = null, mixed $providerMetadata = null, ?ModelMetadata $modelMetadata = null, array $additionalData = array() ) {}
+
 		/** @return string */
 		public function getId(): string { return ''; }
 
@@ -382,6 +441,9 @@ namespace WordPress\AiClient\Results\DTO {
 		 * @return TokenUsage
 		 */
 		public function getTokenUsage(): TokenUsage { return new TokenUsage(); }
+
+		/** @return array<string, mixed> */
+		public function getAdditionalData(): array { return array(); }
 	}
 }
 
@@ -418,6 +480,35 @@ namespace WordPress\AiClient\Providers\Models\DTO {
 
 		/** @return array<int, mixed> */
 		public function getSupportedCapabilities(): array { return array(); }
+	}
+
+	class ModelConfig {
+		/** @param string $systemInstruction System instruction. */
+		public function setSystemInstruction( string $systemInstruction ): void {}
+
+		/** @return string|null */
+		public function getSystemInstruction(): ?string { return null; }
+
+		/** @param int $maxTokens Max tokens. */
+		public function setMaxTokens( int $maxTokens ): void {}
+
+		/** @return int|null */
+		public function getMaxTokens(): ?int { return null; }
+
+		/** @return float|null */
+		public function getTemperature(): ?float { return null; }
+
+		/** @return float|null */
+		public function getTopP(): ?float { return null; }
+
+		/** @param list<\WordPress\AiClient\Tools\DTO\FunctionDeclaration> $functionDeclarations Function declarations. */
+		public function setFunctionDeclarations( array $functionDeclarations ): void {}
+
+		/** @return list<\WordPress\AiClient\Tools\DTO\FunctionDeclaration>|null */
+		public function getFunctionDeclarations(): ?array { return null; }
+
+		/** @return array<string, mixed> */
+		public function getCustomOptions(): array { return array(); }
 	}
 }
 
@@ -516,12 +607,43 @@ namespace WordPress\AiClient\Providers\Contracts {
 
 namespace WordPress\AiClient\Providers\Models\Contracts {
 
-	interface ModelInterface {}
+	interface ModelInterface {
+		/** @return \WordPress\AiClient\Providers\Models\DTO\ModelMetadata */
+		public function metadata(): \WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+
+		/** @return \WordPress\AiClient\Providers\DTO\ProviderMetadata */
+		public function providerMetadata(): \WordPress\AiClient\Providers\DTO\ProviderMetadata;
+
+		/** @param \WordPress\AiClient\Providers\Models\DTO\ModelConfig $config Model config. */
+		public function setConfig( \WordPress\AiClient\Providers\Models\DTO\ModelConfig $config ): void;
+
+		/** @return \WordPress\AiClient\Providers\Models\DTO\ModelConfig */
+		public function getConfig(): \WordPress\AiClient\Providers\Models\DTO\ModelConfig;
+	}
+}
+
+namespace WordPress\AiClient\Providers\Models\TextGeneration\Contracts {
+
+	interface TextGenerationModelInterface {
+		/**
+		 * @param list<\WordPress\AiClient\Messages\DTO\Message> $prompt Prompt messages.
+		 * @return \WordPress\AiClient\Results\DTO\GenerativeAiResult
+		 */
+		public function generateTextResult( array $prompt ): \WordPress\AiClient\Results\DTO\GenerativeAiResult;
+	}
 }
 
 namespace WordPress\AiClient\Providers\Http\Contracts {
 
-	interface RequestAuthenticationInterface {}
+	interface HttpTransporterInterface {
+		/** @return \WordPress\AiClient\Providers\Http\DTO\Response */
+		public function send( \WordPress\AiClient\Providers\Http\DTO\Request $request ): \WordPress\AiClient\Providers\Http\DTO\Response;
+	}
+
+	interface RequestAuthenticationInterface {
+		/** @return \WordPress\AiClient\Providers\Http\DTO\Request */
+		public function authenticateRequest( \WordPress\AiClient\Providers\Http\DTO\Request $request ): \WordPress\AiClient\Providers\Http\DTO\Request;
+	}
 
 	interface WithRequestAuthenticationInterface {
 		/** @param RequestAuthenticationInterface $authentication Authentication. */
@@ -536,7 +658,10 @@ namespace WordPress\AiClient\Providers\Http\Enums {
 		public static function apiKey(): self { return new self(); }
 	}
 
-	class HttpMethodEnum {}
+	class HttpMethodEnum {
+		/** @return self */
+		public static function POST(): self { return new self(); }
+	}
 }
 
 namespace WordPress\AiClient\Providers\Http\DTO {
@@ -597,6 +722,23 @@ namespace WordPress\AiClient\Providers\Http\Traits {
 	}
 }
 
+namespace WordPress\AiClient\Providers\Http\Exception {
+
+	class ClientException extends \Exception {}
+
+	class ResponseException extends \Exception {
+		/** @return self */
+		public static function fromMissingData( string $apiName, string $fieldName ): self { return new self(); }
+	}
+}
+
+namespace WordPress\AiClient\Providers\Http\Util {
+
+	class ResponseUtil {
+		public static function throwIfNotSuccessful( \WordPress\AiClient\Providers\Http\DTO\Response $response ): void {}
+	}
+}
+
 namespace WordPress\AiClient\Providers\ApiBasedImplementation {
 
 	abstract class AbstractApiProvider {
@@ -631,6 +773,52 @@ namespace WordPress\AiClient\Providers\ApiBasedImplementation {
 		 */
 		public static function url( string $path = '' ): string { return $path; }
 	}
+
+	abstract class AbstractApiBasedModel implements \WordPress\AiClient\Providers\Models\Contracts\ModelInterface {
+		/**
+		 * @param \WordPress\AiClient\Providers\Models\DTO\ModelMetadata $metadata Model metadata.
+		 * @param \WordPress\AiClient\Providers\DTO\ProviderMetadata $providerMetadata Provider metadata.
+		 */
+		public function __construct( \WordPress\AiClient\Providers\Models\DTO\ModelMetadata $metadata, \WordPress\AiClient\Providers\DTO\ProviderMetadata $providerMetadata ) {}
+
+		/** @return \WordPress\AiClient\Providers\Models\DTO\ModelMetadata */
+		public function metadata(): \WordPress\AiClient\Providers\Models\DTO\ModelMetadata { return new \WordPress\AiClient\Providers\Models\DTO\ModelMetadata(); }
+
+		/** @return \WordPress\AiClient\Providers\DTO\ProviderMetadata */
+		public function providerMetadata(): \WordPress\AiClient\Providers\DTO\ProviderMetadata { return new \WordPress\AiClient\Providers\DTO\ProviderMetadata(); }
+
+		/** @param \WordPress\AiClient\Providers\Models\DTO\ModelConfig $config Model config. */
+		public function setConfig( \WordPress\AiClient\Providers\Models\DTO\ModelConfig $config ): void {}
+
+		/** @return \WordPress\AiClient\Providers\Models\DTO\ModelConfig */
+		public function getConfig(): \WordPress\AiClient\Providers\Models\DTO\ModelConfig { return new \WordPress\AiClient\Providers\Models\DTO\ModelConfig(); }
+
+		/** @param \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface $httpTransporter HTTP transporter. */
+		public function setHttpTransporter( \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface $httpTransporter ): void {}
+
+		/** @return \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface */
+		public function getHttpTransporter(): \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface {
+			return new class() implements \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface {
+				public function send( \WordPress\AiClient\Providers\Http\DTO\Request $request ): \WordPress\AiClient\Providers\Http\DTO\Response { return new \WordPress\AiClient\Providers\Http\DTO\Response(); }
+			};
+		}
+
+		/** @param \WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface $requestAuthentication Request authentication. */
+		public function setRequestAuthentication( \WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface $requestAuthentication ): void {}
+
+		/** @return \WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface */
+		public function getRequestAuthentication(): \WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface {
+			return new class() implements \WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface {
+				public function authenticateRequest( \WordPress\AiClient\Providers\Http\DTO\Request $request ): \WordPress\AiClient\Providers\Http\DTO\Request { return $request; }
+			};
+		}
+
+		/** @param \WordPress\AiClient\Providers\Http\DTO\RequestOptions $requestOptions Request options. */
+		public function setRequestOptions( \WordPress\AiClient\Providers\Http\DTO\RequestOptions $requestOptions ): void {}
+
+		/** @return \WordPress\AiClient\Providers\Http\DTO\RequestOptions|null */
+		public function getRequestOptions(): ?\WordPress\AiClient\Providers\Http\DTO\RequestOptions { return null; }
+	}
 }
 
 namespace WordPress\AiClient\Providers\OpenAiCompatibleImplementation {
@@ -658,6 +846,41 @@ namespace WordPress\AiClient\Providers\OpenAiCompatibleImplementation {
 
 		/** @return \WordPress\AiClient\Providers\Http\DTO\RequestOptions|null */
 		public function getRequestOptions(): ?\WordPress\AiClient\Providers\Http\DTO\RequestOptions { return null; }
+
+		/** @param \WordPress\AiClient\Providers\Models\DTO\ModelConfig $config Model config. */
+		public function setConfig( \WordPress\AiClient\Providers\Models\DTO\ModelConfig $config ): void {}
+
+		/** @return \WordPress\AiClient\Providers\Models\DTO\ModelConfig */
+		public function getConfig(): \WordPress\AiClient\Providers\Models\DTO\ModelConfig { return new \WordPress\AiClient\Providers\Models\DTO\ModelConfig(); }
+
+		/** @return \WordPress\AiClient\Providers\Models\DTO\ModelMetadata */
+		public function metadata(): \WordPress\AiClient\Providers\Models\DTO\ModelMetadata { return new \WordPress\AiClient\Providers\Models\DTO\ModelMetadata(); }
+
+		/** @return \WordPress\AiClient\Providers\DTO\ProviderMetadata */
+		public function providerMetadata(): \WordPress\AiClient\Providers\DTO\ProviderMetadata { return new \WordPress\AiClient\Providers\DTO\ProviderMetadata(); }
+
+		/** @param \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface $httpTransporter HTTP transporter. */
+		public function setHttpTransporter( \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface $httpTransporter ): void {}
+
+		/** @return \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface */
+		public function getHttpTransporter(): \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface {
+			return new class() implements \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface {
+				public function send( \WordPress\AiClient\Providers\Http\DTO\Request $request ): \WordPress\AiClient\Providers\Http\DTO\Response { return new \WordPress\AiClient\Providers\Http\DTO\Response(); }
+			};
+		}
+
+		/** @param \WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface $requestAuthentication Request authentication. */
+		public function setRequestAuthentication( \WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface $requestAuthentication ): void {}
+
+		/** @return \WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface */
+		public function getRequestAuthentication(): \WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface {
+			return new class() implements \WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface {
+				public function authenticateRequest( \WordPress\AiClient\Providers\Http\DTO\Request $request ): \WordPress\AiClient\Providers\Http\DTO\Request { return $request; }
+			};
+		}
+
+		/** @param list<\WordPress\AiClient\Messages\DTO\Message> $prompt Prompt messages. */
+		public function generateTextResult( array $prompt ): \WordPress\AiClient\Results\DTO\GenerativeAiResult { return new \WordPress\AiClient\Results\DTO\GenerativeAiResult(); }
 	}
 }
 
@@ -766,6 +989,16 @@ namespace {
 
 		/** @param string $message */
 		public static function warning( string $message ): void {}
+	}
+
+	/**
+	 * WordPress PHPUnit base class (stub).
+	 */
+	if ( ! class_exists( 'WP_UnitTestCase' ) ) {
+		abstract class WP_UnitTestCase extends \PHPUnit\Framework\TestCase {
+			/** WordPress test-suite teardown alias. */
+			public function tear_down(): void {}
+		}
 	}
 
 	/**

--- a/stubs/wordpress-7-runtime.php
+++ b/stubs/wordpress-7-runtime.php
@@ -311,6 +311,9 @@ namespace WordPress\AiClient\Results\Enums {
 		/** @return self */
 		public static function toolCalls(): self { return new self(); }
 
+		/** @return self */
+		public static function length(): self { return new self(); }
+
 		/** @return string */
 		public function __toString(): string {
 			return $this->value;

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
@@ -329,6 +329,13 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 						),
 					)
 				),
+				new FunctionDeclaration(
+					'wpab__example-plugin__long-tail',
+					'Long-tail example tool.',
+					array(
+						'type' => 'object',
+					)
+				),
 			)
 		);
 		$model->setConfig( $config );
@@ -341,12 +348,15 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 		$this->assertSame( 512, $params['max_output_tokens'] );
 		$this->assertSame( 'You are a WordPress assistant.', $params['instructions'] );
 		$this->assertFalse( $params['parallel_tool_calls'] );
-		$this->assertSame( array( 'type' => 'tool_search' ), $params['tools'][1] );
+		$this->assertSame( array( 'type' => 'tool_search' ), $params['tools'][2] );
 		$this->assertSame( 'namespace', $params['tools'][0]['type'] );
 		$this->assertSame( 'wp_abilities_sd_ai_agent', $params['tools'][0]['name'] );
 		$this->assertSame( 'function', $params['tools'][0]['tools'][0]['type'] );
-		$this->assertTrue( $params['tools'][0]['tools'][0]['defer_loading'] );
+		$this->assertArrayNotHasKey( 'defer_loading', $params['tools'][0]['tools'][0] );
 		$this->assertSame( 'wpab__sd-ai-agent__list-posts', $params['tools'][0]['tools'][0]['name'] );
+		$this->assertSame( 'namespace', $params['tools'][1]['type'] );
+		$this->assertSame( 'wp_abilities_example_plugin', $params['tools'][1]['name'] );
+		$this->assertTrue( $params['tools'][1]['tools'][0]['defer_loading'] );
 	}
 
 	/**
@@ -404,6 +414,47 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 		$this->assertSame( 'call_123', $call->getId() );
 		$this->assertSame( 'wpab__sd-ai-agent__list-posts', $call->getName() );
 		$this->assertSame( array( 'post_type' => 'page' ), $call->getArgs() );
+	}
+
+	/**
+	 * Incomplete Responses payloads caused by max_output_tokens surface as length finishes.
+	 */
+	public function test_responses_tool_search_response_parses_max_output_tokens_as_length(): void {
+		$this->skip_if_sdk_unavailable();
+
+		$model = new SuperdavAiResponsesToolSearchTextGenerationModel(
+			new ModelMetadata( 'gpt-5.5', 'GPT-5.5', array( CapabilityEnum::textGeneration() ), array() ),
+			SuperdavAiProvider::metadata()
+		);
+
+		$parse  = new \ReflectionMethod( $model, 'parse_response_to_generative_ai_result' );
+		$result = $parse->invoke(
+			$model,
+			new Response(
+				200,
+				array( 'content-type' => 'application/json' ),
+				(string) wp_json_encode(
+					array(
+						'id'                 => 'resp_truncated',
+						'status'             => 'incomplete',
+						'incomplete_details' => array( 'reason' => 'max_output_tokens' ),
+						'output'             => array(
+							array(
+								'type'    => 'message',
+								'content' => array(
+									array(
+										'type' => 'output_text',
+										'text' => 'Partially generated text.',
+									),
+								),
+							),
+						),
+					)
+				)
+			)
+		);
+
+		$this->assertSame( 'length', (string) $result->getCandidates()[0]->getFinishReason() );
 	}
 
 	/**

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
@@ -15,14 +15,19 @@ use SdAiAgent\Core\ModelCapabilityRegistry;
 use SdAiAgent\Core\ProviderCredentialLoader;
 use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiModelMetadataDirectory;
 use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiResponsesToolSearchTextGenerationModel;
 use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiTextGenerationModel;
 use WP_UnitTestCase;
 use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\DTO\UserMessage;
 use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
 use WordPress\AiClient\Providers\Http\DTO\Response;
 use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
+use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
+use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
 use XWP\DI\Decorators\Action;
 
 /**
@@ -39,6 +44,7 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 		remove_all_filters( 'sd_ai_agent_cloud_base_url' );
 		remove_all_filters( 'sd_ai_agent_superdav_default_model' );
 		remove_all_filters( 'sd_ai_agent_superdav_reasoning_effort' );
+		remove_all_filters( 'sd_ai_agent_openai_tool_search_enabled' );
 		parent::tear_down();
 	}
 
@@ -76,7 +82,7 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 
 		$hook = $attributes[0]->newInstance();
 		$this->assertSame( 'init', $hook->tag );
-		$this->assertSame( 5, $hook->prio );
+		$this->assertSame( 5, $hook->__get( 'priority' ) );
 	}
 
 	/**
@@ -181,6 +187,7 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 		$this->assertIsArray( $models );
 		$this->assertCount( 1, $models );
 		$model = $models[0];
+		$this->assertInstanceOf( ModelMetadata::class, $model );
 
 		$this->assertSame( 'example-model', $model->getId() );
 		$this->assertSame( 'Example Model', $model->getName() );
@@ -254,6 +261,149 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 
 		$this->assertNotNull( $request->getOptions() );
 		$this->assertSame( 123.0, $request->getOptions()->getTimeout() );
+	}
+
+	/**
+	 * Tool search is enabled only for the documented GPT-5.4+ model range by default.
+	 *
+	 * @dataProvider tool_search_model_support_provider
+	 */
+	public function test_model_supports_responses_tool_search_range( string $model_id, bool $expected ): void {
+		$this->assertSame( $expected, SuperdavAiProvider::model_supports_responses_tool_search( $model_id ) );
+	}
+
+	/**
+	 * @return array<string, array{0:string, 1:bool}>
+	 */
+	public function tool_search_model_support_provider(): array {
+		return array(
+			'gpt-5.3'       => array( 'gpt-5.3', false ),
+			'gpt-5.4'       => array( 'gpt-5.4', true ),
+			'gpt-5.5-pro'   => array( 'gpt-5.5-pro', true ),
+			'gpt-6'         => array( 'gpt-6', true ),
+			'gpt-4o'        => array( 'gpt-4o', false ),
+			'managed alias' => array( SuperdavAiProvider::DEFAULT_MODEL_ID, false ),
+		);
+	}
+
+	/**
+	 * Provider model creation switches to the Responses tool-search model for GPT-5.5.
+	 */
+	public function test_create_model_uses_responses_tool_search_model_for_gpt_5_5(): void {
+		$this->skip_if_sdk_unavailable();
+
+		$method = new \ReflectionMethod( SuperdavAiProvider::class, 'createModel' );
+		$method->setAccessible( true );
+
+		$model = $method->invoke(
+			null,
+			new ModelMetadata( 'gpt-5.5', 'GPT-5.5', array( CapabilityEnum::textGeneration() ), array() ),
+			SuperdavAiProvider::metadata()
+		);
+
+		$this->assertInstanceOf( SuperdavAiResponsesToolSearchTextGenerationModel::class, $model );
+	}
+
+	/**
+	 * Responses requests use `/responses`, namespaces, deferred functions, and `tool_search`.
+	 */
+	public function test_responses_tool_search_request_shape(): void {
+		$this->skip_if_sdk_unavailable();
+
+		$model  = new SuperdavAiResponsesToolSearchTextGenerationModel(
+			new ModelMetadata( 'gpt-5.5', 'GPT-5.5', array( CapabilityEnum::textGeneration() ), array() ),
+			SuperdavAiProvider::metadata()
+		);
+		$config = new ModelConfig();
+		$config->setSystemInstruction( 'You are a WordPress assistant.' );
+		$config->setMaxTokens( 512 );
+		$config->setFunctionDeclarations(
+			array(
+				new FunctionDeclaration(
+					'wpab__sd-ai-agent__list-posts',
+					'List WordPress posts.',
+					array(
+						'type'       => 'object',
+						'properties' => array(
+							'post_type' => array( 'type' => 'string' ),
+						),
+					)
+				),
+			)
+		);
+		$model->setConfig( $config );
+
+		$prepare = new \ReflectionMethod( $model, 'prepare_responses_params' );
+		$prepare->setAccessible( true );
+		$params = $prepare->invoke( $model, array( new UserMessage( array( new MessagePart( 'List my pages.' ) ) ) ) );
+
+		$this->assertSame( 'gpt-5.5', $params['model'] );
+		$this->assertSame( 512, $params['max_output_tokens'] );
+		$this->assertSame( 'You are a WordPress assistant.', $params['instructions'] );
+		$this->assertFalse( $params['parallel_tool_calls'] );
+		$this->assertSame( array( 'type' => 'tool_search' ), $params['tools'][1] );
+		$this->assertSame( 'namespace', $params['tools'][0]['type'] );
+		$this->assertSame( 'wp_abilities_sd_ai_agent', $params['tools'][0]['name'] );
+		$this->assertSame( 'function', $params['tools'][0]['tools'][0]['type'] );
+		$this->assertTrue( $params['tools'][0]['tools'][0]['defer_loading'] );
+		$this->assertSame( 'wpab__sd-ai-agent__list-posts', $params['tools'][0]['tools'][0]['name'] );
+	}
+
+	/**
+	 * Responses function_call output items map back to SDK FunctionCall parts.
+	 */
+	public function test_responses_tool_search_response_parses_function_call(): void {
+		$this->skip_if_sdk_unavailable();
+
+		$model = new SuperdavAiResponsesToolSearchTextGenerationModel(
+			new ModelMetadata( 'gpt-5.5', 'GPT-5.5', array( CapabilityEnum::textGeneration() ), array() ),
+			SuperdavAiProvider::metadata()
+		);
+
+		$parse  = new \ReflectionMethod( $model, 'parse_response_to_generative_ai_result' );
+		$result = $parse->invoke(
+			$model,
+			new Response(
+				200,
+				array( 'content-type' => 'application/json' ),
+				(string) wp_json_encode(
+					array(
+						'id'     => 'resp_test',
+						'output' => array(
+							array(
+								'type'    => 'tool_search_call',
+								'status'  => 'completed',
+								'arguments' => array( 'paths' => array( 'wp_abilities_sd_ai_agent' ) ),
+							),
+							array(
+								'type'      => 'function_call',
+								'call_id'   => 'call_123',
+								'name'      => 'wpab__sd-ai-agent__list-posts',
+								'arguments' => '{"post_type":"page"}',
+							),
+						),
+						'usage'  => array(
+							'input_tokens'          => 10,
+							'output_tokens'         => 5,
+							'total_tokens'          => 15,
+							'output_tokens_details' => array( 'reasoning_tokens' => 2 ),
+						),
+					)
+				)
+			)
+		);
+
+		$this->assertSame( 'resp_test', $result->getId() );
+		$this->assertSame( 10, $result->getTokenUsage()->getPromptTokens() );
+		$this->assertSame( 5, $result->getTokenUsage()->getCompletionTokens() );
+		$this->assertSame( 2, $result->getTokenUsage()->getThoughtTokens() );
+
+		$parts = $result->getCandidates()[0]->getMessage()->getParts();
+		$call  = $parts[0]->getFunctionCall();
+		$this->assertNotNull( $call );
+		$this->assertSame( 'call_123', $call->getId() );
+		$this->assertSame( 'wpab__sd-ai-agent__list-posts', $call->getName() );
+		$this->assertSame( array( 'post_type' => 'page' ), $call->getArgs() );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Add an experimental Superdav AI Client model that sends GPT-5.4+ requests through the OpenAI Responses API with native `tool_search`.
- Keep managed aliases opt-in via `sd_ai_agent_openai_tool_search_enabled`, and fall back to Chat Completions when `/responses` or `tool_search` is unavailable.
- Expose the same visible AI-chat ability catalog to native tool search while keeping the system prompt on the compact Tier-1 ability list.
- Extend WordPress AI Client stubs and provider tests for model selection, Responses request shape, and function-call response parsing.

## Testing
- `npm run lint`
- `COMPOSER_PROCESS_TIMEOUT=1200 composer phpstan`
- `npm run test:php:setup && npm run test:php`
- `npm run build && npm run check:bundle`

## Worker self-verification
- PHPUnit: Tests: 3725, Assertions: 15595, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.5 plugin for [OpenCode](https://opencode.ai) v1.17.13


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for hosted tool search via the Responses API for compatible GPT-5.4+/GPT-6+ models.
  * Improved tool discovery and prompt/system ability selection when native tool search is enabled.
  * Added a resilient fallback to standard text generation when tool-search responses aren’t compatible.
* **Bug Fixes**
  * Prevented empty/invalid function-call names from being processed.
* **Tests**
  * Expanded coverage for model capability detection, tool-search request construction, and parsing of tool-search function calls and token usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->