### PR TITLE
GH#2279: Reject malformed CSS variables

### DIFF
--- a/advanced-plugin/includes/Services/StyleVariationManager.php
+++ b/advanced-plugin/includes/Services/StyleVariationManager.php
@@ -334,6 +334,20 @@ final class StyleVariationManager {
 				__( 'Style variations must change settings or styles.', 'superdav-ai-agent' )
 			);
 		}
+		$malformed_references = BlockThemeProjectValidator::find_malformed_css_variable_references( $document );
+		if ( [] !== $malformed_references ) {
+			$reference = $malformed_references[0];
+
+			return new WP_Error(
+				'sd_ai_agent_style_variation_css_variable_invalid',
+				__( 'Style variations must use valid CSS var() references.', 'superdav-ai-agent' ),
+				[
+					'path'   => $reference['path'],
+					'reason' => $reference['reason'],
+					'value'  => $reference['value'],
+				]
+			);
+		}
 
 		$semantic_error = $this->validate_compiled_semantics( $document );
 		if ( is_wp_error( $semantic_error ) ) {

--- a/includes/Services/BlockThemeProjectValidator.php
+++ b/includes/Services/BlockThemeProjectValidator.php
@@ -111,7 +111,8 @@ final class BlockThemeProjectValidator {
 		}
 
 		$offset = 0;
-		while ( false !== ( $start = stripos( $value, 'var(', $offset ) ) ) {
+		$start  = stripos( $value, 'var(', $offset );
+		while ( false !== $start ) {
 			$depth       = 1;
 			$end         = null;
 			$length      = strlen( $value );
@@ -156,6 +157,7 @@ final class BlockThemeProjectValidator {
 			}
 
 			$offset = $start + 4;
+			$start  = stripos( $value, 'var(', $offset );
 		}
 
 		return $references;
@@ -1530,9 +1532,10 @@ final class BlockThemeProjectValidator {
 	/**
 	 * Add path-specific malformed CSS variable diagnostics for decoded JSON.
 	 *
-	 * @param list<MalformedCssVariableReference> $references Malformed references.
-	 * @param string                              $relative   Theme-relative source path.
-	 * @param array                               $errors     Diagnostics collected during validation.
+	 * @param array  $references Malformed references.
+	 * @param string $relative Theme-relative source path.
+	 * @param array  $errors Diagnostics collected during validation.
+	 * @phpstan-param list<MalformedCssVariableReference> $references
 	 * @phpstan-param Diagnostics $errors
 	 */
 	private function add_malformed_css_variable_diagnostics( array $references, string $relative, array &$errors ): void {

--- a/includes/Services/BlockThemeProjectValidator.php
+++ b/includes/Services/BlockThemeProjectValidator.php
@@ -28,6 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @phpstan-type ProjectFile array{path:string,size:int}
  * @phpstan-type ProjectFiles array<string,ProjectFile>
  * @phpstan-type TokenMap array<string,true>
+ * @phpstan-type MalformedCssVariableReference array{value:string,path:string,offset:int,reason:string}
  */
 final class BlockThemeProjectValidator {
 
@@ -79,6 +80,85 @@ final class BlockThemeProjectValidator {
 		$encoded = wp_json_encode( self::marker_payload(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES );
 
 		return ( is_string( $encoded ) ? $encoded : '{}' ) . "\n";
+	}
+
+	/**
+	 * Find malformed CSS var() functions in a value tree without parsing CSS.
+	 *
+	 * This deliberately checks only the small CSS-function contract that WordPress
+	 * theme documents emit. It leaves fallback values untouched, including nested
+	 * functions, while rejecting missing delimiters and invalid variable names.
+	 *
+	 * @param mixed  $value     Value tree or text source to inspect.
+	 * @param string $json_path JSON path for value-tree results.
+	 * @return list<MalformedCssVariableReference>
+	 */
+	public static function find_malformed_css_variable_references( mixed $value, string $json_path = '' ): array {
+		$references = [];
+		if ( is_array( $value ) ) {
+			foreach ( $value as $key => $child ) {
+				$next_path = '' === $json_path ? (string) $key : $json_path . '.' . $key;
+				foreach ( self::find_malformed_css_variable_references( $child, $next_path ) as $reference ) {
+					$references[] = $reference;
+				}
+			}
+
+			return $references;
+		}
+
+		if ( ! is_string( $value ) ) {
+			return $references;
+		}
+
+		$offset = 0;
+		while ( false !== ( $start = stripos( $value, 'var(', $offset ) ) ) {
+			$depth       = 1;
+			$end         = null;
+			$length      = strlen( $value );
+			$open_offset = $start + 3;
+			for ( $index = $open_offset + 1; $index < $length; ++$index ) {
+				if ( '(' === $value[ $index ] ) {
+					++$depth;
+				} elseif ( ')' === $value[ $index ] && 0 === --$depth ) {
+					$end = $index;
+					break;
+				}
+			}
+
+			if ( ! is_int( $end ) ) {
+				$references[] = [
+					'value'  => substr( $value, $start ),
+					'path'   => $json_path,
+					'offset' => $start,
+					'reason' => 'missing_closing_parenthesis',
+				];
+				break;
+			}
+
+			$arguments = trim( substr( $value, $open_offset + 1, $end - $open_offset - 1 ) );
+			$name      = trim( explode( ',', $arguments, 2 )[0] );
+			$reason    = '';
+			if ( '' === $name ) {
+				$reason = 'empty_variable_name';
+			} elseif ( ! preg_match( '/^--[A-Za-z_][A-Za-z0-9_-]*$/', $name ) ) {
+				$reason = 'invalid_variable_name';
+			} elseif ( str_starts_with( strtolower( $name ), '--wp--' ) && ! preg_match( '/^--wp--(?:preset|custom)--[a-z0-9]+(?:-+[a-z0-9]+)*$/', $name ) ) {
+				$reason = 'invalid_wordpress_token_name';
+			}
+
+			if ( '' !== $reason ) {
+				$references[] = [
+					'value'  => substr( $value, $start, $end - $start + 1 ),
+					'path'   => $json_path,
+					'offset' => $start,
+					'reason' => $reason,
+				];
+			}
+
+			$offset = $start + 4;
+		}
+
+		return $references;
 	}
 
 	/**
@@ -785,7 +865,12 @@ final class BlockThemeProjectValidator {
 			return;
 		}
 
-		if ( ! is_string( $value ) || ! preg_match_all( '/var\(\s*(--wp--(?:preset|custom)--[a-z0-9-]+)\s*(?:,[^)]*)?\)/i', $value, $matches ) ) {
+		if ( ! is_string( $value ) ) {
+			return;
+		}
+
+		$this->add_malformed_css_variable_diagnostics( self::find_malformed_css_variable_references( $value, $json_path ), $relative, $errors );
+		if ( ! preg_match_all( '/var\(\s*(--wp--(?:preset|custom)--[a-z0-9-]+)\s*(?:,[^)]*)?\)/i', $value, $matches ) ) {
 			return;
 		}
 
@@ -1406,6 +1491,20 @@ final class BlockThemeProjectValidator {
 	 * @phpstan-param Diagnostics $errors
 	 */
 	private function validate_markup_token_references( string $contents, string $relative, array $tokens, array &$errors ): void {
+		foreach ( self::find_malformed_css_variable_references( $contents ) as $malformed ) {
+			$this->add_diagnostic(
+				$errors,
+				'malformed_css_variable_reference',
+				$relative,
+				__( 'A CSS var() reference is malformed.', 'superdav-ai-agent' ),
+				[
+					'line'   => $this->line_for_offset( $contents, $malformed['offset'] ),
+					'reason' => $malformed['reason'],
+					'value'  => $malformed['value'],
+				]
+			);
+		}
+
 		if ( ! preg_match_all( '/var\(\s*(--wp--(?:preset|custom)--[a-z0-9-]+)\s*(?:,[^)]*)?\)/i', $contents, $matches, PREG_OFFSET_CAPTURE ) ) {
 			return;
 		}
@@ -1423,6 +1522,30 @@ final class BlockThemeProjectValidator {
 				[
 					'line'      => $this->line_for_offset( $contents, $match[1] ),
 					'reference' => $reference,
+				]
+			);
+		}
+	}
+
+	/**
+	 * Add path-specific malformed CSS variable diagnostics for decoded JSON.
+	 *
+	 * @param list<MalformedCssVariableReference> $references Malformed references.
+	 * @param string                              $relative   Theme-relative source path.
+	 * @param array                               $errors     Diagnostics collected during validation.
+	 * @phpstan-param Diagnostics $errors
+	 */
+	private function add_malformed_css_variable_diagnostics( array $references, string $relative, array &$errors ): void {
+		foreach ( $references as $reference ) {
+			$this->add_diagnostic(
+				$errors,
+				'malformed_css_variable_reference',
+				$relative,
+				__( 'A CSS var() reference is malformed.', 'superdav-ai-agent' ),
+				[
+					'json_path' => $reference['path'],
+					'reason'    => $reference['reason'],
+					'value'     => $reference['value'],
 				]
 			);
 		}

--- a/tests/SdAiAgent/Abilities/StyleVariationAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/StyleVariationAbilitiesTest.php
@@ -508,6 +508,24 @@ class StyleVariationAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Lifecycle validation shares the generated-project CSS var() syntax guard
+	 * before create or update can persist an invalid style variation.
+	 */
+	public function test_validate_rejects_malformed_css_variable_references(): void {
+		$document = $this->variation_document( 'invalid-variable', '#1d4ed8' );
+		$document['styles']['typography'] = [
+			'fontFamily' => 'var(--wp--custom--font-family',
+		];
+
+		$result = ( new StyleVariationManager() )->validate_document( $document );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'sd_ai_agent_style_variation_css_variable_invalid', $result->get_error_code() );
+		$this->assertSame( 'styles.typography.fontFamily', $result->get_error_data()['path'] );
+		$this->assertSame( 'missing_closing_parenthesis', $result->get_error_data()['reason'] );
+	}
+
+	/**
 	 * Stage one minimal block theme that WordPress can activate and resolve.
 	 */
 	private function stage_theme( string $directory, string $slug, string $name, ?string $parent_slug ): void {

--- a/tests/SdAiAgent/Services/BlockThemeProjectValidatorTest.php
+++ b/tests/SdAiAgent/Services/BlockThemeProjectValidatorTest.php
@@ -172,6 +172,40 @@ class BlockThemeProjectValidatorTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Malformed CSS var() syntax is rejected consistently in root documents,
+	 * style variations, and text sources while valid fallbacks remain accepted.
+	 */
+	public function test_reports_malformed_css_variable_references_in_governed_theme_sources(): void {
+		$this->stage_valid_project();
+		$this->write_fixture_file(
+			'theme.json',
+			"{\n\t\"\\$schema\": \"https://schemas.wp.org/trunk/theme.json\",\n\t\"version\": 3,\n\t\"settings\": {\n\t\t\"custom\": { \"brand\": \"#123456\" }\n\t},\n\t\"styles\": { \"color\": { \"text\": \"var(--wp--custom--brand\" } }\n}\n"
+		);
+		$this->write_fixture_file(
+			'styles/malformed.json',
+			"{\n\t\"\\$schema\": \"https://schemas.wp.org/trunk/theme.json\",\n\t\"version\": 3,\n\t\"slug\": \"malformed\",\n\t\"title\": \"Malformed\",\n\t\"settings\": {},\n\t\"styles\": { \"color\": { \"text\": \"var()\" } }\n}\n"
+		);
+		$this->write_fixture_file( 'templates/index.html', '<!-- wp:paragraph --><p style="color:var(--wp--custom--)">Welcome.</p><!-- /wp:paragraph -->' );
+		$this->write_fixture_file( 'assets/theme.css', '.example { color: var(--wp--custom--brand, #123456); }' );
+
+		$report      = ( new BlockThemeProjectValidator() )->validate( $this->theme_dir );
+		$diagnostics = array_values(
+			array_filter(
+				$report['errors'],
+				static fn( array $diagnostic ): bool => 'malformed_css_variable_reference' === $diagnostic['code']
+			)
+		);
+
+		$this->assertFalse( $report['valid'] );
+		$this->assertSame( [ 'theme.json', 'styles/malformed.json', 'templates/index.html' ], array_column( $diagnostics, 'path' ) );
+		$this->assertSame(
+			[ 'missing_closing_parenthesis', 'empty_variable_name', 'invalid_wordpress_token_name' ],
+			array_column( array_column( $diagnostics, 'location' ), 'reason' )
+		);
+		$this->assertNotContains( 'assets/theme.css', array_column( $diagnostics, 'path' ) );
+	}
+
+	/**
 	 * Stage the smallest complete generated block-theme project.
 	 */
 	private function stage_valid_project(): void {

--- a/tests/SdAiAgent/Services/BlockThemeProjectValidatorTest.php
+++ b/tests/SdAiAgent/Services/BlockThemeProjectValidatorTest.php
@@ -179,11 +179,11 @@ class BlockThemeProjectValidatorTest extends WP_UnitTestCase {
 		$this->stage_valid_project();
 		$this->write_fixture_file(
 			'theme.json',
-			"{\n\t\"\\$schema\": \"https://schemas.wp.org/trunk/theme.json\",\n\t\"version\": 3,\n\t\"settings\": {\n\t\t\"custom\": { \"brand\": \"#123456\" }\n\t},\n\t\"styles\": { \"color\": { \"text\": \"var(--wp--custom--brand\" } }\n}\n"
+			"{\n\t\"\$schema\": \"https://schemas.wp.org/trunk/theme.json\",\n\t\"version\": 3,\n\t\"settings\": {\n\t\t\"custom\": { \"brand\": \"#123456\" }\n\t},\n\t\"styles\": { \"color\": { \"text\": \"var(--wp--custom--brand\" } }\n}\n"
 		);
 		$this->write_fixture_file(
 			'styles/malformed.json',
-			"{\n\t\"\\$schema\": \"https://schemas.wp.org/trunk/theme.json\",\n\t\"version\": 3,\n\t\"slug\": \"malformed\",\n\t\"title\": \"Malformed\",\n\t\"settings\": {},\n\t\"styles\": { \"color\": { \"text\": \"var()\" } }\n}\n"
+			"{\n\t\"\$schema\": \"https://schemas.wp.org/trunk/theme.json\",\n\t\"version\": 3,\n\t\"slug\": \"malformed\",\n\t\"title\": \"Malformed\",\n\t\"settings\": {},\n\t\"styles\": { \"color\": { \"text\": \"var()\" } }\n}\n"
 		);
 		$this->write_fixture_file( 'templates/index.html', '<!-- wp:paragraph --><p style="color:var(--wp--custom--)">Welcome.</p><!-- /wp:paragraph -->' );
 		$this->write_fixture_file( 'assets/theme.css', '.example { color: var(--wp--custom--brand, #123456); }' );
@@ -195,12 +195,21 @@ class BlockThemeProjectValidatorTest extends WP_UnitTestCase {
 				static fn( array $diagnostic ): bool => 'malformed_css_variable_reference' === $diagnostic['code']
 			)
 		);
+		$diagnostics_by_path = array_column( $diagnostics, null, 'path' );
+		ksort( $diagnostics_by_path );
+		$diagnostic_reasons = [];
+		foreach ( $diagnostics_by_path as $path => $diagnostic ) {
+			$diagnostic_reasons[ $path ] = $diagnostic['location']['reason'];
+		}
 
 		$this->assertFalse( $report['valid'] );
-		$this->assertSame( [ 'theme.json', 'styles/malformed.json', 'templates/index.html' ], array_column( $diagnostics, 'path' ) );
 		$this->assertSame(
-			[ 'missing_closing_parenthesis', 'empty_variable_name', 'invalid_wordpress_token_name' ],
-			array_column( array_column( $diagnostics, 'location' ), 'reason' )
+			[
+				'styles/malformed.json' => 'empty_variable_name',
+				'templates/index.html'  => 'invalid_wordpress_token_name',
+				'theme.json'            => 'missing_closing_parenthesis',
+			],
+			$diagnostic_reasons
 		);
 		$this->assertNotContains( 'assets/theme.css', array_column( $diagnostics, 'path' ) );
 	}


### PR DESCRIPTION
## Summary

- Reject malformed CSS `var()` references in generated block-theme sources.
- Reuse the syntax guard before style-variation lifecycle writes.

## Testing

- `php -l includes/Services/BlockThemeProjectValidator.php`
- `php -l advanced-plugin/includes/Services/StyleVariationManager.php`
- `npm run test:php -- --filter='BlockThemeProjectValidatorTest|StyleVariationAbilitiesTest|ValidateBlockThemeProjectAbilityTest'` (blocked: `phpunit` is unavailable in this worktree)

Resolves #2279

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.159 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-terra spent 4m and 118,820 tokens on this as a headless worker.
