### PR TITLE
GH#2241: prevent provider payload-limit failures

### DIFF
--- a/includes/Core/AgentEventLog.php
+++ b/includes/Core/AgentEventLog.php
@@ -76,6 +76,15 @@ class AgentEventLog {
 		'status_code',
 		'reason',
 		'duration_ms',
+		'request_bytes',
+		'request_bytes_estimate',
+		'request_tokens_estimate',
+		'request_budget_bytes',
+		'request_size_class',
+		'request_size_source',
+		'local_rejection',
+		'fallback_attempted',
+		'payload_reduced',
 	);
 
 	/**

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -42,6 +42,7 @@ use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\DTO\ModelMessage;
 use WordPress\AiClient\Messages\DTO\UserMessage;
 use WordPress\AiClient\Messages\Enums\MessageRoleEnum;
+use WordPress\AiClient\Results\DTO\GenerativeAiResult;
 use WordPress\AiClient\Tools\DTO\FunctionCall;
 use WordPress\AiClient\Tools\DTO\FunctionResponse;
 
@@ -206,13 +207,6 @@ class AgentLoop {
 
 	/** @var list<string> Per-agent Tier 1 tool override (empty = use global default). */
 	private array $agent_tier_1_tools = array();
-
-	/**
-	 * Whether this run already consumed its single reduced-payload 413 fallback.
-	 *
-	 * @var bool
-	 */
-	private bool $provider_payload_fallback_used = false;
 
 	/** @var list<string> Ability names approved for one resumed confirmation turn. */
 	private array $approved_once_abilities = array();
@@ -1134,16 +1128,18 @@ class AgentLoop {
 					$followup_result       = $this->send_prompt_with_payload_recovery();
 					$this->last_loop_phase = 'provider_followup_response_received';
 
-					if ( ! is_wp_error( $followup_result ) ) {
-						$followup_message = $followup_result->toMessage();
-						$this->append_assistant_message_to_history( $followup_message );
-						$this->accumulate_tokens( $followup_result );
+					if ( is_wp_error( $followup_result ) ) {
+						return $this->with_error_recovery_data( $followup_result );
+					}
 
-						try {
-							$reply = $followup_result->toText();
-						} catch ( \RuntimeException $e ) {
-							$reply = '';
-						}
+					$followup_message = $followup_result->toMessage();
+					$this->append_assistant_message_to_history( $followup_message );
+					$this->accumulate_tokens( $followup_result );
+
+					try {
+						$reply = $followup_result->toText();
+					} catch ( \RuntimeException $e ) {
+						$reply = '';
 					}
 				}
 
@@ -1384,34 +1380,36 @@ class AgentLoop {
 			$fallback_result       = $this->send_prompt_with_payload_recovery();
 			$this->last_loop_phase = 'provider_fallback_response_received';
 
-			if ( ! is_wp_error( $fallback_result ) ) {
-				$fallback_message = $fallback_result->toMessage();
-				$this->append_assistant_message_to_history( $fallback_message );
-				$this->accumulate_tokens( $fallback_result );
-
-				$reply = '';
-				try {
-					$reply = $fallback_result->toText();
-				} catch ( \RuntimeException $e ) {
-					$reply = '';
-				}
-
-				// Post-process the reply to inject real permalinks from create-post responses.
-				$reply = $this->inject_real_permalinks( $reply );
-
-				return $this->inject_inability_data(
-					$this->with_result_logs(
-						array(
-							'reply'           => $reply,
-							'history'         => $this->serialize_history(),
-							'tool_calls'      => $this->tool_call_log,
-							'token_usage'     => $this->token_usage,
-							'iterations_used' => $this->iterations_used,
-							'model_id'        => $this->model_id,
-						)
-					)
-				);
+			if ( is_wp_error( $fallback_result ) ) {
+				return $this->with_error_recovery_data( $fallback_result );
 			}
+
+			$fallback_message = $fallback_result->toMessage();
+			$this->append_assistant_message_to_history( $fallback_message );
+			$this->accumulate_tokens( $fallback_result );
+
+			$reply = '';
+			try {
+				$reply = $fallback_result->toText();
+			} catch ( \RuntimeException $e ) {
+				$reply = '';
+			}
+
+			// Post-process the reply to inject real permalinks from create-post responses.
+			$reply = $this->inject_real_permalinks( $reply );
+
+			return $this->inject_inability_data(
+				$this->with_result_logs(
+					array(
+						'reply'           => $reply,
+						'history'         => $this->serialize_history(),
+						'tool_calls'      => $this->tool_call_log,
+						'token_usage'     => $this->token_usage,
+						'iterations_used' => $this->iterations_used,
+						'model_id'        => $this->model_id,
+					)
+				)
+			);
 		}
 
 		// Exhausted iterations — return what we have so callers can inspect the log.
@@ -1451,9 +1449,9 @@ class AgentLoop {
 	 *
 	 * @return \WordPress\AiClient\Results\DTO\GenerativeAiResult|WP_Error
 	 */
-	private function send_prompt_with_payload_recovery() {
+	private function send_prompt_with_payload_recovery(): GenerativeAiResult|WP_Error {
 		$provider_id  = $this->resolve_provider_id();
-		$model_id     = (string) $this->model_id;
+		$model_id     = $this->resolve_effective_model_id( $provider_id );
 		$byte_budget  = ConversationTrimmer::get_request_byte_budget( $provider_id, $model_id );
 		$token_budget = ConversationTrimmer::get_request_token_budget( $provider_id, $model_id );
 
@@ -1490,25 +1488,23 @@ class AgentLoop {
 			);
 		}
 
-		$result = $this->send_prompt();
+		$result = $this->send_prompt( $provider_id, $model_id );
 		if ( ! is_wp_error( $result ) || ! $this->is_payload_limit_error( $result ) ) {
 			return $result;
 		}
 
-		ProviderTraceLogger::record_payload_limit(
-			$provider_id,
-			$model_id,
-			413,
-			$before_bytes,
-			$before_tokens,
-			$byte_budget,
-			false,
-			$this->provider_payload_fallback_used,
-			true
-		);
-
-		if ( $this->provider_payload_fallback_used ) {
-			return $this->with_payload_recovery_metadata( $result, $before_bytes, $before_tokens, false );
+		if ( ! $this->is_local_payload_limit_error( $result ) ) {
+			ProviderTraceLogger::record_payload_limit(
+				$provider_id,
+				$model_id,
+				413,
+				$before_bytes,
+				$before_tokens,
+				$byte_budget,
+				false,
+				false,
+				true
+			);
 		}
 
 		$target_bytes  = max( 1, (int) floor( $before_bytes * 0.6 ) );
@@ -1518,12 +1514,11 @@ class AgentLoop {
 		$after_tokens  = ConversationTrimmer::estimate_total_tokens( $reduced );
 
 		if ( $after_bytes >= $before_bytes ) {
-			return $this->with_payload_recovery_metadata( $result, $before_bytes, $before_tokens, false );
+			return $this->with_payload_recovery_metadata( $result, $before_bytes, $before_tokens, false, false );
 		}
 
-		$this->provider_payload_fallback_used = true;
-		$this->history                        = $reduced;
-		$this->message_log[]                  = array(
+		$this->history       = $reduced;
+		$this->message_log[] = array(
 			'type'               => 'provider_payload_recovery',
 			'message'            => __( 'The provider rejected the request size. Retrying once with reduced conversation history.', 'superdav-ai-agent' ),
 			'status_code'        => 413,
@@ -1534,9 +1529,9 @@ class AgentLoop {
 		);
 		$this->fire_progress();
 
-		$retry_result = $this->send_prompt();
+		$retry_result = $this->send_prompt( $provider_id, $model_id );
 		if ( is_wp_error( $retry_result ) ) {
-			if ( $this->is_payload_limit_error( $retry_result ) ) {
+			if ( $this->is_payload_limit_error( $retry_result ) && ! $this->is_local_payload_limit_error( $retry_result ) ) {
 				ProviderTraceLogger::record_payload_limit(
 					$provider_id,
 					$model_id,
@@ -1550,7 +1545,7 @@ class AgentLoop {
 				);
 			}
 
-			return $this->with_payload_recovery_metadata( $retry_result, $after_bytes, $after_tokens, true );
+			return $this->with_payload_recovery_metadata( $retry_result, $after_bytes, $after_tokens, true, true );
 		}
 
 		return $retry_result;
@@ -1566,20 +1561,31 @@ class AgentLoop {
 		return is_array( $data ) && 413 === (int) ( $data['status_code'] ?? 0 );
 	}
 
+	/** Whether a payload-limit error was produced by the local request guard. */
+	private function is_local_payload_limit_error( WP_Error $error ): bool {
+		if ( 'sd_ai_agent_provider_payload_budget_exceeded' === $error->get_error_code() ) {
+			return true;
+		}
+
+		$data = $error->get_error_data();
+		return is_array( $data ) && ! empty( $data['local_rejection'] );
+	}
+
 	/**
 	 * Attach safe fallback diagnostics without replacing recoverable history data.
 	 *
-	 * @param WP_Error $error          Payload error.
-	 * @param int      $request_bytes  Estimated history bytes sent most recently.
-	 * @param int      $request_tokens Estimated history tokens sent most recently.
-	 * @param bool     $reduced        Whether the outgoing history was reduced.
+	 * @param WP_Error $error             Payload error.
+	 * @param int      $request_bytes     Estimated history bytes sent most recently.
+	 * @param int      $request_tokens    Estimated history tokens sent most recently.
+	 * @param bool     $reduced           Whether the outgoing history was reduced.
+	 * @param bool     $fallback_attempted Whether a reduced fallback was attempted.
 	 */
-	private function with_payload_recovery_metadata( WP_Error $error, int $request_bytes, int $request_tokens, bool $reduced ): WP_Error {
+	private function with_payload_recovery_metadata( WP_Error $error, int $request_bytes, int $request_tokens, bool $reduced, bool $fallback_attempted ): WP_Error {
 		$error_data                      = $error->get_error_data();
 		$data                            = is_array( $error_data ) ? $error_data : array();
 		$data['request_bytes_estimate']  = $request_bytes;
 		$data['request_tokens_estimate'] = $request_tokens;
-		$data['fallback_attempted']      = $this->provider_payload_fallback_used;
+		$data['fallback_attempted']      = $fallback_attempted;
 		$data['payload_reduced']         = $reduced;
 		$error->add_data( $data );
 
@@ -1596,9 +1602,7 @@ class AgentLoop {
 	 *
 	 * @return \WordPress\AiClient\Results\DTO\GenerativeAiResult|WP_Error
 	 */
-	private function send_prompt() {
-		$provider_id = $this->resolve_provider_id();
-
+	protected function send_prompt( string $provider_id, string $model_id ): GenerativeAiResult|WP_Error {
 		if ( '' === $provider_id ) {
 			return new WP_Error(
 				'sd_ai_agent_no_provider',
@@ -1650,7 +1654,7 @@ class AgentLoop {
 			$this->system_instruction = $this->instruction_builder->build( $this->settings_for_prompt, $ability_names );
 		}
 		$builder->using_system_instruction( $this->system_instruction );
-		$this->configure_model( $builder );
+		$this->configure_model( $builder, $provider_id, $model_id );
 
 		// NOTE: weak-model temperature/parallel-tool overrides are disabled
 		// alongside the weak-model iteration cap (see constructor comment).
@@ -1679,14 +1683,9 @@ class AgentLoop {
 		// Skip the setter for those model IDs so the request body omits the field
 		// entirely. `max_tokens` is still safe to send.
 		//
-		// Resolve the effective model ID (including connector defaults)
-		// before checking if it rejects temperature, since configure_model()
-		// may have resolved a default model from the connector.
-		$resolved_model_id = $this->model_id;
-		if ( empty( $resolved_model_id ) && function_exists( 'OpenAiCompatibleConnector\\get_default_model' ) ) {
-			$resolved_model_id = (string) \OpenAiCompatibleConnector\get_default_model();
-		}
-		if ( ! self::model_omits_temperature( $resolved_model_id ) ) {
+		// Use the same validated effective model for configuration, request
+		// budgets, temperature handling, and safe trace attribution.
+		if ( ! self::model_omits_temperature( $model_id ) ) {
 			$builder->using_temperature( (float) $this->temperature );
 		}
 		$builder->using_max_tokens( $this->get_effective_max_output_tokens() );
@@ -1705,7 +1704,7 @@ class AgentLoop {
 		$last_error = null;
 
 		for ( $attempt = 1; $attempt <= $this->provider_retry_max_attempts; ++$attempt ) {
-			ProviderTraceLogger::set_runtime_context( $provider_id, (string) $resolved_model_id );
+			ProviderTraceLogger::set_runtime_context( $provider_id, $model_id );
 			try {
 				$result = $builder->generate_text_result();
 				if ( is_wp_error( $result ) ) {
@@ -2075,33 +2074,19 @@ class AgentLoop {
 	 * through ProviderRegistry::getProviderModel(). This avoids creating
 	 * model instances outside the registry which can miss auth binding.
 	 *
-	 * The provider ID is resolved by {@see resolve_provider_id()} before
-	 * this method is called — send_prompt() validates that a provider
-	 * exists and returns a WP_Error early if none is configured.
+	 * The provider and effective model are resolved once by
+	 * {@see send_prompt_with_payload_recovery()} so model-specific budgets and
+	 * trace attribution cannot diverge from the model configured on the builder.
 	 *
-	 * @param \WP_AI_Client_Prompt_Builder $builder The prompt builder.
+	 * @param \WP_AI_Client_Prompt_Builder $builder     The prompt builder.
+	 * @param string                       $provider_id Runtime-selected provider ID.
+	 * @param string                       $model_id    Validated effective model ID.
 	 */
-	private function configure_model( $builder ): void {
-		$provider_id = $this->resolve_provider_id();
-		$model_id    = $this->model_id;
-
+	private function configure_model( $builder, string $provider_id, string $model_id ): void {
 		if ( empty( $provider_id ) ) {
 			// No provider available — send_prompt() will have already
 			// returned a WP_Error, so this is a defensive no-op.
 			return;
-		}
-
-		// Resolve model — fall back to the connector's configured default
-		// when the agent loop was started without one. The connector default
-		// (`ultimate_ai_connector_default_model`) is what produced the
-		// production `gemma4:e4b` regression (GH#1494): it stored a model
-		// the endpoint did not actually serve and the SDK rejected every
-		// chat with a top-level error banner. Validate before adopting.
-		if ( empty( $model_id ) && function_exists( 'OpenAiCompatibleConnector\\get_default_model' ) ) {
-			$candidate = (string) \OpenAiCompatibleConnector\get_default_model();
-			if ( '' !== $candidate && Settings::is_model_advertised( $provider_id, $candidate ) ) {
-				$model_id = $candidate;
-			}
 		}
 
 		try {
@@ -2128,6 +2113,32 @@ class AgentLoop {
 				// Both approaches failed — builder will use default.
 			}
 		}
+	}
+
+	/**
+	 * Resolve one validated effective model ID for a provider invocation.
+	 *
+	 * The connector default is accepted only when it is currently advertised,
+	 * matching the existing stale-default protection in model configuration.
+	 *
+	 * @param string $provider_id Runtime-selected provider ID.
+	 */
+	private function resolve_effective_model_id( string $provider_id ): string {
+		$model_id = trim( (string) $this->model_id );
+		if ( '' !== $model_id ) {
+			return $model_id;
+		}
+
+		if ( ! function_exists( 'OpenAiCompatibleConnector\\get_default_model' ) ) {
+			return '';
+		}
+
+		$candidate = trim( (string) \OpenAiCompatibleConnector\get_default_model() );
+		if ( '' === $candidate || ! Settings::is_model_advertised( $provider_id, $candidate ) ) {
+			return '';
+		}
+
+		return $candidate;
 	}
 
 	/**

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -207,6 +207,13 @@ class AgentLoop {
 	/** @var list<string> Per-agent Tier 1 tool override (empty = use global default). */
 	private array $agent_tier_1_tools = array();
 
+	/**
+	 * Whether this run already consumed its single reduced-payload 413 fallback.
+	 *
+	 * @var bool
+	 */
+	private bool $provider_payload_fallback_used = false;
+
 	/** @var list<string> Ability names approved for one resumed confirmation turn. */
 	private array $approved_once_abilities = array();
 
@@ -998,7 +1005,7 @@ class AgentLoop {
 			$this->save_active_job_checkpoint( self::CHECKPOINT_BEFORE_PROVIDER_CALL, $iterations + 1 );
 
 			$this->last_loop_phase = 'provider_call';
-			$result                = $this->send_prompt();
+			$result                = $this->send_prompt_with_payload_recovery();
 			$this->last_loop_phase = 'provider_response_received';
 
 			if ( is_wp_error( $result ) ) {
@@ -1124,7 +1131,7 @@ class AgentLoop {
 
 					++$this->iterations_used;
 					$this->last_loop_phase = 'provider_followup_call';
-					$followup_result       = $this->send_prompt();
+					$followup_result       = $this->send_prompt_with_payload_recovery();
 					$this->last_loop_phase = 'provider_followup_response_received';
 
 					if ( ! is_wp_error( $followup_result ) ) {
@@ -1374,7 +1381,7 @@ class AgentLoop {
 
 			++$this->iterations_used;
 			$this->last_loop_phase = 'provider_fallback_call';
-			$fallback_result       = $this->send_prompt();
+			$fallback_result       = $this->send_prompt_with_payload_recovery();
 			$this->last_loop_phase = 'provider_fallback_response_received';
 
 			if ( ! is_wp_error( $fallback_result ) ) {
@@ -1437,6 +1444,146 @@ class AgentLoop {
 				)
 			)
 		);
+	}
+
+	/**
+	 * Apply local input budgets and make at most one reduced 413 fallback.
+	 *
+	 * @return \WordPress\AiClient\Results\DTO\GenerativeAiResult|WP_Error
+	 */
+	private function send_prompt_with_payload_recovery() {
+		$provider_id  = $this->resolve_provider_id();
+		$model_id     = (string) $this->model_id;
+		$byte_budget  = ConversationTrimmer::get_request_byte_budget( $provider_id, $model_id );
+		$token_budget = ConversationTrimmer::get_request_token_budget( $provider_id, $model_id );
+
+		$this->history = ConversationTrimmer::trim_to_budget( $this->history, $byte_budget, $token_budget );
+		$before_bytes  = ConversationTrimmer::estimate_total_bytes( $this->history );
+		$before_tokens = ConversationTrimmer::estimate_total_tokens( $this->history );
+
+		if ( ! ConversationTrimmer::fits_budget( $this->history, $byte_budget, $token_budget ) ) {
+			ProviderTraceLogger::record_payload_limit(
+				$provider_id,
+				$model_id,
+				413,
+				$before_bytes,
+				$before_tokens,
+				$byte_budget,
+				true,
+				false,
+				true
+			);
+
+			return new WP_Error(
+				'sd_ai_agent_provider_payload_budget_exceeded',
+				__( 'This request is too large to send safely. Compact the conversation or shorten the latest message and remove large attachments before retrying.', 'superdav-ai-agent' ),
+				array(
+					'status_code'             => 413,
+					'provider_id'             => $provider_id,
+					'model_id'                => $model_id,
+					'request_bytes_estimate'  => $before_bytes,
+					'request_tokens_estimate' => $before_tokens,
+					'request_budget_bytes'    => $byte_budget,
+					'local_rejection'         => true,
+					'fallback_attempted'      => false,
+				)
+			);
+		}
+
+		$result = $this->send_prompt();
+		if ( ! is_wp_error( $result ) || ! $this->is_payload_limit_error( $result ) ) {
+			return $result;
+		}
+
+		ProviderTraceLogger::record_payload_limit(
+			$provider_id,
+			$model_id,
+			413,
+			$before_bytes,
+			$before_tokens,
+			$byte_budget,
+			false,
+			$this->provider_payload_fallback_used,
+			true
+		);
+
+		if ( $this->provider_payload_fallback_used ) {
+			return $this->with_payload_recovery_metadata( $result, $before_bytes, $before_tokens, false );
+		}
+
+		$target_bytes  = max( 1, (int) floor( $before_bytes * 0.6 ) );
+		$target_tokens = max( 1, (int) floor( $before_tokens * 0.6 ) );
+		$reduced       = ConversationTrimmer::trim_to_budget( $this->history, $target_bytes, $target_tokens );
+		$after_bytes   = ConversationTrimmer::estimate_total_bytes( $reduced );
+		$after_tokens  = ConversationTrimmer::estimate_total_tokens( $reduced );
+
+		if ( $after_bytes >= $before_bytes ) {
+			return $this->with_payload_recovery_metadata( $result, $before_bytes, $before_tokens, false );
+		}
+
+		$this->provider_payload_fallback_used = true;
+		$this->history                        = $reduced;
+		$this->message_log[]                  = array(
+			'type'               => 'provider_payload_recovery',
+			'message'            => __( 'The provider rejected the request size. Retrying once with reduced conversation history.', 'superdav-ai-agent' ),
+			'status_code'        => 413,
+			'request_size_class' => ProviderTraceLogger::classify_request_size( $before_bytes ),
+			'fallback_attempted' => true,
+			'payload_reduced'    => true,
+			'sequence'           => $this->next_activity_sequence(),
+		);
+		$this->fire_progress();
+
+		$retry_result = $this->send_prompt();
+		if ( is_wp_error( $retry_result ) ) {
+			if ( $this->is_payload_limit_error( $retry_result ) ) {
+				ProviderTraceLogger::record_payload_limit(
+					$provider_id,
+					$model_id,
+					413,
+					$after_bytes,
+					$after_tokens,
+					$byte_budget,
+					false,
+					true,
+					true
+				);
+			}
+
+			return $this->with_payload_recovery_metadata( $retry_result, $after_bytes, $after_tokens, true );
+		}
+
+		return $retry_result;
+	}
+
+	/** Whether an error represents a local or upstream HTTP 413. */
+	private function is_payload_limit_error( WP_Error $error ): bool {
+		if ( in_array( $error->get_error_code(), array( 'sd_ai_agent_provider_payload_too_large', 'sd_ai_agent_provider_payload_budget_exceeded' ), true ) ) {
+			return true;
+		}
+
+		$data = $error->get_error_data();
+		return is_array( $data ) && 413 === (int) ( $data['status_code'] ?? 0 );
+	}
+
+	/**
+	 * Attach safe fallback diagnostics without replacing recoverable history data.
+	 *
+	 * @param WP_Error $error          Payload error.
+	 * @param int      $request_bytes  Estimated history bytes sent most recently.
+	 * @param int      $request_tokens Estimated history tokens sent most recently.
+	 * @param bool     $reduced        Whether the outgoing history was reduced.
+	 */
+	private function with_payload_recovery_metadata( WP_Error $error, int $request_bytes, int $request_tokens, bool $reduced ): WP_Error {
+		$error_data                      = $error->get_error_data();
+		$data                            = is_array( $error_data ) ? $error_data : array();
+		$data['request_bytes_estimate']  = $request_bytes;
+		$data['request_tokens_estimate'] = $request_tokens;
+		$data['fallback_attempted']      = $this->provider_payload_fallback_used;
+		$data['payload_reduced']         = $reduced;
+		$error->add_data( $data );
+
+		return $error;
 	}
 
 	/**
@@ -1558,6 +1705,7 @@ class AgentLoop {
 		$last_error = null;
 
 		for ( $attempt = 1; $attempt <= $this->provider_retry_max_attempts; ++$attempt ) {
+			ProviderTraceLogger::set_runtime_context( $provider_id, (string) $resolved_model_id );
 			try {
 				$result = $builder->generate_text_result();
 				if ( is_wp_error( $result ) ) {
@@ -1568,6 +1716,8 @@ class AgentLoop {
 				}
 			} catch ( \Throwable $e ) {
 				$last_error = $e;
+			} finally {
+				ProviderTraceLogger::clear_runtime_context();
 			}
 
 			$status_code = $this->extract_provider_error_status( $last_error );
@@ -1802,12 +1952,37 @@ class AgentLoop {
 	 */
 	private function provider_error_to_wp_error( $error, int $status_code ): WP_Error {
 		if ( 413 === $status_code ) {
+			$data     = array( 'status_code' => $status_code );
+			$is_local = false;
+			if ( $error instanceof WP_Error ) {
+				$source_data = $error->get_error_data();
+				$is_local    = 'sd_ai_agent_provider_payload_budget_exceeded' === $error->get_error_code()
+					|| ( is_array( $source_data ) && ! empty( $source_data['local_rejection'] ) );
+
+				if ( is_array( $source_data ) ) {
+					$safe_keys = array(
+						'provider_id',
+						'model_id',
+						'request_bytes',
+						'request_tokens_estimate',
+						'request_budget_bytes',
+						'request_size_class',
+						'local_rejection',
+					);
+					foreach ( $safe_keys as $safe_key ) {
+						if ( isset( $source_data[ $safe_key ] ) && is_scalar( $source_data[ $safe_key ] ) ) {
+							$data[ $safe_key ] = $source_data[ $safe_key ];
+						}
+					}
+				}
+			}
+
 			return new WP_Error(
-				'sd_ai_agent_provider_payload_too_large',
-				__( 'The AI provider rejected this request because it exceeds its payload limit. Start a new chat and send a smaller request. If you attached files, remove or reduce them before retrying.', 'superdav-ai-agent' ),
-				array(
-					'status_code' => $status_code,
-				)
+				$is_local ? 'sd_ai_agent_provider_payload_budget_exceeded' : 'sd_ai_agent_provider_payload_too_large',
+				$is_local
+					? __( 'This request is too large to send safely. Compact the conversation or shorten the latest message and remove large attachments before retrying.', 'superdav-ai-agent' )
+					: __( 'The selected AI provider or intermediary rejected this request because it exceeds its payload limit. Start a new chat and send a smaller request. If you attached files, remove or reduce them before retrying.', 'superdav-ai-agent' ),
+				$data
 			);
 		}
 

--- a/includes/Core/ConversationTrimmer.php
+++ b/includes/Core/ConversationTrimmer.php
@@ -25,6 +25,21 @@ class ConversationTrimmer {
 	 */
 	const DEFAULT_MAX_TURNS = 20;
 
+	/** Default maximum serialized provider request body size (512 KiB). */
+	const DEFAULT_MAX_REQUEST_BYTES = 524288;
+
+	/** Default maximum estimated input tokens retained in conversation history. */
+	const DEFAULT_MAX_REQUEST_TOKENS = 100000;
+
+	/** Maximum history size copied into a deterministically compacted session. */
+	const COMPACT_MAX_BYTES = 65536;
+
+	/** Maximum estimated tokens copied into a deterministically compacted session. */
+	const COMPACT_MAX_TOKENS = 16000;
+
+	/** Marker inserted when older turns are removed by a request-size budget. */
+	private const BUDGET_MARKER_TEXT = '[Earlier conversation turns were compacted to stay within the request safety budget.]';
+
 	/**
 	 * Trim conversation history if it exceeds the configured max turns.
 	 *
@@ -96,6 +111,149 @@ class ConversationTrimmer {
 		// Even with correct boundary detection, edge cases (serialization
 		// round-trips, history corruption) could leave orphaned tool calls.
 		return self::validate_tool_pairs( $merged );
+	}
+
+	/**
+	 * Trim history to byte and token budgets while keeping a contiguous turn suffix.
+	 *
+	 * Unlike the turn-count guard, this path does not permanently retain the first
+	 * turn. Complete recent turns are kept newest-first until adding the next older
+	 * turn would exceed either budget. Tool-call/result cycles remain inside their
+	 * user-turn boundary and are validated again before returning.
+	 *
+	 * If the newest turn alone exceeds a budget, it is returned unchanged. Callers
+	 * can then reject it locally with actionable guidance rather than silently drop
+	 * the user's current request or dispatch the same oversized payload upstream.
+	 *
+	 * @param Message[] $history    Conversation history.
+	 * @param int       $max_bytes  Maximum serialized history bytes. 0 = unlimited.
+	 * @param int       $max_tokens Maximum estimated history tokens. 0 = unlimited.
+	 * @return Message[] Budgeted history with valid tool pairs.
+	 */
+	public static function trim_to_budget( array $history, int $max_bytes, int $max_tokens = 0 ): array {
+		$history = self::validate_tool_pairs( $history );
+
+		if ( empty( $history ) || self::fits_budget( $history, $max_bytes, $max_tokens ) ) {
+			return $history;
+		}
+
+		$turn_starts = self::find_turn_boundaries( $history );
+		if ( empty( $turn_starts ) ) {
+			return $history;
+		}
+
+		$turns      = array();
+		$turn_count = count( $turn_starts );
+		for ( $i = 0; $i < $turn_count; ++$i ) {
+			$start   = $turn_starts[ $i ];
+			$end     = $turn_starts[ $i + 1 ] ?? count( $history );
+			$turns[] = array_slice( $history, $start, $end - $start );
+		}
+
+		$marker = new UserMessage(
+			array(
+				new MessagePart( self::BUDGET_MARKER_TEXT ),
+			)
+		);
+
+		$last_index = count( $turns ) - 1;
+		$kept       = $turns[ $last_index ];
+
+		// The current turn is never discarded. An over-budget newest turn must be
+		// rejected by the caller rather than converted into an unrelated marker.
+		if ( ! self::fits_budget( $kept, $max_bytes, $max_tokens ) ) {
+			return self::validate_tool_pairs( $kept );
+		}
+
+		for ( $i = $last_index - 1; $i >= 0; --$i ) {
+			$candidate = array_merge( array( $marker ), $turns[ $i ], $kept );
+			if ( ! self::fits_budget( $candidate, $max_bytes, $max_tokens ) ) {
+				break;
+			}
+
+			$kept = array_merge( $turns[ $i ], $kept );
+		}
+
+		if ( count( $kept ) < count( $history ) ) {
+			$marked = array_merge( array( $marker ), $kept );
+			if ( self::fits_budget( $marked, $max_bytes, $max_tokens ) ) {
+				$kept = $marked;
+			}
+		}
+
+		return self::validate_tool_pairs( $kept );
+	}
+
+	/**
+	 * Whether history fits all enabled size budgets.
+	 *
+	 * @param Message[] $history    Conversation history.
+	 * @param int       $max_bytes  Maximum bytes. 0 = unlimited.
+	 * @param int       $max_tokens Maximum estimated tokens. 0 = unlimited.
+	 * @return bool True when all enabled budgets are satisfied.
+	 */
+	public static function fits_budget( array $history, int $max_bytes, int $max_tokens = 0 ): bool {
+		if ( $max_bytes > 0 && self::estimate_total_bytes( $history ) > $max_bytes ) {
+			return false;
+		}
+
+		if ( $max_tokens > 0 && self::estimate_total_tokens( $history ) > $max_tokens ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Resolve the configured provider request byte budget.
+	 *
+	 * @param string $provider_id Runtime-selected provider ID.
+	 * @param string $model_id    Runtime-selected model ID.
+	 * @return int Effective request byte budget.
+	 */
+	public static function get_request_byte_budget( string $provider_id = '', string $model_id = '' ): int {
+		// @phpstan-ignore-next-line
+		$configured = (int) Settings::instance()->get( 'provider_request_max_bytes' );
+		if ( $configured <= 0 ) {
+			$configured = self::DEFAULT_MAX_REQUEST_BYTES;
+		}
+
+		/**
+		 * Filter the local provider request body safety budget.
+		 *
+		 * @param int    $configured Configured byte budget.
+		 * @param string $provider_id Runtime-selected provider ID.
+		 * @param string $model_id Runtime-selected model ID.
+		 */
+		$filtered = (int) apply_filters( 'sd_ai_agent_provider_request_max_bytes', $configured, $provider_id, $model_id );
+
+		return max( 1024, $filtered );
+	}
+
+	/**
+	 * Resolve the configured conversation input token budget.
+	 *
+	 * @param string $provider_id Runtime-selected provider ID.
+	 * @param string $model_id    Runtime-selected model ID.
+	 * @return int Effective estimated-token budget.
+	 */
+	public static function get_request_token_budget( string $provider_id = '', string $model_id = '' ): int {
+		// @phpstan-ignore-next-line
+		$configured = (int) Settings::instance()->get( 'provider_request_max_tokens' );
+		if ( $configured <= 0 ) {
+			$configured = self::DEFAULT_MAX_REQUEST_TOKENS;
+		}
+
+		/**
+		 * Filter the local conversation input token safety budget.
+		 *
+		 * @param int    $configured Configured estimated-token budget.
+		 * @param string $provider_id Runtime-selected provider ID.
+		 * @param string $model_id Runtime-selected model ID.
+		 */
+		$filtered = (int) apply_filters( 'sd_ai_agent_provider_request_max_tokens', $configured, $provider_id, $model_id );
+
+		return max( 256, $filtered );
 	}
 
 	/**
@@ -409,6 +567,40 @@ class ConversationTrimmer {
 
 		// Rough estimate: 1 token ~= 4 characters.
 		return (int) ceil( strlen( $text ) / 4 );
+	}
+
+	/**
+	 * Estimate serialized bytes for one message, including attachment/tool data.
+	 *
+	 * @param Message $message Conversation message.
+	 * @return int Estimated serialized bytes.
+	 */
+	public static function estimate_bytes( Message $message ): int {
+		try {
+			$encoded = wp_json_encode( $message->toArray() );
+			if ( is_string( $encoded ) ) {
+				return strlen( $encoded );
+			}
+		} catch ( \Throwable $e ) {
+			// Fall through to the conservative token-derived estimate.
+		}
+
+		return self::estimate_tokens( $message ) * 4;
+	}
+
+	/**
+	 * Estimate total serialized bytes in a history array.
+	 *
+	 * @param Message[] $history Conversation history.
+	 * @return int Estimated serialized bytes.
+	 */
+	public static function estimate_total_bytes( array $history ): int {
+		$total = 0;
+		foreach ( $history as $message ) {
+			$total += self::estimate_bytes( $message );
+		}
+
+		return $total;
 	}
 
 	/**

--- a/includes/Core/ConversationTrimmer.php
+++ b/includes/Core/ConversationTrimmer.php
@@ -37,6 +37,9 @@ class ConversationTrimmer {
 	/** Maximum estimated tokens copied into a deterministically compacted session. */
 	const COMPACT_MAX_TOKENS = 16000;
 
+	/** Maximum characters copied from any single message into compact context. */
+	private const COMPACT_MAX_MESSAGE_CHARS = 2000;
+
 	/** Marker inserted when older turns are removed by a request-size budget. */
 	private const BUDGET_MARKER_TEXT = '[Earlier conversation turns were compacted to stay within the request safety budget.]';
 
@@ -182,6 +185,242 @@ class ConversationTrimmer {
 		}
 
 		return self::validate_tool_pairs( $kept );
+	}
+
+	/**
+	 * Build a bounded deterministic seed message for a compacted session.
+	 *
+	 * This is intentionally not an AI summary request. It runs server-side against
+	 * the already-persisted session, keeps newest useful excerpts until the compact
+	 * budget is reached, and omits attachment bytes plus raw tool arguments/results.
+	 * The client can switch to the returned session without submitting the whole
+	 * transcript back through `/run` as a new prompt.
+	 *
+	 * @param array<int, mixed> $messages   Serialized session messages.
+	 * @param int               $max_bytes  Maximum serialized seed-message bytes.
+	 * @param int               $max_tokens Maximum estimated seed-message tokens.
+	 * @return array{messages:list<array<string,mixed>>,meta:array<string,int|bool>}
+	 */
+	public static function compact_serialized_history( array $messages, int $max_bytes = self::COMPACT_MAX_BYTES, int $max_tokens = self::COMPACT_MAX_TOKENS ): array {
+		$normalized = array();
+		foreach ( $messages as $message ) {
+			if ( is_array( $message ) ) {
+				$normalized[] = $message;
+			}
+		}
+
+		$source_count = count( $normalized );
+		$max_bytes    = max( 1024, $max_bytes );
+		$max_tokens   = max( 256, $max_tokens );
+
+		$per_message_chars = max(
+			160,
+			min( self::COMPACT_MAX_MESSAGE_CHARS, (int) floor( $max_bytes / 4 ) )
+		);
+
+		$lines = array();
+		for ( $i = $source_count - 1; $i >= 0; --$i ) {
+			$excerpt = self::serialized_message_to_compact_excerpt( $normalized[ $i ], $per_message_chars );
+			if ( '' === $excerpt ) {
+				continue;
+			}
+
+			$candidate = $lines;
+			array_unshift( $candidate, $excerpt );
+			if ( self::compact_lines_fit_budget( $candidate, $source_count, $max_bytes, $max_tokens ) ) {
+				$lines = $candidate;
+			}
+		}
+
+		$retained_count = count( $lines );
+		if ( empty( $lines ) ) {
+			$lines          = array( '[No individual message excerpt fit within the compact budget.]' );
+			$retained_count = 0;
+		}
+
+		$text       = self::build_compact_context_text( $source_count, $retained_count, $lines );
+		$message    = self::compact_text_to_message( $text );
+		$line_count = count( $lines );
+
+		while ( ! self::fits_budget( array( $message ), $max_bytes, $max_tokens ) && $line_count > 1 ) {
+			array_shift( $lines );
+			$retained_count = count( $lines );
+			$line_count     = $retained_count;
+			$text           = self::build_compact_context_text( $source_count, $retained_count, $lines );
+			$message        = self::compact_text_to_message( $text );
+		}
+
+		if ( ! self::fits_budget( array( $message ), $max_bytes, $max_tokens ) ) {
+			$retained_count = 0;
+			$text           = self::build_compact_context_text(
+				$source_count,
+				$retained_count,
+				array( '[Conversation details were omitted because the compact budget is smaller than the required metadata.]' )
+			);
+			$message        = self::compact_text_to_message( $text );
+		}
+
+		$estimated_bytes  = self::estimate_bytes( $message );
+		$estimated_tokens = self::estimate_tokens( $message );
+
+		return array(
+			'messages' => array( $message->toArray() ),
+			'meta'     => array(
+				'source_message_count'   => $source_count,
+				'retained_excerpt_count' => $retained_count,
+				'boundary_omitted_count' => max( 0, $source_count - $retained_count ),
+				'estimated_bytes'        => $estimated_bytes,
+				'estimated_tokens'       => $estimated_tokens,
+				'max_bytes'              => $max_bytes,
+				'max_tokens'             => $max_tokens,
+				'attachments_omitted'    => true,
+				'tool_payloads_omitted'  => true,
+			),
+		);
+	}
+
+	/**
+	 * Test whether compact context lines fit the target budgets.
+	 *
+	 * @param string[] $lines        Candidate context lines.
+	 * @param int      $source_count Original message count.
+	 * @param int      $max_bytes    Byte budget.
+	 * @param int      $max_tokens   Estimated-token budget.
+	 */
+	private static function compact_lines_fit_budget( array $lines, int $source_count, int $max_bytes, int $max_tokens ): bool {
+		$message = self::compact_text_to_message(
+			self::build_compact_context_text( $source_count, count( $lines ), $lines )
+		);
+
+		return self::fits_budget( array( $message ), $max_bytes, $max_tokens );
+	}
+
+	/**
+	 * Build the compact-context prompt text.
+	 *
+	 * @param int      $source_count   Original message count.
+	 * @param int      $retained_count Retained excerpt count.
+	 * @param string[] $lines          Retained message excerpts.
+	 */
+	private static function build_compact_context_text( int $source_count, int $retained_count, array $lines ): string {
+		$omitted_count = max( 0, $source_count - $retained_count );
+
+		$header = array(
+			'Conversation compacted server-side to avoid provider payload limits.',
+			"Source messages: {$source_count}; retained excerpts: {$retained_count}; omitted messages: {$omitted_count}.",
+			'Use this compact context to continue from the user\'s next message. File attachments, inline image bytes, and raw tool payloads were omitted.',
+		);
+
+		return implode( "\n", $header ) . "\n\n" . implode( "\n\n", $lines );
+	}
+
+	/** Convert compact text into a single user-message seed. */
+	private static function compact_text_to_message( string $text ): UserMessage {
+		return new UserMessage(
+			array(
+				new MessagePart( $text ),
+			)
+		);
+	}
+
+	/**
+	 * Convert a serialized message to a bounded compact-context excerpt.
+	 *
+	 * @param array<string, mixed> $message   Serialized message array.
+	 * @param int                  $max_chars Character limit for the excerpt body.
+	 */
+	private static function serialized_message_to_compact_excerpt( array $message, int $max_chars ): string {
+		$role  = self::compact_role_label( (string) ( $message['role'] ?? 'message' ) );
+		$parts = isset( $message['parts'] ) && is_array( $message['parts'] ) ? $message['parts'] : array();
+
+		$pieces = array();
+		foreach ( $parts as $part ) {
+			if ( ! is_array( $part ) ) {
+				continue;
+			}
+
+			$piece = self::compact_piece_from_part( $part );
+			if ( '' !== $piece ) {
+				$pieces[] = $piece;
+			}
+		}
+
+		if ( empty( $pieces ) && isset( $message['content'] ) && is_string( $message['content'] ) ) {
+			$pieces[] = $message['content'];
+		}
+
+		$text = self::normalize_compact_text( implode( ' ', $pieces ) );
+		if ( '' === $text ) {
+			return '';
+		}
+
+		if ( strlen( $text ) > $max_chars ) {
+			$text = substr( $text, 0, max( 0, $max_chars - 1 ) ) . '…';
+		}
+
+		return $role . ': ' . $text;
+	}
+
+	/**
+	 * Return a safe compact-context fragment for a serialized message part.
+	 *
+	 * @param array<string, mixed> $part Serialized message part.
+	 */
+	private static function compact_piece_from_part( array $part ): string {
+		if ( isset( $part['text'] ) && is_string( $part['text'] ) ) {
+			return $part['text'];
+		}
+
+		$function_call = $part['functionCall'] ?? $part['function_call'] ?? null;
+		if ( is_array( $function_call ) ) {
+			$name = self::compact_tool_name( $function_call['name'] ?? 'tool' );
+			return '[tool call: ' . $name . ']';
+		}
+
+		$function_response = $part['functionResponse'] ?? $part['function_response'] ?? null;
+		if ( is_array( $function_response ) ) {
+			$name = self::compact_tool_name( $function_response['name'] ?? 'tool' );
+			return '[tool result omitted: ' . $name . ']';
+		}
+
+		if ( isset( $part['image_url'] ) || isset( $part['inlineData'] ) || isset( $part['inline_data'] ) ) {
+			$name = isset( $part['image_name'] ) && is_string( $part['image_name'] ) ? self::normalize_compact_text( $part['image_name'] ) : '';
+			return '' !== $name ? '[image attachment omitted: ' . $name . ']' : '[image attachment omitted]';
+		}
+
+		return '';
+	}
+
+	/** Convert serialized roles into compact-context labels. */
+	private static function compact_role_label( string $role ): string {
+		$role = strtolower( trim( $role ) );
+		return match ( $role ) {
+			'model', 'assistant' => 'Assistant',
+			'user' => 'User',
+			'tool' => 'Tool',
+			default => 'Message',
+		};
+	}
+
+	/** Normalize a tool name for compact context. */
+	private static function compact_tool_name( mixed $name ): string {
+		$name = is_scalar( $name ) ? (string) $name : 'tool';
+		$name = self::normalize_compact_text( $name );
+		if ( '' === $name ) {
+			return 'tool';
+		}
+
+		return strlen( $name ) > 80 ? substr( $name, 0, 79 ) . '…' : $name;
+	}
+
+	/** Normalize compact text while removing inline binary/data payloads. */
+	private static function normalize_compact_text( string $text ): string {
+		$text = preg_replace( '/data:[^;\s]+;base64,[A-Za-z0-9+\/=\r\n]+/i', '[inline data omitted]', $text );
+		$text = is_string( $text ) ? wp_strip_all_tags( $text ) : '';
+		$text = preg_replace( '/[\x00-\x1F\x7F]+/', ' ', $text );
+		$text = is_string( $text ) ? preg_replace( '/\s+/', ' ', $text ) : '';
+
+		return is_string( $text ) ? trim( $text ) : '';
 	}
 
 	/**

--- a/includes/Core/ProviderTraceLogger.php
+++ b/includes/Core/ProviderTraceLogger.php
@@ -35,6 +35,16 @@ class ProviderTraceLogger {
 	private static array $inflight = [];
 
 	/**
+	 * Runtime-selected provider/model for the synchronous SDK request in flight.
+	 *
+	 * @var array{provider_id:string,model_id:string}
+	 */
+	private static array $runtime_context = array(
+		'provider_id' => '',
+		'model_id'    => '',
+	);
+
+	/**
 	 * Known AI provider URL patterns and their canonical provider IDs.
 	 *
 	 * These IDs are used by the lightweight error-log path that runs even
@@ -91,21 +101,48 @@ class ProviderTraceLogger {
 	}
 
 	/**
+	 * Set safe runtime attribution for the next synchronous provider request.
+	 *
+	 * @param string $provider_id Runtime-selected provider ID.
+	 * @param string $model_id    Runtime-selected model ID.
+	 */
+	public static function set_runtime_context( string $provider_id, string $model_id ): void {
+		self::$runtime_context = array(
+			'provider_id' => sanitize_key( $provider_id ),
+			'model_id'    => sanitize_text_field( $model_id ),
+		);
+	}
+
+	/** Clear runtime provider attribution after a synchronous request. */
+	public static function clear_runtime_context(): void {
+		self::$runtime_context = array(
+			'provider_id' => '',
+			'model_id'    => '',
+		);
+	}
+
+	/**
 	 * Hook: pre_http_request — capture outgoing request details.
 	 *
 	 * @param false|array<string, mixed>|\WP_Error $response    A preemptive return value of an HTTP request. Default false.
 	 * @param array<string, mixed>                 $parsed_args HTTP request arguments.
 	 * @param string                               $url         The request URL.
-	 * @return false|array<string, mixed>|\WP_Error Unchanged response (we never short-circuit).
+	 * @return false|array<string, mixed>|\WP_Error Unchanged response, or a safe local size rejection.
 	 */
 	public static function on_pre_http_request( $response, array $parsed_args, string $url ) {
-		if ( ! ProviderTrace::is_enabled() ) {
+		if ( false !== $response ) {
 			return $response;
 		}
 
-		$request_body = is_string( $parsed_args['body'] ?? null )
+		$request_body  = is_string( $parsed_args['body'] ?? null )
 			? $parsed_args['body']
 			: (string) wp_json_encode( $parsed_args['body'] ?? '' );
+		$trace_enabled = ProviderTrace::is_enabled();
+		$has_context   = '' !== self::$runtime_context['provider_id'];
+
+		if ( ! $trace_enabled && ! $has_context ) {
+			return $response;
+		}
 
 		// When tracing is enabled we cast a wider net than the canonical
 		// allowlist so connector plugins that proxy to HuggingFace,
@@ -113,14 +150,55 @@ class ProviderTraceLogger {
 		// captured. The error-log path on `on_http_response()` still uses
 		// the strict allowlist so we don't spam logs for unrelated 4xx
 		// responses.
-		$provider_id = self::resolve_provider_for_trace( $url, $request_body );
-		if ( '' === $provider_id ) {
+		$matched_provider_id = self::resolve_provider_for_trace( $url, $request_body );
+		if ( '' === $matched_provider_id ) {
+			return $response;
+		}
+
+		$provider_id = $has_context ? self::$runtime_context['provider_id'] : $matched_provider_id;
+		$model_id    = self::$runtime_context['model_id'];
+		if ( '' === $model_id ) {
+			$model_id = self::extract_model_id( $request_body );
+		}
+
+		$request_bytes = strlen( $request_body );
+		$byte_budget   = ConversationTrimmer::get_request_byte_budget( $provider_id, $model_id );
+		if ( $has_context && $request_bytes > $byte_budget ) {
+			self::record_payload_limit(
+				$provider_id,
+				$model_id,
+				413,
+				$request_bytes,
+				(int) ceil( $request_bytes / 4 ),
+				$byte_budget,
+				true,
+				false
+			);
+
+			return new \WP_Error(
+				'sd_ai_agent_provider_payload_budget_exceeded',
+				__( 'This request is too large to send safely. Compact the conversation or shorten the latest message and remove large attachments before retrying.', 'superdav-ai-agent' ),
+				array(
+					'status_code'             => 413,
+					'provider_id'             => $provider_id,
+					'model_id'                => $model_id,
+					'request_bytes'           => $request_bytes,
+					'request_tokens_estimate' => (int) ceil( $request_bytes / 4 ),
+					'request_budget_bytes'    => $byte_budget,
+					'request_size_class'      => self::classify_request_size( $request_bytes ),
+					'local_rejection'         => true,
+				)
+			);
+		}
+
+		if ( ! $trace_enabled ) {
 			return $response;
 		}
 
 		// Store in-flight data for correlation with the response.
 		self::$inflight[ $url ] = [
 			'provider_id'     => $provider_id,
+			'model_id'        => $model_id,
 			'url'             => $url,
 			'method'          => strtoupper( $parsed_args['method'] ?? 'POST' ),
 			'request_headers' => self::extract_headers( $parsed_args['headers'] ?? [] ),
@@ -148,31 +226,56 @@ class ProviderTraceLogger {
 	 * @return array<string, mixed> Unchanged response.
 	 */
 	public static function on_http_response( array $response, array $parsed_args, string $url ): array {
+		$request_body = is_string( $parsed_args['body'] ?? null )
+			? $parsed_args['body']
+			: (string) wp_json_encode( $parsed_args['body'] ?? '' );
+		$has_context  = '' !== self::$runtime_context['provider_id'];
+
 		// Lightweight error-log path: emit a greppable line for 4xx/5xx
 		// responses from canonical AI providers regardless of debug mode.
 		// Uses the strict allowlist so unrelated 4xx responses (update
 		// checks, WP.org, etc.) never produce noise here.
 		$canonical_provider_id = self::match_provider( $url );
-		if ( '' !== $canonical_provider_id ) {
+		$request_provider_id   = $canonical_provider_id;
+		if ( $has_context && '' !== self::resolve_provider_for_trace( $url, $request_body ) ) {
+			$request_provider_id = self::$runtime_context['provider_id'];
+		}
+		if ( '' !== $request_provider_id ) {
 			$status_code_for_log = (int) wp_remote_retrieve_response_code( $response );
 			if ( $status_code_for_log >= 400 ) {
-				$model_id_for_log = '';
-				if ( isset( $parsed_args['body'] ) ) {
-					$body_for_log     = is_string( $parsed_args['body'] )
-						? $parsed_args['body']
-						: (string) wp_json_encode( $parsed_args['body'] );
-					$model_id_for_log = self::extract_model_id( $body_for_log );
+				$model_id_for_log = self::$runtime_context['model_id'];
+				if ( '' === $model_id_for_log ) {
+					$model_id_for_log = self::extract_model_id( $request_body );
 				}
+				$request_bytes = strlen( $request_body );
+				$byte_budget   = ConversationTrimmer::get_request_byte_budget( $request_provider_id, $model_id_for_log );
 
-				AgentEventLog::log(
-					'provider_http_error',
-					AgentEventLog::SEVERITY_ERROR,
-					array(
-						'provider_id' => $canonical_provider_id,
-						'model_id'    => $model_id_for_log,
-						'status_code' => $status_code_for_log,
-					)
-				);
+				if ( 413 === $status_code_for_log ) {
+					self::record_payload_limit(
+						$request_provider_id,
+						$model_id_for_log,
+						$status_code_for_log,
+						$request_bytes,
+						(int) ceil( $request_bytes / 4 ),
+						$byte_budget,
+						false,
+						false
+					);
+				} else {
+					AgentEventLog::log(
+						'provider_http_error',
+						AgentEventLog::SEVERITY_ERROR,
+						array(
+							'provider_id'             => $request_provider_id,
+							'model_id'                => $model_id_for_log,
+							'status_code'             => $status_code_for_log,
+							'request_bytes'           => $request_bytes,
+							'request_tokens_estimate' => (int) ceil( $request_bytes / 4 ),
+							'request_size_class'      => self::classify_request_size( $request_bytes ),
+							'request_size_source'     => 'http_body',
+						)
+					);
+				}
 			}
 		}
 
@@ -199,7 +302,10 @@ class ProviderTraceLogger {
 		$response_headers = wp_remote_retrieve_headers( $response );
 
 		// Extract model_id from request body if possible.
-		$model_id = self::extract_model_id( $inflight['request_body'] ?? '' );
+		$model_id = (string) ( $inflight['model_id'] ?? '' );
+		if ( '' === $model_id ) {
+			$model_id = self::extract_model_id( $inflight['request_body'] ?? '' );
+		}
 
 		$decoded_response = null;
 		if ( $status_code >= 200 && $status_code < 300 ) {
@@ -254,25 +360,122 @@ class ProviderTraceLogger {
 			);
 		}
 
+		$trace_url              = $inflight['url'] ?? $url;
+		$trace_request_headers  = $inflight['request_headers'] ?? '{}';
+		$trace_request_body     = $inflight['request_body'] ?? '';
+		$trace_response_headers = $response_headers_json;
+		$trace_response_body    = $response_body;
+		if ( 413 === $status_code ) {
+			$request_bytes          = strlen( (string) $trace_request_body );
+			$trace_url              = self::safe_trace_url( (string) $trace_url );
+			$trace_request_headers  = '{}';
+			$trace_request_body     = (string) wp_json_encode(
+				array(
+					'request_bytes'           => $request_bytes,
+					'request_tokens_estimate' => (int) ceil( $request_bytes / 4 ),
+					'request_size_class'      => self::classify_request_size( $request_bytes ),
+				)
+			);
+			$trace_response_headers = '{}';
+			$trace_response_body    = '';
+			$error                  = 'HTTP 413';
+		}
+
 		ProviderTrace::insert(
 			[
 				'provider_id'           => $inflight['provider_id'] ?? '',
 				'model_id'              => $model_id,
-				'url'                   => $inflight['url'] ?? $url,
+				'url'                   => $trace_url,
 				'method'                => $inflight['method'] ?? 'POST',
 				'status_code'           => $status_code,
 				'duration_ms'           => $duration_ms,
 				'cache_creation_tokens' => $cache_tokens['creation'],
 				'cache_read_tokens'     => $cache_tokens['read'],
-				'request_headers'       => $inflight['request_headers'] ?? '{}',
-				'request_body'          => $inflight['request_body'] ?? '',
-				'response_headers'      => $response_headers_json,
-				'response_body'         => $response_body,
+				'request_headers'       => $trace_request_headers,
+				'request_body'          => $trace_request_body,
+				'response_headers'      => $trace_response_headers,
+				'response_body'         => $trace_response_body,
 				'error'                 => $error,
 			]
 		);
 
 		return $response;
+	}
+
+	/**
+	 * Emit prompt-free payload-limit diagnostics.
+	 *
+	 * @param string $provider_id       Runtime-selected provider ID.
+	 * @param string $model_id          Runtime-selected model ID.
+	 * @param int    $status_code       HTTP-like status code.
+	 * @param int    $request_bytes     Actual or estimated request bytes.
+	 * @param int    $request_tokens    Estimated request tokens.
+	 * @param int    $request_budget    Configured request byte budget.
+	 * @param bool   $local_rejection   Whether dispatch was blocked locally.
+	 * @param bool   $fallback_attempted Whether a reduced fallback was attempted.
+	 * @param bool   $bytes_estimated   Whether request_bytes is a history estimate.
+	 */
+	public static function record_payload_limit(
+		string $provider_id,
+		string $model_id,
+		int $status_code,
+		int $request_bytes,
+		int $request_tokens,
+		int $request_budget,
+		bool $local_rejection,
+		bool $fallback_attempted,
+		bool $bytes_estimated = false
+	): void {
+		$context               = array(
+			'provider_id'             => sanitize_key( $provider_id ),
+			'model_id'                => sanitize_text_field( $model_id ),
+			'status_code'             => $status_code,
+			'request_tokens_estimate' => max( 0, $request_tokens ),
+			'request_budget_bytes'    => max( 0, $request_budget ),
+			'request_size_class'      => self::classify_request_size( $request_bytes ),
+			'request_size_source'     => $bytes_estimated ? 'history_estimate' : 'http_body',
+			'local_rejection'         => $local_rejection,
+			'fallback_attempted'      => $fallback_attempted,
+		);
+		$bytes_key             = $bytes_estimated ? 'request_bytes_estimate' : 'request_bytes';
+		$context[ $bytes_key ] = max( 0, $request_bytes );
+
+		AgentEventLog::log( 'provider_payload_limit', AgentEventLog::SEVERITY_ERROR, $context );
+	}
+
+	/** Classify request size without retaining request content. */
+	public static function classify_request_size( int $request_bytes ): string {
+		if ( $request_bytes < 65536 ) {
+			return 'small';
+		}
+		if ( $request_bytes < 262144 ) {
+			return 'medium';
+		}
+		if ( $request_bytes < 1048576 ) {
+			return 'large';
+		}
+
+		return 'very_large';
+	}
+
+	/**
+	 * Remove query/user-info fragments that can carry credentials from a trace URL.
+	 *
+	 * @param string $url Provider URL.
+	 */
+	private static function safe_trace_url( string $url ): string {
+		$parts = wp_parse_url( $url );
+		if ( ! is_array( $parts ) || empty( $parts['host'] ) ) {
+			return '';
+		}
+
+		$safe = ( $parts['scheme'] ?? 'https' ) . '://' . $parts['host'];
+		if ( isset( $parts['port'] ) ) {
+			$safe .= ':' . (int) $parts['port'];
+		}
+		$safe .= $parts['path'] ?? '';
+
+		return $safe;
 	}
 
 	/**

--- a/includes/Core/ProviderTraceLogger.php
+++ b/includes/Core/ProviderTraceLogger.php
@@ -39,7 +39,8 @@ class ProviderTraceLogger {
 	 *
 	 * @var array{provider_id:string,model_id:string}
 	 */
-	private static array $runtime_context = array(
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase -- Project property naming guidance requires camelCase.
+	private static array $runtimeContext = array(
 		'provider_id' => '',
 		'model_id'    => '',
 	);
@@ -107,7 +108,7 @@ class ProviderTraceLogger {
 	 * @param string $model_id    Runtime-selected model ID.
 	 */
 	public static function set_runtime_context( string $provider_id, string $model_id ): void {
-		self::$runtime_context = array(
+		self::$runtimeContext = array(
 			'provider_id' => sanitize_key( $provider_id ),
 			'model_id'    => sanitize_text_field( $model_id ),
 		);
@@ -115,7 +116,7 @@ class ProviderTraceLogger {
 
 	/** Clear runtime provider attribution after a synchronous request. */
 	public static function clear_runtime_context(): void {
-		self::$runtime_context = array(
+		self::$runtimeContext = array(
 			'provider_id' => '',
 			'model_id'    => '',
 		);
@@ -129,7 +130,7 @@ class ProviderTraceLogger {
 	 * @param string                               $url         The request URL.
 	 * @return false|array<string, mixed>|\WP_Error Unchanged response, or a safe local size rejection.
 	 */
-	public static function on_pre_http_request( $response, array $parsed_args, string $url ) {
+	public static function on_pre_http_request( false|array|\WP_Error $response, array $parsed_args, string $url ): false|array|\WP_Error {
 		if ( false !== $response ) {
 			return $response;
 		}
@@ -138,25 +139,17 @@ class ProviderTraceLogger {
 			? $parsed_args['body']
 			: (string) wp_json_encode( $parsed_args['body'] ?? '' );
 		$trace_enabled = ProviderTrace::is_enabled();
-		$has_context   = '' !== self::$runtime_context['provider_id'];
+		$has_context   = '' !== self::$runtimeContext['provider_id'];
 
 		if ( ! $trace_enabled && ! $has_context ) {
 			return $response;
 		}
 
-		// When tracing is enabled we cast a wider net than the canonical
-		// allowlist so connector plugins that proxy to HuggingFace,
-		// OpenRouter, custom OpenAI-compatible endpoints, etc. are also
-		// captured. The error-log path on `on_http_response()` still uses
-		// the strict allowlist so we don't spam logs for unrelated 4xx
-		// responses.
-		$matched_provider_id = self::resolve_provider_for_trace( $url, $request_body );
-		if ( '' === $matched_provider_id ) {
-			return $response;
-		}
-
-		$provider_id = $has_context ? self::$runtime_context['provider_id'] : $matched_provider_id;
-		$model_id    = self::$runtime_context['model_id'];
+		// Runtime attribution is set only around the synchronous SDK provider
+		// invocation. Trust it for local enforcement so a trace callback cannot
+		// inspect prompt content or veto the request-size guard.
+		$provider_id = $has_context ? self::$runtimeContext['provider_id'] : '';
+		$model_id    = self::$runtimeContext['model_id'];
 		if ( '' === $model_id ) {
 			$model_id = self::extract_model_id( $request_body );
 		}
@@ -195,6 +188,17 @@ class ProviderTraceLogger {
 			return $response;
 		}
 
+		// Only explicit debug tracing may pass a request body through the wider
+		// provider matcher and its extension filter. Payload enforcement above is
+		// deliberately independent of this trace-only resolution result.
+		$matched_provider_id = self::resolve_provider_for_trace( $url, $request_body );
+		if ( '' === $matched_provider_id ) {
+			return $response;
+		}
+		if ( ! $has_context ) {
+			$provider_id = $matched_provider_id;
+		}
+
 		// Store in-flight data for correlation with the response.
 		self::$inflight[ $url ] = [
 			'provider_id'     => $provider_id,
@@ -229,21 +233,18 @@ class ProviderTraceLogger {
 		$request_body = is_string( $parsed_args['body'] ?? null )
 			? $parsed_args['body']
 			: (string) wp_json_encode( $parsed_args['body'] ?? '' );
-		$has_context  = '' !== self::$runtime_context['provider_id'];
+		$has_context  = '' !== self::$runtimeContext['provider_id'];
 
 		// Lightweight error-log path: emit a greppable line for 4xx/5xx
 		// responses from canonical AI providers regardless of debug mode.
 		// Uses the strict allowlist so unrelated 4xx responses (update
 		// checks, WP.org, etc.) never produce noise here.
 		$canonical_provider_id = self::match_provider( $url );
-		$request_provider_id   = $canonical_provider_id;
-		if ( $has_context && '' !== self::resolve_provider_for_trace( $url, $request_body ) ) {
-			$request_provider_id = self::$runtime_context['provider_id'];
-		}
+		$request_provider_id   = $has_context ? self::$runtimeContext['provider_id'] : $canonical_provider_id;
 		if ( '' !== $request_provider_id ) {
 			$status_code_for_log = (int) wp_remote_retrieve_response_code( $response );
 			if ( $status_code_for_log >= 400 ) {
-				$model_id_for_log = self::$runtime_context['model_id'];
+				$model_id_for_log = self::$runtimeContext['model_id'];
 				if ( '' === $model_id_for_log ) {
 					$model_id_for_log = self::extract_model_id( $request_body );
 				}

--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -401,6 +401,11 @@ class Settings {
 			'knowledge_enabled'               => true,
 			'knowledge_auto_index'            => true,
 			'max_history_turns'               => 20,
+			// Local input guards. The byte limit is enforced against the final
+			// serialized HTTP body; the token limit bounds retained conversation
+			// history before the provider builder runs.
+			'provider_request_max_bytes'      => ConversationTrimmer::DEFAULT_MAX_REQUEST_BYTES,
+			'provider_request_max_tokens'     => ConversationTrimmer::DEFAULT_MAX_REQUEST_TOKENS,
 			'suggestion_count'                => 3,
 			'yolo_mode'                       => false,
 			'show_on_frontend'                => true,

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -260,6 +260,33 @@ final class SessionController {
 			)
 		);
 
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/sessions/(?P<id>\d+)/compact',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'handle_compact_session' ),
+				'permission_callback' => array( $this, 'check_session_permission' ),
+				'args'                => array(
+					'id'          => array(
+						'required'          => true,
+						'type'              => 'integer',
+						'sanitize_callback' => 'absint',
+					),
+					'provider_id' => array(
+						'required'          => false,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'model_id'    => array(
+						'required'          => false,
+						'type'              => 'string',
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+			)
+		);
+
 		// Export endpoint.
 		register_rest_route(
 			RestController::NAMESPACE,
@@ -844,6 +871,126 @@ final class SessionController {
 			),
 			201
 		);
+	}
+
+	/**
+	 * Handle POST /sessions/{id}/compact — create a bounded continuation session.
+	 *
+	 * The source transcript is read from the server-side session row and reduced to
+	 * one deterministic context seed. The browser never submits the full transcript
+	 * back to `/run`, which prevents `/compact` itself from hitting provider input
+	 * limits or logging raw attachment/tool payloads.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function handle_compact_session( WP_REST_Request $request ) {
+		$source_session_id = self::get_int_param( $request, 'id' );
+		$source_session    = $this->database->get_session( $source_session_id );
+
+		if ( ! $source_session ) {
+			return new WP_Error(
+				'sd_ai_agent_session_not_found',
+				__( 'Session not found.', 'superdav-ai-agent' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$decoded_messages = json_decode( (string) $source_session->messages, true );
+		$source_messages  = is_array( $decoded_messages ) ? array_values( array_filter( $decoded_messages, 'is_array' ) ) : array();
+
+		if ( empty( $source_messages ) ) {
+			return new WP_Error(
+				'sd_ai_agent_compact_empty_session',
+				__( 'This conversation has no saved messages to compact.', 'superdav-ai-agent' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$compacted     = ConversationTrimmer::compact_serialized_history( $source_messages );
+		$seed_messages = $compacted['messages'];
+		if ( empty( $seed_messages ) ) {
+			return new WP_Error(
+				'sd_ai_agent_compact_failed',
+				__( 'Failed to build compact conversation context.', 'superdav-ai-agent' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$provider_id = (string) ( $request->get_param( 'provider_id' ) ?: $source_session->provider_id );
+		$model_id    = (string) ( $request->get_param( 'model_id' ) ?: $source_session->model_id );
+		$title       = $this->build_compacted_session_title( (string) $source_session->title );
+
+		$new_session_id = $this->database->create_session(
+			array(
+				'user_id'     => get_current_user_id(),
+				'title'       => $title,
+				'provider_id' => sanitize_text_field( $provider_id ),
+				'model_id'    => sanitize_text_field( $model_id ),
+			)
+		);
+
+		if ( ! $new_session_id ) {
+			return new WP_Error(
+				'sd_ai_agent_session_create_failed',
+				__( 'Failed to create compacted session.', 'superdav-ai-agent' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		if ( ! $this->database->append_to_session( (int) $new_session_id, $seed_messages, array() ) ) {
+			$this->database->delete_session( (int) $new_session_id );
+			return new WP_Error(
+				'sd_ai_agent_compact_failed',
+				__( 'Failed to save compact conversation context.', 'superdav-ai-agent' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$new_session = $this->database->get_session( (int) $new_session_id );
+		if ( ! $new_session ) {
+			return new WP_Error(
+				'sd_ai_agent_session_not_found',
+				__( 'Session not found after compaction.', 'superdav-ai-agent' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return new WP_REST_Response(
+			array(
+				'id'             => (int) $new_session->id,
+				'title'          => $new_session->title,
+				'provider_id'    => $new_session->provider_id,
+				'model_id'       => $new_session->model_id,
+				'messages'       => ConversationDisplaySanitizer::sanitize_messages( $seed_messages ),
+				'tool_calls'     => array(),
+				'token_usage'    => array(
+					'prompt'     => 0,
+					'completion' => 0,
+				),
+				'compacted_from' => $source_session_id,
+				'compaction'     => $compacted['meta'],
+				'created_at'     => $new_session->created_at,
+				'updated_at'     => $new_session->updated_at,
+			),
+			201
+		);
+	}
+
+	/** Build a safe title for a server-compacted continuation session. */
+	private function build_compacted_session_title( string $source_title ): string {
+		$source_title = sanitize_text_field( $source_title );
+		if ( '' === $source_title ) {
+			$source_title = __( 'conversation', 'superdav-ai-agent' );
+		}
+
+		$title = sprintf(
+			/* translators: %s: original conversation title. */
+			__( 'Compacted: %s', 'superdav-ai-agent' ),
+			$source_title
+		);
+
+		return strlen( $title ) > 190 ? substr( $title, 0, 189 ) . '…' : $title;
 	}
 
 	/**

--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -55,6 +55,7 @@ require( '../index' );
 
 const { reducer, actions, selectors } = capturedConfig;
 const { resolveProviderSelection } = require( '../slices/providersSlice' );
+const apiFetch = require( '@wordpress/api-fetch' );
 
 // ─── Default state ────────────────────────────────────────────────────────────
 
@@ -307,6 +308,61 @@ describe( 'actions', () => {
 
 	test( 'sendMessage returns a thunk function', () => {
 		expect( typeof actions.sendMessage( 'hello' ) ).toBe( 'function' );
+	} );
+
+	test( 'compactConversation uses the server compact endpoint without resending transcript', async () => {
+		apiFetch.mockReset();
+		const compactedMessages = [
+			{
+				role: 'user',
+				parts: [ { text: 'Server compacted context' } ],
+			},
+		];
+		apiFetch.mockResolvedValue( {
+			id: '77',
+			messages: compactedMessages,
+			tool_calls: [],
+		} );
+
+		const dispatch = {
+			setCurrentSession: jest.fn(),
+			setTokenUsage: jest.fn(),
+			resetSessionTokens: jest.fn(),
+			fetchSessions: jest.fn(),
+			sendMessage: jest.fn(),
+		};
+		const select = {
+			getCurrentSessionId: jest.fn( () => 12 ),
+			getSelectedProviderId: jest.fn( () => 'openai' ),
+			getSelectedModelId: jest.fn( () => 'gpt-test' ),
+			getCurrentSessionMessages: jest.fn( () => [
+				{ role: 'user', parts: [ { text: 'Do not resubmit me' } ] },
+			] ),
+		};
+
+		await actions.compactConversation()( { dispatch, select } );
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/sd-ai-agent/v1/sessions/12/compact',
+			method: 'POST',
+			data: {
+				provider_id: 'openai',
+				model_id: 'gpt-test',
+			},
+		} );
+		expect( select.getCurrentSessionMessages ).not.toHaveBeenCalled();
+		expect( dispatch.setCurrentSession ).toHaveBeenCalledWith(
+			77,
+			compactedMessages,
+			[]
+		);
+		expect( dispatch.setTokenUsage ).toHaveBeenCalledWith( {
+			prompt: 0,
+			completion: 0,
+		} );
+		expect( dispatch.resetSessionTokens ).toHaveBeenCalled();
+		expect( dispatch.fetchSessions ).toHaveBeenCalled();
+		expect( dispatch.sendMessage ).not.toHaveBeenCalled();
 	} );
 
 	test( 'retryLastMessage rewinds to the last user message and resends it', async () => {

--- a/src/store/slices/sessionsSlice.js
+++ b/src/store/slices/sessionsSlice.js
@@ -1377,49 +1377,43 @@ export const actions = {
 	},
 
 	/**
-	 * Compact the current conversation into a new session with a summary.
-	 * Builds a text summary of all messages, creates a new session, and
-	 * sends the summary as the first message to preserve context.
+	 * Compact the current conversation into a new bounded continuation session.
+	 *
+	 * The server reads the persisted session transcript and stores one compact
+	 * context seed in the new session. The browser intentionally does not submit
+	 * the whole in-memory transcript as a `/run` prompt.
 	 *
 	 * @return {Function} Redux thunk.
 	 */
 	compactConversation() {
 		return async ( { dispatch, select } ) => {
-			const messages = select.getCurrentSessionMessages();
-			if ( ! messages.length ) {
+			const sessionId = select.getCurrentSessionId();
+			if ( ! sessionId ) {
 				return;
 			}
 
-			// Build a summary request.
-			const summaryText = messages
-				.map( ( m ) => {
-					const role = m.role === 'model' ? 'Assistant' : 'User';
-					const text = extractMessageText( m );
-					return text ? `${ role }: ${ text }` : null;
-				} )
-				.filter( Boolean )
-				.join( '\n' );
-
-			// Create a new session.
 			try {
 				const session = await apiFetch( {
-					path: '/sd-ai-agent/v1/sessions',
+					path: `/sd-ai-agent/v1/sessions/${ sessionId }/compact`,
 					method: 'POST',
 					data: {
-						title: 'Compacted conversation',
 						provider_id: select.getSelectedProviderId(),
 						model_id: select.getSelectedModelId(),
 					},
 				} );
 
-				// Send the summary as the first message in the new session.
-				dispatch.setCurrentSession( session.id, [], [] );
+				const compactedSessionId =
+					typeof session.id === 'string'
+						? parseInt( session.id, 10 )
+						: session.id;
+
+				dispatch.setCurrentSession(
+					compactedSessionId,
+					session.messages || [],
+					session.tool_calls || []
+				);
 				dispatch.setTokenUsage( { prompt: 0, completion: 0 } );
 				dispatch.resetSessionTokens();
-				dispatch.sendMessage(
-					'Please provide a concise summary of this conversation so we can continue in a fresh context:\n\n' +
-						summaryText
-				);
 				dispatch.fetchSessions();
 			} catch {
 				// ignore

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -32,11 +32,66 @@ namespace SdAiAgent\Tests\Core;
 
 use SdAiAgent\Core\AgentLoop;
 use SdAiAgent\Core\ConversationSerializer;
+use SdAiAgent\Core\ConversationTrimmer;
 use SdAiAgent\Core\ProviderCredentialLoader;
 use SdAiAgent\Core\Settings;
 use SdAiAgent\Core\SystemInstructionBuilder;
 use SdAiAgent\Core\ToolPermissionResolver;
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\DTO\ModelMessage;
+use WordPress\AiClient\Providers\DTO\ProviderMetadata;
+use WordPress\AiClient\Providers\Enums\ProviderTypeEnum;
+use WordPress\AiClient\Providers\Http\Enums\RequestAuthenticationMethod;
+use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
+use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
+use WordPress\AiClient\Results\DTO\Candidate;
+use WordPress\AiClient\Results\DTO\GenerativeAiResult;
+use WordPress\AiClient\Results\DTO\TokenUsage;
+use WordPress\AiClient\Results\Enums\FinishReasonEnum;
+use WP_Error;
 use WP_UnitTestCase;
+
+/** Deterministic provider boundary used to exercise recovery without credentials. */
+final class ScriptedAgentLoop extends AgentLoop {
+
+	/** @var list<GenerativeAiResult|WP_Error> */
+	private array $scriptedResults;
+
+	/** @var list<int> */
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase -- Project property naming guidance requires camelCase.
+	public array $requestSizes = array();
+
+	/**
+	 * @param string                                  $user_message User prompt.
+	 * @param string[]                                $abilities    Enabled abilities.
+	 * @param Message[]                               $history      Prior history.
+	 * @param array<string, mixed>                    $options      Agent options.
+	 * @param list<GenerativeAiResult|WP_Error>       $results      Scripted provider results.
+	 */
+	public function __construct( string $user_message, array $abilities, array $history, array $options, array $results ) {
+		$this->scriptedResults = $results;
+		parent::__construct( $user_message, $abilities, $history, $options );
+	}
+
+	/** Return the next scripted result while recording the outgoing history size. */
+	protected function send_prompt( string $provider_id, string $model_id ): GenerativeAiResult|WP_Error {
+		$history_property = new \ReflectionProperty( AgentLoop::class, 'history' );
+		$history_property->setAccessible( true );
+		$history = $history_property->getValue( $this );
+		if ( is_array( $history ) ) {
+			/** @var Message[] $history */
+			$this->requestSizes[] = ConversationTrimmer::estimate_total_bytes( $history );
+		}
+
+		$result = array_shift( $this->scriptedResults );
+		if ( $result instanceof GenerativeAiResult || $result instanceof WP_Error ) {
+			return $result;
+		}
+
+		return new WP_Error( 'sd_ai_agent_test_script_exhausted', 'Scripted provider results exhausted.' );
+	}
+}
 
 /**
  * Integration tests for AgentLoop.
@@ -491,6 +546,35 @@ class AgentLoopTest extends WP_UnitTestCase {
 		);
 	}
 
+	/** Build a deterministic SDK result for scripted provider recovery tests. */
+	private function create_scripted_result( string $reply ): GenerativeAiResult {
+		$provider_metadata = new ProviderMetadata(
+			'scripted-provider',
+			'Scripted Provider',
+			ProviderTypeEnum::cloud(),
+			null,
+			RequestAuthenticationMethod::apiKey()
+		);
+		$model_metadata    = new ModelMetadata(
+			'scripted-model',
+			'Scripted Model',
+			array( CapabilityEnum::textGeneration() ),
+			array()
+		);
+		$candidate         = new Candidate(
+			new ModelMessage( array( new MessagePart( $reply ) ) ),
+			FinishReasonEnum::stop()
+		);
+
+		return new GenerativeAiResult(
+			'scripted-result',
+			array( $candidate ),
+			new TokenUsage( 10, 5, 15 ),
+			$provider_metadata,
+			$model_metadata
+		);
+	}
+
 	// -------------------------------------------------------------------------
 	// Constructor / configuration tests
 	// -------------------------------------------------------------------------
@@ -885,6 +969,132 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertSame( 'sd_ai_agent_provider_payload_too_large', $result->get_error_code() );
 		$this->assertStringContainsString( 'Start a new chat', $result->get_error_message() );
 		$this->assertSame( 413, $result->get_error_data()['status_code'] );
+	}
+
+	/**
+	 * Each distinct provider invocation may make one demonstrably smaller 413 retry.
+	 */
+	public function test_provider_413_recovery_is_scoped_to_each_provider_invocation(): void {
+		$history = array(
+			new \WordPress\AiClient\Messages\DTO\UserMessage(
+				array( new \WordPress\AiClient\Messages\DTO\MessagePart( str_repeat( 'Old provider context. ', 1200 ) ) )
+			),
+			new \WordPress\AiClient\Messages\DTO\ModelMessage(
+				array( new \WordPress\AiClient\Messages\DTO\MessagePart( 'Old response.' ) )
+			),
+			new \WordPress\AiClient\Messages\DTO\UserMessage(
+				array( new \WordPress\AiClient\Messages\DTO\MessagePart( str_repeat( 'More recent context. ', 300 ) ) )
+			),
+			new \WordPress\AiClient\Messages\DTO\ModelMessage(
+				array( new \WordPress\AiClient\Messages\DTO\MessagePart( 'More recent response.' ) )
+			),
+		);
+
+		$options = array(
+			'provider_id' => 'scripted-provider',
+			'model_id'    => 'scripted-model',
+		);
+		$loop    = new ScriptedAgentLoop(
+			'Current request.',
+			array(),
+			$history,
+			$options,
+			array(
+				new WP_Error( 'sd_ai_agent_provider_payload_too_large', 'Payload too large.', array( 'status_code' => 413 ) ),
+				$this->create_scripted_result( '' ),
+				new WP_Error( 'sd_ai_agent_provider_payload_too_large', 'Payload too large.', array( 'status_code' => 413 ) ),
+				$this->create_scripted_result( 'Recovered after the follow-up retry.' ),
+			)
+		);
+		$result = $loop->run();
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'Recovered after the follow-up retry.', $result['reply'] );
+		$this->assertCount( 4, $loop->requestSizes );
+		$this->assertLessThan( $loop->requestSizes[0], $loop->requestSizes[1] );
+		$this->assertLessThan( $loop->requestSizes[2], $loop->requestSizes[3] );
+
+		$recoveries = array_filter(
+			$result['messages'],
+			static fn( array $entry ): bool => 'provider_payload_recovery' === ( $entry['type'] ?? '' )
+		);
+		$this->assertCount( 2, $recoveries );
+	}
+
+	/**
+	 * A repeated 413 from the auxiliary follow-up is returned with resumable data.
+	 */
+	public function test_followup_propagates_repeated_payload_error_with_recovery_data(): void {
+		$history = array(
+			new \WordPress\AiClient\Messages\DTO\UserMessage(
+				array( new \WordPress\AiClient\Messages\DTO\MessagePart( str_repeat( 'Earlier context. ', 1200 ) ) )
+			),
+			new \WordPress\AiClient\Messages\DTO\ModelMessage(
+				array( new \WordPress\AiClient\Messages\DTO\MessagePart( 'Earlier response.' ) )
+			),
+		);
+
+		$options = array(
+			'provider_id' => 'scripted-provider',
+			'model_id'    => 'scripted-model',
+		);
+		$loop    = new ScriptedAgentLoop(
+			'Current request.',
+			array(),
+			$history,
+			$options,
+			array(
+				$this->create_scripted_result( '' ),
+				new WP_Error( 'sd_ai_agent_provider_payload_too_large', 'Payload too large.', array( 'status_code' => 413 ) ),
+				new WP_Error( 'sd_ai_agent_provider_payload_too_large', 'Payload too large.', array( 'status_code' => 413 ) ),
+			)
+		);
+		$result = $loop->run();
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_provider_payload_too_large', $result->get_error_code() );
+		$this->assertCount( 3, $loop->requestSizes );
+		$data = $result->get_error_data();
+		$this->assertIsArray( $data );
+		$this->assertTrue( $data['fallback_attempted'] );
+		$this->assertTrue( $data['payload_reduced'] );
+		$this->assertTrue( $data['recoverable'] );
+		$this->assertNotEmpty( $data['history'] );
+	}
+
+	/**
+	 * An irreducible newest turn is rejected locally before any provider call.
+	 */
+	public function test_oversized_current_turn_is_rejected_locally_with_recoverable_history(): void {
+		Settings::instance()->update(
+			array(
+				'provider_request_max_bytes'  => 1024,
+				'provider_request_max_tokens' => 256,
+			)
+		);
+
+		$current = str_repeat( 'Oversized current request. ', 400 );
+		$loop    = new ScriptedAgentLoop(
+			$current,
+			array(),
+			array(),
+			array(
+				'provider_id' => 'scripted-provider',
+				'model_id'    => 'scripted-model',
+			),
+			array( $this->create_scripted_result( 'Should not be sent.' ) )
+		);
+		$result  = $loop->run();
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_provider_payload_budget_exceeded', $result->get_error_code() );
+		$this->assertCount( 0, $loop->requestSizes );
+		$data = $result->get_error_data();
+		$this->assertIsArray( $data );
+		$this->assertTrue( $data['local_rejection'] );
+		$this->assertFalse( $data['fallback_attempted'] );
+		$this->assertTrue( $data['recoverable'] );
+		$this->assertStringContainsString( $current, (string) wp_json_encode( $data['history'] ) );
 	}
 
 	// -------------------------------------------------------------------------
@@ -1509,19 +1719,24 @@ class AgentLoopTest extends WP_UnitTestCase {
 			3
 		);
 
-		// Use max_iterations = 2 to keep the test fast.
-		$loop   = new AgentLoop( 'Loop forever', [], [], [ 'max_iterations' => 2 ] );
+		// Use max_iterations = 2 and one no-sleep provider attempt to keep the test fast.
+		$options                   = $this->no_sleep_retry_options( 1 );
+		$options['max_iterations'] = 2;
+		$loop                      = new AgentLoop( 'Loop forever', [], [], $options );
 		$result = $loop->run();
 
-		// Fallback failed → falls through to the WP_Error path.
+		// The auxiliary fallback must propagate its provider failure rather than
+		// replacing it with an unrelated max-iterations error.
 		$this->assertInstanceOf( \WP_Error::class, $result );
-		$this->assertSame( 'sd_ai_agent_max_iterations', $result->get_error_code() );
+		$this->assertSame( 'sd_ai_agent_provider_retry_failed', $result->get_error_code() );
 
-		// Error data should include tool_calls and iterations_used.
+		// Error data should keep resumable history and loop metadata.
 		$data = $result->get_error_data();
 		$this->assertIsArray( $data );
 		$this->assertArrayHasKey( 'tool_calls', $data );
 		$this->assertArrayHasKey( 'iterations_used', $data );
+		$this->assertTrue( $data['recoverable'] );
+		$this->assertNotEmpty( $data['history'] );
 		// 2 loop iterations + 1 fallback attempt = 3.
 		$this->assertSame( 3, $data['iterations_used'] );
 	}

--- a/tests/SdAiAgent/Core/ConversationTrimmerTest.php
+++ b/tests/SdAiAgent/Core/ConversationTrimmerTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Test case for ConversationTrimmer class.
  *
@@ -11,6 +13,7 @@ namespace SdAiAgent\Tests\Core;
 
 use SdAiAgent\Core\ConversationTrimmer;
 use SdAiAgent\Core\Settings;
+use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\UserMessage;
 use WordPress\AiClient\Messages\DTO\AssistantMessage;
 use WordPress\AiClient\Messages\DTO\MessagePart;
@@ -221,7 +224,7 @@ class ConversationTrimmerTest extends WP_UnitTestCase {
 		$result  = ConversationTrimmer::trim_to_budget( $history, 512, 0 );
 		$encoded = (string) wp_json_encode(
 			array_map(
-				static fn( $message ): array => $message->toArray(),
+				static fn( Message $message ): array => $message->toArray(),
 				$result
 			)
 		);

--- a/tests/SdAiAgent/Core/ConversationTrimmerTest.php
+++ b/tests/SdAiAgent/Core/ConversationTrimmerTest.php
@@ -206,6 +206,70 @@ class ConversationTrimmerTest extends WP_UnitTestCase {
 		$this->assertCount( 2, $result );
 	}
 
+	/**
+	 * Byte-budget trimming may discard an oversized first turn.
+	 */
+	public function test_trim_to_budget_drops_oversized_first_turn(): void {
+		$oversized = str_repeat( 'old-context-', 600 );
+		$history   = [
+			$this->create_user_message( $oversized ),
+			$this->create_assistant_message( 'Old response' ),
+			$this->create_user_message( 'Current request' ),
+			$this->create_assistant_message( 'Current response' ),
+		];
+
+		$result  = ConversationTrimmer::trim_to_budget( $history, 512, 0 );
+		$encoded = (string) wp_json_encode(
+			array_map(
+				static fn( $message ): array => $message->toArray(),
+				$result
+			)
+		);
+
+		$this->assertLessThanOrEqual( 512, ConversationTrimmer::estimate_total_bytes( $result ) );
+		$this->assertStringNotContainsString( $oversized, $encoded );
+		$this->assertStringContainsString( 'Current request', $encoded );
+		$this->assertStringContainsString( 'compacted', $encoded );
+	}
+
+	/**
+	 * The newest turn is retained for a caller-side local rejection when it
+	 * cannot fit by itself.
+	 */
+	public function test_trim_to_budget_does_not_silently_drop_oversized_current_turn(): void {
+		$current = str_repeat( 'current-request-', 200 );
+		$history = [ $this->create_user_message( $current ) ];
+
+		$result = ConversationTrimmer::trim_to_budget( $history, 256, 64 );
+
+		$this->assertCount( 1, $result );
+		$this->assertFalse( ConversationTrimmer::fits_budget( $result, 256, 64 ) );
+		$this->assertStringContainsString( $current, (string) wp_json_encode( $result[0]->toArray() ) );
+	}
+
+	/**
+	 * Budget trimming keeps a complete recent tool-call/result cycle.
+	 */
+	public function test_trim_to_budget_preserves_recent_tool_pairs(): void {
+		$history = [
+			$this->create_user_message_mock( str_repeat( 'old context ', 600 ) ),
+			$this->create_assistant_message_mock( 'Old answer' ),
+			$this->create_user_message_mock( 'Run the current tool' ),
+			$this->create_tool_call_message( [
+				[ 'id' => 'call_current', 'name' => 'site-info' ],
+			] ),
+			$this->create_tool_response_message( 'call_current', 'site-info' ),
+			$this->create_assistant_message_mock( 'Current tool completed.' ),
+		];
+
+		$result = ConversationTrimmer::trim_to_budget( $history, 1400, 350 );
+
+		$this->assertTrue( ConversationTrimmer::fits_budget( $result, 1400, 350 ) );
+		$this->assert_tool_pairs_valid( $result );
+		$this->assertContains( 'call_current', $this->extract_all_call_ids_for_test( $result ) );
+		$this->assertContains( 'call_current', $this->extract_all_response_ids_for_test( $result ) );
+	}
+
 	// ── Tool-response pairing tests ──────────────────────────────────────
 
 	/**
@@ -646,6 +710,34 @@ class ConversationTrimmerTest extends WP_UnitTestCase {
 					$ids[] = (string) $fr->getId();
 				}
 			}
+		}
+		return $ids;
+	}
+
+	/**
+	 * Extract every FunctionCall ID from history.
+	 *
+	 * @param object[] $history Conversation history.
+	 * @return string[]
+	 */
+	private function extract_all_call_ids_for_test( array $history ): array {
+		$ids = [];
+		foreach ( $history as $message ) {
+			$ids = array_merge( $ids, $this->extract_call_ids_for_test( $message ) );
+		}
+		return $ids;
+	}
+
+	/**
+	 * Extract every FunctionResponse ID from history.
+	 *
+	 * @param object[] $history Conversation history.
+	 * @return string[]
+	 */
+	private function extract_all_response_ids_for_test( array $history ): array {
+		$ids = [];
+		foreach ( $history as $message ) {
+			$ids = array_merge( $ids, $this->extract_response_ids_for_test( $message ) );
 		}
 		return $ids;
 	}

--- a/tests/SdAiAgent/Core/ConversationTrimmerTest.php
+++ b/tests/SdAiAgent/Core/ConversationTrimmerTest.php
@@ -270,6 +270,60 @@ class ConversationTrimmerTest extends WP_UnitTestCase {
 		$this->assertContains( 'call_current', $this->extract_all_response_ids_for_test( $result ) );
 	}
 
+	/**
+	 * Server-side compacting returns a bounded seed and omits raw binary/tool payloads.
+	 */
+	public function test_compact_serialized_history_builds_bounded_safe_seed(): void {
+		$messages = [
+			[
+				'role'  => 'user',
+				'parts' => [ [ 'text' => str_repeat( 'old transcript ', 1000 ) ] ],
+			],
+			[
+				'role'  => 'model',
+				'parts' => [
+					[
+						'functionCall' => [
+							'name' => 'sd-ai-agent/site-info',
+							'args' => [ 'secret' => 'SHOULD_NOT_COPY_ARGS' ],
+						],
+					],
+				],
+			],
+			[
+				'role'  => 'user',
+				'parts' => [
+					[
+						'functionResponse' => [
+							'name'     => 'sd-ai-agent/site-info',
+							'response' => 'SECRET_TOOL_RESPONSE_SHOULD_NOT_COPY',
+						],
+					],
+				],
+			],
+			[
+				'role'  => 'user',
+				'parts' => [
+					[
+						'text'      => 'Latest request survives compaction.',
+						'image_url' => 'data:image/png;base64,' . str_repeat( 'A', 4000 ),
+					],
+				],
+			],
+		];
+
+		$result = ConversationTrimmer::compact_serialized_history( $messages, 1024, 256 );
+		$json   = (string) wp_json_encode( $result['messages'] );
+
+		$this->assertCount( 1, $result['messages'] );
+		$this->assertLessThanOrEqual( 1024, $result['meta']['estimated_bytes'] );
+		$this->assertSame( 4, $result['meta']['source_message_count'] );
+		$this->assertStringContainsString( 'Latest request survives compaction.', $json );
+		$this->assertStringNotContainsString( 'data:image', $json );
+		$this->assertStringNotContainsString( 'SHOULD_NOT_COPY_ARGS', $json );
+		$this->assertStringNotContainsString( 'SECRET_TOOL_RESPONSE_SHOULD_NOT_COPY', $json );
+	}
+
 	// ── Tool-response pairing tests ──────────────────────────────────────
 
 	/**

--- a/tests/SdAiAgent/Core/ProviderTraceLoggerResolveTest.php
+++ b/tests/SdAiAgent/Core/ProviderTraceLoggerResolveTest.php
@@ -26,8 +26,11 @@ use WP_UnitTestCase;
 class ProviderTraceLoggerResolveTest extends WP_UnitTestCase {
 
 	public function tear_down(): void {
+		ProviderTraceLogger::clear_runtime_context();
 		remove_all_filters( 'sd_ai_agent_trace_match_provider' );
 		remove_all_filters( 'sd_ai_agent_trace_resolve_provider' );
+		remove_all_filters( 'sd_ai_agent_provider_trace_enabled' );
+		remove_all_filters( 'sd_ai_agent_provider_request_max_bytes' );
 		parent::tear_down();
 	}
 
@@ -194,5 +197,87 @@ class ProviderTraceLoggerResolveTest extends WP_UnitTestCase {
 			'anthropic',
 			ProviderTraceLogger::match_provider( 'https://api.anthropic.com/v1/messages' )
 		);
+	}
+
+	/**
+	 * Runtime payload enforcement must not expose prompts to trace callbacks or
+	 * allow a trace veto to disable the local byte guard.
+	 */
+	public function test_runtime_payload_guard_is_independent_of_disabled_tracing(): void {
+		add_filter( 'sd_ai_agent_provider_trace_enabled', '__return_false' );
+		add_filter( 'sd_ai_agent_provider_request_max_bytes', static fn(): int => 1024 );
+
+		$body_seen = null;
+		add_filter(
+			'sd_ai_agent_trace_resolve_provider',
+			static function ( string $provider_id, string $url, string $body ) use ( &$body_seen ): string {
+				$body_seen = $body;
+				return '';
+			},
+			10,
+			3
+		);
+
+		ProviderTraceLogger::set_runtime_context( 'openai_compat', 'gpt-test' );
+		$request_body = (string) wp_json_encode(
+			array(
+				'model'  => 'gpt-test',
+				'prompt' => str_repeat( 'PRIVATE_PROMPT_CONTENT', 100 ),
+			)
+		);
+		$result       = ProviderTraceLogger::on_pre_http_request(
+			false,
+			array( 'body' => $request_body ),
+			'https://private-provider.example/v1/infer'
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_provider_payload_budget_exceeded', $result->get_error_code() );
+		$this->assertTrue( $result->get_error_data()['local_rejection'] );
+		$this->assertNull( $body_seen, 'Disabled tracing must not pass prompt bodies to trace resolution filters.' );
+	}
+
+	/** A traced provider context attributes 413 diagnostics without invoking trace filters when disabled. */
+	public function test_runtime_http_error_attribution_does_not_expose_body_when_tracing_is_disabled(): void {
+		add_filter( 'sd_ai_agent_provider_trace_enabled', '__return_false' );
+
+		$body_seen = null;
+		add_filter(
+			'sd_ai_agent_trace_resolve_provider',
+			static function ( string $provider_id, string $url, string $body ) use ( &$body_seen ): string {
+				$body_seen = $body;
+				return $provider_id;
+			},
+			10,
+			3
+		);
+
+		ProviderTraceLogger::set_runtime_context( 'anthropic', 'claude-test' );
+		$request_body = (string) wp_json_encode(
+			array(
+				'model'    => 'claude-test',
+				'messages' => array( array( 'content' => 'PRIVATE_HTTP_PROMPT' ) ),
+			)
+		);
+		$response     = array(
+			'headers'  => array(),
+			'body'     => (string) wp_json_encode( array( 'error' => array( 'message' => 'Payload too large' ) ) ),
+			'response' => array(
+				'code'    => 413,
+				'message' => 'Payload Too Large',
+			),
+			'cookies'  => array(),
+			'filename' => '',
+		);
+
+		$this->assertSame(
+			$response,
+			ProviderTraceLogger::on_http_response(
+				$response,
+				array( 'body' => $request_body ),
+				'https://private-provider.example/v1/infer'
+			)
+		);
+		$this->assertNull( $body_seen, 'Disabled tracing must not pass 413 prompt bodies to trace resolution filters.' );
 	}
 }

--- a/tests/SdAiAgent/Core/SettingsTest.php
+++ b/tests/SdAiAgent/Core/SettingsTest.php
@@ -9,6 +9,7 @@
 
 namespace SdAiAgent\Tests\Core;
 
+use SdAiAgent\Core\ConversationTrimmer;
 use SdAiAgent\Core\ModelCapabilityRegistry;
 use SdAiAgent\Core\Settings;
 use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
@@ -69,6 +70,8 @@ class SettingsTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'temperature', $defaults );
 		$this->assertArrayHasKey( 'max_output_tokens', $defaults );
 		$this->assertArrayHasKey( 'max_history_turns', $defaults );
+		$this->assertArrayHasKey( 'provider_request_max_bytes', $defaults );
+		$this->assertArrayHasKey( 'provider_request_max_tokens', $defaults );
 		$this->assertArrayHasKey( 'show_on_frontend', $defaults );
 	}
 
@@ -85,6 +88,8 @@ class SettingsTest extends WP_UnitTestCase {
 		// and Settings::get_max_output_tokens_for_model(). Was 4096 until sd-ai-7rl.
 		$this->assertSame( 0, $defaults['max_output_tokens'] );
 		$this->assertSame( 20, $defaults['max_history_turns'] );
+		$this->assertSame( ConversationTrimmer::DEFAULT_MAX_REQUEST_BYTES, $defaults['provider_request_max_bytes'] );
+		$this->assertSame( ConversationTrimmer::DEFAULT_MAX_REQUEST_TOKENS, $defaults['provider_request_max_tokens'] );
 		$this->assertTrue( $defaults['show_on_frontend'] );
 	}
 

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Tests\REST;
 
+use SdAiAgent\Core\ConversationTrimmer;
 use SdAiAgent\Core\Database;
 use SdAiAgent\Core\Settings;
 use SdAiAgent\Automations\HumanApprovalGate;
@@ -156,6 +157,7 @@ class RestControllerTest extends WP_UnitTestCase {
 			'/sd-ai-agent/v1/skills/(?P<id>\d+)',
 			'/sd-ai-agent/v1/sessions',
 			'/sd-ai-agent/v1/sessions/(?P<id>\d+)',
+			'/sd-ai-agent/v1/sessions/(?P<id>\d+)/compact',
 			'/sd-ai-agent/v1/sessions/folders',
 			'/sd-ai-agent/v1/sessions/bulk',
 			'/sd-ai-agent/v1/sessions/trash',
@@ -628,6 +630,86 @@ class RestControllerTest extends WP_UnitTestCase {
 		$this->assertSame( 'Get Session Test', $data['title'] );
 		$this->assertArrayHasKey( 'messages', $data );
 		$this->assertArrayHasKey( 'tool_calls', $data );
+	}
+
+	/**
+	 * Test POST /sessions/{id}/compact creates a bounded server-side continuation.
+	 */
+	public function test_compact_session_creates_bounded_server_side_session(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$session_id = Database::create_session(
+			[
+				'user_id'     => $this->admin_id,
+				'title'       => 'Long Session',
+				'provider_id' => 'anthropic',
+				'model_id'    => 'claude-test',
+			]
+		);
+
+		$messages = [
+			[
+				'role'  => 'user',
+				'parts' => [ [ 'text' => str_repeat( 'large old context ', 2000 ) ] ],
+			],
+			[
+				'role'  => 'model',
+				'parts' => [
+					[
+						'functionCall' => [
+							'name' => 'sd-ai-agent/site-info',
+							'args' => [ 'secret' => 'DO_NOT_COPY_ARGS' ],
+						],
+					],
+				],
+			],
+			[
+				'role'  => 'user',
+				'parts' => [
+					[
+						'functionResponse' => [
+							'name'     => 'sd-ai-agent/site-info',
+							'response' => 'DO_NOT_COPY_TOOL_RESULT',
+						],
+					],
+				],
+			],
+			[
+				'role'  => 'user',
+				'parts' => [ [ 'text' => 'Latest continuation detail.' ] ],
+			],
+		];
+		Database::append_to_session( (int) $session_id, $messages );
+
+		$response = $this->dispatch(
+			'POST',
+			"/sd-ai-agent/v1/sessions/{$session_id}/compact",
+			[
+				'provider_id' => 'openai',
+				'model_id'    => 'gpt-test',
+			]
+		);
+
+		$this->assertStatus( 201, $response );
+		$data = $response->get_data();
+		$this->assertIsArray( $data );
+		$this->assertNotSame( (int) $session_id, (int) $data['id'] );
+		$this->assertSame( (int) $session_id, $data['compacted_from'] );
+		$this->assertSame( 'openai', $data['provider_id'] );
+		$this->assertSame( 'gpt-test', $data['model_id'] );
+		$this->assertCount( 1, $data['messages'] );
+
+		$encoded_messages = (string) wp_json_encode( $data['messages'] );
+		$this->assertLessThanOrEqual( ConversationTrimmer::COMPACT_MAX_BYTES, strlen( $encoded_messages ) );
+		$this->assertStringContainsString( 'Latest continuation detail.', $encoded_messages );
+		$this->assertStringNotContainsString( 'DO_NOT_COPY_ARGS', $encoded_messages );
+		$this->assertStringNotContainsString( 'DO_NOT_COPY_TOOL_RESULT', $encoded_messages );
+
+		$new_session = Database::get_session( (int) $data['id'] );
+		$this->assertNotNull( $new_session );
+		$stored_messages = json_decode( (string) $new_session->messages, true );
+		$this->assertIsArray( $stored_messages );
+		$this->assertCount( 1, $stored_messages );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- add byte and estimated-token budgets for provider-bound conversation history
- add agent-loop payload recovery: preflight budget trimming, local rejection for irreducible oversized requests, and one reduced-history retry after provider 413
- add bounded server-side conversation compaction via `POST /sd-ai-agent/v1/sessions/{id}/compact`, so the browser no longer resubmits the full transcript to `/run`
- omit inline image/data bytes, attachment payloads, raw tool arguments, and raw tool responses from compacted continuation seeds
- record safe provider payload-limit telemetry and scrub 413 trace bodies/headers down to size metadata

## Status

Ready for review. Provider request budgets, local/retry recovery, safe telemetry, and the server-backed `/compact` continuation flow are implemented and pushed in `eee01de7`.

## Testing

- `npm run verify` — lint, PHPStan, full PHPUnit, build, and bundle check succeeded.

Resolves #2241

## Worker self-verification
- PHPUnit: Tests: 3751, Assertions: 15733, Errors: 0, Failures: 0, Skipped: 125, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.147 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 20m and 243,776 tokens on this as a headless worker. Overall, 1h 25m since this issue was created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Conversation history is now automatically trimmed to fit configurable request-size (bytes) and token budgets.
  - Trimming preserves recent complete exchanges, including tool call/response pairs.
  - The newest exchange is retained even if it alone exceeds limits.
  - Added default settings for maximum request bytes and tokens.

- **Bug Fixes**
  - Improved handling of provider “payload too large” (HTTP 413) responses with a one-time reduced-history retry.
  - Enhanced error reporting/metadata and provider tracing, including safer redaction on 413.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
