### PR TITLE
fix: skip stale super admin logins in CLI

### DIFF
--- a/includes/CLI/CliCommand.php
+++ b/includes/CLI/CliCommand.php
@@ -104,6 +104,7 @@ class CliCommand extends \WP_CLI_Command {
 		// configured login until one resolves to a real user instead of assuming
 		// the first entry is still valid.
 		if ( ! get_current_user_id() ) {
+			$resolved_admin = false;
 			foreach ( get_super_admins() as $admin_login ) {
 				$admin = get_user_by( 'login', $admin_login );
 				if ( ! $admin ) {
@@ -111,7 +112,13 @@ class CliCommand extends \WP_CLI_Command {
 				}
 
 				wp_set_current_user( $admin->ID );
+				$resolved_admin = true;
 				break;
+			}
+
+			if ( ! $resolved_admin ) {
+				WP_CLI::error( 'No configured super-admin login resolves to an existing WordPress user.' );
+				return;
 			}
 		}
 

--- a/includes/CLI/CliCommand.php
+++ b/includes/CLI/CliCommand.php
@@ -99,14 +99,19 @@ class CliCommand extends \WP_CLI_Command {
 		$verbose    = \WP_CLI\Utils\get_flag_value( $assoc_args, 'verbose', false );
 
 		// Ensure a user is set so ability permission checks pass.
-		// WP-CLI doesn't set a current user unless --user is passed.
+		// WP-CLI doesn't set a current user unless --user is passed. Some
+		// multisite installs retain stale super-admin logins, so try each
+		// configured login until one resolves to a real user instead of assuming
+		// the first entry is still valid.
 		if ( ! get_current_user_id() ) {
-			$admins = get_super_admins();
-			if ( ! empty( $admins ) ) {
-				$admin = get_user_by( 'login', $admins[0] );
-				if ( $admin ) {
-					wp_set_current_user( $admin->ID );
+			foreach ( get_super_admins() as $admin_login ) {
+				$admin = get_user_by( 'login', $admin_login );
+				if ( ! $admin ) {
+					continue;
 				}
+
+				wp_set_current_user( $admin->ID );
+				break;
 			}
 		}
 


### PR DESCRIPTION
## Summary

- Try each configured multisite super-admin login when WP-CLI starts without `--user`.
- Avoid silently running agent CLI prompts as user `0` when the first stored super-admin login is stale.

## Verification

- `php -l includes/CLI/CliCommand.php`
- `wp --url=https://vidanuevanaz.org eval '...'` reproduced the local stale-super-admin state: first login `admin` did not resolve, while `dave` exists.
- `wp --url=https://vidanuevanaz.org --user=dave sd-ai-agent prompt ...` successfully executed `sd-ai-agent/get-post`, proving the missing-user path was the blocker.

## Notes

- `npm run lint:php -- --standard=phpcs.xml.dist includes/CLI/CliCommand.php` could not run because `vendor/bin/phpcs` is not installed in this checkout.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.175 plugin for [OpenCode](https://opencode.ai) v1.18.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI user initialization by checking all configured super-admin accounts.
  * Ensures a valid administrator is selected when the first configured login does not correspond to an existing user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->