### PR TITLE
fix: honor approved ability permissions

### DIFF
--- a/includes/Abilities/ToolCapabilities.php
+++ b/includes/Abilities/ToolCapabilities.php
@@ -18,9 +18,13 @@ declare(strict_types=1);
  *      Capability names follow the pattern `sd_ai_agent_tool_{name}` where
  *      `{name}` is derived from the ability ID
  *      (`sd-ai-agent/memory-save` → `sd_ai_agent_tool_memory_save`).
+ *      A user confirmation for the current agent turn also satisfies this
+ *      plugin-specific layer so an approved prompt can continue into the
+ *      ability's own permission callback.
  *      If the resolved cap is granted to any role, the current user must
  *      have it. If it is not granted to any role, the check falls back to
- *      `manage_options` so the default is admin-only.
+ *      `manage_options` so the default is admin-only when no turn approval
+ *      exists.
  *
  *   2. Core-cap layer.
  *      The {@see CORE_CAP_MAP} entry for the ability ID lists one or more
@@ -30,14 +34,16 @@ declare(strict_types=1);
  *      for low-risk read-only public-data abilities such as the
  *      `report-inability` feedback channel).
  *
- * Final result is the AND of both layers. Either layer denying access is
- * sufficient to deny the ability execution.
+ * Final result is the per-tool layer or current-turn approval, AND the core
+ * layer. The WordPress core-cap anchor is never bypassed by confirmation.
  *
  * @package SdAiAgent
  * @license GPL-2.0-or-later
  */
 
 namespace SdAiAgent\Abilities;
+
+use SdAiAgent\Core\ToolPermissionResolver;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -380,12 +386,14 @@ class ToolCapabilities {
 	 *      per-tool capability name. If the cap exists in any role, the
 	 *      current user must hold it. Otherwise fall back to
 	 *      `manage_options` so the default is admin-only.
+	 *      A current-turn user approval also satisfies this plugin prompt layer.
 	 *
 	 *   2. Resolve required core capabilities via
 	 *      {@see resolve_core_caps()}. The current user must hold ALL of
 	 *      them (or the ability must be in {@see CORE_CAP_OPTOUT}).
 	 *
-	 * Both layers must pass.
+	 * The plugin prompt layer must pass via capability or current-turn approval;
+	 * the core-cap layer must always pass.
 	 *
 	 * @param string $ability_id The ability ID (e.g. "sd-ai-agent/memory-save").
 	 * @return bool True if the current user has permission.
@@ -402,9 +410,10 @@ class ToolCapabilities {
 		 */
 		$resolved_cap = (string) apply_filters( 'sd_ai_agent_tool_capability', $tool_cap, $ability_id );
 
-		$tool_ok = self::capability_exists( $resolved_cap )
-			? current_user_can( $resolved_cap )
-			: current_user_can( self::FALLBACK_CAP );
+		$tool_ok = self::is_one_turn_approved( $ability_id )
+			|| ( self::capability_exists( $resolved_cap )
+				? current_user_can( $resolved_cap )
+				: current_user_can( self::FALLBACK_CAP ) );
 
 		if ( ! $tool_ok ) {
 			return false;
@@ -437,11 +446,13 @@ class ToolCapabilities {
 		/** This filter is documented in {@see current_user_can()}. */
 		$resolved_cap = (string) apply_filters( 'sd_ai_agent_tool_capability', $tool_cap, $ability_id );
 
-		if ( self::capability_exists( $resolved_cap ) ) {
+		$skip_tool_layer = self::is_one_turn_approved( $ability_id );
+
+		if ( ! $skip_tool_layer && self::capability_exists( $resolved_cap ) ) {
 			if ( ! current_user_can( $resolved_cap ) ) {
 				return self::capability_denial_error( $ability_id, $resolved_cap, 'per-tool' );
 			}
-		} elseif ( ! current_user_can( self::FALLBACK_CAP ) ) {
+		} elseif ( ! $skip_tool_layer && ! current_user_can( self::FALLBACK_CAP ) ) {
 			return self::capability_denial_error( $ability_id, self::FALLBACK_CAP, 'fallback' );
 		}
 
@@ -452,6 +463,21 @@ class ToolCapabilities {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Whether the current confirmed agent turn approved this ability.
+	 *
+	 * Confirmation is intentionally narrower than WordPress authorization: it
+	 * satisfies only the plugin's per-tool approval layer. The required core
+	 * capabilities from {@see resolve_core_caps()} remain mandatory so a user
+	 * cannot click through into operations their WordPress role cannot perform.
+	 *
+	 * @param string $ability_id The ability ID.
+	 */
+	private static function is_one_turn_approved( string $ability_id ): bool {
+		return class_exists( ToolPermissionResolver::class )
+			&& ToolPermissionResolver::is_one_turn_approved( $ability_id );
 	}
 
 	/**

--- a/tests/SdAiAgent/Abilities/ToolCapabilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/ToolCapabilitiesTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Tests\Abilities;
 
 use SdAiAgent\Abilities\ToolCapabilities;
+use SdAiAgent\Core\ToolPermissionResolver;
 use WP_UnitTestCase;
 
 /**
@@ -186,11 +187,12 @@ class ToolCapabilitiesTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Dual-gate: core cap held but per-tool cap missing → false.
+	 * Dual-gate: core cap held but per-tool cap missing → false until confirmed.
 	 *
 	 * Proves the per-tool layer is enforced even when the user holds the
 	 * mapped WordPress core cap. The site administrator who manages role
-	 * caps via a plugin must explicitly grant the per-tool cap.
+	 * caps via a plugin must explicitly grant the per-tool cap, or the user must
+	 * explicitly approve the tool for the current agent turn.
 	 */
 	public function test_dual_gate_core_cap_alone_is_not_sufficient(): void {
 		// list-posts is mapped to edit_posts in CORE_CAP_MAP. Editor has
@@ -201,6 +203,15 @@ class ToolCapabilitiesTest extends WP_UnitTestCase {
 		wp_set_current_user( $editor_id );
 
 		$this->assertFalse( ToolCapabilities::current_user_can( 'sd-ai-agent/list-posts' ) );
+
+		ToolPermissionResolver::set_one_turn_approved_abilities( [ 'sd-ai-agent/list-posts' ] );
+
+		try {
+			$this->assertTrue( ToolCapabilities::current_user_can( 'sd-ai-agent/list-posts' ) );
+			$this->assertNull( ToolCapabilities::permission_denial_error( 'sd-ai-agent/list-posts' ) );
+		} finally {
+			ToolPermissionResolver::clear_one_turn_approved_abilities();
+		}
 	}
 
 	/**
@@ -227,6 +238,29 @@ class ToolCapabilitiesTest extends WP_UnitTestCase {
 
 		// Clean up.
 		$role->remove_cap( $tool_cap );
+	}
+
+	/**
+	 * One-turn approval never bypasses the required WordPress core capability.
+	 */
+	public function test_one_turn_approval_does_not_bypass_core_capability(): void {
+		$ability_id = 'sd-ai-agent/delete-plugin'; // CORE_CAP_MAP → delete_plugins.
+
+		$subscriber_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		wp_set_current_user( $subscriber_id );
+		ToolPermissionResolver::set_one_turn_approved_abilities( [ $ability_id ] );
+
+		try {
+			$this->assertFalse( ToolCapabilities::current_user_can( $ability_id ) );
+
+			$error = ToolCapabilities::permission_denial_error( $ability_id );
+			$this->assertInstanceOf( \WP_Error::class, $error );
+			$this->assertSame( 'ability_invalid_permissions', $error->get_error_code() );
+			$this->assertSame( 'delete_plugins', $error->get_error_data()['missing_capability'] );
+			$this->assertSame( 'core', $error->get_error_data()['permission_layer'] );
+		} finally {
+			ToolPermissionResolver::clear_one_turn_approved_abilities();
+		}
 	}
 
 	/**

--- a/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
+++ b/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
@@ -9,6 +9,7 @@
 
 namespace SdAiAgent\Tests\Tools;
 
+use SdAiAgent\Abilities\ToolCapabilities;
 use SdAiAgent\Core\IdenticalFailureTracker;
 use SdAiAgent\Core\RolePermissions;
 use SdAiAgent\Core\ToolPermissionResolver;
@@ -601,6 +602,64 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 		ToolPermissionResolver::clear_one_turn_approved_abilities();
 		$role->remove_cap( 'manage_options' );
 		$role->remove_cap( 'sd_ai_agent_tool_file_edit' );
+	}
+
+	public function test_ability_call_executes_one_turn_approved_target_when_core_cap_allows(): void {
+		$executed = false;
+		$target   = 'sd-ai-agent/approved-core-edit-tool';
+
+		$core_filter = static function ( array $caps, string $id ) use ( $target ): array {
+			if ( $id === $target ) {
+				return [ 'edit_posts' ];
+			}
+
+			return $caps;
+		};
+		add_filter( 'sd_ai_agent_tool_required_core_cap', $core_filter, 10, 2 );
+
+		$this->register_test_ability(
+			$target,
+			[
+				'label'               => 'Approved Core Edit Tool',
+				'description'         => 'Requires confirmation plus an edit_posts core capability.',
+				'category'            => 'sd-ai-agent',
+				'input_schema'        => [ 'type' => 'object' ],
+				'output_schema'       => [ 'type' => 'object' ],
+				'execute_callback'    => static function () use ( &$executed ): array {
+					$executed = true;
+					return [ 'ok' => true ];
+				},
+				'permission_callback' => static function () use ( $target ): bool {
+					return ToolCapabilities::current_user_can( $target );
+				},
+				'meta'                => [
+					'annotations' => [
+						'readonly'    => false,
+						'destructive' => true,
+					],
+				],
+			]
+		);
+
+		$editor_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $editor_id );
+		ToolPermissionResolver::set_one_turn_approved_abilities( [ $target ] );
+
+		try {
+			$result = ToolDiscovery::handle_ability_call(
+				[
+					'ability'   => $target,
+					'arguments' => [],
+				]
+			);
+
+			$this->assertIsArray( $result );
+			$this->assertTrue( $result['success'] );
+			$this->assertTrue( $executed );
+		} finally {
+			ToolPermissionResolver::clear_one_turn_approved_abilities();
+			remove_filter( 'sd_ai_agent_tool_required_core_cap', $core_filter, 10 );
+		}
 	}
 
 	public function test_ability_search_hides_role_restricted_targets(): void {


### PR DESCRIPTION
## Summary

- Treat a confirmed tool prompt as satisfying the plugin per-tool approval layer for the current agent turn.
- Keep the WordPress core capability layer mandatory, so Allow cannot bypass role capabilities like `delete_plugins` or `edit_files`.
- Add regression coverage for approved ability-call execution and for the core-capability denial path.

## Browser verification

- Used `agent-browser` on the local WordPress admin chat with a real prompt to update a page paragraph block.
- The prompt paused on Tool Confirmation Required for `sd-ai-agent/get-page-blocks` / `sd-ai-agent/update-blocks`.
- After clicking Allow, the page content was updated to `Updated after permission fix.`

## Worker self-verification
- PHPUnit: Tests: 3732, Assertions: 15634, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Additional focused check: `npm run test:php -- --filter='ToolCapabilitiesTest|ToolDiscoveryTest'` passed with 74 tests and 511 assertions.

Follow-up to #2210 and #2211.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.7 plugin for [OpenCode](https://opencode.ai) v1.17.18


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - One-turn approval now satisfies tool-specific permission checks when the required WordPress core capability is also available.
  - Approved tool actions can execute during the current turn without separately registered tool permissions.

- **Bug Fixes**
  - One-turn approval no longer bypasses required core capabilities.
  - Permission errors now accurately identify missing core permissions.

- **Documentation**
  - Updated permission-resolution guidance to clarify the two-layer approval process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->