### PR TITLE
feat: add Superdav image generation model

### DIFF
--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -84,6 +84,7 @@ class Settings {
 		// Superdav managed models.
 		'superdav-chat-fast'            => 128000,
 		'superdav-chat-pro'             => 200000,
+		'superdav-image'                => 32000,
 		// Anthropic.
 		'claude-opus-4-6'               => 200000,
 		'claude-sonnet-4-6'             => 200000,
@@ -185,6 +186,7 @@ class Settings {
 		// ── Superdav managed models ───────────────────────────────────────
 		'superdav-chat-fast'          => 8192,
 		'superdav-chat-pro'           => 16384,
+		'superdav-image'              => 1,
 		// ── Anthropic ──────────────────────────────────────────────────
 		// Opus 4.6 / 4.7 document 128K; Opus 4.5 documents 64K; Opus 4.1
 		// and Opus 4 document 32K. Newer point releases have higher caps

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiImageGenerationModel.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiImageGenerationModel.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Infrastructure\AiClient\Superdav;
+
+use WordPress\AiClient\Providers\Http\DTO\Request;
+use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
+use WordPress\AiClient\Providers\OpenAiCompatibleImplementation\AbstractOpenAiCompatibleImageGenerationModel;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * OpenAI-compatible image generation model for the Superdav AI service.
+ */
+final class SuperdavAiImageGenerationModel extends AbstractOpenAiCompatibleImageGenerationModel {
+
+	/**
+	 * Create an authenticated API request.
+	 *
+	 * @param HttpMethodEnum                     $method  HTTP method.
+	 * @param string                             $path    Endpoint path.
+	 * @param array<string, string|list<string>> $headers Request headers.
+	 * @param string|array<string, mixed>|null   $data    Request body/query data.
+	 * @return Request
+	 */
+	protected function createRequest( HttpMethodEnum $method, string $path, array $headers = array(), mixed $data = null ): Request {
+		return new Request( $method, SuperdavAiProvider::url( $path ), $headers, $data, $this->getRequestOptions() );
+	}
+
+	/**
+	 * Prepare image generation parameters for the managed Superdav image alias.
+	 *
+	 * Superdav forwards this request to the configured OpenAI-compatible image
+	 * backend. Newer GPT image models do not accept `response_format`, so the
+	 * service returns inline image data using the backend default.
+	 *
+	 * @param array<int, mixed> $prompt Prompt messages.
+	 * @return array<string, mixed>
+	 */
+	protected function prepareGenerateImageParams( array $prompt ): array {
+		$params = parent::prepareGenerateImageParams( $prompt );
+		unset( $params['response_format'] );
+
+		return $params;
+	}
+
+	/**
+	 * The Images API may return `created` rather than an explicit result ID.
+	 *
+	 * @param array<string, mixed> $response_data Response data.
+	 * @return string
+	 */
+	protected function getResultId( array $response_data ): string {
+		if ( isset( $response_data['id'] ) && is_string( $response_data['id'] ) ) {
+			return $response_data['id'];
+		}
+
+		return isset( $response_data['created'] ) && is_int( $response_data['created'] )
+			? 'img-' . $response_data['created']
+			: '';
+	}
+}

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiModelMetadataDirectory.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiModelMetadataDirectory.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace SdAiAgent\Infrastructure\AiClient\Superdav;
 
 use SdAiAgent\Bootstrap\ModelCapabilityHandler;
+use WordPress\AiClient\Files\Enums\FileTypeEnum;
+use WordPress\AiClient\Files\Enums\MediaOrientationEnum;
+use WordPress\AiClient\Messages\Enums\ModalityEnum;
 use WordPress\AiClient\Providers\Http\DTO\Request;
 use WordPress\AiClient\Providers\Http\DTO\Response;
 use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
@@ -61,11 +64,13 @@ final class SuperdavAiModelMetadataDirectory extends AbstractOpenAiCompatibleMod
 				? $item['name']
 				: $item['id'];
 
+			$capabilities = self::supported_capabilities( $item );
+
 			$models[] = new ModelMetadata(
 				$item['id'],
 				$name,
-				self::supported_capabilities( $item ),
-				self::supported_options()
+				$capabilities,
+				self::supported_options( $capabilities )
 			);
 		}
 
@@ -73,11 +78,26 @@ final class SuperdavAiModelMetadataDirectory extends AbstractOpenAiCompatibleMod
 	}
 
 	/**
+	 * Common OpenAI-compatible options for the advertised model capabilities.
+	 *
+	 * @param array $capabilities Model capabilities.
+	 * @phpstan-param list<CapabilityEnum> $capabilities
+	 * @return list<SupportedOption>
+	 */
+	private static function supported_options( array $capabilities ): array {
+		if ( self::has_capability( $capabilities, CapabilityEnum::imageGeneration() ) ) {
+			return self::image_supported_options();
+		}
+
+		return self::text_supported_options();
+	}
+
+	/**
 	 * Common OpenAI-compatible text generation options.
 	 *
 	 * @return list<SupportedOption>
 	 */
-	private static function supported_options(): array {
+	private static function text_supported_options(): array {
 		return array(
 			new SupportedOption( OptionEnum::systemInstruction() ),
 			new SupportedOption( OptionEnum::maxTokens() ),
@@ -91,6 +111,49 @@ final class SuperdavAiModelMetadataDirectory extends AbstractOpenAiCompatibleMod
 			new SupportedOption( OptionEnum::outputSchema() ),
 			new SupportedOption( OptionEnum::customOptions() ),
 		);
+	}
+
+	/**
+	 * Common OpenAI-compatible image generation options.
+	 *
+	 * @return list<SupportedOption>
+	 */
+	private static function image_supported_options(): array {
+		return array(
+			new SupportedOption( OptionEnum::inputModalities(), array( array( ModalityEnum::text() ) ) ),
+			new SupportedOption( OptionEnum::outputModalities(), array( array( ModalityEnum::image() ) ) ),
+			new SupportedOption( OptionEnum::candidateCount() ),
+			new SupportedOption( OptionEnum::outputMimeType(), array( 'image/png', 'image/jpeg', 'image/webp' ) ),
+			new SupportedOption( OptionEnum::outputFileType(), array( FileTypeEnum::inline() ) ),
+			new SupportedOption(
+				OptionEnum::outputMediaOrientation(),
+				array(
+					MediaOrientationEnum::square(),
+					MediaOrientationEnum::landscape(),
+					MediaOrientationEnum::portrait(),
+				)
+			),
+			new SupportedOption( OptionEnum::outputMediaAspectRatio(), array( '1:1', '3:2', '2:3' ) ),
+			new SupportedOption( OptionEnum::customOptions() ),
+		);
+	}
+
+	/**
+	 * Determine whether a capability list contains a specific capability.
+	 *
+	 * @param array          $capabilities Model capabilities.
+	 * @phpstan-param list<CapabilityEnum> $capabilities
+	 * @param CapabilityEnum $target Capability to find.
+	 * @return bool
+	 */
+	private static function has_capability( array $capabilities, CapabilityEnum $target ): bool {
+		foreach ( $capabilities as $capability ) {
+			if ( $capability->equals( $target ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php
@@ -12,6 +12,7 @@ use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
 use WordPress\AiClient\Providers\Http\Enums\RequestAuthenticationMethod;
 use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -27,6 +28,7 @@ final class SuperdavAiProvider extends AbstractApiProvider {
 	public const DEFAULT_BASE_URL  = 'https://api.sdaiagent.com/v1';
 	public const FAST_MODEL_ID     = 'superdav-chat-fast';
 	public const DEFAULT_MODEL_ID  = 'superdav-chat-pro';
+	public const IMAGE_MODEL_ID    = 'superdav-image';
 
 	/**
 	 * Reasoning effort hints for managed Superdav model aliases.
@@ -95,6 +97,12 @@ final class SuperdavAiProvider extends AbstractApiProvider {
 	 * @return ModelInterface
 	 */
 	protected static function createModel( ModelMetadata $model_metadata, ProviderMetadata $provider_metadata ): ModelInterface {
+		foreach ( $model_metadata->getSupportedCapabilities() as $capability ) {
+			if ( $capability->equals( CapabilityEnum::imageGeneration() ) ) {
+				return new SuperdavAiImageGenerationModel( $model_metadata, $provider_metadata );
+			}
+		}
+
 		if ( self::responses_tool_search_enabled( $provider_metadata->getId(), $model_metadata->getId() ) ) {
 			return new SuperdavAiResponsesToolSearchTextGenerationModel( $model_metadata, $provider_metadata );
 		}

--- a/stubs/wordpress-7-runtime.php
+++ b/stubs/wordpress-7-runtime.php
@@ -908,6 +908,38 @@ namespace WordPress\AiClient\Providers\OpenAiCompatibleImplementation {
 		/** @return \WordPress\AiClient\Providers\Http\DTO\RequestOptions|null */
 		public function getRequestOptions(): ?\WordPress\AiClient\Providers\Http\DTO\RequestOptions { return null; }
 
+		/** @param \WordPress\AiClient\Providers\Models\DTO\ModelConfig $config Model config. */
+		public function setConfig( \WordPress\AiClient\Providers\Models\DTO\ModelConfig $config ): void {}
+
+		/** @return \WordPress\AiClient\Providers\Models\DTO\ModelConfig */
+		public function getConfig(): \WordPress\AiClient\Providers\Models\DTO\ModelConfig { return new \WordPress\AiClient\Providers\Models\DTO\ModelConfig(); }
+
+		/** @return \WordPress\AiClient\Providers\Models\DTO\ModelMetadata */
+		public function metadata(): \WordPress\AiClient\Providers\Models\DTO\ModelMetadata { return new \WordPress\AiClient\Providers\Models\DTO\ModelMetadata(); }
+
+		/** @return \WordPress\AiClient\Providers\DTO\ProviderMetadata */
+		public function providerMetadata(): \WordPress\AiClient\Providers\DTO\ProviderMetadata { return new \WordPress\AiClient\Providers\DTO\ProviderMetadata(); }
+
+		/** @param \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface $httpTransporter HTTP transporter. */
+		public function setHttpTransporter( \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface $httpTransporter ): void {}
+
+		/** @return \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface */
+		public function getHttpTransporter(): \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface {
+			return new class() implements \WordPress\AiClient\Providers\Http\Contracts\HttpTransporterInterface {
+				public function send( \WordPress\AiClient\Providers\Http\DTO\Request $request ): \WordPress\AiClient\Providers\Http\DTO\Response { return new \WordPress\AiClient\Providers\Http\DTO\Response(); }
+			};
+		}
+
+		/** @param \WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface $requestAuthentication Request authentication. */
+		public function setRequestAuthentication( \WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface $requestAuthentication ): void {}
+
+		/** @return \WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface */
+		public function getRequestAuthentication(): \WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface {
+			return new class() implements \WordPress\AiClient\Providers\Http\Contracts\RequestAuthenticationInterface {
+				public function authenticateRequest( \WordPress\AiClient\Providers\Http\DTO\Request $request ): \WordPress\AiClient\Providers\Http\DTO\Request { return $request; }
+			};
+		}
+
 		/**
 		 * @param array<int, mixed> $prompt Prompt.
 		 * @return array<string, mixed>

--- a/stubs/wordpress-7-runtime.php
+++ b/stubs/wordpress-7-runtime.php
@@ -894,6 +894,26 @@ namespace WordPress\AiClient\Providers\OpenAiCompatibleImplementation {
 		 */
 		protected function prepareMessagesParam( array $messages, ?string $system_instruction = null ): array { return array(); }
 	}
+
+	abstract class AbstractOpenAiCompatibleImageGenerationModel implements \WordPress\AiClient\Providers\Models\Contracts\ModelInterface {
+		/**
+		 * @param \WordPress\AiClient\Providers\Models\DTO\ModelMetadata $metadata          Model metadata.
+		 * @param \WordPress\AiClient\Providers\DTO\ProviderMetadata     $provider_metadata Provider metadata.
+		 */
+		public function __construct( \WordPress\AiClient\Providers\Models\DTO\ModelMetadata $metadata, \WordPress\AiClient\Providers\DTO\ProviderMetadata $provider_metadata ) {}
+
+		/** @param \WordPress\AiClient\Providers\Http\DTO\RequestOptions $request_options Request options. */
+		public function setRequestOptions( \WordPress\AiClient\Providers\Http\DTO\RequestOptions $request_options ): void {}
+
+		/** @return \WordPress\AiClient\Providers\Http\DTO\RequestOptions|null */
+		public function getRequestOptions(): ?\WordPress\AiClient\Providers\Http\DTO\RequestOptions { return null; }
+
+		/**
+		 * @param array<int, mixed> $prompt Prompt.
+		 * @return array<string, mixed>
+		 */
+		protected function prepareGenerateImageParams( array $prompt ): array { return array(); }
+	}
 }
 
 namespace WordPress\AiClient {

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
@@ -13,6 +13,7 @@ namespace SdAiAgent\Tests\Infrastructure\AiClient\Superdav;
 use SdAiAgent\Bootstrap\SuperdavAiProviderHandler;
 use SdAiAgent\Core\ModelCapabilityRegistry;
 use SdAiAgent\Core\ProviderCredentialLoader;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiImageGenerationModel;
 use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiModelMetadataDirectory;
 use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
 use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiResponsesToolSearchTextGenerationModel;
@@ -28,6 +29,7 @@ use WordPress\AiClient\Providers\Http\DTO\Response;
 use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
 use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Providers\Models\DTO\SupportedOption;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 use WordPress\AiClient\Tools\DTO\FunctionDeclaration;
 use WordPress\AiClient\Tools\DTO\FunctionCall;
@@ -244,6 +246,63 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 		$this->assertSame( 32768, $entry['context_length'] );
 		$this->assertSame( 'Example Model', $entry['display_name'] );
 		$this->assertSame( array( 'supports_tool_calling' => true ), $entry['provider_capabilities'] );
+	}
+
+	/**
+	 * Model metadata parsing exposes Superdav image models to the SDK.
+	 */
+	public function test_model_metadata_contains_image_generation_capability(): void {
+		$this->skip_if_sdk_unavailable();
+
+		$directory = new SuperdavAiModelMetadataDirectory();
+		$method    = new \ReflectionMethod( $directory, 'parseResponseToModelMetadataList' );
+		$models    = $method->invoke(
+			$directory,
+			new Response(
+				200,
+				array( 'content-type' => 'application/json' ),
+				'{"data":[{"id":"superdav-image","name":"Superdav Image","capabilities":{"image_generation":true,"text_generation":false}}]}'
+			)
+		);
+
+		$this->assertIsArray( $models );
+		$this->assertCount( 1, $models );
+		$model = $models[0];
+
+		$this->assertSame( SuperdavAiProvider::IMAGE_MODEL_ID, $model->getId() );
+		$this->assertSame( 'Superdav Image', $model->getName() );
+		$this->assertContainsEquals( CapabilityEnum::imageGeneration(), $model->getSupportedCapabilities() );
+
+		$option_names = array_map(
+			static fn( SupportedOption $option ): string => $option->getName()->value,
+			$model->getSupportedOptions()
+		);
+
+		$this->assertContains( 'outputMimeType', $option_names );
+		$this->assertContains( 'outputFileType', $option_names );
+		$this->assertContains( 'outputMediaOrientation', $option_names );
+	}
+
+	/**
+	 * Image-capable metadata creates an image generation model instance.
+	 */
+	public function test_provider_creates_image_generation_model_for_image_capability(): void {
+		$this->skip_if_sdk_unavailable();
+
+		$method = new \ReflectionMethod( SuperdavAiProvider::class, 'createModel' );
+		$method->setAccessible( true );
+		$model = $method->invoke(
+			null,
+			new ModelMetadata(
+				SuperdavAiProvider::IMAGE_MODEL_ID,
+				'Superdav Image',
+				array( CapabilityEnum::imageGeneration() ),
+				array()
+			),
+			SuperdavAiProvider::metadata()
+		);
+
+		$this->assertInstanceOf( SuperdavAiImageGenerationModel::class, $model );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Add a Superdav image generation model wrapper for the WordPress AI Client SDK.
- Advertise image-generation metadata/options for `superdav-image` so existing `sd-ai-agent/generate-image` availability can turn on.
- Route image-capable model metadata to the image model while preserving Responses tool-search routing for text models.
- Add provider tests and runtime stubs for the image model path.

## Verification
- `npm run lint:php`
- `composer phpstan` — 0 errors
- `npm run test:php` — Tests: 3734, Assertions: 15643, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- `npm run lint:js`
- `npm run lint:css`
- `npm run build` — succeeded with existing webpack size warnings
- `npm run check:bundle`
- `git diff --check`
- Real service image E2E: 3/3 `superdav-image` requests returned PNG image bytes via local Superdav service + Sub2API.

## Worker self-verification
- PHPUnit: Tests: 3734, Assertions: 15643, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

## Notes
- Depends on the Superdav service image endpoint being deployed for production image generation.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.8 plugin for [OpenCode](https://opencode.ai) v1.17.18
