### PR TITLE
GH#2209: fix: repair memory save persistence

### DIFF
--- a/includes/Abilities/MemoryAbilities.php
+++ b/includes/Abilities/MemoryAbilities.php
@@ -164,11 +164,16 @@ class MemoryAbilities {
 		$id = Memory::create( $category, $content );
 
 		if ( false === $id ) {
+			$error = Memory::get_last_error();
+			if ( '' === $error ) {
+				$error = 'Memory persistence is unavailable. Check that the Superdav AI Agent database tables exist for the current site and retry.';
+			}
+
 			return [
 				'success' => false,
 				'id'      => 0,
 				'message' => '',
-				'error'   => 'Failed to save memory.',
+				'error'   => 'Failed to save memory: ' . $error,
 			];
 		}
 

--- a/includes/Models/Memory.php
+++ b/includes/Models/Memory.php
@@ -15,6 +15,13 @@ use SdAiAgent\Models\DTO\MemoryRow;
 class Memory {
 
 	/**
+	 * Most recent persistence error, safe for ability responses.
+	 *
+	 * @var string
+	 */
+	private static string $last_error = '';
+
+	/**
 	 * Valid memory categories.
 	 *
 	 * `site_brief` is a dedicated category for the structured site
@@ -32,6 +39,13 @@ class Memory {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 		return $wpdb->prefix . 'sd_ai_agent_memories';
+	}
+
+	/**
+	 * Return the most recent persistence error.
+	 */
+	public static function get_last_error(): string {
+		return self::$last_error;
 	}
 
 	/**
@@ -92,9 +106,14 @@ class Memory {
 	public static function create( string $category, string $content ) {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
+		self::$last_error = '';
 
 		if ( ! in_array( $category, self::CATEGORIES, true ) ) {
 			$category = 'general';
+		}
+
+		if ( ! self::ensure_table_available() ) {
+			return false;
 		}
 
 		$now = current_time( 'mysql', true );
@@ -110,7 +129,77 @@ class Memory {
 			[ '%s', '%s', '%s', '%s' ]
 		);
 
-		return $result ? (int) $wpdb->insert_id : false;
+		if ( $result ) {
+			return (int) $wpdb->insert_id;
+		}
+
+		self::$last_error = '' !== $wpdb->last_error
+			? $wpdb->last_error
+			: 'The memory table insert did not complete.';
+
+		return false;
+	}
+
+	/**
+	 * Ensure the memory table exists for the current blog before writing.
+	 */
+	private static function ensure_table_available(): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$table = self::table_name();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Schema introspection for the current blog's internal memory table.
+		$found = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+		if ( $found === $table ) {
+			return true;
+		}
+
+		self::install_table();
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Re-check after running the schema installer.
+		$found = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) );
+		if ( $found === $table ) {
+			return true;
+		}
+
+		self::$last_error = sprintf(
+			'The memory table %s is unavailable for the current site. Run the Superdav AI Agent database upgrade for this blog and retry.',
+			$table
+		);
+
+		return false;
+	}
+
+	/**
+	 * Create the memory table for the current blog prefix.
+	 */
+	private static function install_table(): void {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$table   = self::table_name();
+		$charset = $wpdb->get_charset_collate();
+
+		$sql = "CREATE TABLE {$table} (
+			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+			category varchar(50) NOT NULL DEFAULT 'general',
+			content text NOT NULL,
+			created_at datetime NOT NULL,
+			updated_at datetime NOT NULL,
+			PRIMARY KEY  (id),
+			KEY category (category)
+		) {$charset};";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Schema introspection for an internal table name.
+		$ft_exists = $wpdb->get_var( "SHOW INDEX FROM {$table} WHERE Key_name = 'ft_content'" );
+		if ( ! $ft_exists ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Required for fulltext index creation during memory table repair.
+			$wpdb->query( "ALTER TABLE {$table} ADD FULLTEXT KEY ft_content (content)" );
+		}
 	}
 
 	/**

--- a/tests/SdAiAgent/Abilities/MemoryAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/MemoryAbilitiesTest.php
@@ -33,6 +33,89 @@ class MemoryAbilitiesTest extends WP_UnitTestCase {
 		$this->assertIsInt( $result['id'] );
 		$this->assertGreaterThan( 0, $result['id'] );
 		$this->assertStringContainsString( 'site_info', $result['message'] );
+
+		$memories = Memory::get_by_category( 'site_info' );
+		$found    = false;
+		foreach ( $memories as $memory ) {
+			if ( (int) $memory->id === $result['id'] ) {
+				$found = true;
+				$this->assertSame( 'Test site info content', $memory->content );
+				break;
+			}
+		}
+		$this->assertTrue( $found, 'site_info memory should be persisted.' );
+	}
+
+	/**
+	 * Test handle_memory_save returns actionable database error detail.
+	 */
+	public function test_handle_memory_save_failure_includes_persistence_detail() {
+		global $wpdb;
+
+		$original_wpdb = $wpdb;
+		$wpdb          = new class( $original_wpdb ) {
+			/** @var \wpdb */
+			private $delegate;
+			/** @var string */
+			public string $prefix;
+			/** @var int */
+			public int $insert_id = 0;
+			/** @var string */
+			public string $last_error = 'Simulated memory insert failure.';
+
+			/**
+			 * @param \wpdb $delegate Original wpdb instance.
+			 */
+			public function __construct( $delegate ) {
+				$this->delegate = $delegate;
+				$this->prefix   = $delegate->prefix;
+			}
+
+			/**
+			 * Proxy method calls to the original wpdb instance.
+			 *
+			 * @param string       $name      Method name.
+			 * @param array<mixed> $arguments Arguments.
+			 * @return mixed
+			 */
+			public function __call( string $name, array $arguments ) {
+				return $this->delegate->{$name}( ...$arguments );
+			}
+
+			/**
+			 * Proxy property reads to the original wpdb instance.
+			 *
+			 * @param string $name Property name.
+			 * @return mixed
+			 */
+			public function __get( string $name ) {
+				return $this->delegate->{$name};
+			}
+
+			/**
+			 * Simulate a failed insert after the table availability check succeeds.
+			 *
+			 * @return false
+			 */
+			public function insert() {
+				return false;
+			}
+		};
+
+		try {
+			$result = MemoryAbilities::handle_memory_save( [
+				'category' => 'site_info',
+				'content'  => 'Initial discovery fact',
+			] );
+		} finally {
+			$wpdb = $original_wpdb;
+		}
+
+		$this->assertIsArray( $result );
+		$this->assertFalse( $result['success'] );
+		$this->assertStringContainsString( 'Failed to save memory:', $result['error'] );
+		$this->assertStringContainsString( 'Simulated memory insert failure.', $result['error'] );
+		$this->assertNotSame( 'Failed to save memory.', $result['error'] );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Repair memory-save persistence by self-healing the current blog memory table when it is missing, returning actionable persistence errors instead of the generic failure, and covering successful site_info saves plus insert failure details in PHPUnit.

## Files Changed

includes/Abilities/MemoryAbilities.php, includes/Models/Memory.php, tests/SdAiAgent/Abilities/MemoryAbilitiesTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run test:php -- --filter=Memory; npm run verify

Resolves #2209


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.5 plugin for [OpenCode](https://opencode.ai) v1.17.13 with gpt-5.5 spent 18m and 154,828 tokens on this as a headless worker.