### PR TITLE
GH#2227: Harden site availability diagnostics

### DIFF
--- a/includes/Abilities/SiteHealthAbilities.php
+++ b/includes/Abilities/SiteHealthAbilities.php
@@ -802,14 +802,13 @@ class SiteHealthAbilities {
 		$response = wp_safe_remote_get(
 			$url,
 			[
-				'timeout'     => 10,
-				'redirection' => 5,
+				'timeout'     => 5,
+				'redirection' => 2,
 			]
 		);
 
 		$frontend = [
 			'url'              => $url,
-			'effective_url'    => $url,
 			'status_code'      => 0,
 			'title'            => '',
 			'body_fingerprint' => '',
@@ -986,7 +985,7 @@ class SiteHealthAbilities {
 			];
 			foreach ( $meta_keys as $key => $meta_key ) {
 				$value = $site->get_meta( $meta_key );
-				if ( null !== $value && '' !== $value ) {
+				if ( ! array_key_exists( $key, $tenant ) && null !== $value && '' !== $value ) {
 					$tenant[ $key ] = $value;
 				}
 			}

--- a/tests/SdAiAgent/Abilities/SiteHealthAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/SiteHealthAbilitiesTest.php
@@ -430,12 +430,12 @@ class SiteHealthAbilitiesTest extends WP_UnitTestCase {
 	public function test_availability_reports_transport_failure_as_critical() {
 		add_filter(
 			'pre_http_request',
-			static function ( mixed $preempt, array $parsed_args ): WP_Error {
+			static function ( mixed $preempt, array $parsed_args ): \WP_Error {
 				unset( $preempt );
 				self::assertSame( 5, $parsed_args['timeout'] );
 				self::assertSame( 2, $parsed_args['redirection'] );
 
-				return new WP_Error( 'http_request_failed', 'Connection refused' );
+				return new \WP_Error( 'http_request_failed', 'Connection refused' );
 			},
 			10,
 			2

--- a/tests/SdAiAgent/Abilities/SiteHealthAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/SiteHealthAbilitiesTest.php
@@ -425,6 +425,62 @@ class SiteHealthAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Frontend transport failures must make availability critical.
+	 */
+	public function test_availability_reports_transport_failure_as_critical() {
+		add_filter(
+			'pre_http_request',
+			static function ( mixed $preempt, array $parsed_args ): WP_Error {
+				unset( $preempt );
+				self::assertSame( 5, $parsed_args['timeout'] );
+				self::assertSame( 2, $parsed_args['redirection'] );
+
+				return new WP_Error( 'http_request_failed', 'Connection refused' );
+			},
+			10,
+			2
+		);
+
+		try {
+			$result = SiteHealthAbilities::diagnose_site_availability();
+			$this->assertSame( 'critical', $result['status'] );
+			$this->assertSame( 'Connection refused', $result['frontend']['transport_error'] );
+			$this->assertSame( 0, $result['frontend']['status_code'] );
+		} finally {
+			remove_all_filters( 'pre_http_request' );
+		}
+	}
+
+	/**
+	 * A normal frontend response without a tenant lock must remain healthy.
+	 */
+	public function test_availability_reports_healthy_frontend() {
+		add_filter(
+			'pre_http_request',
+			static function () {
+				return [
+					'headers'  => [],
+					'body'     => '<html><head><title>Healthy site</title></head><body>Welcome</body></html>',
+					'response' => [ 'code' => 200, 'message' => 'OK' ],
+					'cookies'  => [],
+					'filename' => null,
+				];
+			}
+		);
+
+		try {
+			$result = SiteHealthAbilities::diagnose_site_availability();
+			$this->assertSame( 'healthy', $result['status'] );
+			$this->assertSame( 200, $result['frontend']['status_code'] );
+			$this->assertFalse( $result['frontend']['wp_die_page'] );
+			$this->assertArrayNotHasKey( 'transport_error', $result['frontend'] );
+			$this->assertArrayNotHasKey( 'effective_url', $result['frontend'] );
+		} finally {
+			remove_all_filters( 'pre_http_request' );
+		}
+	}
+
+	/**
 	 * Ultimate Multisite visit overages must expose the frontend lock reason.
 	 */
 	public function test_availability_reports_tenant_visit_limit_lock() {


### PR DESCRIPTION
## Summary

Bound frontend smoke checks, removed the misleading effective URL field, preserved live visit counts over stale metadata, and covered transport-failure and healthy paths.

## Files Changed

- `includes/Abilities/SiteHealthAbilities.php`
- `tests/SdAiAgent/Abilities/SiteHealthAbilitiesTest.php`

## Runtime Testing

- **Risk level:** Low
- **Verification:** Full repository verification passed.

## Worker self-verification

- PHPUnit: Tests: 3740, Assertions: 15669, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded; bundle-size check passed

## Key decisions

- Limit the public frontend smoke check to five seconds and two redirects.
- Use stored visit metadata only when the live visit-count method did not provide a value.

Resolves #2227

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.68 plugin for [OpenCode](https://opencode.ai) v1.17.18 with gpt-5.6-sol spent 8m and 75,011 tokens on this as a headless worker. Overall, 34m since this issue was created.
