### PR TITLE
GH#2283: stop invalid tool call storms

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -66,6 +66,15 @@ class AgentLoop {
 	const MAX_IDLE_ROUNDS = 3;
 
 	/**
+	 * Maximum empty required-input calls before stopping the run.
+	 *
+	 * A model that changes ability names while sending `{}` can evade the
+	 * ordinary same-call spin detector. Three failures leave it enough room to
+	 * correct the first mistake without allowing a validation-error storm.
+	 */
+	const MAX_CONSECUTIVE_EMPTY_TOOL_CALL_FAILURES = 3;
+
+	/**
 	 * Maximum token-estimated size (in characters) for a single tool result
 	 * fed back into the loop. Results exceeding this are truncated.
 	 * ~40K chars ≈ 10K tokens — generous but bounded.
@@ -219,6 +228,9 @@ class AgentLoop {
 
 	/** @var int Consecutive preamble-only truncations observed this run. */
 	private int $preamble_truncation_retries = 0;
+
+	/** @var int Empty calls rejected for missing required input in this run. */
+	private int $consecutive_empty_tool_call_failures = 0;
 
 	/**
 	 * Client-side ability descriptors validated against JsAbilityCatalog.
@@ -1333,6 +1345,10 @@ class AgentLoop {
 			$this->log_tool_responses( $truncated_message );
 			$this->last_loop_phase = 'tool_response_recorded';
 			$this->save_active_job_checkpoint( self::CHECKPOINT_TOOL_RESPONSE_RECORDED, $iterations );
+
+			if ( $this->record_empty_required_input_failures( $assistant_message, $truncated_message ) ) {
+				return $this->abort_on_empty_tool_call_storm();
+			}
 
 			$scaffold_permission_denial = $this->extract_scaffold_block_theme_permission_denial( $truncated_message );
 			if ( null !== $scaffold_permission_denial ) {
@@ -3192,6 +3208,123 @@ class AgentLoop {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Track consecutive empty calls that were rejected for missing required input.
+	 *
+	 * Models sometimes rotate through unrelated abilities with empty argument
+	 * objects. That bypasses the ordinary spin detector, which intentionally
+	 * compares call names as well as arguments. Count only calls that were empty
+	 * and whose matching response confirms a missing required property, then
+	 * reset on any productive or different failure response.
+	 *
+	 * @param Message $call_message     Assistant message containing function calls.
+	 * @param Message $response_message Matching function-response message.
+	 * @return bool True when the terminal threshold has been reached.
+	 */
+	private function record_empty_required_input_failures( Message $call_message, Message $response_message ): bool {
+		$empty_call_ids = array();
+		foreach ( $call_message->getParts() as $part ) {
+			$call = $part->getFunctionCall();
+			if ( ! $call || ! empty( self::normalize_function_call_args( $call->getArgs() ) ) ) {
+				continue;
+			}
+
+			$call_id = (string) $call->getId();
+			if ( '' !== $call_id ) {
+				$empty_call_ids[ $call_id ] = true;
+			}
+		}
+
+		if ( empty( $empty_call_ids ) ) {
+			$this->consecutive_empty_tool_call_failures = 0;
+			return false;
+		}
+
+		$empty_validation_failures = 0;
+		$response_count            = 0;
+		foreach ( $response_message->getParts() as $part ) {
+			$response = $part->getFunctionResponse();
+			if ( ! $response ) {
+				continue;
+			}
+
+			++$response_count;
+			$response_id = (string) $response->getId();
+			if (
+				isset( $empty_call_ids[ $response_id ] )
+				&& self::is_empty_required_input_response( $response->getResponse() )
+			) {
+				++$empty_validation_failures;
+			}
+		}
+
+		if ( 0 === $empty_validation_failures || $empty_validation_failures !== $response_count ) {
+			$this->consecutive_empty_tool_call_failures = 0;
+			return false;
+		}
+
+		$this->consecutive_empty_tool_call_failures += $empty_validation_failures;
+		return $this->consecutive_empty_tool_call_failures >= self::MAX_CONSECUTIVE_EMPTY_TOOL_CALL_FAILURES;
+	}
+
+	/**
+	 * Whether a tool response represents an empty required-input validation error.
+	 *
+	 * @param mixed $response Tool response payload.
+	 * @return bool True for an ability_invalid_input response with missing fields.
+	 */
+	private static function is_empty_required_input_response( $response ): bool {
+		if ( is_string( $response ) ) {
+			$decoded  = json_decode( $response, true );
+			$response = is_array( $decoded ) ? $decoded : array();
+		}
+
+		return is_array( $response )
+			&& 'ability_invalid_input' === ( $response['code'] ?? '' )
+			&& ! empty( $response['missing_required_fields'] );
+	}
+
+	/**
+	 * End a run that is cycling through empty required-input calls.
+	 *
+	 * @return array<string, mixed> Terminal result payload for the chat client.
+	 */
+	private function abort_on_empty_tool_call_storm(): array {
+		$this->last_loop_phase = 'empty_tool_call_storm_aborted';
+		$this->message_log[]   = array(
+			'type'     => 'guardrail',
+			'reason'   => 'empty_tool_call_storm',
+			'count'    => $this->consecutive_empty_tool_call_failures,
+			'sequence' => $this->next_activity_sequence(),
+		);
+
+		AgentEventLog::log(
+			'agent_loop_aborted',
+			AgentEventLog::SEVERITY_WARNING,
+			array(
+				'session_id'      => $this->session_id,
+				'reason'          => 'empty_tool_call_storm',
+				'failures'        => $this->consecutive_empty_tool_call_failures,
+				'iterations_used' => $this->iterations_used,
+				'iterations_max'  => (int) $this->max_iterations,
+				'model_id'        => (string) $this->model_id,
+				'provider_id'     => (string) $this->provider_id,
+			)
+		);
+
+		return $this->with_result_logs(
+			array(
+				'reply'           => __( 'I stopped because repeated tool calls were missing required information, so I could not safely complete the requested change. Please provide the missing target or details and try again.', 'superdav-ai-agent' ),
+				'history'         => $this->serialize_history(),
+				'tool_calls'      => $this->tool_call_log,
+				'token_usage'     => $this->token_usage,
+				'iterations_used' => $this->iterations_used,
+				'model_id'        => $this->model_id,
+				'exit_reason'     => 'empty_tool_call_storm',
+			)
+		);
 	}
 
 	/**

--- a/includes/Core/SystemInstructionBuilder.php
+++ b/includes/Core/SystemInstructionBuilder.php
@@ -444,6 +444,7 @@ class SystemInstructionBuilder {
 			. "4. **Call all needed tools in one response.** When a task requires multiple tools (e.g. create a post AND find an image), call them all at once.\n"
 			. "5. **After receiving tool results, ALWAYS provide a text response summarizing the results for the user.** Never return an empty response after tool calls.\n"
 			. "6. **Only claim completion for work you actually performed.** Do not claim to have set the site title, front page, or created menus unless you have actually called the corresponding tools and received success responses.\n\n"
+			. "7. **Screenshot assignments need matching evidence.** If screenshot capture or media upload fails, report that failure and do not assign an arbitrary existing media ID or claim a fresh screenshot was assigned. Only claim success after the upload response identifies the new media and the assignment response confirms that same media ID. `screenshot-url` can only capture the browser's current origin; for an authorized multisite subdomain, open that site's wp-admin first.\n\n"
 			. "## Content Creation (IMPORTANT)\n"
 			. "To create any page or blog post, use `sd-ai-agent/create-post`.\n"
 			. "To update an existing post or page, use `sd-ai-agent/update-post` (pass post_id plus the fields to change).\n"

--- a/src/abilities/__tests__/screenshot.test.js
+++ b/src/abilities/__tests__/screenshot.test.js
@@ -53,8 +53,9 @@ describe( 'screenshot-url validation', () => {
 			authorized: true,
 			resolved: 'https://template.myshopmaker.ng/product/t-shirt-ne/',
 		} );
-		expect( result.error ).toContain( 'authorized WordPress site' );
-		expect( result.error ).toContain( 'same origin' );
+		expect( result.error ).toContain( 'Authorized WordPress site' );
+		expect( result.error ).toContain( 'screenshot capture requires' );
+		expect( result.error ).toContain( 'wp-admin origin' );
 	} );
 
 	test( 'rejects unrelated external domains even when multisite origins are configured', () => {

--- a/src/abilities/screenshot.js
+++ b/src/abilities/screenshot.js
@@ -155,7 +155,7 @@ export function validateScreenshotUrl( url ) {
 			return {
 				valid: false,
 				resolved: resolved.href,
-				error: `URL is an authorized WordPress site; retry from the same origin (${ resolved.origin }).`,
+				error: `Authorized WordPress site; screenshot capture requires its wp-admin origin (${ resolved.origin }).`,
 				authorized: true,
 			};
 		}
@@ -555,7 +555,7 @@ export async function registerScreenshotUrlAbility() {
 		label: 'Screenshot URL',
 		description:
 			'Capture a same-origin WordPress URL for visual review. ' +
-			'Open multisite subdomains from that origin first.',
+			'Open each multisite site in its own browser tab first.',
 		inputSchema: {
 			type: 'object',
 			properties: {

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -1746,6 +1746,49 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertSame( 3, $data['iterations_used'] );
 	}
 
+	/**
+	 * Empty calls to different abilities must not bypass the validation storm guard.
+	 */
+	public function test_empty_required_input_failures_stop_after_bounded_attempts(): void {
+		if ( ! class_exists( 'WordPress\\AiClient\\Messages\\DTO\\ModelMessage' ) ) {
+			$this->markTestSkipped( 'WP AI Client message classes are not available.' );
+		}
+
+		$loop   = new AgentLoop( 'Update a template screenshot' );
+		$method = new \ReflectionMethod( AgentLoop::class, 'record_empty_required_input_failures' );
+		$method->setAccessible( true );
+
+		for ( $attempt = 1; $attempt <= AgentLoop::MAX_CONSECUTIVE_EMPTY_TOOL_CALL_FAILURES; ++$attempt ) {
+			$call_id = 'call_empty_' . $attempt;
+			$calls   = new \WordPress\AiClient\Messages\DTO\ModelMessage(
+				array(
+					new \WordPress\AiClient\Messages\DTO\MessagePart(
+						new FunctionCall( $call_id, 'wpab__sd-ai-agent__ability-search', array() )
+					)
+				)
+			);
+			$responses = new \WordPress\AiClient\Messages\DTO\UserMessage(
+				array(
+					new \WordPress\AiClient\Messages\DTO\MessagePart(
+						new FunctionResponse(
+							$call_id,
+							'wpab__sd-ai-agent__ability-search',
+							array(
+								'code'                    => 'ability_invalid_input',
+								'missing_required_fields' => array( 'query' ),
+							)
+						)
+					)
+				)
+			);
+
+			$this->assertSame(
+				AgentLoop::MAX_CONSECUTIVE_EMPTY_TOOL_CALL_FAILURES === $attempt,
+				$method->invoke( $loop, $calls, $responses )
+			);
+		}
+	}
+
 	// -------------------------------------------------------------------------
 	// History serialisation / deserialisation
 	// -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Bounds empty required-input validation storms, makes multisite screenshot limits explicit, and requires matching upload/assignment evidence before reporting success.

## Files Changed

includes/Core/AgentLoop.php, includes/Core/SystemInstructionBuilder.php, src/abilities/__tests__/screenshot.test.js, src/abilities/screenshot.js, tests/SdAiAgent/Core/AgentLoopTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** npm run verify passed

## Worker self-verification
- PHPUnit: Tests: 3902, Assertions: 17014, Errors: 0, Failures: 0, Skipped: 126, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Resolves #2283


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.161 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-terra spent 16m and 196,730 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added protection against repeated invalid tool requests, preventing runaway loops and returning a clear terminal error.
  * Improved screenshot guidance when capture must occur from the site’s administrative browser origin.
  * Clarified multisite screenshot instructions for opening sites in separate browser tabs.

* **Tests**
  * Added coverage verifying that repeated missing-input failures stop after a bounded number of attempts.
  * Updated screenshot validation expectations for more specific guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->