### PR TITLE
fix: improve chat credit exhaustion notices

### DIFF
--- a/src/components/chat-redesign/__tests__/SystemMessage.test.js
+++ b/src/components/chat-redesign/__tests__/SystemMessage.test.js
@@ -61,7 +61,7 @@ describe( 'AccountActionSystemMessage', () => {
 	test( 'renders Superdav credit notices as account actions', async () => {
 		const { container, root } = await renderAccountActionSystemMessage( {
 			notice: [
-				"You're almost ready to continue. Add payment information to your Superdav account to keep using Superdav Chat Pro.",
+				"You've used all of your available Superdav credits. Purchase more credits in your account settings to continue using Superdav Chat Pro.",
 				'https://account.example.test/login',
 			],
 		} );
@@ -70,7 +70,7 @@ describe( 'AccountActionSystemMessage', () => {
 			container.querySelector( '.sdaa-cr-msg-system--account-action' )
 		).not.toBeNull();
 		expect( container.textContent ).toContain(
-			"You're almost ready to continue"
+			'Purchase more credits in your account settings'
 		);
 		expect( container.textContent ).not.toMatch(
 			/\b(error|rejected|insufficient)\b/i
@@ -81,7 +81,9 @@ describe( 'AccountActionSystemMessage', () => {
 		expect( action.getAttribute( 'href' ) ).toBe(
 			'https://account.example.test/login'
 		);
-		expect( action.textContent ).toBe( 'Add payment information' );
+		expect( action.getAttribute( 'target' ) ).toBe( '_blank' );
+		expect( action.getAttribute( 'rel' ) ).toBe( 'noopener noreferrer' );
+		expect( action.textContent ).toBe( 'Purchase credits' );
 
 		await act( async () => {
 			root.unmount();

--- a/src/components/chat-redesign/account-action-system-message.js
+++ b/src/components/chat-redesign/account-action-system-message.js
@@ -21,8 +21,13 @@ export default function AccountActionSystemMessage( { notice } ) {
 			>
 				{ notice[ 0 ] }
 				{ actionUrl && (
-					<a className="sdaa-cr-msg-system-action" href={ actionUrl }>
-						{ __( 'Add payment information', 'superdav-ai-agent' ) }
+					<a
+						className="sdaa-cr-msg-system-action"
+						href={ actionUrl }
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						{ __( 'Purchase credits', 'superdav-ai-agent' ) }
 					</a>
 				) }
 			</div>

--- a/src/components/chat-redesign/chat-redesign.css
+++ b/src/components/chat-redesign/chat-redesign.css
@@ -883,6 +883,9 @@ input[type="text"].sdaa-cr-search-input {
 	padding: 10px 14px;
 	border-radius: var(--sdaa-radius-md);
 	font-size: 13px;
+	line-height: 1.55;
+	white-space: pre-wrap;
+	overflow-wrap: anywhere;
 }
 
 .sdaa-cr-msg-system--account-action {
@@ -892,7 +895,8 @@ input[type="text"].sdaa-cr-search-input {
 }
 
 .sdaa-cr-msg-system-action {
-	display: inline-flex;
+	display: flex;
+	width: fit-content;
 	align-items: center;
 	justify-content: center;
 	margin-top: 10px;

--- a/src/components/chat-widget/__tests__/widget-message-list.test.js
+++ b/src/components/chat-widget/__tests__/widget-message-list.test.js
@@ -1,0 +1,108 @@
+/**
+ * Unit tests for the floating widget message list.
+ */
+
+import { createElement } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+
+import WidgetMessageList from '../widget-message-list';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( str ) => str,
+} ) );
+
+jest.mock( '../../../store', () => 'sd-ai-agent' );
+jest.mock( '../../feedback-consent-modal', () => () => null );
+jest.mock( '../../chat-redesign/message-items', () => ( {
+	AssistantMessage: () => null,
+	RunningMessage: () => null,
+	SystemMessage: () => null,
+	UserMessage: () => null,
+} ) );
+jest.mock( '../../chat-redesign/message-helpers', () => ( {
+	extractText: ( message ) => message.parts?.[ 0 ]?.text || '',
+	getRunningToolName: () => '',
+} ) );
+
+/**
+ * Render the floating widget message list with a credit-exhaustion notice.
+ *
+ * @return {Promise<{container: HTMLElement, root: import('react-dom/client').Root}>}
+ *   Rendered container and root.
+ */
+async function renderCreditExhaustionMessage() {
+	const selectors = {
+		getCurrentSessionMessages: () => [
+			{
+				role: 'system',
+				parts: [
+					{
+						text: 'Client error (402): Superdav credit balance is insufficient for this request.',
+					},
+				],
+			},
+		],
+		isSending: () => false,
+		getCurrentSessionId: () => 123,
+		getLiveToolCalls: () => [],
+		getSessionJobs: () => ( {} ),
+		getProviders: () => [
+			{
+				id: 'sd-ai-agent-cloud',
+				status: {
+					account_connect_url: 'https://account.example.test/login',
+				},
+			},
+		],
+	};
+	useSelect.mockImplementation( ( fn ) => fn( () => selectors ) );
+	useDispatch.mockReturnValue( { sendMessage: jest.fn() } );
+
+	const container = document.createElement( 'div' );
+	document.body.appendChild( container );
+	const root = createRoot( container );
+	await act( async () => {
+		root.render( createElement( WidgetMessageList ) );
+	} );
+
+	return { container, root };
+}
+
+describe( 'WidgetMessageList credit exhaustion notice', () => {
+	afterEach( () => {
+		document.body.innerHTML = '';
+		jest.clearAllMocks();
+	} );
+
+	test( 'replaces the provider error with an account-settings credit CTA', async () => {
+		const { container, root } = await renderCreditExhaustionMessage();
+		const notice = container.querySelector(
+			'.sdaa-cr-msg-system--account-action'
+		);
+
+		expect( notice ).not.toBeNull();
+		expect( notice.textContent ).toContain(
+			'Purchase more credits in your account settings'
+		);
+		expect( notice.textContent ).not.toMatch( /\b(error|insufficient)\b/i );
+
+		const action = notice.querySelector( '.sdaa-cr-msg-system-action' );
+		expect( action.textContent ).toBe( 'Purchase credits' );
+		expect( action.getAttribute( 'href' ) ).toBe(
+			'https://account.example.test/login'
+		);
+
+		await act( async () => {
+			root.unmount();
+		} );
+	} );
+} );

--- a/src/components/chat-widget/widget-message-list.js
+++ b/src/components/chat-widget/widget-message-list.js
@@ -30,6 +30,11 @@ import {
 	SystemMessage,
 	UserMessage,
 } from '../chat-redesign/message-items';
+import AccountActionSystemMessage from '../chat-redesign/account-action-system-message';
+import {
+	buildSuperdavCreditNoticeMessage,
+	isSuperdavCreditBalanceNotice,
+} from '../../utils/superdav-credit-notice';
 
 /** Distance (px) from the scroll bottom that is treated as "at the bottom". */
 const SCROLL_THRESHOLD = 100;
@@ -38,17 +43,24 @@ const SCROLL_THRESHOLD = 100;
  *
  */
 export default function WidgetMessageList() {
-	const { messages, sending, currentSessionId, liveToolCalls, sessionJobs } =
-		useSelect( ( sel ) => {
-			const store = sel( STORE_NAME );
-			return {
-				messages: store.getCurrentSessionMessages(),
-				sending: store.isSending(),
-				currentSessionId: store.getCurrentSessionId(),
-				liveToolCalls: store.getLiveToolCalls(),
-				sessionJobs: store.getSessionJobs(),
-			};
-		}, [] );
+	const {
+		messages,
+		sending,
+		currentSessionId,
+		liveToolCalls,
+		sessionJobs,
+		providers,
+	} = useSelect( ( sel ) => {
+		const store = sel( STORE_NAME );
+		return {
+			messages: store.getCurrentSessionMessages(),
+			sending: store.isSending(),
+			currentSessionId: store.getCurrentSessionId(),
+			liveToolCalls: store.getLiveToolCalls(),
+			sessionJobs: store.getSessionJobs(),
+			providers: store.getProviders(),
+		};
+	}, [] );
 
 	const { sendMessage } = useDispatch( STORE_NAME );
 	const ref = useRef( null );
@@ -203,13 +215,29 @@ export default function WidgetMessageList() {
 							);
 						}
 						if ( msg.role === 'system' ) {
+							if ( msg.notice ) {
+								return (
+									<AccountActionSystemMessage
+										key={ index }
+										notice={ msg.notice }
+									/>
+								);
+							}
+							const text = extractText( msg );
+							if ( isSuperdavCreditBalanceNotice( text ) ) {
+								return (
+									<AccountActionSystemMessage
+										key={ index }
+										notice={
+											buildSuperdavCreditNoticeMessage(
+												providers
+											).notice
+										}
+									/>
+								);
+							}
 							return (
-								<SystemMessage
-									key={ index }
-									text={
-										msg.notice?.[ 0 ] || extractText( msg )
-									}
-								/>
+								<SystemMessage key={ index } text={ text } />
 							);
 						}
 						return null;

--- a/src/utils/__tests__/superdav-credit-notice.test.js
+++ b/src/utils/__tests__/superdav-credit-notice.test.js
@@ -71,7 +71,7 @@ describe( 'buildSuperdavCreditNoticeMessage', () => {
 			'https://account.example.test/login'
 		);
 		expect( message.notice[ 0 ] ).toContain(
-			'Add payment information to your Superdav account'
+			'Purchase more credits in your account settings'
 		);
 		expect( message.notice[ 0 ] ).not.toMatch(
 			/\b(error|rejected|insufficient)\b/i

--- a/src/utils/superdav-credit-notice.js
+++ b/src/utils/superdav-credit-notice.js
@@ -53,7 +53,7 @@ export function buildSuperdavCreditNoticeMessage( providers ) {
 		role: 'system',
 		notice: [
 			__(
-				"You're almost ready to continue. Add payment information to your Superdav account to keep using Superdav Chat Pro.",
+				"You've used all of your available Superdav credits. Purchase more credits in your account settings to continue using Superdav Chat Pro.",
 				'superdav-ai-agent'
 			),
 			getSuperdavAccountConnectUrl( providers ),


### PR DESCRIPTION
## Summary

- Replace raw Superdav credit-exhaustion errors in the floating widget with a calm account-action notice.
- Send users to their Superdav account settings with a **Purchase credits** CTA.
- Preserve complete generic system-error text by wrapping long content instead of clipping it.

## Verification

## Worker self-verification
- PHPUnit: Tests: 3904, Assertions: 17024, Errors: 0, Failures: 0, Skipped: 126
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.165 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-terra spent 28m and 200,856 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clearer account notices when Superdav credits are exhausted.
  - Added a **Purchase credits** action linking to account settings and opening in a new tab.

- **Bug Fixes**
  - Replaced confusing credit and provider error messages with actionable guidance.
  - Improved system notice readability, including text wrapping and spacing across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->