### PR TITLE
GH#2334: show account credit activity

### DIFF
--- a/includes/Core/SuperdavSiteConnectionService.php
+++ b/includes/Core/SuperdavSiteConnectionService.php
@@ -31,6 +31,25 @@ final class SuperdavSiteConnectionService {
 	private const ACCOUNT_STATUS_ENDPOINT_PATH = 'site/account';
 
 	/**
+	 * Maximum number of newest-first credit activity rows retained for display.
+	 *
+	 * The account endpoint is intentionally a single bounded summary response:
+	 * it does not accept or expose cursors, and WordPress does not act as a
+	 * billing ledger. The managed service must return only its newest page.
+	 */
+	public const MAX_CREDIT_ACTIVITY_EVENTS = 25;
+
+	/** @var string[] Event types that are safe to render in the account UI. */
+	private const CREDIT_ACTIVITY_EVENT_TYPES = array(
+		'purchase',
+		'promotion',
+		'redeemed',
+		'consumed',
+		'pending',
+		'expired',
+	);
+
+	/**
 	 * Build safe connector status metadata.
 	 *
 	 * @return array<string, mixed>
@@ -72,6 +91,12 @@ final class SuperdavSiteConnectionService {
 			$status['wallet'] = $this->sanitize_wallet_metadata( $metadata['wallet'] );
 		}
 
+		if ( isset( $metadata['credit_activity'] ) && is_array( $metadata['credit_activity'] ) ) {
+			$status['credit_activity'] = $this->sanitize_credit_activity_metadata( $metadata['credit_activity'] );
+		}
+
+		$status['site_timezone'] = wp_timezone_string();
+
 		return $status;
 	}
 
@@ -104,8 +129,9 @@ final class SuperdavSiteConnectionService {
 				),
 				'body'    => wp_json_encode(
 					array(
-						'installation_id' => $this->get_installation_id(),
-						'site_url'        => $this->get_verified_site_url(),
+						'installation_id'       => $this->get_installation_id(),
+						'site_url'              => $this->get_verified_site_url(),
+						'credit_activity_limit' => self::MAX_CREDIT_ACTIVITY_EVENTS,
 					)
 				),
 			)
@@ -134,7 +160,8 @@ final class SuperdavSiteConnectionService {
 			$metadata['account_portal_url'],
 			$metadata['usage'],
 			$metadata['verification'],
-			$metadata['wallet']
+			$metadata['wallet'],
+			$metadata['credit_activity']
 		);
 		$metadata = array_merge( $metadata, $this->sanitize_remote_metadata( $body ) );
 		update_option( self::TOKEN_METADATA_OPTION, $metadata, false );
@@ -516,6 +543,10 @@ final class SuperdavSiteConnectionService {
 			$safe['wallet'] = $this->sanitize_wallet_metadata( $metadata['wallet'] );
 		}
 
+		if ( isset( $metadata['credit_activity'] ) && is_array( $metadata['credit_activity'] ) ) {
+			$safe['credit_activity'] = $this->sanitize_credit_activity_metadata( $metadata['credit_activity'] );
+		}
+
 		return $safe;
 	}
 
@@ -573,6 +604,80 @@ final class SuperdavSiteConnectionService {
 				)
 			)
 		);
+	}
+
+	/**
+	 * Keep the bounded, display-safe credit activity contract from the service.
+	 *
+	 * Each retained event contains only a recognized event type, a signed USD
+	 * micro amount, an effective timestamp, and optionally an expiry timestamp
+	 * and short safe label. Customer, invoice, payment, processor, token, and
+	 * arbitrary event payload fields are never stored or returned.
+	 *
+	 * @param array<int, mixed> $activity Remote credit activity rows.
+	 * @return array<int, array<string, int|string>>
+	 */
+	private function sanitize_credit_activity_metadata( array $activity ): array {
+		$safe_activity = array();
+
+		foreach ( array_slice( $activity, 0, self::MAX_CREDIT_ACTIVITY_EVENTS ) as $event ) {
+			if ( ! is_array( $event ) ) {
+				continue;
+			}
+
+			$type         = $event['type'] ?? '';
+			$amount       = $event['amount_usd_micros'] ?? null;
+			$effective_at = $this->sanitize_credit_activity_timestamp( $event['effective_at'] ?? null );
+
+			if ( ! is_string( $type ) || ! in_array( $type, self::CREDIT_ACTIVITY_EVENT_TYPES, true ) || ! is_int( $amount ) || null === $effective_at ) {
+				continue;
+			}
+
+			$safe_event = array(
+				'type'              => $type,
+				'amount_usd_micros' => $amount,
+				'effective_at'      => $effective_at,
+			);
+			$expires_at = $this->sanitize_credit_activity_timestamp( $event['expires_at'] ?? null );
+			if ( null !== $expires_at ) {
+				$safe_event['expires_at'] = $expires_at;
+			}
+
+			if ( isset( $event['label'] ) && is_string( $event['label'] ) ) {
+				$label = substr( sanitize_text_field( $event['label'] ), 0, 120 );
+				if ( '' !== $label ) {
+					$safe_event['label'] = $label;
+				}
+			}
+
+			$safe_activity[] = $safe_event;
+		}
+
+		usort(
+			$safe_activity,
+			static fn( array $left, array $right ): int => strcmp( $right['effective_at'], $left['effective_at'] )
+		);
+
+		return $safe_activity;
+	}
+
+	/**
+	 * Normalize a valid remote ISO-8601 timestamp to UTC for browser rendering.
+	 *
+	 * @param mixed $timestamp Remote timestamp value.
+	 * @return string|null Normalized timestamp, or null when invalid.
+	 */
+	private function sanitize_credit_activity_timestamp( mixed $timestamp ): ?string {
+		if ( ! is_string( $timestamp ) || '' === trim( $timestamp ) ) {
+			return null;
+		}
+
+		$unix_timestamp = rest_parse_date( $timestamp, true );
+		if ( false === $unix_timestamp ) {
+			return null;
+		}
+
+		return gmdate( 'c', $unix_timestamp );
 	}
 
 	/**

--- a/includes/Core/SuperdavSiteConnectionService.php
+++ b/includes/Core/SuperdavSiteConnectionService.php
@@ -614,7 +614,7 @@ final class SuperdavSiteConnectionService {
 	 * and short safe label. Customer, invoice, payment, processor, token, and
 	 * arbitrary event payload fields are never stored or returned.
 	 *
-	 * @param array<int, mixed> $activity Remote credit activity rows.
+	 * @param array<mixed, mixed> $activity Remote credit activity rows.
 	 * @return array<int, array<string, int|string>>
 	 */
 	private function sanitize_credit_activity_metadata( array $activity ): array {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "superdav-ai-agent",
-	"version": "1.19.0",
+	"version": "1.20.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "superdav-ai-agent",
-			"version": "1.19.0",
+			"version": "1.20.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@codemirror/commands": "^6.10.3",

--- a/src/settings-page/__tests__/superdav-account-manager.test.js
+++ b/src/settings-page/__tests__/superdav-account-manager.test.js
@@ -6,6 +6,8 @@ import { createElement } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 
 import SuperdavAccountManager, {
+	formatCreditActivityDate,
+	formatCreditActivityType,
 	formatWalletAmount,
 } from '../superdav-account-manager';
 
@@ -47,6 +49,18 @@ describe( 'SuperdavAccountManager', () => {
 		expect( formatWalletAmount( 0 ) ).not.toBe( '—' );
 	} );
 
+	test( 'formats safe activity states and unavailable timestamps', () => {
+		expect( formatCreditActivityType( 'promotion' ) ).toBe(
+			'Promotional credit'
+		);
+		expect( formatCreditActivityType( 'unknown' ) ).toBe(
+			'Credit activity'
+		);
+		expect( formatCreditActivityDate( 'invalid', 'UTC' ) ).toBe(
+			'Unavailable'
+		);
+	} );
+
 	test( 'does not show a disconnected warning after a failed request', async () => {
 		apiFetch.mockRejectedValue( new Error( 'Account request failed.' ) );
 
@@ -79,5 +93,50 @@ describe( 'SuperdavAccountManager', () => {
 		expect(
 			container.querySelector( '.sd-ai-agent-superdav-account' )
 		).not.toBeNull();
+	} );
+
+	test( 'renders credit activity and labels missing promotional expiry as unavailable', async () => {
+		apiFetch.mockResolvedValue( {
+			configured: true,
+			site_timezone: 'UTC',
+			wallet: { total_usd_micros: 1000000 },
+			credit_activity: [
+				{
+					type: 'promotion',
+					amount_usd_micros: 1000000,
+					effective_at: '2026-07-16T00:00:00+00:00',
+					label: 'Welcome coupon',
+				},
+			],
+		} );
+
+		await act( async () => {
+			root.render( createElement( SuperdavAccountManager, {} ) );
+		} );
+		await act( async () => {
+			await Promise.resolve();
+		} );
+
+		expect( container.textContent ).toContain( 'Promotional credit' );
+		expect( container.textContent ).toContain( 'Welcome coupon' );
+		expect( container.textContent ).toContain( 'Expiry: Unavailable' );
+	} );
+
+	test( 'renders an explicit empty credit activity state', async () => {
+		apiFetch.mockResolvedValueOnce( {
+			configured: true,
+			credit_activity: [],
+		} );
+
+		await act( async () => {
+			root.render( createElement( SuperdavAccountManager, {} ) );
+		} );
+		await act( async () => {
+			await Promise.resolve();
+		} );
+
+		expect( container.textContent ).toContain(
+			'No recent credit activity is available.'
+		);
 	} );
 } );

--- a/src/settings-page/style.css
+++ b/src/settings-page/style.css
@@ -591,9 +591,50 @@
 	gap: 8px;
 }
 
+.sd-ai-agent-superdav-credit-activity h4 {
+	margin: 0 0 8px;
+}
+
+.sd-ai-agent-superdav-credit-activity-list {
+	margin: 0;
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	background: #fff;
+}
+
+.sd-ai-agent-superdav-credit-activity-list li {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 16px;
+	padding: 12px 14px;
+	border-bottom: 1px solid #f0f0f1;
+}
+
+.sd-ai-agent-superdav-credit-activity-list li:last-child {
+	border-bottom: 0;
+}
+
+.sd-ai-agent-superdav-credit-activity-label,
+.sd-ai-agent-superdav-credit-activity-date,
+.sd-ai-agent-superdav-credit-activity-expiry {
+	display: block;
+	margin-top: 2px;
+	color: #50575e;
+	font-size: 12px;
+}
+
+.sd-ai-agent-superdav-credit-activity-amount {
+	white-space: nowrap;
+}
+
 @media screen and (max-width: 600px) {
 	.sd-ai-agent-superdav-account-header {
 		flex-direction: column;
+	}
+
+	.sd-ai-agent-superdav-credit-activity-list li {
+		gap: 8px;
 	}
 }
 

--- a/src/settings-page/superdav-account-manager.js
+++ b/src/settings-page/superdav-account-manager.js
@@ -30,7 +30,7 @@ export function formatWalletAmount( micros ) {
  * Format a service timestamp in the WordPress site's configured timezone.
  *
  * @param {string|null|undefined} timestamp ISO-8601 timestamp.
- * @param {string|null|undefined} timeZone WordPress site timezone identifier.
+ * @param {string|null|undefined} timeZone  WordPress site timezone identifier.
  * @return {string} Localized timestamp, or an unavailable label.
  */
 export function formatCreditActivityDate( timestamp, timeZone ) {
@@ -133,6 +133,86 @@ export default function SuperdavAccountManager() {
 		? account.credit_activity
 		: null;
 	const siteTimezone = account?.site_timezone || '';
+	let creditActivityContent = (
+		<p className="description">
+			{ __(
+				'Recent credit activity is unavailable.',
+				'superdav-ai-agent'
+			) }
+		</p>
+	);
+
+	if ( creditActivity !== null && creditActivity.length === 0 ) {
+		creditActivityContent = (
+			<p className="description">
+				{ __(
+					'No recent credit activity is available.',
+					'superdav-ai-agent'
+				) }
+			</p>
+		);
+	}
+
+	if ( creditActivity !== null && creditActivity.length > 0 ) {
+		creditActivityContent = (
+			<ol className="sd-ai-agent-superdav-credit-activity-list">
+				{ creditActivity.map( ( event, index ) => {
+					const showsExpiry =
+						event.type === 'promotion' || event.expires_at;
+
+					return (
+						<li
+							key={ `${ event.type }-${ event.effective_at }-${ index }` }
+						>
+							<div>
+								<strong>
+									{ formatCreditActivityType( event.type ) }
+								</strong>
+								{ event.label && (
+									<span className="sd-ai-agent-superdav-credit-activity-label">
+										{ event.label }
+									</span>
+								) }
+								<span className="sd-ai-agent-superdav-credit-activity-date">
+									{ sprintf(
+										/* translators: %s: localized effective timestamp. */
+										__(
+											'Effective: %s',
+											'superdav-ai-agent'
+										),
+										formatCreditActivityDate(
+											event.effective_at,
+											siteTimezone
+										)
+									) }
+								</span>
+								{ showsExpiry && (
+									<span className="sd-ai-agent-superdav-credit-activity-expiry">
+										{ sprintf(
+											/* translators: %s: localized expiry timestamp or unavailable label. */
+											__(
+												'Expiry: %s',
+												'superdav-ai-agent'
+											),
+											formatCreditActivityDate(
+												event.expires_at,
+												siteTimezone
+											)
+										) }
+									</span>
+								) }
+							</div>
+							<strong className="sd-ai-agent-superdav-credit-activity-amount">
+								{ formatWalletAmount(
+									event.amount_usd_micros
+								) }
+							</strong>
+						</li>
+					);
+				} ) }
+			</ol>
+		);
+	}
 
 	return (
 		<div className="sd-ai-agent-superdav-account">
@@ -233,80 +313,7 @@ export default function SuperdavAccountManager() {
 							<h4 id="sd-ai-agent-superdav-credit-activity-heading">
 								{ __( 'Credit activity', 'superdav-ai-agent' ) }
 							</h4>
-							{ creditActivity === null ? (
-								<p className="description">
-									{ __(
-										'Recent credit activity is unavailable.',
-										'superdav-ai-agent'
-									) }
-								</p>
-							) : creditActivity.length === 0 ? (
-								<p className="description">
-									{ __(
-										'No recent credit activity is available.',
-										'superdav-ai-agent'
-									) }
-								</p>
-							) : (
-								<ol className="sd-ai-agent-superdav-credit-activity-list">
-									{ creditActivity.map( ( event, index ) => {
-										const showsExpiry =
-											event.type === 'promotion' || event.expires_at;
-
-										return (
-											<li
-												key={ `${ event.type }-${ event.effective_at }-${ index }` }
-											>
-												<div>
-													<strong>
-														{ formatCreditActivityType(
-															event.type
-														) }
-													</strong>
-													{ event.label && (
-														<span className="sd-ai-agent-superdav-credit-activity-label">
-															{ event.label }
-														</span>
-													) }
-													<span className="sd-ai-agent-superdav-credit-activity-date">
-														{ sprintf(
-															/* translators: %s: localized effective timestamp. */
-															__(
-																'Effective: %s',
-																'superdav-ai-agent'
-															),
-															formatCreditActivityDate(
-																event.effective_at,
-																siteTimezone
-															)
-														) }
-													</span>
-													{ showsExpiry && (
-														<span className="sd-ai-agent-superdav-credit-activity-expiry">
-															{ sprintf(
-																/* translators: %s: localized expiry timestamp or unavailable label. */
-																__(
-																	'Expiry: %s',
-																	'superdav-ai-agent'
-																),
-																formatCreditActivityDate(
-																	event.expires_at,
-																	siteTimezone
-																)
-															) }
-														</span>
-													) }
-												</div>
-												<strong className="sd-ai-agent-superdav-credit-activity-amount">
-													{ formatWalletAmount(
-														event.amount_usd_micros
-													) }
-												</strong>
-											</li>
-										);
-									} ) }
-								</ol>
-							) }
+							{ creditActivityContent }
 						</section>
 
 						{ accountUrl ? (

--- a/src/settings-page/superdav-account-manager.js
+++ b/src/settings-page/superdav-account-manager.js
@@ -27,6 +27,49 @@ export function formatWalletAmount( micros ) {
 }
 
 /**
+ * Format a service timestamp in the WordPress site's configured timezone.
+ *
+ * @param {string|null|undefined} timestamp ISO-8601 timestamp.
+ * @param {string|null|undefined} timeZone WordPress site timezone identifier.
+ * @return {string} Localized timestamp, or an unavailable label.
+ */
+export function formatCreditActivityDate( timestamp, timeZone ) {
+	const date = new Date( timestamp || '' );
+	if ( Number.isNaN( date.getTime() ) ) {
+		return __( 'Unavailable', 'superdav-ai-agent' );
+	}
+
+	try {
+		return new Intl.DateTimeFormat( undefined, {
+			dateStyle: 'medium',
+			timeStyle: 'short',
+			timeZone: timeZone || undefined,
+		} ).format( date );
+	} catch {
+		return __( 'Unavailable', 'superdav-ai-agent' );
+	}
+}
+
+/**
+ * Return a neutral, translated label for a safe credit activity type.
+ *
+ * @param {string} type Safe event type from the managed service.
+ * @return {string} Activity label.
+ */
+export function formatCreditActivityType( type ) {
+	const labels = {
+		purchase: __( 'Purchased credit', 'superdav-ai-agent' ),
+		promotion: __( 'Promotional credit', 'superdav-ai-agent' ),
+		redeemed: __( 'Coupon redeemed', 'superdav-ai-agent' ),
+		consumed: __( 'Credit usage', 'superdav-ai-agent' ),
+		pending: __( 'Pending adjustment', 'superdav-ai-agent' ),
+		expired: __( 'Expired credit', 'superdav-ai-agent' ),
+	};
+
+	return labels[ type ] || __( 'Credit activity', 'superdav-ai-agent' );
+}
+
+/**
  * Manage the connected site's Superdav AI service account.
  *
  * Payment information is never entered or stored in WordPress. Billing actions
@@ -86,6 +129,10 @@ export default function SuperdavAccountManager() {
 	const accountUrl = account?.account_portal_url || '';
 	const configured = !! account?.configured;
 	const tier = account?.tier || '';
+	const creditActivity = Array.isArray( account?.credit_activity )
+		? account.credit_activity
+		: null;
+	const siteTimezone = account?.site_timezone || '';
 
 	return (
 		<div className="sd-ai-agent-superdav-account">
@@ -178,6 +225,89 @@ export default function SuperdavAccountManager() {
 								</strong>
 							</div>
 						</div>
+
+						<section
+							className="sd-ai-agent-superdav-credit-activity"
+							aria-labelledby="sd-ai-agent-superdav-credit-activity-heading"
+						>
+							<h4 id="sd-ai-agent-superdav-credit-activity-heading">
+								{ __( 'Credit activity', 'superdav-ai-agent' ) }
+							</h4>
+							{ creditActivity === null ? (
+								<p className="description">
+									{ __(
+										'Recent credit activity is unavailable.',
+										'superdav-ai-agent'
+									) }
+								</p>
+							) : creditActivity.length === 0 ? (
+								<p className="description">
+									{ __(
+										'No recent credit activity is available.',
+										'superdav-ai-agent'
+									) }
+								</p>
+							) : (
+								<ol className="sd-ai-agent-superdav-credit-activity-list">
+									{ creditActivity.map( ( event, index ) => {
+										const showsExpiry =
+											event.type === 'promotion' || event.expires_at;
+
+										return (
+											<li
+												key={ `${ event.type }-${ event.effective_at }-${ index }` }
+											>
+												<div>
+													<strong>
+														{ formatCreditActivityType(
+															event.type
+														) }
+													</strong>
+													{ event.label && (
+														<span className="sd-ai-agent-superdav-credit-activity-label">
+															{ event.label }
+														</span>
+													) }
+													<span className="sd-ai-agent-superdav-credit-activity-date">
+														{ sprintf(
+															/* translators: %s: localized effective timestamp. */
+															__(
+																'Effective: %s',
+																'superdav-ai-agent'
+															),
+															formatCreditActivityDate(
+																event.effective_at,
+																siteTimezone
+															)
+														) }
+													</span>
+													{ showsExpiry && (
+														<span className="sd-ai-agent-superdav-credit-activity-expiry">
+															{ sprintf(
+																/* translators: %s: localized expiry timestamp or unavailable label. */
+																__(
+																	'Expiry: %s',
+																	'superdav-ai-agent'
+																),
+																formatCreditActivityDate(
+																	event.expires_at,
+																	siteTimezone
+																)
+															) }
+														</span>
+													) }
+												</div>
+												<strong className="sd-ai-agent-superdav-credit-activity-amount">
+													{ formatWalletAmount(
+														event.amount_usd_micros
+													) }
+												</strong>
+											</li>
+										);
+									} ) }
+								</ol>
+							) }
+						</section>
 
 						{ accountUrl ? (
 							<div className="sd-ai-agent-superdav-account-actions">

--- a/tests/SdAiAgent/REST/SettingsControllerTest.php
+++ b/tests/SdAiAgent/REST/SettingsControllerTest.php
@@ -280,6 +280,33 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 								'total_usd_micros' => 15000000,
 								'payment_token'    => 'must-not-be-exposed',
 							),
+							'credit_activity' => array(
+								array(
+									'type'              => 'purchase',
+									'amount_usd_micros' => 12500000,
+									'effective_at'      => '2026-07-15T00:00:00Z',
+									'label'             => 'Credit purchase',
+									'invoice_id'        => 'must-not-be-exposed',
+								),
+								array(
+									'type'              => 'promotion',
+									'amount_usd_micros' => 2500000,
+									'effective_at'      => '2026-07-16T00:00:00Z',
+									'expires_at'        => '2026-08-16T00:00:00Z',
+									'label'             => 'Welcome coupon',
+									'customer_id'       => 'must-not-be-exposed',
+								),
+								array(
+									'type'              => 'processor_event',
+									'amount_usd_micros' => 5000000,
+									'effective_at'      => '2026-07-17T00:00:00Z',
+								),
+								array(
+									'type'              => 'consumed',
+									'amount_usd_micros' => '-1000000',
+									'effective_at'      => 'invalid',
+								),
+							),
 							'access_token'       => 'must-not-be-exposed',
 						)
 					),
@@ -307,10 +334,26 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		$this->assertSame( 15000000, $data['wallet']['total_usd_micros'] );
 		$this->assertSame( 'https://account.example/billing', $data['account_portal_url'] );
 		$this->assertSame( '2026-07-16T00:00:00+00:00', $data['connected_at'] );
+		$this->assertSame( wp_timezone_string(), $data['site_timezone'] );
+		$this->assertCount( 2, $data['credit_activity'] );
+		$this->assertSame( 'promotion', $data['credit_activity'][0]['type'] );
+		$this->assertSame( 2500000, $data['credit_activity'][0]['amount_usd_micros'] );
+		$this->assertSame( '2026-08-16T00:00:00+00:00', $data['credit_activity'][0]['expires_at'] );
+		$this->assertArrayNotHasKey( 'customer_id', $data['credit_activity'][0] );
 		$this->assertArrayNotHasKey( 'usage', $data );
 		$this->assertArrayNotHasKey( 'verification', $data );
 		$this->assertStringNotContainsString( $token, wp_json_encode( $data ) ?: '' );
 		$this->assertStringNotContainsString( 'must-not-be-exposed', wp_json_encode( $data ) ?: '' );
+	}
+
+	/** Superdav account activity remains restricted to site administrators. */
+	public function test_superdav_account_permission_requires_manage_options(): void {
+		$administrator_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $administrator_id );
+		$this->assertTrue( SettingsController::check_admin_permission() );
+
+		wp_set_current_user( 0 );
+		$this->assertFalse( SettingsController::check_admin_permission() );
 	}
 
 	/** Account portal URLs containing centrally blocked query keys are not exposed. */


### PR DESCRIPTION
## Summary

Adds a bounded, sanitized credit-activity response to the Superdav account page.

- Allows only recognized event types and display-safe fields.
- Sorts at most 25 newest-first events without cursor pagination.
- Renders accessible activity, expiry, empty, and unavailable states in the WordPress site timezone.

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — a WordPress CLI fixture retained two safe newest-first events and rejected private invoice, customer, and token fields from the response.

## Worker self-verification

- PHPUnit: blocked locally because the configured test database rejects `root@localhost` without a password.
- JS: targeted `superdav-account-manager.test.js` passed (6 tests).
- Lint: PHP/JS/CSS all clean.
- PHPStan: 0 errors.
- Build: succeeded.

Resolves #2334

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-terra spent 24m and 212,929 tokens on this as a headless worker. Overall, 47m since this issue was created.
