### PR TITLE
GH#2259: make Global Styles adoption atomic

### DIFF
--- a/includes/Services/GlobalStylesService.php
+++ b/includes/Services/GlobalStylesService.php
@@ -62,7 +62,7 @@ final class GlobalStylesService {
 	 */
 	public function get_user_document(): array {
 		$post = $this->get_user_post();
-		if ( ! $post ) {
+		if ( ! $post instanceof WP_Post ) {
 			return [];
 		}
 
@@ -77,7 +77,7 @@ final class GlobalStylesService {
 	public function get_user_post_id(): ?int {
 		$post = $this->get_user_post();
 
-		return $post ? (int) $post->ID : null;
+		return $post instanceof WP_Post ? (int) $post->ID : null;
 	}
 
 	/**
@@ -90,7 +90,11 @@ final class GlobalStylesService {
 		$post     = $this->get_user_post();
 		$document = [];
 
-		if ( $post ) {
+		if ( is_wp_error( $post ) ) {
+			return $post;
+		}
+
+		if ( $post instanceof WP_Post ) {
 			$decoded = json_decode( $post->post_content, true );
 			if ( is_array( $decoded ) ) {
 				$document = $decoded;
@@ -113,7 +117,7 @@ final class GlobalStylesService {
 		}
 
 		$created = false;
-		if ( ! $post ) {
+		if ( ! $post instanceof WP_Post ) {
 			$post = $this->create_user_post();
 			if ( is_wp_error( $post ) ) {
 				return $post;
@@ -155,7 +159,11 @@ final class GlobalStylesService {
 	 */
 	public function delete_user_document(): bool|WP_Error {
 		$post = $this->get_user_post();
-		if ( ! $post ) {
+		if ( is_wp_error( $post ) ) {
+			return $post;
+		}
+
+		if ( ! $post instanceof WP_Post ) {
 			return false;
 		}
 
@@ -176,40 +184,89 @@ final class GlobalStylesService {
 
 	/**
 	 * Resolve the active stylesheet's canonical post without creating one.
+	 *
+	 * @return WP_Post|WP_Error|null Canonical post, adoption error, or no post.
 	 */
-	private function get_user_post(): ?WP_Post {
+	private function get_user_post(): WP_Post|WP_Error|null {
 		if ( $this->userPostLoaded ) {
 			return $this->userPost;
 		}
 
 		$this->userPostLoaded = true;
 
+		$post = $this->get_canonical_user_post();
+		if ( $post instanceof WP_Post ) {
+			$this->userPost = $post;
+
+			return $this->userPost;
+		}
+
+		$legacy_post = $this->adopt_safe_legacy_post();
+		if ( is_wp_error( $legacy_post ) ) {
+			// Keep a transient adoption failure retryable on this service instance.
+			$this->userPostLoaded = false;
+
+			return $legacy_post;
+		}
+
+		$this->userPost = $legacy_post;
+
+		return $this->userPost;
+	}
+
+	/**
+	 * Resolve the active stylesheet's canonical post directly from WordPress.
+	 */
+	private function get_canonical_user_post(): ?WP_Post {
 		$user_data = WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles( wp_get_theme() );
 		$post_id   = isset( $user_data['ID'] ) ? (int) $user_data['ID'] : 0;
 
 		if ( $post_id > 0 ) {
 			$post = get_post( $post_id );
 			if ( $post instanceof WP_Post && 'wp_global_styles' === $post->post_type ) {
-				$this->userPost = $post;
-				return $this->userPost;
+				return $post;
 			}
 		}
 
-		$this->userPost = $this->adopt_safe_legacy_post();
-
-		return $this->userPost;
+		return null;
 	}
 
 	/**
-	 * Create a post through WordPress's active-theme Global Styles resolver.
+	 * Create a post with WordPress's canonical Global Styles fields.
 	 *
 	 * @return WP_Post|WP_Error Created canonical post or an error.
 	 */
 	private function create_user_post(): WP_Post|WP_Error {
-		$user_data = WP_Theme_JSON_Resolver::get_user_data_from_wp_global_styles( wp_get_theme(), true );
-		$post_id   = isset( $user_data['ID'] ) ? (int) $user_data['ID'] : 0;
-		$post      = $post_id > 0 ? get_post( $post_id ) : null;
+		$existing = $this->get_canonical_user_post();
+		if ( $existing instanceof WP_Post ) {
+			$this->userPost       = $existing;
+			$this->userPostLoaded = true;
 
+			return $existing;
+		}
+
+		$stylesheet = get_stylesheet();
+		$post_id    = wp_insert_post(
+			[
+				'post_content' => '{"version": ' . WP_Theme_JSON::LATEST_SCHEMA . ', "isGlobalStylesUserThemeJSON": true }',
+				'post_status'  => 'publish',
+				// Do not make string translatable, see https://core.trac.wordpress.org/ticket/54518.
+				'post_title'   => 'Custom Styles',
+				'post_type'    => 'wp_global_styles',
+				// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.urlencode_urlencode -- Mirrors WordPress core's canonical Global Styles post name.
+				'post_name'    => sprintf( 'wp-global-styles-%s', urlencode( $stylesheet ) ),
+				'tax_input'    => [
+					'wp_theme' => [ $stylesheet ],
+				],
+			],
+			true
+		);
+
+		if ( is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
+
+		$post = get_post( $post_id );
 		if ( ! $post instanceof WP_Post || 'wp_global_styles' !== $post->post_type ) {
 			return new WP_Error(
 				'global_styles_create_failed',
@@ -220,7 +277,17 @@ final class GlobalStylesService {
 		$assigned = $this->ensure_active_theme_assignment( $post );
 		if ( is_wp_error( $assigned ) ) {
 			wp_delete_post( $post->ID, true );
+
 			return $assigned;
+		}
+
+		$canonical = $this->get_canonical_user_post();
+		if ( $canonical instanceof WP_Post && $canonical->ID !== $post->ID ) {
+			wp_delete_post( $post->ID, true );
+			$this->userPost       = $canonical;
+			$this->userPostLoaded = true;
+
+			return $canonical;
 		}
 
 		$this->userPost       = $post;
@@ -238,7 +305,7 @@ final class GlobalStylesService {
 	 * post fallback. Ambiguous records and records assigned to another theme are
 	 * left untouched.
 	 */
-	private function adopt_safe_legacy_post(): ?WP_Post {
+	private function adopt_safe_legacy_post(): WP_Post|WP_Error|null {
 		$stylesheet = get_stylesheet();
 		$identity   = 'wp-global-styles-' . $stylesheet;
 		$candidates = [];
@@ -290,13 +357,21 @@ final class GlobalStylesService {
 			return null;
 		}
 
-		$document = json_decode( $post->post_content, true );
+		$original_content = $post->post_content;
+		$document         = json_decode( $original_content, true );
 		if ( ! is_array( $document ) ) {
-			return null;
+			return new WP_Error(
+				'global_styles_legacy_document_invalid',
+				__( 'The legacy global styles override contains invalid JSON.', 'superdav-ai-agent' )
+			);
 		}
 
 		$terms = wp_get_object_terms( $post->ID, 'wp_theme', [ 'fields' => 'names' ] );
-		if ( is_wp_error( $terms ) || ( ! empty( $terms ) && ! in_array( $stylesheet, $terms, true ) ) ) {
+		if ( is_wp_error( $terms ) ) {
+			return $terms;
+		}
+
+		if ( ! empty( $terms ) && ! in_array( $stylesheet, $terms, true ) ) {
 			return null;
 		}
 
@@ -308,9 +383,13 @@ final class GlobalStylesService {
 		);
 
 		if ( false === $json ) {
-			return null;
+			return new WP_Error(
+				'global_styles_adoption_encode_failed',
+				__( 'Failed to encode the legacy global styles override.', 'superdav-ai-agent' )
+			);
 		}
 
+		$content_updated = false;
 		if ( $json !== $post->post_content ) {
 			$updated = wp_update_post(
 				[
@@ -320,19 +399,76 @@ final class GlobalStylesService {
 				true
 			);
 			if ( is_wp_error( $updated ) ) {
-				return null;
+				return $updated;
 			}
-			$post->post_content = $json;
+			$content_updated = true;
 		}
 
 		$assigned = $this->ensure_active_theme_assignment( $post );
 		if ( is_wp_error( $assigned ) ) {
-			return null;
+			$rollback_error = $this->rollback_legacy_adoption(
+				$post,
+				$original_content,
+				$terms,
+				$content_updated
+			);
+
+			if ( is_wp_error( $rollback_error ) ) {
+				return new WP_Error(
+					'global_styles_adoption_rollback_failed',
+					__( 'Failed to restore the legacy global styles override after adoption failed.', 'superdav-ai-agent' ),
+					[
+						'adoption_error' => $assigned->get_error_code(),
+						'rollback_error' => $rollback_error->get_error_code(),
+					]
+				);
+			}
+
+			return $assigned;
 		}
 
+		$post->post_content = $json;
 		wp_clean_theme_json_cache();
 
 		return $post;
+	}
+
+	/**
+	 * Restore a legacy post after the second half of adoption fails.
+	 *
+	 * @param WP_Post           $post             Legacy post being restored.
+	 * @param string            $original_content Content before normalization.
+	 * @param array<int,string> $original_terms   Theme terms before assignment.
+	 * @param bool              $restore_content  Whether normalization was persisted.
+	 * @return WP_Error|null Rollback error, when restoration cannot complete.
+	 */
+	private function rollback_legacy_adoption(
+		WP_Post $post,
+		string $original_content,
+		array $original_terms,
+		bool $restore_content
+	): ?WP_Error {
+		$rollback_error = null;
+
+		if ( $restore_content ) {
+			$restored = wp_update_post(
+				[
+					'ID'           => $post->ID,
+					'post_content' => $original_content,
+				],
+				true
+			);
+			if ( is_wp_error( $restored ) ) {
+				$rollback_error = $restored;
+			}
+		}
+
+		$restored_terms = wp_set_object_terms( $post->ID, $original_terms, 'wp_theme' );
+		if ( is_wp_error( $restored_terms ) && ! is_wp_error( $rollback_error ) ) {
+			$rollback_error = $restored_terms;
+		}
+
+		return $rollback_error;
 	}
 
 	/**

--- a/tests/SdAiAgent/Services/GlobalStylesServiceTest.php
+++ b/tests/SdAiAgent/Services/GlobalStylesServiceTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Tests\Services;
 
 use SdAiAgent\Services\GlobalStylesService;
+use WP_Error;
 use WP_Theme_JSON;
 use WP_UnitTestCase;
 
@@ -136,6 +137,226 @@ class GlobalStylesServiceTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Canonical insertion preserves the actionable WordPress error code.
+	 */
+	public function test_merge_user_document_preserves_canonical_insertion_error(): void {
+		$filter = static function ( bool $maybe_empty, array $postarr ): bool {
+			if ( 'wp_global_styles' === ( $postarr['post_type'] ?? '' ) && empty( $postarr['ID'] ) ) {
+				return true;
+			}
+
+			return $maybe_empty;
+		};
+
+		add_filter( 'wp_insert_post_empty_content', $filter, 10, 2 );
+		try {
+			$result = ( new GlobalStylesService() )->merge_user_document(
+				[
+					'styles' => [
+						'color' => [ 'text' => '#345678' ],
+					],
+				]
+			);
+		} finally {
+			remove_filter( 'wp_insert_post_empty_content', $filter, 10 );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'empty_content', $result->get_error_code() );
+		$this->assertSame( [], $this->get_global_styles_post_ids() );
+	}
+
+	/**
+	 * A failed legacy content update leaves the original record untouched.
+	 */
+	public function test_legacy_content_update_failure_preserves_original_record_and_does_not_create_duplicate(): void {
+		$legacy_id        = $this->create_legacy_active_theme_document(
+			[
+				'version' => 2,
+				'styles'  => [
+					'color' => [ 'text' => '#778899' ],
+				],
+			]
+		);
+		$original_content = get_post( $legacy_id )->post_content;
+		$filter           = static function ( bool $maybe_empty, array $postarr ) use ( $legacy_id ): bool {
+			if ( $legacy_id === (int) ( $postarr['ID'] ?? 0 ) ) {
+				return true;
+			}
+
+			return $maybe_empty;
+		};
+
+		add_filter( 'wp_insert_post_empty_content', $filter, 10, 2 );
+		try {
+			$result = ( new GlobalStylesService() )->merge_user_document(
+				[
+					'styles' => [
+						'color' => [ 'background' => '#112233' ],
+					],
+				]
+			);
+		} finally {
+			remove_filter( 'wp_insert_post_empty_content', $filter, 10 );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'empty_content', $result->get_error_code() );
+		$this->assertSame( $original_content, get_post( $legacy_id )->post_content );
+		$this->assertSame( [], wp_get_object_terms( $legacy_id, 'wp_theme', [ 'fields' => 'names' ] ) );
+		$this->assertSame( [ $legacy_id ], $this->get_global_styles_post_ids() );
+	}
+
+	/**
+	 * A failed legacy theme assignment restores both content and terms.
+	 */
+	public function test_legacy_theme_assignment_failure_rolls_back_without_creating_duplicate(): void {
+		$legacy_id        = $this->create_legacy_active_theme_document(
+			[
+				'version' => 2,
+				'styles'  => [
+					'color' => [ 'text' => '#778899' ],
+				],
+			]
+		);
+		$original_content = get_post( $legacy_id )->post_content;
+		$stylesheet       = get_stylesheet();
+		$this->delete_active_theme_term();
+		$filter = static function ( string|WP_Error $term, string $taxonomy ) use ( $stylesheet ): string|WP_Error {
+			if ( 'wp_theme' === $taxonomy && $stylesheet === $term ) {
+				return new WP_Error( 'theme_assignment_failed', 'Theme assignment failed.' );
+			}
+
+			return $term;
+		};
+
+		add_filter( 'pre_insert_term', $filter, 10, 2 );
+		try {
+			$result = ( new GlobalStylesService() )->merge_user_document(
+				[
+					'styles' => [
+						'color' => [ 'background' => '#112233' ],
+					],
+				]
+			);
+		} finally {
+			remove_filter( 'pre_insert_term', $filter, 10 );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'theme_assignment_failed', $result->get_error_code() );
+		$this->assertSame( $original_content, get_post( $legacy_id )->post_content );
+		$this->assertSame( [], wp_get_object_terms( $legacy_id, 'wp_theme', [ 'fields' => 'names' ] ) );
+		$this->assertSame( [ $legacy_id ], $this->get_global_styles_post_ids() );
+	}
+
+	/**
+	 * A rollback failure remains distinguishable from the original adoption error.
+	 */
+	public function test_legacy_adoption_reports_rollback_failure(): void {
+		$legacy_id        = $this->create_legacy_active_theme_document(
+			[
+				'version' => 2,
+				'styles'  => [
+					'color' => [ 'text' => '#778899' ],
+				],
+			]
+		);
+		$original_content = get_post( $legacy_id )->post_content;
+		$stylesheet       = get_stylesheet();
+		$this->delete_active_theme_term();
+		$term_filter = static function ( string|WP_Error $term, string $taxonomy ) use ( $stylesheet ): string|WP_Error {
+			if ( 'wp_theme' === $taxonomy && $stylesheet === $term ) {
+				return new WP_Error( 'theme_assignment_failed', 'Theme assignment failed.' );
+			}
+
+			return $term;
+		};
+		$update_filter = static function ( bool $maybe_empty, array $postarr ) use ( $legacy_id, $original_content ): bool {
+			if ( $legacy_id === (int) ( $postarr['ID'] ?? 0 ) && $original_content === ( $postarr['post_content'] ?? '' ) ) {
+				return true;
+			}
+
+			return $maybe_empty;
+		};
+
+		add_filter( 'pre_insert_term', $term_filter, 10, 2 );
+		add_filter( 'wp_insert_post_empty_content', $update_filter, 10, 2 );
+		try {
+			$result = ( new GlobalStylesService() )->merge_user_document(
+				[
+					'styles' => [
+						'color' => [ 'background' => '#112233' ],
+					],
+				]
+			);
+		} finally {
+			remove_filter( 'pre_insert_term', $term_filter, 10 );
+			remove_filter( 'wp_insert_post_empty_content', $update_filter, 10 );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'global_styles_adoption_rollback_failed', $result->get_error_code() );
+		$this->assertSame( 'theme_assignment_failed', $result->get_error_data()['adoption_error'] );
+		$this->assertSame( 'empty_content', $result->get_error_data()['rollback_error'] );
+		$this->assertNotSame( $original_content, get_post( $legacy_id )->post_content );
+		$this->assertSame( [], wp_get_object_terms( $legacy_id, 'wp_theme', [ 'fields' => 'names' ] ) );
+		$this->assertSame( [ $legacy_id ], $this->get_global_styles_post_ids() );
+	}
+
+	/**
+	 * A retry after transient legacy adoption failure reuses one canonical post.
+	 */
+	public function test_legacy_adoption_retry_reuses_one_canonical_post(): void {
+		$legacy_id  = $this->create_legacy_active_theme_document(
+			[
+				'version' => 2,
+				'styles'  => [
+					'color' => [ 'text' => '#778899' ],
+				],
+			]
+		);
+		$stylesheet = get_stylesheet();
+		$this->delete_active_theme_term();
+		$filter = static function ( string|WP_Error $term, string $taxonomy ) use ( $stylesheet ): string|WP_Error {
+			if ( 'wp_theme' === $taxonomy && $stylesheet === $term ) {
+				return new WP_Error( 'theme_assignment_failed', 'Theme assignment failed.' );
+			}
+
+			return $term;
+		};
+		$service = new GlobalStylesService();
+
+		add_filter( 'pre_insert_term', $filter, 10, 2 );
+		try {
+			$failed = $service->merge_user_document(
+				[
+					'styles' => [
+						'color' => [ 'background' => '#112233' ],
+					],
+				]
+			);
+		} finally {
+			remove_filter( 'pre_insert_term', $filter, 10 );
+		}
+
+		$this->assertWPError( $failed );
+
+		$retried = $service->merge_user_document(
+			[
+				'styles' => [
+					'color' => [ 'background' => '#112233' ],
+				],
+			]
+		);
+
+		$this->assertIsArray( $retried );
+		$this->assertSame( $legacy_id, $retried['post_id'] );
+		$this->assertSame( [ $stylesheet ], wp_get_object_terms( $legacy_id, 'wp_theme', [ 'fields' => 'names' ] ) );
+		$this->assertSame( [ $legacy_id ], $this->get_global_styles_post_ids() );
+	}
+
+	/**
 	 * A record assigned to another stylesheet is never returned, changed, or deleted.
 	 */
 	public function test_competing_theme_record_is_isolated_from_active_theme_operations(): void {
@@ -237,5 +458,62 @@ class GlobalStylesServiceTest extends WP_UnitTestCase {
 		$this->assertNotWPError( $terms );
 
 		return $post_id;
+	}
+
+	/**
+	 * Create a legacy active-theme document without a wp_theme taxonomy term.
+	 *
+	 * @param array<string,mixed> $document User-level theme.json document.
+	 * @return int Post ID.
+	 */
+	private function create_legacy_active_theme_document( array $document ): int {
+		$stylesheet = get_stylesheet();
+		$post_id    = wp_insert_post(
+			[
+				'post_content' => wp_json_encode( $document ),
+				'post_status'  => 'publish',
+				'post_title'   => 'Custom Styles',
+				'post_type'    => 'wp_global_styles',
+				'post_name'    => 'wp-global-styles-' . $stylesheet,
+			],
+			true
+		);
+		$this->assertNotWPError( $post_id );
+		update_post_meta( $post_id, 'link', 'wp-global-styles-' . $stylesheet );
+
+		return $post_id;
+	}
+
+	/**
+	 * Return all persisted Global Styles post IDs in a predictable order.
+	 *
+	 * @return list<int>
+	 */
+	private function get_global_styles_post_ids(): array {
+		$post_ids = get_posts(
+			[
+				'post_type'      => 'wp_global_styles',
+				'post_status'    => 'publish',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'orderby'        => 'ID',
+				'order'          => 'ASC',
+			]
+		);
+
+		return array_map( 'intval', $post_ids );
+	}
+
+	/**
+	 * Remove the active stylesheet term so the next assignment reaches wp_insert_term().
+	 */
+	private function delete_active_theme_term(): void {
+		$term = term_exists( get_stylesheet(), 'wp_theme' );
+		if ( ! $term ) {
+			return;
+		}
+
+		$term_id = is_array( $term ) ? (int) $term['term_id'] : (int) $term;
+		wp_delete_term( $term_id, 'wp_theme' );
 	}
 }


### PR DESCRIPTION
## Summary

- Preserve actionable `wp_insert_post()` errors when creating canonical Global Styles documents.
- Restore legacy content and `wp_theme` terms when adoption cannot complete.
- Keep adoption failures retryable and prevent duplicate canonical records.

## Worker self-verification

- PHPUnit: Tests: 3774, Assertions: 15879, Errors: 0, Failures: 0, Skipped: 125
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded
- Bundle: passed

## Key decisions

- Replicate WordPress core's canonical Global Styles creation payload directly so the underlying insertion error is retained.
- Use compensating content and taxonomy rollback because WordPress does not provide a cross-API transaction.

Resolves #2259

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.153 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-terra spent 34m and 295,604 tokens on this as a headless worker. Overall, 1h 1m since this issue was created.
