### PR TITLE
GH#2216: consolidate tool permission gate

### DIFF
--- a/includes/Abilities/ToolCapabilities.php
+++ b/includes/Abilities/ToolCapabilities.php
@@ -410,12 +410,7 @@ class ToolCapabilities {
 		 */
 		$resolved_cap = (string) apply_filters( 'sd_ai_agent_tool_capability', $tool_cap, $ability_id );
 
-		$tool_ok = self::is_one_turn_approved( $ability_id )
-			|| ( self::capability_exists( $resolved_cap )
-				? current_user_can( $resolved_cap )
-				: current_user_can( self::FALLBACK_CAP ) );
-
-		if ( ! $tool_ok ) {
+		if ( ! self::tool_layer_passes( $ability_id, $resolved_cap ) ) {
 			return false;
 		}
 
@@ -446,14 +441,12 @@ class ToolCapabilities {
 		/** This filter is documented in {@see current_user_can()}. */
 		$resolved_cap = (string) apply_filters( 'sd_ai_agent_tool_capability', $tool_cap, $ability_id );
 
-		$skip_tool_layer = self::is_one_turn_approved( $ability_id );
+		if ( ! self::tool_layer_passes( $ability_id, $resolved_cap ) ) {
+			$resolved_cap_exists = self::capability_exists( $resolved_cap );
+			$capability          = $resolved_cap_exists ? $resolved_cap : self::FALLBACK_CAP;
+			$layer               = $resolved_cap_exists ? 'per-tool' : 'fallback';
 
-		if ( ! $skip_tool_layer && self::capability_exists( $resolved_cap ) ) {
-			if ( ! current_user_can( $resolved_cap ) ) {
-				return self::capability_denial_error( $ability_id, $resolved_cap, 'per-tool' );
-			}
-		} elseif ( ! $skip_tool_layer && ! current_user_can( self::FALLBACK_CAP ) ) {
-			return self::capability_denial_error( $ability_id, self::FALLBACK_CAP, 'fallback' );
+			return self::capability_denial_error( $ability_id, $capability, $layer );
 		}
 
 		foreach ( self::resolve_core_caps( $ability_id ) as $core_cap ) {
@@ -463,6 +456,23 @@ class ToolCapabilities {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Whether the plugin-specific permission layer passes for an ability.
+	 *
+	 * Current-turn approval satisfies this layer. Otherwise, the current user
+	 * must hold the resolved per-tool capability when it exists, or the
+	 * admin-only fallback capability when it does not.
+	 *
+	 * @param string $ability_id   The ability ID.
+	 * @param string $resolved_cap The filtered per-tool capability name.
+	 */
+	private static function tool_layer_passes( string $ability_id, string $resolved_cap ): bool {
+		return self::is_one_turn_approved( $ability_id )
+			|| ( self::capability_exists( $resolved_cap )
+				? current_user_can( $resolved_cap )
+				: current_user_can( self::FALLBACK_CAP ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Centralized one-turn approval and per-tool capability resolution in a shared ToolCapabilities helper while preserving precise denial diagnostics and mandatory core capability checks.

## Files Changed

includes/Abilities/ToolCapabilities.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify (PHPUnit: 3732 tests, 15634 assertions, 121 skipped, 4 incomplete; PHP/JS/CSS lint clean; PHPStan 0 errors; build and bundle checks succeeded). Focused ToolCapabilitiesTest: 36 tests, 379 assertions.

Resolves #2216


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.20 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 6m and 56,529 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool permission checks by consistently applying per-tool approvals and fallback permissions.
  * Updated permission-denial messages to accurately identify the required permission layer when access is denied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->