### PR TITLE
fix: autosize docs chat input

### DIFF
--- a/src/embed-widget/__tests__/index.test.js
+++ b/src/embed-widget/__tests__/index.test.js
@@ -72,6 +72,52 @@ describe( 'embed widget', () => {
 		expect( launcher.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
 	} );
 
+	test( 'uses an autosizing multiline textarea for user input', () => {
+		const root = module.mountEmbed( {
+			...module.resolveConfig( null, {} ),
+			apiBase: 'https://example.test/wp-json/sd-ai-agent/v1',
+			mount: '#mount',
+		} );
+		const input = root.querySelector( '.sdaa-embed__input' );
+
+		expect( input.tagName ).toBe( 'TEXTAREA' );
+		expect( input.getAttribute( 'rows' ) ).toBe( '1' );
+
+		Object.defineProperty( input, 'scrollHeight', {
+			configurable: true,
+			value: 72,
+		} );
+		input.value = 'Line one\nLine two\nLine three';
+		input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+
+		expect( input.style.height ).toBe( '72px' );
+	} );
+
+	test( 'submits textarea on Enter while preserving Shift+Enter for newlines', () => {
+		const root = module.mountEmbed( {
+			...module.resolveConfig( null, {} ),
+			apiBase: 'https://example.test/wp-json/sd-ai-agent/v1',
+			mount: '#mount',
+		} );
+		const form = root.querySelector( '.sdaa-embed__form' );
+		const input = root.querySelector( '.sdaa-embed__input' );
+		form.requestSubmit = jest.fn();
+
+		input.dispatchEvent(
+			new KeyboardEvent( 'keydown', {
+				bubbles: true,
+				key: 'Enter',
+				shiftKey: true,
+			} )
+		);
+		expect( form.requestSubmit ).not.toHaveBeenCalled();
+
+		input.dispatchEvent(
+			new KeyboardEvent( 'keydown', { bubbles: true, key: 'Enter' } )
+		);
+		expect( form.requestSubmit ).toHaveBeenCalledTimes( 1 );
+	} );
+
 	test( 'renders assistant markdown and makes source URLs clickable', () => {
 		const root = module.mountEmbed( {
 			...module.resolveConfig( null, {} ),

--- a/src/embed-widget/index.js
+++ b/src/embed-widget/index.js
@@ -466,7 +466,7 @@ export function mountEmbed( config ) {
 			</header>
 			<div class="sdaa-embed__messages"></div>
 			<form class="sdaa-embed__form">
-				<input class="sdaa-embed__input" type="text" autocomplete="off" placeholder="${ STRINGS.placeholder }" />
+				<textarea class="sdaa-embed__input" rows="1" autocomplete="off" placeholder="${ STRINGS.placeholder }"></textarea>
 				<button class="sdaa-embed__send" type="submit">${ STRINGS.send }</button>
 			</form>
 		</section>`;
@@ -483,6 +483,11 @@ export function mountEmbed( config ) {
 	const form = root.querySelector( '.sdaa-embed__form' );
 	const input = root.querySelector( '.sdaa-embed__input' );
 	let sessionToken = '';
+
+	const autosizeInput = () => {
+		input.style.height = 'auto';
+		input.style.height = `${ input.scrollHeight }px`;
+	};
 
 	const setMessageContent = ( item, role, text ) => {
 		item.textContent = '';
@@ -504,6 +509,7 @@ export function mountEmbed( config ) {
 	};
 
 	addMessage( 'assistant', config.greeting );
+	autosizeInput();
 
 	const setUnavailable = ( message = STRINGS.unavailable ) => {
 		root.classList.add( 'is-unavailable' );
@@ -543,6 +549,23 @@ export function mountEmbed( config ) {
 		launcher.setAttribute( 'aria-expanded', 'false' );
 	} );
 
+	input.addEventListener( 'input', autosizeInput );
+
+	input.addEventListener( 'keydown', ( event ) => {
+		if ( event.key !== 'Enter' || event.shiftKey || event.isComposing ) {
+			return;
+		}
+
+		event.preventDefault();
+		if ( typeof form.requestSubmit === 'function' ) {
+			form.requestSubmit();
+		} else {
+			form.dispatchEvent(
+				new Event( 'submit', { bubbles: true, cancelable: true } )
+			);
+		}
+	} );
+
 	form.addEventListener( 'submit', async ( event ) => {
 		event.preventDefault();
 		const message = input.value.trim();
@@ -550,6 +573,7 @@ export function mountEmbed( config ) {
 			return;
 		}
 		input.value = '';
+		autosizeInput();
 		addMessage( 'user', message );
 		const pending = addMessage( 'assistant', STRINGS.thinking );
 		try {

--- a/src/embed-widget/style.css
+++ b/src/embed-widget/style.css
@@ -65,6 +65,7 @@
 }
 
 .sdaa-embed__form {
+	align-items: flex-end;
 	border-top: 1px solid var(--sdaa-embed-border);
 	border-bottom: 0;
 }
@@ -176,12 +177,17 @@
 
 .sdaa-embed__input {
 	min-width: 0;
+	max-height: 140px;
 	flex: 1;
 	padding: 10px 12px;
+	overflow-y: auto;
 	border: 1px solid var(--sdaa-embed-border);
-	border-radius: 999px;
+	border-radius: 20px;
 	background: var(--sdaa-embed-surface);
 	color: var(--sdaa-embed-text);
+	font: inherit;
+	line-height: 1.35;
+	resize: none;
 }
 
 .sdaa-embed__send {


### PR DESCRIPTION
## Summary
- Change the static docs chat composer from a single-line input to a one-row textarea.
- Autosize the textarea as content wraps or new lines are added, capped by CSS with vertical scrolling.
- Preserve chat-style keyboard behavior: Enter submits, Shift+Enter inserts a newline.

## Context
- Markdown rendering and clickable links are already present on `main` from #2199.
- The deployed production site checked during triage was still locked to #2191, so it does not yet include #2199’s compiled markdown renderer. Production should deploy a plugin commit at or after #2199 plus this PR to get both fixes.

## Worker self-verification
- PHPUnit: Tests: 3740, Assertions: 15669, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded (`npm run verify`; webpack reported existing asset-size warnings, bundle budget check passed)
- JS:      `npm run test:js -- src/embed-widget/__tests__/index.test.js --runInBand` passed, 8 tests

## Notes
- No production deploy included.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.138 plugin for [OpenCode](https://opencode.ai) v1.18.3
