### PR TITLE
fix: round-trip Superdav reasoning context

### DIFF
--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiTextGenerationModel.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiTextGenerationModel.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Infrastructure\AiClient\Superdav;
 
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Providers\Http\DTO\Request;
 use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
 use WordPress\AiClient\Providers\OpenAiCompatibleImplementation\AbstractOpenAiCompatibleTextGenerationModel;
@@ -16,6 +18,47 @@ if ( ! defined( 'ABSPATH' ) ) {
  * OpenAI-compatible text generation model for the Superdav AI service.
  */
 final class SuperdavAiTextGenerationModel extends AbstractOpenAiCompatibleTextGenerationModel {
+
+	/**
+	 * Prepare OpenAI-compatible chat messages for the Superdav managed edge.
+	 *
+	 * The upstream OpenAI-compatible SDK adapter parses response
+	 * `reasoning_content` into thought-channel message parts, but it deliberately
+	 * omits thought parts from later requests because OpenAI's public Chat
+	 * Completions API has no matching input field. Superdav's managed endpoint
+	 * does accept the DeepSeek-style `reasoning_content` sibling and needs that
+	 * context round-tripped on later turns, so restore it after the parent adapter
+	 * prepares the normal message content/tool-call shape.
+	 *
+	 * @param array       $messages           Conversation messages.
+	 * @param string|null $system_instruction Optional system instruction.
+	 * @return list<array<string, mixed>>
+	 * @phpstan-param list<Message> $messages
+	 */
+	protected function prepareMessagesParam( array $messages, ?string $system_instruction = null ): array {
+		$messages_param = parent::prepareMessagesParam( $messages, $system_instruction );
+		$offset         = $system_instruction ? 1 : 0;
+
+		foreach ( $messages as $index => $message ) {
+			$reasoning_content = self::extract_reasoning_content( $message );
+			if ( '' === $reasoning_content ) {
+				continue;
+			}
+
+			$param_index = $index + $offset;
+			if ( ! isset( $messages_param[ $param_index ] ) ) {
+				continue;
+			}
+
+			if ( 'assistant' !== ( $messages_param[ $param_index ]['role'] ?? '' ) ) {
+				continue;
+			}
+
+			$messages_param[ $param_index ]['reasoning_content'] = $reasoning_content;
+		}
+
+		return array_values( $messages_param );
+	}
 
 	/**
 	 * Create an authenticated API request.
@@ -36,5 +79,52 @@ final class SuperdavAiTextGenerationModel extends AbstractOpenAiCompatibleTextGe
 		}
 
 		return new Request( $method, SuperdavAiProvider::url( $path ), $headers, $data, $this->getRequestOptions() );
+	}
+
+	/**
+	 * Extract thought-channel text that must be sent back as reasoning context.
+	 *
+	 * @param Message $message Message to inspect.
+	 * @return string Newline-joined thought text, or an empty string when absent.
+	 */
+	private static function extract_reasoning_content( Message $message ): string {
+		$reasoning_parts = array();
+
+		foreach ( $message->getParts() as $part ) {
+			if ( ! self::is_thought_text_part( $part ) ) {
+				continue;
+			}
+
+			$text = trim( $part->getText() );
+			if ( '' !== $text ) {
+				$reasoning_parts[] = $text;
+			}
+		}
+
+		return implode( "\n", $reasoning_parts );
+	}
+
+	/**
+	 * Determine whether a message part is hidden reasoning text.
+	 *
+	 * @param MessagePart $part Message part.
+	 * @return bool
+	 */
+	private static function is_thought_text_part( MessagePart $part ): bool {
+		$type = $part->getType();
+		if ( ! $type->isText() ) {
+			return false;
+		}
+
+		if ( ! method_exists( $part, 'getChannel' ) ) {
+			return false;
+		}
+
+		$channel = $part->getChannel();
+		if ( ! is_object( $channel ) || ! is_callable( array( $channel, 'isThought' ) ) ) {
+			return false;
+		}
+
+		return (bool) $channel->isThought();
 	}
 }

--- a/stubs/wordpress-7-runtime.php
+++ b/stubs/wordpress-7-runtime.php
@@ -133,6 +133,9 @@ namespace WordPress\AiClient\Messages\Enums {
 			$enum->value = 'thought';
 			return $enum;
 		}
+
+		/** @return bool */
+		public function isThought(): bool { return 'thought' === $this->value; }
 	}
 }
 
@@ -658,6 +661,12 @@ namespace WordPress\AiClient\Providers\OpenAiCompatibleImplementation {
 
 		/** @return \WordPress\AiClient\Providers\Http\DTO\RequestOptions|null */
 		public function getRequestOptions(): ?\WordPress\AiClient\Providers\Http\DTO\RequestOptions { return null; }
+
+		/**
+		 * @param array<int, \WordPress\AiClient\Messages\DTO\Message> $messages
+		 * @return array<int, array<string, mixed>>
+		 */
+		protected function prepareMessagesParam( array $messages, ?string $system_instruction = null ): array { return array(); }
 	}
 }
 

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
@@ -18,11 +18,15 @@ use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
 use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiTextGenerationModel;
 use WP_UnitTestCase;
 use WordPress\AiClient\AiClient;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\DTO\ModelMessage;
+use WordPress\AiClient\Messages\Enums\MessagePartChannelEnum;
 use WordPress\AiClient\Providers\Http\DTO\RequestOptions;
 use WordPress\AiClient\Providers\Http\DTO\Response;
 use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
+use WordPress\AiClient\Tools\DTO\FunctionCall;
 use XWP\DI\Decorators\Action;
 
 /**
@@ -149,6 +153,49 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 		$data = $request->getData();
 		$this->assertIsArray( $data );
 		$this->assertSame( $expected_effort, $data['reasoning_effort'] ?? '' );
+	}
+
+	/**
+	 * The managed provider must round-trip hidden reasoning context on later turns.
+	 */
+	public function test_text_generation_request_round_trips_reasoning_content(): void {
+		$this->skip_if_sdk_unavailable();
+
+		$model = new SuperdavAiTextGenerationModel(
+			new ModelMetadata(
+				SuperdavAiProvider::DEFAULT_MODEL_ID,
+				SuperdavAiProvider::DEFAULT_MODEL_ID,
+				array( CapabilityEnum::textGeneration() ),
+				array()
+			),
+			SuperdavAiProvider::metadata()
+		);
+
+		$method = new \ReflectionMethod( $model, 'prepareGenerateTextParams' );
+		$method->setAccessible( true );
+
+		$params = $method->invoke(
+			$model,
+			array(
+				new ModelMessage(
+					array(
+						new MessagePart( 'Use the prior tool result.', MessagePartChannelEnum::thought() ),
+						new MessagePart( 'Visible assistant preamble.' ),
+						new MessagePart( new FunctionCall( 'call_1', 'wpab__sd-ai-agent__site-info', array() ) ),
+					)
+				),
+			)
+		);
+
+		$this->assertIsArray( $params );
+		$this->assertIsArray( $params['messages'] ?? null );
+		$this->assertSame( 'assistant', $params['messages'][0]['role'] ?? '' );
+		$this->assertSame( 'Use the prior tool result.', $params['messages'][0]['reasoning_content'] ?? '' );
+		$this->assertSame(
+			array( array( 'type' => 'text', 'text' => 'Visible assistant preamble.' ) ),
+			$params['messages'][0]['content'] ?? array()
+		);
+		$this->assertNotEmpty( $params['messages'][0]['tool_calls'] ?? array() );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Round-trip Superdav managed-provider hidden reasoning by restoring thought-channel message parts as `reasoning_content` in OpenAI-compatible chat requests.
- Preserve existing visible content and tool-call serialization from the parent SDK adapter.
- Add regression coverage for Superdav reasoning context request serialization and update PHPStan stubs for the protected SDK method.

## Trace evidence

- Before the fix, real Superdav trace rows showed SDK traces preserving `channel: "thought"`, while raw HTTP follow-up requests omitted `reasoning_content`.
- After applying the fix against the real service, follow-up HTTP trace rows included `reasoning_content` and completed successfully.

## Worker self-verification

- PHPUnit: Tests: 3717, Assertions: 15575, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Additional check: `npm run verify` completed successfully, including `npm run check:bundle`.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.5 plugin for [OpenCode](https://opencode.ai) v1.17.13
