### PR TITLE
GH#2327: assert managed profile index repair failure

### DIFF
--- a/tests/SdAiAgent/Core/DatabaseSchemaTest.php
+++ b/tests/SdAiAgent/Core/DatabaseSchemaTest.php
@@ -504,6 +504,9 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 
 			$this->assertSame( Database::DB_VERSION, get_option( Database::DB_VERSION_OPTION ) );
 			$this->assertNotNull( Agent::get_by_slug( 'general' ), 'Built-in agent seeding must continue when the optional unique-index repair fails.' );
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test-only assertion that the repair genuinely failed.
+			$unique_index_after_repair = $wpdb->get_var( "SHOW INDEX FROM {$table} WHERE Key_name = 'managed_profile_key' AND Non_unique = 0" );
+			$this->assertNull( $unique_index_after_repair, 'Unique index repair must remain skipped while historical duplicates exist.' );
 		} finally {
 			$wpdb->suppress_errors( $previous_suppress_errors );
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Test-only fixture cleanup.


### PR DESCRIPTION
## Summary

- Assert that the optional managed-profile index repair remains skipped when duplicate historical keys prevent the unique index from being restored.

## Verification

- `vendor/bin/phpcs tests/SdAiAgent/Core/DatabaseSchemaTest.php`
- `npm run lint:php`, `npm run lint:js`, and `npm run lint:css`
- `composer phpstan`
- `npm run build && npm run check:bundle`
- `npm run test:php -- --filter=DatabaseSchemaTest` *(blocked: local PHPUnit MySQL credentials are unavailable; `npx wp-env start` also fails because Docker has a missing overlayfs snapshot)*

Resolves #2327

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4
