### PR TITLE
fix: scrub Superdav connection metadata

### DIFF
--- a/includes/Core/SuperdavSiteConnectionService.php
+++ b/includes/Core/SuperdavSiteConnectionService.php
@@ -48,20 +48,23 @@ final class SuperdavSiteConnectionService {
 			'account_connect_url'       => $this->get_account_connect_url(),
 		);
 
-		$metadata_keys = array(
-			'tier',
-			'verified',
-			'usage',
-			'verification',
-			'request_id',
-			'wallet',
-			'connection_notice_pending',
-		);
-
-		foreach ( $metadata_keys as $key ) {
-			if ( array_key_exists( $key, $metadata ) ) {
+		foreach ( array( 'tier', 'verified', 'request_id', 'connection_notice_pending' ) as $key ) {
+			if ( array_key_exists( $key, $metadata ) && ( is_scalar( $metadata[ $key ] ) || null === $metadata[ $key ] ) ) {
 				$status[ $key ] = $metadata[ $key ];
 			}
+		}
+
+		foreach ( array( 'usage', 'verification' ) as $key ) {
+			if ( isset( $metadata[ $key ] ) && is_array( $metadata[ $key ] ) ) {
+				$status[ $key ] = array_filter(
+					$metadata[ $key ],
+					static fn( mixed $value ): bool => is_scalar( $value ) || null === $value
+				);
+			}
+		}
+
+		if ( isset( $metadata['wallet'] ) && is_array( $metadata['wallet'] ) ) {
+			$status['wallet'] = $this->sanitize_wallet_metadata( $metadata['wallet'] );
 		}
 
 		return $status;
@@ -403,23 +406,33 @@ final class SuperdavSiteConnectionService {
 		}
 
 		if ( isset( $metadata['wallet'] ) && is_array( $metadata['wallet'] ) ) {
-			$safe['wallet'] = array_intersect_key(
-				array_filter(
-					$metadata['wallet'],
-					static fn( mixed $value ): bool => is_scalar( $value ) || null === $value
-				),
-				array_flip(
-					array(
-						'currency',
-						'promo_usd_micros',
-						'cash_usd_micros',
-						'total_usd_micros',
-					)
-				)
-			);
+			$safe['wallet'] = $this->sanitize_wallet_metadata( $metadata['wallet'] );
 		}
 
 		return $safe;
+	}
+
+	/**
+	 * Keep only safe scalar wallet metadata for UI balance notices.
+	 *
+	 * @param array<string, mixed> $wallet Remote or stored wallet metadata.
+	 * @return array<string, mixed>
+	 */
+	private function sanitize_wallet_metadata( array $wallet ): array {
+		return array_intersect_key(
+			array_filter(
+				$wallet,
+				static fn( mixed $value ): bool => is_scalar( $value ) || null === $value
+			),
+			array_flip(
+				array(
+					'currency',
+					'promo_usd_micros',
+					'cash_usd_micros',
+					'total_usd_micros',
+				)
+			)
+		);
 	}
 
 	/**

--- a/tests/SdAiAgent/REST/ConnectorsControllerTest.php
+++ b/tests/SdAiAgent/REST/ConnectorsControllerTest.php
@@ -56,6 +56,43 @@ final class ConnectorsControllerTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Stored managed-provider metadata is scrubbed before it reaches connector responses.
+	 */
+	public function test_list_sanitizes_stored_managed_wallet_metadata(): void {
+		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, 'secret-site-token', false );
+		update_option(
+			SuperdavSiteConnectionService::TOKEN_METADATA_OPTION,
+			array(
+				'wallet' => array(
+					'account_id'        => 'acct_secretish_internal',
+					'currency'          => 'USD',
+					'promo_usd_micros'  => 10000000,
+					'internal_metadata' => 'hidden',
+				),
+				'usage'  => array(
+					'remaining' => 10,
+					'internal'  => array( 'secret' => 'hidden' ),
+				),
+			),
+			false
+		);
+
+		$response  = ( new ConnectorsController() )->handle_list();
+		$data      = $response->get_data();
+		$superdav  = $this->find_provider( $data['providers'], SuperdavAiProvider::PROVIDER_ID );
+		$status    = $superdav['status'];
+		$serialized = wp_json_encode( $superdav ) ?: '';
+
+		$this->assertSame( 10000000, $status['wallet']['promo_usd_micros'] );
+		$this->assertSame( 'USD', $status['wallet']['currency'] );
+		$this->assertArrayNotHasKey( 'account_id', $status['wallet'] );
+		$this->assertArrayNotHasKey( 'internal_metadata', $status['wallet'] );
+		$this->assertSame( array( 'remaining' => 10 ), $status['usage'] );
+		$this->assertStringNotContainsString( 'secret-site-token', $serialized );
+		$this->assertStringNotContainsString( 'acct_secretish_internal', $serialized );
+	}
+
+	/**
 	 * Managed connection provisions a local site token and returns safe metadata.
 	 */
 	public function test_connect_provisions_site_token_without_returning_secret(): void {


### PR DESCRIPTION
## Summary
- Scrubs stored Superdav connection metadata before connector status responses expose it.
- Keeps only safe scalar usage/verification values and an allowlisted wallet balance shape.
- Adds REST coverage proving tokens, internal wallet IDs, and nested metadata stay out of connector output.

## Worker self-verification
- PHPUnit: Tests: 3743, Assertions: 15685, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

## Verification
- `npm run verify`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.145 plugin for [OpenCode](https://opencode.ai) v1.18.3
