### PR TITLE
GH#2210: fix: explain file-edit capability denials

### DIFF
--- a/includes/Abilities/ToolCapabilities.php
+++ b/includes/Abilities/ToolCapabilities.php
@@ -421,6 +421,66 @@ class ToolCapabilities {
 	}
 
 	/**
+	 * Return a precise denial error for an ability the current user cannot run.
+	 *
+	 * This mirrors {@see current_user_can()} but preserves which layer denied the
+	 * request so meta-tools such as `sd-ai-agent/ability-call` can distinguish a
+	 * user-approved tool confirmation from a missing WordPress capability such as
+	 * `edit_files`.
+	 *
+	 * @param string $ability_id The ability ID.
+	 * @return \WP_Error|null Error when denied; null when the current user passes both gates.
+	 */
+	public static function permission_denial_error( string $ability_id ): ?\WP_Error {
+		$tool_cap = self::cap_name( $ability_id );
+
+		/** This filter is documented in {@see current_user_can()}. */
+		$resolved_cap = (string) apply_filters( 'sd_ai_agent_tool_capability', $tool_cap, $ability_id );
+
+		if ( self::capability_exists( $resolved_cap ) ) {
+			if ( ! current_user_can( $resolved_cap ) ) {
+				return self::capability_denial_error( $ability_id, $resolved_cap, 'per-tool' );
+			}
+		} elseif ( ! current_user_can( self::FALLBACK_CAP ) ) {
+			return self::capability_denial_error( $ability_id, self::FALLBACK_CAP, 'fallback' );
+		}
+
+		foreach ( self::resolve_core_caps( $ability_id ) as $core_cap ) {
+			if ( ! current_user_can( $core_cap ) ) {
+				return self::capability_denial_error( $ability_id, $core_cap, 'core' );
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Build a user-actionable capability denial error.
+	 *
+	 * @param string $ability_id The denied ability ID.
+	 * @param string $capability Missing capability.
+	 * @param string $layer Permission layer that denied the request.
+	 */
+	private static function capability_denial_error( string $ability_id, string $capability, string $layer ): \WP_Error {
+		return new \WP_Error(
+			'ability_invalid_permissions',
+			sprintf(
+				/* translators: 1: ability id, 2: WordPress capability, 3: permission layer */
+				__( 'Ability "%1$s" was approved for this turn, but the current WordPress user still lacks the "%2$s" capability required by the %3$s permission layer. Grant that capability or switch to a user role that has it, then approve the tool call again.', 'superdav-ai-agent' ),
+				$ability_id,
+				$capability,
+				$layer
+			),
+			[
+				'status'             => 403,
+				'ability'            => $ability_id,
+				'missing_capability' => $capability,
+				'permission_layer'   => $layer,
+			]
+		);
+	}
+
+	/**
 	 * Check whether a capability has been granted to at least one role.
 	 *
 	 * This is used to distinguish between "capability exists but user lacks it"

--- a/includes/Tools/ToolDiscovery.php
+++ b/includes/Tools/ToolDiscovery.php
@@ -34,6 +34,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Tools;
 
 use SdAiAgent\Abilities\Js\JsAbilityCatalog;
+use SdAiAgent\Abilities\ToolCapabilities;
 use SdAiAgent\Core\AbilityRegistry;
 use SdAiAgent\Core\AbilityVisibility;
 use SdAiAgent\Core\RolePermissions;
@@ -989,6 +990,11 @@ class ToolDiscovery {
 				),
 				array( 'status' => 403 )
 			);
+		}
+
+		$permission_denial = ToolCapabilities::permission_denial_error( $ability_id );
+		if ( $permission_denial instanceof WP_Error ) {
+			return $permission_denial;
 		}
 
 		// Normalize the arguments to a plain PHP associative array.

--- a/tests/SdAiAgent/Abilities/ToolCapabilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/ToolCapabilitiesTest.php
@@ -230,6 +230,33 @@ class ToolCapabilitiesTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Denial diagnostics identify the missing core capability after a tool grant.
+	 */
+	public function test_permission_denial_error_identifies_missing_core_capability(): void {
+		$ability_id = 'sd-ai-agent/file-edit';
+		$tool_cap   = ToolCapabilities::cap_name( $ability_id );
+
+		$role = get_role( 'subscriber' );
+		$this->assertNotNull( $role );
+		$role->add_cap( $tool_cap, true );
+		$role->add_cap( 'manage_options', true );
+
+		$user_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $user_id );
+
+		$error = ToolCapabilities::permission_denial_error( $ability_id );
+
+		$this->assertInstanceOf( \WP_Error::class, $error );
+		$this->assertSame( 'ability_invalid_permissions', $error->get_error_code() );
+		$this->assertSame( 'edit_files', $error->get_error_data()['missing_capability'] );
+		$this->assertSame( 'core', $error->get_error_data()['permission_layer'] );
+		$this->assertStringContainsString( 'approved for this turn', $error->get_error_message() );
+
+		$role->remove_cap( $tool_cap );
+		$role->remove_cap( 'manage_options' );
+	}
+
+	/**
 	 * Dual-gate: administrator holds both per-tool and core caps → true.
 	 */
 	public function test_dual_gate_administrator_passes_for_mapped_ability(): void {

--- a/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
+++ b/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
@@ -11,6 +11,7 @@ namespace SdAiAgent\Tests\Tools;
 
 use SdAiAgent\Core\IdenticalFailureTracker;
 use SdAiAgent\Core\RolePermissions;
+use SdAiAgent\Core\ToolPermissionResolver;
 use SdAiAgent\Tools\AbilityUsageTracker;
 use SdAiAgent\Tools\ToolDiscovery;
 use WP_UnitTestCase;
@@ -570,6 +571,36 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'ability_forbidden', $result->get_error_code() );
 		$this->assertFalse( $executed );
+	}
+
+	public function test_ability_call_reports_missing_file_edit_core_cap_after_confirmation(): void {
+		$target = 'sd-ai-agent/file-edit';
+		$this->assertNotNull( \wp_get_ability( $target ), 'file-edit must be registered by the advanced file mutation abilities.' );
+
+		$role = get_role( 'subscriber' );
+		$this->assertNotNull( $role );
+		$role->add_cap( 'manage_options', true );
+		$role->add_cap( 'sd_ai_agent_tool_file_edit', true );
+
+		$subscriber_id = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+		ToolPermissionResolver::set_one_turn_approved_abilities( [ $target ] );
+
+		$result = ToolDiscovery::handle_ability_call(
+			[
+				'ability'   => $target,
+				'arguments' => [],
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'ability_invalid_permissions', $result->get_error_code() );
+		$this->assertSame( 'edit_files', $result->get_error_data()['missing_capability'] );
+		$this->assertStringContainsString( 'approved for this turn', $result->get_error_message() );
+
+		ToolPermissionResolver::clear_one_turn_approved_abilities();
+		$role->remove_cap( 'manage_options' );
+		$role->remove_cap( 'sd_ai_agent_tool_file_edit' );
 	}
 
 	public function test_ability_search_hides_role_restricted_targets(): void {


### PR DESCRIPTION
## Summary

Added ToolCapabilities diagnostics for dual-gate denials and made ability-call return a precise missing-capability WP_Error before executing approved abilities. Covered file-edit approval followed by missing edit_files with focused regression tests.

## Files Changed

includes/Abilities/ToolCapabilities.php, includes/Tools/ToolDiscovery.php, tests/SdAiAgent/Abilities/ToolCapabilitiesTest.php, tests/SdAiAgent/Tools/ToolDiscoveryTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** WP_TESTS_DB_NAME=sd_ai_agent_tests_2210 npm run verify (lint, PHPStan, PHPUnit: Tests: 3729, Assertions: 15617, Skipped: 121, Incomplete: 4, build, bundle checks); npm run test:php -- --filter='ToolCapabilitiesTest|ToolDiscoveryTest' (72 tests, 501 assertions)

Resolves #2210


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.5 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 15m and 145,846 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool access denials now provide structured error details, including the missing permission and the permission layer involved.
  * Tool calls now validate all required permissions after confirmation and clearly report any unmet requirements.

* **Bug Fixes**
  * Prevented confirmed tool actions from proceeding when required core permissions are missing.

* **Tests**
  * Added coverage for permission-denial reporting and missing file-edit permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->