### PR TITLE
Fix #2320: Upgrade customer runtime schema globally

### DIFF
--- a/includes/Bootstrap/CustomerAgentRuntimeHandler.php
+++ b/includes/Bootstrap/CustomerAgentRuntimeHandler.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Bootstrap;
 
+use SdAiAgent\Core\Database;
 use SdAiAgent\Services\CustomerAgentRuntimeService;
 use XWP\DI\Decorators\Action;
 use XWP\DI\Decorators\Handler;
@@ -25,6 +26,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	strategy: Handler::INIT_IMMEDIATELY,
 )]
 final class CustomerAgentRuntimeHandler {
+
+	/** Upgrade stale schemas before frontend, REST, CLI, or cron runtime use. */
+	#[Action( tag: 'init', priority: 1 )]
+	public function ensure_database_schema(): void {
+		Database::install();
+	}
 
 	/** Execute one opaque queued customer-agent job. */
 	#[Action( tag: CustomerAgentRuntimeService::PROCESS_HOOK, priority: 10 )]

--- a/tests/SdAiAgent/Core/DatabaseSchemaTest.php
+++ b/tests/SdAiAgent/Core/DatabaseSchemaTest.php
@@ -18,6 +18,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Tests\Core;
 
+use SdAiAgent\Bootstrap\CustomerAgentRuntimeHandler;
 use SdAiAgent\Core\Database;
 use SdAiAgent\Knowledge\KnowledgeDatabase;
 use WP_UnitTestCase;
@@ -545,6 +546,35 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 			$stored,
 			'install() must update the stored version after running on an outdated schema.'
 		);
+	}
+
+	/**
+	 * The global runtime handler upgrades an existing install before runtime use.
+	 */
+	public function test_runtime_handler_upgrades_stale_schema(): void {
+		global $wpdb;
+
+		Database::install();
+
+		$runtime_tables = [
+			Database::customer_agent_conversations_table_name(),
+			Database::customer_agent_jobs_table_name(),
+		];
+
+		foreach ( $runtime_tables as $table ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.SchemaChange -- Test-only simulated pre-runtime schema.
+			$wpdb->query( $wpdb->prepare( 'DROP TABLE IF EXISTS %i', $table ) );
+		}
+		update_option( Database::DB_VERSION_OPTION, '19.5.6' );
+
+		$handler = new CustomerAgentRuntimeHandler();
+		$handler->ensure_database_schema();
+
+		$this->assertSame( Database::DB_VERSION, get_option( Database::DB_VERSION_OPTION ) );
+		foreach ( $runtime_tables as $table ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test-only introspection query.
+			$this->assertSame( $table, $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) );
+		}
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/DatabaseSchemaTest.php
+++ b/tests/SdAiAgent/Core/DatabaseSchemaTest.php
@@ -22,6 +22,7 @@ use SdAiAgent\Bootstrap\CustomerAgentRuntimeHandler;
 use SdAiAgent\Core\Database;
 use SdAiAgent\Knowledge\KnowledgeDatabase;
 use WP_UnitTestCase;
+use XWP\DI\Decorators\Action;
 
 /**
  * Integration tests for Database schema and migrations.
@@ -575,6 +576,20 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test-only introspection query.
 			$this->assertSame( $table, $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) );
 		}
+	}
+
+	/**
+	 * The schema guard runs early in every WordPress request context.
+	 */
+	public function test_runtime_schema_guard_is_registered_on_init(): void {
+		$method     = new \ReflectionMethod( CustomerAgentRuntimeHandler::class, 'ensure_database_schema' );
+		$attributes = $method->getAttributes( Action::class );
+
+		$this->assertCount( 1, $attributes );
+
+		$action = $attributes[0]->newInstance();
+		$this->assertSame( 'init', $action->tag );
+		$this->assertSame( 1, $action->prio );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- run the idempotent database installer from the global customer-runtime handler at early `init`
- upgrade stale schemas before frontend, REST, WP-CLI, or cron runtime use instead of waiting for an admin request
- add a real-database regression test that removes the runtime tables at DB version `19.5.6` and verifies the global guard recreates them

## Root cause

The runtime tables introduced at DB version `19.6.0` were installed on plugin activation and `admin_init` only. An already-active installation could therefore execute frontend, REST, CLI, or cron runtime paths indefinitely without creating those tables.

`Database::install()` already uses an option-backed version guard, so the new global call is a cheap no-op when the schema is current.

## Verification

- `vendor/bin/phpunit --no-coverage tests/SdAiAgent/Core/DatabaseSchemaTest.php` — 31 tests, 245 assertions
- `composer phpcs` — 8/8 passed
- `composer phpstan` — no errors
- PHP syntax and `git diff --check` passed

Resolves #2320

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4
