### PR TITLE
GH#2245: Clarify multisite screenshot origin validation

### DIFF
--- a/includes/Abilities/Js/JsAbilityCatalog.php
+++ b/includes/Abilities/Js/JsAbilityCatalog.php
@@ -166,7 +166,7 @@ class JsAbilityCatalog {
 			array(
 				'name'          => 'sd-ai-agent-js/screenshot-url',
 				'label'         => 'Screenshot URL',
-				'description'   => 'Load any same-origin WordPress page in a hidden iframe and capture a screenshot. Use this to visually review frontend pages without navigating the user away from wp-admin. Multisite subdomain URLs must be opened from that subsite origin before capture. Returns a base64 JPEG image for visual review by the AI.',
+				'description'   => 'Capture a same-origin WordPress URL for visual review. Open multisite subdomains from that origin first.',
 				'category'      => 'sd-ai-agent-js',
 				'input_schema'  => array(
 					'type'       => 'object',

--- a/includes/Abilities/Js/JsAbilityCatalog.php
+++ b/includes/Abilities/Js/JsAbilityCatalog.php
@@ -166,7 +166,7 @@ class JsAbilityCatalog {
 			array(
 				'name'          => 'sd-ai-agent-js/screenshot-url',
 				'label'         => 'Screenshot URL',
-				'description'   => 'Load any page on this WordPress site in a hidden iframe and capture a screenshot. Use this to visually review frontend pages without navigating the user away from wp-admin. The URL must be on the same site. Returns a base64 JPEG image for visual review by the AI.',
+				'description'   => 'Load any same-origin WordPress page in a hidden iframe and capture a screenshot. Use this to visually review frontend pages without navigating the user away from wp-admin. Multisite subdomain URLs must be opened from that subsite origin before capture. Returns a base64 JPEG image for visual review by the AI.',
 				'category'      => 'sd-ai-agent-js',
 				'input_schema'  => array(
 					'type'       => 'object',

--- a/includes/Admin/UnifiedAdminMenu.php
+++ b/includes/Admin/UnifiedAdminMenu.php
@@ -316,6 +316,7 @@ class UnifiedAdminMenu {
 				'menuItems'            => self::getMenuItems(),
 				'connectorsUrl'        => self::getConnectorsUrl(),
 				'connectorsAvailable'  => self::hasNativeConnectorsPage() || self::hasGutenbergConnectorsPage() ? '1' : '',
+				'screenshotOrigins'    => self::getScreenshotAllowedOrigins(),
 				'onboarding_complete'  => \SdAiAgent\Core\OnboardingManager::is_complete(),
 				// Provider trace is a debug-only feature. The JS settings page reads
 				// this flag to show or hide the Provider Trace tab.
@@ -342,6 +343,74 @@ class UnifiedAdminMenu {
 				),
 			)
 		);
+	}
+
+	/**
+	 * Return origins that screenshot-url may treat as WordPress-owned targets.
+	 *
+	 * Browser DOM access is still restricted to the current origin, but exposing
+	 * the authorized WordPress origins lets the client distinguish a multisite
+	 * subdomain from an unrelated external host and return the right guidance.
+	 *
+	 * @return list<string>
+	 */
+	public static function getScreenshotAllowedOrigins(): array {
+		$urls = array(
+			home_url( '/' ),
+			site_url( '/' ),
+		);
+
+		if ( is_multisite() ) {
+			$urls[] = network_home_url( '/' );
+			$urls[] = network_site_url( '/' );
+
+			$site_ids = get_sites(
+				array(
+					'fields'   => 'ids',
+					'number'   => (int) apply_filters( 'sd_ai_agent_screenshot_origin_site_limit', 500 ),
+					'public'   => 1,
+					'archived' => 0,
+					'deleted'  => 0,
+					'spam'     => 0,
+				)
+			);
+
+			foreach ( $site_ids as $site_id ) {
+				$blog_id = (int) $site_id;
+				$urls[]  = get_home_url( $blog_id, '/' );
+				$urls[]  = get_site_url( $blog_id, '/' );
+			}
+		}
+
+		$origins = array();
+		foreach ( $urls as $url ) {
+			$origin = self::originFromUrl( (string) $url );
+			if ( '' !== $origin ) {
+				$origins[] = $origin;
+			}
+		}
+
+		return array_values( array_unique( $origins ) );
+	}
+
+	/**
+	 * Extract a normalized origin from a URL.
+	 *
+	 * @param string $url URL to parse.
+	 * @return string Origin, or empty string when parsing fails.
+	 */
+	private static function originFromUrl( string $url ): string {
+		$parts = wp_parse_url( $url );
+		if ( ! is_array( $parts ) || empty( $parts['scheme'] ) || empty( $parts['host'] ) ) {
+			return '';
+		}
+
+		$origin = strtolower( (string) $parts['scheme'] ) . '://' . strtolower( (string) $parts['host'] );
+		if ( isset( $parts['port'] ) ) {
+			$origin .= ':' . (int) $parts['port'];
+		}
+
+		return $origin;
 	}
 
 	/**

--- a/src/abilities/__tests__/screenshot.test.js
+++ b/src/abilities/__tests__/screenshot.test.js
@@ -54,7 +54,7 @@ describe( 'screenshot-url validation', () => {
 			resolved: 'https://template.myshopmaker.ng/product/t-shirt-ne/',
 		} );
 		expect( result.error ).toContain( 'authorized WordPress site' );
-		expect( result.error ).toContain( 'must run from the same origin' );
+		expect( result.error ).toContain( 'same origin' );
 	} );
 
 	test( 'rejects unrelated external domains even when multisite origins are configured', () => {

--- a/src/abilities/__tests__/screenshot.test.js
+++ b/src/abilities/__tests__/screenshot.test.js
@@ -2,6 +2,9 @@
  * Unit tests for screenshot URL validation.
  */
 
+/**
+ *
+ */
 function loadScreenshotModule() {
 	let mod;
 	jest.isolateModules( () => {
@@ -12,37 +15,30 @@ function loadScreenshotModule() {
 }
 
 describe( 'screenshot-url validation', () => {
-	const originalLocation = window.location;
-
-	function setLocation( href ) {
-		delete window.location;
-		window.location = new URL( href );
-	}
-
 	beforeEach( () => {
-		setLocation( 'https://myshopmaker.ng/wp-admin/admin.php?page=sd-ai-agent' );
 		window.sdAiAgentData = {
 			screenshotOrigins: [
-				'https://myshopmaker.ng',
+				window.location.origin,
 				'https://template.myshopmaker.ng',
 			],
 		};
 	} );
 
 	afterEach( () => {
-		window.location = originalLocation;
 		delete window.sdAiAgentData;
 	} );
 
 	test( 'accepts same-origin URLs from the authorized WordPress origins list', () => {
 		const { validateScreenshotUrl } = loadScreenshotModule();
 
-		expect( validateScreenshotUrl( '/product/t-shirt-ne/' ) ).toMatchObject( {
-			valid: true,
-			authorized: true,
-			resolved: 'https://myshopmaker.ng/product/t-shirt-ne/',
-			error: '',
-		} );
+		expect( validateScreenshotUrl( '/product/t-shirt-ne/' ) ).toMatchObject(
+			{
+				valid: true,
+				authorized: true,
+				resolved: `${ window.location.origin }/product/t-shirt-ne/`,
+				error: '',
+			}
+		);
 	} );
 
 	test( 'recognizes an authorized multisite subdomain and returns capture guidance', () => {

--- a/src/abilities/__tests__/screenshot.test.js
+++ b/src/abilities/__tests__/screenshot.test.js
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for screenshot URL validation.
+ */
+
+function loadScreenshotModule() {
+	let mod;
+	jest.isolateModules( () => {
+		// eslint-disable-next-line global-require
+		mod = require( '../screenshot' );
+	} );
+	return mod;
+}
+
+describe( 'screenshot-url validation', () => {
+	const originalLocation = window.location;
+
+	function setLocation( href ) {
+		delete window.location;
+		window.location = new URL( href );
+	}
+
+	beforeEach( () => {
+		setLocation( 'https://myshopmaker.ng/wp-admin/admin.php?page=sd-ai-agent' );
+		window.sdAiAgentData = {
+			screenshotOrigins: [
+				'https://myshopmaker.ng',
+				'https://template.myshopmaker.ng',
+			],
+		};
+	} );
+
+	afterEach( () => {
+		window.location = originalLocation;
+		delete window.sdAiAgentData;
+	} );
+
+	test( 'accepts same-origin URLs from the authorized WordPress origins list', () => {
+		const { validateScreenshotUrl } = loadScreenshotModule();
+
+		expect( validateScreenshotUrl( '/product/t-shirt-ne/' ) ).toMatchObject( {
+			valid: true,
+			authorized: true,
+			resolved: 'https://myshopmaker.ng/product/t-shirt-ne/',
+			error: '',
+		} );
+	} );
+
+	test( 'recognizes an authorized multisite subdomain and returns capture guidance', () => {
+		const { validateScreenshotUrl } = loadScreenshotModule();
+
+		const result = validateScreenshotUrl(
+			'https://template.myshopmaker.ng/product/t-shirt-ne/'
+		);
+
+		expect( result ).toMatchObject( {
+			valid: false,
+			authorized: true,
+			resolved: 'https://template.myshopmaker.ng/product/t-shirt-ne/',
+		} );
+		expect( result.error ).toContain( 'authorized WordPress site' );
+		expect( result.error ).toContain( 'must run from the same origin' );
+	} );
+
+	test( 'rejects unrelated external domains even when multisite origins are configured', () => {
+		const { validateScreenshotUrl } = loadScreenshotModule();
+
+		const result = validateScreenshotUrl( 'https://example.com/product/' );
+
+		expect( result ).toMatchObject( {
+			valid: false,
+			authorized: false,
+			resolved: 'https://example.com/product/',
+		} );
+		expect( result.error ).toContain( 'authorized WordPress site' );
+		expect( result.error ).toContain( 'https://example.com' );
+	} );
+} );

--- a/src/abilities/screenshot.js
+++ b/src/abilities/screenshot.js
@@ -15,11 +15,11 @@
  * `image` is a base64-encoded JPEG data URL suitable for sending to a
  * vision-capable model.
  *
- * Security: screenshot-url restricts targets to the current WordPress site
- * origin via explicit URL validation in `validateSameOrigin()`. The browser's
- * same-origin policy enforces this at runtime: cross-origin redirects will
- * cause `iframe.contentDocument` access to throw, and the error path returns
- * a structured failure result. The iframe is intentionally NOT `sandbox`'d,
+ * Security: screenshot-url restricts targets to WordPress-owned origins exposed
+ * by the server. The actual capture remains same-origin because html2canvas
+ * needs DOM access to the iframe. Authorized multisite subdomains that are not
+ * the current browser origin return explicit guidance instead of being reported
+ * as unrelated off-site URLs. The iframe is intentionally NOT `sandbox`'d,
  * because a sandboxed iframe gets an opaque origin that would block the
  * same-origin DOM access html2canvas needs.
  */
@@ -97,34 +97,83 @@ function canvasToJpeg( canvas ) {
 }
 
 /**
- * Validate that a URL is within the current WordPress site origin.
+ * Return origins the server identified as WordPress-owned screenshot targets.
+ *
+ * @return {string[]} Allowed origins.
+ */
+export function getAuthorizedScreenshotOrigins() {
+	const origins = window.sdAiAgentData?.screenshotOrigins;
+	if ( ! Array.isArray( origins ) ) {
+		return [ window.location.origin ];
+	}
+
+	return Array.from(
+		new Set(
+			origins
+				.filter( ( origin ) => typeof origin === 'string' )
+				.map( ( origin ) => origin.trim() )
+				.filter( Boolean )
+		)
+	);
+}
+
+/**
+ * Validate that a URL is within an authorized WordPress origin and can be
+ * captured from the current browser page.
  *
  * @param {string} url Absolute or relative URL.
- * @return {{ valid: boolean, resolved: string, error: string }} Validation result.
+ * @return {{ valid: boolean, resolved: string, error: string, authorized: boolean }} Validation result.
  */
-function validateSameOrigin( url ) {
+export function validateScreenshotUrl( url ) {
 	if ( ! url ) {
-		return { valid: false, resolved: '', error: 'URL is required.' };
+		return {
+			valid: false,
+			resolved: '',
+			error: 'URL is required.',
+			authorized: false,
+		};
 	}
 
 	try {
 		// Resolve relative URLs against current origin.
 		const resolved = new URL( url, window.location.origin );
+		const authorizedOrigins = getAuthorizedScreenshotOrigins();
+		const isAuthorized = authorizedOrigins.includes( resolved.origin );
+
+		if ( ! isAuthorized ) {
+			return {
+				valid: false,
+				resolved: resolved.href,
+				error:
+					`URL must be on an authorized WordPress site (${ authorizedOrigins.join( ', ' ) }). ` +
+					`Got: ${ resolved.origin }`,
+				authorized: false,
+			};
+		}
 
 		if ( resolved.origin !== window.location.origin ) {
 			return {
 				valid: false,
 				resolved: resolved.href,
-				error: `URL must be on the same site (${ window.location.origin }). Got: ${ resolved.origin }`,
+				error:
+					`URL is an authorized WordPress site (${ resolved.origin }), but browser screenshot capture must run from the same origin as the target. ` +
+					`Open the AI agent on ${ resolved.origin } or navigate the browser there, then retry screenshot-url.`,
+				authorized: true,
 			};
 		}
 
-		return { valid: true, resolved: resolved.href, error: '' };
+		return {
+			valid: true,
+			resolved: resolved.href,
+			error: '',
+			authorized: true,
+		};
 	} catch ( err ) {
 		return {
 			valid: false,
 			resolved: '',
 			error: `Invalid URL: ${ err.message }`,
+			authorized: false,
 		};
 	}
 }
@@ -279,8 +328,8 @@ async function executeScreenshotUrl( args ) {
 	const viewportHeight = args?.height || 800;
 	const fullPage = args?.fullPage ?? false;
 
-	// Validate same-origin.
-	const { valid, resolved, error: urlError } = validateSameOrigin( rawUrl );
+	// Validate authorized WordPress origin and same-origin capture feasibility.
+	const { valid, resolved, error: urlError } = validateScreenshotUrl( rawUrl );
 	if ( ! valid ) {
 		return {
 			success: false,
@@ -503,9 +552,10 @@ export async function registerScreenshotUrlAbility() {
 		name: 'sd-ai-agent-js/screenshot-url',
 		label: 'Screenshot URL',
 		description:
-			'Load any page on this WordPress site in a hidden iframe and capture a screenshot. ' +
+			'Load any same-origin WordPress page in a hidden iframe and capture a screenshot. ' +
 			'Use this to visually review frontend pages without navigating the user away from wp-admin. ' +
-			'The URL must be on the same site. Returns a base64 JPEG image for visual review by the AI.',
+			'Multisite subdomain URLs must be opened from that subsite origin before capture. ' +
+			'Returns a base64 JPEG image for visual review by the AI.',
 		inputSchema: {
 			type: 'object',
 			properties: {

--- a/src/abilities/screenshot.js
+++ b/src/abilities/screenshot.js
@@ -145,8 +145,9 @@ export function validateScreenshotUrl( url ) {
 				valid: false,
 				resolved: resolved.href,
 				error:
-					`URL must be on an authorized WordPress site (${ authorizedOrigins.join( ', ' ) }). ` +
-					`Got: ${ resolved.origin }`,
+					`URL must be on an authorized WordPress site (${ authorizedOrigins.join(
+						', '
+					) }). ` + `Got: ${ resolved.origin }`,
 				authorized: false,
 			};
 		}
@@ -329,7 +330,11 @@ async function executeScreenshotUrl( args ) {
 	const fullPage = args?.fullPage ?? false;
 
 	// Validate authorized WordPress origin and same-origin capture feasibility.
-	const { valid, resolved, error: urlError } = validateScreenshotUrl( rawUrl );
+	const {
+		valid,
+		resolved,
+		error: urlError,
+	} = validateScreenshotUrl( rawUrl );
 	if ( ! valid ) {
 		return {
 			success: false,

--- a/src/abilities/screenshot.js
+++ b/src/abilities/screenshot.js
@@ -144,10 +144,9 @@ export function validateScreenshotUrl( url ) {
 			return {
 				valid: false,
 				resolved: resolved.href,
-				error:
-					`URL must be on an authorized WordPress site (${ authorizedOrigins.join(
-						', '
-					) }). ` + `Got: ${ resolved.origin }`,
+				error: `Not an authorized WordPress site (${ authorizedOrigins.join(
+					', '
+				) }); got ${ resolved.origin }`,
 				authorized: false,
 			};
 		}
@@ -156,9 +155,7 @@ export function validateScreenshotUrl( url ) {
 			return {
 				valid: false,
 				resolved: resolved.href,
-				error:
-					`URL is an authorized WordPress site (${ resolved.origin }), but browser screenshot capture must run from the same origin as the target. ` +
-					`Open the AI agent on ${ resolved.origin } or navigate the browser there, then retry screenshot-url.`,
+				error: `URL is an authorized WordPress site; retry from the same origin (${ resolved.origin }).`,
 				authorized: true,
 			};
 		}
@@ -557,10 +554,8 @@ export async function registerScreenshotUrlAbility() {
 		name: 'sd-ai-agent-js/screenshot-url',
 		label: 'Screenshot URL',
 		description:
-			'Load any same-origin WordPress page in a hidden iframe and capture a screenshot. ' +
-			'Use this to visually review frontend pages without navigating the user away from wp-admin. ' +
-			'Multisite subdomain URLs must be opened from that subsite origin before capture. ' +
-			'Returns a base64 JPEG image for visual review by the AI.',
+			'Capture a same-origin WordPress URL for visual review. ' +
+			'Open multisite subdomains from that origin first.',
 		inputSchema: {
 			type: 'object',
 			properties: {

--- a/tests/SdAiAgent/Admin/UnifiedAdminMenuTest.php
+++ b/tests/SdAiAgent/Admin/UnifiedAdminMenuTest.php
@@ -267,6 +267,17 @@ class UnifiedAdminMenuTest extends WP_UnitTestCase {
 		$this->assertSame( 'chat', $route );
 	}
 
+	/**
+	 * Test getScreenshotAllowedOrigins() includes the current WordPress origin.
+	 */
+	public function test_get_screenshot_allowed_origins_includes_current_site(): void {
+		$origins = UnifiedAdminMenu::getScreenshotAllowedOrigins();
+		$home    = wp_parse_url( home_url( '/' ) );
+		$origin  = strtolower( (string) $home['scheme'] ) . '://' . strtolower( (string) $home['host'] );
+
+		$this->assertContains( $origin, $origins );
+	}
+
 	// ─── Hook Registration ────────────────────────────────────────────────────
 
 	/**


### PR DESCRIPTION
## Summary
- Localizes authorized WordPress screenshot origins, including multisite subsite origins, into admin data.
- Keeps screenshot capture same-origin while returning explicit guidance for authorized cross-origin multisite subdomains.
- Adds regression coverage for same-origin, same-network subdomain, and unrelated external URL validation.

## Worker self-verification
- PHPUnit: Tests: 3758, Assertions: 15767, Errors: 0, Failures: 0, Skipped: 125, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded; bundle size check passed

Additional targeted check:
- Jest: `npm run test:js -- src/abilities/__tests__/screenshot.test.js --runInBand` passed (3 tests)

Resolves #2245

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.152 plugin for [OpenCode](https://opencode.ai) v1.18.3
