### PR TITLE
GH#2295: test: preserve text model metadata in stale token fixture

### DIFF
--- a/tests/SdAiAgent/REST/SettingsControllerTest.php
+++ b/tests/SdAiAgent/REST/SettingsControllerTest.php
@@ -432,16 +432,18 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 							array(
 								'data' => array(
 									array(
-									'id'                => 'superdav-chat-fast',
-									'name'              => 'Superdav Chat Fast',
+										'id'                => 'superdav-chat-fast',
+										'name'              => 'Superdav Chat Fast',
 										'context_length'    => 128000,
 										'max_output_length' => 8192,
+										'capabilities'      => array( 'text_generation' ),
 									),
 									array(
-									'id'                => 'superdav-chat-pro',
-									'name'              => 'Superdav Chat Pro',
+										'id'                => 'superdav-chat-pro',
+										'name'              => 'Superdav Chat Pro',
 										'context_length'    => 200000,
 										'max_output_length' => 16384,
+										'capabilities'      => array( 'text_generation' ),
 									),
 								),
 							)


### PR DESCRIPTION
## Summary

Add text-generation capabilities to both stale-token Superdav chat model fixture rows so the provider filter preserves the existing model expectations.

## Files Changed

tests/SdAiAgent/REST/SettingsControllerTest.php

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — npm run verify (PHPUnit: Tests: 3907, Assertions: 17035, Errors: 0, Failures: 0, Skipped: 126, Incomplete: 4; PHP/JS/CSS lint clean; PHPStan 0 errors; build and bundle check succeeded)

Resolves #2295


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.168 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-terra spent 13m and 105,763 tokens on this as a headless worker.