### PR TITLE
fix: use public Superdav model aliases

### DIFF
--- a/includes/Core/CostCalculator.php
+++ b/includes/Core/CostCalculator.php
@@ -17,9 +17,9 @@ class CostCalculator {
 	 */
 	private const PRICING = [
 		// Superdav managed models.
-		'gpt-5.6-luna'                         => [ 0.25, 1.00 ],
-		'gpt-5.6-terra'                        => [ 1.50, 6.00 ],
-		'gpt-5.6-sol'                          => [ 1.50, 6.00 ],
+		'superdav-chat-fast'                   => [ 1.75, 14.00 ],
+		'superdav-chat-pro'                    => [ 5.00, 30.00 ],
+		'superdav-chat-strong'                 => [ 5.00, 30.00 ],
 		// Claude models.
 		'claude-sonnet-4-6'                    => [ 3.00, 15.00 ],
 		'claude-opus-4-6'                      => [ 15.00, 75.00 ],

--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -82,9 +82,9 @@ class Settings {
 	 */
 	const MODEL_CONTEXT_WINDOWS = array(
 		// Superdav managed models.
-		'gpt-5.6-luna'                  => 128000,
-		'gpt-5.6-terra'                 => 200000,
-		'gpt-5.6-sol'                   => 200000,
+		'superdav-chat-fast'            => 128000,
+		'superdav-chat-pro'             => 200000,
+		'superdav-chat-strong'          => 200000,
 		'superdav-image'                => 32000,
 		// Anthropic.
 		'claude-opus-4-6'               => 200000,
@@ -185,9 +185,9 @@ class Settings {
 	 */
 	const MODEL_MAX_OUTPUT_TOKENS = array(
 		// ── Superdav managed models ───────────────────────────────────────
-		'gpt-5.6-luna'                => 8192,
-		'gpt-5.6-terra'               => 16384,
-		'gpt-5.6-sol'                 => 16384,
+		'superdav-chat-fast'          => 8192,
+		'superdav-chat-pro'           => 16384,
+		'superdav-chat-strong'        => 16384,
 		'superdav-image'              => 1,
 		// ── Anthropic ──────────────────────────────────────────────────
 		// Opus 4.6 / 4.7 document 128K; Opus 4.5 documents 64K; Opus 4.1

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php
@@ -26,9 +26,9 @@ final class SuperdavAiProvider extends AbstractApiProvider {
 	public const PROVIDER_ID       = 'sd-ai-agent-cloud';
 	public const CREDENTIAL_OPTION = 'connectors_ai_sd_ai_agent_cloud_api_key';
 	public const DEFAULT_BASE_URL  = 'https://api.sdaiagent.com/v1';
-	public const FAST_MODEL_ID     = 'gpt-5.6-luna';
-	public const DEFAULT_MODEL_ID  = 'gpt-5.6-terra';
-	public const STRONG_MODEL_ID   = 'gpt-5.6-sol';
+	public const FAST_MODEL_ID     = 'superdav-chat-fast';
+	public const DEFAULT_MODEL_ID  = 'superdav-chat-pro';
+	public const STRONG_MODEL_ID   = 'superdav-chat-strong';
 	public const IMAGE_MODEL_ID    = 'superdav-image';
 
 	/**

--- a/includes/Tools/ModelHealthTracker.php
+++ b/includes/Tools/ModelHealthTracker.php
@@ -73,7 +73,7 @@ class ModelHealthTracker {
 	private const WEAK_NAME_HINTS = array(
 		// Managed cloud fast route: bootstrap with stricter schema-following
 		// guidance after field reports of empty required-argument tool calls.
-		'gpt-5.6-luna',
+		'superdav-chat-fast',
 		// Small parameter counts.
 		'-1b',
 		'-2b',

--- a/src/components/model-pricing-selector.js
+++ b/src/components/model-pricing-selector.js
@@ -23,9 +23,9 @@ import { __ } from '@wordpress/i18n';
  */
 const PRICING = {
 	// Superdav managed models.
-	'gpt-5.6-luna': [ 0.25, 1.0 ],
-	'gpt-5.6-terra': [ 1.5, 6.0 ],
-	'gpt-5.6-sol': [ 1.5, 6.0 ],
+	'superdav-chat-fast': [ 1.75, 14.0 ],
+	'superdav-chat-pro': [ 5.0, 30.0 ],
+	'superdav-chat-strong': [ 5.0, 30.0 ],
 	// Claude models.
 	'claude-haiku-4': [ 0.8, 4.0 ],
 	'claude-sonnet-4': [ 3.0, 15.0 ],
@@ -87,21 +87,21 @@ const TIERS = [
 const MODEL_CATALOG = [
 	// Superdav
 	{
-		id: 'gpt-5.6-luna',
+		id: 'superdav-chat-fast',
 		provider: 'sd-ai-agent-cloud',
-		name: 'GPT-5.6 Luna',
+		name: 'Superdav Chat Fast',
 		note: __( 'fast', 'superdav-ai-agent' ),
 	},
 	{
-		id: 'gpt-5.6-terra',
+		id: 'superdav-chat-pro',
 		provider: 'sd-ai-agent-cloud',
-		name: 'GPT-5.6 Terra',
+		name: 'Superdav Chat Pro',
 		note: __( 'standard', 'superdav-ai-agent' ),
 	},
 	{
-		id: 'gpt-5.6-sol',
+		id: 'superdav-chat-strong',
 		provider: 'sd-ai-agent-cloud',
-		name: 'GPT-5.6 Sol',
+		name: 'Superdav Chat Strong',
 		note: __( 'strong', 'superdav-ai-agent' ),
 	},
 	// Anthropic

--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -420,11 +420,11 @@ describe( 'resolveProviderSelection', () => {
 			[
 				{
 					id: 'sd-ai-agent-cloud',
-					default_model: 'gpt-5.6-terra',
+					default_model: 'superdav-chat-pro',
 					models: [
-						{ id: 'gpt-5.6-luna' },
-						{ id: 'gpt-5.6-terra' },
-						{ id: 'gpt-5.6-sol' },
+						{ id: 'superdav-chat-fast' },
+						{ id: 'superdav-chat-pro' },
+						{ id: 'superdav-chat-strong' },
 					],
 				},
 			],
@@ -434,7 +434,7 @@ describe( 'resolveProviderSelection', () => {
 
 		expect( selection ).toEqual( {
 			providerId: 'sd-ai-agent-cloud',
-			modelId: 'gpt-5.6-terra',
+			modelId: 'superdav-chat-pro',
 		} );
 	} );
 
@@ -443,21 +443,21 @@ describe( 'resolveProviderSelection', () => {
 			[
 				{
 					id: 'sd-ai-agent-cloud',
-					default_model: 'gpt-5.6-terra',
+					default_model: 'superdav-chat-pro',
 					models: [
-						{ id: 'gpt-5.6-luna' },
-						{ id: 'gpt-5.6-terra' },
-						{ id: 'gpt-5.6-sol' },
+						{ id: 'superdav-chat-fast' },
+						{ id: 'superdav-chat-pro' },
+						{ id: 'superdav-chat-strong' },
 					],
 				},
 			],
 			'sd-ai-agent-cloud',
-			'gpt-5.6-luna'
+			'superdav-chat-fast'
 		);
 
 		expect( selection ).toEqual( {
 			providerId: 'sd-ai-agent-cloud',
-			modelId: 'gpt-5.6-luna',
+			modelId: 'superdav-chat-fast',
 		} );
 	} );
 
@@ -470,11 +470,11 @@ describe( 'resolveProviderSelection', () => {
 				},
 				{
 					id: 'sd-ai-agent-cloud',
-					default_model: 'gpt-5.6-terra',
+					default_model: 'superdav-chat-pro',
 					models: [
-						{ id: 'gpt-5.6-luna' },
-						{ id: 'gpt-5.6-terra' },
-						{ id: 'gpt-5.6-sol' },
+						{ id: 'superdav-chat-fast' },
+						{ id: 'superdav-chat-pro' },
+						{ id: 'superdav-chat-strong' },
 					],
 				},
 			],
@@ -484,7 +484,7 @@ describe( 'resolveProviderSelection', () => {
 
 		expect( selection ).toEqual( {
 			providerId: 'sd-ai-agent-cloud',
-			modelId: 'gpt-5.6-terra',
+			modelId: 'superdav-chat-pro',
 		} );
 	} );
 } );

--- a/tests/SdAiAgent/Abilities/PublicChatSetupAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/PublicChatSetupAbilitiesTest.php
@@ -83,7 +83,7 @@ class PublicChatSetupAbilitiesTest extends WP_UnitTestCase {
 				'origins'            => array( 'HTTPS://Docs.Example.com/path' ),
 				'collection_slugs'   => array( $this->collection_slug ),
 				'provider_id'        => 'sd-ai-agent-cloud',
-				'model_id'           => 'gpt-5.6-terra',
+				'model_id'           => 'superdav-chat-pro',
 				'embed_id'           => 'docs',
 				'rate_limit_per_min' => 99,
 				'message_max_length' => 9000,
@@ -124,7 +124,7 @@ class PublicChatSetupAbilitiesTest extends WP_UnitTestCase {
 				'action'           => 'configure',
 				'collection_slugs' => array( $this->collection_slug ),
 				'provider_id'      => 'sd-ai-agent-cloud',
-				'model_id'         => 'gpt-5.6-terra',
+				'model_id'         => 'superdav-chat-pro',
 			)
 		);
 
@@ -148,7 +148,7 @@ class PublicChatSetupAbilitiesTest extends WP_UnitTestCase {
 				'enabled'          => true,
 				'collection_slugs' => array( $this->collection_slug ),
 				'provider_id'      => 'sd-ai-agent-cloud',
-				'model_id'         => 'gpt-5.6-terra',
+				'model_id'         => 'superdav-chat-pro',
 			)
 		);
 

--- a/tests/SdAiAgent/Core/CostCalculatorTest.php
+++ b/tests/SdAiAgent/Core/CostCalculatorTest.php
@@ -59,9 +59,9 @@ class CostCalculatorTest extends WP_UnitTestCase {
 	 * Test calculate_cost with the managed Superdav pro model.
 	 */
 	public function test_calculate_cost_superdav_pro() {
-		// 1M input tokens at $1.50 + 1M output tokens at $6.00 = $7.50
+		// 1M input tokens at $5.00 + 1M output tokens at $30.00 = $35.00
 		$cost = CostCalculator::calculate_cost( SuperdavAiProvider::DEFAULT_MODEL_ID, 1_000_000, 1_000_000 );
-		$this->assertSame( 7.5, $cost );
+		$this->assertSame( 35.0, $cost );
 	}
 
 	/**

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
@@ -120,7 +120,7 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 	 * The bundled provider defaults clean installs to the standard managed alias.
 	 */
 	public function test_default_model_is_managed_standard_alias(): void {
-		$this->assertSame( 'gpt-5.6-terra', SuperdavAiProvider::default_model_id() );
+		$this->assertSame( 'superdav-chat-pro', SuperdavAiProvider::default_model_id() );
 	}
 
 	/**
@@ -388,7 +388,7 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 			'gpt-5.5-pro'   => array( 'gpt-5.5-pro', true ),
 			'gpt-6'         => array( 'gpt-6', true ),
 			'gpt-4o'        => array( 'gpt-4o', false ),
-			'managed alias' => array( SuperdavAiProvider::DEFAULT_MODEL_ID, true ),
+			'managed alias' => array( SuperdavAiProvider::DEFAULT_MODEL_ID, false ),
 		);
 	}
 

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -1321,7 +1321,7 @@ class RestControllerTest extends WP_UnitTestCase {
 				'tool_calls'       => [ [ 'type' => 'call', 'id' => 'call_1', 'name' => 'wpab__sd-ai-agent__site-info' ] ],
 				'messages'         => [ [ 'type' => 'provider_error', 'message' => 'Provider rejected history.' ] ],
 				'token_usage'      => [ 'prompt' => 12, 'completion' => 0 ],
-				'model_id'         => 'gpt-5.6-terra',
+				'model_id'         => 'superdav-chat-pro',
 				'provider_id'      => 'sd-ai-agent-cloud',
 				'client_abilities' => [],
 			]
@@ -1332,7 +1332,7 @@ class RestControllerTest extends WP_UnitTestCase {
 		$method->setAccessible( true );
 
 		$params     = [ 'message' => 'Please continue after the error.', 'session_id' => $session_id ];
-		$options    = [ 'provider_id' => 'sd-ai-agent-cloud', 'model_id' => 'gpt-5.6-terra' ];
+		$options    = [ 'provider_id' => 'sd-ai-agent-cloud', 'model_id' => 'superdav-chat-pro' ];
 		$job        = [ 'status' => 'error', 'error' => $error->get_error_message(), 'params' => $params ];
 		$error_data = $error->get_error_data();
 		$this->assertIsArray( $error_data );

--- a/tests/SdAiAgent/REST/SettingsControllerTest.php
+++ b/tests/SdAiAgent/REST/SettingsControllerTest.php
@@ -160,8 +160,8 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 							array(
 								'data' => array(
 									array(
-										'id'                => 'gpt-5.6-luna',
-										'name'              => 'GPT-5.6 Luna',
+									'id'                => 'superdav-chat-fast',
+									'name'              => 'Superdav Chat Fast',
 										'context_length'    => 128000,
 										'max_output_length' => 8192,
 									),
@@ -192,7 +192,7 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		$this->assertSame( SuperdavAiProvider::DEFAULT_MODEL_ID, $superdav['default_model'] ?? '' );
 		$this->assertTrue( $superdav['status']['connection_notice_pending'] );
 		$this->assertSame( 10000000, $superdav['status']['wallet']['promo_usd_micros'] );
-		$this->assertSame( 'gpt-5.6-luna', $superdav['models'][0]['id'] ?? '' );
+		$this->assertSame( 'superdav-chat-fast', $superdav['models'][0]['id'] ?? '' );
 		$this->assertStringNotContainsString( 'sdaist_auto_provisioned_token', wp_json_encode( $superdav ) ?: '' );
 
 		$second_response = $controller->handle_providers();
@@ -384,14 +384,14 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 							array(
 								'data' => array(
 									array(
-										'id'                => 'gpt-5.6-luna',
-										'name'              => 'GPT-5.6 Luna',
+									'id'                => 'superdav-chat-fast',
+									'name'              => 'Superdav Chat Fast',
 										'context_length'    => 128000,
 										'max_output_length' => 8192,
 									),
 									array(
-										'id'                => 'gpt-5.6-terra',
-										'name'              => 'GPT-5.6 Terra',
+									'id'                => 'superdav-chat-pro',
+									'name'              => 'Superdav Chat Pro',
 										'context_length'    => 200000,
 										'max_output_length' => 16384,
 									),
@@ -421,7 +421,7 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		$this->assertSame( 'sdaist_refreshed_token', get_option( SuperdavAiProvider::CREDENTIAL_OPTION, '' ) );
 		$this->assertNotNull( $superdav );
 		$this->assertSame( SuperdavAiProvider::DEFAULT_MODEL_ID, $superdav['default_model'] ?? '' );
-		$this->assertSame( array( 'gpt-5.6-luna', 'gpt-5.6-terra' ), wp_list_pluck( $superdav['models'] ?? array(), 'id' ) );
+		$this->assertSame( array( 'superdav-chat-fast', 'superdav-chat-pro' ), wp_list_pluck( $superdav['models'] ?? array(), 'id' ) );
 	}
 
 	/**

--- a/tests/SdAiAgent/Tools/ModelHealthTrackerTest.php
+++ b/tests/SdAiAgent/Tools/ModelHealthTrackerTest.php
@@ -35,7 +35,7 @@ class ModelHealthTrackerTest extends WP_UnitTestCase {
 		$this->assertTrue( ModelHealthTracker::matches_weak_name( 'phi-3-mini' ) );
 		$this->assertTrue( ModelHealthTracker::matches_weak_name( 'tinyllama' ) );
 		$this->assertTrue( ModelHealthTracker::matches_weak_name( 'mistral-7b-q4_k_m.gguf' ) );
-		$this->assertTrue( ModelHealthTracker::matches_weak_name( 'gpt-5.6-luna' ) );
+		$this->assertTrue( ModelHealthTracker::matches_weak_name( 'superdav-chat-fast' ) );
 	}
 
 	public function test_name_heuristic_does_not_flag_strong_models(): void {


### PR DESCRIPTION
## Summary

- switch the managed Superdav client to the public Fast, Pro, and Strong model aliases
- align fallback context/output metadata, health tracking, and public-chat fixtures
- synchronize client cost estimates and selector hints with the service rate card

The service dependency was merged in Ultimate-Multisite/superdav-ai-service#65.

## Worker self-verification
- PHPUnit: Tests: 3895, Assertions: 16978, Errors: 0, Failures: 0, Skipped: 125, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded; bundle checks passed

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.158 plugin for [OpenCode](https://opencode.ai) v1.18.3
