### PR TITLE
fix: address chat review feedback

### DIFF
--- a/src/components/chat-redesign/__tests__/SystemMessage.test.js
+++ b/src/components/chat-redesign/__tests__/SystemMessage.test.js
@@ -67,7 +67,9 @@ describe( 'AccountActionSystemMessage', () => {
 		} );
 
 		expect(
-			container.querySelector( '.sdaa-cr-msg-system--account-action' )
+			container.querySelector(
+				'.sd-ai-agent-cr-msg-system--account-action'
+			)
 		).not.toBeNull();
 		expect( container.textContent ).toContain(
 			'Purchase more credits in your account settings'
@@ -76,7 +78,9 @@ describe( 'AccountActionSystemMessage', () => {
 			/\b(error|rejected|insufficient)\b/i
 		);
 
-		const action = container.querySelector( '.sdaa-cr-msg-system-action' );
+		const action = container.querySelector(
+			'.sd-ai-agent-cr-msg-system-action'
+		);
 		expect( action ).not.toBeNull();
 		expect( action.getAttribute( 'href' ) ).toBe(
 			'https://account.example.test/login'

--- a/src/components/chat-redesign/account-action-system-message.js
+++ b/src/components/chat-redesign/account-action-system-message.js
@@ -16,13 +16,13 @@ export default function AccountActionSystemMessage( { notice } ) {
 	return (
 		<div className="sdaa-cr-msg-row">
 			<div
-				className="sdaa-cr-msg-system sdaa-cr-msg-system--account-action"
+				className="sd-ai-agent-cr-msg-system sd-ai-agent-cr-msg-system--account-action"
 				role="status"
 			>
 				{ notice[ 0 ] }
 				{ actionUrl && (
 					<a
-						className="sdaa-cr-msg-system-action"
+						className="sd-ai-agent-cr-msg-system-action"
 						href={ actionUrl }
 						target="_blank"
 						rel="noopener noreferrer"

--- a/src/components/chat-redesign/chat-redesign.css
+++ b/src/components/chat-redesign/chat-redesign.css
@@ -876,7 +876,7 @@ input[type="text"].sdaa-cr-search-input {
 }
 
 /* System notices */
-.sdaa-cr-msg-system {
+.sd-ai-agent-cr-msg-system {
 	background: var(--sdaa-error-surface);
 	border: 1px solid var(--sdaa-error);
 	color: var(--sdaa-error);
@@ -888,13 +888,13 @@ input[type="text"].sdaa-cr-search-input {
 	overflow-wrap: anywhere;
 }
 
-.sdaa-cr-msg-system--account-action {
+.sd-ai-agent-cr-msg-system--account-action {
 	background: var(--sdaa-surface-active);
 	border-color: var(--sdaa-primary);
 	color: var(--sdaa-text-primary);
 }
 
-.sdaa-cr-msg-system-action {
+.sd-ai-agent-cr-msg-system-action {
 	display: flex;
 	width: fit-content;
 	align-items: center;
@@ -910,8 +910,8 @@ input[type="text"].sdaa-cr-search-input {
 	transition: background var(--sdaa-duration) ease;
 }
 
-.sdaa-cr-msg-system-action:hover,
-.sdaa-cr-msg-system-action:focus {
+.sd-ai-agent-cr-msg-system-action:hover,
+.sd-ai-agent-cr-msg-system-action:focus {
 	background: var(--sdaa-primary-dark);
 	color: #fff;
 	text-decoration: none;

--- a/src/components/chat-redesign/message-items.js
+++ b/src/components/chat-redesign/message-items.js
@@ -505,7 +505,9 @@ export function RunningMessage( { step, liveToolCalls } ) {
 export function SystemMessage( { text } ) {
 	return (
 		<div className="sdaa-cr-msg-row">
-			<div className="sdaa-cr-msg-system">{ linkifyText( text ) }</div>
+			<div className="sd-ai-agent-cr-msg-system">
+				{ linkifyText( text ) }
+			</div>
 		</div>
 	);
 }

--- a/src/components/chat-widget/__tests__/widget-message-list.test.js
+++ b/src/components/chat-widget/__tests__/widget-message-list.test.js
@@ -2,9 +2,8 @@
  * Unit tests for the floating widget message list.
  */
 
-import { createElement } from '@wordpress/element';
+import { createElement, createRoot } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { createRoot } from 'react-dom/client';
 import { act } from 'react';
 
 import WidgetMessageList from '../widget-message-list';
@@ -36,7 +35,7 @@ jest.mock( '../../chat-redesign/message-helpers', () => ( {
 /**
  * Render the floating widget message list with a credit-exhaustion notice.
  *
- * @return {Promise<{container: HTMLElement, root: import('react-dom/client').Root}>}
+ * @return {Promise<{container: HTMLElement, root: import('@wordpress/element').Root}>}
  *   Rendered container and root.
  */
 async function renderCreditExhaustionMessage() {
@@ -86,7 +85,7 @@ describe( 'WidgetMessageList credit exhaustion notice', () => {
 	test( 'replaces the provider error with an account-settings credit CTA', async () => {
 		const { container, root } = await renderCreditExhaustionMessage();
 		const notice = container.querySelector(
-			'.sdaa-cr-msg-system--account-action'
+			'.sd-ai-agent-cr-msg-system--account-action'
 		);
 
 		expect( notice ).not.toBeNull();
@@ -95,7 +94,9 @@ describe( 'WidgetMessageList credit exhaustion notice', () => {
 		);
 		expect( notice.textContent ).not.toMatch( /\b(error|insufficient)\b/i );
 
-		const action = notice.querySelector( '.sdaa-cr-msg-system-action' );
+		const action = notice.querySelector(
+			'.sd-ai-agent-cr-msg-system-action'
+		);
 		expect( action.textContent ).toBe( 'Purchase credits' );
 		expect( action.getAttribute( 'href' ) ).toBe(
 			'https://account.example.test/login'


### PR DESCRIPTION
## Summary

- rename chat system-notice classes to the required `sd-ai-agent-` prefix
- use the WordPress element package for the widget test root renderer

## Testing

- `npm run test:js -- --runInBand`

## Worker self-verification

- PHPUnit: Tests: 3907, Assertions: 17035, Errors: 0, Failures: 0, Skipped: 126, Incomplete: 4
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded

Resolves #2300

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.169 plugin for [OpenCode](https://opencode.ai) v1.18.4
