### PR TITLE
GH#2250: validate generated block-theme projects

### DIFF
--- a/advanced-plugin/includes/Abilities/ScaffoldBlockThemeAbility.php
+++ b/advanced-plugin/includes/Abilities/ScaffoldBlockThemeAbility.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Abilities;
 
 use SdAiAgent\DesignSystem\ArtifactReleaseManager;
+use SdAiAgent\Services\BlockThemeProjectValidator;
 use WP_Error;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -224,6 +225,7 @@ class ScaffoldBlockThemeAbility extends AbstractAbility {
 			'style.css'     => self::build_style_css( $slug, $name, $description, $author ),
 			'functions.php' => self::build_functions_php( $slug ),
 		];
+		$files[ BlockThemeProjectValidator::MARKER_PATH ] = BlockThemeProjectValidator::marker_contents();
 
 		// Lay down minimum template files so the theme is valid on activation:
 		// a block theme requires at least templates/index.html. We provide a

--- a/includes/Abilities/ActivateThemeAbility.php
+++ b/includes/Abilities/ActivateThemeAbility.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Abilities;
 
+use SdAiAgent\Services\BlockThemeProjectValidator;
 use WP_Error;
 use WP_Theme;
 
@@ -125,6 +126,24 @@ class ActivateThemeAbility extends AbstractAbility {
 				'sd_ai_agent_theme_requirements_unmet',
 				$requirements_check->get_error_message()
 			);
+		}
+
+		// Generated projects opt in to a strict, read-only integrity gate. Keep
+		// unmarked third-party themes on WordPress's existing activation path.
+		$theme_root = $theme->get_stylesheet_directory();
+		if ( BlockThemeProjectValidator::is_marked_project( $theme_root ) ) {
+			$report = ( new BlockThemeProjectValidator() )->validate( $theme_root );
+			if ( ! $report['valid'] ) {
+				return new WP_Error(
+					'sd_ai_agent_block_theme_project_invalid',
+					__( 'The generated block-theme project has validation errors and cannot be activated.', 'superdav-ai-agent' ),
+					[
+						'diagnostics'     => $report['errors'],
+						'warnings'        => $report['warnings'],
+						'project_version' => $report['project_version'],
+					]
+				);
+			}
 		}
 
 		$previous_stylesheet = (string) get_stylesheet();

--- a/includes/Abilities/ThemeBuilderAbilities.php
+++ b/includes/Abilities/ThemeBuilderAbilities.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  *
  *   - sd-ai-agent/compile-design-tokens
  *   - sd-ai-agent/scaffold-block-theme
+ *   - sd-ai-agent/validate-block-theme-project
  *   - sd-ai-agent/activate-theme
  *
  * These abilities also stand alone outside onboarding — any agent flow that
@@ -54,6 +55,18 @@ class ThemeBuilderAbilities {
 					'superdav-ai-agent'
 				),
 				'ability_class' => ActivateThemeAbility::class,
+			]
+		);
+
+		wp_register_ability(
+			'sd-ai-agent/validate-block-theme-project',
+			[
+				'label'         => __( 'Validate Block Theme Project', 'superdav-ai-agent' ),
+				'description'   => __(
+					'Read and validate a complete block-theme project before activation. Returns deterministic diagnostics for theme.json, templates, parts, patterns, style variations, assets, placeholders, and block markup without writing files or executing project PHP.',
+					'superdav-ai-agent'
+				),
+				'ability_class' => ValidateBlockThemeProjectAbility::class,
 			]
 		);
 

--- a/includes/Abilities/ToolCapabilities.php
+++ b/includes/Abilities/ToolCapabilities.php
@@ -63,6 +63,8 @@ class ToolCapabilities {
 	 */
 	public const FALLBACK_CAP = 'manage_options';
 
+	private const VALIDATE_THEME_PROJECT_ABILITY = 'sd-ai-agent/validate-block-theme-project';
+
 	/**
 	 * Map of ability ID → required WordPress core capability (or list of
 	 * capabilities — all must be held).
@@ -141,6 +143,7 @@ class ToolCapabilities {
 		'sd-ai-agent/preview-style-variation'    => 'edit_theme_options',
 		'sd-ai-agent/select-style-variation'     => 'edit_theme_options',
 		'sd-ai-agent/reset-style-variation'      => 'edit_theme_options',
+		self::VALIDATE_THEME_PROJECT_ABILITY     => 'edit_theme_options',
 		'sd-ai-agent/generate-logo-svg'          => 'upload_files',
 
 		// ─── Menus ──────────────────────────────────────────────────────────

--- a/includes/Abilities/ValidateBlockThemeProjectAbility.php
+++ b/includes/Abilities/ValidateBlockThemeProjectAbility.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Read-only ability for validating generated block-theme projects.
+ *
+ * @package SdAiAgent\Abilities
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Abilities;
+
+use SdAiAgent\Services\BlockThemeProjectValidator;
+use WP_Error;
+use WP_Theme;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Exposes deterministic generated-theme project validation to agents.
+ */
+class ValidateBlockThemeProjectAbility extends AbstractAbility {
+
+	private const STYLESHEET_PATTERN = '/^[a-z0-9-]+$/';
+
+	protected function label(): string {
+		return __( 'Validate Block Theme Project', 'superdav-ai-agent' );
+	}
+
+	protected function description(): string {
+		return __(
+			'Validate a complete block-theme project before activation. Returns deterministic, path-specific diagnostics for theme.json, templates, parts, patterns, variations, tokens, local assets, placeholders, and block markup without writing files or executing project PHP.',
+			'superdav-ai-agent'
+		);
+	}
+
+	protected function input_schema(): array {
+		return [
+			'type'                 => 'object',
+			'properties'           => [
+				'stylesheet' => [
+					'type'        => 'string',
+					'description' => 'Installed theme stylesheet (directory name) to validate.',
+				],
+			],
+			'required'             => [ 'stylesheet' ],
+			'additionalProperties' => false,
+		];
+	}
+
+	protected function output_schema(): array {
+		return [
+			'type'       => 'object',
+			'properties' => [
+				'valid'           => [ 'type' => 'boolean' ],
+				'marked'          => [ 'type' => 'boolean' ],
+				'project_version' => [ 'type' => 'integer' ],
+				'fingerprint'     => [ 'type' => 'string' ],
+				'files_scanned'   => [ 'type' => 'integer' ],
+				'errors'          => [
+					'type'  => 'array',
+					'items' => [ 'type' => 'object' ],
+				],
+				'warnings'        => [
+					'type'  => 'array',
+					'items' => [ 'type' => 'object' ],
+				],
+			],
+			'required'   => [ 'valid', 'marked', 'project_version', 'fingerprint', 'files_scanned', 'errors', 'warnings' ],
+		];
+	}
+
+	protected function execute_callback( $input ): array|WP_Error {
+		$stylesheet_input = is_array( $input ) && isset( $input['stylesheet'] ) ? (string) $input['stylesheet'] : '';
+		$stylesheet       = sanitize_title( $stylesheet_input );
+
+		if ( '' === $stylesheet || ! preg_match( self::STYLESHEET_PATTERN, $stylesheet ) ) {
+			return new WP_Error(
+				'sd_ai_agent_invalid_stylesheet',
+				__( 'Stylesheet must contain only lowercase letters, digits, and hyphens.', 'superdav-ai-agent' )
+			);
+		}
+
+		if ( ! function_exists( 'wp_get_theme' ) ) {
+			return new WP_Error(
+				'sd_ai_agent_theme_api_unavailable',
+				__( 'WordPress theme API is not loaded.', 'superdav-ai-agent' )
+			);
+		}
+
+		$theme = wp_get_theme( $stylesheet );
+		if ( ! $theme instanceof WP_Theme || ! $theme->exists() ) {
+			return new WP_Error(
+				'sd_ai_agent_theme_not_found',
+				/* translators: %s: theme stylesheet */
+				sprintf( __( 'Theme "%s" is not installed.', 'superdav-ai-agent' ), $stylesheet )
+			);
+		}
+
+		return ( new BlockThemeProjectValidator() )->validate( $theme->get_stylesheet_directory() );
+	}
+
+	protected function permission_callback( $input ): bool {
+		return ToolCapabilities::current_user_can( $this->name )
+			&& current_user_can( 'edit_theme_options' );
+	}
+
+	protected function meta(): array {
+		return [
+			'mcp'          => [ 'public' => true ],
+			'annotations'  => [
+				'readonly'    => true,
+				'destructive' => false,
+				'idempotent'  => true,
+			],
+			'show_in_rest' => true,
+		];
+	}
+}

--- a/includes/Core/BlockValidator.php
+++ b/includes/Core/BlockValidator.php
@@ -219,14 +219,15 @@ class BlockValidator {
 	 * on every recognised block (see {@see CORE_BLOCK_RULES}), then applies
 	 * the content policy (BlockContentPolicy) to every core/html block result.
 	 *
-	 * When the {@see BlockValidatorBridge} cache contains live JS-validator
-	 * results for the same content (keyed by SHA-256), those override the
-	 * server-side report so third-party blocks get true `wp.blocks.validateBlock()`
-	 * coverage.
+	 * When $use_browser_cache is true and the {@see BlockValidatorBridge} cache
+	 * contains live JS-validator results for the same content (keyed by SHA-256),
+	 * those override the server-side report so third-party blocks get true
+	 * `wp.blocks.validateBlock()` coverage.
 	 *
 	 * @since 1.11.0
 	 *
-	 * @param string $content Raw Gutenberg block markup.
+	 * @param string $content           Raw Gutenberg block markup.
+	 * @param bool   $use_browser_cache Whether browser validation cache entries may override the PHP report.
 	 * @return array{
 	 *   totalBlocks: int,
 	 *   validBlocks: int,
@@ -235,27 +236,29 @@ class BlockValidator {
 	 *   source: string,
 	 * } Studio-shaped validation report. `source` is one of: `php`, `js-cached`.
 	 */
-	public function validate( string $content ): array {
-		// Prefer browser-validated cached result when available.
-		$cached = BlockValidatorBridge::get_cached( $content );
-		if ( null !== $cached ) {
-			// Still apply BlockContentPolicy on top of cached JS results so
-			// the core/html policy stays consistent between the two engines.
-			$cached_results = [];
-			foreach ( (array) ( $cached['results'] ?? [] ) as $result ) {
-				/** @var array<string, mixed> $result */
-				$cached_results[] = BlockContentPolicy::apply( $result );
+	public function validate( string $content, bool $use_browser_cache = true ): array {
+		if ( $use_browser_cache ) {
+			// Prefer browser-validated cached result when available.
+			$cached = BlockValidatorBridge::get_cached( $content );
+			if ( null !== $cached ) {
+				// Still apply BlockContentPolicy on top of cached JS results so
+				// the core/html policy stays consistent between the two engines.
+				$cached_results = [];
+				foreach ( (array) ( $cached['results'] ?? [] ) as $result ) {
+					/** @var array<string, mixed> $result */
+					$cached_results[] = BlockContentPolicy::apply( $result );
+				}
+
+				$total                   = count( $cached_results );
+				$invalid                 = count( array_filter( $cached_results, static fn( $r ) => empty( $r['isValid'] ) ) );
+				$cached['results']       = $cached_results;
+				$cached['totalBlocks']   = $total;
+				$cached['validBlocks']   = $total - $invalid;
+				$cached['invalidBlocks'] = $invalid;
+				$cached['source']        = 'js-cached';
+
+				return $cached;
 			}
-
-			$total                   = count( $cached_results );
-			$invalid                 = count( array_filter( $cached_results, static fn( $r ) => empty( $r['isValid'] ) ) );
-			$cached['results']       = $cached_results;
-			$cached['totalBlocks']   = $total;
-			$cached['validBlocks']   = $total - $invalid;
-			$cached['invalidBlocks'] = $invalid;
-			$cached['source']        = 'js-cached';
-
-			return $cached;
 		}
 
 		$parsed  = parse_blocks( $content );
@@ -283,6 +286,25 @@ class BlockValidator {
 			'results'       => $policied,
 			'source'        => 'php',
 		];
+	}
+
+	/**
+	 * Validate content from deterministic server-side parsing only.
+	 *
+	 * Generated project checks must not depend on browser-posted transient
+	 * results because the same files must always produce the same diagnostics.
+	 *
+	 * @param string $content Raw Gutenberg block markup.
+	 * @return array{
+	 *   totalBlocks: int,
+	 *   validBlocks: int,
+	 *   invalidBlocks: int,
+	 *   results: list<array<string, mixed>>,
+	 *   source: string,
+	 * } Studio-shaped validation report with source `php`.
+	 */
+	public function validate_server_side( string $content ): array {
+		return $this->validate( $content, false );
 	}
 
 	/**

--- a/includes/Core/SkillAutoInjector.php
+++ b/includes/Core/SkillAutoInjector.php
@@ -37,6 +37,8 @@ class SkillAutoInjector {
 	 */
 	private const MAX_INJECTED_SKILLS = 1;
 
+	private const VALIDATE_THEME_PROJECT_ABILITY = 'sd-ai-agent/validate-block-theme-project';
+
 	/**
 	 * Keyword-to-skill trigger map.
 	 *
@@ -221,6 +223,7 @@ class SkillAutoInjector {
 		'sd-ai-agent/get-block-type'         => 'gutenberg-blocks',
 		'sd-ai-agent/get-theme-json'         => 'wp-block-themes',
 		'sd-ai-agent/compile-design-tokens'  => 'wp-block-themes',
+		self::VALIDATE_THEME_PROJECT_ABILITY => 'wp-block-themes',
 		'sd-ai-agent/get-global-styles'      => 'wp-block-themes',
 		'sd-ai-agent/update-global-styles'   => 'wp-block-themes',
 		'sd-ai-agent/reset-global-styles'    => 'wp-block-themes',

--- a/includes/Models/Agent.php
+++ b/includes/Models/Agent.php
@@ -626,6 +626,7 @@ class Agent {
 						'sd-ai-agent/get-themes',
 						// Theme + page build suite (from legacy Theme Builder).
 						'sd-ai-agent/scaffold-block-theme',
+						'sd-ai-agent/validate-block-theme-project',
 						'sd-ai-agent/activate-theme',
 						'sd-ai-agent/file-write',
 						'sd-ai-agent/validate-block-content',
@@ -700,9 +701,10 @@ class Agent {
 			. "11. Create the CTA target page as a published page (e.g. /contact/ for services, /shop/ for retail, /menu/ for hospitality — but hospitality CTAs stay as a Phase 3 \"Add menu\" prompt if no menu data exists yet, in which case use /about/ as the temporary CTA target).\n"
 			. "12. Update `templates/front-page.html` to replace `href=\"#\"` and \"Call to action\" with the real CTA URL and text. Re-validate.\n"
 			. "13. Set the published homepage as the front page: `sd-ai-agent/update-option show_on_front=page` and `page_on_front={homepage_id}` (via the options ability path).\n"
-			. "14. Activate the new theme via `sd-ai-agent/activate-theme`.\n"
-			. "15. Save the final site brief and chosen design direction with `sd-ai-agent/memory-save` (category: site_brief).\n"
-			. "16. Reply with a short success message including the live homepage URL and 4–6 Phase 3 follow-up suggestions tailored to the vertical.\n\n";
+			. "14. Call `sd-ai-agent/validate-block-theme-project` for the generated stylesheet. Repair every returned error (including token, asset, placeholder, part, pattern, variation, and block-markup diagnostics) and retry until `valid` is exactly `true`. Do not activate a generated theme with any validation error.\n"
+			. "15. Activate the new theme via `sd-ai-agent/activate-theme`.\n"
+			. "16. Save the final site brief and chosen design direction with `sd-ai-agent/memory-save` (category: site_brief).\n"
+			. "17. Reply with a short success message including the live homepage URL and 4–6 Phase 3 follow-up suggestions tailored to the vertical.\n\n";
 
 		$phase_3 = "## Phase 3: Follow-up loop (both branches)\n\n"
 			. "After the homepage is live (empty-install branch) or after the discover summary (established branch), let the user drive via suggestion chips. Each chip is a discrete, fast action — one ability call or one page at a time. Common chips:\n\n"

--- a/includes/Models/skills/wp-block-themes.md
+++ b/includes/Models/skills/wp-block-themes.md
@@ -39,7 +39,7 @@ In mixed reports #2034, #2050, #2060, #2066, #2074, and #2081, this is only the 
 4. Put templates in `templates/*.html`; put template parts directly in `parts/*.html` (not nested subdirectories).
 5. Prefer filesystem-owned patterns under `patterns/*.php` when the theme should ship reusable layouts.
 6. Put style variations in `styles/*.json`; use the explicit `sd-ai-agent/*-style-variation` lifecycle rather than generic file mutation. Once a user selects a style variation, its selection is stored in the database.
-7. Validate generated block markup before writing templates, parts, or patterns.
+7. Validate generated block markup before writing templates, parts, or patterns; before activation, run `sd-ai-agent/validate-block-theme-project` for its stylesheet and repair every error until `valid: true`. This project-wide, read-only gate checks declarations, references, patterns, variations, local assets, placeholders, and block markup without executing pattern PHP or fetching URLs.
 8. Perform an explicit final quality review before declaring a generated theme complete. Prefer a browser, screenshot, or front-end render check when available; when visual QA is unavailable, perform the structural review in the verification checklist and report that limitation.
 9. For contributor-insight or maintenance changes to this skill, verify future workers load the guidance with `rg -n "wp-block-themes|Full Site Editing|theme.json|validate-block-content" AGENTS.md includes/Models/skills/wp-block-themes.md`.
 

--- a/includes/Services/BlockThemeProjectValidator.php
+++ b/includes/Services/BlockThemeProjectValidator.php
@@ -1,0 +1,1806 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Read-only integrity validation for generated WordPress block-theme projects.
+ *
+ * @package SdAiAgent\Services
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Services;
+
+use SdAiAgent\Core\BlockValidator;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Validates a complete block-theme project without executing project PHP.
+ *
+ * The validator deliberately works from a resolved theme root and only reports
+ * theme-relative paths. It never follows symlinks, mutates files, evaluates
+ * pattern PHP, or requests remote resources.
+ *
+ * @phpstan-type Diagnostic array{code:string,path:string,message:string,location?:array<string,mixed>}
+ * @phpstan-type Diagnostics list<Diagnostic>
+ * @phpstan-type ProjectFile array{path:string,size:int}
+ * @phpstan-type ProjectFiles array<string,ProjectFile>
+ * @phpstan-type TokenMap array<string,true>
+ */
+final class BlockThemeProjectValidator {
+
+	/**
+	 * Hidden, theme-relative marker written by the scaffold ability.
+	 */
+	public const MARKER_PATH = '.sd-ai-agent/block-theme-project.json';
+
+	/**
+	 * Supported marker schema version.
+	 */
+	public const MARKER_SCHEMA_VERSION = 1;
+
+	/**
+	 * Supported validation contract version.
+	 */
+	public const VALIDATION_VERSION = 1;
+
+	/**
+	 * Bounded scanner limits.
+	 */
+	private const MAX_FILE_COUNT      = 500;
+	private const MAX_FILE_SIZE       = 1048576;
+	private const MAX_DIRECTORY_DEPTH = 8;
+
+	/**
+	 * The only remote schema URL permitted in theme.json documents.
+	 */
+	private const THEME_JSON_SCHEMA = 'https://schemas.wp.org/trunk/theme.json';
+
+	/**
+	 * Return the marker payload for a newly scaffolded project.
+	 *
+	 * @return array<string,int|string>
+	 */
+	public static function marker_payload(): array {
+		return [
+			'schema_version'     => self::MARKER_SCHEMA_VERSION,
+			'generator'          => 'sd-ai-agent',
+			'generator_version'  => defined( 'SD_AI_AGENT_VERSION' ) ? (string) SD_AI_AGENT_VERSION : '1.0.0',
+			'validation_version' => self::VALIDATION_VERSION,
+		];
+	}
+
+	/**
+	 * Return a stable marker document suitable for writing to the theme root.
+	 */
+	public static function marker_contents(): string {
+		$encoded = wp_json_encode( self::marker_payload(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
+
+		return ( is_string( $encoded ) ? $encoded : '{}' ) . "\n";
+	}
+
+	/**
+	 * Return an empty typed diagnostic list.
+	 *
+	 * @return Diagnostics
+	 */
+	private static function empty_diagnostics(): array {
+		return [];
+	}
+
+	/**
+	 * Return an empty typed project-file map.
+	 *
+	 * @return ProjectFiles
+	 */
+	private static function empty_project_files(): array {
+		return [];
+	}
+
+	/**
+	 * Return an empty typed CSS-token map.
+	 *
+	 * @return TokenMap
+	 */
+	private static function empty_token_map(): array {
+		return [];
+	}
+
+	/**
+	 * Return an empty typed decoded JSON object.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private static function empty_json_object(): array {
+		return [];
+	}
+
+	/**
+	 * Determine whether the project is opt-in marked for activation gating.
+	 */
+	public static function is_marked_project( string $theme_root ): bool {
+		return file_exists( untrailingslashit( $theme_root ) . '/' . self::MARKER_PATH );
+	}
+
+	/**
+	 * Validate one on-disk project and return exhaustive normalized diagnostics.
+	 *
+	 * @return array{
+	 *   valid:bool,
+	 *   marked:bool,
+	 *   project_version:int,
+	 *   fingerprint:string,
+	 *   files_scanned:int,
+	 *   errors:Diagnostics,
+	 *   warnings:Diagnostics
+	 * }
+	 */
+	public function validate( string $theme_root ): array {
+		$errors   = self::empty_diagnostics();
+		$warnings = self::empty_diagnostics();
+		$root     = $this->resolve_root( $theme_root, $errors );
+
+		if ( null === $root ) {
+			return $this->build_report( false, false, 0, '', 0, $errors, $warnings );
+		}
+
+		$files        = $this->collect_files( $root, $errors );
+		$before       = $this->project_fingerprint( $files );
+		$marker       = $this->validate_marker( $files, $errors );
+		$is_marked    = self::is_marked_project( $root );
+		$project_ver  = is_array( $marker ) ? (int) $marker['schema_version'] : 0;
+		$theme_json   = $this->validate_required_project_files( $files, $errors );
+		$token_values = self::empty_token_map();
+
+		if ( is_array( $theme_json ) ) {
+			$token_values = $this->validate_theme_json( $theme_json, $files, $errors );
+		}
+
+		$this->validate_template_files( $files, $theme_json, $token_values, $errors );
+		$this->validate_pattern_files( $files, basename( $root ), $token_values, $errors );
+		$this->validate_style_variations( $files, $token_values, $errors );
+		$this->validate_text_file_sources( $files, $token_values, $errors );
+
+		$after_diagnostics = self::empty_diagnostics();
+		$after_files       = $this->collect_files( $root, $after_diagnostics );
+		$after             = $this->project_fingerprint( $after_files );
+		if ( $before !== $after ) {
+			$this->add_diagnostic(
+				$errors,
+				'project_changed_during_scan',
+				'.',
+				__( 'The theme project changed during validation. Retry after writes have finished.', 'superdav-ai-agent' ),
+				[ 'retryable' => true ]
+			);
+		}
+
+		return $this->build_report(
+			empty( $errors ),
+			$is_marked,
+			$is_marked ? $project_ver : 0,
+			$before,
+			count( $files ),
+			$errors,
+			$warnings
+		);
+	}
+
+	/**
+	 * Resolve a root only when it is a non-symlinked directory.
+	 *
+	 * @param string $theme_root Theme root supplied for validation.
+	 * @param array  $errors     Diagnostics collected during validation.
+	 * @phpstan-param Diagnostics $errors
+	 */
+	private function resolve_root( string $theme_root, array &$errors ): ?string {
+		$theme_root = untrailingslashit( $theme_root );
+		if ( '' === $theme_root || ! is_dir( $theme_root ) ) {
+			$this->add_diagnostic(
+				$errors,
+				'theme_root_not_found',
+				'.',
+				__( 'The requested theme project directory is unavailable.', 'superdav-ai-agent' )
+			);
+			return null;
+		}
+
+		if ( is_link( $theme_root ) ) {
+			$this->add_diagnostic(
+				$errors,
+				'symlink_theme_root',
+				'.',
+				__( 'The theme project root must not be a symlink.', 'superdav-ai-agent' )
+			);
+			return null;
+		}
+
+		$resolved = realpath( $theme_root );
+		if ( false === $resolved ) {
+			$this->add_diagnostic(
+				$errors,
+				'theme_root_unresolvable',
+				'.',
+				__( 'The theme project root could not be resolved safely.', 'superdav-ai-agent' )
+			);
+			return null;
+		}
+
+		return untrailingslashit( $resolved );
+	}
+
+	/**
+	 * Collect bounded, non-symlinked files beneath a resolved root.
+	 *
+	 * @param string $root        Resolved project root.
+	 * @param array  $diagnostics Diagnostics collected during validation.
+	 * @phpstan-param Diagnostics $diagnostics
+	 * @return ProjectFiles
+	 */
+	private function collect_files( string $root, array &$diagnostics ): array {
+		$files = self::empty_project_files();
+
+		try {
+			$directory = new \RecursiveDirectoryIterator( $root, \FilesystemIterator::SKIP_DOTS );
+			$iterator  = new \RecursiveIteratorIterator( $directory, \RecursiveIteratorIterator::SELF_FIRST );
+			$iterator->setMaxDepth( self::MAX_DIRECTORY_DEPTH );
+
+			foreach ( $iterator as $item ) {
+				$path     = $item->getPathname();
+				$relative = $this->relative_path( $root, $path );
+
+				if ( $item->isLink() ) {
+					$this->add_diagnostic(
+						$diagnostics,
+						'symlink_escape',
+						$relative,
+						__( 'Symlinked project entries are not permitted because they can escape the theme root.', 'superdav-ai-agent' )
+					);
+					continue;
+				}
+
+				if ( $item->isDir() ) {
+					if ( $iterator->getDepth() >= self::MAX_DIRECTORY_DEPTH ) {
+						$this->add_diagnostic(
+							$diagnostics,
+							'directory_depth_exceeded',
+							$relative,
+							__( 'The project contains a directory deeper than the supported validation limit.', 'superdav-ai-agent' )
+						);
+					}
+					continue;
+				}
+
+				if ( ! $item->isFile() ) {
+					continue;
+				}
+
+				$resolved = realpath( $path );
+				if ( false === $resolved || ! $this->is_within_root( $root, $resolved ) ) {
+					$this->add_diagnostic(
+						$diagnostics,
+						'path_escape',
+						$relative,
+						__( 'A project file resolves outside the validated theme root.', 'superdav-ai-agent' )
+					);
+					continue;
+				}
+
+				$size = $item->getSize();
+				if ( ! is_int( $size ) ) {
+					$this->add_diagnostic(
+						$diagnostics,
+						'file_size_unavailable',
+						$relative,
+						__( 'The project file size could not be determined safely.', 'superdav-ai-agent' )
+					);
+					continue;
+				}
+				if ( $size > self::MAX_FILE_SIZE ) {
+					$this->add_diagnostic(
+						$diagnostics,
+						'file_too_large',
+						$relative,
+						__( 'The project file exceeds the supported validation size limit.', 'superdav-ai-agent' ),
+						[ 'max_bytes' => self::MAX_FILE_SIZE ]
+					);
+				}
+
+				$files[ $relative ] = [
+					'path' => $resolved,
+					'size' => $size,
+				];
+
+				if ( count( $files ) > self::MAX_FILE_COUNT ) {
+					$this->add_diagnostic(
+						$diagnostics,
+						'file_count_exceeded',
+						'.',
+						__( 'The project exceeds the supported validation file-count limit.', 'superdav-ai-agent' ),
+						[ 'max_files' => self::MAX_FILE_COUNT ]
+					);
+					break;
+				}
+			}
+		} catch ( \UnexpectedValueException ) {
+			$this->add_diagnostic(
+				$diagnostics,
+				'project_scan_failed',
+				'.',
+				__( 'The theme project could not be scanned safely.', 'superdav-ai-agent' )
+			);
+		}
+
+		ksort( $files, SORT_STRING );
+		return $files;
+	}
+
+	/**
+	 * Return a content fingerprint without including absolute paths.
+	 *
+	 * @param array $files Project files keyed by relative path.
+	 * @phpstan-param ProjectFiles $files
+	 */
+	private function project_fingerprint( array $files ): string {
+		$snapshot = [];
+		foreach ( $files as $relative => $file ) {
+			clearstatcache( true, $file['path'] );
+			$mtime = filemtime( $file['path'] );
+			$hash  = $file['size'] <= self::MAX_FILE_SIZE ? hash_file( 'sha256', $file['path'] ) : false;
+
+			$snapshot[ $relative ] = [
+				'size'  => $file['size'],
+				'mtime' => false === $mtime ? 0 : $mtime,
+				'hash'  => false === $hash ? '' : $hash,
+			];
+		}
+
+		return hash( 'sha256', (string) wp_json_encode( $snapshot ) );
+	}
+
+	/**
+	 * Validate the optional generated-project marker.
+	 *
+	 * @param array $files  Project files keyed by relative path.
+	 * @param array $errors Diagnostics collected during validation.
+	 * @phpstan-param ProjectFiles $files
+	 * @phpstan-param Diagnostics $errors
+	 * @return array<string,mixed>|null Normalized marker when valid.
+	 */
+	private function validate_marker( array $files, array &$errors ): ?array {
+		if ( ! isset( $files[ self::MARKER_PATH ] ) ) {
+			return null;
+		}
+
+		$marker = $this->read_json_file( self::MARKER_PATH, $files, $errors );
+		if ( ! is_array( $marker ) ) {
+			return null;
+		}
+
+		$schema_version = $marker['schema_version'] ?? null;
+		if ( self::MARKER_SCHEMA_VERSION !== $schema_version ) {
+			$this->add_diagnostic(
+				$errors,
+				'unknown_marker_version',
+				self::MARKER_PATH,
+				__( 'The generated-project marker uses an unsupported schema version.', 'superdav-ai-agent' ),
+				[ 'json_path' => 'schema_version' ]
+			);
+		}
+
+		if ( 'sd-ai-agent' !== ( $marker['generator'] ?? null ) ) {
+			$this->add_diagnostic(
+				$errors,
+				'invalid_project_marker',
+				self::MARKER_PATH,
+				__( 'The generated-project marker does not identify the expected generator.', 'superdav-ai-agent' ),
+				[ 'json_path' => 'generator' ]
+			);
+		}
+
+		if ( ! is_string( $marker['generator_version'] ?? null ) || '' === trim( (string) $marker['generator_version'] ) ) {
+			$this->add_diagnostic(
+				$errors,
+				'invalid_project_marker',
+				self::MARKER_PATH,
+				__( 'The generated-project marker must include a generator version.', 'superdav-ai-agent' ),
+				[ 'json_path' => 'generator_version' ]
+			);
+		}
+
+		if ( self::VALIDATION_VERSION !== ( $marker['validation_version'] ?? null ) ) {
+			$this->add_diagnostic(
+				$errors,
+				'unknown_validation_version',
+				self::MARKER_PATH,
+				__( 'The generated-project marker requires an unsupported validator version.', 'superdav-ai-agent' ),
+				[ 'json_path' => 'validation_version' ]
+			);
+		}
+
+		return $marker;
+	}
+
+	/**
+	 * Validate required files and return decoded theme.json when possible.
+	 *
+	 * @param array $files  Project files keyed by relative path.
+	 * @param array $errors Diagnostics collected during validation.
+	 * @phpstan-param ProjectFiles $files
+	 * @phpstan-param Diagnostics $errors
+	 * @return array<string,mixed>|null
+	 */
+	private function validate_required_project_files( array $files, array &$errors ): ?array {
+		foreach ( [ 'theme.json', 'style.css', 'templates/index.html' ] as $required ) {
+			if ( ! isset( $files[ $required ] ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'missing_required_file',
+					$required,
+					__( 'This file is required for a complete WordPress block theme.', 'superdav-ai-agent' )
+				);
+			}
+		}
+
+		if ( isset( $files['style.css'] ) ) {
+			$style_css = $this->read_file( 'style.css', $files, $errors );
+			if ( is_string( $style_css ) && ! preg_match( '/^\s*Theme Name:\s*\S/m', $style_css ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'missing_theme_header',
+					'style.css',
+					__( 'style.css must declare a non-empty Theme Name header.', 'superdav-ai-agent' )
+				);
+			}
+		}
+
+		return $this->read_json_file( 'theme.json', $files, $errors );
+	}
+
+	/**
+	 * Validate theme.json structure and return declared CSS token values.
+	 *
+	 * @param array $theme_json Decoded theme.json object.
+	 * @param array $files      Project files keyed by relative path.
+	 * @param array $errors     Diagnostics collected during validation.
+	 * @phpstan-param array<string,mixed> $theme_json
+	 * @phpstan-param ProjectFiles $files
+	 * @phpstan-param Diagnostics $errors
+	 * @return TokenMap CSS variable definitions.
+	 */
+	private function validate_theme_json( array $theme_json, array $files, array &$errors ): array {
+		if ( 3 !== ( $theme_json['version'] ?? null ) ) {
+			$this->add_diagnostic(
+				$errors,
+				'invalid_theme_json_version',
+				'theme.json',
+				__( 'theme.json must declare version 3 for this WordPress 7.0+ project.', 'superdav-ai-agent' ),
+				[ 'json_path' => 'version' ]
+			);
+		}
+
+		if ( self::THEME_JSON_SCHEMA !== ( $theme_json['$schema'] ?? null ) ) {
+			$this->add_diagnostic(
+				$errors,
+				'invalid_theme_json_schema',
+				'theme.json',
+				__( 'theme.json must declare the canonical WordPress theme.json schema URL.', 'superdav-ai-agent' ),
+				[ 'json_path' => '$schema' ]
+			);
+		}
+
+		$settings = $theme_json['settings'] ?? null;
+		// json_decode( ..., true ) represents a valid empty JSON object as [],
+		// so permit that one ambiguous shape while rejecting populated lists.
+		if ( ! is_array( $settings ) || ( [] !== $settings && array_is_list( $settings ) ) ) {
+			$this->add_diagnostic(
+				$errors,
+				'invalid_theme_json_settings',
+				'theme.json',
+				__( 'theme.json settings must be an object.', 'superdav-ai-agent' ),
+				[ 'json_path' => 'settings' ]
+			);
+			$settings = [];
+		}
+
+		$token_values = $this->collect_token_values( $settings, $errors );
+		$this->validate_font_faces( $settings, $files, $errors );
+		$this->validate_token_references( $theme_json, $token_values, 'theme.json', '', $errors );
+
+		return $token_values;
+	}
+
+	/**
+	 * Collect and validate native preset and custom CSS variable definitions.
+	 *
+	 * @param array $settings Decoded theme.json settings object.
+	 * @param array $errors   Diagnostics collected during validation.
+	 * @phpstan-param array<string,mixed> $settings
+	 * @phpstan-param Diagnostics $errors
+	 * @return TokenMap
+	 */
+	private function collect_token_values( array $settings, array &$errors ): array {
+		$tokens = self::empty_token_map();
+		$this->collect_preset_collection(
+			$settings['color']['palette'] ?? [],
+			'color',
+			'color',
+			[ 'color' ],
+			$tokens,
+			$errors
+		);
+		$this->collect_preset_collection(
+			$settings['typography']['fontFamilies'] ?? [],
+			'font-family',
+			'fontFamily',
+			[ 'typography', 'fontFamilies' ],
+			$tokens,
+			$errors
+		);
+		$this->collect_preset_collection(
+			$settings['typography']['fontSizes'] ?? [],
+			'font-size',
+			'size',
+			[ 'typography', 'fontSizes' ],
+			$tokens,
+			$errors
+		);
+		$this->collect_preset_collection(
+			$settings['spacing']['spacingSizes'] ?? [],
+			'spacing',
+			'size',
+			[ 'spacing', 'spacingSizes' ],
+			$tokens,
+			$errors
+		);
+
+		if ( isset( $settings['custom'] ) ) {
+			if ( ! is_array( $settings['custom'] ) || ( [] !== $settings['custom'] && array_is_list( $settings['custom'] ) ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'invalid_custom_token_definitions',
+					'theme.json',
+					__( 'theme.json settings.custom must be an object when present.', 'superdav-ai-agent' ),
+					[ 'json_path' => 'settings.custom' ]
+				);
+			} else {
+				$this->collect_custom_token_values( $settings['custom'], [], $tokens );
+			}
+		}
+
+		return $tokens;
+	}
+
+	/**
+	 * Validate one native WordPress preset collection.
+	 *
+	 * @param mixed  $items      Preset definitions to validate.
+	 * @param string $kind       WordPress preset kind.
+	 * @param string $value_key  Item key holding the preset value.
+	 * @param array  $json_path  JSON path segments for diagnostics.
+	 * @param array  $tokens     Declared CSS variable names.
+	 * @param array  $errors     Diagnostics collected during validation.
+	 * @phpstan-param list<string> $json_path
+	 * @phpstan-param TokenMap $tokens
+	 * @phpstan-param Diagnostics $errors
+	 */
+	private function collect_preset_collection(
+		mixed $items,
+		string $kind,
+		string $value_key,
+		array $json_path,
+		array &$tokens,
+		array &$errors
+	): void {
+		if ( [] === $items ) {
+			return;
+		}
+
+		$path = implode( '.', $json_path );
+		if ( ! is_array( $items ) || ! array_is_list( $items ) ) {
+			$this->add_diagnostic(
+				$errors,
+				'invalid_preset_definitions',
+				'theme.json',
+				__( 'WordPress preset definitions must be an array of objects.', 'superdav-ai-agent' ),
+				[ 'json_path' => 'settings.' . $path ]
+			);
+			return;
+		}
+
+		$seen = [];
+		foreach ( $items as $index => $item ) {
+			$item_path = 'settings.' . $path . '.' . $index;
+			if ( ! is_array( $item ) || array_is_list( $item ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'invalid_preset_definition',
+					'theme.json',
+					__( 'Each WordPress preset must be an object.', 'superdav-ai-agent' ),
+					[ 'json_path' => $item_path ]
+				);
+				continue;
+			}
+
+			$slug  = $item['slug'] ?? null;
+			$value = $item[ $value_key ] ?? null;
+			$name  = $item['name'] ?? null;
+			if ( ! is_string( $slug ) || ! preg_match( '/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $slug ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'invalid_preset_slug',
+					'theme.json',
+					__( 'Each WordPress preset must have a lowercase kebab-case slug.', 'superdav-ai-agent' ),
+					[ 'json_path' => $item_path . '.slug' ]
+				);
+				continue;
+			}
+
+			if ( isset( $seen[ $slug ] ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'duplicate_preset_slug',
+					'theme.json',
+					__( 'WordPress preset slugs must be unique within their collection.', 'superdav-ai-agent' ),
+					[
+						'json_path' => $item_path . '.slug',
+						'slug'      => $slug,
+					]
+				);
+				continue;
+			}
+			$seen[ $slug ] = true;
+
+			if ( ! is_string( $value ) || '' === trim( $value ) || ! is_string( $name ) || '' === trim( $name ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'invalid_preset_definition',
+					'theme.json',
+					__( 'Each WordPress preset must define non-empty slug, name, and value fields.', 'superdav-ai-agent' ),
+					[ 'json_path' => $item_path ]
+				);
+				continue;
+			}
+
+			$tokens[ '--wp--preset--' . $kind . '--' . $slug ] = true;
+		}
+	}
+
+	/**
+	 * Recursively convert settings.custom leaves to WordPress CSS variable names.
+	 *
+	 * @param mixed $value    Custom token value tree.
+	 * @param array $segments CSS variable path segments.
+	 * @param array $tokens   Declared CSS variable names.
+	 * @phpstan-param list<string> $segments
+	 * @phpstan-param TokenMap $tokens
+	 */
+	private function collect_custom_token_values( mixed $value, array $segments, array &$tokens ): void {
+		if ( ! is_array( $value ) ) {
+			if ( [] !== $segments ) {
+				$tokens[ '--wp--custom--' . implode( '--', $segments ) ] = true;
+			}
+			return;
+		}
+
+		foreach ( $value as $key => $child ) {
+			if ( ! is_string( $key ) || '' === $key ) {
+				continue;
+			}
+			$next   = $segments;
+			$next[] = $this->css_variable_segment( $key );
+			$this->collect_custom_token_values( $child, $next, $tokens );
+		}
+	}
+
+	/**
+	 * Convert a JSON custom-setting key to its CSS variable segment.
+	 */
+	private function css_variable_segment( string $key ): string {
+		$key = preg_replace( '/([a-z0-9])([A-Z])/', '$1-$2', $key ) ?? $key;
+		$key = str_replace( '_', '-', $key );
+
+		return strtolower( $key );
+	}
+
+	/**
+	 * Validate local fontFace source references without fetching them.
+	 *
+	 * @param array $settings Decoded theme.json settings object.
+	 * @param array $files    Project files keyed by relative path.
+	 * @param array $errors   Diagnostics collected during validation.
+	 * @phpstan-param array<string,mixed> $settings
+	 * @phpstan-param ProjectFiles $files
+	 * @phpstan-param Diagnostics $errors
+	 */
+	private function validate_font_faces( array $settings, array $files, array &$errors ): void {
+		$families = $settings['typography']['fontFamilies'] ?? [];
+		if ( ! is_array( $families ) || ! array_is_list( $families ) ) {
+			return;
+		}
+
+		foreach ( $families as $family_index => $family ) {
+			if ( ! is_array( $family ) || ! isset( $family['fontFace'] ) ) {
+				continue;
+			}
+
+			$faces = $family['fontFace'];
+			if ( ! is_array( $faces ) || ! array_is_list( $faces ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'invalid_font_face',
+					'theme.json',
+					__( 'fontFace must be an array of local font declarations.', 'superdav-ai-agent' ),
+					[ 'json_path' => 'settings.typography.fontFamilies.' . $family_index . '.fontFace' ]
+				);
+				continue;
+			}
+
+			foreach ( $faces as $face_index => $face ) {
+				$sources = is_array( $face ) ? ( $face['src'] ?? null ) : null;
+				$sources = is_string( $sources ) ? [ $sources ] : $sources;
+				if ( ! is_array( $sources ) || [] === $sources ) {
+					$this->add_diagnostic(
+						$errors,
+						'invalid_font_face',
+						'theme.json',
+						__( 'Each fontFace declaration must include one or more local source files.', 'superdav-ai-agent' ),
+						[ 'json_path' => 'settings.typography.fontFamilies.' . $family_index . '.fontFace.' . $face_index . '.src' ]
+					);
+					continue;
+				}
+
+				foreach ( $sources as $source_index => $source ) {
+					$this->validate_asset_reference(
+						is_string( $source ) ? $source : '',
+						'theme.json',
+						'font',
+						$files,
+						$errors,
+						[ 'json_path' => 'settings.typography.fontFamilies.' . $family_index . '.fontFace.' . $face_index . '.src.' . $source_index ]
+					);
+				}
+			}
+		}
+	}
+
+	/**
+	 * Validate all emitted WordPress preset/custom CSS references in a value tree.
+	 *
+	 * @param mixed  $value     Value tree to inspect.
+	 * @param array  $tokens    Declared CSS variable names.
+	 * @param string $relative  Theme-relative source path.
+	 * @param string $json_path JSON path for diagnostics.
+	 * @param array  $errors    Diagnostics collected during validation.
+	 * @phpstan-param TokenMap $tokens
+	 * @phpstan-param Diagnostics $errors
+	 */
+	private function validate_token_references( mixed $value, array $tokens, string $relative, string $json_path, array &$errors ): void {
+		if ( is_array( $value ) ) {
+			foreach ( $value as $key => $child ) {
+				$next_path = '' === $json_path ? (string) $key : $json_path . '.' . $key;
+				$this->validate_token_references( $child, $tokens, $relative, $next_path, $errors );
+			}
+			return;
+		}
+
+		if ( ! is_string( $value ) || ! preg_match_all( '/var\(\s*(--wp--(?:preset|custom)--[a-z0-9-]+)\s*(?:,[^)]*)?\)/i', $value, $matches ) ) {
+			return;
+		}
+
+		foreach ( $matches[1] as $reference ) {
+			$reference = strtolower( $reference );
+			if ( isset( $tokens[ $reference ] ) ) {
+				continue;
+			}
+
+			$this->add_diagnostic(
+				$errors,
+				'unresolved_token_reference',
+				$relative,
+				__( 'A WordPress preset or custom token reference does not resolve in theme.json settings.', 'superdav-ai-agent' ),
+				[
+					'json_path' => $json_path,
+					'reference' => $reference,
+				]
+			);
+		}
+	}
+
+	/**
+	 * Validate templates, parts, declarations, references, and block markup.
+	 *
+	 * @param array      $files      Project files keyed by relative path.
+	 * @param array|null $theme_json Decoded theme.json object when valid.
+	 * @param array      $tokens     Declared CSS variable names.
+	 * @param array      $errors     Diagnostics collected during validation.
+	 * @phpstan-param ProjectFiles $files
+	 * @phpstan-param array<string,mixed>|null $theme_json
+	 * @phpstan-param TokenMap $tokens
+	 * @phpstan-param Diagnostics $errors
+	 */
+	private function validate_template_files( array $files, ?array $theme_json, array $tokens, array &$errors ): void {
+		$templates = [];
+		$parts     = [];
+
+		foreach ( array_keys( $files ) as $relative ) {
+			if ( str_starts_with( $relative, 'templates/' ) && str_ends_with( $relative, '.html' ) ) {
+				$templates[] = $relative;
+				if ( 1 !== substr_count( $relative, '/' ) ) {
+					$this->add_diagnostic(
+						$errors,
+						'invalid_template_path',
+						$relative,
+						__( 'Theme templates must live directly under templates/.', 'superdav-ai-agent' )
+					);
+				}
+			}
+			if ( str_starts_with( $relative, 'parts/' ) && str_ends_with( $relative, '.html' ) ) {
+				$parts[] = $relative;
+				if ( 1 !== substr_count( $relative, '/' ) ) {
+					$this->add_diagnostic(
+						$errors,
+						'invalid_template_part_path',
+						$relative,
+						__( 'Theme template parts must live directly under parts/.', 'superdav-ai-agent' )
+					);
+				}
+			}
+		}
+
+		$declared_parts   = $this->validate_template_part_declarations( $theme_json, $parts, $errors );
+		$declared_customs = $this->validate_custom_template_declarations( $theme_json, $templates, $errors );
+		unset( $declared_customs );
+
+		foreach ( array_merge( $templates, $parts ) as $relative ) {
+			$contents = $this->read_file( $relative, $files, $errors );
+			if ( ! is_string( $contents ) ) {
+				continue;
+			}
+
+			$this->validate_template_part_references( $contents, $relative, $parts, $declared_parts, $errors );
+			$this->validate_block_markup( $contents, $relative, $errors );
+			$this->validate_markup_safety( $contents, $relative, $files, $errors );
+			$this->validate_markup_token_references( $contents, $relative, $tokens, $errors );
+		}
+	}
+
+	/**
+	 * Validate theme.json template-part declarations against actual files.
+	 *
+	 * @param array|null $theme_json Decoded theme.json object when valid.
+	 * @param array      $parts      Theme-relative template-part paths.
+	 * @param array      $errors     Diagnostics collected during validation.
+	 * @phpstan-param array<string,mixed>|null $theme_json
+	 * @phpstan-param list<string> $parts
+	 * @phpstan-param Diagnostics $errors
+	 * @return TokenMap Declared part names.
+	 */
+	private function validate_template_part_declarations( ?array $theme_json, array $parts, array &$errors ): array {
+		$declared = self::empty_token_map();
+		$entries  = is_array( $theme_json ) ? ( $theme_json['templateParts'] ?? [] ) : [];
+
+		if ( [] !== $entries && ( ! is_array( $entries ) || ! array_is_list( $entries ) ) ) {
+			$this->add_diagnostic(
+				$errors,
+				'invalid_template_part_declarations',
+				'theme.json',
+				__( 'theme.json templateParts must be an array of declarations.', 'superdav-ai-agent' ),
+				[ 'json_path' => 'templateParts' ]
+			);
+			$entries = [];
+		}
+
+		foreach ( $entries as $index => $entry ) {
+			$name = is_array( $entry ) ? ( $entry['name'] ?? null ) : null;
+			if ( ! is_string( $name ) || ! preg_match( '/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $name ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'invalid_template_part_declaration',
+					'theme.json',
+					__( 'Each template-part declaration requires a lowercase kebab-case name.', 'superdav-ai-agent' ),
+					[ 'json_path' => 'templateParts.' . $index . '.name' ]
+				);
+				continue;
+			}
+			if ( isset( $declared[ $name ] ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'duplicate_template_part_declaration',
+					'theme.json',
+					__( 'Template-part declarations must not repeat a name.', 'superdav-ai-agent' ),
+					[
+						'json_path' => 'templateParts.' . $index . '.name',
+						'name'      => $name,
+					]
+				);
+				continue;
+			}
+			$declared[ $name ] = true;
+			if ( ! in_array( 'parts/' . $name . '.html', $parts, true ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'missing_template_part_file',
+					'parts/' . $name . '.html',
+					__( 'A declared template part must have a matching parts/{name}.html file.', 'superdav-ai-agent' ),
+					[ 'declaration' => 'templateParts.' . $index ]
+				);
+			}
+		}
+
+		foreach ( $parts as $part ) {
+			$name = basename( $part, '.html' );
+			if ( ! isset( $declared[ $name ] ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'undeclared_template_part',
+					$part,
+					__( 'Every generated template-part file must be declared in theme.json templateParts.', 'superdav-ai-agent' )
+				);
+			}
+		}
+
+		return $declared;
+	}
+
+	/**
+	 * Validate custom template declarations against actual template files.
+	 *
+	 * @param array|null $theme_json Decoded theme.json object when valid.
+	 * @param array      $templates  Theme-relative template paths.
+	 * @param array      $errors     Diagnostics collected during validation.
+	 * @phpstan-param array<string,mixed>|null $theme_json
+	 * @phpstan-param list<string> $templates
+	 * @phpstan-param Diagnostics $errors
+	 * @return TokenMap
+	 */
+	private function validate_custom_template_declarations( ?array $theme_json, array $templates, array &$errors ): array {
+		$declared = self::empty_token_map();
+		$entries  = is_array( $theme_json ) ? ( $theme_json['customTemplates'] ?? [] ) : [];
+
+		if ( [] !== $entries && ( ! is_array( $entries ) || ! array_is_list( $entries ) ) ) {
+			$this->add_diagnostic(
+				$errors,
+				'invalid_custom_template_declarations',
+				'theme.json',
+				__( 'theme.json customTemplates must be an array of declarations.', 'superdav-ai-agent' ),
+				[ 'json_path' => 'customTemplates' ]
+			);
+			return $declared;
+		}
+
+		foreach ( $entries as $index => $entry ) {
+			$name      = is_array( $entry ) ? ( $entry['name'] ?? null ) : null;
+			$title     = is_array( $entry ) ? ( $entry['title'] ?? null ) : null;
+			$posttypes = is_array( $entry ) ? ( $entry['postTypes'] ?? null ) : null;
+			if ( ! is_string( $name ) || ! preg_match( '/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $name ) || ! is_string( $title ) || '' === trim( $title ) || ! is_array( $posttypes ) || [] === $posttypes ) {
+				$this->add_diagnostic(
+					$errors,
+					'invalid_custom_template_declaration',
+					'theme.json',
+					__( 'Each custom template must declare name, title, and one or more post types.', 'superdav-ai-agent' ),
+					[ 'json_path' => 'customTemplates.' . $index ]
+				);
+				continue;
+			}
+
+			$declared[ $name ] = true;
+			if ( ! in_array( 'templates/' . $name . '.html', $templates, true ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'missing_custom_template_file',
+					'templates/' . $name . '.html',
+					__( 'A declared custom template must have a matching templates/{name}.html file.', 'superdav-ai-agent' ),
+					[ 'declaration' => 'customTemplates.' . $index ]
+				);
+			}
+		}
+
+		return $declared;
+	}
+
+	/**
+	 * Validate wp:template-part blocks without executing template content.
+	 *
+	 * @param string $contents Template content to inspect.
+	 * @param string $relative Theme-relative template path.
+	 * @param array  $parts    Theme-relative template-part paths.
+	 * @param array  $declared Declared template-part names.
+	 * @param array  $errors   Diagnostics collected during validation.
+	 * @phpstan-param list<string> $parts
+	 * @phpstan-param TokenMap $declared
+	 * @phpstan-param Diagnostics $errors
+	 */
+	private function validate_template_part_references( string $contents, string $relative, array $parts, array $declared, array &$errors ): void {
+		if ( ! preg_match_all( '/<!--\s*wp:template-part\s+(\{.*?\})\s*\/?>/s', $contents, $matches, PREG_OFFSET_CAPTURE ) ) {
+			return;
+		}
+
+		foreach ( $matches[1] as $match ) {
+			$attributes = json_decode( $match[0], true );
+			$line       = $this->line_for_offset( $contents, $match[1] );
+			$slug       = is_array( $attributes ) ? ( $attributes['slug'] ?? null ) : null;
+			if ( ! is_string( $slug ) || ! preg_match( '/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $slug ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'invalid_template_part_reference',
+					$relative,
+					__( 'A wp:template-part block must provide a lowercase kebab-case slug.', 'superdav-ai-agent' ),
+					[ 'line' => $line ]
+				);
+				continue;
+			}
+
+			if ( ! in_array( 'parts/' . $slug . '.html', $parts, true ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'missing_template_part_reference',
+					$relative,
+					__( 'A wp:template-part block references a missing template-part file.', 'superdav-ai-agent' ),
+					[
+						'line' => $line,
+						'slug' => $slug,
+					]
+				);
+			}
+			if ( ! isset( $declared[ $slug ] ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'undeclared_template_part_reference',
+					$relative,
+					__( 'A wp:template-part block references a part not declared in theme.json.', 'superdav-ai-agent' ),
+					[
+						'line' => $line,
+						'slug' => $slug,
+					]
+				);
+			}
+		}
+	}
+
+	/**
+	 * Validate filesystem pattern headers, slugs, and static block bodies.
+	 *
+	 * @param array  $files      Project files keyed by relative path.
+	 * @param string $theme_slug Current theme directory slug.
+	 * @param array  $tokens     Declared CSS variable names.
+	 * @param array  $errors     Diagnostics collected during validation.
+	 * @phpstan-param ProjectFiles $files
+	 * @phpstan-param TokenMap $tokens
+	 * @phpstan-param Diagnostics $errors
+	 */
+	private function validate_pattern_files( array $files, string $theme_slug, array $tokens, array &$errors ): void {
+		$slugs = self::empty_token_map();
+		foreach ( array_keys( $files ) as $relative ) {
+			if ( ! str_starts_with( $relative, 'patterns/' ) || ! str_ends_with( $relative, '.php' ) ) {
+				continue;
+			}
+
+			if ( 1 !== substr_count( $relative, '/' ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'invalid_pattern_path',
+					$relative,
+					__( 'Filesystem patterns must live directly under patterns/.', 'superdav-ai-agent' )
+				);
+			}
+
+			$contents = $this->read_file( $relative, $files, $errors );
+			if ( ! is_string( $contents ) ) {
+				continue;
+			}
+
+			$end = strpos( $contents, '?>' );
+			if ( false === $end ) {
+				$this->add_diagnostic(
+					$errors,
+					'invalid_pattern_header',
+					$relative,
+					__( 'A static filesystem pattern must have a PHP header followed by a closing ?> delimiter.', 'superdav-ai-agent' )
+				);
+				continue;
+			}
+
+			$header = substr( $contents, 0, $end );
+			$body   = substr( $contents, $end + 2 );
+			$title  = $this->pattern_header_value( $header, 'Title' );
+			$slug   = $this->pattern_header_value( $header, 'Slug' );
+			if ( '' === $title ) {
+				$this->add_diagnostic(
+					$errors,
+					'missing_pattern_title',
+					$relative,
+					__( 'A filesystem pattern header must declare a non-empty Title.', 'superdav-ai-agent' )
+				);
+			}
+			if ( ! preg_match( '/^[a-z0-9]+(?:-[a-z0-9]+)*\/[a-z0-9]+(?:-[a-z0-9]+)*$/', $slug ) || ! str_starts_with( $slug, $theme_slug . '/' ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'invalid_pattern_slug',
+					$relative,
+					__( 'A filesystem pattern Slug must use the current theme slug and a lowercase kebab-case pattern name.', 'superdav-ai-agent' )
+				);
+			} elseif ( isset( $slugs[ $slug ] ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'duplicate_pattern_slug',
+					$relative,
+					__( 'Filesystem pattern slugs must be unique within the project.', 'superdav-ai-agent' ),
+					[ 'slug' => $slug ]
+				);
+			} else {
+				$slugs[ $slug ] = true;
+			}
+
+			if ( preg_match( '/<\?(?:php|=)?/i', $body ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'executable_pattern_content',
+					$relative,
+					__( 'Filesystem pattern bodies must contain static block markup and must not execute PHP.', 'superdav-ai-agent' )
+				);
+			}
+
+			$this->validate_block_markup( $body, $relative, $errors );
+			$this->validate_markup_safety( $body, $relative, $files, $errors );
+			$this->validate_markup_token_references( $body, $relative, $tokens, $errors );
+		}
+	}
+
+	/**
+	 * Return a normalized filesystem pattern header field.
+	 */
+	private function pattern_header_value( string $header, string $field ): string {
+		if ( ! preg_match( '/^\s*\*\s*' . preg_quote( $field, '/' ) . ':\s*(.+?)\s*$/mi', $header, $matches ) ) {
+			return '';
+		}
+
+		return trim( $matches[1] );
+	}
+
+	/**
+	 * Validate style-variation documents and their references to root tokens.
+	 *
+	 * @param array $files  Project files keyed by relative path.
+	 * @param array $tokens Declared CSS variable names.
+	 * @param array $errors Diagnostics collected during validation.
+	 * @phpstan-param ProjectFiles $files
+	 * @phpstan-param TokenMap $tokens
+	 * @phpstan-param Diagnostics $errors
+	 */
+	private function validate_style_variations( array $files, array $tokens, array &$errors ): void {
+		foreach ( array_keys( $files ) as $relative ) {
+			if ( ! str_starts_with( $relative, 'styles/' ) || ! str_ends_with( $relative, '.json' ) ) {
+				continue;
+			}
+
+			if ( 1 !== substr_count( $relative, '/' ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'invalid_style_variation_path',
+					$relative,
+					__( 'Style variations must live directly under styles/.', 'superdav-ai-agent' )
+				);
+			}
+
+			$variation = $this->read_json_file( $relative, $files, $errors );
+			if ( ! is_array( $variation ) ) {
+				continue;
+			}
+
+			if ( 3 !== ( $variation['version'] ?? null ) || self::THEME_JSON_SCHEMA !== ( $variation['$schema'] ?? null ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'invalid_style_variation_schema',
+					$relative,
+					__( 'A style variation must declare the canonical theme.json schema and version 3.', 'superdav-ai-agent' )
+				);
+			}
+
+			$slug = $variation['slug'] ?? null;
+			if ( ! is_string( $slug ) || basename( $relative, '.json' ) !== $slug ) {
+				$this->add_diagnostic(
+					$errors,
+					'invalid_style_variation_slug',
+					$relative,
+					__( 'A style variation slug must match its filename.', 'superdav-ai-agent' ),
+					[ 'json_path' => 'slug' ]
+				);
+			}
+			if ( ! is_string( $variation['title'] ?? null ) || '' === trim( (string) $variation['title'] ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'missing_style_variation_title',
+					$relative,
+					__( 'A style variation must declare a non-empty title.', 'superdav-ai-agent' ),
+					[ 'json_path' => 'title' ]
+				);
+			}
+
+			$this->validate_token_references( $variation, $tokens, $relative, '', $errors );
+		}
+	}
+
+	/**
+	 * Validate blocks with both a lightweight delimiter pass and existing policy.
+	 *
+	 * @param string $contents Template or pattern content to inspect.
+	 * @param string $relative Theme-relative source path.
+	 * @param array  $errors   Diagnostics collected during validation.
+	 * @phpstan-param Diagnostics $errors
+	 */
+	private function validate_block_markup( string $contents, string $relative, array &$errors ): void {
+		$this->validate_block_delimiters( $contents, $relative, $errors );
+		if ( ! function_exists( 'parse_blocks' ) || ! class_exists( BlockValidator::class ) ) {
+			return;
+		}
+
+		$report = ( new BlockValidator() )->validate_server_side( $contents );
+		foreach ( (array) ( $report['results'] ?? [] ) as $result ) {
+			if ( ! is_array( $result ) || ! empty( $result['isValid'] ) ) {
+				continue;
+			}
+			$issues = [];
+			foreach ( (array) ( $result['issues'] ?? [] ) as $issue ) {
+				if ( is_string( $issue ) ) {
+					$issues[] = $issue;
+				}
+			}
+			$this->add_diagnostic(
+				$errors,
+				'invalid_block_markup',
+				$relative,
+				__( 'WordPress block validation found invalid markup or a disallowed core/html block.', 'superdav-ai-agent' ),
+				[
+					'block'  => (string) ( $result['blockName'] ?? '' ),
+					'issues' => $issues,
+				]
+			);
+		}
+	}
+
+	/**
+	 * Detect malformed or unclosed block comment delimiters that parse_blocks()
+	 * may otherwise treat as freeform content.
+	 *
+	 * @param string $contents Template or pattern content to inspect.
+	 * @param string $relative Theme-relative source path.
+	 * @param array  $errors   Diagnostics collected during validation.
+	 * @phpstan-param Diagnostics $errors
+	 */
+	private function validate_block_delimiters( string $contents, string $relative, array &$errors ): void {
+		if ( ! str_contains( $contents, '<!-- wp:' ) ) {
+			return;
+		}
+
+		$stack = [];
+		if ( ! preg_match_all( '/<!--\s*(\/?)wp:([a-z0-9-]+(?:\/[a-z0-9-]+)?)(.*?)-->/is', $contents, $matches, PREG_OFFSET_CAPTURE ) ) {
+			$this->add_diagnostic(
+				$errors,
+				'malformed_block_delimiter',
+				$relative,
+				__( 'The template contains a malformed WordPress block comment delimiter.', 'superdav-ai-agent' )
+			);
+			return;
+		}
+
+		foreach ( $matches[0] as $index => $full_match ) {
+			$is_closing = '/' === $matches[1][ $index ][0];
+			$name       = strtolower( $matches[2][ $index ][0] );
+			$tail       = trim( $matches[3][ $index ][0] );
+			$line       = $this->line_for_offset( $contents, $full_match[1] );
+			if ( $is_closing ) {
+				$opened = array_pop( $stack );
+				if ( ! is_array( $opened ) || $name !== $opened['name'] ) {
+					$this->add_diagnostic(
+						$errors,
+						'mismatched_block_delimiter',
+						$relative,
+						__( 'A closing WordPress block comment does not match its opening block.', 'superdav-ai-agent' ),
+						[
+							'line'  => $line,
+							'block' => $name,
+						]
+					);
+				}
+				continue;
+			}
+
+			if ( ! str_ends_with( $tail, '/' ) ) {
+				$stack[] = [
+					'name' => $name,
+					'line' => $line,
+				];
+			}
+		}
+
+		foreach ( $stack as $opened ) {
+			$this->add_diagnostic(
+				$errors,
+				'unclosed_block_delimiter',
+				$relative,
+				__( 'A WordPress block comment is missing its closing delimiter.', 'superdav-ai-agent' ),
+				[
+					'line'  => $opened['line'],
+					'block' => $opened['name'],
+				]
+			);
+		}
+	}
+
+	/**
+	 * Validate source safety for non-template text project files.
+	 *
+	 * @param array $files  Project files keyed by relative path.
+	 * @param array $tokens Declared CSS variable names.
+	 * @param array $errors Diagnostics collected during validation.
+	 * @phpstan-param ProjectFiles $files
+	 * @phpstan-param TokenMap $tokens
+	 * @phpstan-param Diagnostics $errors
+	 */
+	private function validate_text_file_sources( array $files, array $tokens, array &$errors ): void {
+		foreach ( array_keys( $files ) as $relative ) {
+			if ( in_array( $relative, [ 'theme.json' ], true ) || str_starts_with( $relative, 'templates/' ) || str_starts_with( $relative, 'parts/' ) || str_starts_with( $relative, 'patterns/' ) || str_starts_with( $relative, 'styles/' ) || ! $this->is_text_project_file( $relative ) ) {
+				continue;
+			}
+
+			$contents = $this->read_file( $relative, $files, $errors );
+			if ( ! is_string( $contents ) ) {
+				continue;
+			}
+			$this->validate_markup_safety( $contents, $relative, $files, $errors );
+			$this->validate_markup_token_references( $contents, $relative, $tokens, $errors );
+		}
+	}
+
+	/**
+	 * Determine whether an arbitrary project file is safe to inspect as text.
+	 */
+	private function is_text_project_file( string $relative ): bool {
+		$extension = strtolower( pathinfo( $relative, PATHINFO_EXTENSION ) );
+
+		return in_array( $extension, [ 'css', 'html', 'json', 'php', 'svg', 'txt' ], true );
+	}
+
+	/**
+	 * Validate placeholders, local asset references, and remote asset URLs.
+	 *
+	 * @param string $contents Template or text source content.
+	 * @param string $relative Theme-relative source path.
+	 * @param array  $files    Project files keyed by relative path.
+	 * @param array  $errors   Diagnostics collected during validation.
+	 * @phpstan-param ProjectFiles $files
+	 * @phpstan-param Diagnostics $errors
+	 */
+	private function validate_markup_safety( string $contents, string $relative, array $files, array &$errors ): void {
+		$this->validate_placeholder_content( $contents, $relative, $errors );
+
+		if ( preg_match_all( '/\b(?:src|srcset|poster)\s*=\s*(["\'])(.*?)\1/is', $contents, $attributes, PREG_OFFSET_CAPTURE ) ) {
+			foreach ( $attributes[2] as $match ) {
+				$this->validate_asset_reference( $match[0], $relative, 'asset', $files, $errors, [ 'line' => $this->line_for_offset( $contents, $match[1] ) ] );
+			}
+		}
+
+		if ( preg_match_all( '/url\(\s*(["\']?)(.*?)\1\s*\)/is', $contents, $urls, PREG_OFFSET_CAPTURE ) ) {
+			foreach ( $urls[2] as $match ) {
+				$this->validate_asset_reference( $match[0], $relative, 'asset', $files, $errors, [ 'line' => $this->line_for_offset( $contents, $match[1] ) ] );
+			}
+		}
+
+		if ( preg_match_all( '/"(?:url|src)"\s*:\s*"((?:\\\\.|[^"\\\\])*)"/i', $contents, $json_urls, PREG_OFFSET_CAPTURE ) ) {
+			foreach ( $json_urls[1] as $match ) {
+				$this->validate_asset_reference( stripcslashes( $match[0] ), $relative, 'asset', $files, $errors, [ 'line' => $this->line_for_offset( $contents, $match[1] ) ] );
+			}
+		}
+	}
+
+	/**
+	 * Validate CSS variable references in markup/CSS source.
+	 *
+	 * @param string $contents Template or text source content.
+	 * @param string $relative Theme-relative source path.
+	 * @param array  $tokens   Declared CSS variable names.
+	 * @param array  $errors   Diagnostics collected during validation.
+	 * @phpstan-param TokenMap $tokens
+	 * @phpstan-param Diagnostics $errors
+	 */
+	private function validate_markup_token_references( string $contents, string $relative, array $tokens, array &$errors ): void {
+		if ( ! preg_match_all( '/var\(\s*(--wp--(?:preset|custom)--[a-z0-9-]+)\s*(?:,[^)]*)?\)/i', $contents, $matches, PREG_OFFSET_CAPTURE ) ) {
+			return;
+		}
+
+		foreach ( $matches[1] as $match ) {
+			$reference = strtolower( $match[0] );
+			if ( isset( $tokens[ $reference ] ) ) {
+				continue;
+			}
+			$this->add_diagnostic(
+				$errors,
+				'unresolved_token_reference',
+				$relative,
+				__( 'A WordPress preset or custom token reference does not resolve in theme.json settings.', 'superdav-ai-agent' ),
+				[
+					'line'      => $this->line_for_offset( $contents, $match[1] ),
+					'reference' => $reference,
+				]
+			);
+		}
+	}
+
+	/**
+	 * Validate placeholder copy, links, and known placeholder image services.
+	 *
+	 * @param string $contents Template or text source content.
+	 * @param string $relative Theme-relative source path.
+	 * @param array  $errors   Diagnostics collected during validation.
+	 * @phpstan-param Diagnostics $errors
+	 */
+	private function validate_placeholder_content( string $contents, string $relative, array &$errors ): void {
+		$placeholder_pattern = '/\b(?:lorem ipsum|replace (?:this|me|with)|your (?:headline|text|content)|sample (?:text|content)|call to action|todo|tbd)\b/i';
+		if ( preg_match_all( $placeholder_pattern, $contents, $matches, PREG_OFFSET_CAPTURE ) ) {
+			foreach ( $matches[0] as $match ) {
+				$this->add_diagnostic(
+					$errors,
+					'placeholder_content',
+					$relative,
+					__( 'Replace placeholder copy before activating the generated theme.', 'superdav-ai-agent' ),
+					[ 'line' => $this->line_for_offset( $contents, $match[1] ) ]
+				);
+			}
+		}
+
+		if ( preg_match_all( '/\bhref\s*=\s*(["\'])\s*(?:#|)\s*\1/i', $contents, $matches, PREG_OFFSET_CAPTURE ) ) {
+			foreach ( $matches[0] as $match ) {
+				$this->add_diagnostic(
+					$errors,
+					'placeholder_link',
+					$relative,
+					__( 'Replace empty or # placeholder links before activating the generated theme.', 'superdav-ai-agent' ),
+					[ 'line' => $this->line_for_offset( $contents, $match[1] ) ]
+				);
+			}
+		}
+
+		if ( preg_match_all( '/(?:placehold\.(?:co|it|com)|via\.placeholder\.com|picsum\.photos|loremflickr\.com|dummyimage\.com|source\.unsplash\.com)/i', $contents, $matches, PREG_OFFSET_CAPTURE ) ) {
+			foreach ( $matches[0] as $match ) {
+				$this->add_diagnostic(
+					$errors,
+					'placeholder_image_service',
+					$relative,
+					__( 'Placeholder image services are not permitted in generated theme projects.', 'superdav-ai-agent' ),
+					[ 'line' => $this->line_for_offset( $contents, $match[1] ) ]
+				);
+			}
+		}
+	}
+
+	/**
+	 * Validate a local asset reference without requesting its URL.
+	 *
+	 * @param string $reference Asset reference value.
+	 * @param string $relative  Theme-relative source path.
+	 * @param string $kind      Asset kind being checked.
+	 * @param array  $files     Project files keyed by relative path.
+	 * @param array  $errors    Diagnostics collected during validation.
+	 * @param array  $location  Source location metadata.
+	 * @phpstan-param ProjectFiles $files
+	 * @phpstan-param Diagnostics $errors
+	 * @phpstan-param array<string,mixed> $location
+	 */
+	private function validate_asset_reference( string $reference, string $relative, string $kind, array $files, array &$errors, array $location = [] ): void {
+		$reference = trim( $reference );
+		if ( '' === $reference ) {
+			$this->add_diagnostic(
+				$errors,
+				'missing_asset_reference',
+				$relative,
+				__( 'An asset reference must name a local bundled file.', 'superdav-ai-agent' ),
+				$location
+			);
+			return;
+		}
+
+		if ( str_starts_with( strtolower( $reference ), 'data:' ) ) {
+			$this->add_diagnostic(
+				$errors,
+				'non_local_asset',
+				$relative,
+				__( 'Embedded data assets are not permitted; bundle a local project file instead.', 'superdav-ai-agent' ),
+				$location
+			);
+			return;
+		}
+
+		if ( preg_match( '#^(?:https?:)?//#i', $reference ) ) {
+			if ( ! $this->is_local_site_url( $reference ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'remote_asset_url',
+					$relative,
+					__( 'Remote asset URLs are not permitted; import or bundle the asset locally.', 'superdav-ai-agent' ),
+					$location
+				);
+			}
+			return;
+		}
+
+		if ( ! in_array( $kind, [ 'asset', 'font' ], true ) ) {
+			return;
+		}
+
+		$path = $this->normalise_asset_reference( $reference );
+		if ( null === $path ) {
+			$this->add_diagnostic(
+				$errors,
+				'asset_path_traversal',
+				$relative,
+				__( 'Asset paths must stay within the generated theme project.', 'superdav-ai-agent' ),
+				$location
+			);
+			return;
+		}
+
+		if ( str_starts_with( $path, 'wp-content/' ) || str_starts_with( $path, 'wp-includes/' ) ) {
+			return;
+		}
+
+		if ( ! isset( $files[ $path ] ) ) {
+			$this->add_diagnostic(
+				$errors,
+				'missing_local_asset',
+				$relative,
+				__( 'A referenced local asset file is missing from the generated theme project.', 'superdav-ai-agent' ),
+				array_merge( $location, [ 'asset' => $path ] )
+			);
+		}
+	}
+
+	/**
+	 * Normalize a theme-relative asset path or return null for unsafe paths.
+	 */
+	private function normalise_asset_reference( string $reference ): ?string {
+		$reference = preg_replace( '/[?#].*$/', '', $reference ) ?? $reference;
+		$reference = preg_replace( '#^file:#i', '', $reference ) ?? $reference;
+		$reference = rawurldecode( trim( $reference ) );
+		$reference = ltrim( $reference, '/' );
+		while ( str_starts_with( $reference, './' ) ) {
+			$reference = substr( $reference, 2 );
+		}
+
+		if ( '' === $reference || str_contains( $reference, "\0" ) ) {
+			return null;
+		}
+
+		$segments = explode( '/', $reference );
+		foreach ( $segments as $segment ) {
+			if ( '' === $segment || '.' === $segment || '..' === $segment ) {
+				return null;
+			}
+		}
+
+		return implode( '/', $segments );
+	}
+
+	/**
+	 * Allow local-site absolute media URLs without treating them as remote.
+	 */
+	private function is_local_site_url( string $url ): bool {
+		$host = wp_parse_url( $url, PHP_URL_HOST );
+		if ( ! is_string( $host ) || '' === $host ) {
+			return false;
+		}
+
+		$site_host = wp_parse_url( home_url( '/' ), PHP_URL_HOST );
+
+		return is_string( $site_host ) && strtolower( $host ) === strtolower( $site_host );
+	}
+
+	/**
+	 * Read and decode an object-shaped JSON project file.
+	 *
+	 * @param string $relative Theme-relative source path.
+	 * @param array  $files    Project files keyed by relative path.
+	 * @param array  $errors   Diagnostics collected during validation.
+	 * @phpstan-param ProjectFiles $files
+	 * @phpstan-param Diagnostics $errors
+	 * @return array<string,mixed>|null
+	 */
+	private function read_json_file( string $relative, array $files, array &$errors ): ?array {
+		$contents = $this->read_file( $relative, $files, $errors );
+		if ( ! is_string( $contents ) ) {
+			return null;
+		}
+
+		$decoded = json_decode( $contents, true );
+		if ( JSON_ERROR_NONE !== json_last_error() || ! str_starts_with( ltrim( $contents ), '{' ) || ! is_array( $decoded ) || ( [] !== $decoded && array_is_list( $decoded ) ) ) {
+			$this->add_diagnostic(
+				$errors,
+				'invalid_json',
+				$relative,
+				__( 'This file must contain a valid JSON object.', 'superdav-ai-agent' )
+			);
+			return null;
+		}
+
+		$object = self::empty_json_object();
+		foreach ( $decoded as $key => $value ) {
+			if ( ! is_string( $key ) ) {
+				$this->add_diagnostic(
+					$errors,
+					'invalid_json',
+					$relative,
+					__( 'This file must contain a JSON object with string property names.', 'superdav-ai-agent' )
+				);
+				return null;
+			}
+			$object[ $key ] = $value;
+		}
+
+		return $object;
+	}
+
+	/**
+	 * Read one bounded local project file without exposing its absolute path.
+	 *
+	 * @param string $relative Theme-relative source path.
+	 * @param array  $files    Project files keyed by relative path.
+	 * @param array  $errors   Diagnostics collected during validation.
+	 * @phpstan-param ProjectFiles $files
+	 * @phpstan-param Diagnostics $errors
+	 */
+	private function read_file( string $relative, array $files, array &$errors ): ?string {
+		if ( ! isset( $files[ $relative ] ) ) {
+			return null;
+		}
+		if ( $files[ $relative ]['size'] > self::MAX_FILE_SIZE || ! is_readable( $files[ $relative ]['path'] ) ) {
+			$this->add_diagnostic(
+				$errors,
+				'file_unreadable',
+				$relative,
+				__( 'The project file could not be read safely.', 'superdav-ai-agent' )
+			);
+			return null;
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Read-only validation of a bounded local project file.
+		$contents = file_get_contents( $files[ $relative ]['path'] );
+		if ( false === $contents ) {
+			$this->add_diagnostic(
+				$errors,
+				'file_unreadable',
+				$relative,
+				__( 'The project file could not be read safely.', 'superdav-ai-agent' )
+			);
+			return null;
+		}
+
+		return $contents;
+	}
+
+	/**
+	 * Return a normalized relative path for an item below a root.
+	 */
+	private function relative_path( string $root, string $path ): string {
+		$relative = substr( str_replace( '\\', '/', $path ), strlen( str_replace( '\\', '/', $root ) ) + 1 );
+
+		return ltrim( (string) $relative, '/' );
+	}
+
+	/**
+	 * Test whether a resolved path remains below the resolved root.
+	 */
+	private function is_within_root( string $root, string $path ): bool {
+		$root = rtrim( str_replace( '\\', '/', $root ), '/' );
+		$path = str_replace( '\\', '/', $path );
+
+		return $path === $root || str_starts_with( $path, $root . '/' );
+	}
+
+	/**
+	 * Return a one-indexed source line for an offset.
+	 */
+	private function line_for_offset( string $contents, int $offset ): int {
+		return substr_count( substr( $contents, 0, $offset ), "\n" ) + 1;
+	}
+
+	/**
+	 * Add a stable, theme-relative diagnostic.
+	 *
+	 * @param array  $diagnostics Diagnostics collected during validation.
+	 * @param string $code        Stable diagnostic code.
+	 * @param string $path        Theme-relative diagnostic path.
+	 * @param string $message     Human-readable diagnostic message.
+	 * @param array  $location    Source location metadata.
+	 * @phpstan-param Diagnostics $diagnostics
+	 * @param-out Diagnostics     $diagnostics
+	 * @phpstan-param array<string,mixed> $location
+	 */
+	private function add_diagnostic( array &$diagnostics, string $code, string $path, string $message, array $location = [] ): void {
+		$diagnostic = [
+			'code'    => $code,
+			'path'    => $path,
+			'message' => $message,
+		];
+		if ( [] !== $location ) {
+			$diagnostic['location'] = $location;
+		}
+		$diagnostics[] = $diagnostic;
+	}
+
+	/**
+	 * Normalize and sort the public report deterministically.
+	 *
+	 * @return array{
+	 *   valid:bool,
+	 *   marked:bool,
+	 *   project_version:int,
+	 *   fingerprint:string,
+	 *   files_scanned:int,
+	 *   errors:Diagnostics,
+	 *   warnings:Diagnostics
+	 * }
+	 * @param bool   $valid           Whether earlier checks consider the project valid.
+	 * @param bool   $marked          Whether the project marker exists.
+	 * @param int    $project_version Marker schema version.
+	 * @param string $fingerprint     Stable project fingerprint.
+	 * @param int    $files_scanned   Number of project files scanned.
+	 * @param array  $errors          Diagnostics collected during validation.
+	 * @param array  $warnings        Warnings collected during validation.
+	 * @phpstan-param Diagnostics $errors
+	 * @phpstan-param Diagnostics $warnings
+	 */
+	private function build_report( bool $valid, bool $marked, int $project_version, string $fingerprint, int $files_scanned, array $errors, array $warnings ): array {
+		$this->sort_diagnostics( $errors );
+		$this->sort_diagnostics( $warnings );
+
+		return [
+			'valid'           => $valid && [] === $errors,
+			'marked'          => $marked,
+			'project_version' => $project_version,
+			'fingerprint'     => $fingerprint,
+			'files_scanned'   => $files_scanned,
+			'errors'          => $errors,
+			'warnings'        => $warnings,
+		];
+	}
+
+	/**
+	 * Sort diagnostics by path, code, location, then message.
+	 *
+	 * @param array $diagnostics Diagnostics to sort.
+	 * @phpstan-param Diagnostics $diagnostics
+	 * @param-out Diagnostics $diagnostics
+	 */
+	private function sort_diagnostics( array &$diagnostics ): void {
+		usort(
+			$diagnostics,
+			static function ( array $left, array $right ): int {
+				$left_location  = (array) ( $left['location'] ?? [] );
+				$right_location = (array) ( $right['location'] ?? [] );
+				$left_key       = implode(
+					'|',
+					[
+						(string) $left['path'],
+						(string) $left['code'],
+						(string) ( $left_location['line'] ?? '' ),
+						(string) ( $left_location['json_path'] ?? '' ),
+						(string) $left['message'],
+					]
+				);
+				$right_key      = implode(
+					'|',
+					[
+						(string) $right['path'],
+						(string) $right['code'],
+						(string) ( $right_location['line'] ?? '' ),
+						(string) ( $right_location['json_path'] ?? '' ),
+						(string) $right['message'],
+					]
+				);
+
+				return $left_key <=> $right_key;
+			}
+		);
+	}
+}

--- a/includes/Services/BlockThemeProjectValidator.php
+++ b/includes/Services/BlockThemeProjectValidator.php
@@ -150,7 +150,7 @@ final class BlockThemeProjectValidator {
 		$before       = $this->project_fingerprint( $files );
 		$marker       = $this->validate_marker( $files, $errors );
 		$is_marked    = self::is_marked_project( $root );
-		$project_ver  = is_array( $marker ) ? (int) $marker['schema_version'] : 0;
+		$project_ver  = is_array( $marker ) ? (int) ( $marker['schema_version'] ?? 0 ) : 0;
 		$theme_json   = $this->validate_required_project_files( $files, $errors );
 		$token_values = self::empty_token_map();
 
@@ -1341,7 +1341,7 @@ final class BlockThemeProjectValidator {
 	 */
 	private function validate_text_file_sources( array $files, array $tokens, array &$errors ): void {
 		foreach ( array_keys( $files ) as $relative ) {
-			if ( in_array( $relative, [ 'theme.json' ], true ) || str_starts_with( $relative, 'templates/' ) || str_starts_with( $relative, 'parts/' ) || str_starts_with( $relative, 'patterns/' ) || str_starts_with( $relative, 'styles/' ) || ! $this->is_text_project_file( $relative ) ) {
+			if ( in_array( $relative, [ 'theme.json' ], true ) || str_starts_with( $relative, '.sd-ai-agent/' ) || str_starts_with( $relative, 'templates/' ) || str_starts_with( $relative, 'parts/' ) || str_starts_with( $relative, 'patterns/' ) || str_starts_with( $relative, 'styles/' ) || ! $this->is_text_project_file( $relative ) ) {
 				continue;
 			}
 

--- a/includes/Tools/ToolDiscovery.php
+++ b/includes/Tools/ToolDiscovery.php
@@ -48,6 +48,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class ToolDiscovery {
 
+	private const VALIDATE_THEME_PROJECT_ABILITY = 'sd-ai-agent/validate-block-theme-project';
+
 	/**
 	 * Curated cold-start Tier 1 list. These are the abilities the agent
 	 * needs on its very first turn before any usage history exists. The
@@ -838,14 +840,15 @@ class ToolDiscovery {
 	 */
 	private static function ability_search_aliases( string $ability_id ): string {
 		$aliases = array(
-			'sd-ai-agent/update-post'           => 'edit post edit page modify post modify page change content update page update existing page update existing post',
-			'sd-ai-agent/create-post'           => 'add post add page new post new page publish page publish post create page create content',
-			'sd-ai-agent/list-posts'            => 'find post find page search post search page get page id get post id existing pages existing posts',
-			'sd-ai-agent/get-global-styles'     => 'manage global styles read global styles inspect global styles current theme styles style settings theme design settings',
-			'sd-ai-agent/update-global-styles'  => 'manage global styles edit global styles change global styles set global styles apply design system update theme styles change colors change colours change fonts theme json customizations',
-			'sd-ai-agent/reset-global-styles'   => 'manage global styles clear global styles restore theme styles remove style overrides reset theme styles',
-			'sd-ai-agent/get-theme-json'        => 'theme json theme settings theme style configuration global styles configuration',
-			'sd-ai-agent/compile-design-tokens' => 'compile design tokens design token contract generate theme json deterministic theme styles semantic aliases style variation',
+			'sd-ai-agent/update-post'            => 'edit post edit page modify post modify page change content update page update existing page update existing post',
+			'sd-ai-agent/create-post'            => 'add post add page new post new page publish page publish post create page create content',
+			'sd-ai-agent/list-posts'             => 'find post find page search post search page get page id get post id existing pages existing posts',
+			'sd-ai-agent/get-global-styles'      => 'manage global styles read global styles inspect global styles current theme styles style settings theme design settings',
+			'sd-ai-agent/update-global-styles'   => 'manage global styles edit global styles change global styles set global styles apply design system update theme styles change colors change colours change fonts theme json customizations',
+			'sd-ai-agent/reset-global-styles'    => 'manage global styles clear global styles restore theme styles remove style overrides reset theme styles',
+			'sd-ai-agent/get-theme-json'         => 'theme json theme settings theme style configuration global styles configuration',
+			'sd-ai-agent/compile-design-tokens'  => 'compile design tokens design token contract generate theme json deterministic theme styles semantic aliases style variation',
+			self::VALIDATE_THEME_PROJECT_ABILITY => 'validate generated block theme project theme json templates parts patterns variations local assets activation diagnostics',
 		);
 
 		return $aliases[ $ability_id ] ?? '';

--- a/tests/SdAiAgent/Abilities/ScaffoldBlockThemeAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/ScaffoldBlockThemeAbilityTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Tests\Abilities;
 
 use SdAiAgent\Abilities\ScaffoldBlockThemeAbility;
+use SdAiAgent\Services\BlockThemeProjectValidator;
 use WP_UnitTestCase;
 
 /**
@@ -190,6 +191,27 @@ class ScaffoldBlockThemeAbilityTest extends WP_UnitTestCase {
 		$this->assertIsArray( $theme_json );
 		$this->assertSame( 3, $theme_json['version'], 'Default scaffold must write version 3.' );
 		$this->assertFalse( $result['version_coerced'], 'version_coerced must be false when theme_json was omitted (default path).' );
+	}
+
+	/**
+	 * Every scaffolded theme has the versioned marker required for strict
+	 * generated-project validation before activation.
+	 */
+	public function test_scaffold_writes_the_generated_project_marker(): void {
+		$slug    = $this->unique_slug( 'project-marker' );
+		$ability = new ScaffoldBlockThemeAbility( 'sd-ai-agent/scaffold-block-theme' );
+
+		$result = $ability->run( [ 'slug' => $slug, 'name' => 'Project Marker Theme' ] );
+
+		$this->assertIsArray( $result, is_wp_error( $result ) ? $result->get_error_message() : '' );
+		$this->assertContains( BlockThemeProjectValidator::MARKER_PATH, $result['files'] );
+
+		$path   = trailingslashit( get_theme_root() ) . $slug . '/' . BlockThemeProjectValidator::MARKER_PATH;
+		$marker = json_decode( (string) file_get_contents( $path ), true );
+
+		$this->assertFileExists( $path );
+		$this->assertIsArray( $marker );
+		$this->assertSame( BlockThemeProjectValidator::marker_payload(), $marker );
 	}
 
 	// ── front-page CTA ───────────────────────────────────────────────────

--- a/tests/SdAiAgent/Abilities/ThemeBuilderAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/ThemeBuilderAbilitiesTest.php
@@ -18,6 +18,7 @@ namespace SdAiAgent\Tests\Abilities;
 
 use SdAiAgent\Abilities\ActivateThemeAbility;
 use SdAiAgent\Abilities\ScaffoldBlockThemeAbility;
+use SdAiAgent\Services\BlockThemeProjectValidator;
 use WP_UnitTestCase;
 
 /**
@@ -401,6 +402,7 @@ class ThemeBuilderAbilitiesTest extends WP_UnitTestCase {
 			]
 		);
 		$this->assertIsArray( $built );
+		$this->complete_scaffolded_project( $built['theme_dir'] );
 
 		// wp_get_theme caches WP_Theme objects on the themes directory listing;
 		// force a refresh so the just-created theme is visible.
@@ -413,6 +415,47 @@ class ThemeBuilderAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( $previous, $result['previous_stylesheet'] );
 		$this->assertSame( $slug, $result['stylesheet'] );
 		$this->assertSame( $slug, get_stylesheet() );
+	}
+
+	/**
+	 * A generated project with a marker must fail validation before it can
+	 * alter the active stylesheet or template options.
+	 */
+	public function test_activate_rejects_invalid_marked_project_before_switching_theme(): void {
+		$slug = $this->unique_slug( 'marked-invalid' );
+		$this->stage_minimal_theme( $slug, '', '' );
+		$theme_dir = trailingslashit( get_theme_root() ) . $slug;
+		wp_mkdir_p( $theme_dir . '/.sd-ai-agent' );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture marks an intentionally incomplete generated project.
+		file_put_contents( $theme_dir . '/' . BlockThemeProjectValidator::MARKER_PATH, BlockThemeProjectValidator::marker_contents() );
+		wp_clean_themes_cache();
+
+		$ability             = new ActivateThemeAbility( 'sd-ai-agent/activate-theme' );
+		$previous_stylesheet = (string) get_stylesheet();
+		$previous_template   = (string) get_template();
+		$result              = $ability->run( [ 'stylesheet' => $slug ] );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'sd_ai_agent_block_theme_project_invalid', $result->get_error_code() );
+		$this->assertIsArray( $result->get_error_data()['diagnostics'] );
+		$this->assertContains( 'missing_required_file', array_column( $result->get_error_data()['diagnostics'], 'code' ) );
+		$this->assertSame( $previous_stylesheet, (string) get_stylesheet() );
+		$this->assertSame( $previous_template, (string) get_template() );
+	}
+
+	/**
+	 * Unmarked themes retain WordPress's normal activation path even when they
+	 * do not satisfy generated-project-only completeness requirements.
+	 */
+	public function test_activate_does_not_gate_unmarked_theme_projects(): void {
+		$slug = $this->unique_slug( 'unmarked-sparse' );
+		$this->stage_minimal_theme( $slug, '', '' );
+		wp_clean_themes_cache();
+
+		$result = ( new ActivateThemeAbility( 'sd-ai-agent/activate-theme' ) )->run( [ 'stylesheet' => $slug ] );
+
+		$this->assertIsArray( $result, is_wp_error( $result ) ? $result->get_error_message() : '' );
+		$this->assertSame( $slug, $result['stylesheet'] );
 	}
 
 	// ── Helpers ───────────────────────────────────────────────────────────
@@ -464,6 +507,19 @@ class ThemeBuilderAbilitiesTest extends WP_UnitTestCase {
 		// valid by WP_Theme::errors(). Without it the ability returns
 		// sd_ai_agent_theme_invalid before reaching validate_theme_requirements().
 		file_put_contents( $theme_dir . '/templates/index.html', '<!-- wp:paragraph --><p></p><!-- /wp:paragraph -->' );
+	}
+
+	/**
+	 * Replace the scaffold's intentionally incomplete placeholders before the
+	 * happy-path activation test invokes the generated-project gate.
+	 *
+	 * @param string $theme_dir Absolute scaffolded theme directory.
+	 */
+	private function complete_scaffolded_project( string $theme_dir ): void {
+		wp_mkdir_p( $theme_dir . '/parts' );
+		file_put_contents( $theme_dir . '/parts/header.html', '<!-- wp:paragraph --><p class="wp-block-paragraph">Header.</p><!-- /wp:paragraph -->' );
+		file_put_contents( $theme_dir . '/parts/footer.html', '<!-- wp:paragraph --><p class="wp-block-paragraph">Footer.</p><!-- /wp:paragraph -->' );
+		file_put_contents( $theme_dir . '/templates/front-page.html', '<!-- wp:paragraph --><p class="wp-block-paragraph">Welcome.</p><!-- /wp:paragraph -->' );
 	}
 
 	/**

--- a/tests/SdAiAgent/Abilities/ToolCapabilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/ToolCapabilitiesTest.php
@@ -430,6 +430,7 @@ class ToolCapabilitiesTest extends WP_UnitTestCase {
 			'sd-ai-agent/preview-style-variation',
 			'sd-ai-agent/select-style-variation',
 			'sd-ai-agent/reset-style-variation',
+			'sd-ai-agent/validate-block-theme-project',
 		];
 
 		foreach ( $expected as $id ) {
@@ -466,5 +467,15 @@ class ToolCapabilitiesTest extends WP_UnitTestCase {
 				$ability
 			);
 		}
+	}
+
+	/**
+	 * Project validation remains behind the standard theme-options core gate.
+	 */
+	public function test_validate_block_theme_project_requires_edit_theme_options(): void {
+		$this->assertSame(
+			[ 'edit_theme_options' ],
+			ToolCapabilities::resolve_core_caps( 'sd-ai-agent/validate-block-theme-project' )
+		);
 	}
 }

--- a/tests/SdAiAgent/Abilities/ValidateBlockThemeProjectAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/ValidateBlockThemeProjectAbilityTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Tests for the public read-only block-theme project validation ability.
+ *
+ * @package SdAiAgent\Tests\Abilities
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Abilities;
+
+use SdAiAgent\Abilities\ValidateBlockThemeProjectAbility;
+use SdAiAgent\Services\BlockThemeProjectValidator;
+use WP_Error;
+use WP_UnitTestCase;
+
+/**
+ * Verifies the ability exposes deterministic project validation safely.
+ */
+class ValidateBlockThemeProjectAbilityTest extends WP_UnitTestCase {
+
+	/**
+	 * Theme slugs created during tests, removed in tear_down.
+	 *
+	 * @var list<string>
+	 */
+	private array $created_slugs = [];
+
+	private function ability(): ValidateBlockThemeProjectAbility {
+		return new ValidateBlockThemeProjectAbility( 'sd-ai-agent/validate-block-theme-project' );
+	}
+
+	public function tear_down(): void {
+		foreach ( $this->created_slugs as $slug ) {
+			self::rrmdir( trailingslashit( get_theme_root() ) . $slug );
+		}
+		wp_clean_themes_cache();
+		parent::tear_down();
+	}
+
+	/**
+	 * The public registration exposes the declared read-only contract.
+	 */
+	public function test_registered_ability_is_public_readonly_and_rest_visible(): void {
+		$ability = wp_get_ability( 'sd-ai-agent/validate-block-theme-project' );
+
+		$this->assertNotNull( $ability );
+		$this->assertSame( 'sd-ai-agent/validate-block-theme-project', $ability->get_name() );
+		$this->assertTrue( $ability->get_meta()['mcp']['public'] );
+		$this->assertTrue( $ability->get_meta()['annotations']['readonly'] );
+		$this->assertFalse( $ability->get_meta()['annotations']['destructive'] );
+		$this->assertTrue( $ability->get_meta()['annotations']['idempotent'] );
+		$this->assertTrue( $ability->get_meta()['show_in_rest'] );
+		$this->assertSame( [ 'stylesheet' ], $ability->get_input_schema()['required'] );
+	}
+
+	/**
+	 * The direct ability surface accepts an installed marked theme and returns the report.
+	 */
+	public function test_run_returns_validation_report_for_an_installed_marked_theme(): void {
+		$slug = $this->unique_slug();
+		$this->stage_valid_theme( $slug );
+		wp_clean_themes_cache();
+
+		$result = $this->ability()->run( [ 'stylesheet' => $slug ] );
+
+		$this->assertIsArray( $result, is_wp_error( $result ) ? $result->get_error_message() : '' );
+		$this->assertTrue( $result['valid'], (string) wp_json_encode( $result['errors'] ) );
+		$this->assertTrue( $result['marked'] );
+		$this->assertSame( BlockThemeProjectValidator::MARKER_SCHEMA_VERSION, $result['project_version'] );
+		$this->assertSame( [], $result['errors'] );
+	}
+
+	/**
+	 * Sanitized empty stylesheet values return the documented validation error.
+	 */
+	public function test_run_rejects_an_invalid_stylesheet(): void {
+		$result = $this->ability()->run( [ 'stylesheet' => '!!!' ] );
+
+		if ( ! $result instanceof WP_Error ) {
+			$this->fail( 'Expected an invalid stylesheet to return WP_Error.' );
+		}
+		$this->assertSame( 'sd_ai_agent_invalid_stylesheet', $result->get_error_code() );
+	}
+
+	/**
+	 * Create and track a unique valid WordPress theme stylesheet slug.
+	 */
+	private function unique_slug(): string {
+		$slug                  = 'sd-ai-validator-ability-' . strtolower( wp_generate_password( 8, false ) );
+		$this->created_slugs[] = $slug;
+		return $slug;
+	}
+
+	/**
+	 * Stage a valid marked project within the installed themes directory.
+	 *
+	 * @param string $slug Theme directory name.
+	 */
+	private function stage_valid_theme( string $slug ): void {
+		$theme_dir = trailingslashit( get_theme_root() ) . $slug;
+		wp_mkdir_p( $theme_dir . '/templates' );
+		wp_mkdir_p( $theme_dir . '/.sd-ai-agent' );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture setup requires direct local writes.
+		file_put_contents( $theme_dir . '/.sd-ai-agent/block-theme-project.json', BlockThemeProjectValidator::marker_contents() );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture setup requires direct local writes.
+		file_put_contents( $theme_dir . '/style.css', "/*\nTheme Name: Ability validator fixture\nVersion: 1.0.0\n*/\n" );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture setup requires direct local writes.
+		file_put_contents( $theme_dir . '/theme.json', "{\n\t\"\$schema\": \"https://schemas.wp.org/trunk/theme.json\",\n\t\"version\": 3,\n\t\"settings\": {}\n}\n" );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture setup requires direct local writes.
+		file_put_contents( $theme_dir . '/templates/index.html', '<!-- wp:paragraph --><p class="wp-block-paragraph">Welcome.</p><!-- /wp:paragraph -->' );
+	}
+
+	/**
+	 * Recursively delete a fixture directory.
+	 *
+	 * @param string $dir Absolute directory path.
+	 */
+	private static function rrmdir( string $dir ): void {
+		if ( ! is_dir( $dir ) ) {
+			return;
+		}
+		foreach ( scandir( $dir ) ?: [] as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+			$path = $dir . DIRECTORY_SEPARATOR . $entry;
+			if ( is_dir( $path ) ) {
+				self::rrmdir( $path );
+			} else {
+				@unlink( $path );
+			}
+		}
+		@rmdir( $dir );
+	}
+}

--- a/tests/SdAiAgent/Core/SkillAutoInjectorTest.php
+++ b/tests/SdAiAgent/Core/SkillAutoInjectorTest.php
@@ -320,6 +320,7 @@ class SkillAutoInjectorTest extends WP_UnitTestCase {
 		$this->assertSame( 'wp-block-themes', SkillAutoInjector::skill_for_ability( 'sd-ai-agent/get-theme-json' ) );
 		$this->assertSame( 'wp-block-themes', SkillAutoInjector::skill_for_ability( 'sd-ai-agent/update-global-styles' ) );
 		$this->assertSame( 'wp-block-themes', SkillAutoInjector::skill_for_ability( 'sd-ai-agent/compile-design-tokens' ) );
+		$this->assertSame( 'wp-block-themes', SkillAutoInjector::skill_for_ability( 'sd-ai-agent/validate-block-theme-project' ) );
 		$this->assertNotNull( Skill::get_by_slug( 'wp-block-themes' ) );
 		$this->assertNull( Skill::get_by_slug( 'block-themes' ) );
 		$this->assertNull( Skill::get_by_slug( 'full-site-editing' ) );

--- a/tests/SdAiAgent/Models/AgentThemeBuilderTest.php
+++ b/tests/SdAiAgent/Models/AgentThemeBuilderTest.php
@@ -155,6 +155,7 @@ class AgentThemeBuilderTest extends WP_UnitTestCase {
 
 		$required = [
 			'sd-ai-agent/scaffold-block-theme',
+			'sd-ai-agent/validate-block-theme-project',
 			'sd-ai-agent/activate-theme',
 			'sd-ai-agent/file-write',
 			'sd-ai-agent/validate-block-content',

--- a/tests/SdAiAgent/Models/BlockThemesSkillTest.php
+++ b/tests/SdAiAgent/Models/BlockThemesSkillTest.php
@@ -119,6 +119,8 @@ class BlockThemesSkillTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '**No stock image URLs.**', $content );
 		$this->assertStringContainsString( '**Validate before write.**', $content );
 		$this->assertStringContainsString( 'sd-ai-agent/validate-block-content', $content );
+		$this->assertStringContainsString( 'sd-ai-agent/validate-block-theme-project', $content );
+		$this->assertStringContainsString( 'valid: true', $content );
 	}
 
 	/**

--- a/tests/SdAiAgent/Services/BlockThemeProjectValidatorTest.php
+++ b/tests/SdAiAgent/Services/BlockThemeProjectValidatorTest.php
@@ -120,6 +120,41 @@ class BlockThemeProjectValidatorTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A malformed marker without a schema version reports a diagnostic without
+	 * producing a PHP undefined-array-key warning.
+	 */
+	public function test_missing_marker_schema_version_uses_zero_project_version(): void {
+		$this->stage_valid_project();
+		$this->write_fixture_file(
+			BlockThemeProjectValidator::MARKER_PATH,
+			"{\n\t\"generator\": \"sd-ai-agent\",\n\t\"generator_version\": \"1.0.0\",\n\t\"validation_version\": 1\n}\n"
+		);
+
+		$report = ( new BlockThemeProjectValidator() )->validate( $this->theme_dir );
+
+		$this->assertFalse( $report['valid'] );
+		$this->assertSame( 0, $report['project_version'] );
+		$this->assertContains( 'unknown_marker_version', array_column( $report['errors'], 'code' ) );
+	}
+
+	/**
+	 * Internal generated-project metadata is not theme source and must not
+	 * produce asset diagnostics from preserved release metadata.
+	 */
+	public function test_ignores_internal_project_metadata_during_text_source_validation(): void {
+		$this->stage_valid_project();
+		$this->write_fixture_file(
+			'.sd-ai-agent/design-artifacts/manifest.json',
+			'{"url":"https://cdn.invalid/release.json","src":"https://cdn.invalid/release.css"}'
+		);
+
+		$report = ( new BlockThemeProjectValidator() )->validate( $this->theme_dir );
+
+		$this->assertTrue( $report['valid'], (string) wp_json_encode( $report['errors'] ) );
+		$this->assertNotContains( 'remote_asset_url', array_column( $report['errors'], 'code' ) );
+	}
+
+	/**
 	 * Filesystem pattern PHP is inspected as text and never evaluated.
 	 */
 	public function test_never_executes_pattern_php_while_reporting_executable_content(): void {

--- a/tests/SdAiAgent/Services/BlockThemeProjectValidatorTest.php
+++ b/tests/SdAiAgent/Services/BlockThemeProjectValidatorTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Tests for read-only generated block-theme project validation.
+ *
+ * @package SdAiAgent\Tests\Services
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Services;
+
+use SdAiAgent\Core\BlockValidatorBridge;
+use SdAiAgent\Services\BlockThemeProjectValidator;
+use WP_UnitTestCase;
+
+/**
+ * Verifies deterministic, bounded validation of generated theme projects.
+ */
+class BlockThemeProjectValidatorTest extends WP_UnitTestCase {
+
+	/**
+	 * Disposable project root.
+	 */
+	private string $theme_dir;
+
+	public function setUp(): void {
+		parent::setUp();
+		$this->theme_dir = trailingslashit( get_theme_root() ) . 'sd-ai-validator-' . strtolower( wp_generate_password( 8, false ) );
+		wp_mkdir_p( $this->theme_dir );
+	}
+
+	public function tear_down(): void {
+		BlockValidatorBridge::reset_memory_cache();
+		self::rrmdir( $this->theme_dir );
+		parent::tear_down();
+	}
+
+	/**
+	 * A complete marked project produces a stable, empty diagnostic report.
+	 */
+	public function test_valid_marked_project_returns_a_deterministic_relative_report(): void {
+		$this->stage_valid_project();
+		$validator = new BlockThemeProjectValidator();
+
+		$first  = $validator->validate( $this->theme_dir );
+		$second = $validator->validate( $this->theme_dir );
+
+		$this->assertTrue( $first['valid'], (string) wp_json_encode( $first['errors'] ) );
+		$this->assertTrue( $first['marked'] );
+		$this->assertSame( BlockThemeProjectValidator::MARKER_SCHEMA_VERSION, $first['project_version'] );
+		$this->assertSame( [], $first['errors'] );
+		$this->assertSame( [], $first['warnings'] );
+		$this->assertGreaterThanOrEqual( 4, $first['files_scanned'] );
+		$this->assertSame( $first, $second, 'Repeated read-only validation must produce an identical report.' );
+	}
+
+	/**
+	 * Browser-posted block validation cache entries must not affect generated
+	 * project diagnostics or the activation gate that consumes them.
+	 */
+	public function test_ignores_browser_cached_block_validation_results(): void {
+		$this->stage_valid_project();
+		$contents = "<!-- wp:heading {\"level\":3} -->\n<h2 class=\"wp-block-heading\">Incorrect heading</h2>\n<!-- /wp:heading -->";
+		$this->write_fixture_file( 'templates/index.html', $contents );
+		$validator = new BlockThemeProjectValidator();
+		$expected  = $validator->validate( $this->theme_dir );
+
+		BlockValidatorBridge::store(
+			$contents,
+			[
+				'totalBlocks'   => 1,
+				'validBlocks'   => 1,
+				'invalidBlocks' => 0,
+				'results'       => [
+					[
+						'blockName'       => 'core/heading',
+						'isValid'         => true,
+						'issues'          => [],
+						'originalContent' => '<h2 class="wp-block-heading">Incorrect heading</h2>',
+						'expectedContent' => '<h2 class="wp-block-heading">Incorrect heading</h2>',
+					],
+				],
+				'source'        => 'js',
+			]
+		);
+
+		try {
+			$actual = $validator->validate( $this->theme_dir );
+		} finally {
+			BlockValidatorBridge::reset_memory_cache();
+			delete_transient( BlockValidatorBridge::TRANSIENT_PREFIX . hash( 'sha256', $contents ) );
+		}
+
+		$this->assertFalse( $actual['valid'] );
+		$this->assertContains( 'invalid_block_markup', array_column( $actual['errors'], 'code' ) );
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Diagnostics stay theme-relative and report common unsafe generated content.
+	 */
+	public function test_reports_relative_diagnostics_for_placeholder_and_remote_asset_content(): void {
+		$this->stage_valid_project();
+		$this->write_fixture_file(
+			'templates/index.html',
+			'<!-- wp:paragraph --><p>Replace this text.</p><!-- /wp:paragraph --><img src="https://cdn.invalid/hero.jpg" alt="">'
+		);
+
+		$report = ( new BlockThemeProjectValidator() )->validate( $this->theme_dir );
+		$codes  = array_column( $report['errors'], 'code' );
+
+		$this->assertFalse( $report['valid'] );
+		$this->assertContains( 'placeholder_content', $codes );
+		$this->assertContains( 'remote_asset_url', $codes );
+
+		foreach ( $report['errors'] as $diagnostic ) {
+			$this->assertStringNotContainsString( $this->theme_dir, $diagnostic['path'] );
+		}
+	}
+
+	/**
+	 * Filesystem pattern PHP is inspected as text and never evaluated.
+	 */
+	public function test_never_executes_pattern_php_while_reporting_executable_content(): void {
+		$this->stage_valid_project();
+		$this->write_fixture_file(
+			'patterns/static.php',
+			"<?php\n/**\n * Title: Static pattern\n * Slug: " . basename( $this->theme_dir ) . "/static\n */\n?>\n<?php throw new \\RuntimeException( 'must not execute' ); ?>\n<!-- wp:paragraph --><p>Static content.</p><!-- /wp:paragraph -->\n"
+		);
+
+		$report = ( new BlockThemeProjectValidator() )->validate( $this->theme_dir );
+		$codes  = array_column( $report['errors'], 'code' );
+
+		$this->assertFalse( $report['valid'] );
+		$this->assertContains( 'executable_pattern_content', $codes );
+	}
+
+	/**
+	 * Stage the smallest complete generated block-theme project.
+	 */
+	private function stage_valid_project(): void {
+		$this->write_fixture_file( BlockThemeProjectValidator::MARKER_PATH, BlockThemeProjectValidator::marker_contents() );
+		$this->write_fixture_file(
+			'style.css',
+			"/*\nTheme Name: Validator fixture\nVersion: 1.0.0\n*/\n"
+		);
+		$this->write_fixture_file(
+			'theme.json',
+			"{\n\t\"\$schema\": \"https://schemas.wp.org/trunk/theme.json\",\n\t\"version\": 3,\n\t\"settings\": {}\n}\n"
+		);
+		$this->write_fixture_file(
+			'templates/index.html',
+			'<!-- wp:paragraph --><p class="wp-block-paragraph">Welcome.</p><!-- /wp:paragraph -->'
+		);
+	}
+
+	/**
+	 * Write a fixture file beneath the disposable project root.
+	 *
+	 * @param string $relative Theme-relative fixture path.
+	 * @param string $contents Fixture contents.
+	 */
+	private function write_fixture_file( string $relative, string $contents ): void {
+		$path = $this->theme_dir . '/' . ltrim( $relative, '/' );
+		wp_mkdir_p( dirname( $path ) );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Test fixture setup requires direct local writes.
+		$this->assertNotFalse( file_put_contents( $path, $contents ) );
+	}
+
+	/**
+	 * Recursively delete a fixture directory.
+	 *
+	 * @param string $dir Absolute directory path.
+	 */
+	private static function rrmdir( string $dir ): void {
+		if ( ! is_dir( $dir ) ) {
+			return;
+		}
+		foreach ( scandir( $dir ) ?: [] as $entry ) {
+			if ( '.' === $entry || '..' === $entry ) {
+				continue;
+			}
+			$path = $dir . DIRECTORY_SEPARATOR . $entry;
+			if ( is_dir( $path ) ) {
+				self::rrmdir( $path );
+			} else {
+				@unlink( $path );
+			}
+		}
+		@rmdir( $dir );
+	}
+}

--- a/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
+++ b/tests/SdAiAgent/Tools/ToolDiscoveryTest.php
@@ -339,6 +339,24 @@ class ToolDiscoveryTest extends WP_UnitTestCase {
 		$this->assertContains( 'sd-ai-agent/compile-design-tokens', $ids );
 	}
 
+	public function test_ability_search_maps_generated_theme_validation_to_the_project_validator(): void {
+		$result = ToolDiscovery::handle_ability_search(
+			[
+				'query'       => 'validate generated block theme project',
+				'max_results' => 5,
+			]
+		);
+
+		$ids = array_map(
+			static function ( $result ) {
+				return $result['id'];
+			},
+			$result['results']
+		);
+
+		$this->assertContains( 'sd-ai-agent/validate-block-theme-project', $ids );
+	}
+
 	public function test_ability_search_maps_edit_page_to_update_post(): void {
 		$result = ToolDiscovery::handle_ability_search(
 			[


### PR DESCRIPTION
## Summary

- Add deterministic, server-side validation for generated block-theme projects.
- Register `sd-ai-agent/validate-block-theme-project`, protect activation of marked generated projects, and surface validation guidance and tool discovery.
- Add cache-independence, malformed-project, activation-gate, capability, discovery, and skill regressions.
- Harden marker parsing and exclude `.sd-ai-agent/` metadata from text-source validation.
- Rebase onto current `main` while preserving the style-variation lifecycle and the 540-line block-theme skill budget.

Resolves #2250

## Worker self-verification

- PHPUnit: Tests: 3866, Assertions: 16586, Errors: 0, Failures: 0, Skipped: 125
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.155 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-terra spent 1h 48m and 1,296,906 tokens on this as a headless worker. Overall, 14h 49m since this issue was created.
