### PR TITLE
test: preserve text model metadata in stale token fixture

### DIFF
--- a/tests/SdAiAgent/REST/SettingsControllerTest.php
+++ b/tests/SdAiAgent/REST/SettingsControllerTest.php
@@ -432,16 +432,18 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 							array(
 								'data' => array(
 									array(
-									'id'                => 'superdav-chat-fast',
-									'name'              => 'Superdav Chat Fast',
+										'id'                => 'superdav-chat-fast',
+										'name'              => 'Superdav Chat Fast',
 										'context_length'    => 128000,
 										'max_output_length' => 8192,
+										'capabilities'      => array( 'text_generation' ),
 									),
 									array(
-									'id'                => 'superdav-chat-pro',
-									'name'              => 'Superdav Chat Pro',
+										'id'                => 'superdav-chat-pro',
+										'name'              => 'Superdav Chat Pro',
 										'context_length'    => 200000,
 										'max_output_length' => 16384,
+										'capabilities'      => array( 'text_generation' ),
 									),
 								),
 							)


### PR DESCRIPTION
## Summary

- Add text-generation capability metadata to the stale-token Superdav provider fixture.
- Keep the existing chat model assertions aligned with production filtering.

## Testing

- `npm run verify`
- PHPUnit: Tests: 3907, Assertions: 17035, Errors: 0, Failures: 0, Skipped: 126, Incomplete: 4
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build and bundle check: succeeded

Resolves #2295

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.168 plugin for [OpenCode](https://opencode.ai) v1.18.4
