### PR TITLE
GH#2318: prevent unavailable prompt retry loops

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -229,6 +229,9 @@ class AgentLoop {
 	/** @var int Empty calls rejected for missing required input in this run. */
 	private int $consecutive_empty_tool_call_failures = 0;
 
+	/** @var bool Whether an unavailable nested prompt model has already been explained this run. */
+	private bool $prompt_model_unavailable_guidance_injected = false;
+
 	/**
 	 * Client-side ability descriptors validated against JsAbilityCatalog.
 	 * These are abilities the browser can execute; the loop pauses and returns
@@ -3755,6 +3758,7 @@ class AgentLoop {
 				}
 
 				$this->track_block_validation_response( $name, $response->getResponse() );
+				$this->track_prompt_model_unavailable_response( $name, $response->getResponse() );
 				$this->generated_theme_completion_gate->record_tool_response( $name, $response->getResponse() );
 
 				$this->tool_call_log[] = array(
@@ -3768,6 +3772,58 @@ class AgentLoop {
 		}
 
 		$this->fire_progress();
+	}
+
+	/**
+	 * Prevent an unavailable nested prompt ability from consuming the remaining run.
+	 *
+	 * The agent loop itself already has a configured text-generation model. A
+	 * nested `sd-ai-agent/prompt` call can still use the SDK's independent model
+	 * selection and report that no text model is available. That does not make a
+	 * page-editing request impossible, so steer the next turn back to the active
+	 * page-editing tools rather than allowing repeated fallback attempts.
+	 *
+	 * @param string $tool_name Function-response tool name.
+	 * @param mixed  $response  Function-response payload.
+	 */
+	private function track_prompt_model_unavailable_response( string $tool_name, $response ): void {
+		if ( $this->prompt_model_unavailable_guidance_injected || ! is_array( $response ) ) {
+			return;
+		}
+
+		if ( 'sd-ai-agent/ability-call' !== self::normalize_logged_tool_name( $tool_name ) ) {
+			return;
+		}
+
+		$ability = isset( $response['ability'] ) && is_string( $response['ability'] ) ? $response['ability'] : '';
+		$code    = isset( $response['code'] ) && is_string( $response['code'] ) ? $response['code'] : '';
+		$error   = isset( $response['error'] ) && is_string( $response['error'] ) ? $response['error'] : '';
+
+		if (
+			'sd-ai-agent/prompt' !== $ability
+			|| 'prompt_invalid_argument' !== $code
+			|| ! str_contains( strtolower( $error ), 'no models found that support text_generation' )
+		) {
+			return;
+		}
+
+		$this->prompt_model_unavailable_guidance_injected = true;
+		$this->history[]                                  = new UserMessage(
+			array(
+				new MessagePart(
+					'The nested sd-ai-agent/prompt ability has no selectable text-generation model in this environment. '
+					. 'This is not recoverable by retrying it. Do not call that ability again in this run. '
+					. 'Continue the requested work with the current agent and the page/block tools already available. '
+					. 'For translation, compose the text directly, update the requested page, and verify that page before exploring unrelated content.'
+				),
+			)
+		);
+		$this->message_log[] = array(
+			'type'     => 'guardrail',
+			'reason'   => 'prompt_model_unavailable',
+			'ability'  => $ability,
+			'sequence' => $this->next_activity_sequence(),
+		);
 	}
 
 	/**

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -3818,7 +3818,7 @@ class AgentLoop {
 				),
 			)
 		);
-		$this->message_log[] = array(
+		$this->message_log[]                              = array(
 			'type'     => 'guardrail',
 			'reason'   => 'prompt_model_unavailable',
 			'ability'  => $ability,

--- a/includes/Core/SystemInstructionBuilder.php
+++ b/includes/Core/SystemInstructionBuilder.php
@@ -44,6 +44,17 @@ class SystemInstructionBuilder {
 	);
 
 	/**
+	 * Ability names that trigger focused block-editing guidance.
+	 *
+	 * @var string[]
+	 */
+	public const BLOCK_EDITING_ABILITY_NAMES = array(
+		'sd-ai-agent/get-page-blocks',
+		'sd-ai-agent/update-blocks',
+		'sd-ai-agent/rewrite-post-blocks',
+	);
+
+	/**
 	 * @param string                   $model_id     Current AI model ID (for weak-model nudges).
 	 * @param string                   $user_message User's message (for knowledge context RAG).
 	 * @param array<int|string, mixed> $page_context Page context from the widget.
@@ -95,6 +106,20 @@ class SystemInstructionBuilder {
 			. "If the result includes `affected.kind: post`, a matching `post_id`/URL, and `fields` containing `post_content`, the widget's live-preview reflector will attempt to update the visible page automatically; tell the user the page should update live. "
 			. 'If a mutating tool result does not include an `affected` descriptor for the visible page, the browser cannot know what changed and the user must refresh to see it. In that case, call `sd-ai-agent-js/refresh-page` after your server-side write completes; it refreshes the current page while preserving the open widget and current session. '
 			. 'Do not call the refresh tool after a dry run or after read-only inspection. If you are unsure whether live reflection succeeded, use a screenshot/inspection tool or explain that a refresh may be required.';
+	}
+
+	/**
+	 * Return safe operating rules for editing existing Gutenberg content.
+	 *
+	 * @return string
+	 */
+	public static function build_block_editing_section(): string {
+		return "## Existing page block edits\n\n"
+			. 'For translation, localization, and other text-only changes to an existing page, work directly from that page\'s block tree. '
+			. 'First call `sd-ai-agent/get-page-blocks` with `persist_refs:true`, retain its `revision_id`, then update only the requested page with `sd-ai-agent/update-blocks`. '
+			. 'Use the current language context to write the translated text; do not call a nested prompt/model ability as a translation fallback. '
+			. 'For a multi-update batch, validate it with `dry_run:true` before the final write and pass the fetched `revision_id` as `expected_revision`. '
+			. 'If validation fails, use the returned itemized errors and recovery_hints to correct only the failing update. Do not retry an unchanged batch, and do not inspect unrelated posts or media until the requested page update and verification are complete.';
 	}
 
 	/**
@@ -249,6 +274,11 @@ class SystemInstructionBuilder {
 			$base .= "\n\n" . self::build_build_vs_install_section( $ability_names );
 		}
 
+		if ( self::has_block_editing_ability( $ability_names ) ) {
+			// @phpstan-ignore-next-line
+			$base .= "\n\n" . self::build_block_editing_section();
+		}
+
 		// Suggestion chips: instruct the AI to append follow-up suggestions.
 		// @phpstan-ignore-next-line
 		$suggestion_count = (int) ( $settings['suggestion_count'] ?? 3 );
@@ -285,6 +315,21 @@ class SystemInstructionBuilder {
 				return true;
 			}
 		}
+		return false;
+	}
+
+	/**
+	 * Return true when direct tools can inspect or mutate Gutenberg blocks.
+	 *
+	 * @param string[] $ability_names Names of active Tier-1 abilities for this turn.
+	 */
+	public static function has_block_editing_ability( array $ability_names ): bool {
+		foreach ( $ability_names as $name ) {
+			if ( in_array( $name, self::BLOCK_EDITING_ABILITY_NAMES, true ) ) {
+				return true;
+			}
+		}
+
 		return false;
 	}
 

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -1792,6 +1792,43 @@ class AgentLoopTest extends WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * A nested prompt with no text model gets one hard recovery instruction.
+	 */
+	public function test_unavailable_nested_prompt_model_injects_non_retry_guidance(): void {
+		if ( ! class_exists( 'WordPress\\AiClient\\Messages\\DTO\\UserMessage' ) ) {
+			$this->markTestSkipped( 'WP AI Client message classes are not available.' );
+		}
+
+		$loop    = new AgentLoop( 'Make the home page bilingual' );
+		$method  = new \ReflectionMethod( AgentLoop::class, 'track_prompt_model_unavailable_response' );
+		$history = new \ReflectionProperty( AgentLoop::class, 'history' );
+		$logs    = new \ReflectionProperty( AgentLoop::class, 'message_log' );
+		$method->setAccessible( true );
+		$history->setAccessible( true );
+		$logs->setAccessible( true );
+
+		$payload = array(
+			'success' => false,
+			'ability' => 'sd-ai-agent/prompt',
+			'code'    => 'prompt_invalid_argument',
+			'error'   => 'No models found that support text_generation for this prompt.',
+		);
+
+		$method->invoke( $loop, 'wpab__sd-ai-agent__ability-call', $payload );
+		$method->invoke( $loop, 'wpab__sd-ai-agent__ability-call', $payload );
+
+		$history_value = $history->getValue( $loop );
+		$log_value     = $logs->getValue( $loop );
+		$this->assertCount( 1, $history_value );
+		$this->assertCount( 1, $log_value );
+		$this->assertSame( 'prompt_model_unavailable', $log_value[0]['reason'] );
+		$this->assertStringContainsString(
+			'Do not call that ability again in this run.',
+			$history_value[0]->getParts()[0]->getText()
+		);
+	}
+
 	// -------------------------------------------------------------------------
 	// History serialisation / deserialisation
 	// -------------------------------------------------------------------------

--- a/tests/SdAiAgent/Core/SystemInstructionBuilderTest.php
+++ b/tests/SdAiAgent/Core/SystemInstructionBuilderTest.php
@@ -131,6 +131,24 @@ class SystemInstructionBuilderTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Existing page block-editing sessions should avoid unrelated prompt-model fallbacks.
+	 */
+	public function test_build_includes_block_editing_guidance_when_block_tools_are_active(): void {
+		$builder = new SystemInstructionBuilder();
+
+		$instruction = $builder->build(
+			array(),
+			array( 'sd-ai-agent/get-page-blocks', 'sd-ai-agent/update-blocks' )
+		);
+
+		$this->assertStringContainsString( '## Existing page block edits', $instruction );
+		$this->assertStringContainsString( 'persist_refs:true', $instruction );
+		$this->assertStringContainsString( 'dry_run:true', $instruction );
+		$this->assertStringContainsString( 'do not call a nested prompt/model ability as a translation fallback', $instruction );
+		$this->assertStringContainsString( 'Do not retry an unchanged batch', $instruction );
+	}
+
+	/**
 	 * Diagnostic summary prompts must remain read-only unless remediation is explicit.
 	 *
 	 * Regression: issue #2083 — a site health summary request installed and


### PR DESCRIPTION
Resolves #2318

## Summary
- keep existing-page translation work in the requested Gutenberg block tree
- stop retrying nested prompt abilities when no text-generation model is selectable
- guide block-update recovery from returned validation details

## Testing
- `npm run lint:php` passed
- `npm run lint:js` passed
- `npm run lint:css` passed
- `composer phpstan` passed: 0 errors
- `npm run build` succeeded (existing webpack bundle-size warnings)
- `npm run test:php` blocked: local MySQL rejected the default root test connection and no `WP_TESTS_DB_*` credentials are available

## Runtime Testing
- self-assessed: this agent-loop guardrail is covered by focused PHPUnit regression tests

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-terra spent 15m and 196,860 tokens on this as a headless worker. Overall, 3h 7m since this issue was created.
