### PR TITLE
GH#2221: Add actionable memory save diagnostics

### DIFF
--- a/includes/Abilities/MemoryAbilities.php
+++ b/includes/Abilities/MemoryAbilities.php
@@ -164,16 +164,19 @@ class MemoryAbilities {
 		$id = Memory::create( $category, $content );
 
 		if ( false === $id ) {
-			$error = Memory::get_last_error();
+			$error      = Memory::get_last_error();
+			$error_code = Memory::get_last_error_code();
 			if ( '' === $error ) {
-				$error = 'Memory persistence is unavailable. Check that the Superdav AI Agent database tables exist for the current site and retry.';
+				$error      = 'Memory persistence is unavailable. Check that the Superdav AI Agent database tables exist for the current site and retry.';
+				$error_code = 'memory_persistence_unavailable';
 			}
 
 			return [
-				'success' => false,
-				'id'      => 0,
-				'message' => '',
-				'error'   => 'Failed to save memory: ' . $error,
+				'success'    => false,
+				'id'         => 0,
+				'message'    => '',
+				'error_code' => $error_code,
+				'error'      => 'Failed to save memory: ' . $error,
 			];
 		}
 

--- a/includes/Models/Memory.php
+++ b/includes/Models/Memory.php
@@ -22,6 +22,13 @@ class Memory {
 	private static string $last_error = '';
 
 	/**
+	 * Stable code for the most recent persistence error.
+	 *
+	 * @var string
+	 */
+	private static string $last_error_code = '';
+
+	/**
 	 * Valid memory categories.
 	 *
 	 * `site_brief` is a dedicated category for the structured site
@@ -46,6 +53,13 @@ class Memory {
 	 */
 	public static function get_last_error(): string {
 		return self::$last_error;
+	}
+
+	/**
+	 * Return the stable code for the most recent persistence error.
+	 */
+	public static function get_last_error_code(): string {
+		return self::$last_error_code;
 	}
 
 	/**
@@ -106,7 +120,8 @@ class Memory {
 	public static function create( string $category, string $content ) {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
-		self::$last_error = '';
+		self::$last_error      = '';
+		self::$last_error_code = '';
 
 		if ( ! in_array( $category, self::CATEGORIES, true ) ) {
 			$category = 'general';
@@ -133,9 +148,8 @@ class Memory {
 			return (int) $wpdb->insert_id;
 		}
 
-		self::$last_error = '' !== $wpdb->last_error
-			? $wpdb->last_error
-			: 'The memory table insert did not complete.';
+		self::$last_error_code = 'memory_insert_failed';
+		self::$last_error      = 'The database rejected the memory insert. Check the database error log and retry.';
 
 		return false;
 	}
@@ -163,7 +177,8 @@ class Memory {
 			return true;
 		}
 
-		self::$last_error = sprintf(
+		self::$last_error_code = 'memory_table_unavailable';
+		self::$last_error      = sprintf(
 			'The memory table %s is unavailable for the current site. Run the Superdav AI Agent database upgrade for this blog and retry.',
 			$table
 		);

--- a/tests/SdAiAgent/Abilities/MemoryAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/MemoryAbilitiesTest.php
@@ -47,7 +47,7 @@ class MemoryAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test handle_memory_save returns actionable database error detail.
+	 * Test handle_memory_save returns a safe, actionable database diagnostic.
 	 */
 	public function test_handle_memory_save_failure_includes_persistence_detail() {
 		global $wpdb;
@@ -114,7 +114,9 @@ class MemoryAbilitiesTest extends WP_UnitTestCase {
 		$this->assertIsArray( $result );
 		$this->assertFalse( $result['success'] );
 		$this->assertStringContainsString( 'Failed to save memory:', $result['error'] );
-		$this->assertStringContainsString( 'Simulated memory insert failure.', $result['error'] );
+		$this->assertSame( 'memory_insert_failed', $result['error_code'] );
+		$this->assertStringContainsString( 'database error log', $result['error'] );
+		$this->assertStringNotContainsString( 'Simulated memory insert failure.', $result['error'] );
 		$this->assertNotSame( 'Failed to save memory.', $result['error'] );
 	}
 


### PR DESCRIPTION
## Summary

- Add stable diagnostic codes to memory persistence failures.
- Keep database error details out of agent-facing responses while directing operators to database logs.
- Cover the structured, non-secret insert-failure response in PHPUnit.

Resolves #2221

## Worker self-verification

- PHPUnit: Tests: 3736, Assertions: 15649, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded (bundle-size checks passed)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.65 plugin for [OpenCode](https://opencode.ai) v1.17.18
