### PR TITLE
perf: avoid event automation schema query

### DIFF
--- a/includes/Automations/EventAutomations.php
+++ b/includes/Automations/EventAutomations.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Automations;
 
+use SdAiAgent\Core\Database;
+
 class EventAutomations {
 
 	/**
@@ -31,11 +33,11 @@ class EventAutomations {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 
-		$table = self::table_name();
-		if ( ! self::table_exists( $table ) ) {
+		if ( ! self::database_is_installed() ) {
 			return [];
 		}
 
+		$table = self::table_name();
 		$where = $enabled_only ? 'WHERE enabled = 1' : '';
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Custom table query; table/column names from internal methods, not user input.
@@ -45,24 +47,15 @@ class EventAutomations {
 	}
 
 	/**
-	 * Check whether the event automations table exists for the current site.
+	 * Check whether the AI Agent database has been installed for the current site.
 	 *
-	 * Network-activated multisite installs can reach subsites before this custom
-	 * table has been created for the current blog. Guarding the read prevents a
-	 * failed SELECT from running on every request while event hooks attach.
-	 *
-	 * @param string $table Event automations table name.
+	 * Database::install() persists its version in an autoloaded option only after
+	 * it creates the plugin tables. Network-activated multisite installs can reach
+	 * a subsite before that happens, so this avoids both failed SELECT queries and
+	 * per-request schema discovery while event hooks attach.
 	 */
-	private static function table_exists( string $table ): bool {
-		global $wpdb;
-		/** @var \wpdb $wpdb */
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Schema existence check for custom table before querying it.
-		$found = $wpdb->get_var(
-			$wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->esc_like( $table ) )
-		);
-
-		return $found === $table;
+	private static function database_is_installed(): bool {
+		return false !== get_option( Database::DB_VERSION_OPTION, false );
 	}
 
 	/**

--- a/includes/Core/Database.php
+++ b/includes/Core/Database.php
@@ -769,7 +769,7 @@ class Database {
 		// Seed built-in agents (onboarding, general, content-creator, seo, ecommerce).
 		Agent::seed_defaults();
 
-		update_option( self::DB_VERSION_OPTION, self::DB_VERSION );
+		update_option( self::DB_VERSION_OPTION, self::DB_VERSION, true );
 	}
 
 	/**

--- a/tests/SdAiAgent/Automations/EventAutomationsTest.php
+++ b/tests/SdAiAgent/Automations/EventAutomationsTest.php
@@ -10,6 +10,7 @@
 namespace SdAiAgent\Tests\Automations;
 
 use SdAiAgent\Automations\EventAutomations;
+use SdAiAgent\Core\Database;
 use WP_UnitTestCase;
 
 /**
@@ -37,6 +38,13 @@ class EventAutomationsTest extends WP_UnitTestCase {
 			],
 			$overrides
 		);
+	}
+
+	/**
+	 * Test the database version is available through WordPress's alloptions cache.
+	 */
+	public function test_database_version_option_is_autoloaded(): void {
+		$this->assertArrayHasKey( Database::DB_VERSION_OPTION, wp_load_alloptions() );
 	}
 
 	// -------------------------------------------------------------------------
@@ -246,21 +254,25 @@ class EventAutomationsTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test list returns empty without querying a missing subsite table.
+	 * Test list returns empty when the current site has not installed the database.
 	 */
-	public function test_list_returns_empty_when_current_site_table_is_missing(): void {
+	public function test_list_returns_empty_when_database_is_not_installed(): void {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 
-		$original_prefix = $wpdb->prefix;
-		$wpdb->prefix    = $original_prefix . 'missing_';
+		$installed_version = get_option( Database::DB_VERSION_OPTION, false );
+		delete_option( Database::DB_VERSION_OPTION );
 		$wpdb->last_error = '';
 
 		try {
 			$this->assertSame( [], EventAutomations::list( true ) );
 			$this->assertSame( '', $wpdb->last_error );
 		} finally {
-			$wpdb->prefix = $original_prefix;
+			if ( false === $installed_version ) {
+				delete_option( Database::DB_VERSION_OPTION );
+			} else {
+				update_option( Database::DB_VERSION_OPTION, $installed_version );
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- replace the event-automation `SHOW TABLES` query with the per-site AI Agent database-version option
- explicitly autoload the version option when the database schema is installed or upgraded
- cover the autoloaded guard and the uninstalled-site behavior

## Verification

- `php -l includes/Automations/EventAutomations.php`
- `php -l includes/Core/Database.php`
- `php -l tests/SdAiAgent/Automations/EventAutomationsTest.php`
- `vendor/bin/phpcs --standard=phpcs.xml includes/Automations/EventAutomations.php includes/Core/Database.php tests/SdAiAgent/Automations/EventAutomationsTest.php`

`vendor/bin/phpunit --filter EventAutomationsTest` is blocked because the local WordPress test bootstrap is missing `/tmp/wordpress-tests-lib/includes/functions.php`.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.155 plugin for [OpenCode](https://opencode.ai) v1.18.3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automation handling when the plugin database has not been installed.
  * Prevented unnecessary database errors by returning no automations until setup is complete.

* **Reliability**
  * Improved detection of database installation status for more consistent automation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->