### PR TITLE
fix: align theme palette semantic roles

### DIFF
--- a/includes/Abilities/ValidatePaletteContrastAbility.php
+++ b/includes/Abilities/ValidatePaletteContrastAbility.php
@@ -39,7 +39,7 @@ class ValidatePaletteContrastAbility extends AbstractAbility {
 
 	protected function description(): string {
 		return __(
-			'Check a theme.json colour palette against WCAG AA contrast minimums (4.5:1 body, 3:1 large text). Call after the user picks a direction and BEFORE sd-ai-agent/scaffold-block-theme. Returns failing pairs and suggested hex adjustments so the agent can present options or auto-correct.',
+			'Check a theme.json colour palette against WCAG AA contrast minimums (4.5:1 body, 3:1 large text). Requires the semantic roles foreground, background, surface, accent, and on-accent; primary and secondary are optional. Call after the user picks a direction and BEFORE sd-ai-agent/scaffold-block-theme. Returns missing roles, failing pairs, and suggested hex adjustments so the agent can present options or auto-correct.',
 			'superdav-ai-agent'
 		);
 	}
@@ -54,7 +54,7 @@ class ValidatePaletteContrastAbility extends AbstractAbility {
 			'properties' => [
 				'palette' => [
 					'type'        => 'array',
-					'description' => 'Theme.json-shaped colour palette: array of { slug, color } entries. Hex values may be #rgb, #rrggbb, or unprefixed.',
+					'description' => 'Theme.json-shaped colour palette: array of { slug, color } entries. Required semantic slugs: foreground, background, surface, accent, on-accent. Primary and secondary are optional aesthetic groupings, not aliases. Hex values may be #rgb, #rrggbb, or unprefixed.',
 					'items'       => [
 						'type'       => 'object',
 						'properties' => [
@@ -89,9 +89,23 @@ class ValidatePaletteContrastAbility extends AbstractAbility {
 		return [
 			'type'       => 'object',
 			'properties' => [
-				'passed'        => [ 'type' => 'boolean' ],
-				'pairs_checked' => [ 'type' => 'integer' ],
-				'failures'      => [
+				'passed'         => [ 'type' => 'boolean' ],
+				'pairs_checked'  => [ 'type' => 'integer' ],
+				'pairs_expected' => [ 'type' => 'integer' ],
+				'missing_roles'  => [
+					'type'  => 'array',
+					'items' => [
+						'type'       => 'object',
+						'properties' => [
+							'slug'     => [ 'type' => 'string' ],
+							'pair_ids' => [
+								'type'  => 'array',
+								'items' => [ 'type' => 'string' ],
+							],
+						],
+					],
+				],
+				'failures'       => [
 					'type'  => 'array',
 					'items' => [
 						'type'       => 'object',
@@ -107,7 +121,7 @@ class ValidatePaletteContrastAbility extends AbstractAbility {
 						],
 					],
 				],
-				'suggestions'   => [
+				'suggestions'    => [
 					'type'  => 'array',
 					'items' => [
 						'type'       => 'object',

--- a/includes/Models/skills/wp-block-themes.md
+++ b/includes/Models/skills/wp-block-themes.md
@@ -185,18 +185,18 @@ the user did not ask to change:
 
 ### Settings
 
-Recommended palette: 5–7 entries (`primary`, `secondary`, `accent`, `background`, `surface`, plus `light`/`dark` if needed). Set `defaultPalette: false` and `defaultGradients: false` to keep the editor focused on the brand colours. Spacing: 6-step scale slugs `20`–`70` from `0.5rem` to `4rem`. Always set `appearanceTools: true` and `fluid: true` on typography.
-
+Every palette must define the five semantic roles `foreground`, `background`, `surface`, `accent`, and `on-accent`. Use `foreground` on `background` for body text and headings, `accent` on `background` for links, and `on-accent` on `accent` for controls. `primary` and `secondary` may be added as optional aesthetic groupings, but never substitute them for a semantic role. Set `defaultPalette: false` and `defaultGradients: false` to keep the editor focused on the brand colours. Spacing: 6-step scale slugs `20`–`70` from `0.5rem` to `4rem`. Always set `appearanceTools: true` and `fluid: true` on typography.
 ```json
 {
   "settings": {
     "appearanceTools": true,
     "color": {
       "palette": [
-        { "slug": "primary",    "color": "#1a1a1a", "name": "Primary" },
-        { "slug": "accent",     "color": "#e63946", "name": "Accent" },
+        { "slug": "foreground", "color": "#1a1a1a", "name": "Foreground" },
         { "slug": "background", "color": "#ffffff", "name": "Background" },
-        { "slug": "surface",    "color": "#f5f5f5", "name": "Surface" }
+        { "slug": "surface",    "color": "#f5f5f5", "name": "Surface" },
+        { "slug": "accent",     "color": "#b21f2d", "name": "Accent" },
+        { "slug": "on-accent",  "color": "#ffffff", "name": "On Accent" }
       ],
       "defaultPalette": false,
       "defaultGradients": false
@@ -226,7 +226,7 @@ When calling `sd-ai-agent/update-global-styles`, pass only the inner `styles` an
     "elements": {
       "heading": { "typography": { "fontFamily": "var(--wp--preset--font-family--heading)", "lineHeight": "1.2" } },
       "link":    { "color": { "text": "var(--wp--preset--color--accent)" } },
-      "button":  { "color": { "background": "var(--wp--preset--color--accent)", "text": "var(--wp--preset--color--light)" }, "border": { "radius": "0.5rem" } }
+      "button":  { "color": { "background": "var(--wp--preset--color--accent)", "text": "var(--wp--preset--color--on-accent)" }, "border": { "radius": "0.5rem" } }
     }
   }
 }
@@ -275,7 +275,7 @@ The corresponding `templates/blank.html` and `templates/landing.html` files must
  * Categories: featured
  */
 ?>
-<!-- wp:group {"backgroundColor":"primary","textColor":"light","layout":{"type":"constrained"}} -->
+<!-- wp:group {"backgroundColor":"accent","textColor":"on-accent","layout":{"type":"constrained"}} -->
 ...
 <!-- /wp:group -->
 ```
@@ -300,7 +300,7 @@ Alternate visual treatments to avoid monotony:
 | Alternating backgrounds | Alternate `backgroundColor` between `background` and `surface` (or `primary`/`secondary` for bold sections) |
 | Full-bleed imagery | Cover blocks with `"align":"full"` and `overlayColor` from the brand palette |
 | Edge-to-edge media-text | `wp:media-text` with `"align":"full"` for alternating image/content sides |
-| Bold CTA bands | Full-width group with `primary` or `accent` background, centered text |
+| Bold CTA bands | Full-width group with `accent` background and `on-accent` text, centered |
 | Spacer breaks | `wp:spacer` between sections for breathing room |
 
 If two adjacent sections share the same background and layout, the page feels monotonous — change the background, flip the image side, switch from grid to single-column, or insert a cover block break.

--- a/includes/Services/PaletteValidator.php
+++ b/includes/Services/PaletteValidator.php
@@ -30,24 +30,38 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * Input: a theme.json-shaped palette — an array of entries each containing
  * at minimum `slug` and `color` (hex). Output: a structured `check()` result
- * with `failures` (pairs that miss the WCAG threshold) and `suggestions`
- * (nudged hex values that pass while staying close to the user's choice).
+ * with `failures` (pairs that miss the WCAG threshold), `missing_roles`
+ * (required semantic colours that are absent), and `suggestions` (nudged hex
+ * values that pass while staying close to the user's choice).
  *
  * Usage:
  *
  *     $validator = new PaletteValidator( [
  *         [ 'slug' => 'foreground', 'color' => '#1a1a1a' ],
  *         [ 'slug' => 'background', 'color' => '#ffffff' ],
+ *         [ 'slug' => 'surface',    'color' => '#f5f5f5' ],
  *         [ 'slug' => 'accent',     'color' => '#3858e9' ],
+ *         [ 'slug' => 'on-accent',  'color' => '#ffffff' ],
  *     ] );
  *     $result = $validator->check();
- *     // $result['failures']    : list of failing pairs
- *     // $result['suggestions'] : list of suggested hex adjustments
- *     // $result['passed']      : true when every pair meets WCAG AA
+ *     // $result['failures']      : list of failing pairs
+ *     // $result['missing_roles'] : absent required semantic roles
+ *     // $result['suggestions']   : list of suggested hex adjustments
+ *     // $result['passed']        : true when roles exist and pairs pass
  *
  * @since 1.16.0
  */
 final class PaletteValidator {
+
+	/**
+	 * Semantic roles every generated block-theme palette must define.
+	 *
+	 * Primary and secondary remain optional aesthetic groupings and are not
+	 * aliases for these roles.
+	 *
+	 * @var array<int, string>
+	 */
+	private const REQUIRED_ROLES = [ 'foreground', 'background', 'surface', 'accent', 'on-accent' ];
 
 	/**
 	 * WCAG AA contrast ratio for normal-size body text.
@@ -176,22 +190,42 @@ final class PaletteValidator {
 	/**
 	 * Validate the palette against the configured pair set.
 	 *
-	 * @return array{passed:bool, failures:array<int, array<string, mixed>>, suggestions:array<int, array<string, mixed>>, pairs_checked:int}
+	 * `pairs_checked` counts only pairs whose colours were available and
+	 * evaluated. `pairs_expected` counts all configured pairs.
+	 *
+	 * @return array{passed:bool, failures:array<int, array<string, mixed>>, missing_roles:array<int, array{slug:string, pair_ids:array<int, string>}>, suggestions:array<int, array<string, mixed>>, pairs_checked:int, pairs_expected:int}
 	 */
 	public function check(): array {
-		$failures    = [];
-		$suggestions = [];
+		$failures      = [];
+		$suggestions   = [];
+		$pairs_checked = 0;
+		$role_pairs    = array_fill_keys( self::REQUIRED_ROLES, [] );
+
+		foreach ( $this->pairs as $pair ) {
+			$role_pairs[ $pair['fg_slug'] ][] = $pair['id'];
+			$role_pairs[ $pair['bg_slug'] ][] = $pair['id'];
+		}
+
+		$missing_roles = [];
+		foreach ( $role_pairs as $slug => $pair_ids ) {
+			if ( ! isset( $this->palette[ $slug ] ) ) {
+				$missing_roles[] = [
+					'slug'     => $slug,
+					'pair_ids' => array_values( array_unique( $pair_ids ) ),
+				];
+			}
+		}
 
 		foreach ( $this->pairs as $pair ) {
 			$fg_hex = $this->palette[ $pair['fg_slug'] ] ?? null;
 			$bg_hex = $this->palette[ $pair['bg_slug'] ] ?? null;
 
 			if ( null === $fg_hex || null === $bg_hex ) {
-				// Skip pairs that reference palette slugs we don't have.
-				// (Themes commonly omit optional slugs like "tertiary".)
+				// Missing colours are reported above and are not evaluated.
 				continue;
 			}
 
+			++$pairs_checked;
 			$ratio = self::contrast_ratio( $fg_hex, $bg_hex );
 			if ( self::passes( $ratio, $pair['required'] ) ) {
 				continue;
@@ -211,10 +245,12 @@ final class PaletteValidator {
 		}
 
 		return [
-			'passed'        => 0 === count( $failures ),
-			'failures'      => $failures,
-			'suggestions'   => $suggestions,
-			'pairs_checked' => count( $this->pairs ),
+			'passed'         => [] === $failures && [] === $missing_roles,
+			'failures'       => $failures,
+			'missing_roles'  => $missing_roles,
+			'suggestions'    => $suggestions,
+			'pairs_checked'  => $pairs_checked,
+			'pairs_expected' => count( $this->pairs ),
 		];
 	}
 
@@ -301,7 +337,7 @@ final class PaletteValidator {
 				],
 				[
 					'id'       => 'button-text-on-accent',
-					'fg_slug'  => 'background',
+					'fg_slug'  => 'on-accent',
 					'bg_slug'  => 'accent',
 					'required' => self::RATIO_AA_NORMAL,
 					'label'    => 'Button text on accent button background',

--- a/tests/SdAiAgent/Abilities/ValidatePaletteContrastAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/ValidatePaletteContrastAbilityTest.php
@@ -36,7 +36,9 @@ class ValidatePaletteContrastAbilityTest extends WP_UnitTestCase {
 				'palette' => [
 					[ 'slug' => 'foreground', 'color' => '#1a1a1a' ],
 					[ 'slug' => 'background', 'color' => '#ffffff' ],
+					[ 'slug' => 'surface', 'color' => '#f5f5f5' ],
 					[ 'slug' => 'accent', 'color' => '#005fcc' ],
+					[ 'slug' => 'on-accent', 'color' => '#ffffff' ],
 				],
 			]
 		);
@@ -45,6 +47,9 @@ class ValidatePaletteContrastAbilityTest extends WP_UnitTestCase {
 		$this->assertTrue( $result['passed'] );
 		$this->assertSame( [], $result['failures'] );
 		$this->assertSame( [], $result['suggestions'] );
+		$this->assertSame( [], $result['missing_roles'] );
+		$this->assertSame( 4, $result['pairs_checked'] );
+		$this->assertSame( 4, $result['pairs_expected'] );
 	}
 
 	public function test_run_returns_failures_and_suggestions_for_low_contrast_palette(): void {
@@ -53,7 +58,9 @@ class ValidatePaletteContrastAbilityTest extends WP_UnitTestCase {
 				'palette' => [
 					[ 'slug' => 'foreground', 'color' => '#2a2a2a' ],
 					[ 'slug' => 'background', 'color' => '#f4ecd8' ],
+					[ 'slug' => 'surface', 'color' => '#ffffff' ],
 					[ 'slug' => 'accent', 'color' => '#7a8a6b' ],
+					[ 'slug' => 'on-accent', 'color' => '#ffffff' ],
 				],
 			]
 		);
@@ -76,7 +83,11 @@ class ValidatePaletteContrastAbilityTest extends WP_UnitTestCase {
 			[
 				'palette' => [
 					[ 'slug' => 'kicker', 'color' => '#888888' ],
+					[ 'slug' => 'foreground', 'color' => '#000000' ],
 					[ 'slug' => 'background', 'color' => '#ffffff' ],
+					[ 'slug' => 'surface', 'color' => '#f5f5f5' ],
+					[ 'slug' => 'accent', 'color' => '#005fcc' ],
+					[ 'slug' => 'on-accent', 'color' => '#ffffff' ],
 				],
 				'pairs'   => [
 					[
@@ -95,5 +106,6 @@ class ValidatePaletteContrastAbilityTest extends WP_UnitTestCase {
 		$this->assertSame( 1, $result['pairs_checked'] );
 		$this->assertCount( 1, $result['failures'] );
 		$this->assertSame( 'kicker-on-background', $result['failures'][0]['pair_id'] );
+		$this->assertSame( [], $result['missing_roles'] );
 	}
 }

--- a/tests/SdAiAgent/Models/BlockThemesSkillTest.php
+++ b/tests/SdAiAgent/Models/BlockThemesSkillTest.php
@@ -50,7 +50,9 @@ class BlockThemesSkillTest extends WP_UnitTestCase {
 
 		$required_patterns = [
 			'Always declare `$schema` and `version: 3`',
-			'5–7 entries (`primary`, `secondary`, `accent`, `background`, `surface`',
+			'five semantic roles `foreground`, `background`, `surface`, `accent`, and `on-accent`',
+			'`primary` and `secondary` may be added as optional aesthetic groupings',
+			'`on-accent` on `accent` for controls',
 			'6-step scale slugs `20`–`70`',
 			'`parts/header.html` — Site header',
 			'`parts/footer.html` — Site footer',

--- a/tests/SdAiAgent/Services/PaletteValidatorTest.php
+++ b/tests/SdAiAgent/Services/PaletteValidatorTest.php
@@ -12,7 +12,7 @@ declare(strict_types=1);
  *  - check() against a known-passing palette returns passed=true, no failures.
  *  - check() against a known-failing palette (low-contrast accent) returns
  *    the failure with correct fg/bg slugs and ratio.
- *  - check() skips pairs whose slugs are missing from the palette.
+ *  - check() fails closed and reports roles missing from the palette.
  *  - Suggestions returned for a failing pair have a higher contrast ratio
  *    than the original AND pass the required threshold.
  *  - Custom pair overrides are accepted by the constructor.
@@ -130,7 +130,9 @@ class PaletteValidatorTest extends WP_UnitTestCase {
 			[
 				[ 'slug' => 'foreground', 'color' => '#1a1a1a' ],
 				[ 'slug' => 'background', 'color' => '#ffffff' ],
+				[ 'slug' => 'surface', 'color' => '#f5f5f5' ],
 				[ 'slug' => 'accent', 'color' => '#005fcc' ],
+				[ 'slug' => 'on-accent', 'color' => '#ffffff' ],
 			]
 		);
 
@@ -139,7 +141,9 @@ class PaletteValidatorTest extends WP_UnitTestCase {
 		$this->assertTrue( $result['passed'], 'High-contrast palette must pass all default pairs.' );
 		$this->assertSame( [], $result['failures'], 'No failures expected.' );
 		$this->assertSame( [], $result['suggestions'], 'No suggestions expected when palette passes.' );
-		$this->assertGreaterThan( 0, $result['pairs_checked'], 'pairs_checked must report > 0 for a populated palette.' );
+		$this->assertSame( [], $result['missing_roles'] );
+		$this->assertSame( 4, $result['pairs_checked'] );
+		$this->assertSame( 4, $result['pairs_expected'] );
 	}
 
 	// ── check() with failing palette ──────────────────────────────────────
@@ -151,7 +155,9 @@ class PaletteValidatorTest extends WP_UnitTestCase {
 			[
 				[ 'slug' => 'foreground', 'color' => '#2a2a2a' ],
 				[ 'slug' => 'background', 'color' => '#f4ecd8' ],
+				[ 'slug' => 'surface', 'color' => '#ffffff' ],
 				[ 'slug' => 'accent', 'color' => '#7a8a6b' ],
+				[ 'slug' => 'on-accent', 'color' => '#ffffff' ],
 			]
 		);
 
@@ -175,9 +181,7 @@ class PaletteValidatorTest extends WP_UnitTestCase {
 		$this->assertSame( PaletteValidator::RATIO_AA_NORMAL, $failure['required'] );
 	}
 
-	public function test_check_skips_pairs_with_missing_slugs(): void {
-		// Only foreground + background — accent missing means link &
-		// button-text pairs should be silently skipped.
+	public function test_check_reports_missing_roles_and_does_not_count_unevaluated_pairs(): void {
 		$validator = new PaletteValidator(
 			[
 				[ 'slug' => 'foreground', 'color' => '#000000' ],
@@ -187,8 +191,19 @@ class PaletteValidatorTest extends WP_UnitTestCase {
 
 		$result = $validator->check();
 
-		$this->assertTrue( $result['passed'] );
+		$this->assertFalse( $result['passed'] );
 		$this->assertSame( [], $result['failures'] );
+		$this->assertSame(
+			[
+				[ 'slug' => 'surface', 'pair_ids' => [] ],
+				[ 'slug' => 'accent', 'pair_ids' => [ 'link-on-background', 'button-text-on-accent' ] ],
+				[ 'slug' => 'on-accent', 'pair_ids' => [ 'button-text-on-accent' ] ],
+			],
+			$result['missing_roles']
+		);
+		$this->assertSame( 2, $result['pairs_checked'] );
+		$this->assertSame( 4, $result['pairs_expected'] );
+		$this->assertSame( [], $result['suggestions'], 'Absent colours must not produce fabricated suggestions.' );
 	}
 
 	public function test_check_uses_short_hex_after_normalisation(): void {
@@ -196,7 +211,9 @@ class PaletteValidatorTest extends WP_UnitTestCase {
 			[
 				[ 'slug' => 'foreground', 'color' => '#000' ],
 				[ 'slug' => 'background', 'color' => 'FFF' ],
+				[ 'slug' => 'surface', 'color' => '#eee' ],
 				[ 'slug' => 'accent', 'color' => '#00f' ],
+				[ 'slug' => 'on-accent', 'color' => '#fff' ],
 			]
 		);
 
@@ -212,7 +229,9 @@ class PaletteValidatorTest extends WP_UnitTestCase {
 			[
 				[ 'slug' => 'foreground', 'color' => '#2a2a2a' ],
 				[ 'slug' => 'background', 'color' => '#f4ecd8' ],
+				[ 'slug' => 'surface', 'color' => '#ffffff' ],
 				[ 'slug' => 'accent', 'color' => '#7a8a6b' ],
+				[ 'slug' => 'on-accent', 'color' => '#ffffff' ],
 			]
 		);
 
@@ -249,7 +268,9 @@ class PaletteValidatorTest extends WP_UnitTestCase {
 			[
 				[ 'slug' => 'foreground', 'color' => '#cccccc' ],
 				[ 'slug' => 'background', 'color' => '#ffffff' ],
+				[ 'slug' => 'surface', 'color' => '#f5f5f5' ],
 				[ 'slug' => 'accent', 'color' => '#cccccc' ],
+				[ 'slug' => 'on-accent', 'color' => '#ffffff' ],
 			]
 		);
 
@@ -285,6 +306,9 @@ class PaletteValidatorTest extends WP_UnitTestCase {
 		$this->assertContains( 'heading-on-background', $ids );
 		$this->assertContains( 'link-on-background', $ids );
 		$this->assertContains( 'button-text-on-accent', $ids );
+		$button_pair = array_values( array_filter( $validator->get_pairs(), static fn( array $pair ): bool => 'button-text-on-accent' === $pair['id'] ) )[0];
+		$this->assertSame( 'on-accent', $button_pair['fg_slug'] );
+		$this->assertSame( 'accent', $button_pair['bg_slug'] );
 	}
 
 	// ── custom pair overrides ─────────────────────────────────────────────
@@ -294,6 +318,9 @@ class PaletteValidatorTest extends WP_UnitTestCase {
 			[
 				[ 'slug' => 'foreground', 'color' => '#000' ],
 				[ 'slug' => 'background', 'color' => '#fff' ],
+				[ 'slug' => 'surface', 'color' => '#eee' ],
+				[ 'slug' => 'accent', 'color' => '#005fcc' ],
+				[ 'slug' => 'on-accent', 'color' => '#fff' ],
 				[ 'slug' => 'kicker', 'color' => '#888' ],
 			],
 			[
@@ -315,6 +342,33 @@ class PaletteValidatorTest extends WP_UnitTestCase {
 		$this->assertFalse( $result['passed'], '#888 on #fff fails 4.5:1.' );
 		$this->assertCount( 1, $result['failures'] );
 		$this->assertSame( 'kicker-on-background', $result['failures'][0]['pair_id'] );
+		$this->assertSame( [], $result['missing_roles'] );
+	}
+
+	public function test_custom_pair_missing_role_is_reported_with_affected_pair(): void {
+		$validator = new PaletteValidator(
+			[
+				[ 'slug' => 'foreground', 'color' => '#000' ],
+				[ 'slug' => 'background', 'color' => '#fff' ],
+				[ 'slug' => 'surface', 'color' => '#eee' ],
+				[ 'slug' => 'accent', 'color' => '#005fcc' ],
+				[ 'slug' => 'on-accent', 'color' => '#fff' ],
+			],
+			[
+				[
+					'id'      => 'kicker-on-background',
+					'fg_slug' => 'kicker',
+					'bg_slug' => 'background',
+				],
+			]
+		);
+
+		$result = $validator->check();
+
+		$this->assertFalse( $result['passed'] );
+		$this->assertSame( [ [ 'slug' => 'kicker', 'pair_ids' => [ 'kicker-on-background' ] ] ], $result['missing_roles'] );
+		$this->assertSame( 0, $result['pairs_checked'] );
+		$this->assertSame( 1, $result['pairs_expected'] );
 	}
 
 	public function test_custom_pair_override_drops_malformed_entries(): void {


### PR DESCRIPTION
## Summary

- enforce required theme palette roles: `foreground`, `background`, `surface`, `accent`, and `on-accent`
- fail closed with stable `missing_roles` metadata and accurate expected/evaluated pair counts
- align the contrast ability schema, block-theme guidance, examples, and regression tests

## Testing

- `npm run test:php -- --filter='PaletteValidatorTest|ValidatePaletteContrastAbilityTest|BlockThemesSkillTest'` — 33 tests, 126 assertions
- changed-file PHPCS — clean

## Worker self-verification

- PHPUnit: Tests: 3758, Assertions: 15785, Errors: 0, Failures: 0, Skipped: 125, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded; bundle-size checks passed

Resolves #2246

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.152 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 13m and 118,538 tokens on this as a headless worker. Overall, 17m since this issue was created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Palette contrast validation now requires the semantic roles `foreground`, `background`, `surface`, `accent`, and `on-accent`.
  * Validation results now identify missing roles and distinguish expected color pairs from those actually checked.
  * Contrast checks correctly fail when required palette roles are missing.
  * Accent button text validation now uses the appropriate `on-accent` color role.
  * Block-theme guidance and examples now use the updated semantic color-role conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->