### PR TITLE
GH#2349: harden coupon redemption follow-up

### DIFF
--- a/includes/Core/SuperdavSiteConnectionService.php
+++ b/includes/Core/SuperdavSiteConnectionService.php
@@ -217,13 +217,13 @@ final class SuperdavSiteConnectionService {
 			array(
 				'timeout'     => 15,
 				'redirection' => 0,
-				'headers' => array(
+				'headers'     => array(
 					'Authorization'        => 'Bearer ' . $token,
 					'Content-Type'         => 'application/json',
 					'X-Superdav-Timestamp' => $signature['timestamp'],
 					'X-Superdav-Signature' => $signature['value'],
 				),
-				'body'    => $body,
+				'body'        => $body,
 			)
 		);
 

--- a/includes/Core/SuperdavSiteConnectionService.php
+++ b/includes/Core/SuperdavSiteConnectionService.php
@@ -163,6 +163,7 @@ final class SuperdavSiteConnectionService {
 			$metadata['verified'],
 			$metadata['connect_required'],
 			$metadata['request_id'],
+			$metadata['refreshed_at'],
 			$metadata['account_portal_url'],
 			$metadata['usage'],
 			$metadata['verification'],
@@ -214,7 +215,8 @@ final class SuperdavSiteConnectionService {
 		$response = wp_remote_post(
 			$endpoint,
 			array(
-				'timeout' => 15,
+				'timeout'     => 15,
+				'redirection' => 0,
 				'headers' => array(
 					'Authorization'        => 'Bearer ' . $token,
 					'Content-Type'         => 'application/json',
@@ -231,6 +233,10 @@ final class SuperdavSiteConnectionService {
 
 		$status_code = (int) wp_remote_retrieve_response_code( $response );
 		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( $status_code >= 300 && $status_code < 400 ) {
+			return new WP_Error( 'sd_ai_agent_coupon_redemption_unavailable', __( 'Coupon redemption is temporarily unavailable.', 'superdav-ai-agent' ), array( 'status' => 503 ) );
+		}
+
 		if ( $status_code < 200 || $status_code >= 300 ) {
 			return $this->coupon_redemption_error( $body, $status_code );
 		}
@@ -243,6 +249,9 @@ final class SuperdavSiteConnectionService {
 		unset( $metadata['wallet'], $metadata['credit_activity'], $metadata['refreshed_at'], $metadata['request_id'] );
 		$metadata = array_merge( $metadata, $this->sanitize_remote_metadata( $body ) );
 		update_option( self::TOKEN_METADATA_OPTION, $metadata, false );
+		if ( $this->get_metadata() !== $metadata ) {
+			return new WP_Error( 'sd_ai_agent_coupon_redemption_persistence_failed', __( 'Coupon was redeemed, but your account balance could not be refreshed.', 'superdav-ai-agent' ), array( 'status' => 502 ) );
+		}
 
 		return $this->get_status();
 	}
@@ -442,7 +451,7 @@ final class SuperdavSiteConnectionService {
 		 */
 		$endpoint = apply_filters( 'sd_ai_agent_cloud_account_coupon_redemption_endpoint', $endpoint );
 
-		return is_string( $endpoint ) ? esc_url_raw( $endpoint ) : '';
+		return $this->sanitize_account_url( $endpoint );
 	}
 
 	/**
@@ -719,8 +728,10 @@ final class SuperdavSiteConnectionService {
 		$url    = is_string( $url ) ? esc_url_raw( $url ) : '';
 		$scheme = wp_parse_url( $url, PHP_URL_SCHEME );
 		$host   = wp_parse_url( $url, PHP_URL_HOST );
+		$user   = wp_parse_url( $url, PHP_URL_USER );
+		$pass   = wp_parse_url( $url, PHP_URL_PASS );
 
-		if ( '' === $url || 'https' !== $scheme || ! is_string( $host ) || '' === $host ) {
+		if ( '' === $url || 'https' !== $scheme || ! is_string( $host ) || '' === $host || ( is_string( $user ) && '' !== $user ) || ( is_string( $pass ) && '' !== $pass ) ) {
 			return '';
 		}
 

--- a/src/settings-page/__tests__/superdav-account-manager.test.js
+++ b/src/settings-page/__tests__/superdav-account-manager.test.js
@@ -162,7 +162,8 @@ describe( 'SuperdavAccountManager', () => {
 		apiFetch.mockResolvedValueOnce( {
 			configured: true,
 			purchase_credits_url: 'https://account.example/credits/purchase',
-			payment_methods_url: 'https://account.example/billing/payment-methods',
+			payment_methods_url:
+				'https://account.example/billing/payment-methods',
 		} );
 
 		await act( async () => {
@@ -173,7 +174,9 @@ describe( 'SuperdavAccountManager', () => {
 		} );
 
 		expect(
-			container.querySelector( 'a[href="https://account.example/credits/purchase"]' )
+			container.querySelector(
+				'a[href="https://account.example/credits/purchase"]'
+			)
 		).not.toBeNull();
 		expect(
 			container.querySelector(

--- a/src/settings-page/__tests__/superdav-account-manager.test.js
+++ b/src/settings-page/__tests__/superdav-account-manager.test.js
@@ -158,6 +158,30 @@ describe( 'SuperdavAccountManager', () => {
 		);
 	} );
 
+	test( 'renders dedicated billing actions with their service-issued URLs', async () => {
+		apiFetch.mockResolvedValueOnce( {
+			configured: true,
+			purchase_credits_url: 'https://account.example/credits/purchase',
+			payment_methods_url: 'https://account.example/billing/payment-methods',
+		} );
+
+		await act( async () => {
+			root.render( createElement( SuperdavAccountManager, {} ) );
+		} );
+		await act( async () => {
+			await Promise.resolve();
+		} );
+
+		expect(
+			container.querySelector( 'a[href="https://account.example/credits/purchase"]' )
+		).not.toBeNull();
+		expect(
+			container.querySelector(
+				'a[href="https://account.example/billing/payment-methods"]'
+			)
+		).not.toBeNull();
+	} );
+
 	test( 'redeems a coupon, disables submission while pending, and updates the balance', async () => {
 		let resolveRedemption;
 		apiFetch

--- a/tests/SdAiAgent/REST/SettingsControllerTest.php
+++ b/tests/SdAiAgent/REST/SettingsControllerTest.php
@@ -46,7 +46,9 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		delete_option( SuperdavSiteConnectionService::TOKEN_METADATA_OPTION );
 		remove_all_filters( 'sd_ai_agent_cloud_base_url' );
 		remove_all_filters( 'sd_ai_agent_cloud_portal_signing_secret' );
+		remove_all_filters( 'sd_ai_agent_cloud_account_coupon_redemption_endpoint' );
 		remove_all_filters( 'sd_ai_agent_options_read_blocklist' );
+		remove_all_filters( 'pre_update_option_' . SuperdavSiteConnectionService::TOKEN_METADATA_OPTION );
 		remove_all_filters( 'pre_http_request' );
 		parent::tear_down();
 	}
@@ -324,6 +326,7 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 			SuperdavSiteConnectionService::TOKEN_METADATA_OPTION,
 			array(
 				'connected_at' => '2026-07-16T00:00:00+00:00',
+				'refreshed_at'  => '2026-07-15T00:00:00+00:00',
 				'usage'        => array( 'requests' => 99 ),
 				'verification' => array( 'status' => 'stale' ),
 			),
@@ -347,6 +350,7 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'customer_id', $data['credit_activity'][0] );
 		$this->assertArrayNotHasKey( 'usage', $data );
 		$this->assertArrayNotHasKey( 'verification', $data );
+		$this->assertArrayNotHasKey( 'refreshed_at', $data );
 		$this->assertStringNotContainsString( $token, wp_json_encode( $data ) ?: '' );
 		$this->assertStringNotContainsString( 'must-not-be-exposed', wp_json_encode( $data ) ?: '' );
 	}
@@ -382,6 +386,7 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 				$body      = (string) ( $parsed_args['body'] ?? '' );
 				$timestamp = (string) ( $parsed_args['headers']['X-Superdav-Timestamp'] ?? '' );
 				self::assertSame( 'Bearer ' . $token, self::authorization_header_from_args( $parsed_args ) );
+				self::assertSame( 0, $parsed_args['redirection'] ?? null );
 				self::assertSame( $coupon_code, json_decode( $body, true )['coupon_code'] ?? '' );
 				self::assertSame(
 					hash_hmac( 'sha256', $timestamp . '.POST./custom/portal/redeem-coupon.' . $body, $secret ),
@@ -431,6 +436,7 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		$base_url   = 'https://service.example/v1';
 		$redeem_url = $base_url . '/portal/account/redeem-coupon';
 		$responses  = array(
+			array( 'code' => 302, 'error' => 'redirect', 'expected' => 'sd_ai_agent_coupon_redemption_unavailable' ),
 			array( 'code' => 404, 'error' => 'coupon_invalid', 'expected' => 'sd_ai_agent_coupon_invalid' ),
 			array( 'code' => 410, 'error' => 'coupon_expired', 'expected' => 'sd_ai_agent_coupon_expired' ),
 			array( 'code' => 410, 'error' => 'coupon_revoked', 'expected' => 'sd_ai_agent_coupon_revoked' ),
@@ -478,6 +484,77 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( \WP_Error::class, $response );
 		$this->assertSame( 'sd_ai_agent_coupon_code_required', $response->get_error_code() );
+	}
+
+	/** Coupon redemption never sends its bearer token to unsafe filtered endpoints. */
+	public function test_handle_redeem_superdav_coupon_rejects_unsafe_endpoint_overrides(): void {
+		$endpoints = array(
+			'http://service.example/portal/account/redeem-coupon',
+			'https://coupon-user:coupon-password@service.example/portal/account/redeem-coupon',
+			'https://service.example/portal/account/redeem-coupon?access_token=must-not-be-sent',
+		);
+
+		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, 'sdaist_coupon_endpoint_token', false );
+		add_filter( 'sd_ai_agent_cloud_portal_signing_secret', static fn(): string => 'test-portal-signing-secret' );
+		add_filter(
+			'pre_http_request',
+			static function (): void {
+				self::fail( 'Unsafe coupon redemption endpoint must not receive an HTTP request.' );
+			},
+			10,
+			0
+		);
+
+		foreach ( $endpoints as $endpoint ) {
+			add_filter( 'sd_ai_agent_cloud_account_coupon_redemption_endpoint', static fn(): string => $endpoint );
+			$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/superdav-account/redeem-coupon' );
+			$request->set_param( 'coupon_code', 'test-coupon-code' );
+			$response = ( new SettingsController( new Settings(), new Database() ) )->handle_redeem_superdav_coupon( $request );
+
+			$this->assertInstanceOf( \WP_Error::class, $response );
+			$this->assertSame( 'sd_ai_agent_coupon_redemption_unavailable', $response->get_error_code() );
+			remove_all_filters( 'sd_ai_agent_cloud_account_coupon_redemption_endpoint' );
+		}
+	}
+
+	/** A consumed coupon reports a non-retryable refresh error when metadata cannot persist. */
+	public function test_handle_redeem_superdav_coupon_reports_metadata_persistence_failure(): void {
+		$redeem_url = 'https://service.example/portal/account/redeem-coupon';
+		$metadata   = array( 'connected_at' => '2026-07-16T00:00:00+00:00' );
+
+		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, 'sdaist_coupon_persistence_token', false );
+		update_option( SuperdavSiteConnectionService::TOKEN_METADATA_OPTION, $metadata, false );
+		add_filter( 'sd_ai_agent_cloud_account_coupon_redemption_endpoint', static fn(): string => $redeem_url );
+		add_filter( 'sd_ai_agent_cloud_portal_signing_secret', static fn(): string => 'test-portal-signing-secret' );
+		add_filter(
+			'pre_http_request',
+			static function ( mixed $preempt, array $parsed_args, string $url ) use ( $redeem_url ): mixed {
+				if ( $redeem_url !== $url ) {
+					return $preempt;
+				}
+
+				return array(
+					'response' => array( 'code' => 200, 'message' => 'OK' ),
+					'body'     => wp_json_encode( array( 'wallet' => array( 'total_usd_micros' => 6000000 ) ) ),
+				);
+			},
+			10,
+			3
+		);
+		add_filter(
+			'pre_update_option_' . SuperdavSiteConnectionService::TOKEN_METADATA_OPTION,
+			static fn( mixed $value, mixed $old_value ): mixed => $old_value,
+			10,
+			2
+		);
+
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/superdav-account/redeem-coupon' );
+		$request->set_param( 'coupon_code', 'test-coupon-code' );
+		$response = ( new SettingsController( new Settings(), new Database() ) )->handle_redeem_superdav_coupon( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $response );
+		$this->assertSame( 'sd_ai_agent_coupon_redemption_persistence_failed', $response->get_error_code() );
+		$this->assertSame( $metadata, get_option( SuperdavSiteConnectionService::TOKEN_METADATA_OPTION, array() ) );
 	}
 
 	/** Account action URLs containing centrally blocked query keys are not exposed. */


### PR DESCRIPTION
## Summary

- reject unsafe coupon redemption endpoints, redirects, and unconfirmed metadata persistence
- discard stale refresh timestamps and cover service-issued billing actions

## Worker self-verification
- PHPUnit: Tests: 3961, Assertions: 17424, Errors: 0, Failures: 0, Skipped: 126
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded

Resolves #2349

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.181 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-terra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved account refresh handling so outdated refresh metadata is no longer exposed.
  - Strengthened validation of account and coupon service URLs, including rejection of unsafe HTTPS URLs.
  - Coupon redemptions now handle redirects as temporary service unavailability and report failures when token data cannot be saved.
- **New Features**
  - Added dedicated links for purchasing credits and managing payment methods in account settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->