### PR TITLE
fix: clarify provider payload limit errors

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -1801,6 +1801,16 @@ class AgentLoop {
 	 * @param int                      $status_code HTTP status code, or 0 when unknown.
 	 */
 	private function provider_error_to_wp_error( $error, int $status_code ): WP_Error {
+		if ( 413 === $status_code ) {
+			return new WP_Error(
+				'sd_ai_agent_provider_payload_too_large',
+				__( 'The AI provider rejected this request because it exceeds its payload limit. Start a new chat and send a smaller request. If you attached files, remove or reduce them before retrying.', 'superdav-ai-agent' ),
+				array(
+					'status_code' => $status_code,
+				)
+			);
+		}
+
 		if ( $error instanceof WP_Error ) {
 			return $error;
 		}

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -867,6 +867,26 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertSame( 1, $call_count );
 	}
 
+	/**
+	 * A provider 413 must explain how to reduce the request instead of exposing
+	 * the SDK transport error, which offers no recovery action to the user.
+	 */
+	public function test_run_returns_actionable_error_on_payload_too_large(): void {
+		$loop   = new AgentLoop( 'Hello' );
+		$method = new \ReflectionMethod( AgentLoop::class, 'provider_error_to_wp_error' );
+		$method->setAccessible( true );
+		$result = $method->invoke(
+			$loop,
+			new \WP_Error( 'http_request_failed', 'Client error (413): Payload Too Large' ),
+			413
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_provider_payload_too_large', $result->get_error_code() );
+		$this->assertStringContainsString( 'Start a new chat', $result->get_error_message() );
+		$this->assertSame( 413, $result->get_error_data()['status_code'] );
+	}
+
 	// -------------------------------------------------------------------------
 	// Tool call / confirmation flow
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Map upstream HTTP 413 responses to a clear recovery action rather than exposing the WordPress AI Client SDK transport error.
- Tell users to begin a new chat and reduce pasted content or attachments before retrying.
- Add a direct regression test for the provider-error mapper.

## Scope and diagnosis

The plugin delegates model calls to the configured provider through the WordPress AI Client SDK. The reported error proves that the selected provider or its proxy rejected the request; it does not identify OpenAI specifically. The follow-up work will record safe request-size diagnostics and strengthen compaction before attributing a provider-specific limit.

## Worker self-verification
- PHPUnit: Tests: 3745, Assertions: 15705, Errors: 0, Failures: 0, Skipped: 121, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Ref #2241

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.147 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-terra spent 23m and 261,022 tokens on this with the user in an interactive session.
