### PR TITLE
fix: short-circuit empty required ability calls

### DIFF
--- a/includes/Core/AbilityFunctionResolver.php
+++ b/includes/Core/AbilityFunctionResolver.php
@@ -127,6 +127,22 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 			$args = KnowledgeAbilities::hydrate_public_search_args( $args );
 		}
 
+		if ( empty( $args ) ) {
+			// @phpstan-ignore-next-line — get_input_schema() exists at runtime in WP 7.0.
+			$input_schema    = $ability->get_input_schema();
+			$required_fields = SchemaExampleBuilder::get_required_fields( $input_schema );
+			if ( ! empty( $required_fields ) ) {
+				return self::build_empty_arguments_response(
+					$function_id,
+					$function_name,
+					$ability_name,
+					$ability,
+					$input_schema,
+					$required_fields
+				);
+			}
+		}
+
 		// Meta-tool argument coercion for `sd-ai-agent/ability-call`:
 		// Claude (and other LLMs) sometimes emits the nested `arguments`
 		// field as a JSON-encoded STRING instead of an object — e.g.
@@ -297,6 +313,53 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 			}
 		}
 		return $args;
+	}
+
+	/**
+	 * Build a validation response without dispatching an empty required-input call.
+	 *
+	 * The provider can emit null, an empty string, or `{}` for function-call
+	 * arguments. Those shapes cannot satisfy an ability with required inputs, so
+	 * avoid spending an execution attempt solely to receive the validator's error.
+	 *
+	 * @param string      $function_id Provider function-call id.
+	 * @param string      $function_name Provider function name.
+	 * @param string      $ability_name Registered ability id.
+	 * @param \WP_Ability $ability Registered ability.
+	 * @param mixed       $input_schema Ability input schema.
+	 * @param string[]    $required_fields Required input field names.
+	 * @return FunctionResponse
+	 */
+	private static function build_empty_arguments_response( string $function_id, string $function_name, string $ability_name, \WP_Ability $ability, $input_schema, array $required_fields ): FunctionResponse {
+		$error_message = sprintf(
+			/* translators: 1: ability name, 2: required input field name. */
+			__( 'Ability "%1$s" has invalid input. Reason: %2$s is a required property of input.', 'superdav-ai-agent' ),
+			$ability_name,
+			$required_fields[0]
+		);
+		$response_data = array(
+			'error'                   => $error_message,
+			'code'                    => 'ability_invalid_input',
+			'input_schema'            => $input_schema,
+			'missing_required_fields' => $required_fields,
+			'example_arguments'       => SchemaExampleBuilder::build_example( $input_schema ),
+			'hint'                    => 'Copy `example_arguments`, replace each `<placeholder>` with a real value, then retry the ability with those arguments. Do not retry with empty arguments.',
+		);
+
+		AgentEventLog::log(
+			'ability_failed',
+			AgentEventLog::SEVERITY_ERROR,
+			array(
+				'ability' => $ability_name,
+				'code'    => 'ability_invalid_input',
+				'message' => $error_message,
+			)
+		);
+		ModelHealthTracker::record_validation_error();
+
+		$response_data = self::enrich_identical_failure_response( $response_data, $ability_name, array(), 'ability_invalid_input', $ability );
+
+		return new FunctionResponse( $function_id, $function_name, $response_data );
 	}
 
 	/**

--- a/includes/Core/AbilityFunctionResolver.php
+++ b/includes/Core/AbilityFunctionResolver.php
@@ -322,15 +322,15 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 	 * arguments. Those shapes cannot satisfy an ability with required inputs, so
 	 * avoid spending an execution attempt solely to receive the validator's error.
 	 *
-	 * @param string      $function_id Provider function-call id.
-	 * @param string      $function_name Provider function name.
-	 * @param string      $ability_name Registered ability id.
-	 * @param \WP_Ability $ability Registered ability.
-	 * @param mixed       $input_schema Ability input schema.
-	 * @param string[]    $required_fields Required input field names.
+	 * @param string               $function_id Provider function-call id.
+	 * @param string               $function_name Provider function name.
+	 * @param string               $ability_name Registered ability id.
+	 * @param \WP_Ability          $ability Registered ability.
+	 * @param array<string, mixed> $input_schema Ability input schema.
+	 * @param string[]             $required_fields Required input field names.
 	 * @return FunctionResponse
 	 */
-	private static function build_empty_arguments_response( string $function_id, string $function_name, string $ability_name, \WP_Ability $ability, $input_schema, array $required_fields ): FunctionResponse {
+	private static function build_empty_arguments_response( string $function_id, string $function_name, string $ability_name, \WP_Ability $ability, array $input_schema, array $required_fields ): FunctionResponse {
 		$error_message = sprintf(
 			/* translators: 1: ability name, 2: required input field name. */
 			__( 'Ability "%1$s" has invalid input. Reason: %2$s is a required property of input.', 'superdav-ai-agent' ),

--- a/includes/Tools/SchemaExampleBuilder.php
+++ b/includes/Tools/SchemaExampleBuilder.php
@@ -53,7 +53,7 @@ class SchemaExampleBuilder {
 		}
 
 		$properties = isset( $schema['properties'] ) && is_array( $schema['properties'] ) ? $schema['properties'] : array();
-		$required   = isset( $schema['required'] ) && is_array( $schema['required'] ) ? $schema['required'] : array();
+		$required   = self::get_required_fields( $schema );
 
 		if ( empty( $required ) ) {
 			return array();
@@ -69,6 +69,34 @@ class SchemaExampleBuilder {
 		}
 
 		return $example;
+	}
+
+	/**
+	 * Return the fields required by an input schema.
+	 *
+	 * @param mixed $schema The ability input_schema (assoc array).
+	 * @return string[]
+	 */
+	public static function get_required_fields( $schema ): array {
+		if ( ! is_array( $schema ) ) {
+			return array();
+		}
+
+		return self::filter_required_fields( $schema['required'] ?? array() );
+	}
+
+	/**
+	 * Keep only usable required field names from a schema value.
+	 *
+	 * @param mixed $fields Schema required value.
+	 * @return string[]
+	 */
+	private static function filter_required_fields( $fields ): array {
+		if ( ! is_array( $fields ) ) {
+			return array();
+		}
+
+		return array_values( array_filter( $fields, static fn( $field ): bool => is_string( $field ) && '' !== $field ) );
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/AbilityFunctionResolverTest.php
+++ b/tests/SdAiAgent/Core/AbilityFunctionResolverTest.php
@@ -104,6 +104,29 @@ class AbilityFunctionResolverTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'Retry only with arguments', $payload['nudge'] );
 	}
 
+	public function test_empty_arguments_return_schema_guidance_without_dispatching(): void {
+		$this->skip_if_resolver_unavailable();
+
+		$ability = $this->register_schema_thrower_ability();
+		$this->assertNotNull( $ability );
+
+		$resolver = new AbilityFunctionResolver( $ability );
+		$response = $resolver->execute_ability(
+			new FunctionCall(
+				'call_empty_arguments',
+				\WP_AI_Client_Ability_Function_Resolver::ability_name_to_function_name( 'test-plugin/schema-thrower' ),
+				null
+			)
+		);
+
+		$payload = $this->normalise_response_payload( $response->getResponse() );
+
+		$this->assertSame( 'ability_invalid_input', $payload['code'] );
+		$this->assertSame( array( 'query' ), $payload['missing_required_fields'] );
+		$this->assertSame( array( 'query' => '<string — Search keywords. Required.>' ), $payload['example_arguments'] );
+		$this->assertStringContainsString( 'Do not retry with empty arguments', $payload['hint'] );
+	}
+
 	public function test_public_knowledge_search_hydrates_empty_args_from_customer_query(): void {
 		$this->skip_if_resolver_unavailable();
 		$this->ensure_knowledge_search_registered();


### PR DESCRIPTION
## Summary

- Short-circuit required-input ability calls when providers emit empty arguments.
- Return the same schema-guided `ability_invalid_input` recovery payload without invoking the ability.
- Cover null function-call arguments with a resolver regression test.

## Worker self-verification
- PHPUnit: Tests: 3747, Assertions: 15718, Errors: 0, Failures: 0, Skipped: 121
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.147 plugin for [OpenCode](https://opencode.ai) v1.18.3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added early validation for abilities when function-call arguments are empty, returning an `ability_invalid_input` response without attempting execution.
  * Validation feedback now clearly identifies missing required fields and includes schema-guided example arguments.

* **Improvements**
  * Error payloads include guidance to avoid retrying with empty arguments.
  * Improved resilience when input schemas have malformed or unusable required-field definitions.

* **Tests**
  * Added coverage for empty-argument behavior to ensure consistent response structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->