### PR TITLE
GH#2272: harden client completion evidence

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -1231,14 +1231,16 @@ class AgentLoop {
 					// Persist loop state so the resume endpoint can reconstruct it.
 					if ( $this->session_id > 0 ) {
 						$paused_state = array(
-							'history'              => $this->serialize_history(),
-							'tool_call_log'        => $this->tool_call_log,
-							'message_log'          => $this->message_log,
-							'token_usage'          => $this->token_usage,
-							'iterations_remaining' => $iterations,
-							'model_id'             => $this->model_id,
-							'provider_id'          => $this->provider_id,
-							'client_abilities'     => $this->client_abilities,
+							'history'                   => $this->serialize_history(),
+							'tool_call_log'             => $this->tool_call_log,
+							'message_log'               => $this->message_log,
+							'token_usage'               => $this->token_usage,
+							'iterations_remaining'      => $iterations,
+							'model_id'                  => $this->model_id,
+							'provider_id'               => $this->provider_id,
+							'client_abilities'          => $this->client_abilities,
+							// Bind the browser's resume payload to this exact paused batch.
+							'pending_client_tool_calls' => $partition['client'],
 						);
 						Database::save_paused_state( $this->session_id, $paused_state );
 					}

--- a/includes/Core/ClientAbilityRouter.php
+++ b/includes/Core/ClientAbilityRouter.php
@@ -209,6 +209,57 @@ final class ClientAbilityRouter {
 	}
 
 	/**
+	 * Return whether browser results exactly match one paused client-tool batch.
+	 *
+	 * Browser payloads are untrusted at the REST boundary. Matching both the
+	 * opaque call ID and the ability name prevents a result for one pending call
+	 * from being substituted for another call in the same paused loop.
+	 *
+	 * @param array<mixed,mixed> $expected_calls Persisted pending calls.
+	 * @param array<mixed,mixed> $tool_results   Browser-submitted results.
+	 */
+	public static function matches_pending_results( array $expected_calls, array $tool_results ): bool {
+		if ( empty( $expected_calls ) || count( $expected_calls ) !== count( $tool_results ) ) {
+			return false;
+		}
+
+		$expected_by_id = array();
+		foreach ( $expected_calls as $call ) {
+			$id   = (string) ( $call['id'] ?? '' );
+			$name = (string) ( $call['name'] ?? '' );
+			if ( '' === $id || '' === $name || isset( $expected_by_id[ $id ] ) ) {
+				return false;
+			}
+			$expected_by_id[ $id ] = $name;
+		}
+
+		$seen_ids = array();
+		foreach ( $tool_results as $result ) {
+			if ( ! is_array( $result ) ) {
+				return false;
+			}
+
+			$id         = (string) ( $result['id'] ?? '' );
+			$name       = (string) ( $result['name'] ?? '' );
+			$has_result = array_key_exists( 'result', $result );
+			$has_error  = array_key_exists( 'error', $result );
+			if (
+				'' === $id
+				|| ! isset( $expected_by_id[ $id ] )
+				|| $expected_by_id[ $id ] !== $name
+				|| isset( $seen_ids[ $id ] )
+				|| $has_result === $has_error
+			) {
+				return false;
+			}
+
+			$seen_ids[ $id ] = true;
+		}
+
+		return count( $seen_ids ) === count( $expected_by_id );
+	}
+
+	/**
 	 * Build a new Message containing only the given MessagePart objects.
 	 *
 	 * Used to construct a PHP-only sub-message when a mixed assistant message

--- a/includes/Core/GeneratedThemeCompletionGate.php
+++ b/includes/Core/GeneratedThemeCompletionGate.php
@@ -481,6 +481,11 @@ final class GeneratedThemeCompletionGate {
 			return;
 		}
 
+		if ( true === ( $response['browser_execution_unavailable'] ?? false ) ) {
+			$this->last_failure = 'Browser execution was unavailable, so frontend completion evidence could not be collected. Restore browser capability and rerun the full validator; do not treat this as a fatal theme activation failure.';
+			return;
+		}
+
 		if ( ! $this->report_covers_required_surface( $call_args, $response ) ) {
 			$this->last_failure = 'The browser report was partial, failed a required render, or contained deterministic quality violations.';
 			return;
@@ -622,15 +627,17 @@ final class GeneratedThemeCompletionGate {
 			return false;
 		}
 
-		foreach ( $required_urls as $url ) {
+		foreach ( $required_urls as $index => $url ) {
+			$role        = 0 === $index ? 'homepage' : 'interior';
+			$is_homepage = 0 === $index;
 			foreach ( self::REQUIRED_VIEWPORTS as $viewport ) {
-				if ( ! $this->has_passing_viewport_report( $reports, $url, $viewport ) ) {
+				if ( ! $this->has_passing_viewport_report( $reports, $url, $role, $is_homepage, $viewport ) ) {
 					return false;
 				}
 			}
 		}
 
-		return true;
+		return $this->roles_have_distinct_final_urls( $reports );
 	}
 
 	/**
@@ -638,12 +645,20 @@ final class GeneratedThemeCompletionGate {
 	 *
 	 * @param array<int,mixed>                         $reports  Browser report rows.
 	 * @param string                                   $url      Required normalized URL.
+	 * @param string                                   $role     Expected semantic page role.
+	 * @param bool                                     $is_homepage Whether the document must be the homepage.
 	 * @param array{label:string,width:int,height:int} $viewport Required viewport.
 	 */
-	private function has_passing_viewport_report( array $reports, string $url, array $viewport ): bool {
+	private function has_passing_viewport_report( array $reports, string $url, string $role, bool $is_homepage, array $viewport ): bool {
 		$matches = 0;
 		foreach ( $reports as $report ) {
-			if ( ! is_array( $report ) || self::normalize_url( (string) ( $report['url'] ?? '' ) ) !== $url ) {
+			if (
+				! is_array( $report )
+				|| self::normalize_url( (string) ( $report['requested_url'] ?? '' ) ) !== $url
+				|| $role !== (string) ( $report['role'] ?? '' )
+				|| $is_homepage !== ( $report['is_homepage'] ?? null )
+				|| ! self::same_origin_url( $url, (string) ( $report['final_url'] ?? '' ) )
+			) {
 				continue;
 			}
 
@@ -670,12 +685,56 @@ final class GeneratedThemeCompletionGate {
 	}
 
 	/**
+	 * Reject a redirect that maps homepage and interior evidence to one document.
+	 *
+	 * @param array<int,mixed> $reports Browser report rows.
+	 */
+	private function roles_have_distinct_final_urls( array $reports ): bool {
+		$final_urls = array(
+			'homepage' => array(),
+			'interior' => array(),
+		);
+		foreach ( $reports as $report ) {
+			if ( ! is_array( $report ) ) {
+				continue;
+			}
+			$role      = (string) ( $report['role'] ?? '' );
+			$final_url = self::normalize_url( (string) ( $report['final_url'] ?? '' ) );
+			if ( isset( $final_urls[ $role ] ) && '' !== $final_url ) {
+				$final_urls[ $role ][ $final_url ] = true;
+			}
+		}
+
+		return ! empty( $final_urls['homepage'] )
+			&& ! empty( $final_urls['interior'] )
+			&& empty( array_intersect_key( $final_urls['homepage'], $final_urls['interior'] ) );
+	}
+
+	/**
+	 * Return whether a redirected final document remains on the requested origin.
+	 */
+	private static function same_origin_url( string $requested_url, string $final_url ): bool {
+		$requested = wp_parse_url( $requested_url );
+		$final     = wp_parse_url( $final_url );
+		if ( ! is_array( $requested ) || ! is_array( $final ) || empty( $final_url ) ) {
+			return false;
+		}
+
+		return ( $requested['scheme'] ?? '' ) === ( $final['scheme'] ?? '' )
+			&& ( $requested['host'] ?? '' ) === ( $final['host'] ?? '' )
+			&& ( $requested['port'] ?? null ) === ( $final['port'] ?? null );
+	}
+
+	/**
 	 * Detect whether an all-unrenderable browser result requires rollback.
 	 *
 	 * @param array<string,mixed> $response Normalized browser report.
 	 */
 	private static function is_fatal_render_report( array $response ): bool {
-		if ( true !== ( $response['fatal_render_failure'] ?? false ) ) {
+		if (
+			true !== ( $response['fatal_render_failure'] ?? false )
+			|| true === ( $response['browser_execution_unavailable'] ?? false )
+		) {
 			return false;
 		}
 

--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace SdAiAgent\REST;
 
 use SdAiAgent\Core\AgentLoop;
+use SdAiAgent\Core\ClientAbilityRouter;
 use SdAiAgent\Core\ConversationSerializer;
 use SdAiAgent\Core\ConversationTrimmer;
 use SdAiAgent\Core\CostCalculator;
@@ -483,6 +484,31 @@ Assistant: %s',
 			);
 		}
 
+		$pending_client_tool_calls = $paused_state['pending_client_tool_calls'] ?? array();
+		if ( ! is_array( $pending_client_tool_calls ) ) {
+			// load_and_clear_paused_state() protects against a replay race. Restore
+			// this state when validation fails so the real browser batch can still
+			// complete; never resume an unverified payload.
+			Database::save_paused_state( $session_id, $paused_state );
+
+			return new WP_Error(
+				'sd_ai_agent_invalid_client_tool_results',
+				__( 'tool_results must exactly match the pending client tool calls.', 'superdav-ai-agent' ),
+				array( 'status' => 400 )
+			);
+		}
+		$pending_client_tool_calls = array_values( $pending_client_tool_calls );
+		$tool_results              = array_values( $tool_results );
+		if ( ! ClientAbilityRouter::matches_pending_results( $pending_client_tool_calls, $tool_results ) ) {
+			Database::save_paused_state( $session_id, $paused_state );
+
+			return new WP_Error(
+				'sd_ai_agent_invalid_client_tool_results',
+				__( 'tool_results must exactly match the pending client tool calls.', 'superdav-ai-agent' ),
+				array( 'status' => 400 )
+			);
+		}
+
 		// Reconstruct history from the paused state.
 		//
 		// We intentionally do NOT run ConversationTrimmer::validate_tool_pairs()
@@ -539,7 +565,7 @@ Assistant: %s',
 		// Use an empty user message — the loop resumes from history.
 		$loop = new AgentLoop( '', array(), $history, $options );
 		/** @var list<array{id: string, name: string, result?: mixed, error?: string}> $tool_results_typed */
-		$tool_results_typed = array_values( $tool_results );
+		$tool_results_typed = $tool_results;
 		$result             = $loop->resume_after_client_tools( $tool_results_typed, $iterations_remaining );
 
 		if ( is_wp_error( $result ) ) {

--- a/src/abilities/__tests__/theme-completion-validator.test.js
+++ b/src/abilities/__tests__/theme-completion-validator.test.js
@@ -231,6 +231,54 @@ describe( 'generated theme completion validator', () => {
 		);
 	} );
 
+	test( 'reports requested and final URLs with homepage semantics', async () => {
+		loadSameOriginIframe.mockImplementation( async ( { url } ) => ( {
+			success: true,
+			url: url === urls[ 1 ].replace( /\/$/, '' ) ? urls[ 0 ] : url,
+			error: '',
+			document,
+			window,
+			cleanup: jest.fn(),
+		} ) );
+
+		const report = await validateThemeCompletion( {
+			stylesheet,
+			fingerprint,
+			urls,
+		} );
+		const redirectedInterior = report.reports.find(
+			( row ) =>
+				row.role === 'interior' && row.viewport.label === 'mobile'
+		);
+
+		expect( redirectedInterior ).toMatchObject( {
+			requested_url: urls[ 1 ].replace( /\/$/, '' ),
+			final_url: urls[ 0 ].replace( /\/$/, '' ),
+			role: 'interior',
+			is_homepage: true,
+		} );
+	} );
+
+	test( 'keeps browser execution unavailability distinct from fatal rendering', async () => {
+		loadSameOriginIframe.mockImplementation( async ( { url } ) => ( {
+			success: false,
+			url,
+			error: 'Browser execution unavailable.',
+			document: null,
+			window: null,
+			cleanup: jest.fn(),
+		} ) );
+
+		const report = await validateThemeCompletion( {
+			stylesheet,
+			fingerprint,
+			urls,
+		} );
+
+		expect( report.browser_execution_unavailable ).toBe( true );
+		expect( report.fatal_render_failure ).toBe( false );
+	} );
+
 	test( 'passes only after all real URLs and required viewports render cleanly', async () => {
 		const report = await validateThemeCompletion( {
 			stylesheet,
@@ -248,6 +296,21 @@ describe( 'generated theme completion validator', () => {
 			fingerprint,
 		} );
 		expect( report.reports ).toHaveLength( 6 );
+		expect( report.reports ).toEqual(
+			expect.arrayContaining( [
+				expect.objectContaining( {
+					requested_url: urls[ 0 ].replace( /\/$/, '' ),
+					final_url: urls[ 0 ].replace( /\/$/, '' ),
+					role: 'homepage',
+					is_homepage: true,
+				} ),
+				expect.objectContaining( {
+					requested_url: urls[ 1 ].replace( /\/$/, '' ),
+					role: 'interior',
+					is_homepage: false,
+				} ),
+			] )
+		);
 		expect( report.violations ).toEqual( [] );
 	} );
 } );

--- a/src/abilities/theme-completion-iframe.js
+++ b/src/abilities/theme-completion-iframe.js
@@ -121,7 +121,9 @@ export async function loadSameOriginIframe( args ) {
 
 		return {
 			success: true,
-			url: resolved,
+			// contentWindow.location is the final same-origin document after a
+			// canonical redirect; callers retain their requested URL separately.
+			url: iframeWindow.location.href || resolved,
 			error: '',
 			iframe,
 			document: iframeDocument,

--- a/src/abilities/theme-completion-validator.js
+++ b/src/abilities/theme-completion-validator.js
@@ -44,6 +44,41 @@ function normalizeUrl( url ) {
 }
 
 /**
+ * Return whether a loaded document is semantically the site homepage.
+ *
+ * The WordPress body classes carry page semantics through canonical redirects;
+ * URL equality remains a safe fallback for sites that omit those classes.
+ *
+ * @param {Document} doc         Loaded frontend document.
+ * @param {string}   finalUrl    Final document URL.
+ * @param {string}   homepageUrl Requested homepage URL.
+ * @return {boolean} Whether the document is the homepage.
+ */
+function isHomepageDocument( doc, finalUrl, homepageUrl ) {
+	const classes = doc?.body?.classList;
+	if ( classes?.contains( 'home' ) || classes?.contains( 'front-page' ) ) {
+		return true;
+	}
+
+	return normalizeUrl( finalUrl ) === normalizeUrl( homepageUrl );
+}
+
+/**
+ * Return a classification for an iframe failure without mistaking a missing
+ * browser execution environment for a fatal activated-theme render failure.
+ *
+ * @param {string} error Failure evidence.
+ * @return {string} Stable failure classification.
+ */
+function classifyRenderFailure( error ) {
+	return /browser (?:execution|environment).*unavailable|cannot access iframe content|block framing/i.test(
+		String( error || '' )
+	)
+		? 'browser_execution_unavailable'
+		: 'frontend_unrenderable';
+}
+
+/**
  * Escape a CSS identifier even in browser/test environments without CSS.escape.
  *
  * @param {string} value Identifier value.
@@ -816,6 +851,7 @@ export async function validateThemeCompletion( args ) {
 	);
 	const violations = [];
 	const reports = [];
+	const homepageUrl = urls[ 0 ] || '';
 
 	if ( ! /^[a-z0-9-]+$/.test( stylesheet ) ) {
 		addViolation(
@@ -882,6 +918,10 @@ export async function validateThemeCompletion( args ) {
 	}
 
 	for ( const url of urls ) {
+		const role =
+			normalizeUrl( url ) === normalizeUrl( homepageUrl )
+				? 'homepage'
+				: 'interior';
 		for ( const viewport of THEME_COMPLETION_VIEWPORTS ) {
 			// eslint-disable-next-line no-await-in-loop -- Six bounded iframe renders must not race shared browser resources.
 			const loaded = await loadSameOriginIframe( {
@@ -892,6 +932,7 @@ export async function validateThemeCompletion( args ) {
 
 			if ( ! loaded.success || ! loaded.document || ! loaded.window ) {
 				const failedUrl = normalizeUrl( loaded.url || url );
+				const failureKind = classifyRenderFailure( loaded.error );
 				const failedRender = renderFailureViolation(
 					failedUrl,
 					viewport,
@@ -900,6 +941,11 @@ export async function validateThemeCompletion( args ) {
 				addViolation( violations, failedRender );
 				reports.push( {
 					url: failedUrl,
+					requested_url: normalizeUrl( url ),
+					final_url: failedUrl,
+					role,
+					is_homepage: false,
+					failure_kind: failureKind,
 					viewport,
 					success: false,
 					active_stylesheet: '',
@@ -919,6 +965,14 @@ export async function validateThemeCompletion( args ) {
 				} );
 				reports.push( {
 					url: normalizeUrl( loaded.url ),
+					requested_url: normalizeUrl( url ),
+					final_url: normalizeUrl( loaded.url ),
+					role,
+					is_homepage: isHomepageDocument(
+						loaded.document,
+						loaded.url,
+						homepageUrl
+					),
 					viewport,
 					...inspected,
 				} );
@@ -935,6 +989,11 @@ export async function validateThemeCompletion( args ) {
 				addViolation( violations, failedRender );
 				reports.push( {
 					url: failedUrl,
+					requested_url: normalizeUrl( url ),
+					final_url: failedUrl,
+					role,
+					is_homepage: false,
+					failure_kind: 'frontend_unrenderable',
 					viewport,
 					success: false,
 					active_stylesheet: '',
@@ -953,6 +1012,14 @@ export async function validateThemeCompletion( args ) {
 		reports.every( ( report ) => report.success );
 	const complete = allRendered;
 	const passed = complete && violations.length === 0;
+	const allFailuresAreBrowserUnavailable =
+		reports.length === expectedReports &&
+		reports.length > 0 &&
+		reports.every(
+			( report ) =>
+				! report.success &&
+				report.failure_kind === 'browser_execution_unavailable'
+		);
 
 	return {
 		success: allRendered,
@@ -961,7 +1028,12 @@ export async function validateThemeCompletion( args ) {
 		fatal_render_failure:
 			reports.length === expectedReports &&
 			reports.length > 0 &&
-			reports.every( ( report ) => ! report.success ),
+			reports.every(
+				( report ) =>
+					! report.success &&
+					report.failure_kind === 'frontend_unrenderable'
+			),
+		browser_execution_unavailable: allFailuresAreBrowserUnavailable,
 		stylesheet,
 		fingerprint,
 		urls,

--- a/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
@@ -21,6 +21,7 @@ namespace SdAiAgent\Tests\Core;
 
 use SdAiAgent\Abilities\Js\JsAbilityCatalog;
 use SdAiAgent\Core\AgentLoop;
+use SdAiAgent\Core\ClientAbilityRouter;
 use SdAiAgent\Core\Settings;
 use WordPress\AiClient\Messages\DTO\MessagePart;
 use WordPress\AiClient\Messages\DTO\UserMessage;
@@ -249,6 +250,26 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 
 		$this->assertCount( 1, $result['php'] );
 		$this->assertCount( 0, $result['client'] );
+	}
+
+	/**
+	 * Browser results must preserve the complete pending ID/name batch exactly.
+	 */
+	public function test_client_result_matcher_rejects_substituted_or_incomplete_batches(): void {
+		$expected = array(
+			array( 'id' => 'call-one', 'name' => 'sd-ai-agent-js/navigate-to' ),
+			array( 'id' => 'call-two', 'name' => 'sd-ai-agent-js/refresh-page' ),
+		);
+		$valid = array(
+			array( 'id' => 'call-one', 'name' => 'sd-ai-agent-js/navigate-to', 'result' => array() ),
+			array( 'id' => 'call-two', 'name' => 'sd-ai-agent-js/refresh-page', 'error' => 'Denied.' ),
+		);
+
+		$this->assertTrue( ClientAbilityRouter::matches_pending_results( $expected, $valid ) );
+		$this->assertFalse( ClientAbilityRouter::matches_pending_results( $expected, array( array( 'id' => 'call-one', 'name' => 'sd-ai-agent-js/refresh-page', 'result' => array() ), array( 'id' => 'call-two', 'name' => 'sd-ai-agent-js/navigate-to', 'error' => 'Denied.' ) ) ) );
+		$this->assertFalse( ClientAbilityRouter::matches_pending_results( $expected, array( array( 'id' => 'unknown', 'name' => 'sd-ai-agent-js/navigate-to', 'result' => array() ), $valid[1] ) ) );
+		$this->assertFalse( ClientAbilityRouter::matches_pending_results( $expected, array( $valid[0], $valid[0] ) ) );
+		$this->assertFalse( ClientAbilityRouter::matches_pending_results( $expected, array( $valid[0] ) ) );
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/GeneratedThemeCompletionGateTest.php
+++ b/tests/SdAiAgent/Core/GeneratedThemeCompletionGateTest.php
@@ -144,6 +144,42 @@ class GeneratedThemeCompletionGateTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * An interior request which renders the homepage cannot satisfy completion.
+	 */
+	public function test_interior_report_rendering_homepage_is_rejected(): void {
+		$gate   = $this->prepare_activated_gate();
+		$inputs = $gate->get_expected_report_inputs();
+		$report = $this->passing_report( $inputs );
+		$report['reports'][3]['is_homepage'] = true;
+
+		$gate->record_tool_call( GeneratedThemeCompletionGate::CLIENT_ABILITY, $inputs );
+		$gate->record_tool_response( GeneratedThemeCompletionGate::CLIENT_ABILITY, $report );
+
+		$this->assertFalse( $gate->has_current_passing_report() );
+	}
+
+	/**
+	 * A canonical homepage redirect remains valid when it is semantically home
+	 * and remains distinct from the requested interior document.
+	 */
+	public function test_canonical_homepage_redirect_with_distinct_interior_passes(): void {
+		$gate   = $this->prepare_activated_gate();
+		$inputs = $gate->get_expected_report_inputs();
+		$report = $this->passing_report( $inputs );
+		foreach ( $report['reports'] as &$row ) {
+			if ( 'homepage' === $row['role'] ) {
+				$row['final_url'] = 'https://example.test/home';
+			}
+		}
+		unset( $row );
+
+		$gate->record_tool_call( GeneratedThemeCompletionGate::CLIENT_ABILITY, $inputs );
+		$gate->record_tool_response( GeneratedThemeCompletionGate::CLIENT_ABILITY, $report );
+
+		$this->assertTrue( $gate->has_current_passing_report() );
+	}
+
+	/**
 	 * Missing browser capability remains incomplete instead of falling back to review prose.
 	 */
 	public function test_browser_unavailability_never_passes(): void {
@@ -191,6 +227,26 @@ class GeneratedThemeCompletionGateTest extends WP_UnitTestCase {
 
 		$this->assertFalse( $gate->requires_repair() );
 		$this->assertStringContainsString( 'previous stylesheet was restored', $gate->get_terminal_notice() );
+	}
+
+	/**
+	 * An unavailable browser client needs recovery, not a theme rollback.
+	 */
+	public function test_browser_execution_unavailable_does_not_require_restoration(): void {
+		$gate   = $this->prepare_activated_gate();
+		$inputs = $gate->get_expected_report_inputs();
+		$report = $this->passing_report( $inputs );
+		$report['success']                       = false;
+		$report['complete']                      = false;
+		$report['passed']                        = false;
+		$report['fatal_render_failure']          = true;
+		$report['browser_execution_unavailable'] = true;
+
+		$gate->record_tool_call( GeneratedThemeCompletionGate::CLIENT_ABILITY, $inputs );
+		$gate->record_tool_response( GeneratedThemeCompletionGate::CLIENT_ABILITY, $report );
+
+		$this->assertFalse( $gate->requires_restore() );
+		$this->assertStringContainsString( 'Browser execution was unavailable', $gate->get_terminal_notice() );
 	}
 
 	/**
@@ -252,10 +308,14 @@ class GeneratedThemeCompletionGateTest extends WP_UnitTestCase {
 	 */
 	private function passing_report( array $inputs ): array {
 		$reports = array();
-		foreach ( $inputs['urls'] as $url ) {
+		foreach ( $inputs['urls'] as $index => $url ) {
 			foreach ( GeneratedThemeCompletionGate::REQUIRED_VIEWPORTS as $viewport ) {
 				$reports[] = array(
 					'url'              => $url,
+					'requested_url'    => $url,
+					'final_url'        => $url,
+					'role'             => 0 === $index ? 'homepage' : 'interior',
+					'is_homepage'      => 0 === $index,
 					'viewport'         => $viewport,
 					'success'          => true,
 					'active_stylesheet' => self::STYLESHEET,

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -1957,6 +1957,52 @@ class RestControllerTest extends WP_UnitTestCase {
 	// ─── /chat/tool-result regression: 409 loop fix (sd-ai-9ip) ──────────────
 
 	/**
+	 * Invalid browser batches are rejected before resume and preserve the paused
+	 * state so the exact pending calls can still be submitted.
+	 */
+	public function test_tool_result_rejects_invalid_batches_and_restores_paused_state(): void {
+		wp_set_current_user( $this->admin_id );
+		$session_id = Database::create_session( [
+			'user_id' => $this->admin_id,
+			'title'   => 'Client result integrity session',
+		] );
+		$paused_state = [
+			'history'                   => [],
+			'iterations_remaining'      => 3,
+			'pending_client_tool_calls' => [
+				[ 'id' => 'call-one', 'name' => 'sd-ai-agent-js/navigate-to', 'args' => [] ],
+				[ 'id' => 'call-two', 'name' => 'sd-ai-agent-js/refresh-page', 'args' => [] ],
+			],
+		];
+		Database::save_paused_state( $session_id, $paused_state );
+
+		$valid = [
+			[ 'id' => 'call-one', 'name' => 'sd-ai-agent-js/navigate-to', 'result' => [] ],
+			[ 'id' => 'call-two', 'name' => 'sd-ai-agent-js/refresh-page', 'result' => [] ],
+		];
+		$invalid_batches = [
+			[ [ 'id' => 'call-one', 'name' => 'sd-ai-agent-js/refresh-page', 'result' => [] ], [ 'id' => 'call-two', 'name' => 'sd-ai-agent-js/navigate-to', 'result' => [] ] ],
+			[ [ 'id' => 'unknown', 'name' => 'sd-ai-agent-js/navigate-to', 'result' => [] ], $valid[1] ],
+			[ $valid[0], $valid[0] ],
+			[ $valid[0] ],
+		];
+
+		foreach ( $invalid_batches as $tool_results ) {
+			$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/chat/tool-result' );
+			$request->set_body( wp_json_encode( [
+				'session_id'   => $session_id,
+				'tool_results' => $tool_results,
+			] ) );
+			$request->set_header( 'Content-Type', 'application/json' );
+			$this->assertStatus( 400, $this->server->dispatch( $request ) );
+
+			$session_after = Database::get_session( $session_id );
+			$this->assertNotNull( $session_after );
+			$this->assertNotEmpty( $session_after->paused_state );
+		}
+	}
+
+	/**
 	 * Test POST /chat/tool-result cannot consume another user's paused state.
 	 *
 	 * The permission callback must verify access to the supplied session_id before


### PR DESCRIPTION
## Summary

Bound browser results to paused calls and require semantic, redirect-safe completion evidence.

## Files Changed

includes/Core/AgentLoop.php, includes/Core/ClientAbilityRouter.php, includes/Core/GeneratedThemeCompletionGate.php, includes/REST/RestController.php, src/abilities/__tests__/theme-completion-validator.test.js, src/abilities/theme-completion-iframe.js, src/abilities/theme-completion-validator.js, tests/SdAiAgent/Core/AgentLoopClientToolsTest.php, tests/SdAiAgent/Core/GeneratedThemeCompletionGateTest.php, tests/SdAiAgent/REST/RestControllerTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify; focused PHP and JS tests; E2E blocked because wp-env startup is guarded

Resolves #2272


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.156 plugin for [OpenCode](https://opencode.ai) v1.18.3 with gpt-5.6-terra spent 17m and 150,007 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser tool execution recovery by preserving pending actions when an agent pauses.
  * Rejects incomplete, duplicated, or mismatched browser tool results without losing the paused session.
  * Improved theme completion checks for redirects, homepage/interior page roles, and browser execution failures.
  * Reports clearer rendering outcomes and avoids unnecessary restoration when browser execution is unavailable.

* **Tests**
  * Added coverage for tool-result validation, paused-session recovery, redirects, page roles, and browser execution failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->