### PR TITLE
fix: allow repeated child block inserts

### DIFF
--- a/includes/Abilities/BlockAbilities.php
+++ b/includes/Abilities/BlockAbilities.php
@@ -827,6 +827,18 @@ class BlockAbilities {
 										'type'        => 'boolean',
 										'description' => 'Override the Block Bindings write-lock for this update. Default: false.',
 									],
+									'block_def'          => [
+										'type'        => 'object',
+										'description' => 'For insert-child and replace-block: full parsed block definition with blockName, attrs, innerHTML, and optional innerBlocks.',
+									],
+									'position'           => [
+										'type'        => 'integer',
+										'description' => 'For insert-child: 0-based child index to insert at. Omit to append.',
+									],
+									'destination'        => [
+										'type'        => 'object',
+										'description' => 'For insert-child: optional alias for position, e.g. {"index": 0}. For move: target address and placement.',
+									],
 								],
 								'required'   => [ 'op' ],
 							],

--- a/includes/Core/BlockMutator.php
+++ b/includes/Core/BlockMutator.php
@@ -258,6 +258,7 @@ class BlockMutator {
 		// ── Phase 1: pre-flight — resolve addresses, detect duplicates ──
 		$errors         = [];
 		$resolved_paths = [];
+		$resolved_ops   = [];
 
 		foreach ( $updates as $idx => $update ) {
 			if ( ! is_array( $update ) ) {
@@ -299,6 +300,11 @@ class BlockMutator {
 			// Duplicate target detection: two ops on the same resolved path.
 			$path_key = implode( ',', $path );
 			if ( isset( $resolved_paths[ $path_key ] ) ) {
+				$previous_op = $resolved_ops[ $path_key ] ?? '';
+				if ( 'insert-child' === $previous_op && 'insert-child' === $op ) {
+					continue;
+				}
+
 				$errors[] = [
 					'index'   => $idx,
 					'code'    => 'duplicate_target',
@@ -312,6 +318,7 @@ class BlockMutator {
 			}
 
 			$resolved_paths[ $path_key ] = $idx;
+			$resolved_ops[ $path_key ]   = $op;
 		}
 
 		if ( ! empty( $errors ) ) {
@@ -1493,7 +1500,12 @@ class BlockMutator {
 
 		$new_child = self::sanitize_block_tree( $new_child );
 
-		$position = isset( $args['position'] ) ? (int) $args['position'] : null;
+		$position = null;
+		if ( isset( $args['position'] ) ) {
+			$position = (int) $args['position'];
+		} elseif ( isset( $args['destination'] ) && is_array( $args['destination'] ) && isset( $args['destination']['index'] ) ) {
+			$position = (int) $args['destination']['index'];
+		}
 
 		$result = self::mutate_at_path(
 			$blocks,

--- a/tests/SdAiAgent/Core/BlockMutatorBatchTest.php
+++ b/tests/SdAiAgent/Core/BlockMutatorBatchTest.php
@@ -228,6 +228,47 @@ class BlockMutatorBatchTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Multiple insert-child operations may target the same parent in one batch.
+	 */
+	public function test_multiple_insert_child_updates_can_target_same_parent(): void {
+		$parent_ref = 'blk_parent_inserts';
+		$blocks     = [
+			$this->make_block(
+				'core/group',
+				[ 'metadata' => [ BlockReferences::REF_KEY => $parent_ref ] ],
+				[
+					$this->make_block( 'core/paragraph', [], [], '<p>Existing</p>' ),
+				],
+				''
+			),
+		];
+
+		$result = BlockMutator::apply_batch(
+			$blocks,
+			[
+				[
+					'op'        => 'insert-child',
+					'ref'       => $parent_ref,
+					'position'  => 1,
+					'block_def' => $this->make_block( 'core/paragraph', [], [], '<p>First inserted</p>' ),
+				],
+				[
+					'op'          => 'insert-child',
+					'ref'         => $parent_ref,
+					'destination' => [ 'index' => 2 ],
+					'block_def'   => $this->make_block( 'core/paragraph', [], [], '<p>Second inserted</p>' ),
+				],
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 3, $result[0]['innerBlocks'] );
+		$this->assertSame( '<p>Existing</p>', $result[0]['innerBlocks'][0]['innerHTML'] );
+		$this->assertSame( '<p>First inserted</p>', $result[0]['innerBlocks'][1]['innerHTML'] );
+		$this->assertSame( '<p>Second inserted</p>', $result[0]['innerBlocks'][2]['innerHTML'] );
+	}
+
+	/**
 	 * AC2: A batch where item 3 has an invalid ref rejects the entire
 	 * batch with per-item errors, and no modifications to the tree.
 	 */


### PR DESCRIPTION
## Summary

- Allow multiple `insert-child` operations to target the same parent block in one atomic `update-blocks` batch.
- Support `destination.index` as an alias for `position` on `insert-child`, matching the argument shape the model used.
- Document `block_def`, `position`, and `destination` in the `update-blocks` input schema so models receive clearer tool guidance.

## Why

The homepage edit prompt tried to move an address above an “Open Driving Directions” button by removing existing blocks and inserting two replacement children into the same parent. The batch rejected with `batch_validation_failed` because duplicate-target validation treated repeated `insert-child` operations on the same parent as conflicting, even though sequential child inserts are safe and necessary for this workflow.

## Verification

- `php -l includes/Core/BlockMutator.php`
- `php -l includes/Abilities/BlockAbilities.php`
- `php -l tests/SdAiAgent/Core/BlockMutatorBatchTest.php`
- `npm run test:php -- --filter=BlockMutatorBatchTest` could not run because `phpunit` is not installed in this checkout.

## Notes

- Existing duplicate-target protection still rejects conflicting operations on the same block; this only permits repeated `insert-child` operations on the same parent.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.176 plugin for [OpenCode](https://opencode.ai) v1.18.4
