### PR TITLE
GH#2237: harden Superdav account settings

### DIFF
--- a/includes/Core/SuperdavSiteConnectionService.php
+++ b/includes/Core/SuperdavSiteConnectionService.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Core;
 
+use SdAiAgent\Abilities\OptionsAbilities;
 use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
 use WP_Error;
 
@@ -124,7 +125,18 @@ final class SuperdavSiteConnectionService {
 			return new WP_Error( 'sd_ai_agent_cloud_account_invalid', __( 'Superdav AI account response was invalid.', 'superdav-ai-agent' ), array( 'status' => 502 ) );
 		}
 
-		$metadata = array_merge( $this->get_metadata(), $this->sanitize_remote_metadata( $body ) );
+		$metadata = $this->get_metadata();
+		unset(
+			$metadata['tier'],
+			$metadata['verified'],
+			$metadata['connect_required'],
+			$metadata['request_id'],
+			$metadata['account_portal_url'],
+			$metadata['usage'],
+			$metadata['verification'],
+			$metadata['wallet']
+		);
+		$metadata = array_merge( $metadata, $this->sanitize_remote_metadata( $body ) );
 		update_option( self::TOKEN_METADATA_OPTION, $metadata, false );
 
 		return $this->get_status();
@@ -276,7 +288,9 @@ final class SuperdavSiteConnectionService {
 		$default_url = is_string( $default_url ) ? $default_url : '';
 		$url         = apply_filters( 'sd_ai_agent_cloud_account_connect_url', $default_url, $this->get_installation_id(), $this->get_verified_site_url() );
 
-		return is_string( $url ) ? esc_url_raw( $url ) : '';
+		$url = is_string( $url ) ? esc_url_raw( $url ) : '';
+
+		return $this->account_portal_url_has_secret_query_key( $url ) ? '' : $url;
 	}
 
 	/**
@@ -475,6 +489,15 @@ final class SuperdavSiteConnectionService {
 			}
 		}
 
+		if ( isset( $safe['account_portal_url'] ) ) {
+			$url = is_string( $safe['account_portal_url'] ) ? esc_url_raw( $safe['account_portal_url'] ) : '';
+			if ( '' === $url || $this->account_portal_url_has_secret_query_key( $url ) ) {
+				unset( $safe['account_portal_url'] );
+			} else {
+				$safe['account_portal_url'] = $url;
+			}
+		}
+
 		if ( isset( $metadata['usage'] ) && is_array( $metadata['usage'] ) ) {
 			$safe['usage'] = array_filter(
 				$metadata['usage'],
@@ -494,6 +517,39 @@ final class SuperdavSiteConnectionService {
 		}
 
 		return $safe;
+	}
+
+	/**
+	 * Determine whether an account portal URL contains a blocked secret query key.
+	 */
+	private function account_portal_url_has_secret_query_key( string $url ): bool {
+		$query = wp_parse_url( $url, PHP_URL_QUERY );
+		if ( ! is_string( $query ) || '' === $query ) {
+			return false;
+		}
+
+		$parameters = array();
+		parse_str( $query, $parameters );
+
+		$pending = array( $parameters );
+		while ( array() !== $pending ) {
+			$current = array_pop( $pending );
+			if ( ! is_array( $current ) ) {
+				continue;
+			}
+
+			foreach ( $current as $key => $value ) {
+				if ( is_string( $key ) && OptionsAbilities::is_secret_option_name( $key ) ) {
+					return true;
+				}
+
+				if ( is_array( $value ) ) {
+					$pending[] = $value;
+				}
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/src/settings-page/__tests__/superdav-account-manager.test.js
+++ b/src/settings-page/__tests__/superdav-account-manager.test.js
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for settings-page/superdav-account-manager.js.
+ */
+
+import { createElement } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+import SuperdavAccountManager, {
+	formatWalletAmount,
+} from '../superdav-account-manager';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+describe( 'SuperdavAccountManager', () => {
+	let createRoot;
+	let act;
+	let container;
+	let root;
+
+	beforeAll( () => {
+		// eslint-disable-next-line global-require
+		( { createRoot } = require( 'react-dom/client' ) );
+		// eslint-disable-next-line global-require
+		( { act } = require( 'react' ) );
+	} );
+
+	beforeEach( () => {
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		root = createRoot( container );
+	} );
+
+	afterEach( () => {
+		act( () => {
+			root.unmount();
+		} );
+		document.body.removeChild( container );
+		apiFetch.mockReset();
+	} );
+
+	test( 'treats absent wallet amounts as unknown', () => {
+		expect( formatWalletAmount( null ) ).toBe( '—' );
+		expect( formatWalletAmount( undefined ) ).toBe( '—' );
+		expect( formatWalletAmount( '' ) ).toBe( '—' );
+		expect( formatWalletAmount( 0 ) ).not.toBe( '—' );
+	} );
+
+	test( 'does not show a disconnected warning after a failed request', async () => {
+		apiFetch.mockRejectedValue( new Error( 'Account request failed.' ) );
+
+		await act( async () => {
+			root.render( createElement( SuperdavAccountManager, {} ) );
+		} );
+		await act( async () => {
+			await Promise.resolve();
+		} );
+
+		expect( container.textContent ).toContain( 'Account request failed.' );
+		expect( container.textContent ).not.toContain(
+			'Superdav AI is not connected for this site yet.'
+		);
+	} );
+
+	test( 'shows a disconnected warning only after a successful response', async () => {
+		apiFetch.mockResolvedValue( { configured: false } );
+
+		await act( async () => {
+			root.render( createElement( SuperdavAccountManager, {} ) );
+		} );
+		await act( async () => {
+			await Promise.resolve();
+		} );
+
+		expect( container.textContent ).toContain(
+			'Superdav AI is not connected for this site yet.'
+		);
+		expect(
+			container.querySelector( '.sd-ai-agent-superdav-account' )
+		).not.toBeNull();
+	} );
+} );

--- a/src/settings-page/style.css
+++ b/src/settings-page/style.css
@@ -477,75 +477,75 @@
 }
 
 /* Superdav AI account manager */
-.sdaa-superdav-account-loading {
+.sd-ai-agent-superdav-account-loading {
 	padding: 40px;
 	text-align: center;
 }
 
-.sdaa-superdav-account-header {
+.sd-ai-agent-superdav-account-header {
 	display: flex;
 	align-items: flex-start;
 	justify-content: space-between;
 	gap: 16px;
 }
 
-.sdaa-superdav-account-header h3 {
+.sd-ai-agent-superdav-account-header h3 {
 	margin: 0 0 4px;
 	font-size: 15px;
 }
 
-.sdaa-superdav-account-header .description {
+.sd-ai-agent-superdav-account-header .description {
 	margin: 0;
 }
 
-.sdaa-superdav-account-balance {
+.sd-ai-agent-superdav-account-balance {
 	padding: 20px;
 	border: 1px solid #c5d9ed;
 	border-radius: 6px;
 	background: #f0f6fc;
 }
 
-.sdaa-superdav-account-balance-label,
-.sdaa-superdav-account-tier,
-.sdaa-superdav-account-breakdown span {
+.sd-ai-agent-superdav-account-balance-label,
+.sd-ai-agent-superdav-account-tier,
+.sd-ai-agent-superdav-account-breakdown span {
 	display: block;
 	color: #50575e;
 	font-size: 12px;
 }
 
-.sdaa-superdav-account-balance-value {
+.sd-ai-agent-superdav-account-balance-value {
 	margin: 4px 0;
 	font-size: 28px;
 	font-weight: 600;
 	line-height: 1.2;
 }
 
-.sdaa-superdav-account-breakdown {
+.sd-ai-agent-superdav-account-breakdown {
 	display: grid;
 	grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 	gap: 12px;
 }
 
-.sdaa-superdav-account-breakdown > div {
+.sd-ai-agent-superdav-account-breakdown > div {
 	padding: 12px 14px;
 	border: 1px solid #dcdcde;
 	border-radius: 4px;
 }
 
-.sdaa-superdav-account-breakdown strong {
+.sd-ai-agent-superdav-account-breakdown strong {
 	display: block;
 	margin-top: 4px;
 	font-size: 16px;
 }
 
-.sdaa-superdav-account-actions {
+.sd-ai-agent-superdav-account-actions {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 8px;
 }
 
 @media screen and (max-width: 600px) {
-	.sdaa-superdav-account-header {
+	.sd-ai-agent-superdav-account-header {
 		flex-direction: column;
 	}
 }

--- a/src/settings-page/superdav-account-manager.js
+++ b/src/settings-page/superdav-account-manager.js
@@ -7,10 +7,14 @@ import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 
 /**
- * @param {number|string} micros Amount in millionths of a US dollar.
+ * @param {number|string|null|undefined} micros Amount in millionths of a US dollar.
  * @return {string} Localized amount, or an em dash when unknown.
  */
-function formatWalletAmount( micros ) {
+export function formatWalletAmount( micros ) {
+	if ( micros === null || micros === undefined || micros === '' ) {
+		return '—';
+	}
+
 	const amount = Number( micros );
 	if ( ! Number.isFinite( amount ) ) {
 		return '—';
@@ -35,6 +39,7 @@ export default function SuperdavAccountManager() {
 	const [ loading, setLoading ] = useState( true );
 	const [ refreshing, setRefreshing ] = useState( false );
 	const [ error, setError ] = useState( '' );
+	const [ hasLoadedAccount, setHasLoadedAccount ] = useState( false );
 
 	const loadAccount = useCallback( async ( refresh = false ) => {
 		if ( refresh ) {
@@ -50,6 +55,7 @@ export default function SuperdavAccountManager() {
 				method: refresh ? 'POST' : 'GET',
 			} );
 			setAccount( result );
+			setHasLoadedAccount( true );
 		} catch ( err ) {
 			setError(
 				err?.message ||
@@ -70,7 +76,7 @@ export default function SuperdavAccountManager() {
 
 	if ( loading ) {
 		return (
-			<div className="sdaa-superdav-account-loading">
+			<div className="sd-ai-agent-superdav-account-loading">
 				<Spinner />
 			</div>
 		);
@@ -82,8 +88,8 @@ export default function SuperdavAccountManager() {
 	const tier = account?.tier || '';
 
 	return (
-		<div className="sdaa-superdav-account">
-			<div className="sdaa-superdav-account-header">
+		<div className="sd-ai-agent-superdav-account">
+			<div className="sd-ai-agent-superdav-account-header">
 				<div>
 					<h3>
 						{ __( 'Superdav AI account', 'superdav-ai-agent' ) }
@@ -111,103 +117,111 @@ export default function SuperdavAccountManager() {
 				</Notice>
 			) }
 
-			{ ! configured ? (
-				<Notice status="warning" isDismissible={ false }>
-					{ __(
-						'Superdav AI is not connected for this site yet. Connect a provider before managing account credits.',
-						'superdav-ai-agent'
-					) }
-				</Notice>
-			) : (
-				<>
-					<div className="sdaa-superdav-account-balance">
-						<div className="sdaa-superdav-account-balance-label">
-							{ __( 'Available balance', 'superdav-ai-agent' ) }
-						</div>
-						<div className="sdaa-superdav-account-balance-value">
-							{ formatWalletAmount( wallet.total_usd_micros ) }
-						</div>
-						{ tier && (
-							<div className="sdaa-superdav-account-tier">
-								{ sprintf(
-									/* translators: %s: Superdav AI service tier. */
-									__( 'Plan: %s', 'superdav-ai-agent' ),
-									tier
+			{ hasLoadedAccount &&
+				( ! configured ? (
+					<Notice status="warning" isDismissible={ false }>
+						{ __(
+							'Superdav AI is not connected for this site yet. Connect a provider before managing account credits.',
+							'superdav-ai-agent'
+						) }
+					</Notice>
+				) : (
+					<>
+						<div className="sd-ai-agent-superdav-account-balance">
+							<div className="sd-ai-agent-superdav-account-balance-label">
+								{ __(
+									'Available balance',
+									'superdav-ai-agent'
 								) }
 							</div>
-						) }
-					</div>
-
-					<div className="sdaa-superdav-account-breakdown">
-						<div>
-							<span>
-								{ __(
-									'Purchased credits',
-									'superdav-ai-agent'
-								) }
-							</span>
-							<strong>
-								{ formatWalletAmount( wallet.cash_usd_micros ) }
-							</strong>
-						</div>
-						<div>
-							<span>
-								{ __(
-									'Promotional credits',
-									'superdav-ai-agent'
-								) }
-							</span>
-							<strong>
+							<div className="sd-ai-agent-superdav-account-balance-value">
 								{ formatWalletAmount(
-									wallet.promo_usd_micros
+									wallet.total_usd_micros
 								) }
-							</strong>
-						</div>
-					</div>
-
-					{ accountUrl ? (
-						<div className="sdaa-superdav-account-actions">
-							<Button
-								variant="primary"
-								href={ accountUrl }
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								{ __( 'Add credits', 'superdav-ai-agent' ) }
-							</Button>
-							<Button
-								variant="secondary"
-								href={ accountUrl }
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								{ __(
-									'Manage payment methods',
-									'superdav-ai-agent'
-								) }
-							</Button>
-							<Button
-								variant="tertiary"
-								href={ accountUrl }
-								target="_blank"
-								rel="noopener noreferrer"
-							>
-								{ __(
-									'Open account portal',
-									'superdav-ai-agent'
-								) }
-							</Button>
-						</div>
-					) : (
-						<Notice status="info" isDismissible={ false }>
-							{ __(
-								'Account billing is managed by your Superdav AI service administrator.',
-								'superdav-ai-agent'
+							</div>
+							{ tier && (
+								<div className="sd-ai-agent-superdav-account-tier">
+									{ sprintf(
+										/* translators: %s: Superdav AI service tier. */
+										__( 'Plan: %s', 'superdav-ai-agent' ),
+										tier
+									) }
+								</div>
 							) }
-						</Notice>
-					) }
-				</>
-			) }
+						</div>
+
+						<div className="sd-ai-agent-superdav-account-breakdown">
+							<div>
+								<span>
+									{ __(
+										'Purchased credits',
+										'superdav-ai-agent'
+									) }
+								</span>
+								<strong>
+									{ formatWalletAmount(
+										wallet.cash_usd_micros
+									) }
+								</strong>
+							</div>
+							<div>
+								<span>
+									{ __(
+										'Promotional credits',
+										'superdav-ai-agent'
+									) }
+								</span>
+								<strong>
+									{ formatWalletAmount(
+										wallet.promo_usd_micros
+									) }
+								</strong>
+							</div>
+						</div>
+
+						{ accountUrl ? (
+							<div className="sd-ai-agent-superdav-account-actions">
+								<Button
+									variant="primary"
+									href={ accountUrl }
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									{ __( 'Add credits', 'superdav-ai-agent' ) }
+								</Button>
+								<Button
+									variant="secondary"
+									href={ accountUrl }
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									{ __(
+										'Manage payment methods',
+										'superdav-ai-agent'
+									) }
+								</Button>
+								<Button
+									variant="tertiary"
+									href={ accountUrl }
+									target="_blank"
+									rel="noopener noreferrer"
+								>
+									{ __(
+										'Open account portal',
+										'superdav-ai-agent'
+									) }
+								</Button>
+							</div>
+						) : (
+							<Notice status="info" isDismissible={ false }>
+								{ __(
+									'Account billing is managed by your Superdav AI service administrator.',
+									'superdav-ai-agent'
+								) }
+							</Notice>
+						) }
+					</>
+				) ) }
 		</div>
 	);
 }

--- a/tests/SdAiAgent/REST/SettingsControllerTest.php
+++ b/tests/SdAiAgent/REST/SettingsControllerTest.php
@@ -45,6 +45,7 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		delete_option( SuperdavSiteConnectionService::INSTALLATION_ID_OPTION );
 		delete_option( SuperdavSiteConnectionService::TOKEN_METADATA_OPTION );
 		remove_all_filters( 'sd_ai_agent_cloud_base_url' );
+		remove_all_filters( 'sd_ai_agent_options_read_blocklist' );
 		remove_all_filters( 'pre_http_request' );
 		parent::tear_down();
 	}
@@ -241,6 +242,15 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		);
 
 		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, $token, false );
+		update_option(
+			SuperdavSiteConnectionService::TOKEN_METADATA_OPTION,
+			array(
+				'connected_at' => '2026-07-16T00:00:00+00:00',
+				'usage'        => array( 'requests' => 99 ),
+				'verification' => array( 'status' => 'stale' ),
+			),
+			false
+		);
 		$response = ( new SettingsController( new Settings(), new Database() ) )->handle_refresh_superdav_account();
 
 		$this->assertInstanceOf( \WP_REST_Response::class, $response );
@@ -248,8 +258,62 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		$data = $response->get_data();
 		$this->assertSame( 15000000, $data['wallet']['total_usd_micros'] );
 		$this->assertSame( 'https://account.example/billing', $data['account_portal_url'] );
+		$this->assertSame( '2026-07-16T00:00:00+00:00', $data['connected_at'] );
+		$this->assertArrayNotHasKey( 'usage', $data );
+		$this->assertArrayNotHasKey( 'verification', $data );
 		$this->assertStringNotContainsString( $token, wp_json_encode( $data ) ?: '' );
 		$this->assertStringNotContainsString( 'must-not-be-exposed', wp_json_encode( $data ) ?: '' );
+	}
+
+	/** Account portal URLs containing centrally blocked query keys are not exposed. */
+	public function test_handle_refresh_superdav_account_rejects_secret_portal_query(): void {
+		$base_url    = 'https://service.example/v1';
+		$account_url = $base_url . '/site/account';
+
+		add_filter( 'sd_ai_agent_cloud_base_url', static fn(): string => $base_url );
+		add_filter(
+			'sd_ai_agent_options_read_blocklist',
+			static function ( array $blocklist ): array {
+				$blocklist[] = 'access_token';
+
+				return $blocklist;
+			}
+		);
+		add_filter(
+			'pre_http_request',
+			static function ( mixed $preempt, array $parsed_args, string $url ) use ( $account_url ): mixed {
+				if ( $account_url !== $url ) {
+					return $preempt;
+				}
+
+				return array(
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'body'     => wp_json_encode(
+						array(
+							'account_portal_url' => 'https://account.example/billing?access_token=must-not-be-exposed',
+						)
+					),
+				);
+			},
+			10,
+			3
+		);
+
+		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, 'sdaist_portal_test_token', false );
+		$response = ( new SettingsController( new Settings(), new Database() ) )->handle_refresh_superdav_account();
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertSame( '', $data['account_portal_url'] );
+		$this->assertStringNotContainsString( 'must-not-be-exposed', wp_json_encode( $data ) ?: '' );
+		$this->assertStringNotContainsString(
+			'must-not-be-exposed',
+			wp_json_encode( get_option( SuperdavSiteConnectionService::TOKEN_METADATA_OPTION, array() ) ) ?: ''
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Clears stale refresh-owned account metadata before applying service responses.
- Rejects account portal URLs whose query keys match the central secret option blocklist.
- Renames account-settings CSS classes to the required `sd-ai-agent-` prefix.
- Treats empty/null wallet balances as unknown and avoids showing the disconnected notice after fetch failures.
- Adds regression coverage for stale metadata, secret portal parameters, wallet formatting, and request-state rendering.

Resolves #2237

## Worker self-verification

- PHPUnit: Tests: 3745, Assertions: 15709, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

CI also passed canonical naming, lint/style, PHPUnit, static analysis, build/bundle, CodeRabbit, and all three Playwright E2E shards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Account portal links containing sensitive query parameters are now blocked.
  - Account status data is sanitized before being displayed or stored.
  - Account details now render only after the account request completes.

- **Bug Fixes**
  - Connection errors no longer incorrectly show a “not connected” warning.
  - Unknown wallet amounts display an em dash instead of an invalid value.
  - Updated account manager styling and responsive layout selectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->