### PR TITLE
fix: route generated images through Superdav image model

### DIFF
--- a/includes/Abilities/ImageAbilities/GenerateImageAbility.php
+++ b/includes/Abilities/ImageAbilities/GenerateImageAbility.php
@@ -20,6 +20,9 @@ namespace SdAiAgent\Abilities\ImageAbilities;
 
 use SdAiAgent\Abilities\ToolCapabilities;
 use SdAiAgent\Core\Net\SafeHttpClient;
+use SdAiAgent\Core\Settings;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
+use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 use WP_Error;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -157,6 +160,20 @@ class GenerateImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 				'tip'           => [ 'type' => 'string' ],
 			],
 		];
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function meta(): array {
+		$meta                = parent::meta();
+		$meta['annotations'] = [
+			'readonly'    => false,
+			'destructive' => false,
+			'idempotent'  => false,
+		];
+
+		return $meta;
 	}
 
 	/**
@@ -342,7 +359,7 @@ class GenerateImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 			);
 		}
 
-		$file = wp_ai_client_prompt( $prompt )->generate_image();
+		$file = $this->create_image_prompt_builder( $prompt, $options )->generate_image();
 
 		if ( is_wp_error( $file ) ) {
 			return new WP_Error(
@@ -381,6 +398,149 @@ class GenerateImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 			'attachment_id' => $attachment_id,
 			'url'           => $result['url'],
 		];
+	}
+
+	/**
+	 * Create the AI Client prompt builder for image generation.
+	 *
+	 * @param string               $prompt  Image generation prompt.
+	 * @param array<string,string> $options Provider-specific options.
+	 * @return \WP_AI_Client_Prompt_Builder Configured prompt builder.
+	 */
+	protected function create_image_prompt_builder( string $prompt, array $options = [] ): \WP_AI_Client_Prompt_Builder {
+		$builder = wp_ai_client_prompt( $prompt );
+
+		$model_preferences = $this->resolve_image_model_preferences();
+		if ( ! empty( $model_preferences ) ) {
+			$builder = $builder->using_model_preference( ...$model_preferences );
+		}
+
+		$model_config = $this->create_image_model_config( $options );
+		if ( $model_config instanceof ModelConfig ) {
+			$builder = $builder->using_model_config( $model_config );
+		}
+
+		return $builder;
+	}
+
+	/**
+	 * Resolve preferred image models for the SDK prompt builder.
+	 *
+	 * The plugin-wide default model is normally a text model. When the bundled
+	 * Superdav provider is selected, append its image model alias so the SDK can
+	 * fall through from `superdav-chat-*` to `superdav-image` for image requests.
+	 *
+	 * @return list<string|array{0:string,1:string}> Model IDs or provider/model tuples.
+	 */
+	protected function resolve_image_model_preferences(): array {
+		$provider = '';
+		$model    = $this->get_configured_model();
+
+		if ( class_exists( Settings::class ) ) {
+			try {
+				$settings       = Settings::instance();
+				$saved_provider = $settings->get( 'default_provider' );
+				$provider       = is_string( $saved_provider ) ? $saved_provider : '';
+
+				$resolved_provider = $settings->get_default_provider();
+				if ( '' !== $resolved_provider ) {
+					$provider = $resolved_provider;
+				}
+
+				$resolved_model = $settings->get_default_model();
+				if ( '' !== $resolved_model ) {
+					$model = $resolved_model;
+				}
+			} catch ( \Throwable $e ) {
+				// Fall back to the raw configured model when registry validation is unavailable.
+			}
+		}
+
+		$preferences = [];
+		if ( '' !== $model ) {
+			$preferences[] = $model;
+		}
+
+		if ( $this->should_prefer_superdav_image_model( $provider, $model ) ) {
+			$preferences[] = [ SuperdavAiProvider::PROVIDER_ID, SuperdavAiProvider::IMAGE_MODEL_ID ];
+		}
+
+		return $this->unique_image_model_preferences( $preferences );
+	}
+
+	/**
+	 * Build an SDK model config for OpenAI-compatible image options.
+	 *
+	 * @param array<string,string> $options Provider-specific options.
+	 * @return ModelConfig|null Model config, or null when no options are set.
+	 */
+	protected function create_image_model_config( array $options ): ?ModelConfig {
+		$custom_options = [];
+		foreach ( [ 'size', 'style', 'quality' ] as $key ) {
+			$value = isset( $options[ $key ] ) ? trim( (string) $options[ $key ] ) : '';
+			if ( '' !== $value ) {
+				$custom_options[ $key ] = $value;
+			}
+		}
+
+		if ( empty( $custom_options ) ) {
+			return null;
+		}
+
+		$config = new ModelConfig();
+		$config->setCustomOptions( $custom_options );
+
+		return $config;
+	}
+
+	/**
+	 * Whether Superdav image generation should be explicitly preferred.
+	 *
+	 * @param string $provider Configured provider ID.
+	 * @param string $model    Configured/resolved model ID.
+	 * @return bool True when the selected provider/model belongs to Superdav.
+	 */
+	private function should_prefer_superdav_image_model( string $provider, string $model ): bool {
+		if ( SuperdavAiProvider::PROVIDER_ID === $provider ) {
+			return true;
+		}
+
+		return in_array(
+			$model,
+			[
+				SuperdavAiProvider::FAST_MODEL_ID,
+				SuperdavAiProvider::DEFAULT_MODEL_ID,
+				SuperdavAiProvider::STRONG_MODEL_ID,
+				SuperdavAiProvider::IMAGE_MODEL_ID,
+			],
+			true
+		);
+	}
+
+	/**
+	 * Remove duplicate model preferences while preserving order.
+	 *
+	 * @param list<string|array{0:string,1:string}> $preferences Preferences.
+	 * @return list<string|array{0:string,1:string}> Unique preferences.
+	 */
+	private function unique_image_model_preferences( array $preferences ): array {
+		$seen   = [];
+		$unique = [];
+
+		foreach ( $preferences as $preference ) {
+			$key = is_array( $preference )
+				? 'provider:' . $preference[0] . ':model:' . $preference[1]
+				: 'model:' . $preference;
+
+			if ( isset( $seen[ $key ] ) ) {
+				continue;
+			}
+
+			$seen[ $key ] = true;
+			$unique[]     = $preference;
+		}
+
+		return $unique;
 	}
 
 	/**

--- a/includes/Abilities/ImageAbilities/GenerateImageAbility.php
+++ b/includes/Abilities/ImageAbilities/GenerateImageAbility.php
@@ -433,8 +433,9 @@ class GenerateImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 	 * @return list<string|array{0:string,1:string}> Model IDs or provider/model tuples.
 	 */
 	protected function resolve_image_model_preferences(): array {
-		$provider = '';
-		$model    = $this->get_configured_model();
+		$provider           = '';
+		$model              = $this->get_configured_model();
+		$has_explicit_model = '' !== $model;
 
 		if ( class_exists( Settings::class ) ) {
 			try {
@@ -447,9 +448,11 @@ class GenerateImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 					$provider = $resolved_provider;
 				}
 
-				$resolved_model = $settings->get_default_model();
-				if ( '' !== $resolved_model ) {
-					$model = $resolved_model;
+				if ( ! $has_explicit_model ) {
+					$resolved_model = $settings->get_default_model();
+					if ( '' !== $resolved_model ) {
+						$model = $resolved_model;
+					}
 				}
 			} catch ( \Throwable $e ) {
 				// Fall back to the raw configured model when registry validation is unavailable.

--- a/stubs/wordpress-7-runtime.php
+++ b/stubs/wordpress-7-runtime.php
@@ -527,6 +527,9 @@ namespace WordPress\AiClient\Providers\Models\DTO {
 
 		/** @return array<string, mixed> */
 		public function getCustomOptions(): array { return array(); }
+
+		/** @param array<string, mixed> $customOptions Custom provider options. */
+		public function setCustomOptions( array $customOptions ): void {}
 	}
 }
 
@@ -1380,12 +1383,20 @@ namespace {
 		public function using_candidate_count( int $count ): static { return $this; }
 
 		/**
-		 * Set a model preference by model ID string.
+		 * Set model preferences by model ID or provider/model tuple.
 		 *
-		 * @param string $model_id Model identifier.
+		 * @param mixed ...$preferredModels Model identifiers or provider/model tuples.
 		 * @return static
 		 */
-		public function using_model_preference( string $model_id ): static { return $this; }
+		public function using_model_preference( mixed ...$preferredModels ): static { return $this; }
+
+		/**
+		 * Merge model configuration into the prompt builder.
+		 *
+		 * @param \WordPress\AiClient\Providers\Models\DTO\ModelConfig $config Model config.
+		 * @return static
+		 */
+		public function using_model_config( \WordPress\AiClient\Providers\Models\DTO\ModelConfig $config ): static { return $this; }
 
 		/**
 		 * Set the model object (from ModelRegistry::getProviderModel()).

--- a/tests/SdAiAgent/Abilities/AiImageAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/AiImageAbilitiesTest.php
@@ -11,6 +11,10 @@ namespace SdAiAgent\Tests\Abilities;
 
 use SdAiAgent\Abilities\AiImageAbilities;
 use SdAiAgent\Abilities\ImageAbilities\GenerateImageAbility;
+use SdAiAgent\Core\Settings;
+use SdAiAgent\Core\ToolPermissionResolver;
+use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
+use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 use WP_UnitTestCase;
 
 /**
@@ -139,6 +143,101 @@ class AiImageAbilitiesTest extends WP_UnitTestCase {
 		if ( is_wp_error( $result ) ) {
 			$this->assertNotSame( 'invalid_style', $result->get_error_code() );
 		}
+	}
+
+	/**
+	 * Generate-image creates media without destroying data, so default tool
+	 * policy should not pause for user confirmation.
+	 */
+	public function test_generate_image_is_non_destructive_for_default_tool_policy(): void {
+		$ability = new GenerateImageAbility( 'sd-ai-agent/generate-image' );
+		$meta    = $ability->get_meta();
+
+		$this->assertIsArray( $meta['annotations'] ?? null );
+		$this->assertFalse( $meta['annotations']['readonly'] );
+		$this->assertFalse( $meta['annotations']['destructive'] );
+		$this->assertSame( 'write', ToolPermissionResolver::classify_ability( $ability ) );
+		$this->assertFalse( ToolPermissionResolver::ability_needs_confirmation( 'sd-ai-agent/generate-image', $ability, [] ) );
+	}
+
+	/**
+	 * Superdav chat defaults should fall through to the bundled image model.
+	 */
+	public function test_generate_image_prefers_superdav_image_model_for_superdav_default_provider(): void {
+		$previous_settings = get_option( Settings::OPTION_NAME, null );
+
+		update_option(
+			Settings::OPTION_NAME,
+			[
+				'default_provider' => SuperdavAiProvider::PROVIDER_ID,
+				'default_model'    => '',
+			]
+		);
+
+		$filter = static function (): array {
+			return [
+				SuperdavAiProvider::PROVIDER_ID => [
+					SuperdavAiProvider::DEFAULT_MODEL_ID,
+					SuperdavAiProvider::IMAGE_MODEL_ID,
+				],
+			];
+		};
+		add_filter( 'sd_ai_agent_registered_models_for_validation', $filter );
+
+		try {
+			$ability    = new GenerateImageAbility( 'sd-ai-agent/generate-image' );
+			$reflection = new \ReflectionMethod( $ability, 'resolve_image_model_preferences' );
+			$reflection->setAccessible( true );
+
+			$preferences = $reflection->invoke( $ability );
+
+			$this->assertIsArray( $preferences );
+			$this->assertContains( SuperdavAiProvider::DEFAULT_MODEL_ID, $preferences );
+			$this->assertContainsEquals(
+				[ SuperdavAiProvider::PROVIDER_ID, SuperdavAiProvider::IMAGE_MODEL_ID ],
+				$preferences
+			);
+		} finally {
+			remove_filter( 'sd_ai_agent_registered_models_for_validation', $filter );
+			if ( null === $previous_settings ) {
+				delete_option( Settings::OPTION_NAME );
+			} else {
+				update_option( Settings::OPTION_NAME, $previous_settings );
+			}
+		}
+	}
+
+	/**
+	 * Size, style, and quality inputs are passed as OpenAI-compatible image options.
+	 */
+	public function test_generate_image_builds_model_config_from_image_options(): void {
+		if ( ! class_exists( ModelConfig::class ) ) {
+			$this->markTestSkipped( 'WordPress AI Client SDK is unavailable.' );
+		}
+
+		$ability    = new GenerateImageAbility( 'sd-ai-agent/generate-image' );
+		$reflection = new \ReflectionMethod( $ability, 'create_image_model_config' );
+		$reflection->setAccessible( true );
+
+		$config = $reflection->invoke(
+			$ability,
+			[
+				'size'    => '1024x1024',
+				'style'   => 'vivid',
+				'quality' => 'hd',
+				'ignored' => 'not-forwarded',
+			]
+		);
+
+		$this->assertInstanceOf( ModelConfig::class, $config );
+		$this->assertSame(
+			[
+				'size'    => '1024x1024',
+				'style'   => 'vivid',
+				'quality' => 'hd',
+			],
+			$config->getCustomOptions()
+		);
 	}
 
 	// ─── Success-path shape (partial mock) ────────────────────────

--- a/tests/SdAiAgent/Abilities/AiImageAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/AiImageAbilitiesTest.php
@@ -208,6 +208,54 @@ class AiImageAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Explicit saved image defaults should not be replaced by resolved fallbacks.
+	 */
+	public function test_generate_image_preserves_explicit_saved_model_preference(): void {
+		$previous_settings = get_option( Settings::OPTION_NAME, null );
+
+		update_option(
+			Settings::OPTION_NAME,
+			[
+				'default_provider' => SuperdavAiProvider::PROVIDER_ID,
+				'default_model'    => 'custom-image-model',
+			]
+		);
+
+		$filter = static function (): array {
+			return [
+				SuperdavAiProvider::PROVIDER_ID => [
+					SuperdavAiProvider::DEFAULT_MODEL_ID,
+					SuperdavAiProvider::IMAGE_MODEL_ID,
+				],
+			];
+		};
+		add_filter( 'sd_ai_agent_registered_models_for_validation', $filter );
+
+		try {
+			$ability    = new GenerateImageAbility( 'sd-ai-agent/generate-image' );
+			$reflection = new \ReflectionMethod( $ability, 'resolve_image_model_preferences' );
+			$reflection->setAccessible( true );
+
+			$preferences = $reflection->invoke( $ability );
+
+			$this->assertIsArray( $preferences );
+			$this->assertContains( 'custom-image-model', $preferences );
+			$this->assertNotContains( SuperdavAiProvider::DEFAULT_MODEL_ID, $preferences );
+			$this->assertContainsEquals(
+				[ SuperdavAiProvider::PROVIDER_ID, SuperdavAiProvider::IMAGE_MODEL_ID ],
+				$preferences
+			);
+		} finally {
+			remove_filter( 'sd_ai_agent_registered_models_for_validation', $filter );
+			if ( null === $previous_settings ) {
+				delete_option( Settings::OPTION_NAME );
+			} else {
+				update_option( Settings::OPTION_NAME, $previous_settings );
+			}
+		}
+	}
+
+	/**
 	 * Size, style, and quality inputs are passed as OpenAI-compatible image options.
 	 */
 	public function test_generate_image_builds_model_config_from_image_options(): void {


### PR DESCRIPTION
## Summary
- Route generated-image calls through a configured WP AI Client prompt builder.
- Prefer the bundled Superdav `superdav-image` model when the selected/default provider is Superdav.
- Preserve an explicitly saved image `default_model` before applying resolved fallback defaults.
- Forward image `size`, `style`, and `quality` as OpenAI-compatible custom model options and cover the behavior in tests/stubs.

## Review follow-up
- Valid finding: `resolve_image_model_preferences()` could overwrite an explicitly saved `default_model` with `Settings::get_default_model()` fallback resolution. Fixed by tracking whether `get_configured_model()` returned an explicit model and only applying the resolver when no explicit default is configured.
- No other findings were provided in this review batch.

## Worker self-verification
- PHPUnit: Tests: 3960, Assertions: 17390, Errors: 0, Failures: 0, Skipped: 126, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

## Verification commands
- `npm run verify`
- `npm run test:php -- --filter=AiImageAbilitiesTest`

Notes: local PHPUnit is configured against the localhost WordPress database with the `wptests_` prefix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image generation now builds prompts using resolved provider/model preferences, including Superdav image model defaults when applicable.
  * Saved Superdav image defaults are preserved and not overridden by fallback preferences.
  * Image options (size, style, quality) are translated into provider-compatible model configuration.
  * Tool behavior is more clearly classified (non-readonly, non-destructive, no extra user confirmation).

* **Tests**
  * Added coverage for tool metadata, provider/model preference resolution, Superdav default handling, and model-config construction from image options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->