### PR TITLE
GH#2228: delegate Ultimate Multisite diagnostics

### DIFF
--- a/includes/Abilities/SiteHealthAbilities.php
+++ b/includes/Abilities/SiteHealthAbilities.php
@@ -788,12 +788,12 @@ class SiteHealthAbilities {
 	}
 
 	/**
-	 * Diagnose the public frontend and mapped-tenant availability without mutation.
+	 * Diagnose generic public frontend availability without mutation.
 	 *
-	 * Ultimate Multisite integrations can supply tenant data through the
-	 * `sd_ai_agent_site_availability_tenant_context` filter. Expected keys are
-	 * visits_enabled, visit_limit, current_month_visits, site_type, customer_id,
-	 * membership_id, domain_active, and domain_primary.
+	 * Authoritative tenant, mapped-domain, hosting-lock, and visit-limit facts
+	 * belong to the Ultimate Multisite plugin. This generic WordPress health check
+	 * only reports public HTTP evidence and tells the agent which external ability
+	 * family should be used when Ultimate Multisite is installed.
 	 *
 	 * @return array<string, mixed>
 	 */
@@ -831,33 +831,14 @@ class SiteHealthAbilities {
 				|| str_contains( strtolower( $plain_body ), 'this site is not available at this time' );
 		}
 
-		/**
-		 * Filter read-only tenant availability context supplied by a WaaS plugin.
-		 *
-		 * @param array<string, mixed> $tenant Tenant context.
-		 * @param int                  $blog_id Current blog ID.
-		 * @param string               $url Exact mapped site URL being diagnosed.
-		 */
-		$tenant  = self::get_ultimate_multisite_tenant_context();
-		$tenant  = apply_filters( 'sd_ai_agent_site_availability_tenant_context', $tenant, get_current_blog_id(), $url );
-		$tenant  = is_array( $tenant ) ? $tenant : [];
-		$enabled = ! empty( $tenant['visits_enabled'] );
-		$limit   = isset( $tenant['visit_limit'] ) ? (int) $tenant['visit_limit'] : 0;
-		$current = isset( $tenant['current_month_visits'] ) ? (int) $tenant['current_month_visits'] : 0;
-		$locked  = $enabled && $limit > 0 && $current > $limit;
-
-		$tenant['would_lock_frontend'] = $locked;
-		$tenant['lock_reason']         = $locked ? 'visits_exceeded' : null;
-
 		$is_critical = isset( $frontend['transport_error'] )
 			|| (int) $frontend['status_code'] >= 400
-			|| true === $frontend['wp_die_page']
-			|| $locked;
+			|| true === $frontend['wp_die_page'];
 
 		return [
-			'status'            => $is_critical ? 'critical' : 'healthy',
-			'frontend'          => $frontend,
-			'wordpress_context' => [
+			'status'                => $is_critical ? 'critical' : 'healthy',
+			'frontend'              => $frontend,
+			'wordpress_context'     => [
 				'home'                => home_url(),
 				'siteurl'             => site_url(),
 				'is_multisite'        => is_multisite(),
@@ -866,7 +847,7 @@ class SiteHealthAbilities {
 				'domain_current_site' => defined( 'DOMAIN_CURRENT_SITE' ) ? (string) constant( 'DOMAIN_CURRENT_SITE' ) : null,
 				'install_id'          => basename( untrailingslashit( ABSPATH ) ),
 			],
-			'tenant'            => $tenant,
+			'delegated_diagnostics' => self::get_ultimate_multisite_delegation_guidance(),
 		];
 	}
 
@@ -947,51 +928,16 @@ class SiteHealthAbilities {
 	}
 
 	/**
-	 * Read supported availability fields from the current Ultimate Multisite site.
-	 *
-	 * The filter in diagnose_site_availability remains the integration point for
-	 * versions or extensions that store these values under different keys.
+	 * Return guidance for external Ultimate Multisite availability diagnosis.
 	 *
 	 * @return array<string, mixed>
 	 */
-	private static function get_ultimate_multisite_tenant_context(): array {
-		if ( ! function_exists( 'wu_get_current_site' ) ) {
-			return [];
-		}
-
-		$site = wu_get_current_site();
-		if ( ! is_object( $site ) ) {
-			return [];
-		}
-
-		$tenant  = [];
-		$methods = [
-			'site_type'            => 'get_type',
-			'customer_id'          => 'get_customer_id',
-			'membership_id'        => 'get_membership_id',
-			'current_month_visits' => 'get_visits_count',
+	private static function get_ultimate_multisite_delegation_guidance(): array {
+		return [
+			'ultimate_multisite_authoritative' => true,
+			'expected_ability'                 => 'multisite-ultimate/site-availability-diagnose',
+			'fallback_guidance'                => 'If the Ultimate Multisite diagnostic ability is unavailable, report that authoritative tenant lock diagnostics are unavailable instead of inferring visit limits, domain mapping state, or lock reasons from Superdav AI Agent.',
 		];
-		foreach ( $methods as $key => $method ) {
-			if ( is_callable( [ $site, $method ] ) ) {
-				$tenant[ $key ] = $site->{$method}();
-			}
-		}
-
-		if ( is_callable( [ $site, 'get_meta' ] ) ) {
-			$meta_keys = [
-				'visits_enabled'       => 'visits_enabled',
-				'visit_limit'          => 'visits_limit',
-				'current_month_visits' => 'visits_current_month',
-			];
-			foreach ( $meta_keys as $key => $meta_key ) {
-				$value = $site->get_meta( $meta_key );
-				if ( ! array_key_exists( $key, $tenant ) && null !== $value && '' !== $value ) {
-					$tenant[ $key ] = $value;
-				}
-			}
-		}
-
-		return $tenant;
 	}
 
 	/**

--- a/includes/Models/skills/multisite-management.md
+++ b/includes/Models/skills/multisite-management.md
@@ -13,6 +13,12 @@ Use this skill when the user asks about managing a WordPress Multisite network �
 - `wp site archive <id>` — Archive a site
 - Mapped custom domains must be diagnosed using their exact public URL. Pass `--url=<mapped-site-url>` so WordPress selects the intended blog; a network-domain check can target a different tenant and hide frontend locks.
 
+### Ultimate Multisite Availability
+- Start with a public smoke check against the exact mapped frontend URL.
+- Verify the live WordPress context before reading site facts: `ABSPATH`, `home_url()`, `get_current_blog_id()`, and `wp --url=<mapped-site-url> ...` must all point at the intended tenant.
+- Authoritative tenant, domain, hosting, limit, and lock-state diagnostics belong to Ultimate Multisite. If the `multisite-ultimate/site-availability-diagnose` ability is available, call it for those facts instead of inferring them in Superdav AI Agent.
+- If the Ultimate Multisite diagnostic ability is unavailable, say that authoritative tenant lock diagnostics are unavailable and recommend using the Ultimate Multisite admin/API. Do not guess lock reasons from raw SQL, `wu_*` meta, or Superdav-owned visit calculations.
+
 ### Super Admins
 - `wp super-admin list` — List super admins
 - `wp super-admin add <user>` — Grant super admin
@@ -42,4 +48,4 @@ After network changes:
 2. Check that plugins/themes are correctly activated
 3. Confirm user roles across relevant sites
 4. Test network admin access
-5. For Ultimate Multisite customer-owned sites, verify the primary domain mapping and tenant limits (including monthly visits) against the exact mapped URL
+5. For Ultimate Multisite customer-owned sites, delegate primary domain mapping, tenant limits, monthly visits, and lock-state diagnosis to `multisite-ultimate/site-availability-diagnose` or the Ultimate Multisite admin/API

--- a/includes/Models/skills/site-troubleshooting.md
+++ b/includes/Models/skills/site-troubleshooting.md
@@ -9,7 +9,7 @@ Use this skill when the user reports errors, performance issues, white screens, 
 - Run `sd-ai-agent/site-health-summary` first and inspect its `availability` result. A public frontend HTTP 4xx/5xx or WordPress `wp_die` page is critical even when REST, login, and admin routes work.
 - Compare the exact public frontend host with REST, login, and admin responses; do not infer frontend health from an API-only check.
 - On Multisite, target the mapped site URL exactly (`wp --url=<mapped-site-url> ...`) and verify the returned blog/domain context before inspecting tenant limits.
-- For Ultimate Multisite tenants, inspect the active/primary domain mapping, site/customer/membership identity, monthly-visits setting, limit, and current-month total. Keep diagnosis read-only unless remediation was explicitly requested.
+- For Ultimate Multisite tenants, call `multisite-ultimate/site-availability-diagnose` when available for active/primary domain mapping, site/customer/membership identity, monthly visits, limits, and lock reasons. If that ability/API is unavailable, say authoritative tenant lock diagnostics are unavailable and use the Ultimate Multisite admin/API; do not infer lock reasons from raw SQL, `wu_*` meta, or Superdav-owned visit calculations.
 
 ### Error Investigation
 - `wp option get siteurl` / `wp option get home` — Check for URL mismatches

--- a/tests/SdAiAgent/Abilities/SiteHealthAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/SiteHealthAbilitiesTest.php
@@ -452,7 +452,7 @@ class SiteHealthAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A normal frontend response without a tenant lock must remain healthy.
+	 * A normal frontend response must remain healthy without tenant inference.
 	 */
 	public function test_availability_reports_healthy_frontend() {
 		add_filter(
@@ -475,15 +475,17 @@ class SiteHealthAbilitiesTest extends WP_UnitTestCase {
 			$this->assertFalse( $result['frontend']['wp_die_page'] );
 			$this->assertArrayNotHasKey( 'transport_error', $result['frontend'] );
 			$this->assertArrayNotHasKey( 'effective_url', $result['frontend'] );
+			$this->assertArrayNotHasKey( 'tenant', $result );
+			$this->assertSame( 'multisite-ultimate/site-availability-diagnose', $result['delegated_diagnostics']['expected_ability'] );
 		} finally {
 			remove_all_filters( 'pre_http_request' );
 		}
 	}
 
 	/**
-	 * Ultimate Multisite visit overages must expose the frontend lock reason.
+	 * Tenant locks must be delegated to Ultimate Multisite diagnostics.
 	 */
-	public function test_availability_reports_tenant_visit_limit_lock() {
+	public function test_availability_delegates_tenant_lock_diagnosis() {
 		add_filter(
 			'pre_http_request',
 			static function () {
@@ -496,23 +498,16 @@ class SiteHealthAbilitiesTest extends WP_UnitTestCase {
 				];
 			}
 		);
-		add_filter(
-			'sd_ai_agent_site_availability_tenant_context',
-			static fn() => [
-				'visits_enabled'      => true,
-				'visit_limit'         => 2,
-				'current_month_visits' => 3,
-			]
-		);
 
 		try {
 			$result = SiteHealthAbilities::diagnose_site_availability();
-			$this->assertSame( 'critical', $result['status'] );
-			$this->assertTrue( $result['tenant']['would_lock_frontend'] );
-			$this->assertSame( 'visits_exceeded', $result['tenant']['lock_reason'] );
+			$this->assertSame( 'healthy', $result['status'] );
+			$this->assertArrayNotHasKey( 'tenant', $result );
+			$this->assertTrue( $result['delegated_diagnostics']['ultimate_multisite_authoritative'] );
+			$this->assertSame( 'multisite-ultimate/site-availability-diagnose', $result['delegated_diagnostics']['expected_ability'] );
+			$this->assertStringContainsString( 'authoritative tenant lock diagnostics are unavailable', $result['delegated_diagnostics']['fallback_guidance'] );
 		} finally {
 			remove_all_filters( 'pre_http_request' );
-			remove_all_filters( 'sd_ai_agent_site_availability_tenant_context' );
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Removes Superdav-owned Ultimate Multisite tenant/visit-limit lock inference from `sd-ai-agent/site-health-summary` availability diagnostics.
- Keeps generic public frontend smoke checks for HTTP status, response title, body fingerprint, and `wp_die` unavailable pages.
- Adds explicit delegation guidance to call `multisite-ultimate/site-availability-diagnose` or the Ultimate Multisite admin/API for authoritative tenant/domain/lock facts.
- Updates the multisite and site-troubleshooting skills plus regression tests so Superdav validates delegation, not Ultimate Multisite enforcement logic.

Resolves #2228

## Worker self-verification

- PHPUnit: Tests: 3743, Assertions: 15689, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Additional focused check: `npm run test:php -- --filter=SiteHealthAbilitiesTest` passed with 34 tests and 138 assertions.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.145 plugin for [OpenCode](https://opencode.ai) v1.18.3
