### PR TITLE
fix: use canonical wp-cli namespace

### DIFF
--- a/advanced-plugin/includes/Bootstrap/CliHandler.php
+++ b/advanced-plugin/includes/Bootstrap/CliHandler.php
@@ -23,11 +23,11 @@ use XWP\DI\Decorators\Handler;
 final class CliHandler {
 
 	/**
-	 * Primary and alias root namespaces under which advanced subcommands are exposed.
+	 * Canonical root namespace under which advanced subcommands are exposed.
 	 *
 	 * @var list<string>
 	 */
-	private const NAMESPACES = array( 'ai-agent', 'superdav-ai-agent', 'sd-ai-agent' );
+	private const NAMESPACES = array( 'sd-ai-agent' );
 
 	/**
 	 * Register advanced WP-CLI commands.
@@ -35,7 +35,13 @@ final class CliHandler {
 	#[Action( tag: 'cli_init', priority: 20 )]
 	public function register_commands(): void {
 		foreach ( self::NAMESPACES as $namespace ) {
-			WP_CLI::add_command( "{$namespace} benchmark", 'SdAiAgent\\CLI\\BenchmarkCommand' );
+			WP_CLI::add_command(
+				"{$namespace} benchmark",
+				'SdAiAgent\\CLI\\BenchmarkCommand',
+				array(
+					'shortdesc' => 'Run live AI agent benchmark suites, list benchmark questions, and write structured benchmark logs.',
+				)
+			);
 		}
 	}
 }

--- a/includes/Bootstrap/CliHandler.php
+++ b/includes/Bootstrap/CliHandler.php
@@ -25,12 +25,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Registers the plugin's WP-CLI subcommands under both the canonical
- * `ai-agent` namespace and the legacy `sd-ai-agent` alias.
+ * Registers the plugin's WP-CLI subcommands under the canonical
+ * `sd-ai-agent` namespace.
  *
  * Uses the `#[Handler(context: CTX_CLI)]` guard so the container skips
  * loading this class outside of WP-CLI requests. Each subcommand class
- * (`CliCommand`, `TraceCommand`, `BenchmarkCommand`) remains a plain
+ * (`CliCommand`, `KnowledgeCommand`, `ModelsCommand`, `SkillsCommand`,
+ * `TraceCommand`) remains a plain
  * `WP_CLI_Command` subclass — we are not yet migrating them to the
  * `#[CLI_Handler]` / `#[CLI_Command]` decorators, which would require
  * deeper restructuring of their docblock-driven subcommand APIs.
@@ -39,9 +40,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * into attribute-driven handlers; this PR simply moves the registration
  * wiring out of the plugin root file.
  *
-	 * Advanced-only CLI commands such as the benchmark runner are registered by
-	 * the Superdav AI Agent Advanced companion plugin, not by the core CLI
-	 * handler that ships to WordPress.org.
+ * Advanced-only CLI commands such as the benchmark runner are registered by
+ * the Superdav AI Agent Advanced companion plugin, not by the core CLI
+ * handler that ships to WordPress.org.
  */
 #[Handler(
 	container: 'sd-ai-agent',
@@ -53,30 +54,45 @@ final class CliHandler {
 	/**
 	 * Commands always registered regardless of WP_DEBUG.
 	 *
-	 * @var array<string,class-string>
+	 * @var array<string,array{class:class-string,shortdesc:string}>
 	 */
 	private const COMMANDS = array(
-		'prompt'    => CliCommand::class,
-		'knowledge' => KnowledgeCommand::class,
-		'models'    => ModelsCommand::class,
-		'skills'    => SkillsCommand::class,
+		'prompt'    => array(
+			'class'     => CliCommand::class,
+			'shortdesc' => 'Send a prompt to the configured WordPress AI agent and optionally let it use registered abilities/tools.',
+		),
+		'knowledge' => array(
+			'class'     => KnowledgeCommand::class,
+			'shortdesc' => 'Import and maintain AI knowledge-base sources used for retrieval and documentation grounding.',
+		),
+		'models'    => array(
+			'class'     => ModelsCommand::class,
+			'shortdesc' => 'List configured AI providers and their available models in table, JSON, CSV, YAML, or IDs format.',
+		),
+		'skills'    => array(
+			'class'     => SkillsCommand::class,
+			'shortdesc' => 'Discover, inspect, and manage AI agent skills available to the plugin.',
+		),
 	);
 
 	/**
 	 * Commands only registered when WP_DEBUG is active.
 	 *
-	 * @var array<string,class-string>
+	 * @var array<string,array{class:class-string,shortdesc:string}>
 	 */
 	private const DEBUG_COMMANDS = array(
-		'trace' => TraceCommand::class,
+		'trace' => array(
+			'class'     => TraceCommand::class,
+			'shortdesc' => 'Inspect debug traces for AI provider requests, responses, tokens, costs, and related session activity.',
+		),
 	);
 
 	/**
-	 * Primary and alias root namespaces under which every subcommand is exposed.
+	 * Canonical root namespace under which every subcommand is exposed.
 	 *
 	 * @var list<string>
 	 */
-	private const NAMESPACES = array( 'ai-agent', 'superdav-ai-agent', 'sd-ai-agent' );
+	private const NAMESPACES = array( 'sd-ai-agent' );
 
 	/**
 	 * Register every subcommand with WP-CLI.
@@ -97,8 +113,12 @@ final class CliHandler {
 		}
 
 		foreach ( self::NAMESPACES as $ns ) {
-			foreach ( $commands as $sub => $class ) {
-				WP_CLI::add_command( "{$ns} {$sub}", $class );
+			foreach ( $commands as $sub => $command ) {
+				WP_CLI::add_command(
+					"{$ns} {$sub}",
+					$command['class'],
+					array( 'shortdesc' => $command['shortdesc'] )
+				);
 			}
 		}
 	}

--- a/tests/SdAiAgent/CanonicalNamingTest.php
+++ b/tests/SdAiAgent/CanonicalNamingTest.php
@@ -51,4 +51,32 @@ class CanonicalNamingTest extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'Text Domain: sd-ai-agent', $contents );
 		$this->assertStringNotContainsString( 'Text Domain: gratis-ai-agent', $contents );
 	}
+
+	/**
+	 * WP-CLI commands must expose only the canonical internal command namespace.
+	 */
+	public function test_wp_cli_registration_uses_only_sd_ai_agent_namespace(): void {
+		$core_contents     = (string) file_get_contents( $this->root_dir() . '/includes/Bootstrap/CliHandler.php' );
+		$advanced_contents = (string) file_get_contents( $this->root_dir() . '/advanced-plugin/includes/Bootstrap/CliHandler.php' );
+
+		$this->assertStringContainsString( "private const NAMESPACES = array( 'sd-ai-agent' );", $core_contents );
+		$this->assertStringContainsString( "private const NAMESPACES = array( 'sd-ai-agent' );", $advanced_contents );
+		$this->assertStringNotContainsString( "array( 'ai-agent', 'superdav-ai-agent', 'sd-ai-agent' )", $core_contents );
+		$this->assertStringNotContainsString( "array( 'ai-agent', 'superdav-ai-agent', 'sd-ai-agent' )", $advanced_contents );
+	}
+
+	/**
+	 * WP-CLI registrations should describe what each subcommand can do.
+	 */
+	public function test_wp_cli_registration_includes_subcommand_descriptions(): void {
+		$core_contents     = (string) file_get_contents( $this->root_dir() . '/includes/Bootstrap/CliHandler.php' );
+		$advanced_contents = (string) file_get_contents( $this->root_dir() . '/advanced-plugin/includes/Bootstrap/CliHandler.php' );
+
+		$this->assertStringContainsString( "'shortdesc' => 'Send a prompt to the configured WordPress AI agent", $core_contents );
+		$this->assertStringContainsString( "'shortdesc' => 'Import and maintain AI knowledge-base sources", $core_contents );
+		$this->assertStringContainsString( "'shortdesc' => 'List configured AI providers", $core_contents );
+		$this->assertStringContainsString( "'shortdesc' => 'Discover, inspect, and manage AI agent skills", $core_contents );
+		$this->assertStringContainsString( "'shortdesc' => 'Inspect debug traces for AI provider requests", $core_contents );
+		$this->assertStringContainsString( "'shortdesc' => 'Run live AI agent benchmark suites", $advanced_contents );
+	}
 }


### PR DESCRIPTION
## Summary
- Register core WP-CLI subcommands only under `wp sd-ai-agent`.
- Register the advanced benchmark WP-CLI command only under `wp sd-ai-agent benchmark`.
- Add WP-CLI `shortdesc` metadata for each registered command so help output explains what the command can do.
- Add canonical naming tests to prevent reintroducing the `ai-agent` or `superdav-ai-agent` CLI aliases.

## Worker self-verification
- PHPUnit: Tests: 3904, Assertions: 17024, Errors: 0, Failures: 0, Skipped: 126, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

## Additional checks
- `npm run test:php -- --filter=CanonicalNamingTest`: OK (4 tests, 19 assertions)
- `rg -n "private const NAMESPACES = array\( 'ai-agent'|private const NAMESPACES = array\( 'superdav-ai-agent'|array\( 'ai-agent', 'superdav-ai-agent', 'sd-ai-agent' \)" includes/Bootstrap/CliHandler.php advanced-plugin/includes/Bootstrap/CliHandler.php`: no matches

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.161 plugin for [OpenCode](https://opencode.ai) v1.18.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized WP-CLI commands under the `sd-ai-agent` namespace.
  * Added descriptions for registered WP-CLI subcommands, including benchmark and debugging commands.

* **Bug Fixes**
  * Removed legacy WP-CLI namespace aliases to provide consistent command access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->