### PR TITLE
GH#2251: add style variation lifecycle abilities

### DIFF
--- a/advanced-plugin/includes/Abilities/StyleVariationAbilities.php
+++ b/advanced-plugin/includes/Abilities/StyleVariationAbilities.php
@@ -228,11 +228,11 @@ final class StyleVariationAbilities {
 	 * @param string              $description    Ability description.
 	 * @param array<string,mixed> $input_schema   Input schema.
 	 * @param string              $callback       Static callback.
-	 * @param bool                $readonly       Whether no state changes occur.
+	 * @param bool                $is_readonly    Whether no state changes occur.
 	 * @param bool                $destructive    Whether state/files are changed.
 	 * @param bool                $idempotent     Whether identical safe input is a no-op.
 	 */
-	private static function register_ability( string $id, string $label, string $description, array $input_schema, string $callback, bool $readonly, bool $destructive, bool $idempotent ): void {
+	private static function register_ability( string $id, string $label, string $description, array $input_schema, string $callback, bool $is_readonly, bool $destructive, bool $idempotent ): void {
 		wp_register_ability(
 			$id,
 			[
@@ -251,7 +251,7 @@ final class StyleVariationAbilities {
 				'meta'                => [
 					'mcp'          => [ 'public' => true ],
 					'annotations'  => [
-						'readonly'    => $readonly,
+						'readonly'    => $is_readonly,
 						'destructive' => $destructive,
 						'idempotent'  => $idempotent,
 					],
@@ -265,7 +265,7 @@ final class StyleVariationAbilities {
 	 * Resolve a supplied document first, otherwise one existing slug.
 	 *
 	 * @param array<string,mixed> $input Ability input.
-	 * @return array<string,mixed>|WP_Error Validated document or an error.
+	 * @return array{slug:string,title:string,hash:string,document:array<string,mixed>,origin?:string,relative_path?:string,read_only?:bool}|WP_Error Validated document or an error.
 	 */
 	private static function resolve_document( array $input ): array|WP_Error {
 		$manager = new StyleVariationManager();

--- a/advanced-plugin/includes/Abilities/StyleVariationAbilities.php
+++ b/advanced-plugin/includes/Abilities/StyleVariationAbilities.php
@@ -1,0 +1,390 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Explicit WordPress style-variation lifecycle abilities.
+ *
+ * @package SdAiAgent\Abilities
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Abilities;
+
+use SdAiAgent\Services\StyleVariationManager;
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Registers separate contracts for every style-variation lifecycle operation.
+ */
+final class StyleVariationAbilities {
+
+	/**
+	 * Register all explicit lifecycle abilities.
+	 */
+	public static function register_abilities(): void {
+		if ( ! function_exists( 'wp_register_ability' ) ) {
+			return;
+		}
+
+		self::register_ability(
+			'sd-ai-agent/list-style-variations',
+			__( 'List Style Variations', 'superdav-ai-agent' ),
+			__( 'List active stylesheet and inherited parent style variations with origin, hash, read-only, and managed selection state.', 'superdav-ai-agent' ),
+			self::empty_input_schema(),
+			'handle_list',
+			true,
+			false,
+			true
+		);
+		self::register_ability(
+			'sd-ai-agent/create-style-variation',
+			__( 'Create Style Variation', 'superdav-ai-agent' ),
+			__( 'Validate and atomically create one complete theme.json v3 style variation in the active stylesheet styles directory. Existing files are never overwritten.', 'superdav-ai-agent' ),
+			[
+				'type'       => 'object',
+				'properties' => [
+					'document' => self::document_schema(),
+				],
+				'required'   => [ 'document' ],
+			],
+			'handle_create',
+			false,
+			true,
+			false
+		);
+		self::register_ability(
+			'sd-ai-agent/update-style-variation',
+			__( 'Update Style Variation', 'superdav-ai-agent' ),
+			__( 'Validate and atomically replace one complete active stylesheet style variation. The supplied expected hash is required to prevent stale writes; parent files are read-only.', 'superdav-ai-agent' ),
+			[
+				'type'       => 'object',
+				'properties' => [
+					'slug'          => self::slug_schema(),
+					'expected_hash' => self::hash_schema(),
+					'document'      => self::document_schema(),
+				],
+				'required'   => [ 'slug', 'expected_hash', 'document' ],
+			],
+			'handle_update',
+			false,
+			true,
+			false
+		);
+		self::register_ability(
+			'sd-ai-agent/validate-style-variation',
+			__( 'Validate Style Variation', 'superdav-ai-agent' ),
+			__( 'Validate a supplied complete theme.json v3 style variation or an existing active/parent variation without writing files, options, posts, or selection state.', 'superdav-ai-agent' ),
+			self::document_or_slug_schema(),
+			'handle_validate',
+			true,
+			false,
+			true
+		);
+		self::register_ability(
+			'sd-ai-agent/preview-style-variation',
+			__( 'Preview Style Variation', 'superdav-ai-agent' ),
+			__( 'Validate and merge a supplied or existing style variation with the active theme entirely in memory, returning changed theme.json paths and generated CSS without persisting changes.', 'superdav-ai-agent' ),
+			self::document_or_slug_schema(),
+			'handle_preview',
+			true,
+			false,
+			true
+		);
+		self::register_ability(
+			'sd-ai-agent/select-style-variation',
+			__( 'Select Style Variation', 'superdav-ai-agent' ),
+			__( 'Apply a validated style variation to active-theme user Global Styles while preserving an exact plugin-owned baseline. Refuses stale source hashes and intervening Site Editor changes.', 'superdav-ai-agent' ),
+			[
+				'type'       => 'object',
+				'properties' => [
+					'slug'          => self::slug_schema(),
+					'expected_hash' => self::hash_schema(),
+				],
+				'required'   => [ 'slug', 'expected_hash' ],
+			],
+			'handle_select',
+			false,
+			true,
+			true
+		);
+		self::register_ability(
+			'sd-ai-agent/reset-style-variation',
+			__( 'Reset Style Variation', 'superdav-ai-agent' ),
+			__( 'Restore the exact Global Styles baseline saved by select-style-variation only while the selected-state content hash still matches. Never wholesale-resets unrelated customizations.', 'superdav-ai-agent' ),
+			self::empty_input_schema(),
+			'handle_reset',
+			false,
+			true,
+			false
+		);
+	}
+
+	/**
+	 * List installed active/parent variation metadata.
+	 *
+	 * @param array<string,mixed> $input Ability input.
+	 * @return array<string,mixed>|WP_Error Result or an error.
+	 */
+	public static function handle_list( array $input ): array|WP_Error {
+		return ( new StyleVariationManager() )->list();
+	}
+
+	/**
+	 * Create one variation document.
+	 *
+	 * @param array<string,mixed> $input Ability input.
+	 * @return array<string,mixed>|WP_Error Result or an error.
+	 */
+	public static function handle_create( array $input ): array|WP_Error {
+		$document = $input['document'] ?? null;
+		if ( ! is_array( $document ) ) {
+			return self::document_required_error();
+		}
+
+		return ( new StyleVariationManager() )->create( $document );
+	}
+
+	/**
+	 * Replace one variation document after a hash check.
+	 *
+	 * @param array<string,mixed> $input Ability input.
+	 * @return array<string,mixed>|WP_Error Result or an error.
+	 */
+	public static function handle_update( array $input ): array|WP_Error {
+		$document = $input['document'] ?? null;
+		if ( ! is_array( $document ) ) {
+			return self::document_required_error();
+		}
+
+		return ( new StyleVariationManager() )->update(
+			isset( $input['slug'] ) ? (string) $input['slug'] : '',
+			$document,
+			isset( $input['expected_hash'] ) ? (string) $input['expected_hash'] : ''
+		);
+	}
+
+	/**
+	 * Validate a supplied document or existing variation by slug.
+	 *
+	 * @param array<string,mixed> $input Ability input.
+	 * @return array<string,mixed>|WP_Error Result or an error.
+	 */
+	public static function handle_validate( array $input ): array|WP_Error {
+		$variation = self::resolve_document( $input );
+		if ( is_wp_error( $variation ) ) {
+			return $variation;
+		}
+
+		return self::validation_output( $variation );
+	}
+
+	/**
+	 * Preview a supplied document or existing variation by slug.
+	 *
+	 * @param array<string,mixed> $input Ability input.
+	 * @return array<string,mixed>|WP_Error Result or an error.
+	 */
+	public static function handle_preview( array $input ): array|WP_Error {
+		$variation = self::resolve_document( $input );
+		if ( is_wp_error( $variation ) ) {
+			return $variation;
+		}
+
+		return ( new StyleVariationManager() )->preview( $variation['document'] );
+	}
+
+	/**
+	 * Select one variation with source optimistic concurrency.
+	 *
+	 * @param array<string,mixed> $input Ability input.
+	 * @return array<string,mixed>|WP_Error Result or an error.
+	 */
+	public static function handle_select( array $input ): array|WP_Error {
+		return ( new StyleVariationManager() )->select(
+			isset( $input['slug'] ) ? (string) $input['slug'] : '',
+			isset( $input['expected_hash'] ) ? (string) $input['expected_hash'] : ''
+		);
+	}
+
+	/**
+	 * Reset only a verified managed selection state.
+	 *
+	 * @param array<string,mixed> $input Ability input.
+	 * @return array<string,mixed>|WP_Error Result or an error.
+	 */
+	public static function handle_reset( array $input ): array|WP_Error {
+		return ( new StyleVariationManager() )->reset();
+	}
+
+	/**
+	 * Register one explicitly named lifecycle contract.
+	 *
+	 * @param string              $id             Ability ID.
+	 * @param string              $label          Ability label.
+	 * @param string              $description    Ability description.
+	 * @param array<string,mixed> $input_schema   Input schema.
+	 * @param string              $callback       Static callback.
+	 * @param bool                $readonly       Whether no state changes occur.
+	 * @param bool                $destructive    Whether state/files are changed.
+	 * @param bool                $idempotent     Whether identical safe input is a no-op.
+	 */
+	private static function register_ability( string $id, string $label, string $description, array $input_schema, string $callback, bool $readonly, bool $destructive, bool $idempotent ): void {
+		wp_register_ability(
+			$id,
+			[
+				'label'               => $label,
+				'description'         => $description,
+				'category'            => 'sd-ai-agent',
+				'input_schema'        => $input_schema,
+				'output_schema'       => [
+					'type'                 => 'object',
+					'additionalProperties' => true,
+				],
+				'execute_callback'    => [ __CLASS__, $callback ],
+				'permission_callback' => static function () use ( $id ): bool {
+					return ToolCapabilities::current_user_can( $id ) && current_user_can( 'edit_theme_options' );
+				},
+				'meta'                => [
+					'mcp'          => [ 'public' => true ],
+					'annotations'  => [
+						'readonly'    => $readonly,
+						'destructive' => $destructive,
+						'idempotent'  => $idempotent,
+					],
+					'show_in_rest' => true,
+				],
+			]
+		);
+	}
+
+	/**
+	 * Resolve a supplied document first, otherwise one existing slug.
+	 *
+	 * @param array<string,mixed> $input Ability input.
+	 * @return array<string,mixed>|WP_Error Validated document or an error.
+	 */
+	private static function resolve_document( array $input ): array|WP_Error {
+		$manager = new StyleVariationManager();
+		if ( isset( $input['document'] ) ) {
+			if ( ! is_array( $input['document'] ) ) {
+				return self::document_required_error();
+			}
+
+			return $manager->validate_document( $input['document'] );
+		}
+		if ( isset( $input['slug'] ) ) {
+			return $manager->validate_existing( (string) $input['slug'] );
+		}
+
+		return new WP_Error(
+			'sd_ai_agent_style_variation_document_or_slug_required',
+			__( 'Provide either a complete style variation document or an existing variation slug.', 'superdav-ai-agent' )
+		);
+	}
+
+	/**
+	 * Return the public validation response without echoing an entire document.
+	 *
+	 * @param array<string,mixed> $variation Validated document details.
+	 * @return array<string,mixed> Safe validation response.
+	 */
+	private static function validation_output( array $variation ): array {
+		$output = [
+			'valid' => true,
+			'slug'  => $variation['slug'],
+			'title' => $variation['title'],
+			'hash'  => $variation['hash'],
+		];
+		foreach ( [ 'origin', 'relative_path', 'read_only' ] as $field ) {
+			if ( array_key_exists( $field, $variation ) ) {
+				$output[ $field ] = $variation[ $field ];
+			}
+		}
+
+		return $output;
+	}
+
+	/**
+	 * Return a standard missing-document error.
+	 */
+	private static function document_required_error(): WP_Error {
+		return new WP_Error(
+			'sd_ai_agent_style_variation_document_required',
+			__( 'A complete style variation document is required.', 'superdav-ai-agent' )
+		);
+	}
+
+	/**
+	 * Return a schema for an empty object input.
+	 *
+	 * @return array<string,mixed> Input schema.
+	 */
+	private static function empty_input_schema(): array {
+		return [
+			'type'                 => 'object',
+			'properties'           => [],
+			'additionalProperties' => false,
+		];
+	}
+
+	/**
+	 * Return a schema accepting one document or one existing slug.
+	 *
+	 * Runtime validation enforces that at least one is supplied because the
+	 * WordPress ability schema normalizer does not consistently preserve oneOf.
+	 *
+	 * @return array<string,mixed> Input schema.
+	 */
+	private static function document_or_slug_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'document' => self::document_schema(),
+				'slug'     => self::slug_schema(),
+			],
+			'required'   => [],
+		];
+	}
+
+	/**
+	 * Return a schema for a complete theme.json document.
+	 *
+	 * @return array<string,mixed> Document schema.
+	 */
+	private static function document_schema(): array {
+		return [
+			'type'        => 'object',
+			'description' => 'Complete WordPress theme.json v3 style variation document with $schema, version, slug, title, settings, and styles.',
+		];
+	}
+
+	/**
+	 * Return a schema for conservative variation slugs.
+	 *
+	 * @return array<string,mixed> Slug schema.
+	 */
+	private static function slug_schema(): array {
+		return [
+			'type'        => 'string',
+			'pattern'     => '^[a-z0-9][a-z0-9-]*$',
+			'description' => 'Style variation slug from the active stylesheet or inherited parent.',
+		];
+	}
+
+	/**
+	 * Return a schema for canonical SHA-256 optimistic concurrency hashes.
+	 *
+	 * @return array<string,mixed> Hash schema.
+	 */
+	private static function hash_schema(): array {
+		return [
+			'type'        => 'string',
+			'pattern'     => '^[a-f0-9]{64}$',
+			'description' => 'Canonical SHA-256 hash returned by list-style-variations or validate-style-variation.',
+		];
+	}
+}

--- a/advanced-plugin/includes/Bootstrap/AbilitiesHandler.php
+++ b/advanced-plugin/includes/Bootstrap/AbilitiesHandler.php
@@ -14,6 +14,7 @@ use SdAiAgent\Abilities\GitAbilities;
 use SdAiAgent\Abilities\PluginBuilderAbilities;
 use SdAiAgent\Abilities\PluginDownloadAbilities;
 use SdAiAgent\Abilities\ScaffoldBlockThemeAbility;
+use SdAiAgent\Abilities\StyleVariationAbilities;
 use SdAiAgent\Abilities\UserManagementAbilities;
 use SdAiAgent\Abilities\WordPressAdvancedAbilities;
 use SdAiAgent\Abilities\WpCliAbilities;
@@ -44,6 +45,7 @@ final class AbilitiesHandler {
 		WordPressAdvancedAbilities::register_abilities();
 		UserManagementAbilities::register_abilities();
 		$this->register_scaffold_block_theme();
+		StyleVariationAbilities::register_abilities();
 		WpCliAbilities::register_ability();
 		WpRestAbilities::register_abilities();
 	}

--- a/advanced-plugin/includes/Services/StyleVariationManager.php
+++ b/advanced-plugin/includes/Services/StyleVariationManager.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 namespace SdAiAgent\Services;
 
 use SdAiAgent\Core\ChangeLogger;
-use SdAiAgent\Core\Database;
 use SdAiAgent\Core\Filesystem\FileModGate;
 use SdAiAgent\DesignSystem\ArtifactManifest;
 use SdAiAgent\Models\ChangesLog;
@@ -27,6 +26,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 /**
  * Owns safe style-variation file writes and exact Global Styles rollback state.
+ *
+ * @phpstan-type ValidatedDocument array{slug:string,title:string,hash:string,document:array<string,mixed>}
+ * @phpstan-type VariationSource array{slug:string,origin:string,relative_path:string,absolute_path:string,read_only:bool}
+ * @phpstan-type ResolvedVariation array{slug:string,title:string,hash:string,document:array<string,mixed>,origin:string,relative_path:string,read_only:bool}
+ * @phpstan-type GlobalStylesRecord array{exists:bool,post_id:int|null,content:string|null,content_hash:string|null,document:array<string,mixed>,service:GlobalStylesService}
+ * @phpstan-type GlobalStylesWrite array{post_id:int,content:string,content_hash:string,created:bool}
  */
 final class StyleVariationManager {
 
@@ -34,6 +39,16 @@ final class StyleVariationManager {
 	 * Site-scoped option holding per-stylesheet managed selection provenance.
 	 */
 	public const STATE_OPTION = 'sd_ai_agent_style_variation_state';
+
+	/**
+	 * Site-scoped option used to serialize lifecycle mutations.
+	 */
+	private const LOCK_OPTION = 'sd_ai_agent_style_variation_lock';
+
+	/**
+	 * Upper bound for a lock left behind by an interrupted request.
+	 */
+	private const LOCK_TTL_SECONDS = 30;
 
 	/**
 	 * Stored selection-state format version.
@@ -93,17 +108,19 @@ final class StyleVariationManager {
 				continue;
 			}
 
-			$decoded    = json_decode( $content, true );
-			$validated  = is_array( $decoded ) ? $this->validate_document( $decoded ) : new WP_Error(
+			$decoded     = json_decode( $content, true );
+			$validated   = is_array( $decoded ) ? $this->validate_document( $decoded ) : new WP_Error(
 				'sd_ai_agent_style_variation_invalid_json',
 				__( 'The style variation does not contain a JSON object.', 'superdav-ai-agent' )
 			);
-			$raw_hash   = hash( 'sha256', $content );
-			$is_valid   = ! is_wp_error( $validated );
-			$hash       = $is_valid ? $validated['hash'] : $raw_hash;
-			$title      = $is_valid ? $validated['title'] : $source['slug'];
+			$raw_hash    = hash( 'sha256', $content );
+			$is_valid    = ! is_wp_error( $validated );
+			$hash        = $is_valid ? $validated['hash'] : $raw_hash;
+			$title       = $is_valid ? $validated['title'] : $source['slug'];
 			$is_selected = is_array( $state )
 				&& $source['slug'] === $state['selected']['slug']
+				&& $source['origin'] === $state['selected']['origin']
+				&& $source['relative_path'] === $state['selected']['relative_path']
 				&& hash_equals( $state['selected']['source_hash'], $hash );
 
 			$variation = [
@@ -135,6 +152,25 @@ final class StyleVariationManager {
 	 * @return array<string,mixed>|WP_Error Write result or an error.
 	 */
 	public function create( array $document ): array|WP_Error {
+		$lock = $this->acquire_lifecycle_lock();
+		if ( is_wp_error( $lock ) ) {
+			return $lock;
+		}
+
+		try {
+			return $this->create_locked( $document );
+		} finally {
+			$this->release_lifecycle_lock( $lock );
+		}
+	}
+
+	/**
+	 * Perform a create after the lifecycle lock has been acquired.
+	 *
+	 * @param array<string,mixed> $document Complete theme.json v3 variation.
+	 * @return array<string,mixed>|WP_Error Write result or an error.
+	 */
+	private function create_locked( array $document ): array|WP_Error {
 		$validated = $this->validate_document( $document );
 		if ( is_wp_error( $validated ) ) {
 			return $validated;
@@ -165,6 +201,27 @@ final class StyleVariationManager {
 	 * @return array<string,mixed>|WP_Error Write result or an error.
 	 */
 	public function update( string $slug, array $document, string $expected_hash ): array|WP_Error {
+		$lock = $this->acquire_lifecycle_lock();
+		if ( is_wp_error( $lock ) ) {
+			return $lock;
+		}
+
+		try {
+			return $this->update_locked( $slug, $document, $expected_hash );
+		} finally {
+			$this->release_lifecycle_lock( $lock );
+		}
+	}
+
+	/**
+	 * Perform an update after the lifecycle lock has been acquired.
+	 *
+	 * @param string              $slug          Variation slug.
+	 * @param array<string,mixed> $document      Complete replacement document.
+	 * @param string              $expected_hash Canonical hash returned by list or validate.
+	 * @return array<string,mixed>|WP_Error Write result or an error.
+	 */
+	private function update_locked( string $slug, array $document, string $expected_hash ): array|WP_Error {
 		$slug_error = $this->validate_slug( $slug );
 		if ( is_wp_error( $slug_error ) ) {
 			return $slug_error;
@@ -217,7 +274,7 @@ final class StyleVariationManager {
 			);
 		}
 
-		return $this->write_active_document( $theme, $validated, 'update' );
+		return $this->write_active_document( $theme, $validated, 'update', $expected_hash );
 	}
 
 	/**
@@ -227,7 +284,7 @@ final class StyleVariationManager {
 	 * can safely use the same concurrency token across lifecycle operations.
 	 *
 	 * @param array<string,mixed> $document Complete theme.json v3 variation.
-	 * @return array<string,mixed>|WP_Error Validation details or an error.
+	 * @return ValidatedDocument|WP_Error Validation details or an error.
 	 */
 	public function validate_document( array $document ): array|WP_Error {
 		if ( array_is_list( $document ) ) {
@@ -249,7 +306,7 @@ final class StyleVariationManager {
 			);
 		}
 
-		$slug = isset( $document['slug'] ) ? (string) $document['slug'] : '';
+		$slug       = isset( $document['slug'] ) ? (string) $document['slug'] : '';
 		$slug_error = $this->validate_slug( $slug );
 		if ( is_wp_error( $slug_error ) ) {
 			return $slug_error;
@@ -314,7 +371,7 @@ final class StyleVariationManager {
 	 * Validate one on-disk variation resolved with child-over-parent precedence.
 	 *
 	 * @param string $slug Variation slug.
-	 * @return array<string,mixed>|WP_Error Validation details or an error.
+	 * @return ResolvedVariation|WP_Error Validation details or an error.
 	 */
 	public function validate_existing( string $slug ): array|WP_Error {
 		$slug_error = $this->validate_slug( $slug );
@@ -387,6 +444,26 @@ final class StyleVariationManager {
 	 * @return array<string,mixed>|WP_Error Selection result or an error.
 	 */
 	public function select( string $slug, string $expected_hash ): array|WP_Error {
+		$lock = $this->acquire_lifecycle_lock();
+		if ( is_wp_error( $lock ) ) {
+			return $lock;
+		}
+
+		try {
+			return $this->select_locked( $slug, $expected_hash );
+		} finally {
+			$this->release_lifecycle_lock( $lock );
+		}
+	}
+
+	/**
+	 * Perform a selection after the lifecycle lock has been acquired.
+	 *
+	 * @param string $slug          Variation slug.
+	 * @param string $expected_hash Canonical source hash returned by list or validate.
+	 * @return array<string,mixed>|WP_Error Selection result or an error.
+	 */
+	private function select_locked( string $slug, string $expected_hash ): array|WP_Error {
 		$expected_error = $this->validate_hash( $expected_hash, 'sd_ai_agent_style_variation_expected_hash_required' );
 		if ( is_wp_error( $expected_error ) ) {
 			return $expected_error;
@@ -427,6 +504,8 @@ final class StyleVariationManager {
 			}
 			if (
 				$variation['slug'] === $existing_state['selected']['slug']
+				&& $variation['origin'] === $existing_state['selected']['origin']
+				&& $variation['relative_path'] === $existing_state['selected']['relative_path']
 				&& hash_equals( $variation['hash'], $existing_state['selected']['source_hash'] )
 			) {
 				return [
@@ -436,27 +515,47 @@ final class StyleVariationManager {
 					'hash'      => $variation['hash'],
 				];
 			}
-			$baseline = $existing_state['baseline'];
+			$baseline = $this->normalise_associative_array(
+				$existing_state['baseline'] ?? null,
+				'sd_ai_agent_style_variation_state_invalid',
+				__( 'The saved style variation baseline is invalid and was left unchanged.', 'superdav-ai-agent' )
+			);
+			if ( is_wp_error( $baseline ) ) {
+				return $baseline;
+			}
 		} else {
 			$baseline = [
-				'post_exists' => $current['exists'],
-				'post_id'     => $current['post_id'],
-				'content'     => $current['content'],
-				'content_hash'=> $current['content_hash'],
-				'document'    => $current['document'],
+				'post_exists'  => $current['exists'],
+				'post_id'      => $current['post_id'],
+				'content'      => $current['content'],
+				'content_hash' => $current['content_hash'],
+				'document'     => $current['document'],
 			];
 		}
 
-		$desired_document = self::apply_variation_to_baseline( $baseline['document'], $variation['document'] );
-		$written          = $this->write_global_styles_document( $current, $desired_document );
+		$baseline_document = $this->normalise_associative_array(
+			$baseline['document'] ?? null,
+			'sd_ai_agent_style_variation_state_invalid',
+			__( 'The saved style variation baseline is invalid and was left unchanged.', 'superdav-ai-agent' )
+		);
+		if ( is_wp_error( $baseline_document ) ) {
+			return $baseline_document;
+		}
+		$desired_document = self::apply_variation_to_baseline( $baseline_document, $variation['document'] );
+		do_action( 'sd_ai_agent_before_style_variation_select', $variation['slug'], $variation['relative_path'] );
+		$revalidated = $this->revalidate_selection_source( $variation );
+		if ( is_wp_error( $revalidated ) ) {
+			return $revalidated;
+		}
+		$written = $this->write_global_styles_document( $current, $desired_document );
 		if ( is_wp_error( $written ) ) {
 			return $written;
 		}
 
 		$state_map[ $theme->get_stylesheet() ] = [
-			'version'    => self::STATE_VERSION,
-			'baseline'   => $baseline,
-			'selected'   => [
+			'version'  => self::STATE_VERSION,
+			'baseline' => $baseline,
+			'selected' => [
 				'slug'          => $variation['slug'],
 				'origin'        => $variation['origin'],
 				'relative_path' => $variation['relative_path'],
@@ -467,6 +566,7 @@ final class StyleVariationManager {
 				'selected_at'   => gmdate( 'c' ),
 			],
 		];
+
 		$state_written = $this->write_state_map( $state_map );
 		if ( is_wp_error( $state_written ) ) {
 			$recovered = $this->restore_current_global_styles( $current, $written );
@@ -492,6 +592,24 @@ final class StyleVariationManager {
 	 * @return array<string,mixed>|WP_Error Reset result or an error.
 	 */
 	public function reset(): array|WP_Error {
+		$lock = $this->acquire_lifecycle_lock();
+		if ( is_wp_error( $lock ) ) {
+			return $lock;
+		}
+
+		try {
+			return $this->reset_locked();
+		} finally {
+			$this->release_lifecycle_lock( $lock );
+		}
+	}
+
+	/**
+	 * Perform a reset after the lifecycle lock has been acquired.
+	 *
+	 * @return array<string,mixed>|WP_Error Reset result or an error.
+	 */
+	private function reset_locked(): array|WP_Error {
 		$theme = $this->active_theme();
 		if ( is_wp_error( $theme ) ) {
 			return $theme;
@@ -526,9 +644,18 @@ final class StyleVariationManager {
 			return $state_removed;
 		}
 
-		$restored = $this->restore_baseline( $state['baseline'], $current );
+		$baseline = $this->normalise_associative_array(
+			$state['baseline'] ?? null,
+			'sd_ai_agent_style_variation_state_invalid',
+			__( 'The saved style variation baseline is invalid and was left unchanged.', 'superdav-ai-agent' )
+		);
+		if ( is_wp_error( $baseline ) ) {
+			return $baseline;
+		}
+		$restored = $this->restore_baseline( $baseline, $current );
 		if ( is_wp_error( $restored ) ) {
 			$state_map[ $theme->get_stylesheet() ] = $state;
+
 			$recovered = $this->write_state_map( $state_map );
 			if ( is_wp_error( $recovered ) ) {
 				return $this->recovery_error( 'reset', $restored, $recovered );
@@ -542,6 +669,92 @@ final class StyleVariationManager {
 			'slug'          => $state['selected']['slug'],
 			'restored_post' => $state['baseline']['post_exists'],
 		];
+	}
+
+	/**
+	 * Acquire a short-lived, site-scoped lock for one lifecycle mutation.
+	 *
+	 * The add_option() call is an atomic insert, so concurrent requests cannot both own
+	 * this lock. An exact-value delete lets a later request recover from a
+	 * lock left by an interrupted request without deleting a newly acquired one.
+	 *
+	 * @return array{token:string,expires_at:int}|WP_Error Lock details or a busy error.
+	 */
+	private function acquire_lifecycle_lock(): array|WP_Error {
+		$lock = [
+			'token'      => wp_generate_uuid4(),
+			'expires_at' => time() + self::LOCK_TTL_SECONDS,
+		];
+		if ( $this->insert_lifecycle_lock( $lock ) ) {
+			return $lock;
+		}
+
+		$existing = get_option( self::LOCK_OPTION, false );
+		if ( ! is_array( $existing ) || ! isset( $existing['expires_at'] ) || ! is_int( $existing['expires_at'] ) || $existing['expires_at'] >= time() ) {
+			return $this->lifecycle_lock_busy_error();
+		}
+
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Deletes only the exact expired lock before retrying WordPress's atomic option insert.
+		$deleted = $wpdb->delete(
+			$wpdb->options,
+			[
+				'option_name'  => self::LOCK_OPTION,
+				'option_value' => maybe_serialize( $existing ),
+			],
+			[ '%s', '%s' ]
+		);
+		if ( 1 === $deleted ) {
+			wp_cache_delete( self::LOCK_OPTION, 'options' );
+			if ( $this->insert_lifecycle_lock( $lock ) ) {
+				return $lock;
+			}
+		}
+
+		return $this->lifecycle_lock_busy_error();
+	}
+
+	/**
+	 * Attempt one atomic option insert for the lifecycle lock.
+	 *
+	 * @param array{token:string,expires_at:int} $lock Lock details to persist.
+	 * @phpstan-impure
+	 */
+	private function insert_lifecycle_lock( array $lock ): bool {
+		return add_option( self::LOCK_OPTION, $lock, '', false );
+	}
+
+	/**
+	 * Release only the exact lock record owned by this request.
+	 *
+	 * @param array{token:string,expires_at:int} $lock Lock details returned by acquisition.
+	 */
+	private function release_lifecycle_lock( array $lock ): void {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Exact token/value comparison prevents a delayed request from releasing another request's replacement lock.
+		$deleted = $wpdb->delete(
+			$wpdb->options,
+			[
+				'option_name'  => self::LOCK_OPTION,
+				'option_value' => maybe_serialize( $lock ),
+			],
+			[ '%s', '%s' ]
+		);
+		if ( 1 === $deleted ) {
+			wp_cache_delete( self::LOCK_OPTION, 'options' );
+		}
+	}
+
+	/**
+	 * Return the standard retryable lock-contention error.
+	 */
+	private function lifecycle_lock_busy_error(): WP_Error {
+		return new WP_Error(
+			'sd_ai_agent_style_variation_busy',
+			__( 'Another style variation lifecycle operation is in progress. Please retry shortly.', 'superdav-ai-agent' )
+		);
 	}
 
 	/**
@@ -633,7 +846,7 @@ final class StyleVariationManager {
 	 *
 	 * @param WP_Theme $theme Active stylesheet theme.
 	 * @param string   $slug  Variation slug.
-	 * @return array<string,mixed>|WP_Error Source details or an error.
+	 * @return VariationSource|WP_Error Source details or an error.
 	 */
 	private function find_variation( WP_Theme $theme, string $slug ): array|WP_Error {
 		foreach ( $this->variation_sources( $theme ) as $source ) {
@@ -659,7 +872,7 @@ final class StyleVariationManager {
 	 * Read and validate one variation file without leaking its absolute path.
 	 *
 	 * @param string $path Absolute internal file path.
-	 * @return array<string,mixed>|WP_Error Validated document or a safe error.
+	 * @return ValidatedDocument|WP_Error Validated document or a safe error.
 	 */
 	private function read_document_file( string $path ): array|WP_Error {
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading one selected local variation document.
@@ -682,15 +895,47 @@ final class StyleVariationManager {
 	}
 
 	/**
+	 * Confirm that a source has not changed while selection prepared its write.
+	 *
+	 * @param array $variation Originally validated source record.
+	 * @phpstan-param ResolvedVariation $variation
+	 * @return ResolvedVariation|WP_Error Current source or a stale-source error.
+	 */
+	private function revalidate_selection_source( array $variation ): array|WP_Error {
+		$current = $this->validate_existing( $variation['slug'] );
+		if ( is_wp_error( $current ) ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_stale_hash',
+				__( 'The style variation changed since it was read. Fetch it again before selecting.', 'superdav-ai-agent' )
+			);
+		}
+		if (
+			$current['origin'] !== $variation['origin']
+			|| $current['relative_path'] !== $variation['relative_path']
+			|| ! hash_equals( $variation['hash'], $current['hash'] )
+		) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_stale_hash',
+				__( 'The style variation changed since it was read. Fetch it again before selecting.', 'superdav-ai-agent' ),
+				[ 'current_hash' => $current['hash'] ]
+			);
+		}
+
+		return $current;
+	}
+
+	/**
 	 * Atomically write one active stylesheet variation with the generic file
 	 * modification gate and existing Git/change tracking hooks intact.
 	 *
-	 * @param WP_Theme           $theme     Active stylesheet theme.
-	 * @param array<string,mixed> $validated Validated document payload.
-	 * @param string             $operation create or update.
+	 * @param WP_Theme    $theme         Active stylesheet theme.
+	 * @param array       $validated     Validated document payload.
+	 * @phpstan-param ValidatedDocument $validated
+	 * @param string      $operation     Create or update.
+	 * @param string|null $expected_hash Current source hash for an update.
 	 * @return array<string,mixed>|WP_Error Write result or an error.
 	 */
-	private function write_active_document( WP_Theme $theme, array $validated, string $operation ): array|WP_Error {
+	private function write_active_document( WP_Theme $theme, array $validated, string $operation, ?string $expected_hash = null ): array|WP_Error {
 		$relative_path = 'styles/' . $validated['slug'] . '.json';
 		$target        = $this->active_variation_path( $theme, $validated['slug'] );
 		$directory     = dirname( $target );
@@ -712,6 +957,7 @@ final class StyleVariationManager {
 				__( 'The active stylesheet styles directory could not be created.', 'superdav-ai-agent' )
 			);
 		}
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_is_writable -- Pre-flight check before same-directory atomic staging.
 		if ( ! is_writable( $directory ) ) {
 			return new WP_Error(
 				'sd_ai_agent_style_variation_directory_unwritable',
@@ -754,22 +1000,64 @@ final class StyleVariationManager {
 					__( 'The style variation could not be staged for writing.', 'superdav-ai-agent' )
 				);
 			}
+			$file_mode = defined( 'FS_CHMOD_FILE' ) ? (int) FS_CHMOD_FILE : 0644;
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_chmod -- The final hard-linked variation must remain readable with WordPress's normal file mode.
+			if ( ! chmod( $tmp_path, $file_mode ) ) {
+				return new WP_Error(
+					'sd_ai_agent_style_variation_write_failed',
+					__( 'The staged style variation permissions could not be set.', 'superdav-ai-agent' )
+				);
+			}
 
 			$before_hook = 'create' === $operation ? 'sd_ai_agent_before_file_write' : 'sd_ai_agent_before_file_edit';
 			$after_hook  = 'create' === $operation ? 'sd_ai_agent_after_file_write' : 'sd_ai_agent_after_file_edit';
 			do_action( $before_hook, $target );
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- Same-directory replacement preserves atomicity for concurrent readers.
-			if ( ! rename( $tmp_path, $target ) ) {
-				return new WP_Error(
-					'sd_ai_agent_style_variation_write_failed',
-					__( 'The style variation could not be atomically written.', 'superdav-ai-agent' )
-				);
+			if ( 'create' === $operation ) {
+				// A same-directory hard link succeeds only when the target does not
+				// exist. Unlike rename(), it cannot overwrite a file created after
+				// the initial existence check.
+				// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.link_link -- Target-exists contention is an expected safe failure from the atomic no-overwrite create.
+				$linked = function_exists( 'link' ) && @link( $tmp_path, $target );
+				if ( ! $linked ) {
+					clearstatcache( true, $target );
+					if ( file_exists( $target ) ) {
+						return new WP_Error(
+							'sd_ai_agent_style_variation_exists',
+							__( 'A style variation with this slug already exists in the active stylesheet.', 'superdav-ai-agent' )
+						);
+					}
+
+					return new WP_Error(
+						'sd_ai_agent_style_variation_write_failed',
+						__( 'The style variation could not be atomically created.', 'superdav-ai-agent' )
+					);
+				}
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Removing the manager-owned staging link after an atomic create.
+				unlink( $tmp_path );
+				$tmp_path = '';
+			} else {
+				$current = $this->read_document_file( $target );
+				if ( is_wp_error( $current ) ) {
+					return $current;
+				}
+				if ( null === $expected_hash || ! hash_equals( $expected_hash, $current['hash'] ) ) {
+					return new WP_Error(
+						'sd_ai_agent_style_variation_stale_hash',
+						__( 'The style variation changed since it was read. Fetch it again before updating.', 'superdav-ai-agent' ),
+						[ 'current_hash' => $current['hash'] ]
+					);
+				}
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- Same-directory replacement preserves atomicity for concurrent readers after a final hash check.
+				if ( ! rename( $tmp_path, $target ) ) {
+					return new WP_Error(
+						'sd_ai_agent_style_variation_write_failed',
+						__( 'The style variation could not be atomically written.', 'superdav-ai-agent' )
+					);
+				}
+				$tmp_path = '';
 			}
-			$tmp_path = '';
 
 			do_action( $after_hook, $target );
-			$tracking_path = 'themes/' . $theme->get_stylesheet() . '/' . $relative_path;
-			Database::record_modified_file( $tracking_path, 'create' === $operation ? 'write' : 'edit', 0, (int) get_current_user_id() );
 			if ( ChangeLogger::is_active() ) {
 				ChangesLog::record(
 					[
@@ -839,7 +1127,7 @@ final class StyleVariationManager {
 	/**
 	 * Read the active theme's exact persisted Global Styles record.
 	 *
-	 * @return array<string,mixed>|WP_Error Current record details or an error.
+	 * @return GlobalStylesRecord|WP_Error Current record details or an error.
 	 */
 	private function current_global_styles(): array|WP_Error {
 		$service = new GlobalStylesService();
@@ -861,12 +1149,13 @@ final class StyleVariationManager {
 				__( 'The active theme Global Styles record is unavailable.', 'superdav-ai-agent' )
 			);
 		}
-		$document = json_decode( $post->post_content, true );
-		if ( ! is_array( $document ) || array_is_list( $document ) ) {
-			return new WP_Error(
-				'sd_ai_agent_style_variation_global_styles_invalid',
-				__( 'The active theme Global Styles record is not valid JSON.', 'superdav-ai-agent' )
-			);
+		$document = $this->normalise_associative_array(
+			json_decode( $post->post_content, true ),
+			'sd_ai_agent_style_variation_global_styles_invalid',
+			__( 'The active theme Global Styles record is not valid JSON.', 'superdav-ai-agent' )
+		);
+		if ( is_wp_error( $document ) ) {
+			return $document;
 		}
 
 		return [
@@ -887,11 +1176,11 @@ final class StyleVariationManager {
 	 * @return array<string,mixed> New complete user Global Styles document.
 	 */
 	private static function apply_variation_to_baseline( array $baseline, array $variation ): array {
-		$partial = [
+		$partial                                 = [
 			'settings' => $variation['settings'],
 			'styles'   => $variation['styles'],
 		];
-		$document = self::deep_merge( $baseline, $partial );
+		$document                                = self::deep_merge( $baseline, $partial );
 		$document['version']                     = WP_Theme_JSON::LATEST_SCHEMA;
 		$document['isGlobalStylesUserThemeJSON'] = true;
 
@@ -901,9 +1190,10 @@ final class StyleVariationManager {
 	/**
 	 * Persist a complete user Global Styles document and return its exact bytes.
 	 *
-	 * @param array<string,mixed> $current Current record details.
+	 * @param array               $current  Current record details.
+	 * @phpstan-param GlobalStylesRecord $current
 	 * @param array<string,mixed> $document New complete document.
-	 * @return array<string,mixed>|WP_Error Write details or an error.
+	 * @return GlobalStylesWrite|WP_Error Write details or an error.
 	 */
 	private function write_global_styles_document( array $current, array $document ): array|WP_Error {
 		$content = wp_json_encode( $document, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
@@ -967,8 +1257,10 @@ final class StyleVariationManager {
 	/**
 	 * Undo a failed selection's Global Styles write before returning an error.
 	 *
-	 * @param array<string,mixed> $current Original record details.
-	 * @param array<string,mixed> $written New record details.
+	 * @param array $current Original record details.
+	 * @phpstan-param GlobalStylesRecord $current
+	 * @param array $written New record details.
+	 * @phpstan-param GlobalStylesWrite $written
 	 * @return true|WP_Error True after recovery or a recovery error.
 	 */
 	private function restore_current_global_styles( array $current, array $written ): true|WP_Error {
@@ -1003,14 +1295,22 @@ final class StyleVariationManager {
 	 * Restore an exact saved baseline after the state record was safely removed.
 	 *
 	 * @param array<string,mixed> $baseline Original baseline.
-	 * @param array<string,mixed> $current  Current managed selection record.
+	 * @param array               $current  Current managed selection record.
+	 * @phpstan-param GlobalStylesRecord $current
 	 * @return true|WP_Error True when restored or an error.
 	 */
 	private function restore_baseline( array $baseline, array $current ): true|WP_Error {
+		$post_id = $current['post_id'];
+		if ( ! is_int( $post_id ) ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_global_styles_missing',
+				__( 'The active theme Global Styles record is unavailable.', 'superdav-ai-agent' )
+			);
+		}
 		if ( $baseline['post_exists'] ) {
 			$updated = wp_update_post(
 				[
-					'ID'           => $current['post_id'],
+					'ID'           => $post_id,
 					'post_content' => $baseline['content'],
 				],
 				true
@@ -1019,7 +1319,7 @@ final class StyleVariationManager {
 				return $updated;
 			}
 		} else {
-			$deleted = wp_delete_post( $current['post_id'], true );
+			$deleted = wp_delete_post( $post_id, true );
 			if ( ! $deleted instanceof WP_Post ) {
 				return new WP_Error(
 					'sd_ai_agent_style_variation_reset_failed',
@@ -1057,6 +1357,30 @@ final class StyleVariationManager {
 	}
 
 	/**
+	 * Return a string-keyed associative array or an explicit safe error.
+	 *
+	 * @param mixed  $value      Value to validate.
+	 * @param string $error_code Stable error code for malformed state.
+	 * @param string $message    Safe error message.
+	 * @return array<string,mixed>|WP_Error Normalised value or an error.
+	 */
+	private function normalise_associative_array( mixed $value, string $error_code, string $message ): array|WP_Error {
+		if ( ! is_array( $value ) || ( [] !== $value && array_is_list( $value ) ) ) {
+			return new WP_Error( $error_code, $message );
+		}
+
+		$normalised = [];
+		foreach ( $value as $key => $item ) {
+			if ( ! is_string( $key ) ) {
+				return new WP_Error( $error_code, $message );
+			}
+			$normalised[ $key ] = $item;
+		}
+
+		return $normalised;
+	}
+
+	/**
 	 * Read the site-scoped state map without silently accepting malformed data.
 	 *
 	 * @return array<string,mixed>|WP_Error State map or an error.
@@ -1066,14 +1390,12 @@ final class StyleVariationManager {
 		if ( false === $state || [] === $state || null === $state ) {
 			return [];
 		}
-		if ( ! is_array( $state ) || array_is_list( $state ) ) {
-			return new WP_Error(
-				'sd_ai_agent_style_variation_state_invalid',
-				__( 'The saved style variation selection state is invalid and was left unchanged.', 'superdav-ai-agent' )
-			);
-		}
 
-		return $state;
+		return $this->normalise_associative_array(
+			$state,
+			'sd_ai_agent_style_variation_state_invalid',
+			__( 'The saved style variation selection state is invalid and was left unchanged.', 'superdav-ai-agent' )
+		);
 	}
 
 	/**
@@ -1087,10 +1409,16 @@ final class StyleVariationManager {
 		if ( ! isset( $state_map[ $stylesheet ] ) ) {
 			return null;
 		}
-		$state = $state_map[ $stylesheet ];
+		$state = $this->normalise_associative_array(
+			$state_map[ $stylesheet ],
+			'sd_ai_agent_style_variation_state_invalid',
+			__( 'The saved style variation selection state is invalid and was left unchanged.', 'superdav-ai-agent' )
+		);
+		if ( is_wp_error( $state ) ) {
+			return $state;
+		}
 		if (
-			! is_array( $state )
-			|| self::STATE_VERSION !== ( $state['version'] ?? null )
+			self::STATE_VERSION !== ( $state['version'] ?? null )
 			|| ! isset( $state['baseline'], $state['selected'] )
 			|| ! is_array( $state['baseline'] )
 			|| ! is_array( $state['selected'] )
@@ -1103,10 +1431,12 @@ final class StyleVariationManager {
 		$baseline = $state['baseline'];
 		$selected = $state['selected'];
 		if (
-			! isset( $baseline['post_exists'], $baseline['document'], $selected['slug'], $selected['source_hash'], $selected['post_id'], $selected['content_hash'] )
+			! isset( $baseline['post_exists'], $baseline['document'], $selected['slug'], $selected['origin'], $selected['relative_path'], $selected['source_hash'], $selected['post_id'], $selected['content_hash'] )
 			|| ! is_bool( $baseline['post_exists'] )
 			|| ! is_array( $baseline['document'] )
 			|| ! is_string( $selected['slug'] )
+			|| ! is_string( $selected['origin'] )
+			|| ! is_string( $selected['relative_path'] )
 			|| ! is_int( $selected['post_id'] )
 			|| ! is_string( $selected['source_hash'] )
 			|| ! is_string( $selected['content_hash'] )

--- a/advanced-plugin/includes/Services/StyleVariationManager.php
+++ b/advanced-plugin/includes/Services/StyleVariationManager.php
@@ -1,0 +1,1257 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Validated lifecycle management for active-theme style variations.
+ *
+ * @package SdAiAgent\Services
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Services;
+
+use SdAiAgent\Core\ChangeLogger;
+use SdAiAgent\Core\Database;
+use SdAiAgent\Core\Filesystem\FileModGate;
+use SdAiAgent\DesignSystem\ArtifactManifest;
+use SdAiAgent\Models\ChangesLog;
+use WP_Error;
+use WP_Post;
+use WP_Theme;
+use WP_Theme_JSON;
+use WP_Theme_JSON_Resolver;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Owns safe style-variation file writes and exact Global Styles rollback state.
+ */
+final class StyleVariationManager {
+
+	/**
+	 * Site-scoped option holding per-stylesheet managed selection provenance.
+	 */
+	public const STATE_OPTION = 'sd_ai_agent_style_variation_state';
+
+	/**
+	 * Stored selection-state format version.
+	 */
+	private const STATE_VERSION = 1;
+
+	/**
+	 * Canonical schema emitted by the design-token compiler.
+	 */
+	private const SCHEMA_URL = 'https://schemas.wp.org/trunk/theme.json';
+
+	/**
+	 * Conservative filename and WordPress stylesheet slug pattern.
+	 */
+	private const SLUG_PATTERN = '/^[a-z0-9][a-z0-9-]*$/';
+
+	/**
+	 * List active stylesheet and inherited parent style variations.
+	 *
+	 * Parent records remain visible so agents can explain precedence, but are
+	 * explicitly read-only. A child file with the same slug is listed first and
+	 * wins when selecting a variation, matching WordPress core's resolver.
+	 *
+	 * @return array<string,mixed>|WP_Error Variation inventory or an error.
+	 */
+	public function list(): array|WP_Error {
+		$theme = $this->active_theme();
+		if ( is_wp_error( $theme ) ) {
+			return $theme;
+		}
+
+		$state_map = $this->read_state_map();
+		if ( is_wp_error( $state_map ) ) {
+			return $state_map;
+		}
+		$state = $this->state_for_stylesheet( $state_map, $theme->get_stylesheet() );
+		if ( is_wp_error( $state ) ) {
+			return $state;
+		}
+
+		$variations = [];
+		foreach ( $this->variation_sources( $theme ) as $source ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading one installed theme JSON document for a read-only inventory.
+			$content = file_get_contents( $source['absolute_path'] );
+			if ( false === $content ) {
+				$variations[] = [
+					'slug'          => $source['slug'],
+					'title'         => $source['slug'],
+					'origin'        => $source['origin'],
+					'relative_path' => $source['relative_path'],
+					'read_only'     => $source['read_only'],
+					'hash'          => null,
+					'selected'      => false,
+					'valid'         => false,
+					'error'         => __( 'The style variation could not be read.', 'superdav-ai-agent' ),
+				];
+				continue;
+			}
+
+			$decoded    = json_decode( $content, true );
+			$validated  = is_array( $decoded ) ? $this->validate_document( $decoded ) : new WP_Error(
+				'sd_ai_agent_style_variation_invalid_json',
+				__( 'The style variation does not contain a JSON object.', 'superdav-ai-agent' )
+			);
+			$raw_hash   = hash( 'sha256', $content );
+			$is_valid   = ! is_wp_error( $validated );
+			$hash       = $is_valid ? $validated['hash'] : $raw_hash;
+			$title      = $is_valid ? $validated['title'] : $source['slug'];
+			$is_selected = is_array( $state )
+				&& $source['slug'] === $state['selected']['slug']
+				&& hash_equals( $state['selected']['source_hash'], $hash );
+
+			$variation = [
+				'slug'          => $source['slug'],
+				'title'         => $title,
+				'origin'        => $source['origin'],
+				'relative_path' => $source['relative_path'],
+				'read_only'     => $source['read_only'],
+				'hash'          => $hash,
+				'selected'      => $is_selected,
+				'valid'         => $is_valid,
+			];
+			if ( ! $is_valid ) {
+				$variation['error'] = $validated->get_error_message();
+			}
+			$variations[] = $variation;
+		}
+
+		return [
+			'stylesheet' => $theme->get_stylesheet(),
+			'variations' => $variations,
+		];
+	}
+
+	/**
+	 * Create one validated style variation in the active stylesheet only.
+	 *
+	 * @param array<string,mixed> $document Complete theme.json v3 variation.
+	 * @return array<string,mixed>|WP_Error Write result or an error.
+	 */
+	public function create( array $document ): array|WP_Error {
+		$validated = $this->validate_document( $document );
+		if ( is_wp_error( $validated ) ) {
+			return $validated;
+		}
+
+		$theme = $this->active_theme();
+		if ( is_wp_error( $theme ) ) {
+			return $theme;
+		}
+
+		$path = $this->active_variation_path( $theme, $validated['slug'] );
+		if ( file_exists( $path ) ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_exists',
+				__( 'A style variation with this slug already exists in the active stylesheet.', 'superdav-ai-agent' )
+			);
+		}
+
+		return $this->write_active_document( $theme, $validated, 'create' );
+	}
+
+	/**
+	 * Replace one active stylesheet variation after an optimistic hash check.
+	 *
+	 * @param string              $slug          Variation slug.
+	 * @param array<string,mixed> $document      Complete replacement document.
+	 * @param string              $expected_hash Canonical hash returned by list or validate.
+	 * @return array<string,mixed>|WP_Error Write result or an error.
+	 */
+	public function update( string $slug, array $document, string $expected_hash ): array|WP_Error {
+		$slug_error = $this->validate_slug( $slug );
+		if ( is_wp_error( $slug_error ) ) {
+			return $slug_error;
+		}
+		$expected_error = $this->validate_hash( $expected_hash, 'sd_ai_agent_style_variation_expected_hash_required' );
+		if ( is_wp_error( $expected_error ) ) {
+			return $expected_error;
+		}
+
+		$validated = $this->validate_document( $document );
+		if ( is_wp_error( $validated ) ) {
+			return $validated;
+		}
+		if ( $slug !== $validated['slug'] ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_slug_mismatch',
+				__( 'The replacement document slug must match the requested variation slug.', 'superdav-ai-agent' )
+			);
+		}
+
+		$theme = $this->active_theme();
+		if ( is_wp_error( $theme ) ) {
+			return $theme;
+		}
+		$path = $this->active_variation_path( $theme, $slug );
+		if ( ! file_exists( $path ) ) {
+			$inherited = $this->find_variation( $theme, $slug );
+			if ( is_array( $inherited ) && $inherited['read_only'] ) {
+				return new WP_Error(
+					'sd_ai_agent_style_variation_read_only',
+					__( 'Inherited parent style variations are read-only. Create a child variation with a new slug instead.', 'superdav-ai-agent' )
+				);
+			}
+
+			return new WP_Error(
+				'sd_ai_agent_style_variation_not_found',
+				__( 'The requested active stylesheet style variation was not found.', 'superdav-ai-agent' )
+			);
+		}
+
+		$current = $this->read_document_file( $path );
+		if ( is_wp_error( $current ) ) {
+			return $current;
+		}
+		if ( ! hash_equals( $expected_hash, $current['hash'] ) ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_stale_hash',
+				__( 'The style variation changed since it was read. Fetch it again before updating.', 'superdav-ai-agent' ),
+				[ 'current_hash' => $current['hash'] ]
+			);
+		}
+
+		return $this->write_active_document( $theme, $validated, 'update' );
+	}
+
+	/**
+	 * Validate a supplied complete style-variation document without writing it.
+	 *
+	 * The canonical hash is shared with generated-artifact manifests so a caller
+	 * can safely use the same concurrency token across lifecycle operations.
+	 *
+	 * @param array<string,mixed> $document Complete theme.json v3 variation.
+	 * @return array<string,mixed>|WP_Error Validation details or an error.
+	 */
+	public function validate_document( array $document ): array|WP_Error {
+		if ( array_is_list( $document ) ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_document_required',
+				__( 'A complete style variation document must be a JSON object.', 'superdav-ai-agent' )
+			);
+		}
+		if ( self::SCHEMA_URL !== ( $document['$schema'] ?? null ) ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_schema_required',
+				__( 'Style variations must declare the WordPress theme.json v3 schema URL.', 'superdav-ai-agent' )
+			);
+		}
+		if ( WP_Theme_JSON::LATEST_SCHEMA !== ( $document['version'] ?? null ) ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_version_invalid',
+				__( 'Style variations must use the supported theme.json schema version.', 'superdav-ai-agent' )
+			);
+		}
+
+		$slug = isset( $document['slug'] ) ? (string) $document['slug'] : '';
+		$slug_error = $this->validate_slug( $slug );
+		if ( is_wp_error( $slug_error ) ) {
+			return $slug_error;
+		}
+		$title = isset( $document['title'] ) ? trim( (string) $document['title'] ) : '';
+		if ( '' === $title || strlen( $title ) > 200 ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_title_required',
+				__( 'Style variations require a concise non-empty title.', 'superdav-ai-agent' )
+			);
+		}
+
+		foreach ( [ 'settings', 'styles' ] as $section ) {
+			if ( ! isset( $document[ $section ] ) || ! is_array( $document[ $section ] ) || array_is_list( $document[ $section ] ) ) {
+				return new WP_Error(
+					'sd_ai_agent_style_variation_incomplete_document',
+					__( 'Style variations require complete settings and styles objects.', 'superdav-ai-agent' ),
+					[ 'path' => $section ]
+				);
+			}
+		}
+		if ( [] === $document['settings'] && [] === $document['styles'] ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_empty_document',
+				__( 'Style variations must change settings or styles.', 'superdav-ai-agent' )
+			);
+		}
+
+		$semantic_error = $this->validate_compiled_semantics( $document );
+		if ( is_wp_error( $semantic_error ) ) {
+			return $semantic_error;
+		}
+
+		try {
+			// Let the installed WordPress 7.0 theme.json parser sanitize and
+			// resolve the supplied v3 document before any persistence path runs.
+			new WP_Theme_JSON( $document, 'theme' );
+		} catch ( \Throwable $exception ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_theme_json_invalid',
+				__( 'The style variation is not accepted by the installed WordPress theme.json parser.', 'superdav-ai-agent' )
+			);
+		}
+
+		$hash = ArtifactManifest::hash_payload( $document );
+		if ( is_wp_error( $hash ) ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_hash_failed',
+				__( 'The style variation could not be canonically hashed.', 'superdav-ai-agent' )
+			);
+		}
+
+		return [
+			'slug'     => $slug,
+			'title'    => $title,
+			'hash'     => $hash,
+			'document' => $document,
+		];
+	}
+
+	/**
+	 * Validate one on-disk variation resolved with child-over-parent precedence.
+	 *
+	 * @param string $slug Variation slug.
+	 * @return array<string,mixed>|WP_Error Validation details or an error.
+	 */
+	public function validate_existing( string $slug ): array|WP_Error {
+		$slug_error = $this->validate_slug( $slug );
+		if ( is_wp_error( $slug_error ) ) {
+			return $slug_error;
+		}
+		$theme = $this->active_theme();
+		if ( is_wp_error( $theme ) ) {
+			return $theme;
+		}
+		$source = $this->find_variation( $theme, $slug );
+		if ( is_wp_error( $source ) ) {
+			return $source;
+		}
+
+		$document = $this->read_document_file( $source['absolute_path'] );
+		if ( is_wp_error( $document ) ) {
+			return $document;
+		}
+		$document['origin']        = $source['origin'];
+		$document['relative_path'] = $source['relative_path'];
+		$document['read_only']     = $source['read_only'];
+
+		return $document;
+	}
+
+	/**
+	 * Produce an in-memory merged theme.json and stylesheet preview.
+	 *
+	 * @param array<string,mixed> $document Complete theme.json v3 variation.
+	 * @return array<string,mixed>|WP_Error Preview details or an error.
+	 */
+	public function preview( array $document ): array|WP_Error {
+		$validated = $this->validate_document( $document );
+		if ( is_wp_error( $validated ) ) {
+			return $validated;
+		}
+
+		try {
+			// WordPress 7.0's merge() mutates its receiver. Cloning the resolved
+			// theme layer keeps the preview entirely in memory and excludes the
+			// current user override that select/reset guard against separately.
+			$base    = WP_Theme_JSON_Resolver::get_merged_data( 'theme' );
+			$before  = $base->get_data();
+			$preview = clone $base;
+			$preview->merge( new WP_Theme_JSON( $validated['document'], 'theme' ) );
+			$after = $preview->get_data();
+			$css   = $preview->get_stylesheet();
+		} catch ( \Throwable $exception ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_preview_failed',
+				__( 'WordPress could not build an in-memory style variation preview.', 'superdav-ai-agent' )
+			);
+		}
+
+		return [
+			'slug'          => $validated['slug'],
+			'title'         => $validated['title'],
+			'hash'          => $validated['hash'],
+			'changed_paths' => self::changed_paths( $before, $after ),
+			'css'           => $css,
+		];
+	}
+
+	/**
+	 * Select a variation while preserving the exact original user document.
+	 *
+	 * @param string $slug          Variation slug.
+	 * @param string $expected_hash Canonical source hash returned by list or validate.
+	 * @return array<string,mixed>|WP_Error Selection result or an error.
+	 */
+	public function select( string $slug, string $expected_hash ): array|WP_Error {
+		$expected_error = $this->validate_hash( $expected_hash, 'sd_ai_agent_style_variation_expected_hash_required' );
+		if ( is_wp_error( $expected_error ) ) {
+			return $expected_error;
+		}
+		$variation = $this->validate_existing( $slug );
+		if ( is_wp_error( $variation ) ) {
+			return $variation;
+		}
+		if ( ! hash_equals( $expected_hash, $variation['hash'] ) ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_stale_hash',
+				__( 'The style variation changed since it was read. Fetch it again before selecting.', 'superdav-ai-agent' ),
+				[ 'current_hash' => $variation['hash'] ]
+			);
+		}
+
+		$theme = $this->active_theme();
+		if ( is_wp_error( $theme ) ) {
+			return $theme;
+		}
+		$state_map = $this->read_state_map();
+		if ( is_wp_error( $state_map ) ) {
+			return $state_map;
+		}
+		$existing_state = $this->state_for_stylesheet( $state_map, $theme->get_stylesheet() );
+		if ( is_wp_error( $existing_state ) ) {
+			return $existing_state;
+		}
+		$current = $this->current_global_styles();
+		if ( is_wp_error( $current ) ) {
+			return $current;
+		}
+
+		if ( is_array( $existing_state ) ) {
+			$selection_error = $this->assert_selected_state_matches_current( $existing_state, $current );
+			if ( is_wp_error( $selection_error ) ) {
+				return $selection_error;
+			}
+			if (
+				$variation['slug'] === $existing_state['selected']['slug']
+				&& hash_equals( $variation['hash'], $existing_state['selected']['source_hash'] )
+			) {
+				return [
+					'selected'  => true,
+					'unchanged' => true,
+					'slug'      => $variation['slug'],
+					'hash'      => $variation['hash'],
+				];
+			}
+			$baseline = $existing_state['baseline'];
+		} else {
+			$baseline = [
+				'post_exists' => $current['exists'],
+				'post_id'     => $current['post_id'],
+				'content'     => $current['content'],
+				'content_hash'=> $current['content_hash'],
+				'document'    => $current['document'],
+			];
+		}
+
+		$desired_document = self::apply_variation_to_baseline( $baseline['document'], $variation['document'] );
+		$written          = $this->write_global_styles_document( $current, $desired_document );
+		if ( is_wp_error( $written ) ) {
+			return $written;
+		}
+
+		$state_map[ $theme->get_stylesheet() ] = [
+			'version'    => self::STATE_VERSION,
+			'baseline'   => $baseline,
+			'selected'   => [
+				'slug'          => $variation['slug'],
+				'origin'        => $variation['origin'],
+				'relative_path' => $variation['relative_path'],
+				'source_hash'   => $variation['hash'],
+				'post_id'       => $written['post_id'],
+				'content_hash'  => $written['content_hash'],
+				'actor_id'      => (int) get_current_user_id(),
+				'selected_at'   => gmdate( 'c' ),
+			],
+		];
+		$state_written = $this->write_state_map( $state_map );
+		if ( is_wp_error( $state_written ) ) {
+			$recovered = $this->restore_current_global_styles( $current, $written );
+			if ( is_wp_error( $recovered ) ) {
+				return $this->recovery_error( 'selection', $state_written, $recovered );
+			}
+
+			return $state_written;
+		}
+
+		return [
+			'selected'      => true,
+			'unchanged'     => false,
+			'slug'          => $variation['slug'],
+			'hash'          => $variation['hash'],
+			'relative_path' => $variation['relative_path'],
+		];
+	}
+
+	/**
+	 * Restore the exact baseline only while the selected state remains intact.
+	 *
+	 * @return array<string,mixed>|WP_Error Reset result or an error.
+	 */
+	public function reset(): array|WP_Error {
+		$theme = $this->active_theme();
+		if ( is_wp_error( $theme ) ) {
+			return $theme;
+		}
+		$state_map = $this->read_state_map();
+		if ( is_wp_error( $state_map ) ) {
+			return $state_map;
+		}
+		$state = $this->state_for_stylesheet( $state_map, $theme->get_stylesheet() );
+		if ( is_wp_error( $state ) ) {
+			return $state;
+		}
+		if ( ! is_array( $state ) ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_not_selected',
+				__( 'No plugin-managed style variation is selected for this stylesheet.', 'superdav-ai-agent' )
+			);
+		}
+
+		$current = $this->current_global_styles();
+		if ( is_wp_error( $current ) ) {
+			return $current;
+		}
+		$selection_error = $this->assert_selected_state_matches_current( $state, $current );
+		if ( is_wp_error( $selection_error ) ) {
+			return $selection_error;
+		}
+
+		unset( $state_map[ $theme->get_stylesheet() ] );
+		$state_removed = $this->write_state_map( $state_map );
+		if ( is_wp_error( $state_removed ) ) {
+			return $state_removed;
+		}
+
+		$restored = $this->restore_baseline( $state['baseline'], $current );
+		if ( is_wp_error( $restored ) ) {
+			$state_map[ $theme->get_stylesheet() ] = $state;
+			$recovered = $this->write_state_map( $state_map );
+			if ( is_wp_error( $recovered ) ) {
+				return $this->recovery_error( 'reset', $restored, $recovered );
+			}
+
+			return $restored;
+		}
+
+		return [
+			'reset'         => true,
+			'slug'          => $state['selected']['slug'],
+			'restored_post' => $state['baseline']['post_exists'],
+		];
+	}
+
+	/**
+	 * Resolve one installed active stylesheet theme.
+	 *
+	 * @return WP_Theme|WP_Error Active theme or a safe error.
+	 */
+	private function active_theme(): WP_Theme|WP_Error {
+		$theme = wp_get_theme();
+		if ( ! $theme->exists() || '' === $theme->get_stylesheet_directory() ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_theme_unavailable',
+				__( 'The active stylesheet theme is unavailable.', 'superdav-ai-agent' )
+			);
+		}
+
+		return $theme;
+	}
+
+	/**
+	 * Return every direct styles/{slug}.json source in child-first precedence.
+	 *
+	 * @param WP_Theme $theme Active stylesheet theme.
+	 * @return list<array{slug:string,origin:string,relative_path:string,absolute_path:string,read_only:bool}>
+	 */
+	private function variation_sources( WP_Theme $theme ): array {
+		$parent  = $theme->parent();
+		$sources = [
+			[
+				'origin'    => $parent instanceof WP_Theme ? 'child' : 'stylesheet',
+				'directory' => $theme->get_stylesheet_directory(),
+				'read_only' => false,
+			],
+		];
+		if ( $parent instanceof WP_Theme ) {
+			$sources[] = [
+				'origin'    => 'parent',
+				'directory' => $parent->get_stylesheet_directory(),
+				'read_only' => true,
+			];
+		}
+
+		$records = [];
+		foreach ( $sources as $source ) {
+			$directory = trailingslashit( $source['directory'] ) . 'styles';
+			if ( ! is_dir( $directory ) ) {
+				continue;
+			}
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_scandir -- Listing a verified installed theme styles directory.
+			$entries = scandir( $directory );
+			if ( false === $entries ) {
+				continue;
+			}
+			foreach ( $entries as $entry ) {
+				if ( 1 !== preg_match( '/^([a-z0-9][a-z0-9-]*)\.json$/', $entry, $matches ) ) {
+					continue;
+				}
+				$absolute_path = trailingslashit( $directory ) . $entry;
+				if ( ! is_file( $absolute_path ) ) {
+					continue;
+				}
+				$records[] = [
+					'slug'          => $matches[1],
+					'origin'        => $source['origin'],
+					'relative_path' => 'styles/' . $entry,
+					'absolute_path' => $absolute_path,
+					'read_only'     => $source['read_only'],
+				];
+			}
+		}
+
+		usort(
+			$records,
+			static function ( array $left, array $right ): int {
+				$slug = strcmp( $left['slug'], $right['slug'] );
+				if ( 0 !== $slug ) {
+					return $slug;
+				}
+
+				return (int) $left['read_only'] <=> (int) $right['read_only'];
+			}
+		);
+
+		return $records;
+	}
+
+	/**
+	 * Resolve one source with active stylesheet precedence.
+	 *
+	 * @param WP_Theme $theme Active stylesheet theme.
+	 * @param string   $slug  Variation slug.
+	 * @return array<string,mixed>|WP_Error Source details or an error.
+	 */
+	private function find_variation( WP_Theme $theme, string $slug ): array|WP_Error {
+		foreach ( $this->variation_sources( $theme ) as $source ) {
+			if ( $slug === $source['slug'] ) {
+				return $source;
+			}
+		}
+
+		return new WP_Error(
+			'sd_ai_agent_style_variation_not_found',
+			__( 'The requested style variation was not found in the active stylesheet or its parent.', 'superdav-ai-agent' )
+		);
+	}
+
+	/**
+	 * Return the only writable style-variation path for an active stylesheet.
+	 */
+	private function active_variation_path( WP_Theme $theme, string $slug ): string {
+		return trailingslashit( $theme->get_stylesheet_directory() ) . 'styles/' . $slug . '.json';
+	}
+
+	/**
+	 * Read and validate one variation file without leaking its absolute path.
+	 *
+	 * @param string $path Absolute internal file path.
+	 * @return array<string,mixed>|WP_Error Validated document or a safe error.
+	 */
+	private function read_document_file( string $path ): array|WP_Error {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading one selected local variation document.
+		$content = file_get_contents( $path );
+		if ( false === $content ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_read_failed',
+				__( 'The requested style variation could not be read.', 'superdav-ai-agent' )
+			);
+		}
+		$document = json_decode( $content, true );
+		if ( ! is_array( $document ) || array_is_list( $document ) ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_invalid_json',
+				__( 'The requested style variation does not contain a JSON object.', 'superdav-ai-agent' )
+			);
+		}
+
+		return $this->validate_document( $document );
+	}
+
+	/**
+	 * Atomically write one active stylesheet variation with the generic file
+	 * modification gate and existing Git/change tracking hooks intact.
+	 *
+	 * @param WP_Theme           $theme     Active stylesheet theme.
+	 * @param array<string,mixed> $validated Validated document payload.
+	 * @param string             $operation create or update.
+	 * @return array<string,mixed>|WP_Error Write result or an error.
+	 */
+	private function write_active_document( WP_Theme $theme, array $validated, string $operation ): array|WP_Error {
+		$relative_path = 'styles/' . $validated['slug'] . '.json';
+		$target        = $this->active_variation_path( $theme, $validated['slug'] );
+		$directory     = dirname( $target );
+		$exists        = file_exists( $target );
+		if ( 'create' === $operation && $exists ) {
+			return new WP_Error( 'sd_ai_agent_style_variation_exists', __( 'A style variation with this slug already exists in the active stylesheet.', 'superdav-ai-agent' ) );
+		}
+		if ( 'update' === $operation && ! $exists ) {
+			return new WP_Error( 'sd_ai_agent_style_variation_not_found', __( 'The requested active stylesheet style variation was not found.', 'superdav-ai-agent' ) );
+		}
+
+		$allowed = FileModGate::assert_allowed( $target );
+		if ( is_wp_error( $allowed ) ) {
+			return $allowed;
+		}
+		if ( ! is_dir( $directory ) && ! wp_mkdir_p( $directory ) ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_directory_failed',
+				__( 'The active stylesheet styles directory could not be created.', 'superdav-ai-agent' )
+			);
+		}
+		if ( ! is_writable( $directory ) ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_directory_unwritable',
+				__( 'The active stylesheet styles directory is not writable.', 'superdav-ai-agent' )
+			);
+		}
+
+		$content = wp_json_encode( $validated['document'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+		if ( false === $content ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_encode_failed',
+				__( 'The style variation could not be encoded as JSON.', 'superdav-ai-agent' )
+			);
+		}
+		$before_content = '';
+		if ( $exists ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Capturing an exact local before-value for the existing change log.
+			$before_content = file_get_contents( $target );
+			if ( false === $before_content ) {
+				return new WP_Error(
+					'sd_ai_agent_style_variation_read_failed',
+					__( 'The existing style variation could not be read before updating.', 'superdav-ai-agent' )
+				);
+			}
+		}
+
+		$tmp_path = tempnam( $directory, '.sd-ai-agent-style-variation-' );
+		if ( false === $tmp_path ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_temp_failed',
+				__( 'The style variation could not be staged for an atomic write.', 'superdav-ai-agent' )
+			);
+		}
+
+		try {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Writing a same-directory temporary file before atomic replacement.
+			if ( false === file_put_contents( $tmp_path, $content, LOCK_EX ) ) {
+				return new WP_Error(
+					'sd_ai_agent_style_variation_write_failed',
+					__( 'The style variation could not be staged for writing.', 'superdav-ai-agent' )
+				);
+			}
+
+			$before_hook = 'create' === $operation ? 'sd_ai_agent_before_file_write' : 'sd_ai_agent_before_file_edit';
+			$after_hook  = 'create' === $operation ? 'sd_ai_agent_after_file_write' : 'sd_ai_agent_after_file_edit';
+			do_action( $before_hook, $target );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.rename_rename -- Same-directory replacement preserves atomicity for concurrent readers.
+			if ( ! rename( $tmp_path, $target ) ) {
+				return new WP_Error(
+					'sd_ai_agent_style_variation_write_failed',
+					__( 'The style variation could not be atomically written.', 'superdav-ai-agent' )
+				);
+			}
+			$tmp_path = '';
+
+			do_action( $after_hook, $target );
+			$tracking_path = 'themes/' . $theme->get_stylesheet() . '/' . $relative_path;
+			Database::record_modified_file( $tracking_path, 'create' === $operation ? 'write' : 'edit', 0, (int) get_current_user_id() );
+			if ( ChangeLogger::is_active() ) {
+				ChangesLog::record(
+					[
+						'session_id'   => ChangeLogger::get_session_id(),
+						'object_type'  => 'file',
+						'object_id'    => 0,
+						'object_title' => basename( $relative_path ),
+						'ability_name' => ChangeLogger::get_ability_name() ?: 'style-variation-' . $operation,
+						'field_name'   => $target,
+						'before_value' => $before_content,
+						'after_value'  => $content,
+						'revertable'   => true,
+					]
+				);
+			}
+		} finally {
+			if ( '' !== $tmp_path && file_exists( $tmp_path ) ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Removing only the manager-owned same-directory temporary file after a failed write.
+				unlink( $tmp_path );
+			}
+		}
+
+		return [
+			'action'        => 'create' === $operation ? 'created' : 'updated',
+			'slug'          => $validated['slug'],
+			'title'         => $validated['title'],
+			'hash'          => $validated['hash'],
+			'relative_path' => $relative_path,
+		];
+	}
+
+	/**
+	 * Verify the optional semantic map emitted by DesignTokenCompiler.
+	 *
+	 * General WordPress variations remain valid without this extension. When a
+	 * document declares the plugin namespace, all required #2249 semantic roles
+	 * must be present so malformed compiled output never reaches disk.
+	 *
+	 * @param array<string,mixed> $document Style variation document.
+	 * @return true|WP_Error True when valid or a contract error.
+	 */
+	private function validate_compiled_semantics( array $document ): true|WP_Error {
+		$custom = $document['settings']['custom']['sdAiAgent'] ?? null;
+		if ( null === $custom ) {
+			return true;
+		}
+		$colors = is_array( $custom ) ? ( $custom['semantic']['color'] ?? null ) : null;
+		if ( ! is_array( $colors ) || array_is_list( $colors ) ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_semantics_invalid',
+				__( 'Compiled style variations must include the design-token semantic colour map.', 'superdav-ai-agent' )
+			);
+		}
+		foreach ( DesignTokenContract::REQUIRED_COLOR_ROLES as $role ) {
+			if ( ! isset( $colors[ $role ] ) || ! is_string( $colors[ $role ] ) || '' === trim( $colors[ $role ] ) ) {
+				return new WP_Error(
+					'sd_ai_agent_style_variation_semantics_invalid',
+					__( 'Compiled style variations must retain every required semantic colour role.', 'superdav-ai-agent' ),
+					[ 'role' => $role ]
+				);
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Read the active theme's exact persisted Global Styles record.
+	 *
+	 * @return array<string,mixed>|WP_Error Current record details or an error.
+	 */
+	private function current_global_styles(): array|WP_Error {
+		$service = new GlobalStylesService();
+		$post_id = $service->get_user_post_id();
+		if ( null === $post_id ) {
+			return [
+				'exists'       => false,
+				'post_id'      => null,
+				'content'      => null,
+				'content_hash' => null,
+				'document'     => [],
+				'service'      => $service,
+			];
+		}
+		$post = get_post( $post_id );
+		if ( ! $post instanceof WP_Post || 'wp_global_styles' !== $post->post_type ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_global_styles_missing',
+				__( 'The active theme Global Styles record is unavailable.', 'superdav-ai-agent' )
+			);
+		}
+		$document = json_decode( $post->post_content, true );
+		if ( ! is_array( $document ) || array_is_list( $document ) ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_global_styles_invalid',
+				__( 'The active theme Global Styles record is not valid JSON.', 'superdav-ai-agent' )
+			);
+		}
+
+		return [
+			'exists'       => true,
+			'post_id'      => (int) $post->ID,
+			'content'      => $post->post_content,
+			'content_hash' => hash( 'sha256', $post->post_content ),
+			'document'     => $document,
+			'service'      => $service,
+		];
+	}
+
+	/**
+	 * Merge only a variation's settings/styles onto the original exact baseline.
+	 *
+	 * @param array<string,mixed> $baseline  Original user document.
+	 * @param array<string,mixed> $variation Validated variation document.
+	 * @return array<string,mixed> New complete user Global Styles document.
+	 */
+	private static function apply_variation_to_baseline( array $baseline, array $variation ): array {
+		$partial = [
+			'settings' => $variation['settings'],
+			'styles'   => $variation['styles'],
+		];
+		$document = self::deep_merge( $baseline, $partial );
+		$document['version']                     = WP_Theme_JSON::LATEST_SCHEMA;
+		$document['isGlobalStylesUserThemeJSON'] = true;
+
+		return $document;
+	}
+
+	/**
+	 * Persist a complete user Global Styles document and return its exact bytes.
+	 *
+	 * @param array<string,mixed> $current Current record details.
+	 * @param array<string,mixed> $document New complete document.
+	 * @return array<string,mixed>|WP_Error Write details or an error.
+	 */
+	private function write_global_styles_document( array $current, array $document ): array|WP_Error {
+		$content = wp_json_encode( $document, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP );
+		if ( false === $content ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_global_styles_encode_failed',
+				__( 'The selected style variation could not be encoded for Global Styles.', 'superdav-ai-agent' )
+			);
+		}
+
+		if ( ! $current['exists'] ) {
+			$created = $current['service']->merge_user_document( $document );
+			if ( is_wp_error( $created ) ) {
+				return $created;
+			}
+			$post = get_post( $created['post_id'] );
+			if ( ! $post instanceof WP_Post ) {
+				return new WP_Error(
+					'sd_ai_agent_style_variation_global_styles_missing',
+					__( 'The selected Global Styles record could not be reloaded.', 'superdav-ai-agent' )
+				);
+			}
+
+			return [
+				'post_id'      => (int) $post->ID,
+				'content'      => $post->post_content,
+				'content_hash' => hash( 'sha256', $post->post_content ),
+				'created'      => true,
+			];
+		}
+
+		$updated = wp_update_post(
+			[
+				'ID'           => $current['post_id'],
+				'post_content' => $content,
+			],
+			true
+		);
+		if ( is_wp_error( $updated ) ) {
+			return $updated;
+		}
+		if ( function_exists( 'wp_clean_theme_json_cache' ) ) {
+			wp_clean_theme_json_cache();
+		}
+		$post = get_post( $current['post_id'] );
+		if ( ! $post instanceof WP_Post ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_global_styles_missing',
+				__( 'The selected Global Styles record could not be reloaded.', 'superdav-ai-agent' )
+			);
+		}
+
+		return [
+			'post_id'      => (int) $post->ID,
+			'content'      => $post->post_content,
+			'content_hash' => hash( 'sha256', $post->post_content ),
+			'created'      => false,
+		];
+	}
+
+	/**
+	 * Undo a failed selection's Global Styles write before returning an error.
+	 *
+	 * @param array<string,mixed> $current Original record details.
+	 * @param array<string,mixed> $written New record details.
+	 * @return true|WP_Error True after recovery or a recovery error.
+	 */
+	private function restore_current_global_styles( array $current, array $written ): true|WP_Error {
+		if ( ! $current['exists'] ) {
+			$deleted = wp_delete_post( $written['post_id'], true );
+			if ( ! $deleted instanceof WP_Post ) {
+				return new WP_Error(
+					'sd_ai_agent_style_variation_recovery_failed',
+					__( 'The plugin-created Global Styles record could not be removed after selection failed.', 'superdav-ai-agent' )
+				);
+			}
+		} else {
+			$updated = wp_update_post(
+				[
+					'ID'           => $current['post_id'],
+					'post_content' => $current['content'],
+				],
+				true
+			);
+			if ( is_wp_error( $updated ) ) {
+				return $updated;
+			}
+		}
+		if ( function_exists( 'wp_clean_theme_json_cache' ) ) {
+			wp_clean_theme_json_cache();
+		}
+
+		return true;
+	}
+
+	/**
+	 * Restore an exact saved baseline after the state record was safely removed.
+	 *
+	 * @param array<string,mixed> $baseline Original baseline.
+	 * @param array<string,mixed> $current  Current managed selection record.
+	 * @return true|WP_Error True when restored or an error.
+	 */
+	private function restore_baseline( array $baseline, array $current ): true|WP_Error {
+		if ( $baseline['post_exists'] ) {
+			$updated = wp_update_post(
+				[
+					'ID'           => $current['post_id'],
+					'post_content' => $baseline['content'],
+				],
+				true
+			);
+			if ( is_wp_error( $updated ) ) {
+				return $updated;
+			}
+		} else {
+			$deleted = wp_delete_post( $current['post_id'], true );
+			if ( ! $deleted instanceof WP_Post ) {
+				return new WP_Error(
+					'sd_ai_agent_style_variation_reset_failed',
+					__( 'The plugin-created Global Styles record could not be removed during reset.', 'superdav-ai-agent' )
+				);
+			}
+		}
+		if ( function_exists( 'wp_clean_theme_json_cache' ) ) {
+			wp_clean_theme_json_cache();
+		}
+
+		return true;
+	}
+
+	/**
+	 * Refuse to overwrite Site Editor changes made after managed selection.
+	 *
+	 * @param array<string,mixed> $state   Saved managed state.
+	 * @param array<string,mixed> $current Current record details.
+	 * @return true|WP_Error True when unchanged or a drift error.
+	 */
+	private function assert_selected_state_matches_current( array $state, array $current ): true|WP_Error {
+		if (
+			! $current['exists']
+			|| $state['selected']['post_id'] !== $current['post_id']
+			|| ! hash_equals( $state['selected']['content_hash'], $current['content_hash'] )
+		) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_global_styles_changed',
+				__( 'Global Styles changed after the variation was selected. Refusing to overwrite Site Editor changes.', 'superdav-ai-agent' )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Read the site-scoped state map without silently accepting malformed data.
+	 *
+	 * @return array<string,mixed>|WP_Error State map or an error.
+	 */
+	private function read_state_map(): array|WP_Error {
+		$state = get_option( self::STATE_OPTION, [] );
+		if ( false === $state || [] === $state || null === $state ) {
+			return [];
+		}
+		if ( ! is_array( $state ) || array_is_list( $state ) ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_state_invalid',
+				__( 'The saved style variation selection state is invalid and was left unchanged.', 'superdav-ai-agent' )
+			);
+		}
+
+		return $state;
+	}
+
+	/**
+	 * Return one validated selection state or null when this stylesheet has none.
+	 *
+	 * @param array<string,mixed> $state_map  Site state map.
+	 * @param string              $stylesheet Active stylesheet slug.
+	 * @return array<string,mixed>|null|WP_Error State, no state, or an error.
+	 */
+	private function state_for_stylesheet( array $state_map, string $stylesheet ): array|null|WP_Error {
+		if ( ! isset( $state_map[ $stylesheet ] ) ) {
+			return null;
+		}
+		$state = $state_map[ $stylesheet ];
+		if (
+			! is_array( $state )
+			|| self::STATE_VERSION !== ( $state['version'] ?? null )
+			|| ! isset( $state['baseline'], $state['selected'] )
+			|| ! is_array( $state['baseline'] )
+			|| ! is_array( $state['selected'] )
+		) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_state_invalid',
+				__( 'The saved style variation selection state is invalid and was left unchanged.', 'superdav-ai-agent' )
+			);
+		}
+		$baseline = $state['baseline'];
+		$selected = $state['selected'];
+		if (
+			! isset( $baseline['post_exists'], $baseline['document'], $selected['slug'], $selected['source_hash'], $selected['post_id'], $selected['content_hash'] )
+			|| ! is_bool( $baseline['post_exists'] )
+			|| ! is_array( $baseline['document'] )
+			|| ! is_string( $selected['slug'] )
+			|| ! is_int( $selected['post_id'] )
+			|| ! is_string( $selected['source_hash'] )
+			|| ! is_string( $selected['content_hash'] )
+			|| is_wp_error( $this->validate_hash( $selected['source_hash'], 'sd_ai_agent_style_variation_state_invalid' ) )
+			|| is_wp_error( $this->validate_hash( $selected['content_hash'], 'sd_ai_agent_style_variation_state_invalid' ) )
+		) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_state_invalid',
+				__( 'The saved style variation selection state is incomplete and was left unchanged.', 'superdav-ai-agent' )
+			);
+		}
+		if ( $baseline['post_exists'] && ( ! isset( $baseline['post_id'], $baseline['content'], $baseline['content_hash'] ) || ! is_int( $baseline['post_id'] ) || ! is_string( $baseline['content'] ) || ! is_string( $baseline['content_hash'] ) ) ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_state_invalid',
+				__( 'The saved style variation baseline is incomplete and was left unchanged.', 'superdav-ai-agent' )
+			);
+		}
+
+		return $state;
+	}
+
+	/**
+	 * Persist or remove the map, checking WordPress's no-change return semantics.
+	 *
+	 * @param array<string,mixed> $state_map New site state map.
+	 * @return true|WP_Error True when persisted or an error.
+	 */
+	private function write_state_map( array $state_map ): true|WP_Error {
+		if ( [] === $state_map ) {
+			$deleted = delete_option( self::STATE_OPTION );
+			if ( ! $deleted && false !== get_option( self::STATE_OPTION, false ) ) {
+				return new WP_Error(
+					'sd_ai_agent_style_variation_state_write_failed',
+					__( 'The style variation selection state could not be removed.', 'superdav-ai-agent' )
+				);
+			}
+
+			return true;
+		}
+
+		$updated = update_option( self::STATE_OPTION, $state_map );
+		if ( ! $updated && get_option( self::STATE_OPTION, null ) !== $state_map ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_state_write_failed',
+				__( 'The style variation selection state could not be saved.', 'superdav-ai-agent' )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Return an error that preserves both a failed operation and failed recovery.
+	 */
+	private function recovery_error( string $operation, WP_Error $original, WP_Error $recovery ): WP_Error {
+		return new WP_Error(
+			'sd_ai_agent_style_variation_recovery_failed',
+			sprintf(
+				/* translators: %s: operation name. */
+				__( 'Style variation %s failed and its recovery also failed.', 'superdav-ai-agent' ),
+				$operation
+			),
+			[
+				'operation_error' => $original->get_error_code(),
+				'recovery_error'  => $recovery->get_error_code(),
+			]
+		);
+	}
+
+	/**
+	 * Validate a conservative variation slug.
+	 *
+	 * @return true|WP_Error True when valid or an error.
+	 */
+	private function validate_slug( string $slug ): true|WP_Error {
+		if ( '' === $slug || 1 !== preg_match( self::SLUG_PATTERN, $slug ) ) {
+			return new WP_Error(
+				'sd_ai_agent_style_variation_invalid_slug',
+				__( 'Style variation slugs must contain only lowercase letters, digits, and hyphens.', 'superdav-ai-agent' )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validate an SHA-256 concurrency token.
+	 *
+	 * @return true|WP_Error True when valid or an error.
+	 */
+	private function validate_hash( string $hash, string $error_code ): true|WP_Error {
+		if ( 1 !== preg_match( '/^[a-f0-9]{64}$/', $hash ) ) {
+			return new WP_Error(
+				$error_code,
+				__( 'A current canonical style variation hash is required.', 'superdav-ai-agent' )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Deep merge associative theme.json fragments without replacing sibling state.
+	 *
+	 * @param array<string,mixed> $base     Base document fragment.
+	 * @param array<string,mixed> $override Variation fragment.
+	 * @return array<string,mixed> Merged document.
+	 */
+	private static function deep_merge( array $base, array $override ): array {
+		foreach ( $override as $key => $value ) {
+			if ( is_array( $value ) && isset( $base[ $key ] ) && is_array( $base[ $key ] ) && ! array_is_list( $value ) && ! array_is_list( $base[ $key ] ) ) {
+				$base[ $key ] = self::deep_merge( $base[ $key ], $value );
+			} else {
+				$base[ $key ] = $value;
+			}
+		}
+
+		return $base;
+	}
+
+	/**
+	 * Build a bounded list of data paths changed by an in-memory preview.
+	 *
+	 * @param mixed  $before Original value.
+	 * @param mixed  $after  Preview value.
+	 * @param string $path   Current dotted path.
+	 * @return list<string> Changed paths.
+	 */
+	private static function changed_paths( mixed $before, mixed $after, string $path = '' ): array {
+		if ( $before === $after ) {
+			return [];
+		}
+		if ( ! is_array( $before ) || ! is_array( $after ) || array_is_list( $before ) || array_is_list( $after ) ) {
+			return [ '' === $path ? '$' : $path ];
+		}
+
+		$paths = [];
+		foreach ( array_unique( array_merge( array_keys( $before ), array_keys( $after ) ) ) as $key ) {
+			$child_path = '' === $path ? (string) $key : $path . '.' . $key;
+			$paths      = array_merge( $paths, self::changed_paths( $before[ $key ] ?? null, $after[ $key ] ?? null, $child_path ) );
+			if ( count( $paths ) >= 128 ) {
+				return array_slice( $paths, 0, 128 );
+			}
+		}
+
+		return $paths;
+	}
+}

--- a/includes/Abilities/ToolCapabilities.php
+++ b/includes/Abilities/ToolCapabilities.php
@@ -134,6 +134,13 @@ class ToolCapabilities {
 		'sd-ai-agent/render-design-previews'     => 'edit_theme_options',
 		'sd-ai-agent/validate-palette-contrast'  => 'edit_theme_options',
 		'sd-ai-agent/compile-design-tokens'      => 'edit_theme_options',
+		'sd-ai-agent/list-style-variations'      => 'edit_theme_options',
+		'sd-ai-agent/create-style-variation'     => 'edit_theme_options',
+		'sd-ai-agent/update-style-variation'     => 'edit_theme_options',
+		'sd-ai-agent/validate-style-variation'   => 'edit_theme_options',
+		'sd-ai-agent/preview-style-variation'    => 'edit_theme_options',
+		'sd-ai-agent/select-style-variation'     => 'edit_theme_options',
+		'sd-ai-agent/reset-style-variation'      => 'edit_theme_options',
 		'sd-ai-agent/generate-logo-svg'          => 'upload_files',
 
 		// ─── Menus ──────────────────────────────────────────────────────────

--- a/includes/Models/Agent.php
+++ b/includes/Models/Agent.php
@@ -634,6 +634,13 @@ class Agent {
 						'sd-ai-agent/generate-menu-page',
 						'sd-ai-agent/validate-palette-contrast',
 						'sd-ai-agent/compile-design-tokens',
+						'sd-ai-agent/list-style-variations',
+						'sd-ai-agent/create-style-variation',
+						'sd-ai-agent/update-style-variation',
+						'sd-ai-agent/validate-style-variation',
+						'sd-ai-agent/preview-style-variation',
+						'sd-ai-agent/select-style-variation',
+						'sd-ai-agent/reset-style-variation',
 						'sd-ai-agent/site-scrape',
 						'sd-ai-agent/stock-image',
 						'sd-ai-agent/generate-image',
@@ -705,6 +712,7 @@ class Agent {
 			. "- **Add a shop** → if WooCommerce is not active, install via `wp-cli/execute`; collect a representative product list; create product entries.\n"
 			. "- **Add contact details** → ask for phone / email / address / form preference; update the contact page.\n"
 			. "- **Try a different look** → load `design-system-aesthetics`, render three alternative directions via `sd-ai-agent/render-design-previews`, let the user pick, update the saved design-token contract, rerun `sd-ai-agent/compile-design-tokens`, revalidate its palette, then apply its file-only manifest and Global Styles outputs through their dedicated abilities.\n"
+			. "- **Use a saved style variation** → call `sd-ai-agent/list-style-variations`, then validate and preview the selected hash with `sd-ai-agent/validate-style-variation` and `sd-ai-agent/preview-style-variation`. Select only through `sd-ai-agent/select-style-variation` with that exact hash; use `sd-ai-agent/reset-style-variation` only when undoing the plugin-managed selection. Never use generic file writes or wholesale Global Styles reset for this lifecycle.\n"
 			. "- **Try a different logo** → re-run `sd-ai-agent/generate-logo-svg` with adjusted `direction`/`style_cues`, let the user pick.\n"
 			. "- **Use my photos for the hero** → review uploaded attachments, swap hero imagery in `templates/front-page.html` and re-validate.\n"
 			. "- **Tweak colours / fonts** → update the saved design-token contract, rerun `sd-ai-agent/compile-design-tokens`, revalidate its palette, then apply only the newly compiled manifest and Global Styles outputs.\n"

--- a/includes/Models/skills/wp-block-themes.md
+++ b/includes/Models/skills/wp-block-themes.md
@@ -20,15 +20,9 @@ Use this skill for block theme work such as:
 
 If the active theme is classic and the task is to modify that active theme, use `classic-themes` instead. If the task is to generate, convert to, or scaffold a block theme, use this skill even when the currently active theme is classic.
 
-When a contributor-insight issue contains a pasted local-path excerpt headed
-`Block Themes`, `Full Site Editing`, `theme.json`, templates, parts, patterns, or
-style variations, treat that excerpt as a source-mapping clue only. Update this
-committed skill file (and the root `AGENTS.md` summary when repo-wide guidance is
-needed); do not copy private local paths or duplicate the full excerpt into
-issues, PRs, templates, or generated theme files. In mixed reports like issues
-#2034, #2050, #2060, #2066, #2074, and #2081, this file is only the block-theme target; REST,
-Google Search Console, and WordPress.org review-response notes must be mapped to
-their own committed source files instead of being folded into this skill.
+When a contributor-insight issue contains a pasted local-path excerpt headed `Block Themes`, `Full Site Editing`, `theme.json`, templates, parts, patterns, or style variations, treat it only as a source-mapping clue.
+Update this committed skill (and root `AGENTS.md` when guidance is repo-wide); never copy private paths or duplicate the full excerpt in issues, PRs, templates, or generated theme files.
+In mixed reports #2034, #2050, #2060, #2066, #2074, and #2081, this is only the block-theme target; map REST, Google Search Console, and WordPress.org review-response notes to their own committed sources.
 
 ## Inputs required
 
@@ -44,11 +38,10 @@ their own committed source files instead of being folded into this skill.
 3. Decide whether a `theme.json` change belongs under `settings` (what the editor allows) or `styles` (default visual output).
 4. Put templates in `templates/*.html`; put template parts directly in `parts/*.html` (not nested subdirectories).
 5. Prefer filesystem-owned patterns under `patterns/*.php` when the theme should ship reusable layouts.
-6. Put style variations in `styles/*.json`; remember that once a user selects a style variation, that selection is stored in the database.
+6. Put style variations in `styles/*.json`; use the explicit `sd-ai-agent/*-style-variation` lifecycle rather than generic file mutation. Once a user selects a style variation, its selection is stored in the database.
 7. Validate generated block markup before writing templates, parts, or patterns.
 8. Perform an explicit final quality review before declaring a generated theme complete. Prefer a browser, screenshot, or front-end render check when available; when visual QA is unavailable, perform the structural review in the verification checklist and report that limitation.
-9. For contributor-insight or maintenance changes to this skill, verify future
-   workers will load the guidance with `rg -n "wp-block-themes|Full Site Editing|theme.json|validate-block-content" AGENTS.md includes/Models/skills/wp-block-themes.md`.
+9. For contributor-insight or maintenance changes to this skill, verify future workers load the guidance with `rg -n "wp-block-themes|Full Site Editing|theme.json|validate-block-content" AGENTS.md includes/Models/skills/wp-block-themes.md`.
 
 ## Absolute Rules
 
@@ -222,6 +215,13 @@ When calling `sd-ai-agent/update-global-styles`, pass only the inner `styles` an
 ### Compile a design-token contract first
 Compilation is pure. Call `sd-ai-agent/compile-design-tokens` and follow its complete schema-v1 contract exactly (governance identity, bounded primitives, semantic roles, and a style-variation remap); repair any `WP_Error` and never reconstruct raw artifacts independently. Pass `theme_json` to `sd-ai-agent/scaffold-block-theme`, pass `global_styles.settings` and `global_styles.styles` only to `sd-ai-agent/update-global-styles`, validate `palette` with `sd-ai-agent/validate-palette-contrast`, and preserve the file-only `style_variation` plus `artifact_manifest` for `sd-ai-agent/apply-design-artifact-release`; the manifest must never own a second `wp_global_styles` record.
 
+### Style-variation lifecycle
+For a user-requested active-theme variation:
+1. Call `sd-ai-agent/list-style-variations`; parent entries are read-only and child entries win filename collisions. Call `sd-ai-agent/validate-style-variation` and `sd-ai-agent/preview-style-variation` before create, update, or select; preview is in memory only and returns CSS plus changed paths, never a screenshot claim.
+2. Create a complete `styles/{slug}.json` only through `sd-ai-agent/create-style-variation`; replace it only through `sd-ai-agent/update-style-variation` with the hash returned by list or validate.
+3. Select only through `sd-ai-agent/select-style-variation` using the exact source hash. It records the original active-theme Global Styles document and always switches from that original baseline instead of accumulating changes.
+4. Call `sd-ai-agent/reset-style-variation` only to undo a plugin-managed selection. It refuses to overwrite intervening Site Editor changes and restores the exact baseline rather than deleting all user Global Styles.
+Use `sd-ai-agent/apply-design-artifact-release` for a governed generated artifact manifest; use this explicit lifecycle for one active-theme variation. Never use generic file write/edit or `reset-global-styles` to bypass either safety contract.
 ### Generated design artifact governance
 
 Generated token sets, block patterns, and style variations are versioned releases, not ordinary edits.
@@ -230,7 +230,7 @@ Generated token sets, block patterns, and style variations are versioned release
 2. Declare WordPress/`theme.json` ranges, required blocks/features, and theme constraints. Incompatible artifacts are rejected first; inspect the deterministic trace with `sd-ai-agent/resolve-design-artifacts`. Stable is default; candidate and experimental require explicit opt-in, deprecated is never a new default, and automatic selection never crosses a major version.
 3. Use `sd-ai-agent/apply-design-artifact-release` for generated writes and `sd-ai-agent/rollback-design-artifact-release` only with an exact retained release ID. The manager stages and validates before moving the active pointer, restores complete prior state after failure, and refuses unmanaged targets.
 
-Never use `sd-ai-agent/curated-block-patterns`, direct `patterns/`/`styles/` writes, or ordinary global-style editing to bypass this contract. Ordinary user-created patterns and customizations remain outside the registry and must not be silently imported, rewritten, or deleted.
+Never use `sd-ai-agent/curated-block-patterns`, direct generic `patterns/`/`styles/` writes, or ordinary global-style editing to bypass this contract. The dedicated style-variation lifecycle above is the only exception for one validated active-theme variation. Ordinary user-created patterns and customizations remain outside the registry and must not be silently imported, rewritten, or deleted.
 
 ### Typography presets — choose distinctive fonts
 

--- a/tests/SdAiAgent/Abilities/StyleVariationAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/StyleVariationAbilitiesTest.php
@@ -1,0 +1,644 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Tests for the explicit advanced style-variation lifecycle abilities.
+ *
+ * @package SdAiAgent\Tests\Abilities
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Abilities;
+
+use Closure;
+use SdAiAgent\Abilities\StyleVariationAbilities;
+use SdAiAgent\Services\GlobalStylesService;
+use SdAiAgent\Services\StyleVariationManager;
+use WP_Theme_JSON;
+use WP_UnitTestCase;
+
+/**
+ * Covers active-theme style-variation lifecycle safety guarantees.
+ */
+class StyleVariationAbilitiesTest extends WP_UnitTestCase {
+
+	/**
+	 * Original stylesheet restored after each disposable-theme test.
+	 */
+	private string $originalStylesheet;
+
+	/**
+	 * Disposable parent theme slug.
+	 */
+	private string $parentSlug;
+
+	/**
+	 * Disposable active child theme slug.
+	 */
+	private string $childSlug;
+
+	/**
+	 * Disposable parent theme directory.
+	 */
+	private string $parentDir;
+
+	/**
+	 * Disposable active child theme directory.
+	 */
+	private string $childDir;
+
+	/**
+	 * File-modification filter used only for the disposable test themes.
+	 */
+	private Closure $fileModAllowedFilter;
+
+	/**
+	 * Create a temporary parent/child block-theme pair and activate the child.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		$this->originalStylesheet = (string) get_stylesheet();
+		$suffix                   = strtolower( wp_generate_password( 8, false ) );
+		$this->parentSlug         = 'sd-ai-style-parent-' . $suffix;
+		$this->childSlug          = 'sd-ai-style-child-' . $suffix;
+		$this->parentDir          = trailingslashit( get_theme_root() ) . $this->parentSlug;
+		$this->childDir           = trailingslashit( get_theme_root() ) . $this->childSlug;
+
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$this->fileModAllowedFilter = static function ( bool $allowed, string $context ): bool {
+			return 'theme_files' === $context ? true : $allowed;
+		};
+		add_filter( 'file_mod_allowed', $this->fileModAllowedFilter, 10, 2 );
+
+		$this->stage_theme( $this->parentDir, $this->parentSlug, 'Style Variation Parent', null );
+		$this->stage_theme( $this->childDir, $this->childSlug, 'Style Variation Child', $this->parentSlug );
+		wp_clean_themes_cache();
+		switch_theme( $this->childSlug );
+		wp_clean_themes_cache();
+		wp_clean_theme_json_cache();
+		delete_option( StyleVariationManager::STATE_OPTION );
+	}
+
+	/**
+	 * Restore the original theme and remove all test-owned filesystem/database state.
+	 */
+	public function tear_down(): void {
+		$this->delete_child_global_styles();
+		delete_option( StyleVariationManager::STATE_OPTION );
+
+		if ( $this->originalStylesheet !== get_stylesheet() ) {
+			switch_theme( $this->originalStylesheet );
+		}
+		wp_clean_themes_cache();
+		wp_clean_theme_json_cache();
+
+		self::rrmdir( $this->childDir );
+		self::rrmdir( $this->parentDir );
+		remove_filter( 'file_mod_allowed', $this->fileModAllowedFilter, 10 );
+		wp_set_current_user( 0 );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Every lifecycle operation exposes its own explicit capability-gated contract.
+	 */
+	public function test_registers_explicit_lifecycle_ability_contracts(): void {
+		if ( null === wp_get_ability( 'sd-ai-agent/list-style-variations' ) ) {
+			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Standard WordPress hook stack global required by core ability registration.
+			global $wp_current_filter;
+			$wp_current_filter[] = 'wp_abilities_api_init';
+			try {
+				StyleVariationAbilities::register_abilities();
+			} finally {
+				array_pop( $wp_current_filter );
+			}
+		}
+
+		$expected = [
+			'sd-ai-agent/list-style-variations'     => [ true, false, true ],
+			'sd-ai-agent/create-style-variation'   => [ false, true, false ],
+			'sd-ai-agent/update-style-variation'   => [ false, true, false ],
+			'sd-ai-agent/validate-style-variation' => [ true, false, true ],
+			'sd-ai-agent/preview-style-variation'  => [ true, false, true ],
+			'sd-ai-agent/select-style-variation'   => [ false, true, true ],
+			'sd-ai-agent/reset-style-variation'    => [ false, true, false ],
+		];
+
+		foreach ( $expected as $id => $annotations ) {
+			$ability = wp_get_ability( $id );
+
+			$this->assertNotNull( $ability, $id );
+			$this->assertTrue( $ability->get_meta()['mcp']['public'], $id );
+			$this->assertTrue( $ability->get_meta()['show_in_rest'], $id );
+			$this->assertSame( $annotations[0], $ability->get_meta()['annotations']['readonly'], $id );
+			$this->assertSame( $annotations[1], $ability->get_meta()['annotations']['destructive'], $id );
+			$this->assertSame( $annotations[2], $ability->get_meta()['annotations']['idempotent'], $id );
+		}
+	}
+
+	/**
+	 * Create and update use canonical hashes and never let a stale writer replace a file.
+	 */
+	public function test_create_and_update_require_current_hashes(): void {
+		$manager  = new StyleVariationManager();
+		$original = $this->variation_document( 'sunset', '#8b1e3f' );
+		$created  = $manager->create( $original );
+
+		$this->assertIsArray( $created, is_wp_error( $created ) ? $created->get_error_message() : '' );
+		$this->assertSame( 'created', $created['action'] );
+		$this->assertFileExists( $this->childDir . '/styles/sunset.json' );
+
+		$duplicate = $manager->create( $original );
+		$this->assertWPError( $duplicate );
+		$this->assertSame( 'sd_ai_agent_style_variation_exists', $duplicate->get_error_code() );
+
+		$replacement = $this->variation_document( 'sunset', '#155e75' );
+		$stale       = $manager->update( 'sunset', $replacement, str_repeat( '0', 64 ) );
+		$this->assertWPError( $stale );
+		$this->assertSame( 'sd_ai_agent_style_variation_stale_hash', $stale->get_error_code() );
+		$this->assertSame( '#8b1e3f', $this->read_document( $this->childDir . '/styles/sunset.json' )['styles']['color']['text'] );
+		$stale_select = $manager->select( 'sunset', str_repeat( '0', 64 ) );
+		$this->assertWPError( $stale_select );
+		$this->assertSame( 'sd_ai_agent_style_variation_stale_hash', $stale_select->get_error_code() );
+
+		$updated = $manager->update( 'sunset', $replacement, $created['hash'] );
+		$this->assertIsArray( $updated, is_wp_error( $updated ) ? $updated->get_error_message() : '' );
+		$this->assertSame( 'updated', $updated['action'] );
+		$this->assertNotSame( $created['hash'], $updated['hash'] );
+		$this->assertSame( '#155e75', $this->read_document( $this->childDir . '/styles/sunset.json' )['styles']['color']['text'] );
+	}
+
+	/**
+	 * FileModGate rejects theme mutation before a variation file is created.
+	 */
+	public function test_create_respects_file_mod_gate(): void {
+		$deny_theme_writes = static function ( bool $allowed, string $context ): bool {
+			return 'theme_files' === $context ? false : $allowed;
+		};
+		add_filter( 'file_mod_allowed', $deny_theme_writes, 20, 2 );
+		try {
+			$result = ( new StyleVariationManager() )->create( $this->variation_document( 'blocked', '#991b1b' ) );
+		} finally {
+			remove_filter( 'file_mod_allowed', $deny_theme_writes, 20 );
+		}
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'file_mod_not_allowed', $result->get_error_code() );
+		$this->assertFileDoesNotExist( $this->childDir . '/styles/blocked.json' );
+	}
+
+	/**
+	 * A target created while the staged write is pending is never overwritten.
+	 */
+	public function test_create_refuses_to_overwrite_a_concurrently_created_variation(): void {
+		$target   = $this->childDir . '/styles/race.json';
+		$injected = false;
+		$race     = static function ( string $path ) use ( $target, &$injected ): void {
+			if ( $target !== $path || $injected ) {
+				return;
+			}
+			$injected = true;
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Simulates an independent writer winning the create race.
+			file_put_contents( $target, 'independent writer' );
+		};
+		add_action( 'sd_ai_agent_before_file_write', $race );
+		try {
+			$result = ( new StyleVariationManager() )->create( $this->variation_document( 'race', '#9f1239' ) );
+		} finally {
+			remove_action( 'sd_ai_agent_before_file_write', $race );
+		}
+
+		$this->assertTrue( $injected );
+		$this->assertWPError( $result );
+		$this->assertSame( 'sd_ai_agent_style_variation_exists', $result->get_error_code() );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Verifies the independent race winner remains untouched.
+		$this->assertSame( 'independent writer', file_get_contents( $target ) );
+	}
+
+	/**
+	 * A competing lifecycle request is rejected while a manager-owned mutation holds the site lock.
+	 */
+	public function test_lifecycle_lock_refuses_reentrant_mutation(): void {
+		$manager       = new StyleVariationManager();
+		$outer_document = $this->variation_document( 'outer', '#9f1239' );
+		$nested_result  = null;
+		$target         = $this->childDir . '/styles/outer.json';
+		$reentrant      = static function ( string $path ) use ( $manager, $target, &$nested_result, $outer_document ): void {
+			if ( $target !== $path ) {
+				return;
+			}
+
+			$nested_result = $manager->create( array_replace( $outer_document, [ 'slug' => 'nested', 'title' => 'Nested' ] ) );
+		};
+		add_action( 'sd_ai_agent_before_file_write', $reentrant );
+		try {
+			$created = $manager->create( $outer_document );
+		} finally {
+			remove_action( 'sd_ai_agent_before_file_write', $reentrant );
+		}
+
+		$this->assertIsArray( $created, is_wp_error( $created ) ? $created->get_error_message() : '' );
+		$this->assertWPError( $nested_result );
+		$this->assertSame( 'sd_ai_agent_style_variation_busy', $nested_result->get_error_code() );
+		$this->assertFileExists( $target );
+		$this->assertFileDoesNotExist( $this->childDir . '/styles/nested.json' );
+	}
+
+	/**
+	 * An external edit between the optimistic update check and replacement remains untouched.
+	 */
+	public function test_update_rechecks_hash_immediately_before_replacement(): void {
+		$manager      = new StyleVariationManager();
+		$original     = $this->variation_document( 'update-race', '#7c2d12' );
+		$created      = $manager->create( $original );
+		$replacement  = $this->variation_document( 'update-race', '#0f766e' );
+		$intervening  = $this->variation_document( 'update-race', '#4338ca' );
+		$target       = $this->childDir . '/styles/update-race.json';
+		$injected     = false;
+		$independent  = function ( string $path ) use ( $target, $intervening, &$injected ): void {
+			if ( $target !== $path || $injected ) {
+				return;
+			}
+
+			$injected = true;
+			$this->write_document( $target, $intervening );
+		};
+		$this->assertIsArray( $created, is_wp_error( $created ) ? $created->get_error_message() : '' );
+		add_action( 'sd_ai_agent_before_file_edit', $independent );
+		try {
+			$result = $manager->update( 'update-race', $replacement, $created['hash'] );
+		} finally {
+			remove_action( 'sd_ai_agent_before_file_edit', $independent );
+		}
+
+		$this->assertTrue( $injected );
+		$this->assertWPError( $result );
+		$this->assertSame( 'sd_ai_agent_style_variation_stale_hash', $result->get_error_code() );
+		$this->assertSame( '#4338ca', $this->read_document( $target )['styles']['color']['text'] );
+	}
+
+	/**
+	 * Selection rechecks its exact source immediately before persisting Global Styles state.
+	 */
+	public function test_select_refuses_source_changed_while_preparing_global_styles(): void {
+		$manager     = new StyleVariationManager();
+		$original    = $this->variation_document( 'select-race', '#be123c' );
+		$created     = $manager->create( $original );
+		$replacement = $this->variation_document( 'select-race', '#1d4ed8' );
+		$target      = $this->childDir . '/styles/select-race.json';
+		$injected    = false;
+		$independent = function ( string $slug, string $relative_path ) use ( $target, $replacement, &$injected ): void {
+			if ( 'select-race' !== $slug || 'styles/select-race.json' !== $relative_path || $injected ) {
+				return;
+			}
+
+			$injected = true;
+			$this->write_document( $target, $replacement );
+		};
+		$this->assertIsArray( $created, is_wp_error( $created ) ? $created->get_error_message() : '' );
+		add_action( 'sd_ai_agent_before_style_variation_select', $independent, 10, 2 );
+		try {
+			$result = $manager->select( 'select-race', $created['hash'] );
+		} finally {
+			remove_action( 'sd_ai_agent_before_style_variation_select', $independent, 10 );
+		}
+
+		$this->assertTrue( $injected );
+		$this->assertWPError( $result );
+		$this->assertSame( 'sd_ai_agent_style_variation_stale_hash', $result->get_error_code() );
+		$this->assertFalse( get_option( StyleVariationManager::STATE_OPTION, false ) );
+	}
+
+	/**
+	 * Existing file mutation hooks remain available to change tracking for both write paths.
+	 */
+	public function test_create_and_update_emit_existing_file_mutation_hooks(): void {
+		$manager  = new StyleVariationManager();
+		$events   = [];
+		$record   = static function ( string $event ) use ( &$events ): callable {
+			return static function () use ( $event, &$events ): void {
+				$events[] = $event;
+			};
+		};
+		$before_write = $record( 'before-write' );
+		$after_write  = $record( 'after-write' );
+		$before_edit  = $record( 'before-edit' );
+		$after_edit   = $record( 'after-edit' );
+		add_action( 'sd_ai_agent_before_file_write', $before_write );
+		add_action( 'sd_ai_agent_after_file_write', $after_write );
+		add_action( 'sd_ai_agent_before_file_edit', $before_edit );
+		add_action( 'sd_ai_agent_after_file_edit', $after_edit );
+		try {
+			$created = $manager->create( $this->variation_document( 'hooked', '#7e22ce' ) );
+			$this->assertIsArray( $created, is_wp_error( $created ) ? $created->get_error_message() : '' );
+			$updated = $manager->update( 'hooked', $this->variation_document( 'hooked', '#0f766e' ), $created['hash'] );
+		} finally {
+			remove_action( 'sd_ai_agent_before_file_write', $before_write );
+			remove_action( 'sd_ai_agent_after_file_write', $after_write );
+			remove_action( 'sd_ai_agent_before_file_edit', $before_edit );
+			remove_action( 'sd_ai_agent_after_file_edit', $after_edit );
+		}
+
+		$this->assertIsArray( $updated, is_wp_error( $updated ) ? $updated->get_error_message() : '' );
+		$this->assertSame( [ 'before-write', 'after-write', 'before-edit', 'after-edit' ], $events );
+	}
+
+	/**
+	 * Parent variation files remain visible but cannot be mutated, while child files win by slug.
+	 */
+	public function test_child_precedence_and_parent_read_only_behavior(): void {
+		$shared_document = $this->variation_document( 'shared', '#6b21a8' );
+		$this->write_document(
+			$this->parentDir . '/styles/shared.json',
+			$shared_document
+		);
+		$manager = new StyleVariationManager();
+		$child   = $manager->create( $shared_document );
+		$this->assertIsArray( $child, is_wp_error( $child ) ? $child->get_error_message() : '' );
+
+		$inventory = $manager->list();
+		$this->assertIsArray( $inventory, is_wp_error( $inventory ) ? $inventory->get_error_message() : '' );
+		$shared = array_values(
+			array_filter(
+				$inventory['variations'],
+				static fn( array $variation ): bool => 'shared' === $variation['slug']
+			)
+		);
+
+		$this->assertCount( 2, $shared );
+		$this->assertSame( 'child', $shared[0]['origin'] );
+		$this->assertFalse( $shared[0]['read_only'] );
+		$this->assertSame( 'parent', $shared[1]['origin'] );
+		$this->assertTrue( $shared[1]['read_only'] );
+
+		$resolved = $manager->validate_existing( 'shared' );
+		$this->assertIsArray( $resolved, is_wp_error( $resolved ) ? $resolved->get_error_message() : '' );
+		$this->assertSame( 'child', $resolved['origin'] );
+		$this->assertSame( $child['hash'], $resolved['hash'] );
+		$this->assertSame( $child['hash'], $shared[1]['hash'] );
+
+		$selected = $manager->select( 'shared', $child['hash'] );
+		$this->assertIsArray( $selected, is_wp_error( $selected ) ? $selected->get_error_message() : '' );
+		$selected_inventory = $manager->list();
+		$this->assertIsArray( $selected_inventory, is_wp_error( $selected_inventory ) ? $selected_inventory->get_error_message() : '' );
+		$selected_records = array_values(
+			array_filter(
+				$selected_inventory['variations'],
+				static fn( array $variation ): bool => 'shared' === $variation['slug'] && $variation['selected']
+			)
+		);
+		$this->assertCount( 1, $selected_records );
+		$this->assertSame( 'child', $selected_records[0]['origin'] );
+
+		$this->write_document(
+			$this->parentDir . '/styles/parent-only.json',
+			$this->variation_document( 'parent-only', '#4c1d95' )
+		);
+		$parent = $manager->validate_existing( 'parent-only' );
+		$this->assertIsArray( $parent, is_wp_error( $parent ) ? $parent->get_error_message() : '' );
+		$this->assertTrue( $parent['read_only'] );
+
+		$update = $manager->update(
+			'parent-only',
+			$this->variation_document( 'parent-only', '#7e22ce' ),
+			$parent['hash']
+		);
+		$this->assertWPError( $update );
+		$this->assertSame( 'sd_ai_agent_style_variation_read_only', $update->get_error_code() );
+	}
+
+	/**
+	 * Preview is pure; selection and reset restore exact pre-selection bytes.
+	 */
+	public function test_preview_is_pure_and_reset_restores_exact_global_styles_baseline(): void {
+		$manager  = new StyleVariationManager();
+		$document = $this->variation_document( 'ocean', '#0e7490' );
+		$created  = $manager->create( $document );
+		$this->assertIsArray( $created, is_wp_error( $created ) ? $created->get_error_message() : '' );
+
+		$baseline = ( new GlobalStylesService() )->merge_user_document(
+			[
+				'settings' => [ 'custom' => [ 'userOwned' => 'preserve-me' ] ],
+				'styles'   => [ 'color' => [ 'text' => '#111111' ] ],
+			]
+		);
+		$this->assertIsArray( $baseline, is_wp_error( $baseline ) ? $baseline->get_error_message() : '' );
+		$before_content = (string) get_post( $baseline['post_id'] )->post_content;
+
+		$preview = $manager->preview( $document );
+		$this->assertIsArray( $preview, is_wp_error( $preview ) ? $preview->get_error_message() : '' );
+		$this->assertNotEmpty( $preview['changed_paths'] );
+		$this->assertIsString( $preview['css'] );
+		$this->assertSame( $before_content, (string) get_post( $baseline['post_id'] )->post_content );
+		$this->assertFalse( get_option( StyleVariationManager::STATE_OPTION, false ) );
+
+		$selected = $manager->select( 'ocean', $created['hash'] );
+		$this->assertIsArray( $selected, is_wp_error( $selected ) ? $selected->get_error_message() : '' );
+		$this->assertTrue( $selected['selected'] );
+
+		$selected_content = (string) get_post( $baseline['post_id'] )->post_content;
+		$this->assertNotSame( $before_content, $selected_content );
+		$selected_document = json_decode( $selected_content, true );
+		$this->assertIsArray( $selected_document );
+		$this->assertSame( 'preserve-me', $selected_document['settings']['custom']['userOwned'] );
+		$this->assertSame( '#0e7490', $selected_document['styles']['color']['text'] );
+
+		$state = get_option( StyleVariationManager::STATE_OPTION );
+		$this->assertIsArray( $state );
+		$this->assertSame( $before_content, $state[ $this->childSlug ]['baseline']['content'] );
+
+		$reset = $manager->reset();
+		$this->assertIsArray( $reset, is_wp_error( $reset ) ? $reset->get_error_message() : '' );
+		$this->assertTrue( $reset['reset'] );
+		$this->assertSame( $before_content, (string) get_post( $baseline['post_id'] )->post_content );
+		$this->assertFalse( get_option( StyleVariationManager::STATE_OPTION, false ) );
+	}
+
+	/**
+	 * Reset refuses to overwrite intervening Site Editor changes.
+	 */
+	public function test_reset_refuses_intervening_global_styles_changes(): void {
+		$manager  = new StyleVariationManager();
+		$created  = $manager->create( $this->variation_document( 'forest', '#166534' ) );
+		$this->assertIsArray( $created, is_wp_error( $created ) ? $created->get_error_message() : '' );
+		$selected = $manager->select( 'forest', $created['hash'] );
+		$this->assertIsArray( $selected, is_wp_error( $selected ) ? $selected->get_error_message() : '' );
+
+		$state       = get_option( StyleVariationManager::STATE_OPTION );
+		$post_id     = $state[ $this->childSlug ]['selected']['post_id'];
+		$site_editor = wp_update_post(
+			[
+				'ID'           => $post_id,
+				'post_content' => wp_json_encode(
+					[
+						'version'                     => WP_Theme_JSON::LATEST_SCHEMA,
+						'isGlobalStylesUserThemeJSON' => true,
+						'settings'                    => [ 'custom' => [ 'siteEditor' => 'do-not-overwrite' ] ],
+					]
+				),
+			],
+			true
+		);
+		$this->assertNotWPError( $site_editor );
+		$changed_content = (string) get_post( $post_id )->post_content;
+
+		$reset = $manager->reset();
+		$this->assertWPError( $reset );
+		$this->assertSame( 'sd_ai_agent_style_variation_global_styles_changed', $reset->get_error_code() );
+		$this->assertSame( $changed_content, (string) get_post( $post_id )->post_content );
+		$this->assertIsArray( get_option( StyleVariationManager::STATE_OPTION ) );
+	}
+
+	/**
+	 * Generated semantic-map documents must preserve every design-token colour role.
+	 */
+	public function test_validate_rejects_incomplete_compiled_semantic_map(): void {
+		$document = $this->variation_document( 'incomplete', '#1d4ed8' );
+		$document['settings']['custom']['sdAiAgent'] = [
+			'semantic' => [
+				'color' => [ 'primary' => 'var:preset|color|brand' ],
+			],
+		];
+
+		$result = ( new StyleVariationManager() )->validate_document( $document );
+		$this->assertWPError( $result );
+		$this->assertSame( 'sd_ai_agent_style_variation_semantics_invalid', $result->get_error_code() );
+	}
+
+	/**
+	 * Stage one minimal block theme that WordPress can activate and resolve.
+	 */
+	private function stage_theme( string $directory, string $slug, string $name, ?string $parent_slug ): void {
+		wp_mkdir_p( $directory . '/styles' );
+		wp_mkdir_p( $directory . '/templates' );
+
+		$template_header = null === $parent_slug ? '' : "Template: {$parent_slug}\n";
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test-only disposable theme fixture.
+		file_put_contents(
+			$directory . '/style.css',
+			"/*\nTheme Name: {$name}\n{$template_header}Version: 1.0.0\n*/\n"
+		);
+		$this->write_document(
+			$directory . '/theme.json',
+			[
+				'$schema'  => 'https://schemas.wp.org/trunk/theme.json',
+				'version'  => WP_Theme_JSON::LATEST_SCHEMA,
+				'settings' => [],
+				'styles'   => [],
+			]
+		);
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test-only disposable block template fixture.
+		file_put_contents( $directory . '/templates/index.html', '<!-- wp:paragraph --><p>Fixture</p><!-- /wp:paragraph -->' );
+	}
+
+	/**
+	 * Return one valid complete style-variation document.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function variation_document( string $slug, string $color ): array {
+		return [
+			'$schema'  => 'https://schemas.wp.org/trunk/theme.json',
+			'version'  => WP_Theme_JSON::LATEST_SCHEMA,
+			'slug'     => $slug,
+			'title'    => ucwords( str_replace( '-', ' ', $slug ) ),
+			'settings' => [
+				'color' => [
+					'palette' => [
+						[
+							'slug'  => 'brand',
+							'name'  => 'Brand',
+							'color' => $color,
+						],
+					],
+				],
+			],
+			'styles'   => [
+				'color' => [
+					'text'       => $color,
+					'background' => '#ffffff',
+				],
+			],
+		];
+	}
+
+	/**
+	 * Write one test-only JSON document.
+	 *
+	 * @param array<string,mixed> $document JSON document.
+	 */
+	private function write_document( string $path, array $document ): void {
+		$json = wp_json_encode( $document, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+		$this->assertIsString( $json );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture setup.
+		file_put_contents( $path, $json );
+	}
+
+	/**
+	 * Read one test-only JSON document.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function read_document( string $path ): array {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Test fixture assertion.
+		$document = json_decode( (string) file_get_contents( $path ), true );
+		$this->assertIsArray( $document );
+
+		return $document;
+	}
+
+	/**
+	 * Delete only Global Styles posts assigned to this disposable child stylesheet.
+	 */
+	private function delete_child_global_styles(): void {
+		$posts = get_posts(
+			[
+				'post_type'      => 'wp_global_styles',
+				'post_status'    => 'any',
+				'posts_per_page' => -1,
+				'tax_query'      => [
+					[
+						'taxonomy' => 'wp_theme',
+						'field'    => 'name',
+						'terms'    => $this->childSlug,
+					],
+				],
+				'no_found_rows'  => true,
+			]
+		);
+
+		foreach ( $posts as $post ) {
+			wp_delete_post( $post->ID, true );
+		}
+	}
+
+	/**
+	 * Recursively remove a disposable test theme.
+	 */
+	private static function rrmdir( string $directory ): void {
+		if ( ! is_dir( $directory ) ) {
+			return;
+		}
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_scandir -- Test-only disposable theme cleanup.
+		$entries = scandir( $directory );
+		if ( false === $entries ) {
+			return;
+		}
+		foreach ( $entries as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+			$path = $directory . '/' . $entry;
+			if ( is_dir( $path ) ) {
+				self::rrmdir( $path );
+				continue;
+			}
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Test-only disposable theme cleanup.
+			unlink( $path );
+		}
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.rmdir_rmdir -- Test-only disposable theme cleanup.
+		rmdir( $directory );
+	}
+}

--- a/tests/SdAiAgent/Abilities/ToolCapabilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/ToolCapabilitiesTest.php
@@ -423,6 +423,13 @@ class ToolCapabilitiesTest extends WP_UnitTestCase {
 			'sd-ai-agent/file-write',
 			'sd-ai-agent/navigate',
 			'sd-ai-agent/compile-design-tokens',
+			'sd-ai-agent/list-style-variations',
+			'sd-ai-agent/create-style-variation',
+			'sd-ai-agent/update-style-variation',
+			'sd-ai-agent/validate-style-variation',
+			'sd-ai-agent/preview-style-variation',
+			'sd-ai-agent/select-style-variation',
+			'sd-ai-agent/reset-style-variation',
 		];
 
 		foreach ( $expected as $id ) {
@@ -438,5 +445,26 @@ class ToolCapabilitiesTest extends WP_UnitTestCase {
 			[ 'edit_theme_options' ],
 			ToolCapabilities::resolve_core_caps( 'sd-ai-agent/compile-design-tokens' )
 		);
+	}
+
+	/**
+	 * Style-variation lifecycle abilities stay behind the standard theme gate.
+	 */
+	public function test_style_variation_lifecycle_requires_edit_theme_options(): void {
+		foreach ( [
+			'sd-ai-agent/list-style-variations',
+			'sd-ai-agent/create-style-variation',
+			'sd-ai-agent/update-style-variation',
+			'sd-ai-agent/validate-style-variation',
+			'sd-ai-agent/preview-style-variation',
+			'sd-ai-agent/select-style-variation',
+			'sd-ai-agent/reset-style-variation',
+		] as $ability ) {
+			$this->assertSame(
+				[ 'edit_theme_options' ],
+				ToolCapabilities::resolve_core_caps( $ability ),
+				$ability
+			);
+		}
 	}
 }

--- a/tests/SdAiAgent/Models/AgentThemeBuilderTest.php
+++ b/tests/SdAiAgent/Models/AgentThemeBuilderTest.php
@@ -164,6 +164,13 @@ class AgentThemeBuilderTest extends WP_UnitTestCase {
 			'sd-ai-agent/generate-menu-page',
 			'sd-ai-agent/validate-palette-contrast',
 			'sd-ai-agent/compile-design-tokens',
+			'sd-ai-agent/list-style-variations',
+			'sd-ai-agent/create-style-variation',
+			'sd-ai-agent/update-style-variation',
+			'sd-ai-agent/validate-style-variation',
+			'sd-ai-agent/preview-style-variation',
+			'sd-ai-agent/select-style-variation',
+			'sd-ai-agent/reset-style-variation',
 			'sd-ai-agent/site-scrape',
 			'sd-ai-agent/stock-image',
 			'sd-ai-agent/generate-image',
@@ -240,6 +247,27 @@ class AgentThemeBuilderTest extends WP_UnitTestCase {
 		$this->assertNotFalse( $scaffold_position );
 		$this->assertLessThan( $scaffold_position, $validation_position );
 		$this->assertStringContainsString( '`passed` field is exactly `true`', $agent->system_prompt );
+	}
+
+	/**
+	 * The Setup Assistant routes variation changes through the explicit lifecycle.
+	 */
+	public function test_setup_assistant_uses_style_variation_lifecycle(): void {
+		Agent::reset_defaults();
+
+		$agent = Agent::get_by_slug( Agent::ONBOARDING_AGENT_SLUG );
+		$this->assertNotNull( $agent );
+
+		foreach ( [
+			'sd-ai-agent/list-style-variations',
+			'sd-ai-agent/validate-style-variation',
+			'sd-ai-agent/preview-style-variation',
+			'sd-ai-agent/select-style-variation',
+			'sd-ai-agent/reset-style-variation',
+			'Never use generic file writes or wholesale Global Styles reset',
+		] as $required ) {
+			$this->assertStringContainsString( $required, $agent->system_prompt );
+		}
 	}
 
 	/**

--- a/tests/SdAiAgent/Models/BlockThemesSkillTest.php
+++ b/tests/SdAiAgent/Models/BlockThemesSkillTest.php
@@ -66,6 +66,28 @@ class BlockThemesSkillTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Dedicated variation lifecycle guidance protects files and Global Styles.
+	 */
+	public function test_block_themes_skill_documents_style_variation_lifecycle(): void {
+		$content = Skill::get_builtin_definitions()['wp-block-themes']['content'];
+
+		foreach ( [
+			'### Style-variation lifecycle',
+			'sd-ai-agent/list-style-variations',
+			'sd-ai-agent/create-style-variation',
+			'sd-ai-agent/update-style-variation',
+			'sd-ai-agent/validate-style-variation',
+			'sd-ai-agent/preview-style-variation',
+			'sd-ai-agent/select-style-variation',
+			'sd-ai-agent/reset-style-variation',
+			'original baseline',
+			'intervening Site Editor changes',
+		] as $required ) {
+			$this->assertStringContainsString( $required, $content );
+		}
+	}
+
+	/**
 	 * The skill includes the animation, reduced-motion, and editor-visibility safeguards.
 	 */
 	public function test_block_themes_skill_includes_motion_and_editor_visibility_safeguards(): void {


### PR DESCRIPTION
Resolves #2251

## Summary

- Adds safe lifecycle management for block-theme style variations, including site-scoped locking and expired-lock recovery.
- Revalidates variation sources immediately before selection persistence and exposes the lifecycle actions through explicit abilities and capability mappings.
- Adds lifecycle race, stale-hash, hook, preview, parent/child, reset, and agent-guidance coverage.

## Worker self-verification

- PHPUnit: Tests: 3852, Assertions: 16497, Errors: 0, Failures: 0, Skipped: 125, Incomplete: 4
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.155 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-terra spent 1h 28m and 1,276,893 tokens on this as a headless worker.
