### PR TITLE
docs: auto-dispatch feedback triage issues

### DIFF
--- a/.agents/scripts/commands/feedback-triage.md
+++ b/.agents/scripts/commands/feedback-triage.md
@@ -349,15 +349,15 @@ Do not use shell heredocs, process substitution, or command substitution to
 inline the body or signature. Those forms are rejected by the aidevops GitHub
 signature gate. Create the GitHub issue through the repo helper so the required
 aidevops signature footer is appended automatically and the fallback signature is
-used if the framework signature helper is unavailable. Apply `origin:worker` and
-`status:available` alongside `bug` so the issue is traceable as feedback-triage
-output and visible to claim routines:
+used if the framework signature helper is unavailable. Apply `origin:worker`,
+`status:available`, and `auto-dispatch` alongside `bug` so the issue is
+traceable as feedback-triage output and visible to claim routines:
 
 ```bash
 .agents/scripts/issue-sync-helper.sh --repo Ultimate-Multisite/superdav-ai-agent create-signed-issue \
   --title "<concise bug title>" \
   --body-file /tmp/opencode/r020-triage/issue-<id>-body.md \
-  --label "bug,origin:worker,status:available"
+  --label "bug,origin:worker,status:available,auto-dispatch"
 ```
 
 If any referenced screenshot, prompt, or generated artifact returns
@@ -384,13 +384,13 @@ status):
 #### 4f: Create GitHub issue (missing_ability)
 
 Use `enhancement` in place of `bug`; keep the rest of the label set
-(`enhancement,origin:worker,status:available`). Title format:
+(`enhancement,origin:worker,status:available,auto-dispatch`). Title format:
 `ability: <action> — <context>`.
 
 #### 4f.1: Create GitHub issue (contributor_insight)
 
 Use `contributor-insight` in place of `bug`; keep the rest of the label set
-(`contributor-insight,origin:worker,status:available`). Title format:
+(`contributor-insight,origin:worker,status:available,auto-dispatch`). Title format:
 `Contributor insight: <instruction/script gap>`.
 
 The issue body must include a `## Worker Guidance` section with:


### PR DESCRIPTION
## Summary
- Require r020 feedback-triage issue creation to include `auto-dispatch` with `origin:worker` and `status:available`.
- Update bug, missing-ability, and contributor-insight label examples in the SOP.

## Verification
- `rg -n "auto-dispatch|bug,origin:worker,status:available|enhancement,origin:worker,status:available|contributor-insight,origin:worker,status:available" .agents/scripts/commands/feedback-triage.md .opencode/command/feedback-triage.md`
- `gh issue view 2318 -R Ultimate-Multisite/superdav-ai-agent --json labels --jq "[.labels[].name]"` -> includes `auto-dispatch`

Docs-only change; no code gates run.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated feedback-triage guidance for creating bug reports, including the `auto-dispatch` label for signed issues.
  * Revised contributor-insight issue instructions to apply the `contributor-insight` and `auto-dispatch` labels.
  * Preserved existing issue-title formatting guidance for consistent reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->