### PR TITLE
GH#2343: add dedicated Superdav billing actions

### DIFF
--- a/includes/Core/SuperdavSiteConnectionService.php
+++ b/includes/Core/SuperdavSiteConnectionService.php
@@ -58,7 +58,9 @@ final class SuperdavSiteConnectionService {
 		$token    = $this->get_stored_token();
 		$metadata = $this->get_metadata();
 
-		$account_portal_url = $this->get_account_portal_url( $metadata );
+		$account_portal_url   = $this->get_account_portal_url( $metadata );
+		$purchase_credits_url = $this->get_account_action_url( $metadata, 'purchase_credits_url' );
+		$payment_methods_url  = $this->get_account_action_url( $metadata, 'payment_methods_url' );
 
 		$status = array(
 			'configured'                => '' !== $token,
@@ -70,6 +72,8 @@ final class SuperdavSiteConnectionService {
 			'account_connect_available' => '' !== $account_portal_url,
 			'account_connect_url'       => $account_portal_url,
 			'account_portal_url'        => $account_portal_url,
+			'purchase_credits_url'      => $purchase_credits_url,
+			'payment_methods_url'       => $payment_methods_url,
 		);
 
 		foreach ( array( 'tier', 'verified', 'request_id', 'connection_notice_pending' ) as $key ) {
@@ -315,9 +319,18 @@ final class SuperdavSiteConnectionService {
 		$default_url = is_string( $default_url ) ? $default_url : '';
 		$url         = apply_filters( 'sd_ai_agent_cloud_account_connect_url', $default_url, $this->get_installation_id(), $this->get_verified_site_url() );
 
-		$url = is_string( $url ) ? esc_url_raw( $url ) : '';
+		return $this->sanitize_account_url( $url );
+	}
 
-		return $this->account_portal_url_has_secret_query_key( $url ) ? '' : $url;
+	/**
+	 * Return a dedicated, service-issued billing action URL when available.
+	 *
+	 * @param array<string, mixed> $metadata Safe connection metadata.
+	 * @param string               $key      Dedicated action metadata key.
+	 * @return string Service-issued action URL, or empty when unavailable.
+	 */
+	private function get_account_action_url( array $metadata, string $key ): string {
+		return $this->sanitize_account_url( $metadata[ $key ] ?? '' );
 	}
 
 	/**
@@ -507,6 +520,8 @@ final class SuperdavSiteConnectionService {
 			'connect_required',
 			'request_id',
 			'account_portal_url',
+			'purchase_credits_url',
+			'payment_methods_url',
 		);
 		$safe         = array();
 
@@ -516,12 +531,14 @@ final class SuperdavSiteConnectionService {
 			}
 		}
 
-		if ( isset( $safe['account_portal_url'] ) ) {
-			$url = is_string( $safe['account_portal_url'] ) ? esc_url_raw( $safe['account_portal_url'] ) : '';
-			if ( '' === $url || $this->account_portal_url_has_secret_query_key( $url ) ) {
-				unset( $safe['account_portal_url'] );
-			} else {
-				$safe['account_portal_url'] = $url;
+		foreach ( array( 'account_portal_url', 'purchase_credits_url', 'payment_methods_url' ) as $key ) {
+			if ( isset( $safe[ $key ] ) ) {
+				$url = $this->sanitize_account_url( $safe[ $key ] );
+				if ( '' === $url ) {
+					unset( $safe[ $key ] );
+				} else {
+					$safe[ $key ] = $url;
+				}
 			}
 		}
 
@@ -551,9 +568,30 @@ final class SuperdavSiteConnectionService {
 	}
 
 	/**
-	 * Determine whether an account portal URL contains a blocked secret query key.
+	 * Sanitize a service-issued account action URL.
+	 *
+	 * External billing actions must use a complete HTTPS URL and must not expose
+	 * credentials in their query string.
+	 *
+	 * @param mixed $url Potential account action URL.
+	 * @return string Safe account action URL, or empty when invalid.
 	 */
-	private function account_portal_url_has_secret_query_key( string $url ): bool {
+	private function sanitize_account_url( mixed $url ): string {
+		$url    = is_string( $url ) ? esc_url_raw( $url ) : '';
+		$scheme = wp_parse_url( $url, PHP_URL_SCHEME );
+		$host   = wp_parse_url( $url, PHP_URL_HOST );
+
+		if ( '' === $url || 'https' !== $scheme || ! is_string( $host ) || '' === $host ) {
+			return '';
+		}
+
+		return $this->account_url_has_secret_query_key( $url ) ? '' : $url;
+	}
+
+	/**
+	 * Determine whether an account action URL contains a blocked secret query key.
+	 */
+	private function account_url_has_secret_query_key( string $url ): bool {
 		$query = wp_parse_url( $url, PHP_URL_QUERY );
 		if ( ! is_string( $query ) || '' === $query ) {
 			return false;
@@ -570,7 +608,7 @@ final class SuperdavSiteConnectionService {
 			}
 
 			foreach ( $current as $key => $value ) {
-				if ( is_string( $key ) && OptionsAbilities::is_secret_option_name( $key ) ) {
+				if ( is_string( $key ) && $this->is_secret_account_url_query_key( $key ) ) {
 					return true;
 				}
 
@@ -581,6 +619,27 @@ final class SuperdavSiteConnectionService {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Determine whether an account action query parameter could expose a secret.
+	 *
+	 * The option read blocklist remains the canonical protection for WordPress
+	 * secrets. Remote account URLs also need to reject conventional credential
+	 * parameter names, which are not WordPress option names.
+	 */
+	private function is_secret_account_url_query_key( string $key ): bool {
+		if ( OptionsAbilities::is_secret_option_name( $key ) ) {
+			return true;
+		}
+
+		$normalized_key = preg_replace( '/(?<!^)[A-Z]/', '_$0', $key ) ?? $key;
+		$normalized_key = strtolower( $normalized_key );
+
+		return 1 === preg_match(
+			'/(?:^|[_-])(?:access[_-]?token|api[_-]?key|auth[_-]?token|authorization|bearer|client[_-]?secret|credential(?:s)?|key|password|secret|token)(?:$|[_-])/',
+			$normalized_key
+		);
 	}
 
 	/**

--- a/src/settings-page/__tests__/superdav-account-manager.test.js
+++ b/src/settings-page/__tests__/superdav-account-manager.test.js
@@ -139,4 +139,60 @@ describe( 'SuperdavAccountManager', () => {
 			'No recent credit activity is available.'
 		);
 	} );
+
+	test( 'uses dedicated service URLs for credit and payment actions', async () => {
+		apiFetch.mockResolvedValue( {
+			configured: true,
+			account_portal_url: 'https://account.example/portal',
+			purchase_credits_url: 'https://account.example/credits',
+			payment_methods_url: 'https://account.example/payment-methods',
+		} );
+
+		await act( async () => {
+			root.render( createElement( SuperdavAccountManager, {} ) );
+		} );
+		await act( async () => {
+			await Promise.resolve();
+		} );
+
+		expect(
+			container.querySelector(
+				'a[href="https://account.example/credits"]'
+			).textContent
+		).toBe( 'Add credits' );
+		expect(
+			container.querySelector(
+				'a[href="https://account.example/payment-methods"]'
+			).textContent
+		).toBe( 'Manage payment methods' );
+		expect(
+			container.querySelector(
+				'a[href="https://account.example/portal"]'
+			).textContent
+		).toBe( 'Open account portal' );
+	} );
+
+	test( 'renders only the generic portal fallback when dedicated URLs are absent', async () => {
+		apiFetch.mockResolvedValue( {
+			configured: true,
+			account_portal_url: 'https://account.example/portal',
+		} );
+
+		await act( async () => {
+			root.render( createElement( SuperdavAccountManager, {} ) );
+		} );
+		await act( async () => {
+			await Promise.resolve();
+		} );
+
+		expect( container.textContent ).not.toContain( 'Add credits' );
+		expect( container.textContent ).not.toContain(
+			'Manage payment methods'
+		);
+		expect(
+			container.querySelector(
+				'a[href="https://account.example/portal"]'
+			).textContent
+		).toBe( 'Open account portal' );
+	} );
 } );

--- a/src/settings-page/superdav-account-manager.js
+++ b/src/settings-page/superdav-account-manager.js
@@ -127,6 +127,10 @@ export default function SuperdavAccountManager() {
 
 	const wallet = account?.wallet || {};
 	const accountUrl = account?.account_portal_url || '';
+	const purchaseCreditsUrl = account?.purchase_credits_url || '';
+	const paymentMethodsUrl = account?.payment_methods_url || '';
+	const hasAccountActions =
+		purchaseCreditsUrl || paymentMethodsUrl || accountUrl;
 	const configured = !! account?.configured;
 	const tier = account?.tier || '';
 	const creditActivity = Array.isArray( account?.credit_activity )
@@ -316,38 +320,47 @@ export default function SuperdavAccountManager() {
 							{ creditActivityContent }
 						</section>
 
-						{ accountUrl ? (
+						{ hasAccountActions ? (
 							<div className="sd-ai-agent-superdav-account-actions">
-								<Button
-									variant="primary"
-									href={ accountUrl }
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									{ __( 'Add credits', 'superdav-ai-agent' ) }
-								</Button>
-								<Button
-									variant="secondary"
-									href={ accountUrl }
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									{ __(
-										'Manage payment methods',
-										'superdav-ai-agent'
-									) }
-								</Button>
-								<Button
-									variant="tertiary"
-									href={ accountUrl }
-									target="_blank"
-									rel="noopener noreferrer"
-								>
-									{ __(
-										'Open account portal',
-										'superdav-ai-agent'
-									) }
-								</Button>
+								{ purchaseCreditsUrl && (
+									<Button
+										variant="primary"
+										href={ purchaseCreditsUrl }
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										{ __(
+											'Add credits',
+											'superdav-ai-agent'
+										) }
+									</Button>
+								) }
+								{ paymentMethodsUrl && (
+									<Button
+										variant="secondary"
+										href={ paymentMethodsUrl }
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										{ __(
+											'Manage payment methods',
+											'superdav-ai-agent'
+										) }
+									</Button>
+								) }
+								{ accountUrl && (
+									<Button
+										variant="tertiary"
+										href={ accountUrl }
+										target="_blank"
+										rel="noopener noreferrer"
+									>
+										{ __(
+											'Open account portal',
+											'superdav-ai-agent'
+										) }
+									</Button>
+								) }
 							</div>
 						) : (
 							<Notice status="info" isDismissible={ false }>

--- a/tests/SdAiAgent/REST/SettingsControllerTest.php
+++ b/tests/SdAiAgent/REST/SettingsControllerTest.php
@@ -271,8 +271,10 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 					),
 					'body'     => wp_json_encode(
 						array(
-							'tier'               => 'pro',
-							'account_portal_url' => 'https://account.example/billing',
+							'tier'                 => 'pro',
+							'account_portal_url'   => 'https://account.example/billing',
+							'purchase_credits_url' => 'https://account.example/credits/purchase',
+							'payment_methods_url'  => 'https://account.example/billing/payment-methods',
 							'wallet'             => array(
 								'currency'         => 'USD',
 								'promo_usd_micros' => 2500000,
@@ -333,6 +335,8 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		$data = $response->get_data();
 		$this->assertSame( 15000000, $data['wallet']['total_usd_micros'] );
 		$this->assertSame( 'https://account.example/billing', $data['account_portal_url'] );
+		$this->assertSame( 'https://account.example/credits/purchase', $data['purchase_credits_url'] );
+		$this->assertSame( 'https://account.example/billing/payment-methods', $data['payment_methods_url'] );
 		$this->assertSame( '2026-07-16T00:00:00+00:00', $data['connected_at'] );
 		$this->assertSame( wp_timezone_string(), $data['site_timezone'] );
 		$this->assertCount( 2, $data['credit_activity'] );
@@ -356,20 +360,12 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		$this->assertFalse( SettingsController::check_admin_permission() );
 	}
 
-	/** Account portal URLs containing centrally blocked query keys are not exposed. */
-	public function test_handle_refresh_superdav_account_rejects_secret_portal_query(): void {
+	/** Account action URLs containing centrally blocked query keys are not exposed. */
+	public function test_handle_refresh_superdav_account_rejects_secret_action_queries(): void {
 		$base_url    = 'https://service.example/v1';
 		$account_url = $base_url . '/site/account';
 
 		add_filter( 'sd_ai_agent_cloud_base_url', static fn(): string => $base_url );
-		add_filter(
-			'sd_ai_agent_options_read_blocklist',
-			static function ( array $blocklist ): array {
-				$blocklist[] = 'access_token';
-
-				return $blocklist;
-			}
-		);
 		add_filter(
 			'pre_http_request',
 			static function ( mixed $preempt, array $parsed_args, string $url ) use ( $account_url ): mixed {
@@ -384,7 +380,9 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 					),
 					'body'     => wp_json_encode(
 						array(
-							'account_portal_url' => 'https://account.example/billing?access_token=must-not-be-exposed',
+							'account_portal_url'   => 'https://account.example/billing?access_token=must-not-be-exposed',
+							'purchase_credits_url' => 'https://account.example/credits?access_token=must-not-be-exposed',
+							'payment_methods_url'  => 'https://account.example/payment-methods?api_key=must-not-be-exposed',
 						)
 					),
 				);
@@ -400,6 +398,8 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		$this->assertSame( 200, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertSame( '', $data['account_portal_url'] );
+		$this->assertSame( '', $data['purchase_credits_url'] );
+		$this->assertSame( '', $data['payment_methods_url'] );
 		$this->assertStringNotContainsString( 'must-not-be-exposed', wp_json_encode( $data ) ?: '' );
 		$this->assertStringNotContainsString(
 			'must-not-be-exposed',


### PR DESCRIPTION
## Summary

- Add sanitized service-issued URLs for purchasing credits and managing payment methods.
- Render each billing action only for its dedicated URL while retaining the generic account portal independently.
- Reject HTTP and credential-bearing action URLs before persistence or REST output.

## Worker self-verification

- PHPUnit: Tests: 3956, Assertions: 17380, Errors: 0, Failures: 0, Skipped: 126, Incomplete: 4
- Targeted PHP: `npm run test:php -- --filter=SettingsControllerTest` — 14 tests, 97 assertions
- Targeted JS: `npm run test:js -- superdav-account-manager.test.js` — 8 passed
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded

Resolves #2343

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.180 plugin for [OpenCode](https://opencode.ai) v1.18.4 with gpt-5.6-terra spent 5m and 85,893 tokens on this as a headless worker.
