### PR TITLE
GH#2320: add customer agent runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,67 @@ The agent uses an **async job + polling** pattern to handle long-running inferen
 
 This avoids HTTP timeout issues with multi-step agentic loops that can take 30+ seconds.
 
+### Customer-agent runtime PHP contract
+
+Trusted plugins on the same WordPress install can use the versioned, server-side
+customer-agent runtime without calling `/public-chat/*`, creating browser tokens,
+or depending on `SessionController` job arrays. There is intentionally no new
+unauthenticated REST endpoint.
+
+Register a constrained profile from the consuming plugin, then discover the
+contract before use. V1 accepts only server-owned system instructions, the
+`sd-ai-agent/knowledge-search` ability, and declared knowledge collections.
+Client tools, browser tools, mutations, attachments, and caller-supplied prompts
+are unavailable.
+
+```php
+add_filter(
+	'sd_ai_agent_customer_agent_integrations',
+	static function( array $integrations ): array {
+		$integrations['ultimate-multisite-support-tickets'] = array(
+			'enabled'             => true,
+			'profile'             => 'support-customer',
+			'system_instruction'  => 'Answer customers only from the approved support knowledge base.',
+			'abilities'           => array( 'sd-ai-agent/knowledge-search' ),
+			'collections'         => array( 'support-docs' ),
+			'provider_id'         => '', // Uses the server default when empty.
+			'model_id'            => '',
+			'max_message_length'  => 4000,
+			'max_history_turns'   => 8,
+			'max_iterations'      => 6,
+			'max_runtime_seconds' => 120,
+		);
+		return $integrations;
+	}
+);
+
+$runtime = sd_ai_agent_customer_agent_runtime();
+$caps    = $runtime->discover_capabilities();
+
+if ( version_compare( $caps['contract_version'], '1.0.0', '<' ) ) {
+	return;
+}
+
+$conversation = $runtime->create_or_recover_conversation(
+	'ultimate-multisite-support-tickets',
+	$external_session_id
+);
+$job = $runtime->enqueue_turn(
+	'ultimate-multisite-support-tickets',
+	$external_session_id,
+	$external_message_id,
+	$customer_message
+);
+```
+
+`enqueue_turn()` is idempotent for the integration key, external session ID,
+and external message ID. `inspect_job()` is non-consuming: complete, failed,
+and cancelled jobs remain readable for at least seven days. `cancel_job()`
+prevents a late result from becoming deliverable, although an in-flight provider
+request may already be physically running. `close_conversation()` cancels and
+purges the constrained runtime history; the consumer remains responsible for its
+own customer transcript and routing state.
+
 ### Extending
 
 **Register custom abilities** that the agent can use:

--- a/includes/Bootstrap/CustomerAgentRuntimeHandler.php
+++ b/includes/Bootstrap/CustomerAgentRuntimeHandler.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * DI wiring for the durable customer-agent runtime worker.
+ *
+ * @package SdAiAgent\Bootstrap
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Bootstrap;
+
+use SdAiAgent\Services\CustomerAgentRuntimeService;
+use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Handler;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/** Wires the private WP-Cron processing hook in every WordPress context. */
+#[Handler(
+	container: 'sd-ai-agent',
+	context: Handler::CTX_GLOBAL,
+	strategy: Handler::INIT_IMMEDIATELY,
+)]
+final class CustomerAgentRuntimeHandler {
+
+	/** Execute one opaque queued customer-agent job. */
+	#[Action( tag: CustomerAgentRuntimeService::PROCESS_HOOK, priority: 10 )]
+	public function process_job( string $job_id ): void {
+		CustomerAgentRuntimeService::instance()->process_job( $job_id );
+	}
+}

--- a/includes/Contracts/CustomerAgentRuntimeInterface.php
+++ b/includes/Contracts/CustomerAgentRuntimeInterface.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Public server-side contract for trusted customer-agent integrations.
+ *
+ * @package SdAiAgent\Contracts
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Contracts;
+
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Defines the versioned PHP API used by trusted same-install integrations.
+ *
+ * Implementations own only a bounded runtime history. The consuming plugin
+ * remains the source of truth for its customer transcript and routing state.
+ */
+interface CustomerAgentRuntimeInterface {
+
+	/**
+	 * Discover the semantic contract version, supported operations, and limits.
+	 *
+	 * @return array{contract_version:string,features:array<string,bool>,limits:array<string,int>}
+	 */
+	public function discover_capabilities(): array;
+
+	/**
+	 * Create or recover the constrained runtime conversation for an external session.
+	 *
+	 * @return array{conversation_id:string,status:string,recovered:bool,expires_at:string}|WP_Error
+	 */
+	public function create_or_recover_conversation( string $integration_key, string $external_session_id ): array|WP_Error;
+
+	/**
+	 * Queue one idempotent customer turn.
+	 *
+	 * @return array{conversation_id:string,job_id:string,status:string,created:bool,expires_at:string}|WP_Error
+	 */
+	public function enqueue_turn( string $integration_key, string $external_session_id, string $external_message_id, string $message ): array|WP_Error;
+
+	/**
+	 * Inspect an external job without consuming its terminal result.
+	 *
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public function inspect_job( string $integration_key, string $external_session_id, string $job_id ): array|WP_Error;
+
+	/**
+	 * Cancel a queued or processing external job.
+	 *
+	 * @return array<string,mixed>|WP_Error
+	 */
+	public function cancel_job( string $integration_key, string $external_session_id, string $job_id ): array|WP_Error;
+
+	/**
+	 * Cancel and purge the runtime conversation owned by an external session.
+	 *
+	 * @return array{conversation_id:string,status:string}|WP_Error
+	 */
+	public function close_conversation( string $integration_key, string $external_session_id ): array|WP_Error;
+}

--- a/includes/Core/Database.php
+++ b/includes/Core/Database.php
@@ -36,7 +36,7 @@ use SdAiAgent\Tools\CustomTools;
 class Database {
 
 	const DB_VERSION_OPTION = 'sd_ai_agent_db_version';
-	const DB_VERSION        = '19.5.6';
+	const DB_VERSION        = '19.6.0';
 
 	// ─── Table Name Registry ──────────────────────────────────────────────────
 
@@ -235,6 +235,24 @@ class Database {
 	}
 
 	/**
+	 * Get the durable customer-agent runtime conversations table name.
+	 */
+	public static function customer_agent_conversations_table_name(): string {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+		return $wpdb->prefix . 'sd_ai_agent_customer_agent_conversations';
+	}
+
+	/**
+	 * Get the durable customer-agent runtime jobs table name.
+	 */
+	public static function customer_agent_jobs_table_name(): string {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+		return $wpdb->prefix . 'sd_ai_agent_customer_agent_jobs';
+	}
+
+	/**
 	 * Get the skill usage table name.
 	 *
 	 * Tracks which skills are loaded per session/model and records
@@ -273,30 +291,32 @@ class Database {
 			return;
 		}
 
-		$table                        = self::table_name();
-		$usage_table                  = self::usage_table_name();
-		$memories_table               = self::memories_table_name();
-		$skills_table                 = self::skills_table_name();
-		$custom_tools_table           = self::custom_tools_table_name();
-		$automations_table            = self::automations_table_name();
-		$automation_logs_table        = self::automation_logs_table_name();
-		$approval_requests_table      = self::approval_requests_table_name();
-		$calendar_reminders_table     = self::calendar_reminders_table_name();
-		$event_automations_table      = self::event_automations_table_name();
-		$conversation_templates_table = self::conversation_templates_table_name();
-		$git_tracked_files_table      = self::git_tracked_files_table_name();
-		$changes_log_table            = self::changes_log_table_name();
-		$modified_files_table         = self::modified_files_table_name();
-		$agents_table                 = self::agents_table_name();
-		$shared_sessions_table        = self::shared_sessions_table_name();
-		$benchmark_runs_table         = self::benchmark_runs_table_name();
-		$benchmark_results_table      = self::benchmark_results_table_name();
-		$provider_trace_table         = self::provider_trace_table_name();
-		$generated_plugins_table      = self::generated_plugins_table_name();
-		$active_jobs_table            = self::active_jobs_table_name();
-		$skill_usage_table            = self::skill_usage_table_name();
-		$contact_mappings_table       = self::contact_mappings_table_name();
-		$charset                      = $wpdb->get_charset_collate();
+		$table                              = self::table_name();
+		$usage_table                        = self::usage_table_name();
+		$memories_table                     = self::memories_table_name();
+		$skills_table                       = self::skills_table_name();
+		$custom_tools_table                 = self::custom_tools_table_name();
+		$automations_table                  = self::automations_table_name();
+		$automation_logs_table              = self::automation_logs_table_name();
+		$approval_requests_table            = self::approval_requests_table_name();
+		$calendar_reminders_table           = self::calendar_reminders_table_name();
+		$event_automations_table            = self::event_automations_table_name();
+		$conversation_templates_table       = self::conversation_templates_table_name();
+		$git_tracked_files_table            = self::git_tracked_files_table_name();
+		$changes_log_table                  = self::changes_log_table_name();
+		$modified_files_table               = self::modified_files_table_name();
+		$agents_table                       = self::agents_table_name();
+		$shared_sessions_table              = self::shared_sessions_table_name();
+		$benchmark_runs_table               = self::benchmark_runs_table_name();
+		$benchmark_results_table            = self::benchmark_results_table_name();
+		$provider_trace_table               = self::provider_trace_table_name();
+		$generated_plugins_table            = self::generated_plugins_table_name();
+		$active_jobs_table                  = self::active_jobs_table_name();
+		$customer_agent_conversations_table = self::customer_agent_conversations_table_name();
+		$customer_agent_jobs_table          = self::customer_agent_jobs_table_name();
+		$skill_usage_table                  = self::skill_usage_table_name();
+		$contact_mappings_table             = self::contact_mappings_table_name();
+		$charset                            = $wpdb->get_charset_collate();
 
 		// Knowledge tables.
 		$sql = KnowledgeDatabase::get_schema( $charset );
@@ -708,6 +728,55 @@ class Database {
 			KEY session_id (session_id),
 			KEY user_id_status (user_id, status),
 			KEY status_updated_at (status, updated_at)
+		) {$charset};
+
+		CREATE TABLE {$customer_agent_conversations_table} (
+			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+			conversation_id varchar(36) NOT NULL,
+			integration_hash binary(64) NOT NULL,
+			external_session_hash binary(64) NOT NULL,
+			profile_id varchar(100) NOT NULL,
+			runtime_history longtext NOT NULL,
+			expires_at datetime NOT NULL,
+			created_at datetime NOT NULL,
+			updated_at datetime NOT NULL,
+			PRIMARY KEY  (id),
+			UNIQUE KEY conversation_id (conversation_id),
+			UNIQUE KEY integration_session (integration_hash, external_session_hash),
+			KEY expires_at (expires_at)
+		) {$charset};
+
+		CREATE TABLE {$customer_agent_jobs_table} (
+			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+			job_id varchar(36) NOT NULL,
+			conversation_id varchar(36) NOT NULL,
+			integration_hash binary(64) NOT NULL,
+			external_session_hash binary(64) NOT NULL,
+			external_message_hash binary(64) NOT NULL,
+			status varchar(20) NOT NULL DEFAULT 'queued',
+			request_payload longtext NOT NULL,
+			profile_snapshot longtext NOT NULL,
+			result_payload longtext NOT NULL,
+			error_code varchar(100) NOT NULL DEFAULT '',
+			error_message text NOT NULL DEFAULT '',
+			provider_id varchar(100) NOT NULL DEFAULT '',
+			model_id varchar(100) NOT NULL DEFAULT '',
+			iterations_used int(10) unsigned NOT NULL DEFAULT 0,
+			prompt_tokens bigint(20) unsigned NOT NULL DEFAULT 0,
+			completion_tokens bigint(20) unsigned NOT NULL DEFAULT 0,
+			started_at datetime NULL,
+			completed_at datetime NULL,
+			cancelled_at datetime NULL,
+			deadline_at datetime NOT NULL,
+			expires_at datetime NOT NULL,
+			created_at datetime NOT NULL,
+			updated_at datetime NOT NULL,
+			PRIMARY KEY  (id),
+			UNIQUE KEY job_id (job_id),
+			UNIQUE KEY integration_session_message (integration_hash, external_session_hash, external_message_hash),
+			KEY conversation_id (conversation_id),
+			KEY status_deadline (status, deadline_at),
+			KEY expires_at (expires_at)
 		) {$charset};
 
 		CREATE TABLE {$skill_usage_table} (

--- a/includes/Core/JobErrorSanitizer.php
+++ b/includes/Core/JobErrorSanitizer.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Customer-safe summaries for low-level background-job failures.
+ *
+ * @package SdAiAgent\Core
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Core;
+
+use SdAiAgent\Abilities\OptionsAbilities;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Removes technical and secret-bearing fragments before job data is exposed.
+ */
+final class JobErrorSanitizer {
+
+	/** Default maximum length for a customer-visible runtime value. */
+	public const DEFAULT_MAX_LENGTH = 180;
+
+	/**
+	 * Return a compact, customer-safe summary, or an empty string when redaction
+	 * removes all useful content.
+	 */
+	public static function sanitize( string $detail, int $max_length = self::DEFAULT_MAX_LENGTH ): string {
+		$detail = trim( wp_strip_all_tags( $detail ) );
+		if ( '' === $detail ) {
+			return '';
+		}
+
+		foreach ( OptionsAbilities::get_secret_read_blocklist() as $secret_option ) {
+			if ( preg_match( '/\b' . preg_quote( $secret_option, '/' ) . '\b/i', $detail ) ) {
+				return '';
+			}
+		}
+
+		$detail = preg_replace( '/#[0-9]+\s+[^;]+/', '[stack_trace]', $detail ) ?? $detail;
+		$detail = preg_replace( '#\b(?:/[^\s;:]+){2,}(?::[0-9]+)?#', '[path]', $detail ) ?? $detail;
+		$detail = preg_replace( '#\b[A-Za-z]:\\\\[^\s;]+#', '[path]', $detail ) ?? $detail;
+		$detail = preg_replace( '/\b(?:api[_-]?key|token|secret|password|credential|authorization)\s*[:=]\s*[^\s;]+/i', '[redacted_credential]', $detail ) ?? $detail;
+		$detail = preg_replace( '/\bsk-[A-Za-z0-9_-]{8,}\b/', '[redacted_token]', $detail ) ?? $detail;
+		$detail = preg_replace( '/\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/', '[redacted_email]', $detail ) ?? $detail;
+		$detail = sanitize_text_field( $detail );
+		$detail = preg_replace( '/\s+/', ' ', $detail ) ?? $detail;
+		$detail = trim( $detail );
+
+		if ( '' === $detail || preg_match( '/^\[(?:path|stack_trace|redacted_credential|redacted_token|redacted_email)\]$/', $detail ) ) {
+			return '';
+		}
+
+		$max_length = max( 1, $max_length );
+		if ( strlen( $detail ) > $max_length ) {
+			$detail = substr( $detail, 0, max( 1, $max_length - 3 ) ) . '...';
+		}
+
+		return $detail;
+	}
+}

--- a/includes/Models/CustomerAgentRuntimeRepository.php
+++ b/includes/Models/CustomerAgentRuntimeRepository.php
@@ -1,0 +1,405 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Durable storage for the customer-agent runtime contract.
+ *
+ * @package SdAiAgent\Models
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Models;
+
+use SdAiAgent\Core\Database;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Stores opaque external conversations and idempotent runtime jobs.
+ */
+class CustomerAgentRuntimeRepository {
+
+	/** Get the customer-agent conversations table name. */
+	public static function conversations_table_name(): string {
+		return Database::customer_agent_conversations_table_name();
+	}
+
+	/** Get the customer-agent jobs table name. */
+	public static function jobs_table_name(): string {
+		return Database::customer_agent_jobs_table_name();
+	}
+
+	/**
+	 * Locate a conversation by its opaque internal identifier.
+	 *
+	 * @return array<string,mixed>|null
+	 */
+	public static function get_conversation( string $conversation_id ): ?array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE conversation_id = %s LIMIT 1',
+				self::conversations_table_name(),
+				$conversation_id
+			),
+			ARRAY_A
+		);
+
+		return self::normalise_row( $row );
+	}
+
+	/**
+	 * Locate a conversation through its hashed integration and external session.
+	 *
+	 * @return array<string,mixed>|null
+	 */
+	public static function find_conversation( string $integration_hash, string $external_session_hash ): ?array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE integration_hash = %s AND external_session_hash = %s LIMIT 1',
+				self::conversations_table_name(),
+				$integration_hash,
+				$external_session_hash
+			),
+			ARRAY_A
+		);
+
+		return self::normalise_row( $row );
+	}
+
+	/**
+	 * Insert an external conversation.
+	 *
+	 * @param array<string,mixed> $data Conversation storage fields.
+	 */
+	public static function create_conversation( array $data ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$result = $wpdb->insert(
+			self::conversations_table_name(),
+			$data,
+			array( '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s' )
+		);
+
+		return false !== $result;
+	}
+
+	/**
+	 * Refresh a conversation's profile and retention window.
+	 */
+	public static function touch_conversation( string $conversation_id, string $profile_id, string $expires_at ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$result = $wpdb->update(
+			self::conversations_table_name(),
+			array(
+				'profile_id' => $profile_id,
+				'expires_at' => $expires_at,
+				'updated_at' => current_time( 'mysql', true ),
+			),
+			array( 'conversation_id' => $conversation_id ),
+			array( '%s', '%s', '%s' ),
+			array( '%s' )
+		);
+
+		return false !== $result;
+	}
+
+	/**
+	 * Persist only the bounded runtime history needed for the next turn.
+	 */
+	public static function update_runtime_history( string $conversation_id, string $history, string $expires_at ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$result = $wpdb->update(
+			self::conversations_table_name(),
+			array(
+				'runtime_history' => $history,
+				'expires_at'      => $expires_at,
+				'updated_at'      => current_time( 'mysql', true ),
+			),
+			array( 'conversation_id' => $conversation_id ),
+			array( '%s', '%s', '%s' ),
+			array( '%s' )
+		);
+
+		return false !== $result;
+	}
+
+	/**
+	 * Find one job by its opaque identifier.
+	 *
+	 * @return array<string,mixed>|null
+	 */
+	public static function get_job( string $job_id ): ?array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE job_id = %s LIMIT 1',
+				self::jobs_table_name(),
+				$job_id
+			),
+			ARRAY_A
+		);
+
+		return self::normalise_row( $row );
+	}
+
+	/**
+	 * Find a job through the idempotency tuple.
+	 *
+	 * @return array<string,mixed>|null
+	 */
+	public static function find_job_by_idempotency( string $integration_hash, string $external_session_hash, string $external_message_hash ): ?array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE integration_hash = %s AND external_session_hash = %s AND external_message_hash = %s LIMIT 1',
+				self::jobs_table_name(),
+				$integration_hash,
+				$external_session_hash,
+				$external_message_hash
+			),
+			ARRAY_A
+		);
+
+		return self::normalise_row( $row );
+	}
+
+	/**
+	 * Insert a queued customer-agent job.
+	 *
+	 * @param array<string,mixed> $data Job storage fields.
+	 */
+	public static function create_job( array $data ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$result = $wpdb->insert(
+			self::jobs_table_name(),
+			$data,
+			array(
+				'%s',
+				'%s',
+				'%s',
+				'%s',
+				'%s',
+				'%s',
+				'%s',
+				'%s',
+				'%s',
+				'%s',
+				'%s',
+				'%s',
+				'%s',
+				'%d',
+				'%d',
+				'%d',
+				'%s',
+				'%s',
+				'%s',
+				'%s',
+				'%s',
+				'%s',
+				'%s',
+			)
+		);
+
+		return false !== $result;
+	}
+
+	/**
+	 * Atomically claim a queued job so concurrent cron events cannot bill twice.
+	 */
+	public static function claim_queued_job( string $job_id, string $now ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE %i SET status = 'processing', started_at = %s, updated_at = %s WHERE job_id = %s AND status = 'queued' AND deadline_at >= %s",
+				self::jobs_table_name(),
+				$now,
+				$now,
+				$job_id,
+				$now
+			)
+		);
+
+		return 1 === (int) $result;
+	}
+
+	/**
+	 * Mark a queued or processing job failed once its delivery deadline passes.
+	 */
+	public static function mark_timed_out( string $job_id, string $now, string $error_code, string $error_message ): bool {
+		return self::mark_terminal_job( $job_id, array( 'queued', 'processing' ), 'failed', $now, $error_code, $error_message );
+	}
+
+	/**
+	 * Mark a queued or processing job as cancelled.
+	 */
+	public static function mark_cancelled( string $job_id, string $now ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE %i SET status = 'cancelled', cancelled_at = %s, completed_at = %s, updated_at = %s WHERE job_id = %s AND status IN ('queued', 'processing')",
+				self::jobs_table_name(),
+				$now,
+				$now,
+				$now,
+				$job_id
+			)
+		);
+
+		return 1 === (int) $result;
+	}
+
+	/**
+	 * Persist a terminal failed state unless cancellation already won the race.
+	 */
+	public static function mark_failed( string $job_id, string $now, string $error_code, string $error_message ): bool {
+		return self::mark_terminal_job( $job_id, array( 'queued', 'processing' ), 'failed', $now, $error_code, $error_message );
+	}
+
+	/**
+	 * Persist a complete result only while the job is still processing.
+	 *
+	 * This conditional update prevents a late provider result from becoming
+	 * deliverable after cancellation or timeout.
+	 */
+	public static function mark_complete( string $job_id, string $now, string $result_payload, string $provider_id, string $model_id, int $iterations_used, int $prompt_tokens, int $completion_tokens ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE %i SET status = 'complete', result_payload = %s, provider_id = %s, model_id = %s, iterations_used = %d, prompt_tokens = %d, completion_tokens = %d, error_code = '', error_message = '', completed_at = %s, updated_at = %s WHERE job_id = %s AND status = 'processing'",
+				self::jobs_table_name(),
+				$result_payload,
+				$provider_id,
+				$model_id,
+				$iterations_used,
+				$prompt_tokens,
+				$completion_tokens,
+				$now,
+				$now,
+				$job_id
+			)
+		);
+
+		return 1 === (int) $result;
+	}
+
+	/**
+	 * Return every job identifier that belongs to a conversation, then purge it.
+	 *
+	 * @return array{deleted:bool,job_ids:list<string>}
+	 */
+	public static function purge_conversation( string $conversation_id ): array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$raw_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				'SELECT job_id FROM %i WHERE conversation_id = %s',
+				self::jobs_table_name(),
+				$conversation_id
+			)
+		);
+		$job_ids = array();
+		foreach ( $raw_ids as $raw_id ) {
+			if ( is_string( $raw_id ) && '' !== $raw_id ) {
+				$job_ids[] = $raw_id;
+			}
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Purging a private runtime record requires an atomic direct delete.
+		$wpdb->delete( self::jobs_table_name(), array( 'conversation_id' => $conversation_id ), array( '%s' ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Purging a private runtime record requires an atomic direct delete.
+		$deleted = $wpdb->delete( self::conversations_table_name(), array( 'conversation_id' => $conversation_id ), array( '%s' ) );
+
+		return array(
+			'deleted' => false !== $deleted,
+			'job_ids' => $job_ids,
+		);
+	}
+
+	/**
+	 * Convert a WordPress database result into an associative storage map.
+	 *
+	 * @param mixed $row Raw database row.
+	 * @return array<string,mixed>|null
+	 */
+	private static function normalise_row( mixed $row ): ?array {
+		if ( ! is_array( $row ) ) {
+			return null;
+		}
+
+		$normalised = array();
+		foreach ( $row as $key => $value ) {
+			if ( ! is_string( $key ) ) {
+				return null;
+			}
+			$normalised[ $key ] = $value;
+		}
+
+		return $normalised;
+	}
+
+	/**
+	 * Update a terminal active-job row without letting it override cancellation.
+	 *
+	 * @param string $job_id        Runtime job identifier.
+	 * @param array  $from_statuses Expected current runtime statuses.
+	 * @phpstan-param list<string> $from_statuses
+	 * @param string $new_status    Terminal runtime status.
+	 * @param string $now           Current UTC MySQL timestamp.
+	 * @param string $error_code    Stable public error code.
+	 * @param string $error_message Customer-safe error message.
+	 */
+	private static function mark_terminal_job( string $job_id, array $from_statuses, string $new_status, string $now, string $error_code, string $error_message ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		if ( empty( $from_statuses ) ) {
+			return false;
+		}
+
+		$placeholders = implode( ', ', array_fill( 0, count( $from_statuses ), '%s' ) );
+		$sql          = "UPDATE %i SET status = %s, error_code = %s, error_message = %s, completed_at = %s, updated_at = %s WHERE job_id = %s AND status IN ({$placeholders})";
+		$args         = array_merge(
+			array(
+				self::jobs_table_name(),
+				$new_status,
+				$error_code,
+				$error_message,
+				$now,
+				$now,
+				$job_id,
+			),
+			$from_statuses
+		);
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Status placeholders are generated internally and every value is passed to wpdb::prepare().
+		$result = $wpdb->query( $wpdb->prepare( $sql, ...$args ) );
+
+		return 1 === (int) $result;
+	}
+}

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -34,6 +34,7 @@ use SdAiAgent\Bootstrap\AiClientEventTraceHandler;
 use SdAiAgent\Bootstrap\AutomationsHandler;
 use SdAiAgent\Bootstrap\ChangeLoggingHandler;
 use SdAiAgent\Bootstrap\CliHandler;
+use SdAiAgent\Bootstrap\CustomerAgentRuntimeHandler;
 use SdAiAgent\Bootstrap\FrontendAssetsHandler;
 use SdAiAgent\Bootstrap\HealthEndpointHandler;
 use SdAiAgent\Bootstrap\HttpTraceHandler;
@@ -114,6 +115,7 @@ use XWP\DI\Decorators\Module;
 		HealthEndpointHandler::class,
 		AutomationsHandler::class,
 		OnboardingHandler::class,
+		CustomerAgentRuntimeHandler::class,
 		CachePolicy::class,
 		FrontendAssetsHandler::class,
 		MemoryController::class,

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace SdAiAgent\REST;
 
-use SdAiAgent\Abilities\OptionsAbilities;
 use SdAiAgent\Core\AgentLoop;
 use SdAiAgent\Core\ConversationDisplaySanitizer;
 use SdAiAgent\Core\ConversationSerializer;
@@ -19,6 +18,7 @@ use SdAiAgent\Core\ConversationTrimmer;
 use SdAiAgent\Core\CostCalculator;
 use SdAiAgent\Core\Database;
 use SdAiAgent\Core\Export;
+use SdAiAgent\Core\JobErrorSanitizer;
 use SdAiAgent\Core\Settings;
 use SdAiAgent\Core\ToolPermissionResolver;
 use SdAiAgent\Models\ActiveJobRepository;
@@ -1538,36 +1538,7 @@ final class SessionController {
 	 * @return string Bounded, client-safe summary, or empty string when fully redacted.
 	 */
 	private function sanitize_job_error_detail( string $detail ): string {
-		$detail = trim( wp_strip_all_tags( $detail ) );
-		if ( '' === $detail ) {
-			return '';
-		}
-
-		foreach ( OptionsAbilities::get_secret_read_blocklist() as $secret_option ) {
-			if ( preg_match( '/\b' . preg_quote( $secret_option, '/' ) . '\b/i', $detail ) ) {
-				return '';
-			}
-		}
-
-		$detail = preg_replace( '/#[0-9]+\s+[^;]+/', '[stack_trace]', $detail ) ?? $detail;
-		$detail = preg_replace( '#\b(?:/[^\s;:]+){2,}(?::[0-9]+)?#', '[path]', $detail ) ?? $detail;
-		$detail = preg_replace( '#\b[A-Za-z]:\\\\[^\s;]+#', '[path]', $detail ) ?? $detail;
-		$detail = preg_replace( '/\b(?:api[_-]?key|token|secret|password|credential|authorization)\s*[:=]\s*[^\s;]+/i', '[redacted_credential]', $detail ) ?? $detail;
-		$detail = preg_replace( '/\bsk-[A-Za-z0-9_-]{8,}\b/', '[redacted_token]', $detail ) ?? $detail;
-		$detail = preg_replace( '/\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/', '[redacted_email]', $detail ) ?? $detail;
-		$detail = sanitize_text_field( $detail );
-		$detail = preg_replace( '/\s+/', ' ', $detail ) ?? $detail;
-		$detail = trim( $detail );
-
-		if ( '' === $detail || preg_match( '/^\[(?:path|stack_trace|redacted_credential|redacted_token|redacted_email)\]$/', $detail ) ) {
-			return '';
-		}
-
-		if ( strlen( $detail ) > self::JOB_ERROR_DETAIL_MAX_LENGTH ) {
-			$detail = substr( $detail, 0, self::JOB_ERROR_DETAIL_MAX_LENGTH - 3 ) . '...';
-		}
-
-		return $detail;
+		return JobErrorSanitizer::sanitize( $detail, self::JOB_ERROR_DETAIL_MAX_LENGTH );
 	}
 
 	/**

--- a/includes/Services/CustomerAgentRuntimeService.php
+++ b/includes/Services/CustomerAgentRuntimeService.php
@@ -1,0 +1,1069 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Versioned PHP runtime for trusted customer-facing integrations.
+ *
+ * @package SdAiAgent\Services
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Services;
+
+use SdAiAgent\Contracts\CustomerAgentRuntimeInterface;
+use SdAiAgent\Core\AgentLoop;
+use SdAiAgent\Core\ConversationSerializer;
+use SdAiAgent\Core\ConversationTrimmer;
+use SdAiAgent\Core\JobErrorSanitizer;
+use SdAiAgent\Models\ActiveJobRepository;
+use SdAiAgent\Models\CustomerAgentRuntimeRepository;
+use WP_Error;
+use WordPress\AiClient\Messages\DTO\Message;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Executes constrained asynchronous customer turns without exposing REST tokens.
+ *
+ * @phpstan-type RuntimeProfile array{
+ *     profile_id: string,
+ *     system_instruction: string,
+ *     abilities: list<string>,
+ *     collections: list<string>,
+ *     provider_id: string,
+ *     model_id: string,
+ *     max_message_length: int,
+ *     max_history_turns: int,
+ *     max_iterations: int,
+ *     max_runtime_seconds: int
+ * }
+ */
+class CustomerAgentRuntimeService implements CustomerAgentRuntimeInterface {
+
+	/** Semantic version consumers use for fail-closed compatibility checks. */
+	public const CONTRACT_VERSION = '1.0.0';
+
+	/** WP-Cron hook used exclusively by the durable runtime queue. */
+	public const PROCESS_HOOK = 'sd_ai_agent_customer_agent_process_job';
+
+	/** Runtime data is retained for at least seven days after creation. */
+	public const RETENTION_SECONDS = 604800;
+
+	private const DEFAULT_MAX_MESSAGE_LENGTH  = 4000;
+	private const MAX_MESSAGE_LENGTH          = 12000;
+	private const DEFAULT_MAX_HISTORY_TURNS   = 8;
+	private const MAX_HISTORY_TURNS           = 20;
+	private const DEFAULT_MAX_ITERATIONS      = 6;
+	private const MAX_ITERATIONS              = 12;
+	private const DEFAULT_MAX_RUNTIME_SECONDS = 120;
+	private const MAX_RUNTIME_SECONDS         = 600;
+	private const MAX_REPLY_LENGTH            = 12000;
+
+	/** @var list<string> V1 forbids meta-tools, mutations, browser, and client tools. */
+	private const SAFE_ABILITIES = array( 'sd-ai-agent/knowledge-search' );
+
+	private static ?self $instance = null;
+
+	/**
+	 * Optional test seam. Production execution always uses AgentLoop directly.
+	 *
+	 * @var callable|null
+	 */
+	private $executor;
+
+	/**
+	 * @param callable|null $executor Test-only callable accepting job, conversation, and profile arrays.
+	 */
+	public function __construct( ?callable $executor = null ) {
+		$this->executor = $executor;
+	}
+
+	/** Return the stable singleton exposed by the plugin-level PHP function. */
+	public static function instance(): self {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function discover_capabilities(): array {
+		return array(
+			'contract_version' => self::CONTRACT_VERSION,
+			'features'         => array(
+				'durable_jobs'             => true,
+				'idempotent_enqueue'       => true,
+				'non_consuming_polling'    => true,
+				'cancellation'             => true,
+				'opaque_identifiers'       => true,
+				'client_tools_supported'   => false,
+				'attachments_supported'    => false,
+				'caller_prompts_supported' => false,
+			),
+			'limits'           => array(
+				'max_message_length'  => self::MAX_MESSAGE_LENGTH,
+				'max_history_turns'   => self::MAX_HISTORY_TURNS,
+				'max_iterations'      => self::MAX_ITERATIONS,
+				'max_runtime_seconds' => self::MAX_RUNTIME_SECONDS,
+				'retention_seconds'   => self::RETENTION_SECONDS,
+			),
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function create_or_recover_conversation( string $integration_key, string $external_session_id ): array|WP_Error {
+		$profile = $this->resolve_integration( $integration_key );
+		if ( is_wp_error( $profile ) ) {
+			return $profile;
+		}
+
+		$external_session_id = $this->validate_external_identifier( $external_session_id, 'session' );
+		if ( is_wp_error( $external_session_id ) ) {
+			return $external_session_id;
+		}
+
+		$conversation = $this->get_or_create_conversation( $integration_key, $external_session_id, $profile );
+		if ( is_wp_error( $conversation ) ) {
+			return $conversation;
+		}
+
+		return array(
+			'conversation_id' => (string) $conversation['row']['conversation_id'],
+			'status'          => 'open',
+			'recovered'       => (bool) $conversation['recovered'],
+			'expires_at'      => (string) $conversation['row']['expires_at'],
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function enqueue_turn( string $integration_key, string $external_session_id, string $external_message_id, string $message ): array|WP_Error {
+		$profile = $this->resolve_integration( $integration_key );
+		if ( is_wp_error( $profile ) ) {
+			return $profile;
+		}
+
+		$external_session_id = $this->validate_external_identifier( $external_session_id, 'session' );
+		if ( is_wp_error( $external_session_id ) ) {
+			return $external_session_id;
+		}
+		$external_message_id = $this->validate_external_identifier( $external_message_id, 'message' );
+		if ( is_wp_error( $external_message_id ) ) {
+			return $external_message_id;
+		}
+
+		$message = trim( wp_strip_all_tags( wp_check_invalid_utf8( $message ) ) );
+		if ( '' === $message ) {
+			return new WP_Error(
+				'sd_ai_agent_customer_agent_empty_message',
+				__( 'A customer message is required.', 'superdav-ai-agent' ),
+				array( 'status' => 400 )
+			);
+		}
+		if ( strlen( $message ) > $profile['max_message_length'] ) {
+			return new WP_Error(
+				'sd_ai_agent_customer_agent_message_too_long',
+				__( 'The customer message exceeds this runtime profile limit.', 'superdav-ai-agent' ),
+				array( 'status' => 413 )
+			);
+		}
+
+		$conversation = $this->get_or_create_conversation( $integration_key, $external_session_id, $profile );
+		if ( is_wp_error( $conversation ) ) {
+			return $conversation;
+		}
+
+		$integration_hash      = $this->hash_identifier( 'integration', $integration_key );
+		$external_session_hash = $this->hash_identifier( 'session', $external_session_id );
+		$external_message_hash = $this->hash_identifier( 'message', $external_message_id );
+		$existing              = CustomerAgentRuntimeRepository::find_job_by_idempotency(
+			$integration_hash,
+			$external_session_hash,
+			$external_message_hash
+		);
+
+		if ( null !== $existing ) {
+			return $this->enqueue_response( $existing, false );
+		}
+
+		$now                         = current_time( 'mysql', true );
+		$expires_at                  = $this->future_mysql_time( self::RETENTION_SECONDS );
+		$deadline                    = $this->future_mysql_time( $profile['max_runtime_seconds'] );
+		$job_id                      = wp_generate_uuid4();
+		$snapshot                    = $profile;
+		$snapshot['integration_key'] = sanitize_key( $integration_key );
+		$request_payload             = wp_json_encode( array( 'message' => $message ) );
+		$profile_snapshot            = wp_json_encode( $snapshot );
+
+		if ( ! is_string( $request_payload ) || ! is_string( $profile_snapshot ) ) {
+			return new WP_Error(
+				'sd_ai_agent_customer_agent_storage_failed',
+				__( 'The customer-agent runtime could not persist the request.', 'superdav-ai-agent' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$created = CustomerAgentRuntimeRepository::create_job(
+			array(
+				'job_id'                => $job_id,
+				'conversation_id'       => (string) $conversation['row']['conversation_id'],
+				'integration_hash'      => $integration_hash,
+				'external_session_hash' => $external_session_hash,
+				'external_message_hash' => $external_message_hash,
+				'status'                => 'queued',
+				'request_payload'       => $request_payload,
+				'profile_snapshot'      => $profile_snapshot,
+				'result_payload'        => '{}',
+				'error_code'            => '',
+				'error_message'         => '',
+				'provider_id'           => $profile['provider_id'],
+				'model_id'              => $profile['model_id'],
+				'iterations_used'       => 0,
+				'prompt_tokens'         => 0,
+				'completion_tokens'     => 0,
+				'started_at'            => null,
+				'completed_at'          => null,
+				'cancelled_at'          => null,
+				'deadline_at'           => $deadline,
+				'expires_at'            => $expires_at,
+				'created_at'            => $now,
+				'updated_at'            => $now,
+			)
+		);
+
+		if ( ! $created ) {
+			// The unique idempotency index is the concurrency gate. A conflicting
+			// insert means another request already owns this external message.
+			$existing = CustomerAgentRuntimeRepository::find_job_by_idempotency(
+				$integration_hash,
+				$external_session_hash,
+				$external_message_hash
+			);
+			if ( null !== $existing ) {
+				return $this->enqueue_response( $existing, false );
+			}
+
+			return new WP_Error(
+				'sd_ai_agent_customer_agent_storage_failed',
+				__( 'The customer-agent runtime could not queue the request.', 'superdav-ai-agent' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$queued = CustomerAgentRuntimeRepository::get_job( $job_id );
+		if ( null === $queued ) {
+			return new WP_Error(
+				'sd_ai_agent_customer_agent_storage_failed',
+				__( 'The customer-agent runtime could not load the queued request.', 'superdav-ai-agent' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$this->emit_lifecycle_event( 'queued', $queued );
+		$scheduled = wp_schedule_single_event( time(), self::PROCESS_HOOK, array( $job_id ), true );
+		if ( false === $scheduled || is_wp_error( $scheduled ) ) {
+			$this->fail_job(
+				$queued,
+				'sd_ai_agent_customer_agent_queue_unavailable',
+				__( 'The customer-agent runtime could not schedule the request.', 'superdav-ai-agent' )
+			);
+			return new WP_Error(
+				'sd_ai_agent_customer_agent_queue_unavailable',
+				__( 'The customer-agent runtime could not schedule the request.', 'superdav-ai-agent' ),
+				array( 'status' => 503 )
+			);
+		}
+
+		if ( function_exists( 'spawn_cron' ) ) {
+			spawn_cron();
+		}
+
+		return $this->enqueue_response( $queued, true );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function inspect_job( string $integration_key, string $external_session_id, string $job_id ): array|WP_Error {
+		$owned_job = $this->find_owned_job( $integration_key, $external_session_id, $job_id );
+		if ( is_wp_error( $owned_job ) ) {
+			return $owned_job;
+		}
+
+		if ( $this->deadline_has_passed( $owned_job ) ) {
+			$this->mark_job_timed_out( $owned_job );
+			$owned_job = CustomerAgentRuntimeRepository::get_job( $job_id ) ?? $owned_job;
+		}
+
+		return $this->public_job_dto( $owned_job );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function cancel_job( string $integration_key, string $external_session_id, string $job_id ): array|WP_Error {
+		$owned_job = $this->find_owned_job( $integration_key, $external_session_id, $job_id );
+		if ( is_wp_error( $owned_job ) ) {
+			return $owned_job;
+		}
+
+		if ( 'cancelled' === $owned_job['status'] ) {
+			return $this->public_job_dto( $owned_job );
+		}
+		if ( ! in_array( $owned_job['status'], array( 'queued', 'processing' ), true ) ) {
+			return new WP_Error(
+				'sd_ai_agent_customer_agent_job_not_cancellable',
+				__( 'The customer-agent job is already terminal.', 'superdav-ai-agent' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		$now = current_time( 'mysql', true );
+		if ( CustomerAgentRuntimeRepository::mark_cancelled( $job_id, $now ) ) {
+			ActiveJobRepository::update_status(
+				$job_id,
+				'error',
+				array( 'error' => 'Customer-agent runtime cancelled before result delivery.' )
+			);
+			$cancelled = CustomerAgentRuntimeRepository::get_job( $job_id );
+			if ( null !== $cancelled ) {
+				$this->emit_lifecycle_event( 'cancelled', $cancelled );
+				return $this->public_job_dto( $cancelled );
+			}
+		}
+
+		$latest = CustomerAgentRuntimeRepository::get_job( $job_id );
+		if ( null !== $latest && 'cancelled' === $latest['status'] ) {
+			return $this->public_job_dto( $latest );
+		}
+
+		return new WP_Error(
+			'sd_ai_agent_customer_agent_job_not_cancellable',
+			__( 'The customer-agent job is already terminal.', 'superdav-ai-agent' ),
+			array( 'status' => 409 )
+		);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function close_conversation( string $integration_key, string $external_session_id ): array|WP_Error {
+		$profile = $this->resolve_integration( $integration_key );
+		if ( is_wp_error( $profile ) ) {
+			return $profile;
+		}
+		$external_session_id = $this->validate_external_identifier( $external_session_id, 'session' );
+		if ( is_wp_error( $external_session_id ) ) {
+			return $external_session_id;
+		}
+
+		$conversation = CustomerAgentRuntimeRepository::find_conversation(
+			$this->hash_identifier( 'integration', $integration_key ),
+			$this->hash_identifier( 'session', $external_session_id )
+		);
+		if ( null === $conversation ) {
+			return new WP_Error(
+				'sd_ai_agent_customer_agent_conversation_not_found',
+				__( 'Customer-agent conversation not found.', 'superdav-ai-agent' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$purged = CustomerAgentRuntimeRepository::purge_conversation( (string) $conversation['conversation_id'] );
+		if ( ! $purged['deleted'] ) {
+			return new WP_Error(
+				'sd_ai_agent_customer_agent_storage_failed',
+				__( 'The customer-agent runtime could not close the conversation.', 'superdav-ai-agent' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		foreach ( $purged['job_ids'] as $job_id ) {
+			ActiveJobRepository::delete( $job_id );
+		}
+		$this->emit_lifecycle_event(
+			'closed',
+			array(
+				'integration_hash' => (string) $conversation['integration_hash'],
+				'conversation_id'  => (string) $conversation['conversation_id'],
+				'job_id'           => '',
+			)
+		);
+
+		return array(
+			'conversation_id' => (string) $conversation['conversation_id'],
+			'status'          => 'closed',
+		);
+	}
+
+	/**
+	 * Run the queued job. Called only by the DI-wired WP-Cron hook.
+	 */
+	public function process_job( string $job_id ): void {
+		$job = CustomerAgentRuntimeRepository::get_job( $job_id );
+		if ( null === $job ) {
+			return;
+		}
+		if ( $this->deadline_has_passed( $job ) ) {
+			$this->mark_job_timed_out( $job );
+			return;
+		}
+
+		$now = current_time( 'mysql', true );
+		if ( ! CustomerAgentRuntimeRepository::claim_queued_job( $job_id, $now ) ) {
+			return;
+		}
+		$job = CustomerAgentRuntimeRepository::get_job( $job_id );
+		if ( null === $job ) {
+			return;
+		}
+
+		if ( null === ActiveJobRepository::get_by_job_id( $job_id ) ) {
+			if ( false === ActiveJobRepository::create( 0, $job_id, 0 ) ) {
+				$this->fail_job(
+					$job,
+					'sd_ai_agent_customer_agent_storage_failed',
+					__( 'The customer-agent runtime could not prepare the request.', 'superdav-ai-agent' )
+				);
+				return;
+			}
+		} else {
+			ActiveJobRepository::update_status( $job_id, 'processing' );
+		}
+		$this->emit_lifecycle_event( 'processing', $job );
+
+		$profile_snapshot = $this->decode_object( (string) $job['profile_snapshot'] );
+		$integration_key  = isset( $profile_snapshot['integration_key'] ) && is_string( $profile_snapshot['integration_key'] )
+			? $profile_snapshot['integration_key']
+			: '';
+		$profile          = $this->resolve_integration( $integration_key );
+		if ( $profile instanceof WP_Error ) {
+			$this->fail_job(
+				$job,
+				'sd_ai_agent_customer_agent_profile_unavailable',
+				__( 'The customer-agent profile is no longer available.', 'superdav-ai-agent' )
+			);
+			return;
+		}
+
+		$conversation = CustomerAgentRuntimeRepository::get_conversation( (string) $job['conversation_id'] );
+		if ( null === $conversation ) {
+			$this->fail_job(
+				$job,
+				'sd_ai_agent_customer_agent_conversation_not_found',
+				__( 'The customer-agent conversation is no longer available.', 'superdav-ai-agent' )
+			);
+			return;
+		}
+
+		$result = $this->execute_turn( $job, $conversation, $profile );
+		if ( is_wp_error( $result ) ) {
+			$this->fail_job( $job, 'sd_ai_agent_customer_agent_execution_failed', $result->get_error_message() );
+			return;
+		}
+		if ( ! is_array( $result ) || ! empty( $result['awaiting_confirmation'] ) || ! empty( $result['pending_client_tool_calls'] ) ) {
+			$this->fail_job(
+				$job,
+				'sd_ai_agent_customer_agent_unsupported_pause',
+				__( 'The customer-agent runtime may not wait for client tools or confirmations.', 'superdav-ai-agent' )
+			);
+			return;
+		}
+
+		if ( $this->deadline_has_passed( $job ) ) {
+			$this->mark_job_timed_out( $job );
+			return;
+		}
+
+		$history = $this->bounded_serialized_history( $result['history'] ?? array(), $profile['max_history_turns'] );
+		$reply   = JobErrorSanitizer::sanitize( (string) ( $result['reply'] ?? '' ), self::MAX_REPLY_LENGTH );
+		$tokens  = isset( $result['token_usage'] ) && is_array( $result['token_usage'] ) ? $result['token_usage'] : array();
+		$payload = wp_json_encode(
+			array(
+				'reply'           => $reply,
+				'provider_id'     => $profile['provider_id'],
+				'model_id'        => (string) ( $result['model_id'] ?? $profile['model_id'] ),
+				'iterations_used' => (int) ( $result['iterations_used'] ?? 0 ),
+				'token_usage'     => array(
+					'prompt'     => (int) ( $tokens['prompt'] ?? 0 ),
+					'completion' => (int) ( $tokens['completion'] ?? 0 ),
+				),
+			)
+		);
+		if ( ! is_string( $payload ) ) {
+			$this->fail_job(
+				$job,
+				'sd_ai_agent_customer_agent_storage_failed',
+				__( 'The customer-agent runtime could not persist the result.', 'superdav-ai-agent' )
+			);
+			return;
+		}
+
+		$completed = CustomerAgentRuntimeRepository::mark_complete(
+			$job_id,
+			current_time( 'mysql', true ),
+			$payload,
+			$profile['provider_id'],
+			(string) ( $result['model_id'] ?? $profile['model_id'] ),
+			(int) ( $result['iterations_used'] ?? 0 ),
+			(int) ( $tokens['prompt'] ?? 0 ),
+			(int) ( $tokens['completion'] ?? 0 )
+		);
+		if ( ! $completed ) {
+			// Cancellation and timeout both win this conditional-write race. A late
+			// provider result is deliberately discarded instead of becoming visible.
+			return;
+		}
+
+		$history_json = wp_json_encode( $history );
+		if ( is_string( $history_json ) ) {
+			CustomerAgentRuntimeRepository::update_runtime_history(
+				(string) $job['conversation_id'],
+				$history_json,
+				$this->future_mysql_time( self::RETENTION_SECONDS )
+			);
+		}
+		ActiveJobRepository::update_status( $job_id, 'complete' );
+		$completed_job = CustomerAgentRuntimeRepository::get_job( $job_id );
+		if ( null !== $completed_job ) {
+			$this->emit_lifecycle_event( 'complete', $completed_job );
+		}
+	}
+
+	/**
+	 * Resolve a trusted integration profile from server-side registration only.
+	 *
+	 * @return RuntimeProfile|WP_Error
+	 */
+	private function resolve_integration( string $integration_key ): array|WP_Error {
+		$integration_key = sanitize_key( $integration_key );
+		if ( '' === $integration_key ) {
+			return new WP_Error(
+				'sd_ai_agent_customer_agent_unknown_integration',
+				__( 'Customer-agent integration is not registered.', 'superdav-ai-agent' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		/**
+		 * Registers trusted same-install customer-agent profiles.
+		 *
+		 * @param array<string,array<string,mixed>> $integrations Integration-key map.
+		 */
+		$integrations = apply_filters( 'sd_ai_agent_customer_agent_integrations', array() );
+		$config       = is_array( $integrations ) && isset( $integrations[ $integration_key ] ) && is_array( $integrations[ $integration_key ] )
+			? $integrations[ $integration_key ]
+			: null;
+		if ( ! is_array( $config ) ) {
+			return new WP_Error(
+				'sd_ai_agent_customer_agent_unknown_integration',
+				__( 'Customer-agent integration is not registered.', 'superdav-ai-agent' ),
+				array( 'status' => 403 )
+			);
+		}
+		if ( empty( $config['enabled'] ) ) {
+			return new WP_Error(
+				'sd_ai_agent_customer_agent_profile_disabled',
+				__( 'Customer-agent profile is disabled.', 'superdav-ai-agent' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		$profile_id         = sanitize_key( (string) ( $config['profile'] ?? '' ) );
+		$system_instruction = trim( (string) ( $config['system_instruction'] ?? '' ) );
+		$abilities          = $this->sanitize_string_list( $config['abilities'] ?? array(), false );
+		$collections        = $this->sanitize_string_list( $config['collections'] ?? array(), true );
+		if ( '' === $profile_id || '' === $system_instruction || empty( $abilities ) || empty( $collections ) || ! empty( array_diff( $abilities, self::SAFE_ABILITIES ) ) ) {
+			return new WP_Error(
+				'sd_ai_agent_customer_agent_invalid_profile',
+				__( 'Customer-agent profile is not safely configured.', 'superdav-ai-agent' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return array(
+			'profile_id'          => $profile_id,
+			'system_instruction'  => $system_instruction,
+			'abilities'           => $abilities,
+			'collections'         => $collections,
+			'provider_id'         => sanitize_text_field( (string) ( $config['provider_id'] ?? '' ) ),
+			'model_id'            => sanitize_text_field( (string) ( $config['model_id'] ?? '' ) ),
+			'max_message_length'  => $this->bounded_setting( $config['max_message_length'] ?? self::DEFAULT_MAX_MESSAGE_LENGTH, 256, self::MAX_MESSAGE_LENGTH ),
+			'max_history_turns'   => $this->bounded_setting( $config['max_history_turns'] ?? self::DEFAULT_MAX_HISTORY_TURNS, 1, self::MAX_HISTORY_TURNS ),
+			'max_iterations'      => $this->bounded_setting( $config['max_iterations'] ?? self::DEFAULT_MAX_ITERATIONS, 1, self::MAX_ITERATIONS ),
+			'max_runtime_seconds' => $this->bounded_setting( $config['max_runtime_seconds'] ?? self::DEFAULT_MAX_RUNTIME_SECONDS, 30, self::MAX_RUNTIME_SECONDS ),
+		);
+	}
+
+	/**
+	 * Get or atomically create a runtime conversation for one external session.
+	 *
+	 * @param string              $integration_key     Trusted same-install integration key.
+	 * @param string              $external_session_id Consumer-owned opaque session identifier.
+	 * @param array<string,mixed> $profile Safe profile configuration.
+	 * @phpstan-param RuntimeProfile $profile
+	 * @return array{row:array<string,mixed>,recovered:bool}|WP_Error
+	 */
+	private function get_or_create_conversation( string $integration_key, string $external_session_id, array $profile ): array|WP_Error {
+		$integration_hash      = $this->hash_identifier( 'integration', $integration_key );
+		$external_session_hash = $this->hash_identifier( 'session', $external_session_id );
+		$expires_at            = $this->future_mysql_time( self::RETENTION_SECONDS );
+		$existing              = CustomerAgentRuntimeRepository::find_conversation( $integration_hash, $external_session_hash );
+		if ( null !== $existing ) {
+			CustomerAgentRuntimeRepository::touch_conversation( (string) $existing['conversation_id'], $profile['profile_id'], $expires_at );
+			$existing['profile_id'] = $profile['profile_id'];
+			$existing['expires_at'] = $expires_at;
+			return array(
+				'row'       => $existing,
+				'recovered' => true,
+			);
+		}
+
+		$now             = current_time( 'mysql', true );
+		$conversation_id = wp_generate_uuid4();
+		$created         = CustomerAgentRuntimeRepository::create_conversation(
+			array(
+				'conversation_id'       => $conversation_id,
+				'integration_hash'      => $integration_hash,
+				'external_session_hash' => $external_session_hash,
+				'profile_id'            => $profile['profile_id'],
+				'runtime_history'       => '[]',
+				'expires_at'            => $expires_at,
+				'created_at'            => $now,
+				'updated_at'            => $now,
+			)
+		);
+		if ( ! $created ) {
+			$existing = CustomerAgentRuntimeRepository::find_conversation( $integration_hash, $external_session_hash );
+			if ( null !== $existing ) {
+				return array(
+					'row'       => $existing,
+					'recovered' => true,
+				);
+			}
+
+			return new WP_Error(
+				'sd_ai_agent_customer_agent_storage_failed',
+				__( 'The customer-agent runtime could not create the conversation.', 'superdav-ai-agent' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$row = CustomerAgentRuntimeRepository::get_conversation( $conversation_id );
+		if ( null === $row ) {
+			return new WP_Error(
+				'sd_ai_agent_customer_agent_storage_failed',
+				__( 'The customer-agent runtime could not load the conversation.', 'superdav-ai-agent' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		$this->emit_lifecycle_event( 'conversation_created', array_merge( $row, array( 'job_id' => '' ) ) );
+		return array(
+			'row'       => $row,
+			'recovered' => false,
+		);
+	}
+
+	/**
+	 * Check that an opaque job belongs to the requesting integration/session.
+	 *
+	 * @return array<string,mixed>|WP_Error
+	 */
+	private function find_owned_job( string $integration_key, string $external_session_id, string $job_id ): array|WP_Error {
+		$profile = $this->resolve_integration( $integration_key );
+		if ( is_wp_error( $profile ) ) {
+			return $profile;
+		}
+		$external_session_id = $this->validate_external_identifier( $external_session_id, 'session' );
+		if ( is_wp_error( $external_session_id ) ) {
+			return $external_session_id;
+		}
+		$job_id = trim( $job_id );
+		if ( '' === $job_id || strlen( $job_id ) > 64 ) {
+			return new WP_Error(
+				'sd_ai_agent_customer_agent_job_not_found',
+				__( 'Customer-agent job not found.', 'superdav-ai-agent' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$conversation = CustomerAgentRuntimeRepository::find_conversation(
+			$this->hash_identifier( 'integration', $integration_key ),
+			$this->hash_identifier( 'session', $external_session_id )
+		);
+		if ( null === $conversation ) {
+			return new WP_Error(
+				'sd_ai_agent_customer_agent_conversation_not_found',
+				__( 'Customer-agent conversation not found.', 'superdav-ai-agent' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$job = CustomerAgentRuntimeRepository::get_job( $job_id );
+		if ( null === $job || ! hash_equals( (string) $conversation['conversation_id'], (string) $job['conversation_id'] ) ) {
+			return new WP_Error(
+				'sd_ai_agent_customer_agent_job_not_found',
+				__( 'Customer-agent job not found.', 'superdav-ai-agent' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		return $job;
+	}
+
+	/**
+	 * Run AgentLoop with server-owned profile configuration and no client inputs.
+	 *
+	 * @param array<string,mixed> $job          Durable job row.
+	 * @param array<string,mixed> $conversation Durable conversation row.
+	 * @param array<string,mixed> $profile      Current registered profile.
+	 * @phpstan-param RuntimeProfile $profile
+	 * @return array<string,mixed>|WP_Error
+	 */
+	private function execute_turn( array $job, array $conversation, array $profile ): array|WP_Error {
+		if ( null !== $this->executor ) {
+			$result = call_user_func( $this->executor, $job, $conversation, $profile );
+			if ( $result instanceof WP_Error ) {
+				return $result;
+			}
+			$result = $this->normalise_associative_array( $result );
+			if ( null !== $result ) {
+				return $result;
+			}
+
+			return new WP_Error(
+				'sd_ai_agent_customer_agent_execution_failed',
+				__( 'The customer-agent executor returned an invalid result.', 'superdav-ai-agent' )
+			);
+		}
+
+		$request = $this->decode_object( (string) $job['request_payload'] );
+		$message = isset( $request['message'] ) && is_string( $request['message'] ) ? $request['message'] : '';
+		if ( '' === $message ) {
+			return new WP_Error(
+				'sd_ai_agent_customer_agent_execution_failed',
+				__( 'The customer-agent request is invalid.', 'superdav-ai-agent' )
+			);
+		}
+
+		$history = $this->deserialize_runtime_history( (string) $conversation['runtime_history'], $profile['max_history_turns'] );
+		$options = array(
+			'system_instruction'            => $profile['system_instruction'],
+			'max_iterations'                => $profile['max_iterations'],
+			'provider_id'                   => $profile['provider_id'],
+			'model_id'                      => $profile['model_id'],
+			'page_context'                  => array(
+				'customer_agent_runtime' => true,
+				'profile_id'             => $profile['profile_id'],
+			),
+			'anonymous_allowed_abilities'   => $profile['abilities'],
+			'anonymous_allowed_collections' => $profile['collections'],
+			'client_abilities'              => array(),
+			'yolo_mode'                     => false,
+			'active_job_id'                 => (string) $job['job_id'],
+		);
+
+		try {
+			$loop = new AgentLoop( $message, $profile['abilities'], $history, $options );
+			return $loop->run();
+		} catch ( \Throwable $exception ) {
+			// Do not log raw exception details: this public contract must never
+			// retain provider payloads, paths, prompts, or credentials.
+			return new WP_Error(
+				'sd_ai_agent_customer_agent_execution_failed',
+				__( 'The customer-agent runtime could not complete the request.', 'superdav-ai-agent' )
+			);
+		}
+	}
+
+	/**
+	 * Build the non-consuming public DTO for an owned runtime job.
+	 *
+	 * @param array<string,mixed> $job Durable job row.
+	 * @return array<string,mixed>
+	 */
+	private function public_job_dto( array $job ): array {
+		$payload = $this->decode_object( (string) $job['result_payload'] );
+		$status  = (string) ( $job['status'] ?? 'failed' );
+		$dto     = array(
+			'job_id'          => (string) $job['job_id'],
+			'conversation_id' => (string) $job['conversation_id'],
+			'status'          => $status,
+			'provider_id'     => (string) ( $job['provider_id'] ?? '' ),
+			'model_id'        => (string) ( $job['model_id'] ?? '' ),
+			'iterations_used' => (int) ( $job['iterations_used'] ?? 0 ),
+			'token_usage'     => array(
+				'prompt'     => (int) ( $job['prompt_tokens'] ?? 0 ),
+				'completion' => (int) ( $job['completion_tokens'] ?? 0 ),
+			),
+			'created_at'      => (string) ( $job['created_at'] ?? '' ),
+			'updated_at'      => (string) ( $job['updated_at'] ?? '' ),
+			'expires_at'      => (string) ( $job['expires_at'] ?? '' ),
+		);
+
+		if ( 'complete' === $status ) {
+			$dto['reply'] = JobErrorSanitizer::sanitize( (string) ( $payload['reply'] ?? '' ), self::MAX_REPLY_LENGTH );
+			if ( isset( $payload['provider_id'] ) && is_string( $payload['provider_id'] ) ) {
+				$dto['provider_id'] = $payload['provider_id'];
+			}
+			if ( isset( $payload['model_id'] ) && is_string( $payload['model_id'] ) ) {
+				$dto['model_id'] = $payload['model_id'];
+			}
+		}
+
+		if ( 'failed' === $status ) {
+			$dto['error'] = array(
+				'code'    => (string) ( $job['error_code'] ?? 'sd_ai_agent_customer_agent_execution_failed' ),
+				'message' => $this->customer_safe_error_message( (string) ( $job['error_message'] ?? '' ) ),
+			);
+		}
+
+		return $dto;
+	}
+
+	/**
+	 * Mark one runtime job as timed out and prevent a later result publication.
+	 *
+	 * @param array<string,mixed> $job Durable job row.
+	 */
+	private function mark_job_timed_out( array $job ): void {
+		$job_id  = (string) $job['job_id'];
+		$message = __( 'The customer-agent request timed out before a reply was available.', 'superdav-ai-agent' );
+		if ( CustomerAgentRuntimeRepository::mark_timed_out( $job_id, current_time( 'mysql', true ), 'sd_ai_agent_customer_agent_timeout', $message ) ) {
+			ActiveJobRepository::update_status( $job_id, 'error', array( 'error' => $message ) );
+			$timed_out = CustomerAgentRuntimeRepository::get_job( $job_id );
+			if ( null !== $timed_out ) {
+				$this->emit_lifecycle_event( 'failed', $timed_out );
+			}
+		}
+	}
+
+	/**
+	 * Persist a sanitized failure only while cancellation has not already won.
+	 *
+	 * @param array<string,mixed> $job Durable job row.
+	 */
+	private function fail_job( array $job, string $error_code, string $detail ): void {
+		$job_id  = (string) $job['job_id'];
+		$message = $this->customer_safe_error_message( $detail );
+		if ( CustomerAgentRuntimeRepository::mark_failed( $job_id, current_time( 'mysql', true ), $error_code, $message ) ) {
+			ActiveJobRepository::update_status( $job_id, 'error', array( 'error' => $message ) );
+			$failed = CustomerAgentRuntimeRepository::get_job( $job_id );
+			if ( null !== $failed ) {
+				$this->emit_lifecycle_event( 'failed', $failed );
+			}
+		}
+	}
+
+	/**
+	 * @param array<string,mixed> $job Durable job row.
+	 */
+	private function deadline_has_passed( array $job ): bool {
+		$deadline = strtotime( (string) ( $job['deadline_at'] ?? '' ) . ' UTC' );
+		return false !== $deadline && $deadline < time();
+	}
+
+	/**
+	 * @param array<string,mixed> $job Durable job row.
+	 * @return array{conversation_id:string,job_id:string,status:string,created:bool,expires_at:string}
+	 */
+	private function enqueue_response( array $job, bool $created ): array {
+		return array(
+			'conversation_id' => (string) $job['conversation_id'],
+			'job_id'          => (string) $job['job_id'],
+			'status'          => (string) $job['status'],
+			'created'         => $created,
+			'expires_at'      => (string) $job['expires_at'],
+		);
+	}
+
+	/**
+	 * Deserialize and bound the internal-only runtime history.
+	 *
+	 * @return list<Message>
+	 */
+	private function deserialize_runtime_history( string $serialized, int $max_history_turns ): array {
+		$messages = $this->decode_message_history( $serialized );
+
+		try {
+			$history = ConversationSerializer::deserialize( $messages );
+			$history = ConversationTrimmer::trim( $history, $max_history_turns );
+			return ConversationTrimmer::validate_tool_pairs( $history );
+		} catch ( \Throwable $exception ) {
+			return array();
+		}
+	}
+
+	/**
+	 * Convert returned loop history into a bounded durable internal history.
+	 *
+	 * @param mixed $history Raw AgentLoop history output.
+	 * @return list<array<string,mixed>>
+	 */
+	private function bounded_serialized_history( $history, int $max_history_turns ): array {
+		if ( ! is_array( $history ) ) {
+			return array();
+		}
+		$messages = array();
+		foreach ( $history as $message ) {
+			$message = $this->normalise_associative_array( $message );
+			if ( null !== $message ) {
+				$messages[] = $message;
+			}
+		}
+
+		try {
+			$objects = ConversationSerializer::deserialize( $messages );
+			$objects = ConversationTrimmer::trim( $objects, $max_history_turns );
+			return ConversationSerializer::serialize( ConversationTrimmer::validate_tool_pairs( $objects ) );
+		} catch ( \Throwable $exception ) {
+			return array();
+		}
+	}
+
+	/**
+	 * Decode a persisted JSON object without accepting list-shaped payloads.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function decode_object( string $value ): array {
+		$decoded = json_decode( $value, true );
+		return $this->normalise_associative_array( $decoded ) ?? array();
+	}
+
+	/**
+	 * Decode only the serialized message maps accepted by ConversationSerializer.
+	 *
+	 * @return list<array<string,mixed>>
+	 */
+	private function decode_message_history( string $serialized ): array {
+		$decoded = json_decode( $serialized, true );
+		if ( ! is_array( $decoded ) ) {
+			return array();
+		}
+
+		$messages = array();
+		foreach ( $decoded as $message ) {
+			$message = $this->normalise_associative_array( $message );
+			if ( null !== $message ) {
+				$messages[] = $message;
+			}
+		}
+
+		return $messages;
+	}
+
+	/**
+	 * Convert an untrusted PHP value into an associative map with string keys.
+	 *
+	 * @param mixed $value Raw callback or decoded JSON value.
+	 * @return array<string,mixed>|null
+	 */
+	private function normalise_associative_array( mixed $value ): ?array {
+		if ( ! is_array( $value ) ) {
+			return null;
+		}
+
+		$normalised = array();
+		foreach ( $value as $key => $item ) {
+			if ( ! is_string( $key ) ) {
+				return null;
+			}
+			$normalised[ $key ] = $item;
+		}
+
+		return $normalised;
+	}
+
+	/**
+	 * @param mixed $value Raw profile setting.
+	 */
+	private function bounded_setting( $value, int $minimum, int $maximum ): int {
+		return max( $minimum, min( $maximum, (int) $value ) );
+	}
+
+	/**
+	 * @param mixed $value Raw profile list.
+	 * @return list<string>
+	 */
+	private function sanitize_string_list( $value, bool $keys ): array {
+		if ( ! is_array( $value ) ) {
+			return array();
+		}
+
+		$sanitized = array();
+		foreach ( $value as $item ) {
+			if ( ! is_string( $item ) ) {
+				continue;
+			}
+			$item = $keys ? sanitize_key( $item ) : trim( $item );
+			if ( '' !== $item ) {
+				$sanitized[ $item ] = true;
+			}
+		}
+
+		return array_keys( $sanitized );
+	}
+
+	/**
+	 * @return string|WP_Error
+	 */
+	private function validate_external_identifier( string $identifier, string $type ): string|WP_Error {
+		$identifier = trim( wp_check_invalid_utf8( $identifier ) );
+		if ( '' === $identifier || strlen( $identifier ) > 255 ) {
+			return new WP_Error(
+				'sd_ai_agent_customer_agent_invalid_' . $type . '_id',
+				__( 'Customer-agent identifier is invalid.', 'superdav-ai-agent' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return $identifier;
+	}
+
+	/** Return an opaque stable hash without emitting the original identifier. */
+	private function hash_identifier( string $kind, string $identifier ): string {
+		return hash( 'sha256', $kind . '|' . $identifier );
+	}
+
+	/** Generate a UTC MySQL timestamp offset from the current request. */
+	private function future_mysql_time( int $seconds ): string {
+		return gmdate( 'Y-m-d H:i:s', time() + max( 0, $seconds ) );
+	}
+
+	/** Return a generic fallback if technical redaction removes all detail. */
+	private function customer_safe_error_message( string $detail ): string {
+		$sanitized = JobErrorSanitizer::sanitize( $detail );
+		return '' !== $sanitized
+			? $sanitized
+			: __( 'The customer-agent runtime could not complete the request.', 'superdav-ai-agent' );
+	}
+
+	/**
+	 * Emit opaque, privacy-safe lifecycle metadata only; message bodies are never included.
+	 *
+	 * @param string              $event Lifecycle event name.
+	 * @param array<string,mixed> $job   Runtime row or equivalent lifecycle metadata.
+	 */
+	private function emit_lifecycle_event( string $event, array $job ): void {
+		do_action(
+			'sd_ai_agent_customer_agent_runtime_event',
+			$event,
+			array(
+				'integration_hash' => (string) ( $job['integration_hash'] ?? '' ),
+				'conversation_id'  => (string) ( $job['conversation_id'] ?? '' ),
+				'job_id'           => (string) ( $job['job_id'] ?? '' ),
+				'status'           => (string) ( $job['status'] ?? '' ),
+			)
+		);
+	}
+}

--- a/superdav-ai-agent.php
+++ b/superdav-ai-agent.php
@@ -97,8 +97,22 @@ if ( ! $sd_ai_agent_autoload_available ) {
 }
 
 use SdAiAgent\Bootstrap\LifecycleHandler;
+use SdAiAgent\Contracts\CustomerAgentRuntimeInterface;
 use SdAiAgent\Core\ActiveJobsCleanupService;
 use SdAiAgent\Plugin;
+use SdAiAgent\Services\CustomerAgentRuntimeService;
+
+/**
+ * Return the stable PHP API for trusted same-install customer-agent consumers.
+ *
+ * The API intentionally has no unauthenticated REST equivalent. Consumers must
+ * register a constrained profile through the documented server-side filter.
+ */
+if ( ! function_exists( 'sd_ai_agent_customer_agent_runtime' ) ) {
+	function sd_ai_agent_customer_agent_runtime(): CustomerAgentRuntimeInterface {
+		return CustomerAgentRuntimeService::instance();
+	}
+}
 
 // In repository checkouts, load the sibling advanced companion plugin before
 // bootstrapping the DI container so local development gets both plugins with

--- a/tests/SdAiAgent/Core/DatabaseSchemaTest.php
+++ b/tests/SdAiAgent/Core/DatabaseSchemaTest.php
@@ -62,6 +62,8 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 		'sd_ai_agent_provider_trace',
 		'sd_ai_agent_generated_plugins',
 		'sd_ai_agent_active_jobs',
+		'sd_ai_agent_customer_agent_conversations',
+		'sd_ai_agent_customer_agent_jobs',
 		'sd_ai_agent_skill_usage',
 		'sd_ai_agent_contact_mappings',
 	];
@@ -414,6 +416,24 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 				$columns,
 				"active_jobs table missing column '{$col}' — see GH#2026."
 			);
+		}
+	}
+
+	/**
+	 * Customer-agent runtime tables persist opaque ownership and terminal result
+	 * state independently from transient-backed browser jobs.
+	 */
+	public function test_customer_agent_runtime_tables_have_durable_columns(): void {
+		Database::install();
+
+		$conversation_columns = $this->get_column_names( Database::customer_agent_conversations_table_name() );
+		foreach ( [ 'conversation_id', 'integration_hash', 'external_session_hash', 'profile_id', 'runtime_history', 'expires_at' ] as $column ) {
+			$this->assertContains( $column, $conversation_columns, "Customer-agent conversation table missing column '{$column}'." );
+		}
+
+		$job_columns = $this->get_column_names( Database::customer_agent_jobs_table_name() );
+		foreach ( [ 'job_id', 'conversation_id', 'external_message_hash', 'status', 'request_payload', 'result_payload', 'error_code', 'deadline_at', 'expires_at' ] as $column ) {
+			$this->assertContains( $column, $job_columns, "Customer-agent job table missing column '{$column}'." );
 		}
 	}
 

--- a/tests/SdAiAgent/Services/CustomerAgentRuntimeServiceTest.php
+++ b/tests/SdAiAgent/Services/CustomerAgentRuntimeServiceTest.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Regression tests for the server-side customer-agent runtime contract.
+ *
+ * @package SdAiAgent\Tests\Services
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Services;
+
+use SdAiAgent\Core\Database;
+use SdAiAgent\Models\CustomerAgentRuntimeRepository;
+use SdAiAgent\Services\CustomerAgentRuntimeService;
+use WP_Error;
+use WP_UnitTestCase;
+
+class CustomerAgentRuntimeServiceTest extends WP_UnitTestCase {
+
+	private const INTEGRATION = 'test-customer-runtime';
+	private const OTHER_INTEGRATION = 'other-customer-runtime';
+
+	private CustomerAgentRuntimeService $service;
+
+	private int $executor_runs = 0;
+
+	public function set_up(): void {
+		parent::set_up();
+		delete_option( Database::DB_VERSION_OPTION );
+		Database::install();
+		$this->delete_runtime_rows();
+		$this->executor_runs = 0;
+		$this->service       = new CustomerAgentRuntimeService(
+			function (): array {
+				++$this->executor_runs;
+				return array(
+					'reply'           => 'Helpful <strong>customer</strong> answer.',
+					'history'         => array(),
+					'model_id'        => 'test-model',
+					'iterations_used' => 2,
+					'token_usage'     => array(
+						'prompt'     => 12,
+						'completion' => 24,
+					),
+				);
+			}
+		);
+		add_filter( 'sd_ai_agent_customer_agent_integrations', array( $this, 'register_integrations' ) );
+	}
+
+	public function tear_down(): void {
+		remove_filter( 'sd_ai_agent_customer_agent_integrations', array( $this, 'register_integrations' ) );
+		wp_clear_scheduled_hook( CustomerAgentRuntimeService::PROCESS_HOOK );
+		$this->delete_runtime_rows();
+		parent::tear_down();
+	}
+
+	/**
+	 * V1 advertises a stable semantic version and fails closed client features.
+	 */
+	public function test_discovers_versioned_fail_closed_capabilities(): void {
+		$capabilities = $this->service->discover_capabilities();
+
+		$this->assertSame( '1.0.0', $capabilities['contract_version'] );
+		$this->assertTrue( $capabilities['features']['durable_jobs'] );
+		$this->assertFalse( $capabilities['features']['client_tools_supported'] );
+		$this->assertFalse( $capabilities['features']['attachments_supported'] );
+		$this->assertFalse( $capabilities['features']['caller_prompts_supported'] );
+	}
+
+	/**
+	 * A conversation is stable across retries for one trusted integration/session.
+	 */
+	public function test_creates_and_recovers_opaque_conversation(): void {
+		$first = $this->service->create_or_recover_conversation( self::INTEGRATION, 'customer-session-1' );
+		$this->assertNotInstanceOf( WP_Error::class, $first );
+		$this->assertFalse( $first['recovered'] );
+
+		$second = $this->service->create_or_recover_conversation( self::INTEGRATION, 'customer-session-1' );
+		$this->assertNotInstanceOf( WP_Error::class, $second );
+		$this->assertTrue( $second['recovered'] );
+		$this->assertSame( $first['conversation_id'], $second['conversation_id'] );
+	}
+
+	/**
+	 * Repeated message IDs resolve to one job, execute once, and terminal reads
+	 * remain available without destructive polling.
+	 */
+	public function test_enqueue_is_idempotent_and_terminal_reads_are_non_consuming(): void {
+		$first = $this->service->enqueue_turn( self::INTEGRATION, 'customer-session-2', 'message-1', 'Please help.' );
+		$this->assertNotInstanceOf( WP_Error::class, $first );
+		$this->assertTrue( $first['created'] );
+		$this->assertSame( 'queued', $first['status'] );
+
+		$retry = $this->service->enqueue_turn( self::INTEGRATION, 'customer-session-2', 'message-1', 'Please help.' );
+		$this->assertNotInstanceOf( WP_Error::class, $retry );
+		$this->assertFalse( $retry['created'] );
+		$this->assertSame( $first['job_id'], $retry['job_id'] );
+
+		$this->service->process_job( $first['job_id'] );
+		$this->service->process_job( $first['job_id'] );
+		$this->assertSame( 1, $this->executor_runs );
+
+		$one = $this->service->inspect_job( self::INTEGRATION, 'customer-session-2', $first['job_id'] );
+		$two = $this->service->inspect_job( self::INTEGRATION, 'customer-session-2', $first['job_id'] );
+		$this->assertNotInstanceOf( WP_Error::class, $one );
+		$this->assertNotInstanceOf( WP_Error::class, $two );
+		$this->assertSame( 'complete', $one['status'] );
+		$this->assertSame( $one, $two );
+		$this->assertSame( 'Helpful customer answer.', $one['reply'] );
+		$this->assertSame( 'test-model', $one['model_id'] );
+		$this->assertSame( 12, $one['token_usage']['prompt'] );
+	}
+
+	/** Different integration/session keys cannot inspect another job. */
+	public function test_job_isolated_by_integration_and_external_session(): void {
+		$job = $this->service->enqueue_turn( self::INTEGRATION, 'customer-session-3', 'message-1', 'Please help.' );
+		$this->assertNotInstanceOf( WP_Error::class, $job );
+
+		$other_integration = $this->service->inspect_job( self::OTHER_INTEGRATION, 'customer-session-3', $job['job_id'] );
+		$this->assertInstanceOf( WP_Error::class, $other_integration );
+		$this->assertSame( 'sd_ai_agent_customer_agent_conversation_not_found', $other_integration->get_error_code() );
+
+		$other_session = $this->service->inspect_job( self::INTEGRATION, 'customer-session-other', $job['job_id'] );
+		$this->assertInstanceOf( WP_Error::class, $other_session );
+		$this->assertSame( 'sd_ai_agent_customer_agent_conversation_not_found', $other_session->get_error_code() );
+	}
+
+	/**
+	 * Cancellation wins a late-result race and processing cannot publish it.
+	 */
+	public function test_cancellation_prevents_late_result_delivery(): void {
+		$service = null;
+		$service = new CustomerAgentRuntimeService(
+			function ( array $job ) use ( &$service ): array {
+				$runtime = $service;
+				if ( ! $runtime instanceof CustomerAgentRuntimeService ) {
+					throw new \LogicException( 'Customer-agent runtime service was not initialized.' );
+				}
+
+				$cancelled = $runtime->cancel_job( self::INTEGRATION, 'customer-session-4', (string) $job['job_id'] );
+				$this->assertNotInstanceOf( WP_Error::class, $cancelled );
+				return array(
+					'reply'       => 'Late provider answer.',
+					'history'     => array(),
+					'token_usage' => array(),
+				);
+			}
+		);
+
+		$job = $service->enqueue_turn( self::INTEGRATION, 'customer-session-4', 'message-1', 'Please help.' );
+		$this->assertNotInstanceOf( WP_Error::class, $job );
+		$service->process_job( $job['job_id'] );
+
+		$status = $service->inspect_job( self::INTEGRATION, 'customer-session-4', $job['job_id'] );
+		$this->assertNotInstanceOf( WP_Error::class, $status );
+		$this->assertSame( 'cancelled', $status['status'] );
+		$this->assertArrayNotHasKey( 'reply', $status );
+	}
+
+	/** Stuck jobs are converted to a stable timeout response during reconciliation. */
+	public function test_stuck_job_becomes_timeout_failure(): void {
+		global $wpdb;
+
+		$job = $this->service->enqueue_turn( self::INTEGRATION, 'customer-session-5', 'message-1', 'Please help.' );
+		$this->assertNotInstanceOf( WP_Error::class, $job );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test-only deadline reconciliation setup.
+		$wpdb->update(
+			CustomerAgentRuntimeRepository::jobs_table_name(),
+			array( 'deadline_at' => '2000-01-01 00:00:00' ),
+			array( 'job_id' => $job['job_id'] ),
+			array( '%s' ),
+			array( '%s' )
+		);
+
+		$status = $this->service->inspect_job( self::INTEGRATION, 'customer-session-5', $job['job_id'] );
+		$this->assertNotInstanceOf( WP_Error::class, $status );
+		$this->assertSame( 'failed', $status['status'] );
+		$this->assertSame( 'sd_ai_agent_customer_agent_timeout', $status['error']['code'] );
+	}
+
+	/** External identifiers are stored only as fixed-length opaque hashes. */
+	public function test_persistence_hashes_external_identifiers(): void {
+		$external_session_id = 'customer-session-private-1';
+		$external_message_id = 'customer-message-private-1';
+		$job                 = $this->service->enqueue_turn( self::INTEGRATION, $external_session_id, $external_message_id, 'Please help.' );
+		$this->assertNotInstanceOf( WP_Error::class, $job );
+
+		$stored = CustomerAgentRuntimeRepository::get_job( $job['job_id'] );
+		$this->assertNotNull( $stored );
+		$this->assertNotSame( $external_session_id, $stored['external_session_hash'] );
+		$this->assertNotSame( $external_message_id, $stored['external_message_hash'] );
+		$this->assertSame( 64, strlen( (string) $stored['external_session_hash'] ) );
+		$this->assertSame( 64, strlen( (string) $stored['external_message_hash'] ) );
+	}
+
+	/** Executor errors are redacted before durable storage or customer delivery. */
+	public function test_sanitizes_executor_failures_before_delivery(): void {
+		$service = new CustomerAgentRuntimeService(
+			static function ( array $job, array $conversation, array $profile ): WP_Error {
+				return new WP_Error( 'provider_failure', 'Provider failure: token=test-only-secret-value' );
+			}
+		);
+		$job = $service->enqueue_turn( self::INTEGRATION, 'customer-session-privacy', 'message-1', 'Please help.' );
+		$this->assertNotInstanceOf( WP_Error::class, $job );
+
+		$service->process_job( $job['job_id'] );
+
+		$status = $service->inspect_job( self::INTEGRATION, 'customer-session-privacy', $job['job_id'] );
+		$this->assertNotInstanceOf( WP_Error::class, $status );
+		$this->assertSame( 'failed', $status['status'] );
+		$this->assertSame( 'sd_ai_agent_customer_agent_execution_failed', $status['error']['code'] );
+		$this->assertStringContainsString( '[redacted_credential]', $status['error']['message'] );
+		$this->assertStringNotContainsString( 'test-only-secret-value', $status['error']['message'] );
+
+		$stored = CustomerAgentRuntimeRepository::get_job( $job['job_id'] );
+		$this->assertNotNull( $stored );
+		$this->assertStringNotContainsString( 'test-only-secret-value', (string) $stored['error_message'] );
+	}
+
+	/** Unknown or unsafe registrations fail before a conversation can be created. */
+	public function test_rejects_unknown_and_unsafe_integrations(): void {
+		$unknown = $this->service->create_or_recover_conversation( 'unregistered-runtime', 'customer-session-6' );
+		$this->assertInstanceOf( WP_Error::class, $unknown );
+		$this->assertSame( 'sd_ai_agent_customer_agent_unknown_integration', $unknown->get_error_code() );
+
+		$unsafe = $this->service->create_or_recover_conversation( 'unsafe-customer-runtime', 'customer-session-6' );
+		$this->assertInstanceOf( WP_Error::class, $unsafe );
+		$this->assertSame( 'sd_ai_agent_customer_agent_invalid_profile', $unsafe->get_error_code() );
+	}
+
+	/** Close purges the runtime record and makes follow-up reads impossible. */
+	public function test_close_conversation_purges_runtime_state(): void {
+		$conversation = $this->service->create_or_recover_conversation( self::INTEGRATION, 'customer-session-7' );
+		$this->assertNotInstanceOf( WP_Error::class, $conversation );
+
+		$closed = $this->service->close_conversation( self::INTEGRATION, 'customer-session-7' );
+		$this->assertNotInstanceOf( WP_Error::class, $closed );
+		$this->assertSame( 'closed', $closed['status'] );
+
+		$missing = $this->service->create_or_recover_conversation( self::INTEGRATION, 'customer-session-7' );
+		$this->assertNotInstanceOf( WP_Error::class, $missing );
+		$this->assertFalse( $missing['recovered'] );
+	}
+
+	/**
+	 * @param array<string,array<string,mixed>> $integrations Existing registrations.
+	 * @return array<string,array<string,mixed>>
+	 */
+	public function register_integrations( array $integrations ): array {
+		$profile = array(
+			'enabled'             => true,
+			'profile'             => 'test-customer-profile',
+			'system_instruction'  => 'Answer only from the approved support knowledge base.',
+			'abilities'           => array( 'sd-ai-agent/knowledge-search' ),
+			'collections'         => array( 'support-docs' ),
+			'provider_id'         => 'test-provider',
+			'model_id'            => 'test-model',
+			'max_message_length'  => 1000,
+			'max_history_turns'   => 4,
+			'max_iterations'      => 3,
+			'max_runtime_seconds' => 60,
+		);
+
+		$integrations[ self::INTEGRATION ]       = $profile;
+		$integrations[ self::OTHER_INTEGRATION ] = $profile;
+		$integrations['unsafe-customer-runtime'] = array_merge(
+			$profile,
+			array( 'abilities' => array( 'sd-ai-agent/ability-search' ) )
+		);
+
+		return $integrations;
+	}
+
+	/** Clear only test-owned durable runtime rows. */
+	private function delete_runtime_rows(): void {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test isolation for private runtime tables.
+		$wpdb->query( 'DELETE FROM ' . CustomerAgentRuntimeRepository::jobs_table_name() );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test isolation for private runtime tables.
+		$wpdb->query( 'DELETE FROM ' . CustomerAgentRuntimeRepository::conversations_table_name() );
+	}
+}


### PR DESCRIPTION
## Summary

- Add a versioned PHP runtime for trusted same-install customer-agent integrations.
- Persist opaque conversations and idempotent async jobs with cancellation, timeout, and sanitized terminal results.
- Restrict V1 execution to server-registered knowledge-search profiles and document the integration contract.

## Files Changed

- Runtime contract, service, repository, cron handler, and public entry point.
- Database schema, shared job-error sanitization, documentation, and PHPUnit coverage.

## Runtime Testing

- **Risk level:** high
- **Verification:** GitHub CI PHPUnit, static analysis, PHP/JS/CSS linting, canonical-identifier checks, and the production build pass on the exact pushed head. Playwright E2E remains asynchronous with no terminal failure observed.

## Worker self-verification

- PHPUnit: GitHub CI passed; local execution was unavailable because the local test database rejected access and Docker reported an overlayfs snapshot error while starting the isolated WordPress environment.
- Lint: PHP/JS/CSS clean
- PHPStan: 0 errors
- Build: succeeded

Resolves #2320


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a trusted, versioned server-side customer-agent runtime for PHP integrations.
  * Supports durable conversations, asynchronous message processing, job inspection, cancellation, idempotent submissions, and conversation closure.
  * Added capability discovery with enforced integration and contract validation.
  * Added customer-safe error redaction and protection of sensitive information.
  * Added persistent storage for conversations and jobs, with automatic retention and timeout handling.

* **Documentation**
  * Added integration guidance, runtime guarantees, and PHP usage examples to the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->