### PR TITLE
GH#2239: improve multisite screenshot recovery

### DIFF
--- a/includes/Abilities/Js/JsAbilityCatalog.php
+++ b/includes/Abilities/Js/JsAbilityCatalog.php
@@ -166,14 +166,14 @@ class JsAbilityCatalog {
 			array(
 				'name'          => 'sd-ai-agent-js/screenshot-url',
 				'label'         => 'Screenshot URL',
-				'description'   => 'Load any page on this WordPress site in a hidden iframe and capture a screenshot. Use this to visually review frontend pages without navigating the user away from wp-admin. The URL must be on the same site. Returns a base64 JPEG image for visual review by the AI.',
+				'description'   => 'Load any page on this WordPress site in a hidden iframe and capture a screenshot. Use this to visually review frontend pages without navigating the user away from wp-admin. The URL must be on the same browser origin. For multisite subsites on another subdomain, run the chat/widget from that subsite and retry with a relative path. Returns a base64 JPEG image for visual review by the AI.',
 				'category'      => 'sd-ai-agent-js',
 				'input_schema'  => array(
 					'type'       => 'object',
 					'properties' => array(
 						'url'      => array(
 							'type'        => 'string',
-							'description' => 'URL to screenshot. Can be a full URL on this site or a relative path (e.g. "/about/", "/contact/", "/").',
+							'description' => 'URL to screenshot. Use a full URL on the current browser origin or a relative path (e.g. "/about/", "/contact/", "/"). For multisite subsites on another subdomain, open the agent on that subsite first.',
 						),
 						'width'    => array(
 							'type'        => 'integer',

--- a/includes/Admin/FloatingWidget.php
+++ b/includes/Admin/FloatingWidget.php
@@ -17,6 +17,7 @@ use SdAiAgent\Core\Features;
 use SdAiAgent\Core\OnboardingManager;
 use SdAiAgent\Core\RolePermissions;
 use SdAiAgent\Core\Settings;
+use SdAiAgent\Core\SiteOrigins;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -201,6 +202,7 @@ class FloatingWidget {
 				'viewedPostId'        => $viewed_post_id,
 				'viewedPostType'      => $viewed_post_type,
 				'viewedTitle'         => $viewed_title,
+				'screenshotOrigins'   => SiteOrigins::screenshot_allowed_origins(),
 			]
 		);
 	}

--- a/includes/Admin/UnifiedAdminMenu.php
+++ b/includes/Admin/UnifiedAdminMenu.php
@@ -337,7 +337,7 @@ class UnifiedAdminMenu {
 				'wpThemeRoot'          => get_theme_root(),
 				'pluginEditorUrl'      => admin_url( 'plugin-editor.php' ),
 				'themeEditorUrl'       => admin_url( 'theme-editor.php' ),
-				'screenshotOrigins'   => SiteOrigins::screenshot_allowed_origins(),
+				'screenshotOrigins'    => SiteOrigins::screenshot_allowed_origins(),
 				'fileModAllowed'       => array(
 					'plugin' => wp_is_file_mod_allowed( 'plugin_files' ),
 					'theme'  => wp_is_file_mod_allowed( 'theme_files' ),

--- a/includes/Admin/UnifiedAdminMenu.php
+++ b/includes/Admin/UnifiedAdminMenu.php
@@ -15,6 +15,7 @@ namespace SdAiAgent\Admin;
 
 use SdAiAgent\Core\Features;
 use SdAiAgent\Core\InstructionsAddendum;
+use SdAiAgent\Core\SiteOrigins;
 use SdAiAgent\Core\WordPressPaths;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -336,6 +337,7 @@ class UnifiedAdminMenu {
 				'wpThemeRoot'          => get_theme_root(),
 				'pluginEditorUrl'      => admin_url( 'plugin-editor.php' ),
 				'themeEditorUrl'       => admin_url( 'theme-editor.php' ),
+				'screenshotOrigins'   => SiteOrigins::screenshot_allowed_origins(),
 				'fileModAllowed'       => array(
 					'plugin' => wp_is_file_mod_allowed( 'plugin_files' ),
 					'theme'  => wp_is_file_mod_allowed( 'theme_files' ),

--- a/includes/Core/SiteOrigins.php
+++ b/includes/Core/SiteOrigins.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Site origin helpers for browser-executed abilities.
+ *
+ * @package SdAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class SiteOrigins {
+
+	/**
+	 * Maximum network sites included in the browser hint payload.
+	 */
+	private const MAX_NETWORK_SITES = 100;
+
+	/**
+	 * Return origins that belong to this WordPress site/network.
+	 *
+	 * The browser screenshot ability still cannot iframe and inspect a different
+	 * origin. This list lets the client distinguish an unknown third-party URL
+	 * from a valid multisite subsite and return actionable same-origin guidance.
+	 *
+	 * @return string[] Origin strings such as https://example.com.
+	 */
+	public static function screenshot_allowed_origins(): array {
+		$origins = array();
+
+		self::add_origin( $origins, home_url( '/' ) );
+		self::add_origin( $origins, site_url( '/' ) );
+		self::add_origin( $origins, admin_url() );
+
+		if ( is_multisite() && function_exists( 'get_sites' ) ) {
+			$sites = get_sites(
+				array(
+					'number' => self::MAX_NETWORK_SITES,
+					'fields' => 'ids',
+				)
+			);
+
+			foreach ( $sites as $site_id ) {
+				$site_id = (int) $site_id;
+				if ( $site_id <= 0 ) {
+					continue;
+				}
+
+				self::add_origin( $origins, get_home_url( $site_id, '/' ) );
+				self::add_origin( $origins, get_site_url( $site_id, '/' ) );
+			}
+		}
+
+		return array_values( array_unique( $origins ) );
+	}
+
+	/**
+	 * Add a parsed origin from a URL to the accumulator.
+	 *
+	 * @param string[] $origins Origin accumulator.
+	 * @param string   $url     URL to parse.
+	 * @return void
+	 */
+	private static function add_origin( array &$origins, string $url ): void {
+		$scheme = wp_parse_url( $url, PHP_URL_SCHEME );
+		$host   = wp_parse_url( $url, PHP_URL_HOST );
+		$port   = wp_parse_url( $url, PHP_URL_PORT );
+
+		if ( ! is_string( $scheme ) || '' === $scheme || ! is_string( $host ) || '' === $host ) {
+			return;
+		}
+
+		$origin = strtolower( $scheme ) . '://' . strtolower( $host );
+		if ( is_int( $port ) && ! in_array( $port, array( 80, 443 ), true ) ) {
+			$origin .= ':' . $port;
+		}
+
+		$origins[] = $origin;
+	}
+}

--- a/src/abilities/__tests__/screenshot.test.js
+++ b/src/abilities/__tests__/screenshot.test.js
@@ -35,12 +35,20 @@ describe( 'screenshot-url validation', () => {
 	} );
 
 	test( 'returns actionable guidance for recognised multisite subsite origins', () => {
-		const result = validateSameOrigin( 'https://template.myshopmaker.ng/shop/' );
+		const result = validateSameOrigin(
+			'https://template.myshopmaker.ng/shop/'
+		);
 
 		expect( result.valid ).toBe( false );
-		expect( result.resolved ).toBe( 'https://template.myshopmaker.ng/shop/' );
-		expect( result.error ).toContain( 'another site in this WordPress network' );
-		expect( result.error ).toContain( 'Open the AI Agent chat or floating widget' );
+		expect( result.resolved ).toBe(
+			'https://template.myshopmaker.ng/shop/'
+		);
+		expect( result.error ).toContain(
+			'another site in this WordPress network'
+		);
+		expect( result.error ).toContain(
+			'Open the AI Agent chat or floating widget'
+		);
 		expect( result.error ).toContain( 'retry with a relative path' );
 	} );
 

--- a/src/abilities/__tests__/screenshot.test.js
+++ b/src/abilities/__tests__/screenshot.test.js
@@ -1,0 +1,55 @@
+import { validateSameOrigin } from '../screenshot';
+
+jest.mock( '../registry', () => ( {
+	registerClientAbility: jest.fn(),
+} ) );
+
+describe( 'screenshot-url validation', () => {
+	let originalLocation;
+	let originalData;
+
+	beforeEach( () => {
+		originalLocation = window.location.href;
+		originalData = window.sdAiAgentData;
+
+		window.history.pushState( {}, '', '/wp-admin/admin.php' );
+		window.sdAiAgentData = {
+			screenshotOrigins: [
+				window.location.origin,
+				'https://template.myshopmaker.ng',
+			],
+		};
+	} );
+
+	afterEach( () => {
+		window.history.pushState( {}, '', originalLocation );
+		window.sdAiAgentData = originalData;
+	} );
+
+	test( 'accepts relative paths on the current browser origin', () => {
+		expect( validateSameOrigin( '/shop/' ) ).toEqual( {
+			valid: true,
+			resolved: `${ window.location.origin }/shop/`,
+			error: '',
+		} );
+	} );
+
+	test( 'returns actionable guidance for recognised multisite subsite origins', () => {
+		const result = validateSameOrigin( 'https://template.myshopmaker.ng/shop/' );
+
+		expect( result.valid ).toBe( false );
+		expect( result.resolved ).toBe( 'https://template.myshopmaker.ng/shop/' );
+		expect( result.error ).toContain( 'another site in this WordPress network' );
+		expect( result.error ).toContain( 'Open the AI Agent chat or floating widget' );
+		expect( result.error ).toContain( 'retry with a relative path' );
+	} );
+
+	test( 'rejects unknown off-site origins without calling them WordPress network sites', () => {
+		const result = validateSameOrigin( 'https://example.net/' );
+
+		expect( result.valid ).toBe( false );
+		expect( result.error ).toBe(
+			`URL must be on the same browser origin (${ window.location.origin }). Got: https://example.net`
+		);
+	} );
+} );

--- a/src/abilities/screenshot.js
+++ b/src/abilities/screenshot.js
@@ -15,8 +15,10 @@
  * `image` is a base64-encoded JPEG data URL suitable for sending to a
  * vision-capable model.
  *
- * Security: screenshot-url restricts targets to the current WordPress site
- * origin via explicit URL validation in `validateSameOrigin()`. The browser's
+ * Security: screenshot-url restricts targets to the current browser origin
+ * via explicit URL validation in `validateSameOrigin()`. Network subsite
+ * origins are recognised only to return actionable same-origin guidance; the
+ * browser's
  * same-origin policy enforces this at runtime: cross-origin redirects will
  * cause `iframe.contentDocument` access to throw, and the error path returns
  * a structured failure result. The iframe is intentionally NOT `sandbox`'d,
@@ -102,7 +104,7 @@ function canvasToJpeg( canvas ) {
  * @param {string} url Absolute or relative URL.
  * @return {{ valid: boolean, resolved: string, error: string }} Validation result.
  */
-function validateSameOrigin( url ) {
+export function validateSameOrigin( url ) {
 	if ( ! url ) {
 		return { valid: false, resolved: '', error: 'URL is required.' };
 	}
@@ -112,10 +114,19 @@ function validateSameOrigin( url ) {
 		const resolved = new URL( url, window.location.origin );
 
 		if ( resolved.origin !== window.location.origin ) {
+			const allowedOrigins = Array.isArray(
+				window.sdAiAgentData?.screenshotOrigins
+			)
+				? window.sdAiAgentData.screenshotOrigins
+				: [];
+			const isKnownWordPressSite = allowedOrigins.includes( resolved.origin );
+
 			return {
 				valid: false,
 				resolved: resolved.href,
-				error: `URL must be on the same site (${ window.location.origin }). Got: ${ resolved.origin }`,
+				error: isKnownWordPressSite
+					? `URL is on another site in this WordPress network (${ resolved.origin }), but screenshots must run from the same browser origin as the target (${ window.location.origin }). Open the AI Agent chat or floating widget on ${ resolved.origin } and retry with a relative path, or ask the user to navigate there first.`
+					: `URL must be on the same browser origin (${ window.location.origin }). Got: ${ resolved.origin }`,
 			};
 		}
 
@@ -505,14 +516,14 @@ export async function registerScreenshotUrlAbility() {
 		description:
 			'Load any page on this WordPress site in a hidden iframe and capture a screenshot. ' +
 			'Use this to visually review frontend pages without navigating the user away from wp-admin. ' +
-			'The URL must be on the same site. Returns a base64 JPEG image for visual review by the AI.',
+			'The URL must be on the same browser origin. For multisite subsites on another subdomain, run the chat/widget from that subsite and retry with a relative path. Returns a base64 JPEG image for visual review by the AI.',
 		inputSchema: {
 			type: 'object',
 			properties: {
 				url: {
 					type: 'string',
 					description:
-						'URL to screenshot. Can be a full URL on this site or a relative path (e.g. "/about/", "/contact/", "/").',
+						'URL to screenshot. Use a full URL on the current browser origin or a relative path (e.g. "/about/", "/contact/", "/"). For multisite subsites on another subdomain, open the agent on that subsite first.',
 				},
 				width: {
 					type: 'integer',

--- a/src/abilities/screenshot.js
+++ b/src/abilities/screenshot.js
@@ -119,7 +119,9 @@ export function validateSameOrigin( url ) {
 			)
 				? window.sdAiAgentData.screenshotOrigins
 				: [];
-			const isKnownWordPressSite = allowedOrigins.includes( resolved.origin );
+			const isKnownWordPressSite = allowedOrigins.includes(
+				resolved.origin
+			);
 
 			return {
 				valid: false,


### PR DESCRIPTION
Resolves #2239

## Summary
- Adds a server-provided list of WordPress site/network origins for browser screenshot guidance.
- Updates `sd-ai-agent-js/screenshot-url` to distinguish unknown off-site URLs from recognised multisite subsite origins.
- Returns actionable guidance when a subsite runs on a different browser origin: open the AI Agent chat/widget on that subsite and retry with a relative path.
- Adds JS coverage for current-origin, multisite-subsite, and unknown off-site URL validation.

## Worker self-verification
- PHPUnit: BLOCKED by shared test database instability after reset; `npm run test:php:setup && npm run test:php` reached `Tests: 3757, Assertions: 15766, Failures: 1, Skipped: 125, Incomplete: 4` with repeated `Deadlock found when trying to get lock` / `Table definition has changed` database errors; a later rerun without another reset showed broad missing-table fallout from the same database corruption.
- Focused JS: `npm run test:js -- --runTestsByPath src/abilities/__tests__/screenshot.test.js` passed (`Tests: 3 passed, 3 total`).
- Lint: PHP/JS/CSS all clean (`npm run lint:php`, `npm run lint:js`, `npm run lint:css`).
- PHPStan: 0 errors (`composer phpstan`).
- Build: succeeded (`npm run build`; webpack emitted existing size warnings only).

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.152 plugin for [OpenCode](https://opencode.ai) v1.18.3
