### PR TITLE
GH#2302: recover managed Superdav model discovery

### DIFF
--- a/includes/CLI/ModelsCommand.php
+++ b/includes/CLI/ModelsCommand.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 namespace SdAiAgent\CLI;
 
 use SdAiAgent\Core\ProviderCredentialLoader;
+use SdAiAgent\Core\ProviderModelDiscovery;
 use SdAiAgent\Core\Settings;
 use WP_CLI;
 use WP_CLI_Command;
@@ -92,15 +93,16 @@ class ModelsCommand extends WP_CLI_Command {
 	private function show_providers( array $providers, string $format ): void {
 		$rows = array_map(
 			fn( $p ) => array(
-				'id'     => $p['id'],
-				'name'   => $p['name'],
-				'type'   => $p['type'] ?? 'cloud',
-				'models' => count( $p['models'] ?? array() ),
+				'id'        => $p['id'],
+				'name'      => $p['name'],
+				'type'      => $p['type'] ?? 'cloud',
+				'models'    => count( $p['models'] ?? array() ),
+				'discovery' => is_array( $p['model_discovery'] ?? null ) ? (string) ( $p['model_discovery']['code'] ?? 'unavailable' ) : 'available',
 			),
 			$providers
 		);
 
-		WP_CLI\Utils\format_items( $format, $rows, array( 'id', 'name', 'type', 'models' ) );
+		WP_CLI\Utils\format_items( $format, $rows, array( 'id', 'name', 'type', 'models', 'discovery' ) );
 	}
 
 	/**
@@ -128,6 +130,12 @@ class ModelsCommand extends WP_CLI_Command {
 		$models = $match['models'] ?? array();
 
 		if ( empty( $models ) ) {
+			if ( is_array( $match['model_discovery'] ?? null ) ) {
+				$code = sanitize_key( (string) ( $match['model_discovery']['code'] ?? 'unavailable' ) );
+				WP_CLI::warning( "Provider '{$provider_id}' model discovery is unavailable ({$code}). Retry the command after the provider recovers." );
+				return;
+			}
+
 			WP_CLI::warning( "Provider '{$provider_id}' has no models listed (SDK will use its default)." );
 			return;
 		}
@@ -177,9 +185,10 @@ class ModelsCommand extends WP_CLI_Command {
 					continue;
 				}
 
-				$class    = $registry->getProviderClassName( $provider_id );
-				$metadata = $class::metadata();
-				$models   = array();
+				$class           = $registry->getProviderClassName( $provider_id );
+				$metadata        = $class::metadata();
+				$models          = array();
+				$model_discovery = null;
 
 				// OpenAI-compatible connectors expose a model list endpoint.
 				// Pass the SDK provider_id so the connector can resolve the
@@ -202,28 +211,34 @@ class ModelsCommand extends WP_CLI_Command {
 						}
 					}
 				} else {
-					try {
-						$directory = $class::modelMetadataDirectory();
-						foreach ( $directory->listModelMetadata() as $model_meta ) {
-							$model_id = $model_meta->getId();
-							$models[] = array(
-								'id'             => $model_id,
-								'name'           => $model_meta->getName(),
-								'context_window' => Settings::MODEL_CONTEXT_WINDOWS[ $model_id ] ?? 128000,
-							);
+					$discovery       = ProviderModelDiscovery::discover( $provider_id, $class );
+					$model_discovery = $discovery['failure'];
+					foreach ( $discovery['metadata'] as $model_meta ) {
+						if ( ! method_exists( $model_meta, 'getId' ) || ! method_exists( $model_meta, 'getName' ) ) {
+							continue;
 						}
-					} catch ( \Throwable $e ) {
-						// Model listing failed — include provider without models.
+
+						$model_id = (string) $model_meta->getId();
+						$models[] = array(
+							'id'             => $model_id,
+							'name'           => $model_meta->getName(),
+							'context_window' => Settings::MODEL_CONTEXT_WINDOWS[ $model_id ] ?? 128000,
+						);
 					}
 				}
 
-				$providers[] = array(
+				$provider_response = array(
 					'id'         => $provider_id,
 					'name'       => $metadata->getName(),
 					'type'       => (string) $metadata->getType(),
 					'configured' => true,
 					'models'     => $models,
 				);
+				if ( is_array( $model_discovery ) ) {
+					$provider_response['model_discovery'] = $model_discovery;
+				}
+
+				$providers[] = $provider_response;
 			} catch ( \Throwable $e ) {
 				continue;
 			}

--- a/includes/Core/AgentEventLog.php
+++ b/includes/Core/AgentEventLog.php
@@ -75,6 +75,7 @@ class AgentEventLog {
 		'code',
 		'status_code',
 		'reason',
+		'attempts',
 		'duration_ms',
 		'request_bytes',
 		'request_bytes_estimate',

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -84,9 +84,6 @@ class AgentLoop {
 	/** Maximum provider-call attempts for retryable transient failures. */
 	private const PROVIDER_RETRY_MAX_ATTEMPTS = 4;
 
-	/** Retryable upstream/network statuses. */
-	private const PROVIDER_RETRYABLE_STATUS_CODES = array( 408, 429, 500, 502, 503, 504 );
-
 	/** Default exponential backoff schedule in seconds. */
 	private const PROVIDER_RETRY_DELAYS = array( 1, 2, 4 );
 
@@ -1794,20 +1791,7 @@ class AgentLoop {
 	 * @param int                      $status_code HTTP status code, or 0 when unknown.
 	 */
 	private function is_retryable_provider_error( $error, int $status_code ): bool {
-		if ( in_array( $status_code, self::PROVIDER_RETRYABLE_STATUS_CODES, true ) ) {
-			return true;
-		}
-
-		if ( $status_code >= 400 ) {
-			return false;
-		}
-
-		$message = $this->get_provider_error_message( $error );
-		if ( '' === $message ) {
-			return false;
-		}
-
-		return (bool) preg_match( '/\b(timeout|timed out|connection reset|connection refused|network|cURL error|internal server error|bad gateway|service unavailable|gateway timeout|too many requests|rate limit)\b/i', $message );
+		return ProviderErrorClassifier::is_retryable( $error, $status_code );
 	}
 
 	/**
@@ -1816,39 +1800,7 @@ class AgentLoop {
 	 * @param WP_Error|\Throwable|null $error Last provider error.
 	 */
 	private function extract_provider_error_status( $error ): int {
-		if ( $error instanceof WP_Error ) {
-			$code = $error->get_error_code();
-			if ( is_numeric( $code ) ) {
-				return (int) $code;
-			}
-
-			$data = $error->get_error_data();
-			if ( is_array( $data ) ) {
-				foreach ( [ 'status', 'status_code', 'code' ] as $key ) {
-					if ( isset( $data[ $key ] ) && is_numeric( $data[ $key ] ) ) {
-						return (int) $data[ $key ];
-					}
-				}
-			}
-		}
-
-		if ( $error instanceof \Throwable ) {
-			$code = $error->getCode();
-			if ( $code >= 400 && $code <= 599 ) {
-				return (int) $code;
-			}
-		}
-
-		$message = $this->get_provider_error_message( $error );
-		if ( preg_match( '/\((\d{3})\)|\bHTTP\s+(\d{3})\b|\bstatus\s*(?:code)?\s*[:=]?\s*(\d{3})\b/i', $message, $matches ) ) {
-			foreach ( array_slice( $matches, 1 ) as $match ) {
-				if ( '' !== $match ) {
-					return (int) $match;
-				}
-			}
-		}
-
-		return 0;
+		return ProviderErrorClassifier::extract_status_code( $error );
 	}
 
 	/**

--- a/includes/Core/ProviderErrorClassifier.php
+++ b/includes/Core/ProviderErrorClassifier.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Core;
+
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Normalizes provider errors without retaining provider response content.
+ */
+final class ProviderErrorClassifier {
+
+	/** Retryable upstream/network statuses. */
+	public const RETRYABLE_STATUS_CODES = array( 408, 429, 500, 502, 503, 504 );
+
+	/**
+	 * Extract an HTTP status code from provider errors produced by SDK layers.
+	 *
+	 * @param WP_Error|\Throwable|null $error Provider error.
+	 * @return int HTTP status code, or 0 when unavailable.
+	 */
+	public static function extract_status_code( $error ): int {
+		if ( $error instanceof WP_Error ) {
+			$code = $error->get_error_code();
+			if ( is_numeric( $code ) ) {
+				return (int) $code;
+			}
+
+			$data = $error->get_error_data();
+			if ( is_array( $data ) ) {
+				foreach ( array( 'status', 'status_code', 'code' ) as $key ) {
+					if ( isset( $data[ $key ] ) && is_numeric( $data[ $key ] ) ) {
+						return (int) $data[ $key ];
+					}
+				}
+			}
+		}
+
+		if ( $error instanceof \Throwable ) {
+			$code = $error->getCode();
+			if ( $code >= 400 && $code <= 599 ) {
+				return (int) $code;
+			}
+		}
+
+		$message = self::get_message( $error );
+		if ( preg_match( '/\((\d{3})\)|\bHTTP\s+(\d{3})\b|\bstatus\s*(?:code)?\s*[:=]?\s*(\d{3})\b/i', $message, $matches ) ) {
+			foreach ( array_slice( $matches, 1 ) as $match ) {
+				if ( '' !== $match ) {
+					return (int) $match;
+				}
+			}
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Determine whether a provider failure is safe to retry once.
+	 *
+	 * @param WP_Error|\Throwable|null $error       Provider error.
+	 * @param int                      $status_code HTTP status code, or 0 when unknown.
+	 * @return bool Whether the failure is retryable.
+	 */
+	public static function is_retryable( $error, int $status_code = 0 ): bool {
+		if ( 0 === $status_code ) {
+			$status_code = self::extract_status_code( $error );
+		}
+
+		if ( in_array( $status_code, self::RETRYABLE_STATUS_CODES, true ) ) {
+			return true;
+		}
+
+		if ( $status_code >= 400 ) {
+			return false;
+		}
+
+		$message = self::get_message( $error );
+		if ( '' === $message ) {
+			return false;
+		}
+
+		return (bool) preg_match( '/\b(timeout|timed out|connection reset|connection refused|network|cURL error|internal server error|bad gateway|service unavailable|gateway timeout|too many requests|rate limit)\b/i', $message );
+	}
+
+	/**
+	 * Determine whether a provider error represents an unauthorized response.
+	 *
+	 * @param WP_Error|\Throwable|null $error       Provider error.
+	 * @param int                      $status_code HTTP status code, or 0 when unknown.
+	 * @return bool Whether the error is unauthorized.
+	 */
+	public static function is_unauthorized( $error, int $status_code = 0 ): bool {
+		if ( 0 === $status_code ) {
+			$status_code = self::extract_status_code( $error );
+		}
+
+		return 401 === $status_code || str_contains( self::get_message( $error ), 'Unauthorized (401)' );
+	}
+
+	/**
+	 * Return a scrubbed category that is safe for REST and diagnostic output.
+	 *
+	 * @param WP_Error|\Throwable|null $error       Provider error.
+	 * @param int                      $status_code HTTP status code, or 0 when unknown.
+	 * @return string Normalized failure category.
+	 */
+	public static function get_failure_category( $error, int $status_code = 0 ): string {
+		if ( 0 === $status_code ) {
+			$status_code = self::extract_status_code( $error );
+		}
+
+		if ( self::is_unauthorized( $error, $status_code ) ) {
+			return 'unauthorized';
+		}
+
+		if ( $status_code >= 500 ) {
+			return 'upstream';
+		}
+
+		if ( $status_code >= 400 ) {
+			return 'client';
+		}
+
+		if ( self::is_retryable( $error, $status_code ) ) {
+			return 'transport';
+		}
+
+		if ( $error instanceof WP_Error ) {
+			return 'wp_error';
+		}
+
+		return 'unknown';
+	}
+
+	/**
+	 * Return the provider error message only for local classification.
+	 *
+	 * Callers must never return or log this value.
+	 *
+	 * @param WP_Error|\Throwable|null $error Provider error.
+	 * @return string Error message.
+	 */
+	private static function get_message( $error ): string {
+		if ( $error instanceof WP_Error ) {
+			return $error->get_error_message();
+		}
+
+		if ( $error instanceof \Throwable ) {
+			return $error->getMessage();
+		}
+
+		return '';
+	}
+}

--- a/includes/Core/ProviderModelDiscovery.php
+++ b/includes/Core/ProviderModelDiscovery.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Core;
+
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Performs bounded, scrubbed provider model metadata discovery.
+ */
+final class ProviderModelDiscovery {
+
+	/** One short retry delay prevents immediate cache/thundering-herd repeats. */
+	private const RETRY_BACKOFF_MICROSECONDS = 100000;
+
+	/**
+	 * List model metadata and recover managed Superdav discovery failures once.
+	 *
+	 * @param string $provider_id Provider ID.
+	 * @param string $class       Provider class name.
+	 * @return array{metadata:array<int, object>,failure:array<string, bool|int|string>|null} Discovery result.
+	 */
+	public static function discover( string $provider_id, string $class ): array {
+		$started_at = microtime( true );
+
+		try {
+			return self::success( self::list_metadata( $class ) );
+		} catch ( \Throwable $error ) {
+			$status_code = ProviderErrorClassifier::extract_status_code( $error );
+
+			if ( SuperdavAiProvider::PROVIDER_ID === $provider_id && ProviderErrorClassifier::is_unauthorized( $error, $status_code ) ) {
+				return self::recover_unauthorized_discovery( $provider_id, $class, $started_at );
+			}
+
+			if ( SuperdavAiProvider::PROVIDER_ID === $provider_id && ProviderErrorClassifier::is_retryable( $error, $status_code ) ) {
+				return self::retry_after_cache_invalidation( $provider_id, $class, $started_at );
+			}
+
+			return self::failure( $provider_id, $error, $status_code, 1, $started_at );
+		}
+	}
+
+	/**
+	 * Recover the existing managed token-refresh path after a 401 model listing.
+	 *
+	 * @param string $provider_id Provider ID.
+	 * @param string $class       Provider class name.
+	 * @param float  $started_at  Discovery start timestamp.
+	 * @return array{metadata:array<int, object>,failure:array<string, bool|int|string>|null} Discovery result.
+	 */
+	private static function recover_unauthorized_discovery( string $provider_id, string $class, float $started_at ): array {
+		$status = ( new SuperdavSiteConnectionService() )->provision_site_token();
+		if ( $status instanceof WP_Error ) {
+			return self::failure( $provider_id, $status, ProviderErrorClassifier::extract_status_code( $status ), 1, $started_at );
+		}
+
+		ProviderCredentialLoader::load();
+
+		try {
+			return self::success( self::list_metadata_after_cache_invalidation( $class ) );
+		} catch ( \Throwable $error ) {
+			return self::failure(
+				$provider_id,
+				$error,
+				ProviderErrorClassifier::extract_status_code( $error ),
+				2,
+				$started_at
+			);
+		}
+	}
+
+	/**
+	 * Retry one explicitly retryable managed discovery failure after cache invalidation.
+	 *
+	 * @param string $provider_id Provider ID.
+	 * @param string $class       Provider class name.
+	 * @param float  $started_at  Discovery start timestamp.
+	 * @return array{metadata:array<int, object>,failure:array<string, bool|int|string>|null} Discovery result.
+	 */
+	private static function retry_after_cache_invalidation( string $provider_id, string $class, float $started_at ): array {
+		usleep( self::RETRY_BACKOFF_MICROSECONDS );
+
+		try {
+			return self::success( self::list_metadata_after_cache_invalidation( $class ) );
+		} catch ( \Throwable $error ) {
+			return self::failure(
+				$provider_id,
+				$error,
+				ProviderErrorClassifier::extract_status_code( $error ),
+				2,
+				$started_at
+			);
+		}
+	}
+
+	/**
+	 * List metadata after invalidating a directory cache when the installed SDK supports it.
+	 *
+	 * @param string $class Provider class name.
+	 * @return array<int, object> Model metadata DTOs.
+	 */
+	private static function list_metadata_after_cache_invalidation( string $class ): array {
+		$directory = self::get_directory( $class );
+		if ( method_exists( $directory, 'invalidateCaches' ) ) {
+			$directory->invalidateCaches();
+		}
+
+		return self::list_metadata_from_directory( $directory );
+	}
+
+	/**
+	 * List model metadata from a provider class.
+	 *
+	 * @param string $class Provider class name.
+	 * @return array<int, object> Model metadata DTOs.
+	 */
+	private static function list_metadata( string $class ): array {
+		return self::list_metadata_from_directory( self::get_directory( $class ) );
+	}
+
+	/**
+	 * Get a usable model metadata directory from a provider class.
+	 *
+	 * @param string $class Provider class name.
+	 * @return object Model metadata directory.
+	 */
+	private static function get_directory( string $class ): object {
+		$factory_candidate = array( $class, 'modelMetadataDirectory' );
+		if ( ! is_callable( $factory_candidate ) ) {
+			throw new \UnexpectedValueException( 'Provider model metadata directory is unavailable.' );
+		}
+
+		/** @var callable(): mixed $factory */
+		$factory   = $factory_candidate;
+		$directory = $factory();
+		if ( ! is_object( $directory ) || ! method_exists( $directory, 'listModelMetadata' ) ) {
+			throw new \UnexpectedValueException( 'Provider model metadata directory is unavailable.' );
+		}
+
+		return $directory;
+	}
+
+	/**
+	 * Read metadata from a directory-like SDK object.
+	 *
+	 * @param object $directory Model metadata directory.
+	 * @return array<int, object> Model metadata DTOs.
+	 */
+	private static function list_metadata_from_directory( object $directory ): array {
+		$list_metadata_candidate = array( $directory, 'listModelMetadata' );
+		if ( ! is_callable( $list_metadata_candidate ) ) {
+			throw new \UnexpectedValueException( 'Provider model metadata directory is unavailable.' );
+		}
+
+		/** @var callable(): mixed $list_metadata */
+		$list_metadata  = $list_metadata_candidate;
+		$model_metadata = $list_metadata();
+		if ( ! is_array( $model_metadata ) ) {
+			throw new \UnexpectedValueException( 'Provider model metadata response is invalid.' );
+		}
+
+		return array_values( array_filter( $model_metadata, 'is_object' ) );
+	}
+
+	/**
+	 * Build a successful discovery result.
+	 *
+	 * @param array<int, object> $metadata Model metadata DTOs.
+	 * @return array{metadata:array<int, object>,failure:null} Discovery result.
+	 */
+	private static function success( array $metadata ): array {
+		return array(
+			'metadata' => $metadata,
+			'failure'  => null,
+		);
+	}
+
+	/**
+	 * Build and record a scrubbed failure response.
+	 *
+	 * @param string                   $provider_id Provider ID.
+	 * @param WP_Error|\Throwable|null $error       Provider error.
+	 * @param int                      $status_code HTTP status code, or 0 when unavailable.
+	 * @param int                      $attempts    Number of model listing attempts.
+	 * @param float                    $started_at  Discovery start timestamp.
+	 * @return array{metadata:array<int, object>,failure:array<string, bool|int|string>} Discovery result.
+	 */
+	private static function failure( string $provider_id, $error, int $status_code, int $attempts, float $started_at ): array {
+		$retryable   = ProviderErrorClassifier::is_retryable( $error, $status_code );
+		$category    = ProviderErrorClassifier::get_failure_category( $error, $status_code );
+		$duration_ms = max( 0, (int) round( ( microtime( true ) - $started_at ) * 1000 ) );
+		$failure     = array(
+			'state'     => $retryable ? 'retryable_unavailable' : 'unavailable',
+			'code'      => 'model_discovery_' . $category,
+			'retryable' => $retryable,
+			'attempts'  => max( 1, $attempts ),
+		);
+
+		if ( $status_code > 0 ) {
+			$failure['status'] = $status_code;
+		}
+
+		ProviderTraceLogger::record_model_discovery_failure(
+			$provider_id,
+			$category,
+			$status_code,
+			$attempts,
+			$duration_ms
+		);
+
+		return array(
+			'metadata' => array(),
+			'failure'  => $failure,
+		);
+	}
+}

--- a/includes/Core/ProviderTraceLogger.php
+++ b/includes/Core/ProviderTraceLogger.php
@@ -444,6 +444,35 @@ class ProviderTraceLogger {
 		AgentEventLog::log( 'provider_payload_limit', AgentEventLog::SEVERITY_ERROR, $context );
 	}
 
+	/**
+	 * Emit prompt-free model discovery diagnostics even when HTTP tracing is disabled.
+	 *
+	 * @param string $provider_id Provider ID.
+	 * @param string $category    Normalized failure category.
+	 * @param int    $status_code HTTP status code, or 0 when unavailable.
+	 * @param int    $attempts    Number of model listing attempts.
+	 * @param int    $duration_ms Discovery duration in milliseconds.
+	 */
+	public static function record_model_discovery_failure( string $provider_id, string $category, int $status_code, int $attempts, int $duration_ms ): void {
+		$allowed_categories = array( 'client', 'transport', 'unauthorized', 'unknown', 'upstream', 'wp_error' );
+		$category           = sanitize_key( $category );
+		if ( ! in_array( $category, $allowed_categories, true ) ) {
+			$category = 'unknown';
+		}
+
+		$context = array(
+			'provider_id' => sanitize_key( $provider_id ),
+			'code'        => $category,
+			'attempts'    => max( 1, $attempts ),
+			'duration_ms' => max( 0, $duration_ms ),
+		);
+		if ( $status_code > 0 ) {
+			$context['status_code'] = $status_code;
+		}
+
+		AgentEventLog::log( 'provider_model_discovery_failed', AgentEventLog::SEVERITY_ERROR, $context );
+	}
+
 	/** Classify request size without retaining request content. */
 	public static function classify_request_size( int $request_bytes ): string {
 		if ( $request_bytes < 65536 ) {

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -22,6 +22,7 @@ use SdAiAgent\Core\Database;
 use SdAiAgent\Core\Features;
 use SdAiAgent\Core\ModelCapabilityRegistry;
 use SdAiAgent\Core\ProviderCredentialLoader;
+use SdAiAgent\Core\ProviderModelDiscovery;
 use SdAiAgent\Core\RolePermissions;
 use SdAiAgent\Core\Settings;
 use SdAiAgent\Core\SuperdavSiteConnectionService;
@@ -32,7 +33,6 @@ use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
 use WP_REST_Server;
-use WordPress\AiClient\Providers\Http\Exception\ClientException;
 use XWP\DI\Decorators\Action;
 use XWP\DI\Decorators\Handler;
 
@@ -1224,9 +1224,10 @@ final class SettingsController {
 					continue;
 				}
 
-				$class    = $registry->getProviderClassName( $provider_id );
-				$metadata = $class::metadata();
-				$models   = array();
+				$class           = $registry->getProviderClassName( $provider_id );
+				$metadata        = $class::metadata();
+				$models          = array();
+				$model_discovery = null;
 
 				// For the OpenAI-compatible connector, fetch models directly
 				// from the endpoint rather than going through the SDK model
@@ -1253,7 +1254,9 @@ final class SettingsController {
 						}
 					}
 				} else {
-					$models = $this->list_model_metadata_for_provider( $provider_id, $class );
+					$discovery       = ProviderModelDiscovery::discover( $provider_id, $class );
+					$models          = self::format_model_metadata_list_for_response( $discovery['metadata'] );
+					$model_discovery = $discovery['failure'];
 				}
 
 				$models = self::filter_text_generation_models( $models );
@@ -1265,6 +1268,9 @@ final class SettingsController {
 					'configured' => true,
 					'models'     => $models,
 				);
+				if ( is_array( $model_discovery ) ) {
+					$provider_response['model_discovery'] = $model_discovery;
+				}
 
 				if ( SuperdavAiProvider::PROVIDER_ID === $provider_id ) {
 					$provider_response['default_model'] = SuperdavAiProvider::default_model_id();
@@ -1293,60 +1299,6 @@ final class SettingsController {
 		} catch ( \Throwable ) {
 			return;
 		}
-	}
-
-	/**
-	 * List provider model metadata, refreshing the managed Superdav token once when it is stale.
-	 *
-	 * @param string $provider_id Provider ID.
-	 * @param string $class       Provider class name.
-	 * @return array<int, array<string, mixed>> Safe model rows for the provider picker.
-	 */
-	private function list_model_metadata_for_provider( string $provider_id, string $class ): array {
-		try {
-			return self::list_model_metadata_from_directory( $class::modelMetadataDirectory() );
-		} catch ( \Throwable $e ) {
-			if ( SuperdavAiProvider::PROVIDER_ID !== $provider_id || ! self::is_unauthorized_model_listing_error( $e ) ) {
-				return array();
-			}
-		}
-
-		$status = ( new SuperdavSiteConnectionService() )->provision_site_token();
-		if ( $status instanceof WP_Error ) {
-			return array();
-		}
-
-		ProviderCredentialLoader::load();
-
-		try {
-			$directory = $class::modelMetadataDirectory();
-			if ( is_object( $directory ) && method_exists( $directory, 'invalidateCaches' ) ) {
-				$directory->invalidateCaches();
-			}
-
-			return self::list_model_metadata_from_directory( $directory );
-		} catch ( \Throwable ) {
-			return array();
-		}
-	}
-
-	/**
-	 * List and format model metadata from an SDK directory-like object.
-	 *
-	 * @param mixed $directory SDK model metadata directory candidate.
-	 * @return array<int, array<string, mixed>> Safe model rows for the provider picker.
-	 */
-	private static function list_model_metadata_from_directory( mixed $directory ): array {
-		if ( ! is_object( $directory ) || ! method_exists( $directory, 'listModelMetadata' ) ) {
-			return array();
-		}
-
-		$model_metadata = $directory->listModelMetadata();
-		if ( ! is_array( $model_metadata ) ) {
-			return array();
-		}
-
-		return self::format_model_metadata_list_for_response( array_values( $model_metadata ) );
 	}
 
 	/**
@@ -1427,17 +1379,6 @@ final class SettingsController {
 	 */
 	private static function is_text_generation_capability( string $capability ): bool {
 		return 'text_generation' === str_replace( '-', '_', strtolower( $capability ) );
-	}
-
-	/**
-	 * Determine whether a model listing failure is due to an invalid/stale site token.
-	 */
-	private static function is_unauthorized_model_listing_error( \Throwable $error ): bool {
-		if ( $error instanceof ClientException && 401 === (int) $error->getCode() ) {
-			return true;
-		}
-
-		return str_contains( $error->getMessage(), 'Unauthorized (401)' );
 	}
 
 	/**

--- a/src/components/chat-redesign/ModelPicker.js
+++ b/src/components/chat-redesign/ModelPicker.js
@@ -36,7 +36,8 @@ export default function ModelPicker() {
 		},
 		[]
 	);
-	const { setSelectedProvider, setSelectedModel } = useDispatch( STORE_NAME );
+	const { setSelectedProvider, setSelectedModel, fetchProviders } =
+		useDispatch( STORE_NAME );
 	const [ open, setOpen ] = useState( false );
 	const [ pos, setPos ] = useState( {
 		left: 0,
@@ -153,6 +154,10 @@ export default function ModelPicker() {
 		return null;
 	}
 
+	const unavailableLabel = __(
+		'(models unavailable; retry)',
+		'superdav-ai-agent'
+	);
 	const pick = ( providerId, modelId ) => {
 		if ( providerId !== selectedProviderId ) {
 			setSelectedProvider( providerId );
@@ -224,7 +229,12 @@ export default function ModelPicker() {
 				ref={ chipRef }
 				type="button"
 				className="sdaa-cr-model-chip"
-				onClick={ () => setOpen( ( v ) => ! v ) }
+				onClick={ () =>
+					! activeProvider.models?.length &&
+					activeProvider.model_discovery
+						? fetchProviders()
+						: setOpen( ( v ) => ! v )
+				}
 				aria-haspopup="menu"
 				aria-expanded={ open }
 				title={ __( 'Change model', 'sd-ai-agent' ) }
@@ -235,7 +245,9 @@ export default function ModelPicker() {
 				<span className="sdaa-cr-model-chip-model">
 					{ activeModel?.name ||
 						activeModel?.id ||
-						__( '(default)', 'sd-ai-agent' ) }
+						( activeProvider.model_discovery
+							? unavailableLabel
+							: __( '(default)', 'sd-ai-agent' ) ) }
 				</span>
 				<Icon icon={ chevronDown } size={ 14 } />
 			</button>

--- a/src/components/chat-redesign/__tests__/ModelPicker.test.js
+++ b/src/components/chat-redesign/__tests__/ModelPicker.test.js
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for the shared chat model picker.
+ */
+
+import { createElement } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import ModelPicker from '../ModelPicker';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( str ) => str,
+} ) );
+
+jest.mock( 'react-dom', () => ( {
+	...jest.requireActual( 'react-dom' ),
+	createPortal: ( children ) => children,
+} ) );
+
+jest.mock( '../../../store', () => 'sd-ai-agent' );
+
+/**
+ * Render the picker with a retryable model discovery failure.
+ *
+ * @param {Object} dispatchMap Bound store actions.
+ * @return {Promise<{container: HTMLElement, root: import('react-dom/client').Root}>} Rendered picker.
+ */
+async function renderUnavailablePicker( dispatchMap ) {
+	const selectors = {
+		getProviders: () => [
+			{
+				id: 'sd-ai-agent-cloud',
+				name: 'Superdav AI',
+				models: [],
+				model_discovery: {
+					state: 'retryable_unavailable',
+					retryable: true,
+				},
+			},
+		],
+		getSelectedProviderId: () => 'sd-ai-agent-cloud',
+		getSelectedModelId: () => 'superdav-chat-pro',
+	};
+
+	useSelect.mockImplementation( ( callback ) => callback( () => selectors ) );
+	useDispatch.mockReturnValue( dispatchMap );
+
+	const container = document.createElement( 'div' );
+	document.body.appendChild( container );
+	const root = createRoot( container );
+	await act( async () => {
+		root.render( createElement( ModelPicker ) );
+	} );
+
+	return { container, root };
+}
+
+describe( 'ModelPicker model discovery recovery', () => {
+	let container;
+	let root;
+
+	afterEach( async () => {
+		if ( root ) {
+			await act( async () => {
+				root.unmount();
+			} );
+			document.body.removeChild( container );
+		}
+		container = undefined;
+		root = undefined;
+		jest.clearAllMocks();
+	} );
+
+	test( 'shows an unavailable state and retries provider discovery', async () => {
+		const fetchProviders = jest.fn();
+		( { container, root } = await renderUnavailablePicker( {
+			setSelectedProvider: jest.fn(),
+			setSelectedModel: jest.fn(),
+			fetchProviders,
+		} ) );
+
+		expect( container.textContent ).toContain(
+			'(models unavailable; retry)'
+		);
+
+		await act( async () => {
+			container
+				.querySelector( '.sdaa-cr-model-chip' )
+				.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+		} );
+
+		expect( fetchProviders ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -54,7 +54,10 @@ jest.mock( '@wordpress/data', () => ( {
 require( '../index' );
 
 const { reducer, actions, selectors } = capturedConfig;
-const { resolveProviderSelection } = require( '../slices/providersSlice' );
+const {
+	resolveProviderSelection,
+	preserveRecoverableProviderModels,
+} = require( '../slices/providersSlice' );
 const apiFetch = require( '@wordpress/api-fetch' );
 
 // ─── Default state ────────────────────────────────────────────────────────────
@@ -653,6 +656,70 @@ describe( 'resolveProviderSelection', () => {
 			providerId: 'sd-ai-agent-cloud',
 			modelId: 'superdav-chat-pro',
 		} );
+	} );
+
+	test( 'preserves a saved model during a retryable discovery outage', () => {
+		const selection = resolveProviderSelection(
+			[
+				{
+					id: 'sd-ai-agent-cloud',
+					models: [],
+					model_discovery: {
+						state: 'retryable_unavailable',
+						retryable: true,
+					},
+				},
+				{
+					id: 'openai',
+					models: [ { id: 'gpt-4o' } ],
+				},
+			],
+			'sd-ai-agent-cloud',
+			'superdav-chat-pro'
+		);
+
+		expect( selection ).toEqual( {
+			providerId: 'sd-ai-agent-cloud',
+			modelId: 'superdav-chat-pro',
+		} );
+	} );
+
+	test( 'retains last-known models only for retryable discovery failures', () => {
+		const providers = preserveRecoverableProviderModels(
+			[
+				{
+					id: 'sd-ai-agent-cloud',
+					models: [ { id: 'superdav-chat-fast' } ],
+				},
+				{
+					id: 'openai',
+					models: [ { id: 'gpt-4o' } ],
+				},
+			],
+			[
+				{
+					id: 'sd-ai-agent-cloud',
+					models: [],
+					model_discovery: {
+						state: 'retryable_unavailable',
+						retryable: true,
+					},
+				},
+				{
+					id: 'openai',
+					models: [],
+					model_discovery: {
+						state: 'unavailable',
+						retryable: false,
+					},
+				},
+			]
+		);
+
+		expect( providers[ 0 ].models ).toEqual( [
+			{ id: 'superdav-chat-fast' },
+		] );
+		expect( providers[ 1 ].models ).toEqual( [] );
 	} );
 } );
 

--- a/src/store/slices/providersSlice.js
+++ b/src/store/slices/providersSlice.js
@@ -22,37 +22,36 @@ export function resolveProviderSelection(
 	savedProviderId,
 	savedModelId
 ) {
-	const providerHasModels = ( candidate ) =>
-		Array.isArray( candidate?.models ) && candidate.models.length > 0;
 	const savedProvider = providers.find(
 		( candidate ) => candidate.id === savedProviderId
 	);
-	const firstProviderWithModels = providers.find( providerHasModels );
 	const provider =
-		( savedProvider && providerHasModels( savedProvider )
+		savedProvider?.models?.length ||
+		isRetryableModelDiscoveryFailure( savedProvider )
 			? savedProvider
-			: null ) ||
-		firstProviderWithModels ||
-		savedProvider ||
-		providers[ 0 ];
+			: providers.find( ( candidate ) => candidate?.models?.length ) ||
+			  savedProvider ||
+			  providers[ 0 ];
 
 	if ( ! provider ) {
 		return { providerId: '', modelId: '' };
 	}
 
-	const models = Array.isArray( provider.models ) ? provider.models : [];
-	const hasSavedModel = models.some( ( model ) => model.id === savedModelId );
-	const defaultModelId = provider.default_model || '';
-	const hasProviderDefaultModel = models.some(
-		( model ) => model.id === defaultModelId
-	);
-	let modelId = models[ 0 ]?.id || '';
+	const models = provider.models || [];
+	let modelId =
+		(
+			models.find(
+				( model ) =>
+					model.id === savedModelId ||
+					model.id === provider.default_model
+			) || models[ 0 ]
+		)?.id || '';
 
-	if ( hasProviderDefaultModel ) {
-		modelId = defaultModelId;
-	}
-
-	if ( hasSavedModel ) {
+	if (
+		! models.length &&
+		isRetryableModelDiscoveryFailure( provider ) &&
+		savedModelId
+	) {
 		modelId = savedModelId;
 	}
 
@@ -60,6 +59,38 @@ export function resolveProviderSelection(
 		providerId: provider.id,
 		modelId,
 	};
+}
+
+/**
+ * Determine whether a provider's model list is temporarily unavailable.
+ *
+ * @param {Provider} provider Provider response from the REST API.
+ * @return {boolean} Whether a stale model list is safe to retain.
+ */
+const isRetryableModelDiscoveryFailure = ( provider ) =>
+	!! provider?.model_discovery?.retryable;
+
+/**
+ * Retain last-known selectable models only for an explicitly retryable failure.
+ *
+ * @param {Provider[]} previousProviders Last successful provider response.
+ * @param {Provider[]} nextProviders     Newly fetched provider response.
+ * @return {Provider[]} Provider response safe for selection.
+ */
+export function preserveRecoverableProviderModels(
+	previousProviders,
+	nextProviders
+) {
+	return nextProviders.map( ( provider ) => {
+		return (
+			( isRetryableModelDiscoveryFailure( provider ) &&
+				previousProviders.find(
+					( candidate ) =>
+						candidate.id === provider.id && candidate.models?.length
+				) ) ||
+			provider
+		);
+	} );
 }
 
 export const initialState = {
@@ -130,14 +161,18 @@ export const actions = {
 				const providers = await apiFetch( {
 					path: '/sd-ai-agent/v1/providers',
 				} );
-				dispatch.setProviders( providers );
+				const recoveredProviders = preserveRecoverableProviderModels(
+					select.getProviders(),
+					providers
+				);
+				dispatch.setProviders( recoveredProviders );
 
 				const savedProviderId =
 					localStorage.getItem( 'sdAiAgentProvider' ) || '';
 				const savedModelId =
 					localStorage.getItem( 'sdAiAgentModel' ) || '';
 				const selection = resolveProviderSelection(
-					providers,
+					recoveredProviders,
 					savedProviderId,
 					savedModelId
 				);
@@ -150,7 +185,6 @@ export const actions = {
 					dispatch.setSelectedModel( selection.modelId );
 				}
 			} catch ( err ) {
-				dispatch.setProviders( [] );
 				const status = err?.data?.status ?? err?.code;
 				if ( status === 403 || status === 401 ) {
 					dispatch.setBootError( {
@@ -234,10 +268,7 @@ export const selectors = {
 	 */
 	getModelContextWindow( state, modelId ) {
 		for ( const provider of state.providers ) {
-			if ( ! Array.isArray( provider.models ) ) {
-				continue;
-			}
-			const model = provider.models.find( ( m ) => m.id === modelId );
+			const model = provider.models?.find( ( m ) => m.id === modelId );
 			if ( model?.context_window ) {
 				return model.context_window;
 			}

--- a/src/types.js
+++ b/src/types.js
@@ -59,14 +59,26 @@
  */
 
 /**
+ * A scrubbed model-discovery failure state.
+ *
+ * @typedef {Object} ModelDiscoveryFailure
+ * @property {'retryable_unavailable'|'unavailable'} state     Current discovery state.
+ * @property {string}                                code      Normalized failure code.
+ * @property {boolean}                               retryable Whether refresh may recover.
+ * @property {number}                                attempts  Model listing attempts.
+ * @property {number}                                [status]  Safe HTTP status when available.
+ */
+
+/**
  * An AI provider configuration.
  *
  * @typedef {Object} Provider
- * @property {string}          id              - Provider identifier.
- * @property {string}          name            - Human-readable provider name.
- * @property {string}          [default_model] - Provider-preferred default model ID.
- * @property {ProviderModel[]} [models]        - Available models for this provider.
- * @property {Object}          [status]        - Provider-specific safe status metadata.
+ * @property {string}                id                - Provider identifier.
+ * @property {string}                name              - Human-readable provider name.
+ * @property {string}                [default_model]   - Provider-preferred default model ID.
+ * @property {ProviderModel[]}       [models]          - Available models for this provider.
+ * @property {Object}                [status]          - Provider-specific safe status metadata.
+ * @property {ModelDiscoveryFailure} [model_discovery] - Safe discovery failure metadata.
  */
 
 /**

--- a/tests/SdAiAgent/Core/AgentEventLogTest.php
+++ b/tests/SdAiAgent/Core/AgentEventLogTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Tests\Core;
 
 use SdAiAgent\Core\AgentEventLog;
+use SdAiAgent\Core\ProviderTraceLogger;
 use WP_UnitTestCase;
 
 /**
@@ -75,6 +76,7 @@ class AgentEventLogTest extends WP_UnitTestCase {
 		}
 		AgentEventLog::clear_session();
 		remove_all_actions( 'sd_ai_agent_event_logged' );
+		remove_all_filters( 'sd_ai_agent_provider_trace_enabled' );
 		parent::tear_down();
 	}
 
@@ -161,6 +163,30 @@ class AgentEventLogTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'event=provider_http_error', $contents );
 		$this->assertStringContainsString( 'status_code=529', $contents );
 		$this->assertStringContainsString( 'provider_id=anthropic', $contents );
+	}
+
+	/** Model-discovery diagnostics are available without optional HTTP tracing. */
+	public function test_emits_scrubbed_model_discovery_failure_when_tracing_is_disabled(): void {
+		add_filter( 'sd_ai_agent_provider_trace_enabled', '__return_false' );
+
+		ProviderTraceLogger::record_model_discovery_failure(
+			'sd-ai-agent-cloud',
+			'upstream',
+			503,
+			2,
+			125
+		);
+
+		$contents = $this->read_log();
+
+		$this->assertStringContainsString( 'event=provider_model_discovery_failed', $contents );
+		$this->assertStringContainsString( 'provider_id=sd-ai-agent-cloud', $contents );
+		$this->assertStringContainsString( 'code=upstream', $contents );
+		$this->assertStringContainsString( 'status_code=503', $contents );
+		$this->assertStringContainsString( 'attempts=2', $contents );
+		$this->assertStringContainsString( 'duration_ms=125', $contents );
+		$this->assertStringNotContainsString( 'authorization', $contents );
+		$this->assertStringNotContainsString( 'request_body', $contents );
 	}
 
 	// ── agent_loop_aborted ─────────────────────────────────────────────────

--- a/tests/SdAiAgent/REST/SettingsControllerTest.php
+++ b/tests/SdAiAgent/REST/SettingsControllerTest.php
@@ -475,6 +475,145 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * /providers retries one retryable managed Superdav model discovery failure.
+	 */
+	public function test_handle_providers_retries_retryable_managed_model_discovery_failure(): void {
+		if ( ! class_exists( AiClient::class ) ) {
+			$this->markTestSkipped( 'WordPress AI Client SDK is unavailable.' );
+		}
+
+		$base_url   = 'https://service.example/v1';
+		$models_url = $base_url . '/models';
+		$model_hits = 0;
+
+		add_filter( 'sd_ai_agent_cloud_base_url', static fn(): string => $base_url );
+		add_filter(
+			'pre_http_request',
+			static function ( mixed $preempt, array $parsed_args, string $url ) use ( $models_url, &$model_hits ): mixed {
+				if ( $models_url !== $url ) {
+					return $preempt;
+				}
+
+				++$model_hits;
+				if ( 1 === $model_hits ) {
+					return array(
+						'response' => array(
+							'code'    => 503,
+							'message' => 'Service Unavailable',
+						),
+						'body'     => wp_json_encode( array( 'error' => array( 'message' => 'Temporary upstream outage.' ) ) ),
+					);
+				}
+
+				return array(
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'body'     => wp_json_encode(
+						array(
+							'data' => array(
+								array(
+									'id'           => 'superdav-chat-fast',
+									'capabilities' => array( 'text_generation' ),
+								),
+								array(
+									'id'           => 'superdav-chat-pro',
+									'capabilities' => array( 'text_generation' ),
+								),
+								array(
+									'id'           => 'superdav-chat-strong',
+									'capabilities' => array( 'text_generation' ),
+								),
+								array(
+									'id'           => 'superdav-image',
+									'capabilities' => array( 'image_generation' ),
+								),
+							),
+						)
+					),
+				);
+			},
+			10,
+			3
+		);
+
+		$token = 'sdaist_retryable_discovery_token';
+		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, $token, false );
+		( new SuperdavAiProviderHandler() )->register_provider();
+
+		$response  = ( new SettingsController( new Settings(), new Database() ) )->handle_providers();
+		$providers = $response->get_data();
+		$superdav  = $this->find_provider( is_array( $providers ) ? $providers : array(), SuperdavAiProvider::PROVIDER_ID );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 2, $model_hits );
+		$this->assertSame( $token, get_option( SuperdavAiProvider::CREDENTIAL_OPTION, '' ) );
+		$this->assertNotNull( $superdav );
+		$this->assertSame( array( 'superdav-chat-fast', 'superdav-chat-pro', 'superdav-chat-strong' ), wp_list_pluck( $superdav['models'] ?? array(), 'id' ) );
+		$this->assertArrayNotHasKey( 'model_discovery', $superdav );
+	}
+
+	/**
+	 * /providers exposes scrubbed discovery metadata without rotating credentials for a client failure.
+	 */
+	public function test_handle_providers_reports_scrubbed_nonretryable_managed_model_discovery_failure(): void {
+		if ( ! class_exists( AiClient::class ) ) {
+			$this->markTestSkipped( 'WordPress AI Client SDK is unavailable.' );
+		}
+
+		$base_url   = 'https://service.example/v1';
+		$models_url = $base_url . '/models';
+		$model_hits = 0;
+		$token      = 'sdaist_nonretryable_discovery_token';
+
+		add_filter( 'sd_ai_agent_cloud_base_url', static fn(): string => $base_url );
+		add_filter(
+			'pre_http_request',
+			static function ( mixed $preempt, array $parsed_args, string $url ) use ( $models_url, &$model_hits, $token ): mixed {
+				if ( $models_url !== $url ) {
+					return $preempt;
+				}
+
+				++$model_hits;
+				return array(
+					'response' => array(
+						'code'    => 400,
+						'message' => 'Bad Request',
+					),
+					'body'     => wp_json_encode(
+						array( 'error' => array( 'message' => "Invalid request with {$token}." ) )
+					),
+				);
+			},
+			10,
+			3
+		);
+
+		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, $token, false );
+		( new SuperdavAiProviderHandler() )->register_provider();
+
+		$response  = ( new SettingsController( new Settings(), new Database() ) )->handle_providers();
+		$providers = $response->get_data();
+		$superdav  = $this->find_provider( is_array( $providers ) ? $providers : array(), SuperdavAiProvider::PROVIDER_ID );
+		$encoded   = wp_json_encode( $superdav );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 1, $model_hits );
+		$this->assertSame( $token, get_option( SuperdavAiProvider::CREDENTIAL_OPTION, '' ) );
+		$this->assertNotNull( $superdav );
+		$this->assertSame( array(), $superdav['models'] ?? null );
+		$this->assertSame( 'unavailable', $superdav['model_discovery']['state'] ?? '' );
+		$this->assertSame( 'model_discovery_client', $superdav['model_discovery']['code'] ?? '' );
+		$this->assertFalse( $superdav['model_discovery']['retryable'] ?? true );
+		$this->assertSame( 400, $superdav['model_discovery']['status'] ?? 0 );
+		$this->assertSame( 1, $superdav['model_discovery']['attempts'] ?? 0 );
+		$this->assertIsString( $encoded );
+		$this->assertStringNotContainsString( $token, $encoded );
+		$this->assertStringNotContainsString( 'Invalid request with', $encoded );
+	}
+
+	/**
 	 * SMS provider settings can be saved and read without exposing the API key.
 	 */
 	public function test_handle_sms_provider_save_and_get_returns_safe_metadata(): void {


### PR DESCRIPTION
## Summary

- Adds bounded managed Superdav model-discovery recovery and scrubbed failure metadata.
- Preserves the 401 token-refresh path, exposes retryable picker state, and keeps CLI discovery output aligned with REST.

## Files Changed

- `includes/Core/ProviderErrorClassifier.php` and `includes/Core/ProviderModelDiscovery.php`
- `includes/REST/SettingsController.php`, `includes/CLI/ModelsCommand.php`, and discovery diagnostics/event logging
- `src/components/chat-redesign/ModelPicker.js` and provider store recovery state
- Focused PHP and JavaScript coverage for recovery, logging, and picker behaviour

## Runtime Testing

- **Risk level:** medium
- **Verification:** runtime-verified — WordPress CLI booted the current worktree, registered the managed provider, and returned 4 models with no discovery failure in 1 attempt.

## Worker self-verification
- PHPUnit: Tests: 3910, Assertions: 17062, Errors: 0, Failures: 0, Skipped: 126, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Resolves #2302

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.172 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-terra spent 1h 13m and 1,036,988 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider and model listings now use improved model discovery, with clearer availability status.
  * Model discovery failures provide actionable retry guidance in the CLI and model picker.
  * The model picker can retry loading unavailable models directly.
* **Bug Fixes**
  * Previously loaded models are preserved during temporary, retryable provider outages.
  * Provider failures are classified more consistently, improving automatic retry behavior.
  * Sensitive provider error details remain protected in responses and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->