### PR TITLE
GH#2218: Clarify site inspection tool arguments

### DIFF
--- a/includes/Abilities/FileAbilities.php
+++ b/includes/Abilities/FileAbilities.php
@@ -1068,7 +1068,7 @@ class ContentSearchAbility extends AbstractFileAbility {
 	}
 
 	protected function description(): string {
-		return __( 'Search for text content within files in wp-content.', 'superdav-ai-agent' );
+		return __( 'Search for literal text within files in wp-content. The needle argument is required and must contain the text to find; derive it from the user request before calling. Never call this ability with empty arguments.', 'superdav-ai-agent' );
 	}
 
 	protected function input_schema(): array {
@@ -1077,7 +1077,7 @@ class ContentSearchAbility extends AbstractFileAbility {
 			'properties' => [
 				'needle'       => [
 					'type'        => 'string',
-					'description' => 'The text to search for',
+					'description' => 'Required literal text to search for (for example, a template name, CSS class, URL fragment, or visible label from the user request).',
 				],
 				'directory'    => [
 					'type'        => 'string',

--- a/includes/Abilities/GetPageHtmlAbility.php
+++ b/includes/Abilities/GetPageHtmlAbility.php
@@ -30,7 +30,7 @@ class GetPageHtmlAbility extends AbstractAbility {
 	}
 
 	protected function description(): string {
-		return __( 'Get the HTML content of elements on the current page the user is viewing. Use CSS selectors to query specific elements. Returns the outer HTML of matched elements.', 'superdav-ai-agent' );
+		return __( 'Get the HTML content of elements on the current page the user is viewing. The selector argument is required; use "body" when the exact element is unknown, then refine the selector from the returned HTML. Never call this ability with empty arguments.', 'superdav-ai-agent' );
 	}
 
 	protected function input_schema(): array {
@@ -39,7 +39,7 @@ class GetPageHtmlAbility extends AbstractAbility {
 			'properties' => [
 				'selector'   => [
 					'type'        => 'string',
-					'description' => 'CSS selector to query (e.g., "#main-content", ".entry-title", "article", "body")',
+					'description' => 'Required CSS selector to query (e.g., "#main-content", ".entry-title", "article"). Use "body" when the exact selector is unknown.',
 				],
 				'max_length' => [
 					'type'        => 'number',

--- a/tests/SdAiAgent/Abilities/FileAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/FileAbilitiesTest.php
@@ -569,6 +569,24 @@ class FileAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The model-facing schema makes the search term requirement actionable.
+	 */
+	public function test_content_search_schema_exposes_required_needle_guidance(): void {
+		$ability = new \SdAiAgent\Abilities\ContentSearchAbility(
+			'sd-ai-agent/content-search',
+			[
+				'label'       => 'Search Content',
+				'description' => 'Search for text content within files in wp-content.',
+			]
+		);
+		$schema  = $ability->get_input_schema();
+
+		$this->assertSame( [ 'needle' ], $schema['required'] );
+		$this->assertStringContainsString( 'Required literal text', $schema['properties']['needle']['description'] );
+		$this->assertStringContainsString( 'user request', $schema['properties']['needle']['description'] );
+	}
+
+	/**
 	 * Test handle_search_content returns array structure.
 	 */
 	public function test_handle_search_content_returns_structure() {

--- a/tests/SdAiAgent/Abilities/GetPageHtmlAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/GetPageHtmlAbilityTest.php
@@ -64,6 +64,18 @@ class GetPageHtmlAbilityTest extends WP_UnitTestCase {
 		$this->assertSame( 'sd_ai_agent_empty_selector', $result->get_error_code() );
 	}
 
+	/**
+	 * The model-facing schema explains how to recover when the exact selector is unknown.
+	 */
+	public function test_schema_exposes_required_selector_with_fallback_guidance(): void {
+		$ability = $this->make_ability();
+		$schema  = $ability->get_input_schema();
+
+		$this->assertSame( [ 'selector' ], $schema['required'] );
+		$this->assertStringContainsString( 'Required CSS selector', $schema['properties']['selector']['description'] );
+		$this->assertStringContainsString( 'Use "body"', $schema['properties']['selector']['description'] );
+	}
+
 	// ── execute_callback — valid selector ─────────────────────────────────
 
 	/**


### PR DESCRIPTION
## Summary

Made required content-search and get-page-html arguments explicit in model-facing descriptions and schemas, including a safe body selector fallback, with regression tests for both schemas.

## Files Changed

includes/Abilities/FileAbilities.php, includes/Abilities/GetPageHtmlAbility.php, tests/SdAiAgent/Abilities/FileAbilitiesTest.php, tests/SdAiAgent/Abilities/GetPageHtmlAbilityTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify; PHPUnit: 3734 tests, 15640 assertions, 121 skipped, 4 incomplete; lint clean; PHPStan 0 errors; build and bundle checks succeeded

Resolves #2218


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.23 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 7m and 91,549 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Clarified search and page retrieval tool instructions to identify required inputs and prevent empty requests.
  * Added clearer guidance for providing literal search text and CSS selectors, including selector fallback examples.

* **Tests**
  * Added coverage verifying that required input guidance is correctly exposed in the tool schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->