### PR TITLE
fix: filter non-text agent models

### DIFF
--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -1256,6 +1256,8 @@ final class SettingsController {
 					$models = $this->list_model_metadata_for_provider( $provider_id, $class );
 				}
 
+				$models = self::filter_text_generation_models( $models );
+
 				$provider_response = array(
 					'id'         => $provider_id,
 					'name'       => $metadata->getName(),
@@ -1363,6 +1365,68 @@ final class SettingsController {
 		}
 
 		return $models;
+	}
+
+	/**
+	 * Keep only models that advertise the SDK text-generation capability.
+	 *
+	 * The agent can use text models with additional capabilities, such as image
+	 * input, but must not offer image, video, speech, music, embedding, or
+	 * unknown models as chat selections. Both SDK-formatted rows and the raw
+	 * OpenAI-compatible connector response carry this metadata under one of the
+	 * fields inspected here.
+	 *
+	 * @param array<mixed> $models Provider model rows.
+	 * @return list<array<mixed>> Agent-selectable model rows.
+	 */
+	private static function filter_text_generation_models( array $models ): array {
+		$selectable_models = array();
+
+		foreach ( $models as $model ) {
+			if ( ! is_array( $model ) || ! self::model_supports_text_generation( $model ) ) {
+				continue;
+			}
+
+			$selectable_models[] = $model;
+		}
+
+		return $selectable_models;
+	}
+
+	/**
+	 * Determine whether a provider model row explicitly supports text generation.
+	 *
+	 * @param array<string, mixed> $model Provider model row.
+	 * @return bool Whether the model is safe to present to the agent.
+	 */
+	private static function model_supports_text_generation( array $model ): bool {
+		foreach ( array( 'capabilities', 'supported_capabilities' ) as $key ) {
+			if ( ! isset( $model[ $key ] ) || ! is_array( $model[ $key ] ) ) {
+				continue;
+			}
+
+			foreach ( $model[ $key ] as $capability_key => $capability_value ) {
+				if ( is_string( $capability_key ) && true === $capability_value && self::is_text_generation_capability( $capability_key ) ) {
+					return true;
+				}
+
+				if ( is_string( $capability_value ) && self::is_text_generation_capability( $capability_value ) ) {
+					return true;
+				}
+			}
+		}
+
+		return isset( $model['supports_text_generation'] ) && true === $model['supports_text_generation'];
+	}
+
+	/**
+	 * Check a provider capability value against the SDK text-generation value.
+	 *
+	 * @param string $capability Provider capability value.
+	 * @return bool Whether the value denotes text generation.
+	 */
+	private static function is_text_generation_capability( string $capability ): bool {
+		return 'text_generation' === str_replace( '-', '_', strtolower( $capability ) );
 	}
 
 	/**

--- a/tests/SdAiAgent/REST/SettingsControllerTest.php
+++ b/tests/SdAiAgent/REST/SettingsControllerTest.php
@@ -160,10 +160,31 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 							array(
 								'data' => array(
 									array(
-									'id'                => 'superdav-chat-fast',
-									'name'              => 'Superdav Chat Fast',
+										'id'                => 'superdav-chat-fast',
+										'name'              => 'Superdav Chat Fast',
 										'context_length'    => 128000,
 										'max_output_length' => 8192,
+										'capabilities'      => array( 'text_generation' ),
+									),
+									array(
+										'id'           => 'superdav-image',
+										'name'         => 'Superdav Image',
+										'capabilities' => array( 'image_generation' ),
+									),
+									array(
+										'id'           => 'superdav-video',
+										'name'         => 'Superdav Video',
+										'capabilities' => array( 'video_generation' ),
+									),
+									array(
+										'id'           => 'superdav-tts',
+										'name'         => 'Superdav TTS',
+										'capabilities' => array( 'text_to_speech_conversion' ),
+									),
+									array(
+										'id'           => 'superdav-embedding',
+										'name'         => 'Superdav Embeddings',
+										'capabilities' => array( 'embedding_generation' ),
 									),
 								),
 							)
@@ -193,11 +214,38 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		$this->assertTrue( $superdav['status']['connection_notice_pending'] );
 		$this->assertSame( 10000000, $superdav['status']['wallet']['promo_usd_micros'] );
 		$this->assertSame( 'superdav-chat-fast', $superdav['models'][0]['id'] ?? '' );
+		$this->assertSame( array( 'superdav-chat-fast' ), wp_list_pluck( $superdav['models'], 'id' ) );
 		$this->assertStringNotContainsString( 'sdaist_auto_provisioned_token', wp_json_encode( $superdav ) ?: '' );
 
 		$second_response = $controller->handle_providers();
 		$this->assertSame( 200, $second_response->get_status() );
 		$this->assertSame( 1, $registration_hits );
+	}
+
+	/**
+	 * Agent model lists use declared capabilities rather than model identifiers.
+	 */
+	public function test_text_generation_model_filter_uses_provider_metadata(): void {
+		$method = new \ReflectionMethod( SettingsController::class, 'filter_text_generation_models' );
+		$method->setAccessible( true );
+
+		$models = $method->invoke(
+			null,
+			array(
+				array( 'id' => 'text-list', 'capabilities' => array( 'text_generation' ) ),
+				array( 'id' => 'text-map', 'capabilities' => array( 'text_generation' => true ) ),
+				array( 'id' => 'text-supported', 'supported_capabilities' => array( 'text-generation' ) ),
+				array( 'id' => 'text-flag', 'supports_text_generation' => true ),
+				array( 'id' => 'image', 'capabilities' => array( 'image_generation' ) ),
+				array( 'id' => 'video', 'capabilities' => array( 'video_generation' ) ),
+				array( 'id' => 'tts', 'capabilities' => array( 'text_to_speech_conversion' ) ),
+				array( 'id' => 'speech', 'capabilities' => array( 'speech_generation' ) ),
+				array( 'id' => 'embedding', 'capabilities' => array( 'embedding_generation' ) ),
+				array( 'id' => 'unknown' ),
+			)
+		);
+
+		$this->assertSame( array( 'text-list', 'text-map', 'text-supported', 'text-flag' ), wp_list_pluck( $models, 'id' ) );
 	}
 
 	/** Superdav account refresh returns safe wallet metadata without a bearer token. */


### PR DESCRIPTION
## Summary

- Filter agent-selectable provider models on explicit `text_generation` capability metadata.
- Exclude image, video, text-to-speech, speech, embedding, and metadata-less models from the shared `/providers` response used by model selectors.
- Cover SDK and OpenAI-compatible connector metadata shapes, plus mixed provider model listings.

## Worker self-verification

- PHPUnit: Tests: 3907, Assertions: 17035, Errors: 0, Failures: 0, Skipped: 126, Incomplete: 4
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.166 plugin for [OpenCode](https://opencode.ai) v1.18.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider model lists now show only models that support text generation.
  * Models intended for images, video, audio, embeddings, or other capabilities are no longer offered as text-generation options.
  * Capability metadata is interpreted consistently across supported response formats.

* **Tests**
  * Added coverage verifying accurate filtering of models based on their advertised capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->