### PR TITLE
fix: hide upstream retry errors

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -2042,11 +2042,10 @@ class AgentLoop {
 	 */
 	private function build_provider_retry_failed_error( $error, int $elapsed_seconds ): WP_Error {
 		$message = sprintf(
-			/* translators: 1: attempts, 2: elapsed seconds, 3: provider error message */
-			__( 'Provider retry failed after %1$d attempts over %2$ds — try resending your last message. Last error: %3$s', 'superdav-ai-agent' ),
+			/* translators: 1: attempts, 2: elapsed seconds */
+			__( 'The AI service is temporarily unavailable after %1$d attempts over %2$ds. Please try again shortly.', 'superdav-ai-agent' ),
 			$this->provider_retry_max_attempts,
-			$elapsed_seconds,
-			$this->get_provider_error_message( $error )
+			$elapsed_seconds
 		);
 
 		$hint = $this->get_provider_retry_failure_hint();

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -859,7 +859,7 @@ class AgentLoopTest extends WP_UnitTestCase {
 				[
 					'status'  => 503,
 					'message' => 'Service Unavailable',
-					'body'    => wp_json_encode( [ 'error' => [ 'message' => 'Service unavailable' ] ] ),
+					'body'    => wp_json_encode( [ 'error' => [ 'message' => 'Sub2API is unavailable.' ] ] ),
 				],
 			],
 			$call_count
@@ -875,7 +875,8 @@ class AgentLoopTest extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'sd_ai_agent_provider_retry_failed', $result->get_error_code() );
-		$this->assertStringContainsString( 'Provider retry failed after 3 attempts', $result->get_error_message() );
+		$this->assertStringContainsString( 'The AI service is temporarily unavailable after 3 attempts', $result->get_error_message() );
+		$this->assertStringNotContainsString( 'Sub2API', $result->get_error_message() );
 		$this->assertSame( 3, $call_count );
 		$data = $result->get_error_data();
 		$this->assertIsArray( $data );


### PR DESCRIPTION
## Summary

- Replace raw exhausted-retry error text with a generic customer-safe message.
- Cover an upstream error that contains an internal gateway name and assert it is not returned to the client.

## Verification

- `php -l includes/Core/AgentLoop.php`
- `php -l tests/SdAiAgent/Core/AgentLoopTest.php`
- `npm run test:php -- --filter=AgentLoopTest` could not run because this worktree has no `phpunit` binary.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.159 plugin for [OpenCode](https://opencode.ai) v1.18.4
