### PR TITLE
GH#2247: centralize Global Styles persistence

### DIFF
--- a/includes/Abilities/DesignSystemAbilities.php
+++ b/includes/Abilities/DesignSystemAbilities.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Abilities;
 
+use SdAiAgent\Services\GlobalStylesService;
 use WP_Error;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -418,17 +419,18 @@ class DesignSystemAbilities {
 	 * @return array<string,mixed>|\WP_Error
 	 */
 	public static function handle_theme_json_presets( array $input ) {
-		$action = $input['action'] ?? '';
+		$action  = $input['action'] ?? '';
+		$service = new GlobalStylesService();
 
 		switch ( $action ) {
 			case 'get':
-				return self::get_global_styles();
+				return self::get_global_styles( $service );
 
 			case 'update':
-				return self::update_global_styles( $input );
+				return self::update_global_styles( $input, $service );
 
 			case 'reset':
-				return self::reset_global_styles();
+				return self::reset_global_styles( $service );
 
 			default:
 				return new WP_Error( 'invalid_action', 'action must be one of: get, update, reset.' );
@@ -625,10 +627,11 @@ class DesignSystemAbilities {
 	 *
 	 * @return array<string,mixed>
 	 */
-	private static function get_global_styles(): array {
-		$post = self::get_global_styles_post();
+	private static function get_global_styles( GlobalStylesService $service ): array {
+		$document = $service->get_user_document();
+		$post_id  = $service->get_user_post_id() ?? 0;
 
-		if ( ! $post ) {
+		if ( 0 === $post_id ) {
 			return [
 				'success'       => true,
 				'action'        => 'get',
@@ -638,16 +641,11 @@ class DesignSystemAbilities {
 			];
 		}
 
-		$decoded = json_decode( $post->post_content, true );
-		if ( ! is_array( $decoded ) ) {
-			$decoded = [];
-		}
-
 		return [
 			'success'       => true,
 			'action'        => 'get',
-			'global_styles' => $decoded,
-			'post_id'       => $post->ID,
+			'global_styles' => $document,
+			'post_id'       => $post_id,
 			'message'       => __( 'Global styles retrieved.', 'superdav-ai-agent' ),
 		];
 	}
@@ -655,54 +653,18 @@ class DesignSystemAbilities {
 	/**
 	 * Update the user-level global styles by merging provided styles.
 	 *
-	 * @param array<string,mixed> $input Input args with 'styles'.
+	 * @param array<string,mixed> $input   Input args with 'styles'.
+	 * @param GlobalStylesService $service Canonical persistence service.
 	 * @return array<string,mixed>|\WP_Error
 	 */
-	private static function update_global_styles( array $input ) {
+	private static function update_global_styles( array $input, GlobalStylesService $service ) {
 		$new_styles = $input['styles'] ?? null;
 
 		if ( empty( $new_styles ) || ! is_array( $new_styles ) ) {
 			return new WP_Error( 'missing_styles', 'styles object is required for action "update".' );
 		}
 
-		$post    = self::get_global_styles_post();
-		$current = [];
-
-		if ( $post ) {
-			$decoded = json_decode( $post->post_content, true );
-			if ( is_array( $decoded ) ) {
-				$current = $decoded;
-			}
-		}
-
-		// Deep merge: new_styles takes precedence.
-		$merged = self::deep_merge( $current, $new_styles );
-
-		$json = wp_json_encode( $merged, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
-		if ( false === $json ) {
-			return new WP_Error( 'json_encode_failed', 'Failed to encode styles as JSON.' );
-		}
-
-		if ( $post ) {
-			$result = wp_update_post(
-				[
-					'ID'           => $post->ID,
-					'post_content' => $json,
-				],
-				true
-			);
-		} else {
-			$result = wp_insert_post(
-				[
-					'post_title'   => 'Custom Styles',
-					'post_content' => $json,
-					'post_status'  => 'publish',
-					'post_type'    => 'wp_global_styles',
-				],
-				true
-			);
-		}
-
+		$result = $service->merge_user_document( $new_styles );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
@@ -710,8 +672,8 @@ class DesignSystemAbilities {
 		return [
 			'success'       => true,
 			'action'        => 'update',
-			'global_styles' => $merged,
-			'post_id'       => is_int( $result ) ? $result : ( $post ? $post->ID : 0 ),
+			'global_styles' => $result['document'],
+			'post_id'       => $result['post_id'],
 			'message'       => __( 'Global styles updated successfully.', 'superdav-ai-agent' ),
 		];
 	}
@@ -719,12 +681,16 @@ class DesignSystemAbilities {
 	/**
 	 * Reset the user-level global styles override.
 	 *
+	 * @param GlobalStylesService $service Canonical persistence service.
 	 * @return array<string,mixed>|\WP_Error
 	 */
-	private static function reset_global_styles() {
-		$post = self::get_global_styles_post();
+	private static function reset_global_styles( GlobalStylesService $service ) {
+		$deleted = $service->delete_user_document();
+		if ( is_wp_error( $deleted ) ) {
+			return new WP_Error( 'reset_failed', 'Failed to delete the global styles override.' );
+		}
 
-		if ( ! $post ) {
+		if ( ! $deleted ) {
 			return [
 				'success'       => true,
 				'action'        => 'reset',
@@ -734,12 +700,6 @@ class DesignSystemAbilities {
 			];
 		}
 
-		$deleted = wp_delete_post( $post->ID, true );
-
-		if ( ! $deleted ) {
-			return new WP_Error( 'reset_failed', 'Failed to delete the global styles override.' );
-		}
-
 		return [
 			'success'       => true,
 			'action'        => 'reset',
@@ -747,68 +707,5 @@ class DesignSystemAbilities {
 			'post_id'       => 0,
 			'message'       => __( 'Global styles reset to theme defaults.', 'superdav-ai-agent' ),
 		];
-	}
-
-	/**
-	 * Retrieve the user-level wp_global_styles CPT post.
-	 *
-	 * WordPress stores user customisations in a wp_global_styles post with
-	 * post_name = 'wp-global-styles-{stylesheet}'. We look for the most recent
-	 * published post of this type.
-	 *
-	 * @return \WP_Post|null
-	 */
-	private static function get_global_styles_post(): ?\WP_Post {
-		$stylesheet = get_stylesheet();
-		$post_name  = 'wp-global-styles-' . $stylesheet;
-
-		$posts = get_posts(
-			[
-				'post_type'      => 'wp_global_styles',
-				'post_status'    => 'publish',
-				'name'           => $post_name,
-				'posts_per_page' => 1,
-				'orderby'        => 'date',
-				'order'          => 'DESC',
-			]
-		);
-
-		if ( ! empty( $posts ) ) {
-			return $posts[0];
-		}
-
-		// Fallback: any published wp_global_styles post (theme-agnostic).
-		$posts = get_posts(
-			[
-				'post_type'      => 'wp_global_styles',
-				'post_status'    => 'publish',
-				'posts_per_page' => 1,
-				'orderby'        => 'date',
-				'order'          => 'DESC',
-			]
-		);
-
-		return ! empty( $posts ) ? $posts[0] : null;
-	}
-
-	/**
-	 * Recursively merge two arrays, with $override taking precedence.
-	 *
-	 * Unlike array_merge_recursive(), this replaces scalar values rather than
-	 * creating arrays of values.
-	 *
-	 * @param array<string,mixed> $base     Base array.
-	 * @param array<string,mixed> $override Override array.
-	 * @return array<string,mixed> Merged result.
-	 */
-	private static function deep_merge( array $base, array $override ): array {
-		foreach ( $override as $key => $value ) {
-			if ( is_array( $value ) && isset( $base[ $key ] ) && is_array( $base[ $key ] ) ) {
-				$base[ $key ] = self::deep_merge( $base[ $key ], $value );
-			} else {
-				$base[ $key ] = $value;
-			}
-		}
-		return $base;
 	}
 }

--- a/includes/Abilities/GlobalStylesAbilities.php
+++ b/includes/Abilities/GlobalStylesAbilities.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Abilities;
 
+use SdAiAgent\Services\GlobalStylesService;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -274,23 +276,23 @@ class GlobalStylesAbilities {
 			return $switched;
 		}
 
-		$styles = self::get_merged_global_styles();
+		try {
+			$styles = ( new GlobalStylesService() )->get_resolved_styles();
 
-		if ( $switched ) {
-			restore_current_blog();
-		}
+			if ( $section !== 'all' && isset( $styles[ $section ] ) ) {
+				return [
+					'styles'  => [ $section => $styles[ $section ] ],
+					'section' => $section,
+				];
+			}
 
-		if ( $section !== 'all' && isset( $styles[ $section ] ) ) {
 			return [
-				'styles'  => [ $section => $styles[ $section ] ],
-				'section' => $section,
+				'styles'  => $styles,
+				'section' => 'all',
 			];
+		} finally {
+			self::restore_switched_blog( $switched );
 		}
-
-		return [
-			'styles'  => $styles,
-			'section' => 'all',
-		];
 	}
 
 	/**
@@ -313,66 +315,29 @@ class GlobalStylesAbilities {
 			return $switched;
 		}
 
-		$post_id = self::get_or_create_global_styles_post();
-
-		if ( is_wp_error( $post_id ) ) {
-			if ( $switched ) {
-				restore_current_blog();
+		try {
+			$partial = [];
+			if ( ! empty( $new_styles ) && is_array( $new_styles ) ) {
+				$partial['styles'] = $new_styles;
 			}
-			return $post_id;
-		}
-
-		$post = get_post( $post_id );
-		if ( ! $post ) {
-			if ( $switched ) {
-				restore_current_blog();
+			if ( ! empty( $new_settings ) && is_array( $new_settings ) ) {
+				$partial['settings'] = $new_settings;
 			}
-			return new \WP_Error( 'post_not_found', 'Could not retrieve global styles post.' );
-		}
 
-		$existing = json_decode( $post->post_content, true );
-		if ( ! is_array( $existing ) ) {
-			$existing = [ 'version' => 2 ];
-		}
-
-		// Merge styles.
-		if ( ! empty( $new_styles ) && is_array( $new_styles ) ) {
-			if ( ! isset( $existing['styles'] ) || ! is_array( $existing['styles'] ) ) {
-				$existing['styles'] = [];
+			$result = ( new GlobalStylesService() )->merge_user_document( $partial );
+			if ( is_wp_error( $result ) ) {
+				return $result;
 			}
-			$existing['styles'] = self::deep_merge( (array) $existing['styles'], $new_styles );
+
+			return [
+				'success'  => true,
+				'post_id'  => $result['post_id'],
+				'message'  => __( 'Global styles updated successfully.', 'superdav-ai-agent' ),
+				'affected' => self::build_affected_payload( [ 'styles', 'settings' ] ),
+			];
+		} finally {
+			self::restore_switched_blog( $switched );
 		}
-
-		// Merge settings.
-		if ( ! empty( $new_settings ) && is_array( $new_settings ) ) {
-			if ( ! isset( $existing['settings'] ) || ! is_array( $existing['settings'] ) ) {
-				$existing['settings'] = [];
-			}
-			$existing['settings'] = self::deep_merge( (array) $existing['settings'], $new_settings );
-		}
-
-		$updated = wp_update_post(
-			[
-				'ID'           => $post_id,
-				'post_content' => wp_json_encode( $existing ),
-			],
-			true
-		);
-
-		if ( $switched ) {
-			restore_current_blog();
-		}
-
-		if ( is_wp_error( $updated ) ) {
-			return $updated;
-		}
-
-		return [
-			'success'  => true,
-			'post_id'  => $post_id,
-			'message'  => __( 'Global styles updated successfully.', 'superdav-ai-agent' ),
-			'affected' => self::build_affected_payload( [ 'styles', 'settings' ] ),
-		];
 	}
 
 	/**
@@ -438,33 +403,27 @@ class GlobalStylesAbilities {
 			return $switched;
 		}
 
-		$post_id = self::find_global_styles_post();
-
-		if ( ! $post_id ) {
-			if ( $switched ) {
-				restore_current_blog();
+		try {
+			$deleted = ( new GlobalStylesService() )->delete_user_document();
+			if ( is_wp_error( $deleted ) ) {
+				return new \WP_Error( 'delete_failed', 'Failed to delete global styles post.' );
 			}
+
+			if ( ! $deleted ) {
+				return [
+					'success' => true,
+					'message' => __( 'No global style customizations found — already at theme defaults.', 'superdav-ai-agent' ),
+				];
+			}
+
 			return [
-				'success' => true,
-				'message' => __( 'No global style customizations found — already at theme defaults.', 'superdav-ai-agent' ),
+				'success'  => true,
+				'message'  => __( 'Global styles reset to theme defaults.', 'superdav-ai-agent' ),
+				'affected' => self::build_affected_payload( [ 'reset' ] ),
 			];
+		} finally {
+			self::restore_switched_blog( $switched );
 		}
-
-		$deleted = wp_delete_post( $post_id, true );
-
-		if ( $switched ) {
-			restore_current_blog();
-		}
-
-		if ( ! $deleted ) {
-			return new \WP_Error( 'delete_failed', 'Failed to delete global styles post.' );
-		}
-
-		return [
-			'success'  => true,
-			'message'  => __( 'Global styles reset to theme defaults.', 'superdav-ai-agent' ),
-			'affected' => self::build_affected_payload( [ 'reset' ] ),
-		];
 	}
 
 	/**
@@ -507,99 +466,6 @@ class GlobalStylesAbilities {
 	// ─── Private helpers ──────────────────────────────────────────
 
 	/**
-	 * Get the merged global styles (theme defaults + user customizations).
-	 *
-	 * @return array<string,mixed> Merged styles object.
-	 */
-	private static function get_merged_global_styles(): array {
-		$post_id = self::find_global_styles_post();
-
-		if ( ! $post_id ) {
-			return [];
-		}
-
-		$post = get_post( $post_id );
-		if ( ! $post ) {
-			return [];
-		}
-
-		$data = json_decode( $post->post_content, true );
-		if ( ! is_array( $data ) ) {
-			return [];
-		}
-
-		return $data['styles'] ?? [];
-	}
-
-	/**
-	 * Find the wp_global_styles post for the current theme.
-	 *
-	 * @return int|null Post ID or null if not found.
-	 */
-	private static function find_global_styles_post(): ?int {
-		$stylesheet = get_stylesheet();
-
-		$posts = get_posts(
-			[
-				'post_type'      => 'wp_global_styles',
-				'post_status'    => 'publish',
-				'posts_per_page' => 1,
-				'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-					[
-						'key'   => 'link',
-						'value' => 'wp-global-styles-' . $stylesheet,
-					],
-				],
-				'no_found_rows'  => true,
-			]
-		);
-
-		if ( empty( $posts ) ) {
-			return null;
-		}
-
-		return (int) $posts[0]->ID;
-	}
-
-	/**
-	 * Get or create the wp_global_styles post for the current theme.
-	 *
-	 * @return int|\WP_Error Post ID or WP_Error on failure.
-	 */
-	private static function get_or_create_global_styles_post() {
-		$existing = self::find_global_styles_post();
-		if ( $existing ) {
-			return $existing;
-		}
-
-		$stylesheet = get_stylesheet();
-
-		$initial_content = wp_json_encode( [ 'version' => 2 ] );
-		if ( $initial_content === false ) {
-			$initial_content = '{"version":2}';
-		}
-
-		$post_id = wp_insert_post(
-			[
-				'post_title'   => 'Custom Styles',
-				'post_name'    => 'wp-global-styles-' . $stylesheet,
-				'post_type'    => 'wp_global_styles',
-				'post_status'  => 'publish',
-				'post_content' => $initial_content,
-			],
-			true
-		);
-
-		if ( is_wp_error( $post_id ) ) {
-			return $post_id;
-		}
-
-		update_post_meta( $post_id, 'link', 'wp-global-styles-' . $stylesheet );
-
-		return $post_id;
-	}
-
-	/**
 	 * Switch to a subsite by URL if multisite is active.
 	 *
 	 * @param string $site_url Subsite URL to switch to.
@@ -631,20 +497,16 @@ class GlobalStylesAbilities {
 	}
 
 	/**
-	 * Deep merge two arrays, with values from $override taking precedence.
+	 * Restore the original blog and clear resolver state after a multisite call.
 	 *
-	 * @param array<string,mixed> $base     Base array.
-	 * @param array<string,mixed> $override Override array.
-	 * @return array<string,mixed> Merged result.
+	 * @param bool $switched Whether the handler switched blogs.
 	 */
-	private static function deep_merge( array $base, array $override ): array {
-		foreach ( $override as $key => $value ) {
-			if ( is_array( $value ) && isset( $base[ $key ] ) && is_array( $base[ $key ] ) ) {
-				$base[ $key ] = self::deep_merge( $base[ $key ], $value );
-			} else {
-				$base[ $key ] = $value;
-			}
+	private static function restore_switched_blog( bool $switched ): void {
+		if ( ! $switched ) {
+			return;
 		}
-		return $base;
+
+		restore_current_blog();
+		wp_clean_theme_json_cache();
 	}
 }

--- a/includes/Services/GlobalStylesService.php
+++ b/includes/Services/GlobalStylesService.php
@@ -1,0 +1,403 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Canonical active-theme Global Styles reads and persistence.
+ *
+ * @package SdAiAgent\Services
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Services;
+
+use WP_Error;
+use WP_Post;
+use WP_Theme_JSON;
+use WP_Theme_JSON_Resolver;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Owns the user-level wp_global_styles document for the active stylesheet.
+ */
+final class GlobalStylesService {
+
+	/**
+	 * Whether the active-theme post has already been resolved for this service instance.
+	 *
+	 * @var bool
+	 */
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase -- Project property naming guidance requires camelCase.
+	private bool $userPostLoaded = false;
+
+	/**
+	 * The canonical active-theme Global Styles post, when one exists.
+	 *
+	 * @var WP_Post|null
+	 */
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase -- Project property naming guidance requires camelCase.
+	private ?WP_Post $userPost = null;
+
+	/**
+	 * Get WordPress's resolved active-theme styles view.
+	 *
+	 * @return array<string,mixed> Core, theme, and user styles merged by WordPress.
+	 */
+	public function get_resolved_styles(): array {
+		// Resolve a safely identifiable pre-service record before asking WordPress
+		// for its merged view. New records already use the wp_theme taxonomy.
+		$this->get_user_post();
+
+		$styles = wp_get_global_styles();
+
+		return is_array( $styles ) ? self::string_keyed_array( $styles ) : [];
+	}
+
+	/**
+	 * Get the complete saved user-level theme.json document.
+	 *
+	 * @return array<string,mixed> Saved document, or an empty array when none exists.
+	 */
+	public function get_user_document(): array {
+		$post = $this->get_user_post();
+		if ( ! $post ) {
+			return [];
+		}
+
+		$document = json_decode( $post->post_content, true );
+
+		return is_array( $document ) ? self::string_keyed_array( $document ) : [];
+	}
+
+	/**
+	 * Get the active-theme user Global Styles post ID without creating a post.
+	 */
+	public function get_user_post_id(): ?int {
+		$post = $this->get_user_post();
+
+		return $post ? (int) $post->ID : null;
+	}
+
+	/**
+	 * Deep-merge a partial document into the active theme's user document.
+	 *
+	 * @param array<string,mixed> $partial Partial settings/styles document.
+	 * @return array{post_id:int,document:array<string,mixed>}|WP_Error Saved document details, or an error.
+	 */
+	public function merge_user_document( array $partial ): array|WP_Error {
+		$post     = $this->get_user_post();
+		$document = [];
+
+		if ( $post ) {
+			$decoded = json_decode( $post->post_content, true );
+			if ( is_array( $decoded ) ) {
+				$document = $decoded;
+			}
+		}
+
+		$document                                = self::deep_merge( $document, $partial );
+		$document['version']                     = WP_Theme_JSON::LATEST_SCHEMA;
+		$document['isGlobalStylesUserThemeJSON'] = true;
+		$json                                    = wp_json_encode(
+			$document,
+			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
+		);
+
+		if ( false === $json ) {
+			return new WP_Error(
+				'json_encode_failed',
+				__( 'Failed to encode styles as JSON.', 'superdav-ai-agent' )
+			);
+		}
+
+		$created = false;
+		if ( ! $post ) {
+			$post = $this->create_user_post();
+			if ( is_wp_error( $post ) ) {
+				return $post;
+			}
+			$created = true;
+		}
+
+		$updated = wp_update_post(
+			[
+				'ID'           => $post->ID,
+				'post_content' => $json,
+			],
+			true
+		);
+
+		if ( is_wp_error( $updated ) ) {
+			if ( $created ) {
+				wp_delete_post( $post->ID, true );
+				$this->userPost = null;
+			}
+			return $updated;
+		}
+
+		$post->post_content   = $json;
+		$this->userPost       = $post;
+		$this->userPostLoaded = true;
+		wp_clean_theme_json_cache();
+
+		return [
+			'post_id'  => (int) $post->ID,
+			'document' => $document,
+		];
+	}
+
+	/**
+	 * Delete only the active stylesheet's canonical user document.
+	 *
+	 * @return bool|WP_Error True when deleted, false when absent, or an error on failure.
+	 */
+	public function delete_user_document(): bool|WP_Error {
+		$post = $this->get_user_post();
+		if ( ! $post ) {
+			return false;
+		}
+
+		$deleted = wp_delete_post( $post->ID, true );
+		if ( ! $deleted instanceof WP_Post ) {
+			return new WP_Error(
+				'global_styles_delete_failed',
+				__( 'Failed to delete the global styles override.', 'superdav-ai-agent' )
+			);
+		}
+
+		$this->userPost       = null;
+		$this->userPostLoaded = true;
+		wp_clean_theme_json_cache();
+
+		return true;
+	}
+
+	/**
+	 * Resolve the active stylesheet's canonical post without creating one.
+	 */
+	private function get_user_post(): ?WP_Post {
+		if ( $this->userPostLoaded ) {
+			return $this->userPost;
+		}
+
+		$this->userPostLoaded = true;
+
+		$user_data = WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles( wp_get_theme() );
+		$post_id   = isset( $user_data['ID'] ) ? (int) $user_data['ID'] : 0;
+
+		if ( $post_id > 0 ) {
+			$post = get_post( $post_id );
+			if ( $post instanceof WP_Post && 'wp_global_styles' === $post->post_type ) {
+				$this->userPost = $post;
+				return $this->userPost;
+			}
+		}
+
+		$this->userPost = $this->adopt_safe_legacy_post();
+
+		return $this->userPost;
+	}
+
+	/**
+	 * Create a post through WordPress's active-theme Global Styles resolver.
+	 *
+	 * @return WP_Post|WP_Error Created canonical post or an error.
+	 */
+	private function create_user_post(): WP_Post|WP_Error {
+		$user_data = WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles( wp_get_theme(), true );
+		$post_id   = isset( $user_data['ID'] ) ? (int) $user_data['ID'] : 0;
+		$post      = $post_id > 0 ? get_post( $post_id ) : null;
+
+		if ( ! $post instanceof WP_Post || 'wp_global_styles' !== $post->post_type ) {
+			return new WP_Error(
+				'global_styles_create_failed',
+				__( 'Failed to create the global styles override.', 'superdav-ai-agent' )
+			);
+		}
+
+		$assigned = $this->ensure_active_theme_assignment( $post );
+		if ( is_wp_error( $assigned ) ) {
+			wp_delete_post( $post->ID, true );
+			return $assigned;
+		}
+
+		$this->userPost       = $post;
+		$this->userPostLoaded = true;
+
+		return $post;
+	}
+
+	/**
+	 * Adopt one historical record only when its active-theme identity is unambiguous.
+	 *
+	 * Earlier ability implementations used the exact post name and `link` meta
+	 * instead of WordPress's `wp_theme` taxonomy. An on-access adoption preserves
+	 * those active-theme documents without selecting the old unrestricted latest
+	 * post fallback. Ambiguous records and records assigned to another theme are
+	 * left untouched.
+	 */
+	private function adopt_safe_legacy_post(): ?WP_Post {
+		$stylesheet = get_stylesheet();
+		$identity   = 'wp-global-styles-' . $stylesheet;
+		$candidates = [];
+
+		$name_posts = get_posts(
+			[
+				'post_type'      => 'wp_global_styles',
+				'post_status'    => 'publish',
+				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.urlencode_urlencode -- Mirrors WordPress core's canonical Global Styles post name.
+				'name'           => sprintf( 'wp-global-styles-%s', urlencode( $stylesheet ) ),
+				'posts_per_page' => 2,
+				'no_found_rows'  => true,
+			]
+		);
+
+		foreach ( $name_posts as $post ) {
+			if ( $post instanceof WP_Post ) {
+				$candidates[ $post->ID ] = $post;
+			}
+		}
+
+		$meta_posts = get_posts(
+			[
+				'post_type'      => 'wp_global_styles',
+				'post_status'    => 'publish',
+				'posts_per_page' => 2,
+				'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- One-time compatibility lookup scoped to an exact active-theme identity.
+					[
+						'key'   => 'link',
+						'value' => $identity,
+					],
+				],
+				'no_found_rows'  => true,
+			]
+		);
+
+		foreach ( $meta_posts as $post ) {
+			if ( $post instanceof WP_Post ) {
+				$candidates[ $post->ID ] = $post;
+			}
+		}
+
+		if ( 1 !== count( $candidates ) ) {
+			return null;
+		}
+
+		$post = reset( $candidates );
+		if ( ! $post instanceof WP_Post ) {
+			return null;
+		}
+
+		$document = json_decode( $post->post_content, true );
+		if ( ! is_array( $document ) ) {
+			return null;
+		}
+
+		$terms = wp_get_object_terms( $post->ID, 'wp_theme', [ 'fields' => 'names' ] );
+		if ( is_wp_error( $terms ) || ( ! empty( $terms ) && ! in_array( $stylesheet, $terms, true ) ) ) {
+			return null;
+		}
+
+		$document['version']                     = $document['version'] ?? WP_Theme_JSON::LATEST_SCHEMA;
+		$document['isGlobalStylesUserThemeJSON'] = true;
+		$json                                    = wp_json_encode(
+			$document,
+			JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
+		);
+
+		if ( false === $json ) {
+			return null;
+		}
+
+		if ( $json !== $post->post_content ) {
+			$updated = wp_update_post(
+				[
+					'ID'           => $post->ID,
+					'post_content' => $json,
+				],
+				true
+			);
+			if ( is_wp_error( $updated ) ) {
+				return null;
+			}
+			$post->post_content = $json;
+		}
+
+		$assigned = $this->ensure_active_theme_assignment( $post );
+		if ( is_wp_error( $assigned ) ) {
+			return null;
+		}
+
+		wp_clean_theme_json_cache();
+
+		return $post;
+	}
+
+	/**
+	 * Ensure a new or safely adopted post belongs only to the active stylesheet.
+	 *
+	 * @return true|WP_Error True on success or an assignment error.
+	 */
+	private function ensure_active_theme_assignment( WP_Post $post ): true|WP_Error {
+		$stylesheet = get_stylesheet();
+		$terms      = wp_get_object_terms( $post->ID, 'wp_theme', [ 'fields' => 'names' ] );
+
+		if ( is_wp_error( $terms ) ) {
+			return $terms;
+		}
+
+		if ( in_array( $stylesheet, $terms, true ) ) {
+			return true;
+		}
+
+		if ( ! empty( $terms ) ) {
+			return new WP_Error(
+				'global_styles_theme_mismatch',
+				__( 'The global styles override belongs to another theme.', 'superdav-ai-agent' )
+			);
+		}
+
+		$assigned = wp_set_object_terms( $post->ID, $stylesheet, 'wp_theme' );
+
+		return is_wp_error( $assigned ) ? $assigned : true;
+	}
+
+	/**
+	 * Recursively merge arrays, replacing scalar values with the override.
+	 *
+	 * @param array<string,mixed> $base     Existing document fragment.
+	 * @param array<string,mixed> $override New document fragment.
+	 * @return array<string,mixed> Merged fragment.
+	 */
+	private static function deep_merge( array $base, array $override ): array {
+		foreach ( $override as $key => $value ) {
+			if ( is_array( $value ) && isset( $base[ $key ] ) && is_array( $base[ $key ] ) ) {
+				$base[ $key ] = self::deep_merge( $base[ $key ], $value );
+			} else {
+				$base[ $key ] = $value;
+			}
+		}
+
+		return $base;
+	}
+
+	/**
+	 * Retain the string-keyed top-level shape required by theme.json documents.
+	 *
+	 * @param array<mixed> $data Untrusted decoded or WordPress-returned data.
+	 * @return array<string,mixed> String-keyed document data.
+	 */
+	private static function string_keyed_array( array $data ): array {
+		$result = [];
+
+		foreach ( $data as $key => $value ) {
+			if ( is_string( $key ) ) {
+				$result[ $key ] = $value;
+			}
+		}
+
+		return $result;
+	}
+}

--- a/tests/SdAiAgent/Abilities/DesignSystemAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/DesignSystemAbilitiesTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Tests for Design System Global Styles persistence.
+ *
+ * @package SdAiAgent\Tests\Abilities
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Abilities;
+
+use SdAiAgent\Abilities\DesignSystemAbilities;
+use SdAiAgent\Abilities\GlobalStylesAbilities;
+use WP_Theme_JSON;
+use WP_UnitTestCase;
+
+/**
+ * Tests the theme-json-presets façade against the shared persistence service.
+ */
+class DesignSystemAbilitiesTest extends WP_UnitTestCase {
+
+	/**
+	 * Run persistence calls with theme permissions and a clean resolver cache.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		wp_clean_theme_json_cache();
+	}
+
+	/**
+	 * Clear resolver state after each test.
+	 */
+	public function tear_down(): void {
+		wp_clean_theme_json_cache();
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	/**
+	 * Both public façades read and mutate the same active-theme document.
+	 */
+	public function test_updates_are_visible_across_both_global_styles_facades(): void {
+		$global_update = GlobalStylesAbilities::handle_update_global_styles(
+			[
+				'styles' => [
+					'color' => [ 'text' => '#102030' ],
+				],
+			]
+		);
+		$this->assertIsArray( $global_update );
+
+		$design_get = DesignSystemAbilities::handle_theme_json_presets( [ 'action' => 'get' ] );
+		$this->assertIsArray( $design_get );
+		$this->assertSame( 'get', $design_get['action'] );
+		$this->assertSame( $global_update['post_id'], $design_get['post_id'] );
+		$this->assertSame( '#102030', $design_get['global_styles']['styles']['color']['text'] );
+		$this->assertTrue( $design_get['global_styles']['isGlobalStylesUserThemeJSON'] );
+
+		$design_update = DesignSystemAbilities::handle_theme_json_presets(
+			[
+				'action' => 'update',
+				'styles' => [
+					'settings' => [
+						'color' => [
+							'palette' => [
+								[
+									'slug'  => 'primary',
+									'color' => '#102030',
+									'name'  => 'Primary',
+								],
+							],
+						],
+					],
+					'styles'   => [
+						'typography' => [ 'lineHeight' => '1.7' ],
+					],
+				],
+			]
+		);
+
+		$this->assertIsArray( $design_update );
+		$this->assertSame( $global_update['post_id'], $design_update['post_id'] );
+		$this->assertSame( '#102030', $design_update['global_styles']['styles']['color']['text'] );
+		$this->assertSame( 'primary', $design_update['global_styles']['settings']['color']['palette'][0]['slug'] );
+
+		$global_get = GlobalStylesAbilities::handle_get_global_styles( [] );
+		$this->assertIsArray( $global_get );
+		$this->assertSame( '#102030', $global_get['styles']['color']['text'] );
+		$this->assertSame( '1.7', $global_get['styles']['typography']['lineHeight'] );
+	}
+
+	/**
+	 * Theme-json-presets no longer falls back to an arbitrary latest post.
+	 */
+	public function test_get_ignores_unidentified_global_styles_post(): void {
+		$post_id = wp_insert_post(
+			[
+				'post_title'   => 'Unidentified Styles',
+				'post_name'    => 'unidentified-styles',
+				'post_content' => wp_json_encode(
+					[
+						'version'                     => WP_Theme_JSON::LATEST_SCHEMA,
+						'isGlobalStylesUserThemeJSON' => true,
+						'styles'                      => [
+							'color' => [ 'text' => '#ff0000' ],
+						],
+					]
+				),
+				'post_status'  => 'publish',
+				'post_type'    => 'wp_global_styles',
+			],
+			true
+		);
+		$this->assertNotWPError( $post_id );
+
+		$result = DesignSystemAbilities::handle_theme_json_presets( [ 'action' => 'get' ] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 0, $result['post_id'] );
+		$this->assertEquals( (object) [], $result['global_styles'] );
+		$this->assertNotNull( get_post( $post_id ) );
+	}
+
+	/**
+	 * Reset remains idempotent and preserves the existing response contract.
+	 */
+	public function test_reset_returns_empty_document_contract(): void {
+		$result = DesignSystemAbilities::handle_theme_json_presets( [ 'action' => 'reset' ] );
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'reset', $result['action'] );
+		$this->assertSame( 0, $result['post_id'] );
+		$this->assertEquals( (object) [], $result['global_styles'] );
+	}
+}

--- a/tests/SdAiAgent/Abilities/GlobalStylesAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/GlobalStylesAbilitiesTest.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * Test case for GlobalStylesAbilities class.
  *
@@ -16,6 +18,24 @@ use WP_UnitTestCase;
  * Test GlobalStylesAbilities handler methods.
  */
 class GlobalStylesAbilitiesTest extends WP_UnitTestCase {
+
+	/**
+	 * Isolate the active-theme resolver and run mutations with theme permissions.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		wp_clean_theme_json_cache();
+	}
+
+	/**
+	 * Clear resolver state after every ability call.
+	 */
+	public function tear_down(): void {
+		wp_clean_theme_json_cache();
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
 
 	/**
 	 * Test update-global-styles schema nudges agents toward non-empty styles.
@@ -52,6 +72,27 @@ class GlobalStylesAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 'global_styles', $result['affected']['kind'] );
 		$this->assertNotEmpty( $result['affected']['url'] );
 		$this->assertContains( 'styles', $result['affected']['fields'] );
+		$this->assertContains( 'settings', $result['affected']['fields'] );
+	}
+
+	/**
+	 * Get-global-styles returns WordPress's resolved view of the saved user styles.
+	 */
+	public function test_handle_get_global_styles_returns_resolved_user_styles(): void {
+		$update = GlobalStylesAbilities::handle_update_global_styles(
+			[
+				'styles' => [
+					'color' => [ 'text' => '#334455' ],
+				],
+			]
+		);
+		$this->assertIsArray( $update );
+
+		$result = GlobalStylesAbilities::handle_get_global_styles( [ 'section' => 'color' ] );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'color', $result['section'] );
+		$this->assertSame( '#334455', $result['styles']['color']['text'] );
 	}
 
 	/**

--- a/tests/SdAiAgent/Services/GlobalStylesServiceTest.php
+++ b/tests/SdAiAgent/Services/GlobalStylesServiceTest.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Tests for the canonical Global Styles persistence service.
+ *
+ * @package SdAiAgent\Tests\Services
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Services;
+
+use SdAiAgent\Services\GlobalStylesService;
+use WP_Theme_JSON;
+use WP_UnitTestCase;
+
+/**
+ * Tests active-theme Global Styles reads and persistence.
+ */
+class GlobalStylesServiceTest extends WP_UnitTestCase {
+
+	/**
+	 * Run service calls as a user who can assign the private wp_theme taxonomy.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		wp_clean_theme_json_cache();
+	}
+
+	/**
+	 * Prevent the resolver's static cache from leaking between tests.
+	 */
+	public function tear_down(): void {
+		wp_clean_theme_json_cache();
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	/**
+	 * Repeated partial merges reuse one active-theme post and retain the full document.
+	 */
+	public function test_merge_user_document_reuses_canonical_active_theme_post(): void {
+		$service = new GlobalStylesService();
+
+		$first = $service->merge_user_document(
+			[
+				'styles' => [
+					'color' => [ 'text' => '#111111' ],
+				],
+			]
+		);
+
+		$this->assertIsArray( $first );
+		$this->assertGreaterThan( 0, $first['post_id'] );
+
+		$second = $service->merge_user_document(
+			[
+				'settings' => [
+					'color' => [ 'custom' => false ],
+				],
+				'styles'   => [
+					'typography' => [ 'lineHeight' => '1.6' ],
+				],
+			]
+		);
+
+		$this->assertIsArray( $second );
+		$this->assertSame( $first['post_id'], $second['post_id'] );
+		$this->assertSame( '#111111', $second['document']['styles']['color']['text'] );
+		$this->assertSame( '1.6', $second['document']['styles']['typography']['lineHeight'] );
+		$this->assertFalse( $second['document']['settings']['color']['custom'] );
+		$this->assertTrue( $second['document']['isGlobalStylesUserThemeJSON'] );
+		$this->assertSame( WP_Theme_JSON::LATEST_SCHEMA, $second['document']['version'] );
+		$this->assertSame( $second['document'], $service->get_user_document() );
+		$this->assertSame( $second['post_id'], $service->get_user_post_id() );
+
+		$theme_terms = wp_get_object_terms( $second['post_id'], 'wp_theme', [ 'fields' => 'names' ] );
+		$this->assertNotWPError( $theme_terms );
+		$this->assertSame( [ get_stylesheet() ], $theme_terms );
+	}
+
+	/**
+	 * Resolved reads use WordPress's core/theme/user merger.
+	 */
+	public function test_get_resolved_styles_includes_active_theme_user_styles(): void {
+		$service = new GlobalStylesService();
+		$result  = $service->merge_user_document(
+			[
+				'styles' => [
+					'color' => [ 'text' => '#123456' ],
+				],
+			]
+		);
+
+		$this->assertIsArray( $result );
+
+		$resolved = $service->get_resolved_styles();
+
+		$this->assertSame( '#123456', $resolved['color']['text'] );
+	}
+
+	/**
+	 * One provably active pre-service record is adopted without a bulk migration.
+	 */
+	public function test_exact_legacy_active_theme_record_is_safely_adopted(): void {
+		$stylesheet = get_stylesheet();
+		$post_id    = wp_insert_post(
+			[
+				'post_content' => wp_json_encode(
+					[
+						'version' => 2,
+						'styles'  => [
+							'color' => [ 'text' => '#778899' ],
+						],
+					]
+				),
+				'post_status'  => 'publish',
+				'post_title'   => 'Custom Styles',
+				'post_type'    => 'wp_global_styles',
+				'post_name'    => 'wp-global-styles-' . $stylesheet,
+			],
+			true
+		);
+		$this->assertNotWPError( $post_id );
+		update_post_meta( $post_id, 'link', 'wp-global-styles-' . $stylesheet );
+
+		$service  = new GlobalStylesService();
+		$document = $service->get_user_document();
+
+		$this->assertSame( $post_id, $service->get_user_post_id() );
+		$this->assertSame( '#778899', $document['styles']['color']['text'] );
+		$this->assertTrue( $document['isGlobalStylesUserThemeJSON'] );
+		$this->assertSame( [ $stylesheet ], wp_get_object_terms( $post_id, 'wp_theme', [ 'fields' => 'names' ] ) );
+		$this->assertSame( '#778899', $service->get_resolved_styles()['color']['text'] );
+	}
+
+	/**
+	 * A record assigned to another stylesheet is never returned, changed, or deleted.
+	 */
+	public function test_competing_theme_record_is_isolated_from_active_theme_operations(): void {
+		$other_document = [
+			'version'                     => WP_Theme_JSON::LATEST_SCHEMA,
+			'isGlobalStylesUserThemeJSON' => true,
+			'styles'                      => [
+				'color' => [ 'text' => '#abcdef' ],
+			],
+		];
+		$other_id       = $this->create_theme_document( 'competing-theme', $other_document );
+		$other_content  = get_post( $other_id )->post_content;
+		$service        = new GlobalStylesService();
+
+		$this->assertSame( [], $service->get_user_document() );
+		$this->assertNull( $service->get_user_post_id() );
+
+		$created = $service->merge_user_document(
+			[
+				'styles' => [
+					'color' => [ 'text' => '#654321' ],
+				],
+			]
+		);
+
+		$this->assertIsArray( $created );
+		$this->assertNotSame( $other_id, $created['post_id'] );
+		$this->assertSame( $other_content, get_post( $other_id )->post_content );
+		$this->assertTrue( $service->delete_user_document() );
+		$this->assertNull( get_post( $created['post_id'] ) );
+		$this->assertSame( $other_content, get_post( $other_id )->post_content );
+	}
+
+	/**
+	 * JSON encoding failure leaves the previous persisted document unchanged.
+	 */
+	public function test_merge_encoding_failure_preserves_existing_document(): void {
+		$service = new GlobalStylesService();
+		$created = $service->merge_user_document(
+			[
+				'styles' => [
+					'color' => [ 'text' => '#222222' ],
+				],
+			]
+		);
+		$this->assertIsArray( $created );
+
+		$before = get_post( $created['post_id'] )->post_content;
+		$stream = fopen( 'php://memory', 'r' );
+		if ( false === $stream ) {
+			$this->fail( 'Could not create the in-memory stream used by this test.' );
+		}
+
+		try {
+			$result = $service->merge_user_document(
+				[
+					'styles' => [ 'invalid' => $stream ],
+				]
+			);
+		} finally {
+			fclose( $stream );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'json_encode_failed', $result->get_error_code() );
+		$this->assertSame( $before, get_post( $created['post_id'] )->post_content );
+	}
+
+	/**
+	 * Deleting when no active-theme customization exists is idempotent.
+	 */
+	public function test_delete_user_document_returns_false_when_nothing_exists(): void {
+		$service = new GlobalStylesService();
+
+		$this->assertFalse( $service->delete_user_document() );
+	}
+
+	/**
+	 * Create a canonical Global Styles post assigned to a specific stylesheet.
+	 *
+	 * @param string              $stylesheet Stylesheet slug.
+	 * @param array<string,mixed> $document   User-level theme.json document.
+	 * @return int Post ID.
+	 */
+	private function create_theme_document( string $stylesheet, array $document ): int {
+		$post_id = wp_insert_post(
+			[
+				'post_content' => wp_json_encode( $document ),
+				'post_status'  => 'publish',
+				'post_title'   => 'Custom Styles',
+				'post_type'    => 'wp_global_styles',
+				'post_name'    => sprintf( 'wp-global-styles-%s', urlencode( $stylesheet ) ),
+			],
+			true
+		);
+		$this->assertNotWPError( $post_id );
+
+		$terms = wp_set_object_terms( $post_id, $stylesheet, 'wp_theme' );
+		$this->assertNotWPError( $terms );
+
+		return $post_id;
+	}
+}


### PR DESCRIPTION
## Summary

- centralize resolved Global Styles reads and user-document persistence in `GlobalStylesService`
- route `get-global-styles`, `update-global-styles`, `reset-global-styles`, and `theme-json-presets` through the shared service without changing their public contracts
- use WordPress's active `wp_theme` identity, safely adopt one provably active historical record, and leave arbitrary or competing-theme records untouched
- restore multisite context in `finally` blocks and clear resolver state after switching back

## Worker self-verification
- PHPUnit: Tests: 3768, Assertions: 15849, Errors: 0, Failures: 0, Skipped: 125
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

PHPUnit also reported 4 incomplete tests and exited successfully. The production build and deterministic bundle-size check passed; webpack emitted its existing advisory asset-size warnings.

## Runtime Testing

- `runtime-verified` through the full WordPress integration suite
- focused cross-façade coverage: 13 tests, 79 assertions
- WordPress 7.0.3 branch behavior was validated against `WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles()` and `wp_get_global_styles()` before implementation

Resolves #2247

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.152 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-sol spent 31m and 307,905 tokens on this as a headless worker. Solved in 36m.
