### PR TITLE
GH#2347: assert itemized recovery messages

### DIFF
--- a/tests/SdAiAgent/Core/AbilityFunctionResolverTest.php
+++ b/tests/SdAiAgent/Core/AbilityFunctionResolverTest.php
@@ -188,6 +188,8 @@ class AbilityFunctionResolverTest extends WP_UnitTestCase {
 		$this->assertSame( 400, $payload['details']['status'] );
 		$this->assertSame( 0, $payload['details']['errors'][0]['index'] );
 		$this->assertSame( 'block_not_found', $payload['details']['errors'][0]['code'] );
+		$this->assertArrayHasKey( 'message', $payload['details']['errors'][0] );
+		$this->assertNotEmpty( $payload['details']['errors'][0]['message'] );
 		$this->assertSame( 'update-attrs', $payload['details']['errors'][0]['op'] );
 		$this->assertSame( 'blk_missing', $payload['details']['errors'][0]['ref'] );
 		$this->assertArrayNotHasKey( 'attributes', $payload['details']['errors'][0] );


### PR DESCRIPTION
## Summary

Require a non-empty message for each failed block update's itemized recovery detail.

## Files Changed

tests/SdAiAgent/Core/AbilityFunctionResolverTest.php

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — npm run lint; composer phpstan; npm run test:php (Tests: 3959, Assertions: 17410, Errors: 0, Failures: 0, Skipped: 126); npm run build; npm run check:bundle

Resolves #2347


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.181 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-terra spent 11m and 97,760 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation to ensure batch update errors include a non-empty, user-readable error message.
  * Preserved coverage for the error code, status, item index, operation, reference, and response structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->