### PR TITLE
GH#2289: avoid wp-cli during onboarding

### DIFF
--- a/includes/Models/Agent.php
+++ b/includes/Models/Agent.php
@@ -371,7 +371,24 @@ class Agent {
 			$options['max_iterations'] = $agent->max_iterations;
 		}
 		if ( ! empty( $agent->tier_1_tools ) ) {
-			$options['tier_1_tools'] = $agent->tier_1_tools;
+			$tier_1_tools = $agent->tier_1_tools;
+
+			// Built-in onboarding records are seeded only once, so an upgraded
+			// site can retain the former direct WP-CLI entry. Keep the broad
+			// dispatcher out of Phase 0 even when the stored agent row predates
+			// the safer dedicated discovery tools.
+			if ( self::ONBOARDING_AGENT_SLUG === $agent->slug && $agent->is_builtin ) {
+				$tier_1_tools = array_values(
+					array_filter(
+						$tier_1_tools,
+						static fn( string $tool ): bool => 'wp-cli/execute' !== $tool
+					)
+				);
+			}
+
+			if ( ! empty( $tier_1_tools ) ) {
+				$options['tier_1_tools'] = $tier_1_tools;
+			}
 		}
 
 		return $options;
@@ -511,7 +528,6 @@ class Agent {
 			'sd-ai-agent/skill-load',
 			'sd-ai-agent/knowledge-search',
 			'sd-ai-agent/public-chat-setup',
-			'wp-cli/execute',
 			'sd-ai-agent/create-post',
 			'sd-ai-agent/update-post',
 			'sd-ai-agent/list-posts',
@@ -624,6 +640,9 @@ class Agent {
 						'sd-ai-agent/list-posts',
 						'sd-ai-agent/get-plugins',
 						'sd-ai-agent/get-themes',
+						// Use a dedicated, confirmation-aware ability instead of the
+						// broad WP-CLI dispatcher when setup needs WooCommerce.
+						'sd-ai-agent/install-plugin',
 						// Theme + page build suite (from legacy Theme Builder).
 						'sd-ai-agent/scaffold-block-theme',
 						'sd-ai-agent/validate-block-theme-project',
@@ -668,6 +687,7 @@ class Agent {
 			. "2. `sd-ai-agent/list-posts` — recent posts AND pages (look at post_type, status, title, snippet).\n"
 			. "3. `sd-ai-agent/get-plugins` — what's active (notably WooCommerce).\n"
 			. "4. `sd-ai-agent/get-themes` — the active theme.\n\n"
+			. "Use these dedicated abilities for Phase 0. Do not use the generic `wp-cli/execute` dispatcher for site title, tagline, active-plugin, or theme discovery: it requires broader permissions and the dedicated abilities above are safer and available now.\n\n"
 			. "Decide which branch you are in. The user never sees this decision:\n\n"
 			. "- **Empty install** = the active theme is a WordPress default (twenty-twentyfive, twenty-twentyfour, twenty-twentythree, etc.) AND there are 0–1 real published posts/pages. The seed \"Hello world!\" post and the seed \"Sample Page\" do NOT count as real content.\n"
 			. "- **Established site** = anything else (a non-default theme, or 2+ real published items).\n\n"
@@ -716,7 +736,7 @@ class Agent {
 			. "- **Add menu page** (hospitality) → run the structured menu interview (categories → items + prices → optional descriptions / dietary tags / PDF URL), then call `sd-ai-agent/generate-menu-page`. Never write menus as prose.\n"
 			. "- **Add team page** → ask for names + roles + (optional) bios, then `sd-ai-agent/create-post` (page).\n"
 			. "- **Add events page** → ask for event list (name, date, description), then `sd-ai-agent/create-post` (page).\n"
-			. "- **Add a shop** → if WooCommerce is not active, install via `wp-cli/execute`; collect a representative product list; create product entries.\n"
+			. "- **Add a shop** → if WooCommerce is not active, install via `sd-ai-agent/install-plugin`; collect a representative product list; create product entries.\n"
 			. "- **Add contact details** → ask for phone / email / address / form preference; update the contact page.\n"
 			. "- **Try a different look** → load `design-system-aesthetics`, render three alternative directions via `sd-ai-agent/render-design-previews`, let the user pick, update the saved design-token contract, rerun `sd-ai-agent/compile-design-tokens`, revalidate its palette, then apply its file-only manifest and Global Styles outputs through their dedicated abilities.\n"
 			. "- **Use a saved style variation** → call `sd-ai-agent/list-style-variations`, then validate and preview the selected hash with `sd-ai-agent/validate-style-variation` and `sd-ai-agent/preview-style-variation`. Select only through `sd-ai-agent/select-style-variation` with that exact hash; use `sd-ai-agent/reset-style-variation` only when undoing the plugin-managed selection. Never use generic file writes or wholesale Global Styles reset for this lifecycle.\n"

--- a/includes/Tools/ToolDiscovery.php
+++ b/includes/Tools/ToolDiscovery.php
@@ -115,9 +115,6 @@ class ToolDiscovery {
 		'sd-ai-agent/get-page-blocks',
 		'sd-ai-agent/update-blocks',
 		'sd-ai-agent/validate-block-content',
-		// WP-CLI is the proper tool for admin commands like `wp site list`,
-		// `wp plugin list`, etc. Registered by the cli-abilities-bridge plugin.
-		'wp-cli/execute',
 		// `create-post` is the single most common WordPress operation the
 		// agent is ever asked for. Keeping it in cold-start so smaller
 		// local models don't fall back to `run-php` + positional-arg

--- a/tests/SdAiAgent/Models/AgentTest.php
+++ b/tests/SdAiAgent/Models/AgentTest.php
@@ -446,6 +446,51 @@ class AgentTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Setup discovery must prefer dedicated read-only abilities instead of the
+	 * broad, permission-gated WP-CLI dispatcher.
+	 *
+	 * Regression test for #2289: fresh onboarding attempted option and plugin
+	 * inspection through wp-cli/execute, which failed for customer admins before
+	 * they could see an actionable permission prompt.
+	 */
+	public function test_onboarding_uses_dedicated_discovery_abilities_instead_of_wp_cli(): void {
+		$reflection = new \ReflectionClass( Agent::class );
+		$method     = $reflection->getMethod( 'get_onboarding_definition' );
+		$method->setAccessible( true );
+
+		$definition = $method->invoke( null, Agent::get_general_tier_1_tools() );
+		$tools      = $definition['tier_1_tools'];
+		$prompt     = $definition['system_prompt'];
+
+		$this->assertContains( 'sd-ai-agent/list-options', $tools );
+		$this->assertContains( 'sd-ai-agent/get-plugins', $tools );
+		$this->assertContains( 'sd-ai-agent/get-themes', $tools );
+		$this->assertContains( 'sd-ai-agent/install-plugin', $tools );
+		$this->assertNotContains( 'wp-cli/execute', $tools );
+		$this->assertStringContainsString( 'Do not use the generic `wp-cli/execute` dispatcher for site title, tagline, active-plugin, or theme discovery', $prompt );
+	}
+
+	/**
+	 * Existing built-in onboarding rows retain their original tool list across
+	 * upgrades, so the runtime must also exclude the retired direct dispatcher.
+	 */
+	public function test_onboarding_loop_options_exclude_wp_cli_from_existing_builtin(): void {
+		Agent::reset_defaults();
+		$agent = Agent::get_by_slug( 'onboarding' );
+		$this->assertNotNull( $agent );
+
+		$original_tools = $agent->tier_1_tools;
+		Agent::update( $agent->id, [ 'tier_1_tools' => [ 'sd-ai-agent/get-option', 'wp-cli/execute' ] ] );
+
+		try {
+			$options = Agent::get_loop_options( $agent->id );
+			$this->assertSame( [ 'sd-ai-agent/get-option' ], $options['tier_1_tools'] );
+		} finally {
+			Agent::update( $agent->id, [ 'tier_1_tools' => $original_tools ] );
+		}
+	}
+
+	/**
 	 * Every ability mentioned in a built-in agent's system prompt must be
 	 * present in that agent's tier_1_tools (or in the meta-tools that the
 	 * resolver always exposes). Catches drift between prompt and tool surface

--- a/tests/SdAiAgent/Models/AgentTest.php
+++ b/tests/SdAiAgent/Models/AgentTest.php
@@ -475,7 +475,7 @@ class AgentTest extends WP_UnitTestCase {
 	 * upgrades, so the runtime must also exclude the retired direct dispatcher.
 	 */
 	public function test_onboarding_loop_options_exclude_wp_cli_from_existing_builtin(): void {
-		Agent::reset_defaults();
+		Agent::seed_defaults();
 		$agent = Agent::get_by_slug( 'onboarding' );
 		$this->assertNotNull( $agent );
 


### PR DESCRIPTION
## Summary

- Prefer dedicated onboarding discovery abilities over the broad `wp-cli/execute` dispatcher.
- Keep the generic dispatcher out of default Tier 1 discovery while leaving it discoverable for explicit advanced use.
- Cover the onboarding tool contract with a regression test.

## Testing

- `npm run test:php -- --filter=AgentTest`
- `vendor/bin/phpcs includes/Models/Agent.php includes/Tools/ToolDiscovery.php tests/SdAiAgent/Models/AgentTest.php`

## Runtime Testing

- Self-assessed: prompt and server-side tool-surface changes covered by PHPUnit; no interactive runtime is required for this low-risk guidance change.

Resolves #2289

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.165 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-terra spent 5m and 165,488 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the Setup Assistant’s setup flows by using dedicated discovery and installation tools for plugins, themes, and options.

* **Bug Fixes**
  * Prevented the onboarding assistant from using the generic WP-CLI execution tool when dedicated capabilities are available.
  * Ensured existing onboarding configurations automatically filter out the unsupported generic dispatcher.

* **Tests**
  * Added coverage verifying dedicated tool selection and filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->