### PR TITLE
feat: direct users to Advanced companion

### DIFF
--- a/includes/Abilities/FileAbilities.php
+++ b/includes/Abilities/FileAbilities.php
@@ -37,7 +37,7 @@ class FileAbilities {
 			'sd_ai_agent_advanced_plugin_required',
 			sprintf(
 				/* translators: %s: ability name */
-				__( 'The %s ability is provided by Superdav AI Agent Advanced. Download it from https://sdaiagent.com/advanced/, then upload and activate the ZIP from Plugins > Add New.', 'superdav-ai-agent' ),
+				__( 'The %s ability is provided by Superdav AI Agent Advanced. Download it from https://sdaiagent.com/advanced/, upload it via Plugins > Add New > Upload Plugin, install it, then activate the installed plugin.', 'superdav-ai-agent' ),
 				$ability_name
 			)
 		);

--- a/includes/Abilities/FileAbilities.php
+++ b/includes/Abilities/FileAbilities.php
@@ -37,7 +37,7 @@ class FileAbilities {
 			'sd_ai_agent_advanced_plugin_required',
 			sprintf(
 				/* translators: %s: ability name */
-				__( 'The %s ability is provided by Superdav AI Agent Advanced. Install and activate the advanced plugin to use this tool.', 'superdav-ai-agent' ),
+				__( 'The %s ability is provided by Superdav AI Agent Advanced. Download it from https://sdaiagent.com/advanced/, then upload and activate the ZIP from Plugins > Add New.', 'superdav-ai-agent' ),
 				$ability_name
 			)
 		);

--- a/includes/Abilities/WordPressAbilities.php
+++ b/includes/Abilities/WordPressAbilities.php
@@ -33,7 +33,7 @@ class WordPressAbilities {
 			'sd_ai_agent_advanced_plugin_required',
 			sprintf(
 				/* translators: %s: ability name */
-				__( 'The %s ability is provided by Superdav AI Agent Advanced. Download it from https://sdaiagent.com/advanced/, then upload and activate the ZIP from Plugins > Add New.', 'superdav-ai-agent' ),
+				__( 'The %s ability is provided by Superdav AI Agent Advanced. Download it from https://sdaiagent.com/advanced/, upload it via Plugins > Add New > Upload Plugin, install it, then activate the installed plugin.', 'superdav-ai-agent' ),
 				$ability_name
 			)
 		);

--- a/includes/Abilities/WordPressAbilities.php
+++ b/includes/Abilities/WordPressAbilities.php
@@ -33,7 +33,7 @@ class WordPressAbilities {
 			'sd_ai_agent_advanced_plugin_required',
 			sprintf(
 				/* translators: %s: ability name */
-				__( 'The %s ability is provided by Superdav AI Agent Advanced. Install and activate the advanced plugin to use this tool.', 'superdav-ai-agent' ),
+				__( 'The %s ability is provided by Superdav AI Agent Advanced. Download it from https://sdaiagent.com/advanced/, then upload and activate the ZIP from Plugins > Add New.', 'superdav-ai-agent' ),
 				$ability_name
 			)
 		);

--- a/includes/Core/SystemInstructionBuilder.php
+++ b/includes/Core/SystemInstructionBuilder.php
@@ -111,6 +111,7 @@ class SystemInstructionBuilder {
 		// Use custom system prompt if set, otherwise the built-in default.
 		$custom = $settings['system_prompt'] ?? '';
 		$base   = is_string( $custom ) && '' !== $custom ? $custom : self::default_system_instruction();
+		$base  .= "\n\n" . self::build_advanced_companion_section();
 
 		// Append memory section if memories exist.
 		$memory_text = Memory::get_formatted_for_prompt();
@@ -410,6 +411,17 @@ class SystemInstructionBuilder {
 		}
 
 		return $section;
+	}
+
+	/**
+	 * Return guidance for capabilities supplied by the Advanced companion plugin.
+	 *
+	 * @return string
+	 */
+	public static function build_advanced_companion_section(): string {
+		return "## Advanced Companion\n\n"
+			. 'Your active ability manifest is authoritative. If a requested action needs an ability that is not available, or a tool returns the `sd_ai_agent_advanced_plugin_required` error, explain that the capability is provided by Superdav AI Agent Advanced. '
+			. 'Do not attempt to download, install, activate, or update Advanced automatically. Direct the site administrator to https://sdaiagent.com/advanced/ for the direct ZIP download and manual installation instructions.';
 	}
 
 	/**

--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -1855,9 +1855,9 @@ export default function SettingsApp() {
 							case 'advanced':
 								return (
 									<div className="sdaa-settings-section">
-										<div className="sdaa-advanced-companion-card">
+										<div className="sd-ai-agent-advanced-companion-card">
 											<div>
-												<p className="sdaa-advanced-companion-card__eyebrow">
+												<p className="sd-ai-agent-advanced-companion-card__eyebrow">
 													{ __(
 														'Extend your toolkit',
 														'superdav-ai-agent'

--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -1855,6 +1855,39 @@ export default function SettingsApp() {
 							case 'advanced':
 								return (
 									<div className="sdaa-settings-section">
+										<div className="sdaa-advanced-companion-card">
+											<div>
+												<p className="sdaa-advanced-companion-card__eyebrow">
+													{ __(
+														'Extend your toolkit',
+														'superdav-ai-agent'
+													) }
+												</p>
+												<h3>
+													{ __(
+														'Superdav AI Agent Advanced',
+														'superdav-ai-agent'
+													) }
+												</h3>
+												<p>
+													{ __(
+														'Add self-hosted administrator and developer tools, including advanced plugin and file-management capabilities.',
+														'superdav-ai-agent'
+													) }
+												</p>
+											</div>
+											<a
+												className="button button-primary"
+												href="https://sdaiagent.com/advanced/"
+												rel="noopener noreferrer"
+												target="_blank"
+											>
+												{ __(
+													'Get Advanced',
+													'superdav-ai-agent'
+												) }
+											</a>
+										</div>
 										<h3 className="sdaa-settings-section-title">
 											{ __(
 												'Model Parameters',

--- a/src/settings-page/style.css
+++ b/src/settings-page/style.css
@@ -126,6 +126,53 @@
 	gap: 8px;
 }
 
+/* Advanced companion */
+.sdaa-advanced-companion-card {
+	align-items: center;
+	background: linear-gradient(135deg, #f0f6fc, #fff);
+	border: 1px solid #72aee6;
+	border-radius: 4px;
+	display: flex;
+	gap: 24px;
+	justify-content: space-between;
+	padding: 20px;
+}
+
+.sdaa-advanced-companion-card h3,
+.sdaa-advanced-companion-card p {
+	margin: 0;
+}
+
+.sdaa-advanced-companion-card h3 {
+	font-size: 16px;
+	margin-bottom: 4px;
+}
+
+.sdaa-advanced-companion-card p:not(.sdaa-advanced-companion-card__eyebrow) {
+	max-width: 620px;
+}
+
+.sdaa-advanced-companion-card__eyebrow {
+	color: #135e96;
+	font-size: 12px;
+	font-weight: 600;
+	letter-spacing: 0.04em;
+	margin-bottom: 6px !important;
+	text-transform: uppercase;
+}
+
+.sdaa-advanced-companion-card .button {
+	flex: 0 0 auto;
+}
+
+@media screen and (max-width: 600px) {
+	.sdaa-advanced-companion-card {
+		align-items: flex-start;
+		flex-direction: column;
+		gap: 16px;
+	}
+}
+
 /* YOLO mode section */
 .sdaa-settings-yolo-section {
 	display: flex;

--- a/src/settings-page/style.css
+++ b/src/settings-page/style.css
@@ -127,7 +127,7 @@
 }
 
 /* Advanced companion */
-.sdaa-advanced-companion-card {
+.sd-ai-agent-advanced-companion-card {
 	align-items: center;
 	background: linear-gradient(135deg, #f0f6fc, #fff);
 	border: 1px solid #72aee6;
@@ -138,21 +138,21 @@
 	padding: 20px;
 }
 
-.sdaa-advanced-companion-card h3,
-.sdaa-advanced-companion-card p {
+.sd-ai-agent-advanced-companion-card h3,
+.sd-ai-agent-advanced-companion-card p {
 	margin: 0;
 }
 
-.sdaa-advanced-companion-card h3 {
+.sd-ai-agent-advanced-companion-card h3 {
 	font-size: 16px;
 	margin-bottom: 4px;
 }
 
-.sdaa-advanced-companion-card p:not(.sdaa-advanced-companion-card__eyebrow) {
+.sd-ai-agent-advanced-companion-card p:not(.sd-ai-agent-advanced-companion-card__eyebrow) {
 	max-width: 620px;
 }
 
-.sdaa-advanced-companion-card__eyebrow {
+.sd-ai-agent-advanced-companion-card__eyebrow {
 	color: #135e96;
 	font-size: 12px;
 	font-weight: 600;
@@ -161,12 +161,12 @@
 	text-transform: uppercase;
 }
 
-.sdaa-advanced-companion-card .button {
+.sd-ai-agent-advanced-companion-card .button {
 	flex: 0 0 auto;
 }
 
 @media screen and (max-width: 600px) {
-	.sdaa-advanced-companion-card {
+	.sd-ai-agent-advanced-companion-card {
 		align-items: flex-start;
 		flex-direction: column;
 		gap: 16px;

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -1806,6 +1806,17 @@ class AgentLoopTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the Advanced companion guidance gives administrators a manual path.
+	 */
+	public function test_advanced_companion_guidance_links_to_manual_download(): void {
+		$guidance = SystemInstructionBuilder::build_advanced_companion_section();
+
+		$this->assertStringContainsString( 'sd_ai_agent_advanced_plugin_required', $guidance );
+		$this->assertStringContainsString( 'https://sdaiagent.com/advanced/', $guidance );
+		$this->assertStringContainsString( 'Do not attempt to download, install, activate, or update', $guidance );
+	}
+
+	/**
 	 * Test custom system_instruction option is used when provided.
 	 */
 	public function test_custom_system_instruction_is_used(): void {

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -1809,11 +1809,15 @@ class AgentLoopTest extends WP_UnitTestCase {
 	 * Test the Advanced companion guidance gives administrators a manual path.
 	 */
 	public function test_advanced_companion_guidance_links_to_manual_download(): void {
-		$guidance = SystemInstructionBuilder::build_advanced_companion_section();
+		$builder     = new SystemInstructionBuilder();
+		$guidance    = SystemInstructionBuilder::build_advanced_companion_section();
+		$instruction = $builder->build( array() );
 
 		$this->assertStringContainsString( 'sd_ai_agent_advanced_plugin_required', $guidance );
 		$this->assertStringContainsString( 'https://sdaiagent.com/advanced/', $guidance );
 		$this->assertStringContainsString( 'Do not attempt to download, install, activate, or update', $guidance );
+		$this->assertStringContainsString( 'sd_ai_agent_advanced_plugin_required', $instruction );
+		$this->assertStringContainsString( 'https://sdaiagent.com/advanced/', $instruction );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Adds Advanced companion download and manual installation guidance to unavailable Advanced-only abilities.
- Adds a prominent Advanced settings card linking administrators to the official companion page.
- Adds system-instruction guidance that prevents automatic Advanced installation attempts.
- Uses the canonical `sd-ai-agent-` prefix for the new card styles and covers the final assembled system prompt.

## Review feedback addressed
- Corrected the WordPress installation sequence to upload, install, then activate the plugin.
- Renamed the new CSS selectors from `sdaa-` to `sd-ai-agent-`.
- Extended the regression test through `SystemInstructionBuilder::build()`.

## Worker self-verification
- PHPUnit: Tests: 3894, Assertions: 16977, Errors: 0, Failures: 0, Skipped: 125, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  passed

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.156 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 1d 7h and 5,288,666 tokens on this with the user in an interactive session. Overall, 1d 23h since this issue was created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Advanced companion” promotional card to the Advanced settings tab with a direct link to manually download the package.
  * Added system guidance to prevent auto-download/install/update and direct administrators to the manual download flow.
* **Bug Fixes**
  * Improved Advanced “plugin required” messaging to use the manual download + upload/activate ZIP instructions.
* **Tests**
  * Added an integration test ensuring the correct manual download link and “do not auto-install/update” guidance are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->