### PR TITLE
Fix Advanced dependency notice for network-active core

### DIFF
--- a/advanced-plugin/superdav-ai-agent-advanced.php
+++ b/advanced-plugin/superdav-ai-agent-advanced.php
@@ -34,21 +34,37 @@ require_once SD_AI_AGENT_ADVANCED_DIR . '/includes/Autoloader.php';
 
 \SdAiAgentAdvanced\Autoloader::register( SD_AI_AGENT_ADVANCED_DIR );
 
-if ( ! defined( 'SD_AI_AGENT_VERSION' ) ) {
-	add_action(
-		'admin_notices',
-		static function (): void {
-			printf(
-				'<div class="notice notice-error"><p>%s</p></div>',
-				esc_html__(
-					'Superdav AI Agent Advanced requires the core Superdav AI Agent plugin to be installed and active.',
-					'superdav-ai-agent'
-				)
-			);
+// When both plugins are network active, WordPress can load the advanced plugin
+// before the core plugin. Defer the dependency notice until all normal plugins
+// have had a chance to define SD_AI_AGENT_VERSION, but register the container
+// extension filter immediately so the core plugin can still discover the
+// advanced module when it boots later in the same request.
+add_action(
+	'plugins_loaded',
+	static function (): void {
+		if ( defined( 'SD_AI_AGENT_VERSION' ) ) {
+			return;
 		}
-	);
-	return;
-}
+
+		$notice_hook = function_exists( 'is_network_admin' ) && is_network_admin()
+			? 'network_admin_notices'
+			: 'admin_notices';
+
+		add_action(
+			$notice_hook,
+			static function (): void {
+				printf(
+					'<div class="notice notice-error"><p>%s</p></div>',
+					esc_html__(
+						'Superdav AI Agent Advanced requires the core Superdav AI Agent plugin to be installed and active.',
+						'superdav-ai-agent'
+					)
+				);
+			}
+		);
+	},
+	PHP_INT_MAX
+);
 
 add_filter(
 	'xwp_extend_import_sd-ai-agent',


### PR DESCRIPTION
## Summary

- Defers the Advanced companion plugin's missing-core notice until `plugins_loaded` so network-active core has time to load first.
- Keeps the `xwp_extend_import_sd-ai-agent` filter registration immediate so the core DI container can still discover the Advanced module when core loads later in the request.
- Sends the missing-core notice to `network_admin_notices` when viewed from network admin.

## Worker self-verification
- PHPUnit: Tests: 3866, Assertions: 16586, Errors: 0, Failures: 0, Skipped: 125, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Additional targeted checks:

- `php -l advanced-plugin/superdav-ai-agent-advanced.php`
- Simulated advanced-before-core load order: passed
- Simulated missing-core network-admin notice: passed
- `git diff --check`: clean

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.156 plugin for [OpenCode](https://opencode.ai) v1.18.3
