### PR TITLE
fix: simplify chat progress details

### DIFF
--- a/includes/Core/Settings.php
+++ b/includes/Core/Settings.php
@@ -410,6 +410,7 @@ class Settings {
 			'provider_request_max_tokens'     => ConversationTrimmer::DEFAULT_MAX_REQUEST_TOKENS,
 			'suggestion_count'                => 3,
 			'yolo_mode'                       => false,
+			'show_tool_call_details'          => false,
 			'show_on_frontend'                => true,
 			'public_chat_embed_id'            => 'docs',
 			'keyboard_shortcut'               => 'alt+a',

--- a/src/components/chat-redesign/MessageList.js
+++ b/src/components/chat-redesign/MessageList.js
@@ -22,7 +22,11 @@ import STORE_NAME from '../../store';
 import RecoverableJobActionCard from '../recoverable-job-action-card';
 import FeedbackConsentModal from '../feedback-consent-modal';
 import useTextToSpeech from '../use-text-to-speech';
-import { extractText, getRunningToolName } from './message-helpers';
+import {
+	extractText,
+	getFriendlyToolLabel,
+	getRunningToolName,
+} from './message-helpers';
 import AccountActionSystemMessage from './account-action-system-message';
 import {
 	buildSuperdavCreditNoticeMessage,
@@ -56,8 +60,10 @@ export default function MessageList() {
 		hasStreamError,
 		pendingActionCard,
 		providers,
+		showToolCallDetails,
 	} = useSelect( ( sel ) => {
 		const store = sel( STORE_NAME );
+		const settings = store.getSettings();
 		return {
 			messages: store.getCurrentSessionMessages(),
 			sending: store.isSending(),
@@ -65,7 +71,7 @@ export default function MessageList() {
 			liveToolCalls: store.getLiveToolCalls(),
 			sessionJobs: store.getSessionJobs(),
 			greeting:
-				store.getSettings()?.greeting_message ||
+				settings?.greeting_message ||
 				__(
 					'Ask the agent to make a change, write a post, or audit your site.',
 					'sd-ai-agent'
@@ -77,6 +83,7 @@ export default function MessageList() {
 			hasStreamError: store.hasStreamError(),
 			pendingActionCard: store.getPendingActionCard(),
 			providers: store.getProviders(),
+			showToolCallDetails: settings?.show_tool_call_details === true,
 		};
 	}, [] );
 
@@ -255,8 +262,8 @@ export default function MessageList() {
 
 	const runningToolName = getRunningToolName( runningToolCalls );
 	const runningStep = runningToolName
-		? `${ __( 'Running', 'sd-ai-agent' ) } ${ runningToolName }…`
-		: __( 'Composing reply…', 'sd-ai-agent' );
+		? `${ getFriendlyToolLabel( runningToolName ) }…`
+		: __( 'Composing reply…', 'superdav-ai-agent' );
 
 	// ── Render ────────────────────────────────────────────────────────────────
 
@@ -325,6 +332,7 @@ export default function MessageList() {
 						<RunningMessage
 							step={ runningStep }
 							liveToolCalls={ runningToolCalls }
+							showToolCallDetails={ showToolCallDetails }
 						/>
 					) }
 

--- a/src/components/chat-redesign/ToolCard.js
+++ b/src/components/chat-redesign/ToolCard.js
@@ -163,6 +163,32 @@ function extractDesignPreviews( call, response ) {
 }
 
 /**
+ * Render rich, user-facing tool results that should remain visible even when
+ * raw tool-call details are hidden.
+ *
+ * @param {Object} root0
+ * @param {*}      root0.call
+ * @param {*}      root0.response
+ */
+export function ToolResultHighlights( { call, response } ) {
+	const designPreviews = extractDesignPreviews( call, response );
+	const previewMessage = response?.response?.message
+		? formatValue( response.response.message )
+		: null;
+
+	if ( ! designPreviews ) {
+		return null;
+	}
+
+	return (
+		<DesignPreviewGallery
+			designPreviews={ designPreviews }
+			message={ previewMessage }
+		/>
+	);
+}
+
+/**
  * Return itemized update-blocks errors from a structured tool response.
  *
  * @param {*} response Tool response pair entry.
@@ -219,9 +245,6 @@ export default function ToolCard( {
 	const hasRecoveryHints =
 		Array.isArray( recoveryHints ) && recoveryHints.length > 0;
 	const hasValidationFeedback = itemizedErrors.length > 0 || hasRecoveryHints;
-	const previewMessage = response?.response?.message
-		? formatValue( response.response.message )
-		: null;
 
 	return (
 		<div
@@ -260,10 +283,7 @@ export default function ToolCard( {
 
 			{ /* Design preview gallery is always visible when previews exist */ }
 			{ designPreviews && (
-				<DesignPreviewGallery
-					designPreviews={ designPreviews }
-					message={ previewMessage }
-				/>
+				<ToolResultHighlights call={ call } response={ response } />
 			) }
 
 			{ open && (

--- a/src/components/chat-redesign/__tests__/ToolCard.test.js
+++ b/src/components/chat-redesign/__tests__/ToolCard.test.js
@@ -7,7 +7,7 @@
 
 import { createElement } from '@wordpress/element';
 import { renderToStaticMarkup } from 'react-dom/server.node';
-import ToolCard from '../ToolCard';
+import ToolCard, { ToolResultHighlights } from '../ToolCard';
 
 jest.mock( '@wordpress/i18n', () => ( {
 	__: ( str ) => str,
@@ -21,7 +21,10 @@ jest.mock( '@wordpress/icons', () => ( {
 	caution: 'caution',
 } ) );
 
-jest.mock( '../../design-preview-gallery', () => () => null );
+jest.mock(
+	'../../design-preview-gallery',
+	() => () => 'Design preview gallery'
+);
 
 describe( 'ToolCard', () => {
 	test( 'stringifies object-shaped response summaries before rendering', () => {
@@ -114,5 +117,30 @@ describe( 'ToolCard', () => {
 			'Re-run get-page-blocks with the current revision.'
 		);
 		expect( html ).not.toContain( 'Validation errors' );
+	} );
+
+	test( 'renders design previews as standalone result highlights', () => {
+		const html = renderToStaticMarkup(
+			createElement( ToolResultHighlights, {
+				call: {
+					id: 'tool-4',
+					name: 'sd-ai-agent/render-design-previews',
+					args: {},
+				},
+				response: {
+					id: 'tool-4',
+					response: {
+						design_previews: [
+							{
+								name: 'Design 1',
+								html_url: 'https://example.test/design-1.html',
+							},
+						],
+					},
+				},
+			} )
+		);
+
+		expect( html ).toContain( 'Design preview gallery' );
 	} );
 } );

--- a/src/components/chat-redesign/__tests__/message-helpers.test.js
+++ b/src/components/chat-redesign/__tests__/message-helpers.test.js
@@ -12,12 +12,19 @@
  * - extractText() concatenates only text parts.
  */
 
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( str ) => str,
+} ) );
+
 import {
 	buildRunningItems,
+	buildToolProgressSummary,
 	extractText,
+	getFriendlyToolLabel,
 	getRunningToolName,
 	pairToolCalls,
 	parseSuggestions,
+	sanitizeProgressText,
 } from '../message-helpers';
 
 describe( 'extractText', () => {
@@ -198,6 +205,74 @@ describe( 'getRunningToolName', () => {
 			{ type: 'response', id: 'a', response: { ok: true } },
 		];
 		expect( getRunningToolName( log ) ).toBeNull();
+	} );
+} );
+
+describe( 'friendly tool progress summaries', () => {
+	test( 'converts raw ability names to friendly labels', () => {
+		expect(
+			getFriendlyToolLabel( 'wpab__sd-ai-agent__compile-design-tokens' )
+		).toBe( 'Preparing design tokens' );
+		expect( getFriendlyToolLabel( 'sd-ai-agent/update-post' ) ).toBe(
+			'Updating content'
+		);
+	} );
+
+	test( 'sanitizes progress narration before default display', () => {
+		const text = sanitizeProgressText(
+			'Next I will call `sd-ai-agent/compile-design-tokens` and then `sd-ai-agent/validate-palette-contrast`.'
+		);
+
+		expect( text ).not.toContain( 'sd-ai-agent/' );
+		expect( text ).toContain( 'preparing design tokens' );
+		expect( text ).toContain( 'checking colour contrast' );
+	} );
+
+	test( 'summarizes completed, failed, and running steps', () => {
+		const summary = buildToolProgressSummary( [
+			{
+				type: 'preamble',
+				text: 'I will use sd-ai-agent/compile-design-tokens first.',
+			},
+			{
+				type: 'call',
+				id: 'compile',
+				name: 'wpab__sd-ai-agent__compile-design-tokens',
+			},
+			{
+				type: 'response',
+				id: 'compile',
+				response: { success: true },
+			},
+			{
+				type: 'call',
+				id: 'contrast',
+				name: 'sd-ai-agent/validate-palette-contrast',
+			},
+			{
+				type: 'response',
+				id: 'contrast',
+				response: { error: 'Contrast failed.' },
+			},
+			{
+				type: 'call',
+				id: 'image',
+				name: 'sd-ai-agent/generate-image',
+			},
+		] );
+
+		expect( summary.hasActivity ).toBe( true );
+		expect( summary.totalCount ).toBe( 3 );
+		expect( summary.completedCount ).toBe( 1 );
+		expect( summary.failedCount ).toBe( 1 );
+		expect( summary.runningCount ).toBe( 1 );
+		expect( summary.currentLabel ).toBe( 'Generating an image' );
+		expect( summary.latestThought ).not.toContain( 'sd-ai-agent/' );
+		expect( summary.recentSteps.map( ( step ) => step.label ) ).toEqual( [
+			'Preparing design tokens',
+			'Checking colour contrast',
+			'Generating an image',
+		] );
 	} );
 } );
 

--- a/src/components/chat-redesign/__tests__/message-items.test.js
+++ b/src/components/chat-redesign/__tests__/message-items.test.js
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for shared chat-redesign message item rendering.
+ */
+
+import { createElement } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+
+import { AssistantMessage } from '../message-items';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( str ) => str,
+} ) );
+
+jest.mock( '@wordpress/icons', () => ( {
+	Icon: () => null,
+	copy: 'copy',
+	check: 'check',
+	pencil: 'pencil',
+	thumbsDown: 'thumbsDown',
+} ) );
+
+jest.mock( '../../../store', () => 'sd-ai-agent' );
+
+jest.mock(
+	'../../markdown-message',
+	() =>
+		( { content } ) =>
+			content
+);
+
+jest.mock( '../icons', () => ( {
+	AiIcon: () => null,
+} ) );
+
+jest.mock( '../ToolCard', () => ( {
+	__esModule: true,
+	default: () => null,
+	ToolResultHighlights: () => null,
+} ) );
+
+/**
+ * Render an assistant message with mocked store selectors.
+ *
+ * @param {Object}  root0                Options.
+ * @param {boolean} root0.hasStreamError Whether the active session has a send error.
+ * @param {string}  root0.text           Assistant message text.
+ * @return {Promise<{container: HTMLElement, root: import('react-dom/client').Root}>}
+ *   Rendered container and root.
+ */
+async function renderAssistantMessage( { hasStreamError, text = '' } ) {
+	const selectors = {
+		getMessageTokens: () => [],
+		getSettings: () => ( { show_tool_call_details: false } ),
+		hasStreamError: () => hasStreamError,
+	};
+	useSelect.mockImplementation( ( fn ) => fn( () => selectors ) );
+
+	const container = document.createElement( 'div' );
+	document.body.appendChild( container );
+	const root = createRoot( container );
+	await act( async () => {
+		root.render(
+			createElement( AssistantMessage, {
+				msg: {
+					role: 'model',
+					parts: [ { text } ],
+					toolCalls: [
+						{
+							type: 'call',
+							id: 'theme',
+							name: 'sd-ai-agent/get-theme-json',
+						},
+						{
+							type: 'response',
+							id: 'theme',
+							response: { success: true },
+						},
+					],
+				},
+				index: 0,
+				onSuggestionSelect: jest.fn(),
+				onThumbsDown: jest.fn(),
+				isLastModel: true,
+			} )
+		);
+	} );
+
+	return { container, root };
+}
+
+describe( 'AssistantMessage progress summary', () => {
+	afterEach( () => {
+		document.body.innerHTML = '';
+		jest.clearAllMocks();
+	} );
+
+	test( 'shows an interrupted progress state when the final response failed', async () => {
+		const { container, root } = await renderAssistantMessage( {
+			hasStreamError: true,
+			text: 'Error: The AI service is unavailable.',
+		} );
+
+		const summary = container.querySelector( '.sdaa-cr-progress-summary' );
+		expect( summary ).not.toBeNull();
+		expect( summary.classList.contains( 'is-error' ) ).toBe( true );
+		expect( summary.textContent ).toContain( 'Work paused' );
+		expect( summary.textContent ).toContain(
+			'The agent completed several steps, then stopped before finishing the reply.'
+		);
+		expect( summary.textContent ).not.toContain( 'Work completed' );
+
+		await act( async () => {
+			root.unmount();
+		} );
+	} );
+
+	test( 'does not call a tool-only final message complete when no reply was written', async () => {
+		const { container, root } = await renderAssistantMessage( {
+			hasStreamError: false,
+		} );
+
+		const summary = container.querySelector( '.sdaa-cr-progress-summary' );
+		expect( summary ).not.toBeNull();
+		expect( summary.classList.contains( 'is-error' ) ).toBe( true );
+		expect( summary.textContent ).toContain( 'Work paused' );
+		expect( summary.textContent ).not.toContain( 'Work completed' );
+
+		await act( async () => {
+			root.unmount();
+		} );
+	} );
+} );

--- a/src/components/chat-redesign/chat-redesign.css
+++ b/src/components/chat-redesign/chat-redesign.css
@@ -1124,6 +1124,146 @@ input[type="text"].sdaa-cr-search-input {
 }
 
 /* Running indicator */
+.sdaa-cr-progress-summary {
+	border: 1px solid var(--sdaa-border-subtle);
+	border-radius: var(--sdaa-radius-md);
+	background: #fff;
+	padding: 12px 14px;
+	margin: 4px 0 10px;
+	display: grid;
+	gap: 10px;
+	box-shadow: 0 1px 2px rgb(0 0 0 / 3%);
+}
+
+.sdaa-cr-progress-summary.is-running {
+	border-color: var(--sdaa-bubble-user-border);
+	background: linear-gradient(180deg, #f8fbff 0%, #fff 100%);
+}
+
+.sdaa-cr-progress-summary.is-complete {
+	background: var(--sdaa-surface);
+}
+
+.sdaa-cr-progress-main {
+	display: grid;
+	gap: 4px;
+}
+
+.sdaa-cr-progress-title {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	font-weight: 600;
+	color: var(--sdaa-text-primary);
+	font-size: 14px;
+}
+
+.sdaa-cr-progress-title-dot {
+	display: inline-block;
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	background: var(--sdaa-success);
+	flex-shrink: 0;
+}
+
+.sdaa-cr-progress-title-dot.is-running {
+	background: var(--sdaa-primary);
+	animation: sdaa-cr-pulse 1.2s ease-in-out infinite;
+}
+
+.sdaa-cr-progress-description {
+	color: var(--sdaa-text-secondary);
+	font-size: 13px;
+	line-height: 1.45;
+}
+
+.sdaa-cr-progress-stats {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+}
+
+.sdaa-cr-progress-stat {
+	display: inline-flex;
+	align-items: center;
+	border: 1px solid var(--sdaa-border-subtle);
+	border-radius: var(--sdaa-radius-pill);
+	padding: 2px 8px;
+	font-size: 11.5px;
+	color: var(--sdaa-text-secondary);
+	background: #fff;
+}
+
+.sdaa-cr-progress-stat.is-complete {
+	border-color: #d8eddb;
+	color: var(--sdaa-success);
+}
+
+.sdaa-cr-progress-stat.is-running {
+	border-color: var(--sdaa-bubble-user-border);
+	color: var(--sdaa-primary);
+}
+
+.sdaa-cr-progress-stat.is-error {
+	border-color: #f1b0b7;
+	color: var(--sdaa-error);
+	background: var(--sdaa-error-surface);
+}
+
+.sdaa-cr-progress-steps {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+	display: grid;
+	gap: 6px;
+}
+
+.sdaa-cr-progress-step {
+	display: grid;
+	grid-template-columns: auto minmax(0, 1fr) auto;
+	align-items: center;
+	gap: 8px;
+	font-size: 12px;
+	color: var(--sdaa-text-secondary);
+}
+
+.sdaa-cr-progress-step-dot {
+	width: 7px;
+	height: 7px;
+	border-radius: 50%;
+	background: var(--sdaa-success);
+}
+
+.sdaa-cr-progress-step.is-running .sdaa-cr-progress-step-dot {
+	background: var(--sdaa-primary);
+	animation: sdaa-cr-pulse 1.2s ease-in-out infinite;
+}
+
+.sdaa-cr-progress-step.is-error .sdaa-cr-progress-step-dot {
+	background: var(--sdaa-error);
+}
+
+.sdaa-cr-progress-step.is-warn .sdaa-cr-progress-step-dot {
+	background: var(--sdaa-warning);
+}
+
+.sdaa-cr-progress-step-label {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.sdaa-cr-progress-step-status {
+	color: var(--sdaa-text-muted);
+	font-size: 11px;
+	white-space: nowrap;
+}
+
+.sdaa-cr-progress-step.is-error .sdaa-cr-progress-step-status {
+	color: var(--sdaa-error);
+}
+
 .sdaa-cr-running-line {
 	display: flex;
 	align-items: center;

--- a/src/components/chat-redesign/chat-redesign.css
+++ b/src/components/chat-redesign/chat-redesign.css
@@ -1144,6 +1144,11 @@ input[type="text"].sdaa-cr-search-input {
 	background: var(--sdaa-surface);
 }
 
+.sdaa-cr-progress-summary.is-error {
+	border-color: #f1b0b7;
+	background: var(--sdaa-error-surface);
+}
+
 .sdaa-cr-progress-main {
 	display: grid;
 	gap: 4px;
@@ -1170,6 +1175,10 @@ input[type="text"].sdaa-cr-search-input {
 .sdaa-cr-progress-title-dot.is-running {
 	background: var(--sdaa-primary);
 	animation: sdaa-cr-pulse 1.2s ease-in-out infinite;
+}
+
+.sdaa-cr-progress-title-dot.is-error {
+	background: var(--sdaa-error);
 }
 
 .sdaa-cr-progress-description {

--- a/src/components/chat-redesign/message-helpers.js
+++ b/src/components/chat-redesign/message-helpers.js
@@ -4,7 +4,329 @@
  * in one place so the two UIs render the same store data identically.
  */
 
+import { __ } from '@wordpress/i18n';
+
 import { extractMessageText } from '../../utils/message-parts';
+
+const FRIENDLY_TOOL_LABELS = {
+	'ability-search': __( 'Finding the right capability', 'superdav-ai-agent' ),
+	'ability-call': __(
+		'Running the selected capability',
+		'superdav-ai-agent'
+	),
+	'skill-load': __( 'Loading specialist guidance', 'superdav-ai-agent' ),
+	'skill-list': __( 'Checking available skills', 'superdav-ai-agent' ),
+	'site-info': __( 'Checking site details', 'superdav-ai-agent' ),
+	'memory-list': __( 'Checking memory', 'superdav-ai-agent' ),
+	'memory-save': __( 'Saving a useful memory', 'superdav-ai-agent' ),
+	'knowledge-search': __( 'Searching knowledge', 'superdav-ai-agent' ),
+	'get-post': __( 'Reading content', 'superdav-ai-agent' ),
+	'get-page-blocks': __( 'Reading page content', 'superdav-ai-agent' ),
+	'create-post': __( 'Creating content', 'superdav-ai-agent' ),
+	'append-post-content': __( 'Adding content', 'superdav-ai-agent' ),
+	'update-post': __( 'Updating content', 'superdav-ai-agent' ),
+	'update-blocks': __( 'Updating page content', 'superdav-ai-agent' ),
+	'generate-image': __( 'Generating an image', 'superdav-ai-agent' ),
+	'stock-image-search': __( 'Finding images', 'superdav-ai-agent' ),
+	'render-design-previews': __(
+		'Rendering design previews',
+		'superdav-ai-agent'
+	),
+	'compile-design-tokens': __(
+		'Preparing design tokens',
+		'superdav-ai-agent'
+	),
+	'validate-palette-contrast': __(
+		'Checking colour contrast',
+		'superdav-ai-agent'
+	),
+	'get-theme-json': __( 'Reading theme settings', 'superdav-ai-agent' ),
+	'get-global-styles': __( 'Reading site styles', 'superdav-ai-agent' ),
+	'update-global-styles': __( 'Applying site styles', 'superdav-ai-agent' ),
+	'scaffold-block-theme': __( 'Preparing theme files', 'superdav-ai-agent' ),
+	'apply-design-artifact-release': __(
+		'Applying the design package',
+		'superdav-ai-agent'
+	),
+};
+
+const PROGRESS_TOOL_PATTERN =
+	/`?(?:wpab__)?(?:sd-ai-agent|sd-ai-agent-js)(?:__|\/)[a-z0-9][a-z0-9-]*`?/gi;
+
+/**
+ * Normalize provider/native ability bridge names into canonical ability IDs.
+ *
+ * @param {string} name Raw tool/function name.
+ * @return {string} Canonical display name.
+ */
+export function normalizeToolName( name ) {
+	let display = String( name || '' ).trim();
+	display = display.replace( /^[`"']+|[`"']+$/g, '' );
+	if ( display.startsWith( 'wpab__' ) ) {
+		display = display.substring( 6 );
+	}
+	return display.replace( /__/g, '/' );
+}
+
+/**
+ * Return the ability slug after the namespace.
+ *
+ * @param {string} name Raw or normalized tool/function name.
+ * @return {string} Ability slug.
+ */
+function getToolSlug( name ) {
+	const normalized = normalizeToolName( name );
+	const parts = normalized.split( '/' );
+	return parts[ parts.length - 1 ] || normalized;
+}
+
+/**
+ * Convert a slug into readable words while preserving common acronyms.
+ *
+ * @param {string} slug Hyphen/underscore-separated slug.
+ * @return {string} Human-readable words.
+ */
+function humanizeSlug( slug ) {
+	const acronymMap = {
+		ai: 'AI',
+		api: 'API',
+		css: 'CSS',
+		html: 'HTML',
+		id: 'ID',
+		json: 'JSON',
+		seo: 'SEO',
+		url: 'URL',
+		wp: 'WordPress',
+	};
+
+	return String( slug || '' )
+		.replace( /[_-]+/g, ' ' )
+		.trim()
+		.split( /\s+/ )
+		.filter( Boolean )
+		.map( ( word ) => acronymMap[ word.toLowerCase() ] || word )
+		.join( ' ' );
+}
+
+/**
+ * Produce a user-friendly action label for a tool without exposing ability IDs.
+ *
+ * @param {string} name Raw or normalized tool/function name.
+ * @return {string} Friendly action label.
+ */
+export function getFriendlyToolLabel( name ) {
+	const slug = getToolSlug( name ).toLowerCase();
+	if ( FRIENDLY_TOOL_LABELS[ slug ] ) {
+		return FRIENDLY_TOOL_LABELS[ slug ];
+	}
+
+	const verbGroups = [
+		{
+			verbs: [
+				'get',
+				'list',
+				'read',
+				'fetch',
+				'search',
+				'find',
+				'inspect',
+				'check',
+				'validate',
+				'verify',
+				'audit',
+				'analyze',
+				'analyse',
+			],
+			label: __( 'Checking', 'superdav-ai-agent' ),
+		},
+		{
+			verbs: [
+				'create',
+				'generate',
+				'render',
+				'compile',
+				'scaffold',
+				'build',
+			],
+			label: __( 'Creating', 'superdav-ai-agent' ),
+		},
+		{
+			verbs: [ 'execute', 'run' ],
+			label: __( 'Running', 'superdav-ai-agent' ),
+		},
+		{
+			verbs: [
+				'update',
+				'set',
+				'apply',
+				'append',
+				'save',
+				'write',
+				'publish',
+				'draft',
+				'move',
+				'install',
+				'activate',
+				'deactivate',
+				'delete',
+				'remove',
+				'clear',
+				'import',
+				'revert',
+			],
+			label: __( 'Updating', 'superdav-ai-agent' ),
+		},
+	];
+
+	for ( const group of verbGroups ) {
+		const verb = group.verbs.find( ( candidate ) =>
+			slug.startsWith( `${ candidate }-` )
+		);
+		if ( verb ) {
+			const target = humanizeSlug( slug.substring( verb.length + 1 ) );
+			return target ? `${ group.label } ${ target }` : group.label;
+		}
+	}
+
+	const fallback = humanizeSlug( slug );
+	return fallback
+		? fallback.charAt( 0 ).toUpperCase() + fallback.slice( 1 )
+		: __( 'Working on a site step', 'superdav-ai-agent' );
+}
+
+/**
+ * Remove raw ability IDs from progress narration before it is shown by default.
+ *
+ * @param {string} text Progress narration emitted by the model.
+ * @return {string} Sanitized, user-friendly narration.
+ */
+export function sanitizeProgressText( text ) {
+	return String( text || '' )
+		.replace( PROGRESS_TOOL_PATTERN, ( match ) =>
+			getFriendlyToolLabel( match ).toLowerCase()
+		)
+		.replace( /\s+/g, ' ' )
+		.trim();
+}
+
+/**
+ * Keep live progress narration compact in the chat timeline.
+ *
+ * @param {string} text Text to truncate.
+ * @return {string} Truncated text.
+ */
+function truncateProgressText( text ) {
+	const maxLength = 180;
+	if ( text.length <= maxLength ) {
+		return text;
+	}
+	return `${ text.substring( 0, maxLength - 1 ).trimEnd() }…`;
+}
+
+/**
+ * Derive a compact status from a paired tool response.
+ *
+ * @param {*} response Tool response entry.
+ * @return {'running'|'done'|'warn'|'error'} Progress status.
+ */
+function deriveProgressStatus( response ) {
+	if ( ! response ) {
+		return 'running';
+	}
+	const result = response.response;
+	if ( result && typeof result === 'object' ) {
+		if ( result.success === false || result.error ) {
+			return 'error';
+		}
+		if ( result.warning ) {
+			return 'warn';
+		}
+	}
+	return 'done';
+}
+
+/**
+ * Summarize a flat tool-call log into user-facing progress metadata.
+ *
+ * @param {Array} toolCalls Flat tool-call log entries.
+ * @return {Object} Progress summary for the chat UI.
+ */
+export function buildToolProgressSummary( toolCalls ) {
+	if ( ! toolCalls?.length ) {
+		return {
+			hasActivity: false,
+			totalCount: 0,
+			finishedCount: 0,
+			completedCount: 0,
+			failedCount: 0,
+			runningCount: 0,
+			currentLabel: '',
+			latestThought: '',
+			recentSteps: [],
+		};
+	}
+
+	const responses = {};
+	const calls = [];
+	const thoughts = [];
+	for ( const entry of toolCalls ) {
+		if (
+			( entry.type === 'response' || entry.type === 'result' ) &&
+			entry.id
+		) {
+			responses[ entry.id ] = entry;
+		}
+		if ( entry.type === 'call' ) {
+			calls.push( entry );
+		}
+		if ( entry.type === 'preamble' && typeof entry.text === 'string' ) {
+			const text = sanitizeProgressText( entry.text );
+			if ( text ) {
+				thoughts.push( text );
+			}
+		}
+	}
+
+	const steps = calls.map( ( call ) => {
+		const response = call.id ? responses[ call.id ] || null : null;
+		return {
+			id: call.id || call.name || '',
+			label: getFriendlyToolLabel( call.name ),
+			status: deriveProgressStatus( response ),
+		};
+	} );
+
+	const finishedCount = steps.filter(
+		( step ) => step.status !== 'running'
+	).length;
+	const failedCount = steps.filter(
+		( step ) => step.status === 'error'
+	).length;
+	const runningCount = steps.filter(
+		( step ) => step.status === 'running'
+	).length;
+	const completedCount = steps.filter(
+		( step ) => step.status === 'done' || step.status === 'warn'
+	).length;
+	const currentStep =
+		[ ...steps ].reverse().find( ( step ) => step.status === 'running' ) ||
+		steps[ steps.length - 1 ] ||
+		null;
+
+	return {
+		hasActivity: steps.length > 0 || thoughts.length > 0,
+		totalCount: steps.length,
+		finishedCount,
+		completedCount,
+		failedCount,
+		runningCount,
+		currentLabel: currentStep?.label || '',
+		latestThought: truncateProgressText(
+			thoughts[ thoughts.length - 1 ] || ''
+		),
+		recentSteps: steps.slice( -3 ),
+	};
+}
 
 /**
  *

--- a/src/components/chat-redesign/message-items.js
+++ b/src/components/chat-redesign/message-items.js
@@ -30,6 +30,7 @@ import { AiIcon } from './icons';
 import ToolCard from './ToolCard';
 import {
 	buildRunningItems,
+	buildToolProgressSummary,
 	extractText,
 	parseSuggestions,
 } from './message-helpers';
@@ -136,6 +137,147 @@ function AssistantMeta( { tokens } ) {
 		withSeps.push( p );
 	} );
 	return <span className="sdaa-cr-msg-meta-text">{ withSeps }</span>;
+}
+
+/**
+ * Build the headline for a friendly progress summary.
+ *
+ * @param {Object}  summary      Progress summary from buildToolProgressSummary().
+ * @param {boolean} isRunning    Whether the agent is still working.
+ * @param {string}  fallbackStep Fallback text when no step label is available.
+ * @return {string} Summary headline.
+ */
+function getProgressSummaryTitle( summary, isRunning, fallbackStep ) {
+	if ( isRunning ) {
+		return (
+			summary.currentLabel ||
+			fallbackStep ||
+			__( 'Working on it…', 'superdav-ai-agent' )
+		);
+	}
+
+	if ( summary.failedCount > 0 ) {
+		return __( 'Some steps need attention', 'superdav-ai-agent' );
+	}
+
+	return __( 'Work completed', 'superdav-ai-agent' );
+}
+
+/**
+ * Human-readable status text for a summarized tool step.
+ *
+ * @param {string} status Progress status from buildToolProgressSummary().
+ * @return {string} User-facing status label.
+ */
+function getProgressStepStatusLabel( status ) {
+	if ( status === 'running' ) {
+		return __( 'In progress', 'superdav-ai-agent' );
+	}
+	if ( status === 'error' ) {
+		return __( 'Needs attention', 'superdav-ai-agent' );
+	}
+	if ( status === 'warn' ) {
+		return __( 'Completed with a note', 'superdav-ai-agent' );
+	}
+	return __( 'Completed', 'superdav-ai-agent' );
+}
+
+/**
+ * Friendly progress card shown instead of raw tool-call cards by default.
+ *
+ * @param {Object} root0
+ * @param {Object} root0.summary      Progress summary.
+ * @param {string} root0.mode         Either 'running' or 'complete'.
+ * @param {string} root0.fallbackStep Fallback running text.
+ */
+function ToolProgressSummary( {
+	summary,
+	mode = 'running',
+	fallbackStep = '',
+} ) {
+	const isRunning = mode === 'running';
+	const title = getProgressSummaryTitle( summary, isRunning, fallbackStep );
+	let description = isRunning ? summary.latestThought : '';
+
+	if ( ! description ) {
+		description = isRunning
+			? __(
+					'I’m working through your request step by step.',
+					'superdav-ai-agent'
+			  )
+			: __(
+					'The agent used several steps and summarized the result below.',
+					'superdav-ai-agent'
+			  );
+	}
+
+	return (
+		<div
+			className={ `sdaa-cr-progress-summary${
+				isRunning ? ' is-running' : ' is-complete'
+			}` }
+		>
+			<div className="sdaa-cr-progress-main">
+				<div className="sdaa-cr-progress-title">
+					<span
+						className={ `sdaa-cr-progress-title-dot${
+							isRunning ? ' is-running' : ' is-complete'
+						}` }
+						aria-hidden="true"
+					/>
+					<span>{ title }</span>
+				</div>
+				<div className="sdaa-cr-progress-description">
+					{ description }
+				</div>
+			</div>
+
+			{ summary.totalCount > 0 && (
+				<div className="sdaa-cr-progress-stats">
+					{ summary.completedCount > 0 && (
+						<span className="sdaa-cr-progress-stat is-complete">
+							{ summary.completedCount }{ ' ' }
+							{ __( 'completed', 'superdav-ai-agent' ) }
+						</span>
+					) }
+					{ summary.runningCount > 0 && (
+						<span className="sdaa-cr-progress-stat is-running">
+							{ summary.runningCount }{ ' ' }
+							{ __( 'in progress', 'superdav-ai-agent' ) }
+						</span>
+					) }
+					{ summary.failedCount > 0 && (
+						<span className="sdaa-cr-progress-stat is-error">
+							{ summary.failedCount }{ ' ' }
+							{ __( 'need attention', 'superdav-ai-agent' ) }
+						</span>
+					) }
+				</div>
+			) }
+
+			{ summary.recentSteps.length > 0 && (
+				<ul className="sdaa-cr-progress-steps">
+					{ summary.recentSteps.map( ( step, index ) => (
+						<li
+							key={ `${ step.id || step.label }-${ index }` }
+							className={ `sdaa-cr-progress-step is-${ step.status }` }
+						>
+							<span
+								className="sdaa-cr-progress-step-dot"
+								aria-hidden="true"
+							/>
+							<span className="sdaa-cr-progress-step-label">
+								{ step.label }
+							</span>
+							<span className="sdaa-cr-progress-step-status">
+								{ getProgressStepStatusLabel( step.status ) }
+							</span>
+						</li>
+					) ) }
+				</ul>
+			) }
+		</div>
+	);
 }
 
 /**
@@ -347,10 +489,15 @@ export function AssistantMessage( {
 } ) {
 	const [ copied, setCopied ] = useState( false );
 
-	const { messageToken } = useSelect(
+	const { messageToken, showToolCallDetails } = useSelect(
 		( sel ) => {
-			const tokens = sel( STORE_NAME ).getMessageTokens() || [];
-			return { messageToken: tokens[ index ] };
+			const store = sel( STORE_NAME );
+			const tokens = store.getMessageTokens() || [];
+			return {
+				messageToken: tokens[ index ],
+				showToolCallDetails:
+					store.getSettings()?.show_tool_call_details === true,
+			};
 		},
 		[ index ]
 	);
@@ -366,6 +513,13 @@ export function AssistantMessage( {
 	const items = ( buildRunningItems( msg.toolCalls ) || [] ).filter(
 		( it ) => it.kind === 'pair'
 	);
+	const progressSummary = buildToolProgressSummary( msg.toolCalls );
+	const showProgressSummary =
+		progressSummary.hasActivity &&
+		! showToolCallDetails &&
+		( progressSummary.totalCount > 1 ||
+			progressSummary.failedCount > 0 ||
+			! cleanText );
 
 	const handleCopy = () => {
 		if ( ! cleanText ) {
@@ -383,16 +537,23 @@ export function AssistantMessage( {
 				<AiIcon />
 			</div>
 			<div className="sdaa-cr-msg-body">
-				{ items.map( ( item ) => (
-					<ToolCard
-						key={ item.key }
-						call={ item.call }
-						response={ item.response }
-						defaultOpen={ Boolean(
-							item.response?.response?.error
-						) }
+				{ showProgressSummary && (
+					<ToolProgressSummary
+						summary={ progressSummary }
+						mode="complete"
 					/>
-				) ) }
+				) }
+				{ showToolCallDetails &&
+					items.map( ( item ) => (
+						<ToolCard
+							key={ item.key }
+							call={ item.call }
+							response={ item.response }
+							defaultOpen={ Boolean(
+								item.response?.response?.error
+							) }
+						/>
+					) ) }
 				{ cleanText && <MarkdownMessage content={ cleanText } /> }
 				{ isLastModel && suggestions.length > 0 && (
 					<div className="sdaa-cr-suggestions">
@@ -455,46 +616,54 @@ export function AssistantMessage( {
 
 /**
  *
- * @param {Object} root0
- * @param {*}      root0.step
- * @param {*}      root0.liveToolCalls
+ * @param {Object}  root0
+ * @param {*}       root0.step
+ * @param {*}       root0.liveToolCalls
+ * @param {boolean} root0.showToolCallDetails
  */
-export function RunningMessage( { step, liveToolCalls } ) {
+export function RunningMessage( {
+	step,
+	liveToolCalls,
+	showToolCallDetails = false,
+} ) {
 	// Render preamble narration and tool-call cards in original emission
 	// order so the user sees context like "Looking that up first…" directly
 	// above the tool card it precedes. buildRunningItems returns a flat list
 	// of { kind: 'preamble' | 'pair', ... } items.
 	const items = buildRunningItems( liveToolCalls );
+	const progressSummary = buildToolProgressSummary( liveToolCalls );
 	return (
 		<div className="sdaa-cr-msg-row sdaa-cr-msg-assistant">
 			<div className="sdaa-cr-avatar" aria-hidden="true">
 				<AiIcon thinking={ true } />
 			</div>
 			<div className="sdaa-cr-msg-body">
-				{ items.map( ( item ) => {
-					if ( item.kind === 'preamble' ) {
+				<ToolProgressSummary
+					summary={ progressSummary }
+					mode="running"
+					fallbackStep={ step }
+				/>
+				{ showToolCallDetails &&
+					items.map( ( item ) => {
+						if ( item.kind === 'preamble' ) {
+							return (
+								<div
+									key={ item.key }
+									className="sdaa-cr-running-preamble"
+								>
+									<MarkdownMessage content={ item.text } />
+								</div>
+							);
+						}
 						return (
-							<div
+							<ToolCard
 								key={ item.key }
-								className="sdaa-cr-running-preamble"
-							>
-								<MarkdownMessage content={ item.text } />
-							</div>
+								call={ item.call }
+								response={ item.response }
+								defaultOpen={ ! item.response }
+							/>
 						);
-					}
-					return (
-						<ToolCard
-							key={ item.key }
-							call={ item.call }
-							response={ item.response }
-							defaultOpen={ ! item.response }
-						/>
-					);
-				} ) }
-				<div className="sdaa-cr-running-line">
-					<span className="sdaa-cr-running-dot" aria-hidden="true" />
-					<span>{ step }</span>
-				</div>
+					} ) }
 			</div>
 		</div>
 	);

--- a/src/components/chat-redesign/message-items.js
+++ b/src/components/chat-redesign/message-items.js
@@ -27,7 +27,7 @@ import {
 import STORE_NAME from '../../store';
 import MarkdownMessage from '../markdown-message';
 import { AiIcon } from './icons';
-import ToolCard from './ToolCard';
+import ToolCard, { ToolResultHighlights } from './ToolCard';
 import {
 	buildRunningItems,
 	buildToolProgressSummary,
@@ -142,18 +142,22 @@ function AssistantMeta( { tokens } ) {
 /**
  * Build the headline for a friendly progress summary.
  *
- * @param {Object}  summary      Progress summary from buildToolProgressSummary().
- * @param {boolean} isRunning    Whether the agent is still working.
- * @param {string}  fallbackStep Fallback text when no step label is available.
+ * @param {Object} summary      Progress summary from buildToolProgressSummary().
+ * @param {string} mode         Progress display mode.
+ * @param {string} fallbackStep Fallback text when no step label is available.
  * @return {string} Summary headline.
  */
-function getProgressSummaryTitle( summary, isRunning, fallbackStep ) {
-	if ( isRunning ) {
+function getProgressSummaryTitle( summary, mode, fallbackStep ) {
+	if ( mode === 'running' ) {
 		return (
 			summary.currentLabel ||
 			fallbackStep ||
 			__( 'Working on it…', 'superdav-ai-agent' )
 		);
+	}
+
+	if ( mode === 'error' ) {
+		return __( 'Work paused', 'superdav-ai-agent' );
 	}
 
 	if ( summary.failedCount > 0 ) {
@@ -187,7 +191,7 @@ function getProgressStepStatusLabel( status ) {
  *
  * @param {Object} root0
  * @param {Object} root0.summary      Progress summary.
- * @param {string} root0.mode         Either 'running' or 'complete'.
+ * @param {string} root0.mode         Either 'running', 'complete', or 'error'.
  * @param {string} root0.fallbackStep Fallback running text.
  */
 function ToolProgressSummary( {
@@ -196,33 +200,41 @@ function ToolProgressSummary( {
 	fallbackStep = '',
 } ) {
 	const isRunning = mode === 'running';
-	const title = getProgressSummaryTitle( summary, isRunning, fallbackStep );
+	const isError = mode === 'error';
+	let statusClass = 'is-complete';
+	if ( isRunning ) {
+		statusClass = 'is-running';
+	} else if ( isError ) {
+		statusClass = 'is-error';
+	}
+	const title = getProgressSummaryTitle( summary, mode, fallbackStep );
 	let description = isRunning ? summary.latestThought : '';
 
 	if ( ! description ) {
-		description = isRunning
-			? __(
-					'I’m working through your request step by step.',
-					'superdav-ai-agent'
-			  )
-			: __(
-					'The agent used several steps and summarized the result below.',
-					'superdav-ai-agent'
-			  );
+		if ( isRunning ) {
+			description = __(
+				'I’m working through your request step by step.',
+				'superdav-ai-agent'
+			);
+		} else if ( isError ) {
+			description = __(
+				'The agent completed several steps, then stopped before finishing the reply.',
+				'superdav-ai-agent'
+			);
+		} else {
+			description = __(
+				'The agent used several steps and summarized the result below.',
+				'superdav-ai-agent'
+			);
+		}
 	}
 
 	return (
-		<div
-			className={ `sdaa-cr-progress-summary${
-				isRunning ? ' is-running' : ' is-complete'
-			}` }
-		>
+		<div className={ `sdaa-cr-progress-summary ${ statusClass }` }>
 			<div className="sdaa-cr-progress-main">
 				<div className="sdaa-cr-progress-title">
 					<span
-						className={ `sdaa-cr-progress-title-dot${
-							isRunning ? ' is-running' : ' is-complete'
-						}` }
+						className={ `sdaa-cr-progress-title-dot ${ statusClass }` }
 						aria-hidden="true"
 					/>
 					<span>{ title }</span>
@@ -489,7 +501,7 @@ export function AssistantMessage( {
 } ) {
 	const [ copied, setCopied ] = useState( false );
 
-	const { messageToken, showToolCallDetails } = useSelect(
+	const { messageToken, showToolCallDetails, hasStreamError } = useSelect(
 		( sel ) => {
 			const store = sel( STORE_NAME );
 			const tokens = store.getMessageTokens() || [];
@@ -497,6 +509,7 @@ export function AssistantMessage( {
 				messageToken: tokens[ index ],
 				showToolCallDetails:
 					store.getSettings()?.show_tool_call_details === true,
+				hasStreamError: store.hasStreamError?.() === true,
 			};
 		},
 		[ index ]
@@ -514,11 +527,19 @@ export function AssistantMessage( {
 		( it ) => it.kind === 'pair'
 	);
 	const progressSummary = buildToolProgressSummary( msg.toolCalls );
+	const hasUnfinishedReply =
+		! cleanText &&
+		progressSummary.completedCount > 0 &&
+		progressSummary.failedCount === 0 &&
+		progressSummary.runningCount === 0;
+	const showInterruptedProgress =
+		isLastModel && ( hasStreamError || hasUnfinishedReply );
 	const showProgressSummary =
 		progressSummary.hasActivity &&
 		! showToolCallDetails &&
 		( progressSummary.totalCount > 1 ||
 			progressSummary.failedCount > 0 ||
+			showInterruptedProgress ||
 			! cleanText );
 
 	const handleCopy = () => {
@@ -540,7 +561,7 @@ export function AssistantMessage( {
 				{ showProgressSummary && (
 					<ToolProgressSummary
 						summary={ progressSummary }
-						mode="complete"
+						mode={ showInterruptedProgress ? 'error' : 'complete' }
 					/>
 				) }
 				{ showToolCallDetails &&
@@ -552,6 +573,14 @@ export function AssistantMessage( {
 							defaultOpen={ Boolean(
 								item.response?.response?.error
 							) }
+						/>
+					) ) }
+				{ ! showToolCallDetails &&
+					items.map( ( item ) => (
+						<ToolResultHighlights
+							key={ `${ item.key }-highlights` }
+							call={ item.call }
+							response={ item.response }
 						/>
 					) ) }
 				{ cleanText && <MarkdownMessage content={ cleanText } /> }
@@ -664,6 +693,16 @@ export function RunningMessage( {
 							/>
 						);
 					} ) }
+				{ ! showToolCallDetails &&
+					items
+						.filter( ( item ) => item.kind === 'pair' )
+						.map( ( item ) => (
+							<ToolResultHighlights
+								key={ `${ item.key }-highlights` }
+								call={ item.call }
+								response={ item.response }
+							/>
+						) ) }
 			</div>
 		</div>
 	);

--- a/src/components/chat-widget/__tests__/widget-message-list.test.js
+++ b/src/components/chat-widget/__tests__/widget-message-list.test.js
@@ -29,6 +29,7 @@ jest.mock( '../../chat-redesign/message-items', () => ( {
 } ) );
 jest.mock( '../../chat-redesign/message-helpers', () => ( {
 	extractText: ( message ) => message.parts?.[ 0 ]?.text || '',
+	getFriendlyToolLabel: () => 'Working',
 	getRunningToolName: () => '',
 } ) );
 
@@ -54,6 +55,7 @@ async function renderCreditExhaustionMessage() {
 		getCurrentSessionId: () => 123,
 		getLiveToolCalls: () => [],
 		getSessionJobs: () => ( {} ),
+		getSettings: () => ( {} ),
 		hasStreamError: () => false,
 		getProviders: () => [
 			{
@@ -126,6 +128,7 @@ describe( 'WidgetMessageList recoverable-job action card', () => {
 			getCurrentSessionId: () => 123,
 			getLiveToolCalls: () => [],
 			getSessionJobs: () => ( {} ),
+			getSettings: () => ( {} ),
 			hasStreamError: () => true,
 			getProviders: () => [],
 		};

--- a/src/components/chat-widget/widget-message-list.js
+++ b/src/components/chat-widget/widget-message-list.js
@@ -29,6 +29,7 @@ import STORE_NAME from '../../store';
 import FeedbackConsentModal from '../feedback-consent-modal';
 import {
 	extractText,
+	getFriendlyToolLabel,
 	getRunningToolName,
 } from '../chat-redesign/message-helpers';
 import {
@@ -61,8 +62,10 @@ export default function WidgetMessageList() {
 		sessionJobs,
 		hasStreamError,
 		providers,
+		showToolCallDetails,
 	} = useSelect( ( sel ) => {
 		const store = sel( STORE_NAME );
+		const settings = store.getSettings();
 		return {
 			messages: store.getCurrentSessionMessages(),
 			sending: store.isSending(),
@@ -71,6 +74,7 @@ export default function WidgetMessageList() {
 			sessionJobs: store.getSessionJobs(),
 			hasStreamError: store.hasStreamError(),
 			providers: store.getProviders(),
+			showToolCallDetails: settings?.show_tool_call_details === true,
 		};
 	}, [] );
 
@@ -194,8 +198,8 @@ export default function WidgetMessageList() {
 
 	const runningToolName = getRunningToolName( runningToolCalls );
 	const runningStep = runningToolName
-		? `${ __( 'Running', 'sd-ai-agent' ) } ${ runningToolName }…`
-		: __( 'Composing reply…', 'sd-ai-agent' );
+		? `${ getFriendlyToolLabel( runningToolName ) }…`
+		: __( 'Composing reply…', 'superdav-ai-agent' );
 
 	// ── Render ────────────────────────────────────────────────────────────────
 
@@ -261,6 +265,7 @@ export default function WidgetMessageList() {
 						<RunningMessage
 							step={ runningStep }
 							liveToolCalls={ runningToolCalls }
+							showToolCallDetails={ showToolCallDetails }
 						/>
 					) }
 

--- a/src/settings-page/settings-app.js
+++ b/src/settings-page/settings-app.js
@@ -933,6 +933,36 @@ export default function SettingsApp() {
 														/>
 													</td>
 												</tr>
+												<tr>
+													<th scope="row">
+														{ __(
+															'Debug Details',
+															'superdav-ai-agent'
+														) }
+													</th>
+													<td>
+														<ToggleControl
+															label={ __(
+																'Show technical tool-call details',
+																'superdav-ai-agent'
+															) }
+															checked={
+																!! local.show_tool_call_details
+															}
+															onChange={ ( v ) =>
+																updateField(
+																	'show_tool_call_details',
+																	v
+																)
+															}
+															help={ __(
+																'Displays raw ability names, arguments, and results in chat. Leave off for a simpler progress summary.',
+																'superdav-ai-agent'
+															) }
+															__nextHasNoMarginBottom
+														/>
+													</td>
+												</tr>
 											</tbody>
 										</table>
 

--- a/src/types.js
+++ b/src/types.js
@@ -133,6 +133,7 @@
  * @property {string}  [default_provider]       - Default provider ID.
  * @property {string}  [default_model]          - Default model ID.
  * @property {number}  [context_window_default] - Default context window size in tokens.
+ * @property {boolean} [show_tool_call_details] - Show raw technical tool-call details in chat.
  */
 
 /**

--- a/tests/SdAiAgent/Core/SettingsTest.php
+++ b/tests/SdAiAgent/Core/SettingsTest.php
@@ -72,6 +72,7 @@ class SettingsTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'max_history_turns', $defaults );
 		$this->assertArrayHasKey( 'provider_request_max_bytes', $defaults );
 		$this->assertArrayHasKey( 'provider_request_max_tokens', $defaults );
+		$this->assertArrayHasKey( 'show_tool_call_details', $defaults );
 		$this->assertArrayHasKey( 'show_on_frontend', $defaults );
 	}
 
@@ -90,6 +91,7 @@ class SettingsTest extends WP_UnitTestCase {
 		$this->assertSame( 20, $defaults['max_history_turns'] );
 		$this->assertSame( ConversationTrimmer::DEFAULT_MAX_REQUEST_BYTES, $defaults['provider_request_max_bytes'] );
 		$this->assertSame( ConversationTrimmer::DEFAULT_MAX_REQUEST_TOKENS, $defaults['provider_request_max_tokens'] );
+		$this->assertFalse( $defaults['show_tool_call_details'] );
 		$this->assertTrue( $defaults['show_on_frontend'] );
 	}
 


### PR DESCRIPTION
## Summary
- Replace the default long-running task view with a friendly progress summary instead of raw ability/tool-call cards.
- Add the `show_tool_call_details` setting and Settings UI toggle so technical ability names, arguments, and results are shown only when explicitly enabled.
- Share friendly tool labels, progress sanitization, and summary logic across the main chat and floating widget.
- Keep user-facing rich results, such as design preview galleries, visible even when raw tool-call details are hidden.
- Show interrupted tool-only transcripts as “Work paused” instead of “Work completed” when no final reply was written.

## Testing
- `npm run verify`
- `npm run test:js -- --runTestsByPath src/components/chat-redesign/__tests__/ToolCard.test.js src/components/chat-redesign/__tests__/message-items.test.js src/components/chat-redesign/__tests__/message-helpers.test.js src/components/chat-widget/__tests__/widget-message-list.test.js src/components/chat-redesign/__tests__/MessageList.test.js`
- Manual local UX check on `http://wordpress.local:8080/wp-admin/admin.php?page=sd-ai-agent`: sent a real read-only health-check prompt and verified the progress card used friendly labels, hid raw ability IDs, and showed “Work paused” for the interrupted tool-only transcript.

## Worker self-verification
- PHPUnit: Tests: 3953, Assertions: 17369, Errors: 0, Failures: 0, Skipped: 126, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4
