### PR TITLE
GH#2233: add Superdav AI account settings

### DIFF
--- a/includes/Core/SuperdavSiteConnectionService.php
+++ b/includes/Core/SuperdavSiteConnectionService.php
@@ -25,8 +25,9 @@ final class SuperdavSiteConnectionService {
 	public const INSTALLATION_ID_OPTION = 'sd_ai_agent_site_installation_id';
 	public const TOKEN_METADATA_OPTION  = 'sd_ai_agent_cloud_connection_metadata';
 
-	private const REGISTRATION_ENDPOINT_PATH = 'site/installations';
-	private const REVOCATION_ENDPOINT_PATH   = 'site/token/revoke';
+	private const REGISTRATION_ENDPOINT_PATH   = 'site/installations';
+	private const REVOCATION_ENDPOINT_PATH     = 'site/token/revoke';
+	private const ACCOUNT_STATUS_ENDPOINT_PATH = 'site/account';
 
 	/**
 	 * Build safe connector status metadata.
@@ -37,6 +38,8 @@ final class SuperdavSiteConnectionService {
 		$token    = $this->get_stored_token();
 		$metadata = $this->get_metadata();
 
+		$account_portal_url = $this->get_account_portal_url( $metadata );
+
 		$status = array(
 			'configured'                => '' !== $token,
 			'provider'                  => SuperdavAiProvider::PROVIDER_ID,
@@ -44,8 +47,9 @@ final class SuperdavSiteConnectionService {
 			'installation_id'           => $this->get_installation_id(),
 			'site_url'                  => $this->get_verified_site_url(),
 			'connected_at'              => $metadata['connected_at'] ?? null,
-			'account_connect_available' => '' !== $this->get_account_connect_url(),
-			'account_connect_url'       => $this->get_account_connect_url(),
+			'account_connect_available' => '' !== $account_portal_url,
+			'account_connect_url'       => $account_portal_url,
+			'account_portal_url'        => $account_portal_url,
 		);
 
 		foreach ( array( 'tier', 'verified', 'request_id', 'connection_notice_pending' ) as $key ) {
@@ -68,6 +72,62 @@ final class SuperdavSiteConnectionService {
 		}
 
 		return $status;
+	}
+
+	/**
+	 * Refresh safe account metadata from the managed Superdav service.
+	 *
+	 * The bearer token remains inside WordPress and is never included in the
+	 * response. Payment data is handled only by the external account portal.
+	 *
+	 * @return array<string, mixed>|WP_Error Safe account status or refresh error.
+	 */
+	public function refresh_account_status(): array|WP_Error {
+		$token = $this->get_stored_token();
+		if ( '' === $token ) {
+			return new WP_Error( 'sd_ai_agent_cloud_account_unavailable', __( 'Connect Superdav AI before refreshing your account.', 'superdav-ai-agent' ), array( 'status' => 412 ) );
+		}
+
+		$endpoint = $this->get_account_status_endpoint();
+		if ( '' === $endpoint ) {
+			return new WP_Error( 'sd_ai_agent_cloud_account_unavailable', __( 'Superdav AI account status is unavailable.', 'superdav-ai-agent' ), array( 'status' => 503 ) );
+		}
+
+		$response = wp_remote_post(
+			$endpoint,
+			array(
+				'timeout' => 15,
+				'headers' => array(
+					'Authorization' => 'Bearer ' . $token,
+					'Content-Type'  => 'application/json',
+				),
+				'body'    => wp_json_encode(
+					array(
+						'installation_id' => $this->get_installation_id(),
+						'site_url'        => $this->get_verified_site_url(),
+					)
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( 'sd_ai_agent_cloud_account_refresh_failed', __( 'Superdav AI account refresh failed.', 'superdav-ai-agent' ), array( 'status' => 502 ) );
+		}
+
+		$status_code = (int) wp_remote_retrieve_response_code( $response );
+		if ( $status_code < 200 || $status_code >= 300 ) {
+			return new WP_Error( 'sd_ai_agent_cloud_account_refresh_failed', __( 'Superdav AI account refresh failed.', 'superdav-ai-agent' ), array( 'status' => 502 ) );
+		}
+
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( ! is_array( $body ) ) {
+			return new WP_Error( 'sd_ai_agent_cloud_account_invalid', __( 'Superdav AI account response was invalid.', 'superdav-ai-agent' ), array( 'status' => 502 ) );
+		}
+
+		$metadata = array_merge( $this->get_metadata(), $this->sanitize_remote_metadata( $body ) );
+		update_option( self::TOKEN_METADATA_OPTION, $metadata, false );
+
+		return $this->get_status();
 	}
 
 	/**
@@ -198,9 +258,9 @@ final class SuperdavSiteConnectionService {
 	}
 
 	/**
-	 * Return the account/OAuth connect URL when the service exposes one.
+	 * Return the account portal URL when the service exposes one.
 	 */
-	private function get_account_connect_url(): string {
+	private function get_account_portal_url( array $metadata ): string {
 		/**
 		 * Filters the Superdav account connection URL for future paid-account flows.
 		 *
@@ -210,9 +270,30 @@ final class SuperdavSiteConnectionService {
 		 * @param string $installation_id Durable site-installation identity.
 		 * @param string $site_url        Verified site URL.
 		 */
-		$url = apply_filters( 'sd_ai_agent_cloud_account_connect_url', '', $this->get_installation_id(), $this->get_verified_site_url() );
+		$default_url = $metadata['account_portal_url'] ?? '';
+		$default_url = is_string( $default_url ) ? $default_url : '';
+		$url         = apply_filters( 'sd_ai_agent_cloud_account_connect_url', $default_url, $this->get_installation_id(), $this->get_verified_site_url() );
 
 		return is_string( $url ) ? esc_url_raw( $url ) : '';
+	}
+
+	/**
+	 * Resolve the managed service endpoint used to refresh safe wallet metadata.
+	 */
+	private function get_account_status_endpoint(): string {
+		$endpoint = $this->configured_endpoint( 'SD_AI_AGENT_CLOUD_ACCOUNT_STATUS_ENDPOINT', self::ACCOUNT_STATUS_ENDPOINT_PATH );
+
+		/**
+		 * Filters the Superdav account status endpoint.
+		 *
+		 * The endpoint receives the site token server-to-server and must never be
+		 * exposed to the browser or include credential query parameters.
+		 *
+		 * @param string $endpoint Account-status endpoint URL.
+		 */
+		$endpoint = apply_filters( 'sd_ai_agent_cloud_account_status_endpoint', $endpoint );
+
+		return is_string( $endpoint ) ? esc_url_raw( $endpoint ) : '';
 	}
 
 	/**
@@ -382,6 +463,7 @@ final class SuperdavSiteConnectionService {
 			'verified',
 			'connect_required',
 			'request_id',
+			'account_portal_url',
 		);
 		$safe         = array();
 

--- a/includes/Core/SuperdavSiteConnectionService.php
+++ b/includes/Core/SuperdavSiteConnectionService.php
@@ -259,6 +259,8 @@ final class SuperdavSiteConnectionService {
 
 	/**
 	 * Return the account portal URL when the service exposes one.
+	 *
+	 * @param array<string, mixed> $metadata Safe connection metadata.
 	 */
 	private function get_account_portal_url( array $metadata ): string {
 		/**

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -129,6 +129,24 @@ final class SettingsController {
 			)
 		);
 
+		// Superdav AI account balance and account-portal metadata.
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/superdav-account',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'handle_get_superdav_account' ),
+					'permission_callback' => array( __CLASS__, 'check_admin_permission' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'handle_refresh_superdav_account' ),
+					'permission_callback' => array( __CLASS__, 'check_admin_permission' ),
+				),
+			)
+		);
+
 		// Role permissions endpoints — only registered when access control feature is enabled.
 		if ( Features::is_enabled( Features::ACCESS_CONTROL ) ) {
 			register_rest_route(
@@ -500,6 +518,27 @@ final class SettingsController {
 		$this->settings->update( $data );
 
 		return new WP_REST_Response( $this->settings->get(), 200 );
+	}
+
+	/**
+	 * Return safe account metadata for the Superdav AI account manager.
+	 */
+	public function handle_get_superdav_account(): WP_REST_Response {
+		return new WP_REST_Response( ( new SuperdavSiteConnectionService() )->get_status(), 200 );
+	}
+
+	/**
+	 * Refresh the account balance from the managed Superdav service.
+	 *
+	 * @return WP_REST_Response|WP_Error Safe account status or service error.
+	 */
+	public function handle_refresh_superdav_account(): WP_REST_Response|WP_Error {
+		$status = ( new SuperdavSiteConnectionService() )->refresh_account_status();
+		if ( $status instanceof WP_Error ) {
+			return $status;
+		}
+
+		return new WP_REST_Response( $status, 200 );
 	}
 
 	/**

--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -43,6 +43,7 @@ import AgentBuilder from './agent-builder';
 import BrandingManager from './branding-manager';
 import AbilitiesManager from './abilities-manager';
 import ProviderTraceViewer from './provider-trace-viewer';
+import SuperdavAccountManager from './superdav-account-manager';
 
 /**
  * Resolve the default model to select for a provider row.
@@ -132,7 +133,7 @@ export default function SettingsApp() {
 	// Tabs that manage their own save actions — hide the global Save Settings button.
 	// Note: 'access-branding' was removed from this list because BrandingManager
 	// does not have its own save button — it uses the global Save Settings button.
-	const selfSavingTabs = [ 'provider-trace' ];
+	const selfSavingTabs = [ 'superdav-account', 'provider-trace' ];
 
 	// Google Analytics integration state.
 	const [ gaPropertyId, setGaPropertyId ] = useState( '' );
@@ -541,6 +542,11 @@ export default function SettingsApp() {
 	// features it hosts (access_control, branding) is enabled.
 	const allTabs = [
 		{
+			name: 'superdav-account',
+			title: __( 'Superdav AI', 'superdav-ai-agent' ),
+			className: 'sdaa-settings-tab',
+		},
+		{
 			name: 'general',
 			title: __( 'General', 'sd-ai-agent' ),
 			className: 'sdaa-settings-tab',
@@ -633,6 +639,20 @@ export default function SettingsApp() {
 				<TabPanel tabs={ tabs } onSelect={ setActiveTab }>
 					{ ( tab ) => {
 						switch ( tab.name ) {
+							case 'superdav-account':
+								return (
+									<div className="sdaa-settings-section">
+										<ErrorBoundary
+											label={ __(
+												'Superdav AI account manager',
+												'superdav-ai-agent'
+											) }
+										>
+											<SuperdavAccountManager />
+										</ErrorBoundary>
+									</div>
+								);
+
 							case 'general':
 								return (
 									<div className="sdaa-settings-section">

--- a/src/settings-page/style.css
+++ b/src/settings-page/style.css
@@ -476,6 +476,80 @@
 	transition: width 0.3s;
 }
 
+/* Superdav AI account manager */
+.sdaa-superdav-account-loading {
+	padding: 40px;
+	text-align: center;
+}
+
+.sdaa-superdav-account-header {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 16px;
+}
+
+.sdaa-superdav-account-header h3 {
+	margin: 0 0 4px;
+	font-size: 15px;
+}
+
+.sdaa-superdav-account-header .description {
+	margin: 0;
+}
+
+.sdaa-superdav-account-balance {
+	padding: 20px;
+	border: 1px solid #c5d9ed;
+	border-radius: 6px;
+	background: #f0f6fc;
+}
+
+.sdaa-superdav-account-balance-label,
+.sdaa-superdav-account-tier,
+.sdaa-superdav-account-breakdown span {
+	display: block;
+	color: #50575e;
+	font-size: 12px;
+}
+
+.sdaa-superdav-account-balance-value {
+	margin: 4px 0;
+	font-size: 28px;
+	font-weight: 600;
+	line-height: 1.2;
+}
+
+.sdaa-superdav-account-breakdown {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+	gap: 12px;
+}
+
+.sdaa-superdav-account-breakdown > div {
+	padding: 12px 14px;
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+}
+
+.sdaa-superdav-account-breakdown strong {
+	display: block;
+	margin-top: 4px;
+	font-size: 16px;
+}
+
+.sdaa-superdav-account-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 8px;
+}
+
+@media screen and (max-width: 600px) {
+	.sdaa-superdav-account-header {
+		flex-direction: column;
+	}
+}
+
 /* Test Result */
 .sdaa-test-result {
 	margin-top: 12px;

--- a/src/settings-page/superdav-account-manager.js
+++ b/src/settings-page/superdav-account-manager.js
@@ -1,0 +1,213 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useEffect, useState } from '@wordpress/element';
+import { Button, Notice, Spinner } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * @param {number|string} micros Amount in millionths of a US dollar.
+ * @return {string} Localized amount, or an em dash when unknown.
+ */
+function formatWalletAmount( micros ) {
+	const amount = Number( micros );
+	if ( ! Number.isFinite( amount ) ) {
+		return '—';
+	}
+
+	return new Intl.NumberFormat( undefined, {
+		style: 'currency',
+		currency: 'USD',
+	} ).format( amount / 1_000_000 );
+}
+
+/**
+ * Manage the connected site's Superdav AI service account.
+ *
+ * Payment information is never entered or stored in WordPress. Billing actions
+ * open the service-provided account portal in a separate tab.
+ *
+ * @return {JSX.Element} Account management panel.
+ */
+export default function SuperdavAccountManager() {
+	const [ account, setAccount ] = useState( null );
+	const [ loading, setLoading ] = useState( true );
+	const [ refreshing, setRefreshing ] = useState( false );
+	const [ error, setError ] = useState( '' );
+
+	const loadAccount = useCallback( async ( refresh = false ) => {
+		if ( refresh ) {
+			setRefreshing( true );
+		} else {
+			setLoading( true );
+		}
+		setError( '' );
+
+		try {
+			const result = await apiFetch( {
+				path: '/sd-ai-agent/v1/superdav-account',
+				method: refresh ? 'POST' : 'GET',
+			} );
+			setAccount( result );
+		} catch ( err ) {
+			setError(
+				err?.message ||
+					__(
+						'Unable to load your Superdav AI account.',
+						'superdav-ai-agent'
+					)
+			);
+		} finally {
+			setLoading( false );
+			setRefreshing( false );
+		}
+	}, [] );
+
+	useEffect( () => {
+		loadAccount();
+	}, [ loadAccount ] );
+
+	if ( loading ) {
+		return (
+			<div className="sdaa-superdav-account-loading">
+				<Spinner />
+			</div>
+		);
+	}
+
+	const wallet = account?.wallet || {};
+	const accountUrl = account?.account_portal_url || '';
+	const configured = !! account?.configured;
+	const tier = account?.tier || '';
+
+	return (
+		<div className="sdaa-superdav-account">
+			<div className="sdaa-superdav-account-header">
+				<div>
+					<h3>
+						{ __( 'Superdav AI account', 'superdav-ai-agent' ) }
+					</h3>
+					<p className="description">
+						{ __(
+							'View your available credits and securely manage billing with Superdav AI.',
+							'superdav-ai-agent'
+						) }
+					</p>
+				</div>
+				<Button
+					variant="secondary"
+					onClick={ () => loadAccount( true ) }
+					isBusy={ refreshing }
+					disabled={ refreshing || ! configured }
+				>
+					{ __( 'Refresh balance', 'superdav-ai-agent' ) }
+				</Button>
+			</div>
+
+			{ error && (
+				<Notice status="error" isDismissible={ false }>
+					{ error }
+				</Notice>
+			) }
+
+			{ ! configured ? (
+				<Notice status="warning" isDismissible={ false }>
+					{ __(
+						'Superdav AI is not connected for this site yet. Connect a provider before managing account credits.',
+						'superdav-ai-agent'
+					) }
+				</Notice>
+			) : (
+				<>
+					<div className="sdaa-superdav-account-balance">
+						<div className="sdaa-superdav-account-balance-label">
+							{ __( 'Available balance', 'superdav-ai-agent' ) }
+						</div>
+						<div className="sdaa-superdav-account-balance-value">
+							{ formatWalletAmount( wallet.total_usd_micros ) }
+						</div>
+						{ tier && (
+							<div className="sdaa-superdav-account-tier">
+								{ sprintf(
+									/* translators: %s: Superdav AI service tier. */
+									__( 'Plan: %s', 'superdav-ai-agent' ),
+									tier
+								) }
+							</div>
+						) }
+					</div>
+
+					<div className="sdaa-superdav-account-breakdown">
+						<div>
+							<span>
+								{ __(
+									'Purchased credits',
+									'superdav-ai-agent'
+								) }
+							</span>
+							<strong>
+								{ formatWalletAmount( wallet.cash_usd_micros ) }
+							</strong>
+						</div>
+						<div>
+							<span>
+								{ __(
+									'Promotional credits',
+									'superdav-ai-agent'
+								) }
+							</span>
+							<strong>
+								{ formatWalletAmount(
+									wallet.promo_usd_micros
+								) }
+							</strong>
+						</div>
+					</div>
+
+					{ accountUrl ? (
+						<div className="sdaa-superdav-account-actions">
+							<Button
+								variant="primary"
+								href={ accountUrl }
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								{ __( 'Add credits', 'superdav-ai-agent' ) }
+							</Button>
+							<Button
+								variant="secondary"
+								href={ accountUrl }
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								{ __(
+									'Manage payment methods',
+									'superdav-ai-agent'
+								) }
+							</Button>
+							<Button
+								variant="tertiary"
+								href={ accountUrl }
+								target="_blank"
+								rel="noopener noreferrer"
+							>
+								{ __(
+									'Open account portal',
+									'superdav-ai-agent'
+								) }
+							</Button>
+						</div>
+					) : (
+						<Notice status="info" isDismissible={ false }>
+							{ __(
+								'Account billing is managed by your Superdav AI service administrator.',
+								'superdav-ai-agent'
+							) }
+						</Notice>
+					) }
+				</>
+			) }
+		</div>
+	);
+}

--- a/tests/SdAiAgent/REST/SettingsControllerTest.php
+++ b/tests/SdAiAgent/REST/SettingsControllerTest.php
@@ -199,6 +199,59 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		$this->assertSame( 1, $registration_hits );
 	}
 
+	/** Superdav account refresh returns safe wallet metadata without a bearer token. */
+	public function test_handle_refresh_superdav_account_returns_safe_wallet_metadata(): void {
+		$base_url    = 'https://service.example/v1';
+		$account_url = $base_url . '/site/account';
+		$token       = 'sdaist_account_refresh_token';
+
+		add_filter( 'sd_ai_agent_cloud_base_url', static fn(): string => $base_url );
+		add_filter(
+			'pre_http_request',
+			static function ( mixed $preempt, array $parsed_args, string $url ) use ( $account_url, $token ): mixed {
+				if ( $account_url !== $url ) {
+					return $preempt;
+				}
+
+				self::assertSame( 'Bearer ' . $token, self::authorization_header_from_args( $parsed_args ) );
+
+				return array(
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'body'     => wp_json_encode(
+						array(
+							'tier'               => 'pro',
+							'account_portal_url' => 'https://account.example/billing',
+							'wallet'             => array(
+								'currency'         => 'USD',
+								'promo_usd_micros' => 2500000,
+								'cash_usd_micros'  => 12500000,
+								'total_usd_micros' => 15000000,
+								'payment_token'    => 'must-not-be-exposed',
+							),
+							'access_token'       => 'must-not-be-exposed',
+						)
+					),
+				);
+			},
+			10,
+			3
+		);
+
+		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, $token, false );
+		$response = ( new SettingsController( new Settings(), new Database() ) )->handle_refresh_superdav_account();
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertSame( 15000000, $data['wallet']['total_usd_micros'] );
+		$this->assertSame( 'https://account.example/billing', $data['account_portal_url'] );
+		$this->assertStringNotContainsString( $token, wp_json_encode( $data ) ?: '' );
+		$this->assertStringNotContainsString( 'must-not-be-exposed', wp_json_encode( $data ) ?: '' );
+	}
+
 	/**
 	 * /providers refreshes a stale managed Superdav token when model listing returns 401.
 	 */


### PR DESCRIPTION
## Summary

- Adds a Superdav AI account settings tab with balance, tier, wallet breakdown, refresh, and account/billing portal actions.
- Adds the admin-only account refresh endpoint and server-side metadata scrubbing so bearer tokens and payment fields are not returned to the browser.
- Adds REST coverage for account status redaction and portal metadata.
- Follow-up commit fixes PHPStan's missing iterable value type for account portal metadata.

Resolves #2233

## Worker self-verification

- PHPUnit: Tests: 3744, Assertions: 15692, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

CI also passed canonical naming, lint/style, PHPUnit, static analysis, build/bundle, CodeRabbit, and all three Playwright E2E shards after the PHPStan fix.
