### PR TITLE
GH#2285: cover empty calls across abilities

### DIFF
--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -1759,11 +1759,14 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$method->setAccessible( true );
 
 		for ( $attempt = 1; $attempt <= AgentLoop::MAX_CONSECUTIVE_EMPTY_TOOL_CALL_FAILURES; ++$attempt ) {
-			$call_id = 'call_empty_' . $attempt;
+			$call_id      = 'call_empty_' . $attempt;
+			$ability_name = 1 === $attempt % 2
+				? 'wpab__sd-ai-agent__ability-search'
+				: 'wpab__sd-ai-agent__memory-list';
 			$calls   = new \WordPress\AiClient\Messages\DTO\ModelMessage(
 				array(
 					new \WordPress\AiClient\Messages\DTO\MessagePart(
-						new FunctionCall( $call_id, 'wpab__sd-ai-agent__ability-search', array() )
+						new FunctionCall( $call_id, $ability_name, array() )
 					)
 				)
 			);
@@ -1772,7 +1775,7 @@ class AgentLoopTest extends WP_UnitTestCase {
 					new \WordPress\AiClient\Messages\DTO\MessagePart(
 						new FunctionResponse(
 							$call_id,
-							'wpab__sd-ai-agent__ability-search',
+							$ability_name,
 							array(
 								'code'                    => 'ability_invalid_input',
 								'missing_required_fields' => array( 'query' ),


### PR DESCRIPTION
## Summary

- Exercise empty required-input failures across alternating ability names.
- Preserve the bounded validation-storm assertion.

## Testing

- `npm run verify`

## Worker self-verification

- PHPUnit: Tests: 3902, Assertions: 17014, Errors: 0, Failures: 0, Skipped: 126, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

## Runtime Testing

- Self-assessed: test-only coverage change.

Resolves #2285

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.161 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-terra spent 3m and 61,765 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated coverage for empty-input failures involving alternating tool calls.
  * Continued validating that processing stops after the configured maximum consecutive failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->