### PR TITLE
feat: enrich agent event tracing

### DIFF
--- a/includes/Core/AbilityFunctionResolver.php
+++ b/includes/Core/AbilityFunctionResolver.php
@@ -199,10 +199,18 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 			AgentEventLog::log(
 				'ability_failed',
 				AgentEventLog::SEVERITY_ERROR,
-				array(
-					'ability' => $ability_name,
-					'code'    => $error_code,
-					'message' => $e->getMessage(),
+				self::build_trace_context(
+					array(
+						'ability' => $ability_name,
+						'code'    => $error_code,
+						'message' => $e->getMessage(),
+					),
+					$args,
+					$function_id,
+					array(
+						'exception_file' => $e->getFile(),
+						'exception_line' => $e->getLine(),
+					)
 				)
 			);
 
@@ -242,10 +250,15 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 			AgentEventLog::log(
 				'ability_failed',
 				AgentEventLog::SEVERITY_ERROR,
-				array(
-					'ability' => $ability_name,
-					'code'    => $error_code,
-					'message' => (string) $result->get_error_message(),
+				self::build_trace_context(
+					array(
+						'ability' => $ability_name,
+						'code'    => $error_code,
+						'message' => (string) $result->get_error_message(),
+					),
+					$args,
+					$function_id,
+					$result->get_error_data()
 				)
 			);
 
@@ -349,10 +362,14 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 		AgentEventLog::log(
 			'ability_failed',
 			AgentEventLog::SEVERITY_ERROR,
-			array(
-				'ability' => $ability_name,
-				'code'    => 'ability_invalid_input',
-				'message' => $error_message,
+			self::build_trace_context(
+				array(
+					'ability' => $ability_name,
+					'code'    => 'ability_invalid_input',
+					'message' => $error_message,
+				),
+				array(),
+				$function_id
 			)
 		);
 		ModelHealthTracker::record_validation_error();
@@ -360,6 +377,32 @@ class AbilityFunctionResolver extends \WP_AI_Client_Ability_Function_Resolver {
 		$response_data = self::enrich_identical_failure_response( $response_data, $ability_name, array(), 'ability_invalid_input', $ability );
 
 		return new FunctionResponse( $function_id, $function_name, $response_data );
+	}
+
+	/**
+	 * Build safe trace context for an ability failure event.
+	 *
+	 * @param array<string, mixed> $base        Base event context.
+	 * @param array<string, mixed> $args        Normalised ability arguments.
+	 * @param string               $function_id Provider tool-call ID.
+	 * @param mixed                $result_payload Optional result/error data to preview.
+	 * @return array<string, mixed>
+	 */
+	private static function build_trace_context( array $base, array $args, string $function_id, $result_payload = null ): array {
+		$keys = array_map( 'strval', array_keys( $args ) );
+		sort( $keys );
+
+		$base['tool_call_id'] = $function_id;
+		$base['args_hash']    = AgentEventLog::payload_hash( $args );
+		$base['args_keys']    = implode( ',', $keys );
+		$base['args_preview'] = AgentEventLog::payload_preview( $args );
+
+		if ( null !== $result_payload ) {
+			$base['result_hash']    = AgentEventLog::payload_hash( $result_payload );
+			$base['result_preview'] = AgentEventLog::payload_preview( $result_payload );
+		}
+
+		return $base;
 	}
 
 	/**

--- a/includes/Core/AgentEventLog.php
+++ b/includes/Core/AgentEventLog.php
@@ -56,6 +56,16 @@ class AgentEventLog {
 	const MAX_MESSAGE_LENGTH = 200;
 
 	/**
+	 * Maximum length of a redacted argument preview stored in event context.
+	 */
+	const MAX_PREVIEW_LENGTH = 2000;
+
+	/**
+	 * Replacement used when a known-sensitive field is redacted.
+	 */
+	const REDACTED_VALUE = '[redacted]';
+
+	/**
 	 * Whitelisted scalar context keys that are safe to inline into the log line.
 	 *
 	 * Anything not listed here is dropped. This is the single defence against
@@ -66,17 +76,34 @@ class AgentEventLog {
 	private const SAFE_CONTEXT_KEYS = array(
 		'session_id',
 		'agent_id',
+		'job_id',
+		'trace_id',
+		'phase',
 		'iterations',
 		'iterations_used',
 		'iterations_max',
 		'provider_id',
 		'model_id',
 		'ability',
+		'tool_call_id',
+		'tool_name',
+		'tool_count',
+		'tool_call_count',
+		'client_tool_count',
+		'php_tool_count',
+		'history_count',
 		'code',
 		'status_code',
 		'reason',
 		'attempts',
 		'duration_ms',
+		'args_hash',
+		'args_keys',
+		'args_preview',
+		'result_hash',
+		'result_preview',
+		'pending_state_found',
+		'paused_state_saved',
 		'request_bytes',
 		'request_bytes_estimate',
 		'request_tokens_estimate',
@@ -217,6 +244,85 @@ class AgentEventLog {
 		 * @param array<string, mixed> $context  Original (un-redacted) context as passed to log().
 		 */
 		do_action( 'sd_ai_agent_event_logged', $event, $severity, $context );
+	}
+
+	/**
+	 * Build a deterministic short hash for a trace payload.
+	 *
+	 * The hash lets operators correlate identical failed tool arguments without
+	 * persisting raw request bodies in the single-line PHP log.
+	 *
+	 * @param mixed $payload Payload to hash.
+	 * @return string Twelve-character SHA-256 prefix, or empty string on encode failure.
+	 */
+	public static function payload_hash( $payload ): string {
+		$encoded = wp_json_encode( $payload );
+		if ( ! is_string( $encoded ) ) {
+			return '';
+		}
+
+		return substr( hash( 'sha256', $encoded ), 0, 12 );
+	}
+
+	/**
+	 * Return a redacted, bounded JSON preview for safe trace context.
+	 *
+	 * This is intentionally conservative: values under secret-looking keys are
+	 * replaced, objects are converted to arrays, and the final JSON is capped.
+	 * The network log sink stores this in `context` so an operator can understand
+	 * what kind of tool input failed without exposing credentials.
+	 *
+	 * @param mixed $payload Payload to preview.
+	 * @return string Redacted JSON preview, or empty string on encode failure.
+	 */
+	public static function payload_preview( $payload ): string {
+		$redacted = self::redact_payload( $payload );
+		$encoded  = wp_json_encode( $redacted );
+		if ( ! is_string( $encoded ) ) {
+			return '';
+		}
+
+		$encoded = self::truncate_and_flatten( $encoded, self::MAX_PREVIEW_LENGTH );
+		return $encoded;
+	}
+
+	/**
+	 * Redact recursively before persisting trace previews.
+	 *
+	 * @param mixed $payload Raw payload.
+	 * @return mixed Redacted payload.
+	 */
+	private static function redact_payload( $payload ) {
+		if ( $payload instanceof \stdClass ) {
+			$payload = (array) $payload;
+		}
+
+		if ( is_array( $payload ) ) {
+			$out = array();
+			foreach ( $payload as $key => $value ) {
+				$key_string = is_int( $key ) ? (string) $key : (string) $key;
+				if ( self::is_sensitive_key( $key_string ) ) {
+					$out[ $key ] = self::REDACTED_VALUE;
+					continue;
+				}
+
+				$out[ $key ] = self::redact_payload( $value );
+			}
+			return $out;
+		}
+
+		if ( is_resource( $payload ) ) {
+			return '[resource]';
+		}
+
+		return $payload;
+	}
+
+	/**
+	 * Whether an array key is likely to contain credentials or secrets.
+	 */
+	private static function is_sensitive_key( string $key ): bool {
+		return 1 === preg_match( '/(api[_-]?key|authorization|bearer|client[_-]?secret|credential|nonce|password|private[_-]?key|secret|token)/i', $key );
 	}
 
 	/**

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -821,6 +821,17 @@ class AgentLoop {
 			$response_message = new UserMessage( $parts );
 			$this->append_tool_response_to_history( $response_message );
 
+			AgentEventLog::log(
+				'client_tools_result_received',
+				AgentEventLog::SEVERITY_INFO,
+				$this->build_loop_event_context(
+					array(
+						'client_tool_count' => count( $results ),
+						'reason'            => 'browser_result_posted',
+					)
+				)
+			);
+
 			// Log the client tool responses for transparency.
 			foreach ( $results as $result ) {
 				$id   = (string) ( $result['id'] ?? '' );
@@ -868,6 +879,29 @@ class AgentLoop {
 			$payload['generated_theme_completion'] = $this->generated_theme_completion_gate->get_status();
 		}
 		return $payload;
+	}
+
+	/**
+	 * Add common loop state to an operator-facing event context.
+	 *
+	 * @param array<string, mixed> $context Specific event context.
+	 * @return array<string, mixed>
+	 */
+	private function build_loop_event_context( array $context = array() ): array {
+		return array_merge(
+			array(
+				'session_id'      => $this->session_id,
+				'job_id'          => $this->active_job_id,
+				'phase'           => $this->last_loop_phase,
+				'iterations_used' => $this->iterations_used,
+				'iterations_max'  => (int) $this->max_iterations,
+				'model_id'        => (string) $this->model_id,
+				'provider_id'     => (string) $this->provider_id,
+				'tool_call_count' => count( $this->tool_call_log ),
+				'history_count'   => count( $this->history ),
+			),
+			$context
+		);
 	}
 
 	/**
@@ -1036,14 +1070,11 @@ class AgentLoop {
 				AgentEventLog::log(
 					'agent_loop_aborted',
 					AgentEventLog::SEVERITY_ERROR,
-					array(
-						'session_id'      => $this->session_id,
-						'reason'          => (string) $result->get_error_code(),
-						'iterations_used' => $this->iterations_used,
-						'iterations_max'  => (int) $this->max_iterations,
-						'model_id'        => (string) $this->model_id,
-						'provider_id'     => (string) $this->provider_id,
-						'message'         => (string) $result->get_error_message(),
+					$this->build_loop_event_context(
+						array(
+							'reason'  => (string) $result->get_error_code(),
+							'message' => (string) $result->get_error_message(),
+						)
 					)
 				);
 				return $result;
@@ -1253,6 +1284,19 @@ class AgentLoop {
 						);
 						Database::save_paused_state( $this->session_id, $paused_state );
 					}
+
+					AgentEventLog::log(
+						'client_tools_pending',
+						AgentEventLog::SEVERITY_INFO,
+						$this->build_loop_event_context(
+							array(
+								'client_tool_count'  => count( $partition['client'] ),
+								'php_tool_count'     => count( $partition['php'] ),
+								'paused_state_saved' => $this->session_id > 0,
+								'reason'             => 'browser_tool_required',
+							)
+						)
+					);
 
 					// Return pending client tool calls to the browser.
 					return $this->with_paused_logs(

--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace SdAiAgent\REST;
 
 use SdAiAgent\Core\AgentLoop;
+use SdAiAgent\Core\AgentEventLog;
 use SdAiAgent\Core\ClientAbilityRouter;
 use SdAiAgent\Core\ConversationSerializer;
 use SdAiAgent\Core\ConversationTrimmer;
@@ -477,6 +478,21 @@ Assistant: %s',
 			// helper updates the DB row only.
 			self::clear_pending_client_tool_calls( $job_id );
 
+			AgentEventLog::log(
+				'client_tools_resume_failed',
+				AgentEventLog::SEVERITY_ERROR,
+				array(
+					'session_id'          => $session_id,
+					'job_id'              => $job_id,
+					'phase'               => 'tool_result_resume',
+					'code'                => 'sd_ai_agent_no_paused_state',
+					'reason'              => 'paused_state_missing',
+					'pending_state_found' => false,
+					'client_tool_count'   => count( $tool_results ),
+					'message'             => __( 'No paused agent state found for this session. The session may have already been resumed or expired.', 'superdav-ai-agent' ),
+				)
+			);
+
 			return new WP_Error(
 				'sd_ai_agent_no_paused_state',
 				__( 'No paused agent state found for this session. The session may have already been resumed or expired.', 'superdav-ai-agent' ),
@@ -491,6 +507,21 @@ Assistant: %s',
 			// complete; never resume an unverified payload.
 			Database::save_paused_state( $session_id, $paused_state );
 
+			AgentEventLog::log(
+				'client_tools_resume_failed',
+				AgentEventLog::SEVERITY_ERROR,
+				array(
+					'session_id'          => $session_id,
+					'job_id'              => $job_id,
+					'phase'               => 'tool_result_validation',
+					'code'                => 'sd_ai_agent_invalid_client_tool_results',
+					'reason'              => 'pending_calls_not_array',
+					'pending_state_found' => true,
+					'client_tool_count'   => count( $tool_results ),
+					'message'             => __( 'tool_results must exactly match the pending client tool calls.', 'superdav-ai-agent' ),
+				)
+			);
+
 			return new WP_Error(
 				'sd_ai_agent_invalid_client_tool_results',
 				__( 'tool_results must exactly match the pending client tool calls.', 'superdav-ai-agent' ),
@@ -501,6 +532,22 @@ Assistant: %s',
 		$tool_results              = array_values( $tool_results );
 		if ( ! ClientAbilityRouter::matches_pending_results( $pending_client_tool_calls, $tool_results ) ) {
 			Database::save_paused_state( $session_id, $paused_state );
+
+			AgentEventLog::log(
+				'client_tools_resume_failed',
+				AgentEventLog::SEVERITY_ERROR,
+				array(
+					'session_id'          => $session_id,
+					'job_id'              => $job_id,
+					'phase'               => 'tool_result_validation',
+					'code'                => 'sd_ai_agent_invalid_client_tool_results',
+					'reason'              => 'result_mismatch',
+					'pending_state_found' => true,
+					'client_tool_count'   => count( $tool_results ),
+					'tool_count'          => count( $pending_client_tool_calls ),
+					'message'             => __( 'tool_results must exactly match the pending client tool calls.', 'superdav-ai-agent' ),
+				)
+			);
 
 			return new WP_Error(
 				'sd_ai_agent_invalid_client_tool_results',

--- a/tests/SdAiAgent/Core/AgentEventLogTest.php
+++ b/tests/SdAiAgent/Core/AgentEventLogTest.php
@@ -340,4 +340,22 @@ class AgentEventLogTest extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'request_body', $contents );
 		$this->assertStringNotContainsString( 'authorization', $contents );
 	}
+
+	public function test_payload_preview_redacts_sensitive_values(): void {
+		$preview = AgentEventLog::payload_preview(
+			array(
+				'query'       => 'SELECT post_title FROM wp_posts WHERE post_type = %s',
+				'params'      => array( 'page' ),
+				'api_key'     => 'sk-secret-value',
+				'nested'      => array(
+					'access_token' => 'secret-token-value',
+				),
+			)
+		);
+
+		$this->assertStringContainsString( 'SELECT post_title', $preview );
+		$this->assertStringContainsString( AgentEventLog::REDACTED_VALUE, $preview );
+		$this->assertStringNotContainsString( 'sk-secret-value', $preview );
+		$this->assertStringNotContainsString( 'secret-token-value', $preview );
+	}
 }


### PR DESCRIPTION
## Summary

- Enriches `AgentEventLog` with safe trace fields for failed abilities, loop aborts, and browser-client tool resume failures.
- Adds redacted argument/result previews plus stable hashes so operators can reconstruct failures without storing credentials.
- Emits explicit `client_tools_resume_failed`, `client_tools_pending`, and `client_tools_result_received` events for the browser tool-result flow.

## Context

This supports debugging network log incidents like:

- `ability_failed` from `sd-ai-agent/db-query` with `sd_ai_agent_sql_unprepared_literal`
- `ability_failed` from `sd-ai-agent/update-blocks` with `batch_validation_failed`
- `agent_loop_aborted` provider/client errors such as credit exhaustion
- stale browser tool-result resumes where paused state is already gone

## Verification

- `php -l includes/Core/AgentEventLog.php`
- `php -l includes/Core/AbilityFunctionResolver.php`
- `php -l includes/Core/AgentLoop.php`
- `php -l includes/REST/RestController.php`
- `php -l tests/SdAiAgent/Core/AgentEventLogTest.php`

PHPUnit/PHPCS were attempted but local dev dependencies/sniffs were unavailable in this worktree (`phpunit: not found`, `vendor/bin/phpcs: not found`, missing WPCS sniffs).

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.175 plugin for [OpenCode](https://opencode.ai) v1.18.4
