### PR TITLE
GH#2220: clarify tool denial messages

### DIFF
--- a/includes/Abilities/ToolCapabilities.php
+++ b/includes/Abilities/ToolCapabilities.php
@@ -441,17 +441,19 @@ class ToolCapabilities {
 		/** This filter is documented in {@see current_user_can()}. */
 		$resolved_cap = (string) apply_filters( 'sd_ai_agent_tool_capability', $tool_cap, $ability_id );
 
+		$approved_for_turn = self::is_one_turn_approved( $ability_id );
+
 		if ( ! self::tool_layer_passes( $ability_id, $resolved_cap ) ) {
 			$resolved_cap_exists = self::capability_exists( $resolved_cap );
 			$capability          = $resolved_cap_exists ? $resolved_cap : self::FALLBACK_CAP;
 			$layer               = $resolved_cap_exists ? 'per-tool' : 'fallback';
 
-			return self::capability_denial_error( $ability_id, $capability, $layer );
+			return self::capability_denial_error( $ability_id, $capability, $layer, false );
 		}
 
 		foreach ( self::resolve_core_caps( $ability_id ) as $core_cap ) {
 			if ( ! current_user_can( $core_cap ) ) {
-				return self::capability_denial_error( $ability_id, $core_cap, 'core' );
+				return self::capability_denial_error( $ability_id, $core_cap, 'core', $approved_for_turn );
 			}
 		}
 
@@ -496,22 +498,36 @@ class ToolCapabilities {
 	 * @param string $ability_id The denied ability ID.
 	 * @param string $capability Missing capability.
 	 * @param string $layer Permission layer that denied the request.
+	 * @param bool   $approved_for_turn Whether current-turn approval satisfied the tool layer.
 	 */
-	private static function capability_denial_error( string $ability_id, string $capability, string $layer ): \WP_Error {
-		return new \WP_Error(
-			'ability_invalid_permissions',
-			sprintf(
+	private static function capability_denial_error( string $ability_id, string $capability, string $layer, bool $approved_for_turn ): \WP_Error {
+		if ( $approved_for_turn ) {
+			$message = sprintf(
 				/* translators: 1: ability id, 2: WordPress capability, 3: permission layer */
 				__( 'Ability "%1$s" was approved for this turn, but the current WordPress user still lacks the "%2$s" capability required by the %3$s permission layer. Grant that capability or switch to a user role that has it, then approve the tool call again.', 'superdav-ai-agent' ),
 				$ability_id,
 				$capability,
 				$layer
-			),
+			);
+		} else {
+			$message = sprintf(
+				/* translators: 1: ability id, 2: WordPress capability, 3: permission layer */
+				__( 'Ability "%1$s" cannot run because the current WordPress user lacks the "%2$s" capability required by the %3$s permission layer. Grant that capability or switch to a user role that has it, then retry the tool call.', 'superdav-ai-agent' ),
+				$ability_id,
+				$capability,
+				$layer
+			);
+		}
+
+		return new \WP_Error(
+			'ability_invalid_permissions',
+			$message,
 			[
 				'status'             => 403,
 				'ability'            => $ability_id,
 				'missing_capability' => $capability,
 				'permission_layer'   => $layer,
+				'approved_for_turn'  => $approved_for_turn,
 			]
 		);
 	}

--- a/tests/SdAiAgent/Abilities/ToolCapabilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/ToolCapabilitiesTest.php
@@ -203,6 +203,10 @@ class ToolCapabilitiesTest extends WP_UnitTestCase {
 		wp_set_current_user( $editor_id );
 
 		$this->assertFalse( ToolCapabilities::current_user_can( 'sd-ai-agent/list-posts' ) );
+		$error = ToolCapabilities::permission_denial_error( 'sd-ai-agent/list-posts' );
+		$this->assertInstanceOf( \WP_Error::class, $error );
+		$this->assertSame( 'fallback', $error->get_error_data()['permission_layer'] );
+		$this->assertStringNotContainsString( 'approved for this turn', $error->get_error_message() );
 
 		ToolPermissionResolver::set_one_turn_approved_abilities( [ 'sd-ai-agent/list-posts' ] );
 
@@ -258,6 +262,8 @@ class ToolCapabilitiesTest extends WP_UnitTestCase {
 			$this->assertSame( 'ability_invalid_permissions', $error->get_error_code() );
 			$this->assertSame( 'delete_plugins', $error->get_error_data()['missing_capability'] );
 			$this->assertSame( 'core', $error->get_error_data()['permission_layer'] );
+			$this->assertTrue( $error->get_error_data()['approved_for_turn'] );
+			$this->assertStringContainsString( 'approved for this turn', $error->get_error_message() );
 		} finally {
 			ToolPermissionResolver::clear_one_turn_approved_abilities();
 		}
@@ -284,7 +290,7 @@ class ToolCapabilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 'ability_invalid_permissions', $error->get_error_code() );
 		$this->assertSame( 'edit_files', $error->get_error_data()['missing_capability'] );
 		$this->assertSame( 'core', $error->get_error_data()['permission_layer'] );
-		$this->assertStringContainsString( 'approved for this turn', $error->get_error_message() );
+		$this->assertStringNotContainsString( 'approved for this turn', $error->get_error_message() );
 
 		$role->remove_cap( $tool_cap );
 		$role->remove_cap( 'manage_options' );


### PR DESCRIPTION
## Summary

- Clarifies `ability_invalid_permissions` messages so only core-capability denials after one-turn approval say the ability was approved for the turn.
- Keeps per-tool/fallback denials and core denials after role grants focused on the missing WordPress capability.
- Adds regression coverage for approved and non-approved denial message paths.

Resolves #2220

## Worker self-verification

- PHPUnit: Tests: 3743, Assertions: 15690, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Additional local check: `php -l includes/Abilities/ToolCapabilities.php && php -l tests/SdAiAgent/Abilities/ToolCapabilitiesTest.php` passed.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.145 plugin for [OpenCode](https://opencode.ai) v1.18.3
