### PR TITLE
feat: add GPT-5.6 chat aliases

### DIFF
--- a/includes/Core/CostCalculator.php
+++ b/includes/Core/CostCalculator.php
@@ -17,8 +17,9 @@ class CostCalculator {
 	 */
 	private const PRICING = [
 		// Superdav managed models.
-		'superdav-chat-fast'                   => [ 0.25, 1.00 ],
-		'superdav-chat-pro'                    => [ 1.50, 6.00 ],
+		'gpt-5.6-luna'                         => [ 0.25, 1.00 ],
+		'gpt-5.6-terra'                        => [ 1.50, 6.00 ],
+		'gpt-5.6-sol'                          => [ 1.50, 6.00 ],
 		// Claude models.
 		'claude-sonnet-4-6'                    => [ 3.00, 15.00 ],
 		'claude-opus-4-6'                      => [ 15.00, 75.00 ],

--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -82,8 +82,9 @@ class Settings {
 	 */
 	const MODEL_CONTEXT_WINDOWS = array(
 		// Superdav managed models.
-		'superdav-chat-fast'            => 128000,
-		'superdav-chat-pro'             => 200000,
+		'gpt-5.6-luna'                  => 128000,
+		'gpt-5.6-terra'                 => 200000,
+		'gpt-5.6-sol'                   => 200000,
 		'superdav-image'                => 32000,
 		// Anthropic.
 		'claude-opus-4-6'               => 200000,
@@ -184,8 +185,9 @@ class Settings {
 	 */
 	const MODEL_MAX_OUTPUT_TOKENS = array(
 		// ── Superdav managed models ───────────────────────────────────────
-		'superdav-chat-fast'          => 8192,
-		'superdav-chat-pro'           => 16384,
+		'gpt-5.6-luna'                => 8192,
+		'gpt-5.6-terra'               => 16384,
+		'gpt-5.6-sol'                 => 16384,
 		'superdav-image'              => 1,
 		// ── Anthropic ──────────────────────────────────────────────────
 		// Opus 4.6 / 4.7 document 128K; Opus 4.5 documents 64K; Opus 4.1

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php
@@ -26,8 +26,9 @@ final class SuperdavAiProvider extends AbstractApiProvider {
 	public const PROVIDER_ID       = 'sd-ai-agent-cloud';
 	public const CREDENTIAL_OPTION = 'connectors_ai_sd_ai_agent_cloud_api_key';
 	public const DEFAULT_BASE_URL  = 'https://api.sdaiagent.com/v1';
-	public const FAST_MODEL_ID     = 'superdav-chat-fast';
-	public const DEFAULT_MODEL_ID  = 'superdav-chat-pro';
+	public const FAST_MODEL_ID     = 'gpt-5.6-luna';
+	public const DEFAULT_MODEL_ID  = 'gpt-5.6-terra';
+	public const STRONG_MODEL_ID   = 'gpt-5.6-sol';
 	public const IMAGE_MODEL_ID    = 'superdav-image';
 
 	/**
@@ -41,8 +42,9 @@ final class SuperdavAiProvider extends AbstractApiProvider {
 	 * @var array<string, string>
 	 */
 	private const MODEL_REASONING_EFFORTS = array(
-		self::FAST_MODEL_ID    => 'medium',
-		self::DEFAULT_MODEL_ID => 'high',
+		self::FAST_MODEL_ID    => 'low',
+		self::DEFAULT_MODEL_ID => 'medium',
+		self::STRONG_MODEL_ID  => 'high',
 	);
 
 	/**

--- a/includes/Tools/ModelHealthTracker.php
+++ b/includes/Tools/ModelHealthTracker.php
@@ -73,7 +73,7 @@ class ModelHealthTracker {
 	private const WEAK_NAME_HINTS = array(
 		// Managed cloud fast route: bootstrap with stricter schema-following
 		// guidance after field reports of empty required-argument tool calls.
-		'superdav-chat-fast',
+		'gpt-5.6-luna',
 		// Small parameter counts.
 		'-1b',
 		'-2b',

--- a/src/components/chat-redesign/__tests__/MessageList.test.js
+++ b/src/components/chat-redesign/__tests__/MessageList.test.js
@@ -62,6 +62,7 @@ function buildSelectors( {
 		getTtsRate: () => 1,
 		getTtsPitch: () => 1,
 		hasStreamError: () => hasStreamError,
+		getProviders: () => [],
 	};
 }
 

--- a/src/components/model-pricing-selector.js
+++ b/src/components/model-pricing-selector.js
@@ -23,8 +23,9 @@ import { __ } from '@wordpress/i18n';
  */
 const PRICING = {
 	// Superdav managed models.
-	'superdav-chat-fast': [ 0.25, 1.0 ],
-	'superdav-chat-pro': [ 1.5, 6.0 ],
+	'gpt-5.6-luna': [ 0.25, 1.0 ],
+	'gpt-5.6-terra': [ 1.5, 6.0 ],
+	'gpt-5.6-sol': [ 1.5, 6.0 ],
 	// Claude models.
 	'claude-haiku-4': [ 0.8, 4.0 ],
 	'claude-sonnet-4': [ 3.0, 15.0 ],
@@ -86,16 +87,22 @@ const TIERS = [
 const MODEL_CATALOG = [
 	// Superdav
 	{
-		id: 'superdav-chat-fast',
+		id: 'gpt-5.6-luna',
 		provider: 'sd-ai-agent-cloud',
-		name: 'Superdav Chat Fast',
-		note: __( 'fast', 'sd-ai-agent' ),
+		name: 'GPT-5.6 Luna',
+		note: __( 'fast', 'superdav-ai-agent' ),
 	},
 	{
-		id: 'superdav-chat-pro',
+		id: 'gpt-5.6-terra',
 		provider: 'sd-ai-agent-cloud',
-		name: 'Superdav Chat Pro',
-		note: __( '$10 free credit eligible', 'sd-ai-agent' ),
+		name: 'GPT-5.6 Terra',
+		note: __( 'standard', 'superdav-ai-agent' ),
+	},
+	{
+		id: 'gpt-5.6-sol',
+		provider: 'sd-ai-agent-cloud',
+		name: 'GPT-5.6 Sol',
+		note: __( 'strong', 'superdav-ai-agent' ),
 	},
 	// Anthropic
 	{

--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -420,10 +420,11 @@ describe( 'resolveProviderSelection', () => {
 			[
 				{
 					id: 'sd-ai-agent-cloud',
-					default_model: 'superdav-chat-pro',
+					default_model: 'gpt-5.6-terra',
 					models: [
-						{ id: 'superdav-chat-fast' },
-						{ id: 'superdav-chat-pro' },
+						{ id: 'gpt-5.6-luna' },
+						{ id: 'gpt-5.6-terra' },
+						{ id: 'gpt-5.6-sol' },
 					],
 				},
 			],
@@ -433,7 +434,7 @@ describe( 'resolveProviderSelection', () => {
 
 		expect( selection ).toEqual( {
 			providerId: 'sd-ai-agent-cloud',
-			modelId: 'superdav-chat-pro',
+			modelId: 'gpt-5.6-terra',
 		} );
 	} );
 
@@ -442,20 +443,21 @@ describe( 'resolveProviderSelection', () => {
 			[
 				{
 					id: 'sd-ai-agent-cloud',
-					default_model: 'superdav-chat-pro',
+					default_model: 'gpt-5.6-terra',
 					models: [
-						{ id: 'superdav-chat-fast' },
-						{ id: 'superdav-chat-pro' },
+						{ id: 'gpt-5.6-luna' },
+						{ id: 'gpt-5.6-terra' },
+						{ id: 'gpt-5.6-sol' },
 					],
 				},
 			],
 			'sd-ai-agent-cloud',
-			'superdav-chat-fast'
+			'gpt-5.6-luna'
 		);
 
 		expect( selection ).toEqual( {
 			providerId: 'sd-ai-agent-cloud',
-			modelId: 'superdav-chat-fast',
+			modelId: 'gpt-5.6-luna',
 		} );
 	} );
 
@@ -468,10 +470,11 @@ describe( 'resolveProviderSelection', () => {
 				},
 				{
 					id: 'sd-ai-agent-cloud',
-					default_model: 'superdav-chat-pro',
+					default_model: 'gpt-5.6-terra',
 					models: [
-						{ id: 'superdav-chat-fast' },
-						{ id: 'superdav-chat-pro' },
+						{ id: 'gpt-5.6-luna' },
+						{ id: 'gpt-5.6-terra' },
+						{ id: 'gpt-5.6-sol' },
 					],
 				},
 			],
@@ -481,7 +484,7 @@ describe( 'resolveProviderSelection', () => {
 
 		expect( selection ).toEqual( {
 			providerId: 'sd-ai-agent-cloud',
-			modelId: 'superdav-chat-pro',
+			modelId: 'gpt-5.6-terra',
 		} );
 	} );
 } );

--- a/superdav-ai-agent.php
+++ b/superdav-ai-agent.php
@@ -44,7 +44,7 @@ define( 'SD_AI_AGENT_URL', plugin_dir_url( __FILE__ ) );
  * Developers can override the effective default at runtime via the
  * `sd_ai_agent_default_model` filter rather than changing this constant.
  */
-define( 'SD_AI_AGENT_DEFAULT_MODEL', 'superdav-chat-pro' );
+define( 'SD_AI_AGENT_DEFAULT_MODEL', 'gpt-5.6-terra' );
 
 // ── Feature flags ─────────────────────────────────────────────────────────────
 // Each constant defaults to `true` (enabled) when not defined.

--- a/tests/SdAiAgent/Abilities/PublicChatSetupAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/PublicChatSetupAbilitiesTest.php
@@ -83,7 +83,7 @@ class PublicChatSetupAbilitiesTest extends WP_UnitTestCase {
 				'origins'            => array( 'HTTPS://Docs.Example.com/path' ),
 				'collection_slugs'   => array( $this->collection_slug ),
 				'provider_id'        => 'sd-ai-agent-cloud',
-				'model_id'           => 'superdav-chat-pro',
+				'model_id'           => 'gpt-5.6-terra',
 				'embed_id'           => 'docs',
 				'rate_limit_per_min' => 99,
 				'message_max_length' => 9000,
@@ -124,7 +124,7 @@ class PublicChatSetupAbilitiesTest extends WP_UnitTestCase {
 				'action'           => 'configure',
 				'collection_slugs' => array( $this->collection_slug ),
 				'provider_id'      => 'sd-ai-agent-cloud',
-				'model_id'         => 'superdav-chat-pro',
+				'model_id'         => 'gpt-5.6-terra',
 			)
 		);
 
@@ -148,7 +148,7 @@ class PublicChatSetupAbilitiesTest extends WP_UnitTestCase {
 				'enabled'          => true,
 				'collection_slugs' => array( $this->collection_slug ),
 				'provider_id'      => 'sd-ai-agent-cloud',
-				'model_id'         => 'superdav-chat-pro',
+				'model_id'         => 'gpt-5.6-terra',
 			)
 		);
 

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
@@ -117,10 +117,10 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The bundled provider defaults clean installs to the pro managed alias.
+	 * The bundled provider defaults clean installs to the standard managed alias.
 	 */
-	public function test_default_model_is_managed_pro_alias(): void {
-		$this->assertSame( 'superdav-chat-pro', SuperdavAiProvider::default_model_id() );
+	public function test_default_model_is_managed_standard_alias(): void {
+		$this->assertSame( 'gpt-5.6-terra', SuperdavAiProvider::default_model_id() );
 	}
 
 	/**
@@ -210,8 +210,9 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 	 */
 	public function managed_model_effort_provider(): array {
 		return array(
-			'fast' => array( SuperdavAiProvider::FAST_MODEL_ID, 'medium' ),
-			'pro'  => array( SuperdavAiProvider::DEFAULT_MODEL_ID, 'high' ),
+			'fast'     => array( SuperdavAiProvider::FAST_MODEL_ID, 'low' ),
+			'standard' => array( SuperdavAiProvider::DEFAULT_MODEL_ID, 'medium' ),
+			'strong'   => array( SuperdavAiProvider::STRONG_MODEL_ID, 'high' ),
 		);
 	}
 
@@ -387,7 +388,7 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 			'gpt-5.5-pro'   => array( 'gpt-5.5-pro', true ),
 			'gpt-6'         => array( 'gpt-6', true ),
 			'gpt-4o'        => array( 'gpt-4o', false ),
-			'managed alias' => array( SuperdavAiProvider::DEFAULT_MODEL_ID, false ),
+			'managed alias' => array( SuperdavAiProvider::DEFAULT_MODEL_ID, true ),
 		);
 	}
 

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -1321,7 +1321,7 @@ class RestControllerTest extends WP_UnitTestCase {
 				'tool_calls'       => [ [ 'type' => 'call', 'id' => 'call_1', 'name' => 'wpab__sd-ai-agent__site-info' ] ],
 				'messages'         => [ [ 'type' => 'provider_error', 'message' => 'Provider rejected history.' ] ],
 				'token_usage'      => [ 'prompt' => 12, 'completion' => 0 ],
-				'model_id'         => 'superdav-chat-pro',
+				'model_id'         => 'gpt-5.6-terra',
 				'provider_id'      => 'sd-ai-agent-cloud',
 				'client_abilities' => [],
 			]
@@ -1332,7 +1332,7 @@ class RestControllerTest extends WP_UnitTestCase {
 		$method->setAccessible( true );
 
 		$params     = [ 'message' => 'Please continue after the error.', 'session_id' => $session_id ];
-		$options    = [ 'provider_id' => 'sd-ai-agent-cloud', 'model_id' => 'superdav-chat-pro' ];
+		$options    = [ 'provider_id' => 'sd-ai-agent-cloud', 'model_id' => 'gpt-5.6-terra' ];
 		$job        = [ 'status' => 'error', 'error' => $error->get_error_message(), 'params' => $params ];
 		$error_data = $error->get_error_data();
 		$this->assertIsArray( $error_data );

--- a/tests/SdAiAgent/REST/SettingsControllerTest.php
+++ b/tests/SdAiAgent/REST/SettingsControllerTest.php
@@ -160,8 +160,8 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 							array(
 								'data' => array(
 									array(
-										'id'                => 'superdav-chat-fast',
-										'name'              => 'Superdav Chat Fast',
+										'id'                => 'gpt-5.6-luna',
+										'name'              => 'GPT-5.6 Luna',
 										'context_length'    => 128000,
 										'max_output_length' => 8192,
 									),
@@ -192,7 +192,7 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		$this->assertSame( SuperdavAiProvider::DEFAULT_MODEL_ID, $superdav['default_model'] ?? '' );
 		$this->assertTrue( $superdav['status']['connection_notice_pending'] );
 		$this->assertSame( 10000000, $superdav['status']['wallet']['promo_usd_micros'] );
-		$this->assertSame( 'superdav-chat-fast', $superdav['models'][0]['id'] ?? '' );
+		$this->assertSame( 'gpt-5.6-luna', $superdav['models'][0]['id'] ?? '' );
 		$this->assertStringNotContainsString( 'sdaist_auto_provisioned_token', wp_json_encode( $superdav ) ?: '' );
 
 		$second_response = $controller->handle_providers();
@@ -384,14 +384,14 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 							array(
 								'data' => array(
 									array(
-										'id'                => 'superdav-chat-fast',
-										'name'              => 'Superdav Chat Fast',
+										'id'                => 'gpt-5.6-luna',
+										'name'              => 'GPT-5.6 Luna',
 										'context_length'    => 128000,
 										'max_output_length' => 8192,
 									),
 									array(
-										'id'                => 'superdav-chat-pro',
-										'name'              => 'Superdav Chat Pro',
+										'id'                => 'gpt-5.6-terra',
+										'name'              => 'GPT-5.6 Terra',
 										'context_length'    => 200000,
 										'max_output_length' => 16384,
 									),
@@ -421,7 +421,7 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		$this->assertSame( 'sdaist_refreshed_token', get_option( SuperdavAiProvider::CREDENTIAL_OPTION, '' ) );
 		$this->assertNotNull( $superdav );
 		$this->assertSame( SuperdavAiProvider::DEFAULT_MODEL_ID, $superdav['default_model'] ?? '' );
-		$this->assertSame( array( 'superdav-chat-fast', 'superdav-chat-pro' ), wp_list_pluck( $superdav['models'] ?? array(), 'id' ) );
+		$this->assertSame( array( 'gpt-5.6-luna', 'gpt-5.6-terra' ), wp_list_pluck( $superdav['models'] ?? array(), 'id' ) );
 	}
 
 	/**

--- a/tests/SdAiAgent/Tools/ModelHealthTrackerTest.php
+++ b/tests/SdAiAgent/Tools/ModelHealthTrackerTest.php
@@ -35,7 +35,7 @@ class ModelHealthTrackerTest extends WP_UnitTestCase {
 		$this->assertTrue( ModelHealthTracker::matches_weak_name( 'phi-3-mini' ) );
 		$this->assertTrue( ModelHealthTracker::matches_weak_name( 'tinyllama' ) );
 		$this->assertTrue( ModelHealthTracker::matches_weak_name( 'mistral-7b-q4_k_m.gguf' ) );
-		$this->assertTrue( ModelHealthTracker::matches_weak_name( 'superdav-chat-fast' ) );
+		$this->assertTrue( ModelHealthTracker::matches_weak_name( 'gpt-5.6-luna' ) );
 	}
 
 	public function test_name_heuristic_does_not_flag_strong_models(): void {


### PR DESCRIPTION
## Summary
- Replace managed chat aliases with GPT-5.6 Luna (fast), Terra (standard), and Sol (strong).
- Make Terra the clean-install fallback and map the aliases to low, medium, and high reasoning effort.
- Update selector metadata, cost/context fallbacks, and provider contract tests.

## Worker self-verification
- PHPUnit: Tests: 3868, Assertions: 16591, Errors: 0, Failures: 0, Skipped: 125
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- JavaScript tests: 363 passed

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.156 plugin for [OpenCode](https://opencode.ai) v1.18.3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added GPT-5.6 Luna, Terra, and Sol models to the model selector.
  - Updated model labels, pricing, context limits, and output limits.
  - Terra is now the default model when no model is configured.
  - Updated reasoning levels and tool-search support for managed models.

- **Bug Fixes**
  - Updated model health detection and provider selection to recognize the new GPT-5.6 models.

- **Tests**
  - Updated automated coverage for model selection, pricing, provider behavior, health tracking, and error recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->