### PR TITLE
fix: discard expired tool confirmations

### DIFF
--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -1227,6 +1227,19 @@ final class SessionController {
 					array( 'status' => 404 )
 				);
 			}
+			if ( $this->discard_expired_paused_job( $db_row ) ) {
+				// A paused job needs the transient's serialized loop state to resume.
+				// Never resurrect its DB-only tool list as a confirmation dialog: the
+				// subsequent confirm/reject request cannot safely execute it.
+				return new WP_REST_Response(
+					array(
+						'status'     => 'expired',
+						'from_db'    => true,
+						'session_id' => $db_row->session_id,
+					),
+					200
+				);
+			}
 			return $this->job_status_from_db_row( $job_id, $db_row );
 		}
 
@@ -3114,7 +3127,7 @@ final class SessionController {
 		$session_id = (int) $request->get_param( 'id' );
 		$db_row     = ActiveJobRepository::get_by_session_id( $session_id );
 
-		if ( null === $db_row ) {
+		if ( null === $db_row || $this->discard_expired_paused_job( $db_row ) ) {
 			return new WP_Error(
 				'sd_ai_agent_no_active_job',
 				__( 'No active job for this session.', 'superdav-ai-agent' ),
@@ -3154,9 +3167,37 @@ final class SessionController {
 					'status'     => $row->status,
 				);
 			},
-			$rows
+			array_filter(
+				$rows,
+				fn( ActiveJobRow $row ): bool => ! $this->discard_expired_paused_job( $row )
+			)
 		);
 
 		return new WP_REST_Response( array_values( $data ), 200 );
+	}
+
+	/**
+	 * Remove a paused job whose transient has expired.
+	 *
+	 * The active-jobs table deliberately stores summary data for polling
+	 * recovery, but does not contain the serialized loop state required to
+	 * resume a confirmation or client-tool pause. Returning such a row after its
+	 * transient expires makes the UI show an approval it can never submit.
+	 *
+	 * @param ActiveJobRow $row Persistent active-job row.
+	 * @return bool Whether an expired paused row was discarded.
+	 */
+	private function discard_expired_paused_job( ActiveJobRow $row ): bool {
+		if ( ! in_array( $row->status, array( 'awaiting_confirmation', 'awaiting_client_tools' ), true ) ) {
+			return false;
+		}
+
+		$job = get_transient( RestController::JOB_PREFIX . $row->job_id );
+		if ( is_array( $job ) ) {
+			return false;
+		}
+
+		ActiveJobRepository::delete( $row->job_id );
+		return true;
 	}
 }

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -1174,6 +1174,77 @@ class RestControllerTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A DB-only confirmation must not re-open a dialog that cannot be resumed.
+	 */
+	public function test_job_status_discards_expired_confirmation_instead_of_returning_it(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$session_id = Database::create_session( [
+			'user_id' => $this->admin_id,
+			'title'   => 'Expired confirmation',
+		] );
+		$job_id     = '55555555-6666-7777-8888-999999999999';
+
+		ActiveJobRepository::create( $session_id, $job_id, $this->admin_id, 'awaiting_confirmation' );
+		ActiveJobRepository::update_status(
+			$job_id,
+			'awaiting_confirmation',
+			[ 'pending_tools' => wp_json_encode( [ [ 'name' => 'wpab__sd-ai-agent__ability-call' ] ] ) ]
+		);
+		delete_transient( RestController::JOB_PREFIX . $job_id );
+
+		$response = $this->dispatch( 'GET', "/sd-ai-agent/v1/job/{$job_id}" );
+
+		$this->assertStatus( 200, $response );
+		$this->assertSame( 'expired', $response->get_data()['status'] );
+		$this->assertArrayNotHasKey( 'pending_tools', $response->get_data() );
+		$this->assertNull( ActiveJobRepository::get_by_job_id( $job_id ) );
+	}
+
+	/**
+	 * Page-load active-job discovery must not restore expired confirmations.
+	 */
+	public function test_active_jobs_omits_expired_confirmation(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$session_id = Database::create_session( [
+			'user_id' => $this->admin_id,
+			'title'   => 'Stale confirmation discovery',
+		] );
+		$job_id     = '66666666-7777-8888-9999-000000000000';
+
+		ActiveJobRepository::create( $session_id, $job_id, $this->admin_id, 'awaiting_confirmation' );
+		delete_transient( RestController::JOB_PREFIX . $job_id );
+
+		$response = $this->dispatch( 'GET', '/sd-ai-agent/v1/sessions/active-jobs' );
+
+		$this->assertStatus( 200, $response );
+		$this->assertNotContains( $job_id, wp_list_pluck( $response->get_data(), 'job_id' ) );
+		$this->assertNull( ActiveJobRepository::get_by_job_id( $job_id ) );
+	}
+
+	/**
+	 * Opening a session must not revive an expired confirmation either.
+	 */
+	public function test_session_active_job_discards_expired_confirmation(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$session_id = Database::create_session( [
+			'user_id' => $this->admin_id,
+			'title'   => 'Stale confirmation session',
+		] );
+		$job_id     = '77777777-8888-9999-0000-111111111111';
+
+		ActiveJobRepository::create( $session_id, $job_id, $this->admin_id, 'awaiting_confirmation' );
+		delete_transient( RestController::JOB_PREFIX . $job_id );
+
+		$response = $this->dispatch( 'GET', "/sd-ai-agent/v1/sessions/{$session_id}/active-job" );
+
+		$this->assertStatus( 404, $response );
+		$this->assertNull( ActiveJobRepository::get_by_job_id( $job_id ) );
+	}
+
+	/**
 	 * Test terminal DB error rows keep recoverable metadata when paused state exists.
 	 */
 	public function test_job_status_from_db_error_row_includes_recoverable_when_paused_state_exists(): void {


### PR DESCRIPTION
## Summary
- discard paused jobs whose transient state has expired instead of reopening an unresumable confirmation dialog
- prevent both global and session-scoped active-job restoration from surfacing stale confirmations
- cover polling and both restoration endpoints with REST regression tests

## Worker self-verification
- PHPUnit: Tests: 3956, Assertions: 17376, Errors: 0, Failures: 0, Skipped: 126
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4
