### PR TITLE
fix: keep onboarding verification tools direct

### DIFF
--- a/includes/Models/Agent.php
+++ b/includes/Models/Agent.php
@@ -46,6 +46,27 @@ class Agent {
 	public const THEME_BUILDER_AGENT_SLUG = 'theme-builder';
 
 	/**
+	 * Setup Assistant tools that must stay directly callable for first-run flows.
+	 *
+	 * Built-in agent rows are seeded once and may keep an older stored tool list,
+	 * so the runtime also appends this set in get_loop_options(). These abilities
+	 * are common immediate follow-ups after the homepage is created: navigation
+	 * finishing plus read-only URL/loopback verification. Keeping them in Tier 1
+	 * avoids an `ability_not_allowed` recovery turn when a model calls a discovered
+	 * ability directly instead of routing through `sd-ai-agent/ability-call`.
+	 *
+	 * @var list<string>
+	 */
+	private const ONBOARDING_REQUIRED_TIER_1_TOOLS = array(
+		'sd-ai-agent/create-menu',
+		'sd-ai-agent/add-menu-item',
+		'sd-ai-agent/list-menus',
+		'sd-ai-agent/assign-menu-location',
+		'sd-ai-agent/site-loopback-check',
+		'sd-ai-agent/fetch-url',
+	);
+
+	/**
 	 * Get the agents table name.
 	 */
 	public static function table_name(): string {
@@ -551,9 +572,14 @@ class Agent {
 			// the safer dedicated discovery tools.
 			if ( self::ONBOARDING_AGENT_SLUG === $agent->slug && $agent->is_builtin ) {
 				$tier_1_tools = array_values(
-					array_filter(
-						$tier_1_tools,
-						static fn( string $tool ): bool => 'wp-cli/execute' !== $tool
+					array_unique(
+						array_merge(
+							array_filter(
+								$tier_1_tools,
+								static fn( string $tool ): bool => 'wp-cli/execute' !== $tool
+							),
+							self::ONBOARDING_REQUIRED_TIER_1_TOOLS
+						)
 					)
 				);
 			}
@@ -814,6 +840,9 @@ class Agent {
 						'sd-ai-agent/list-posts',
 						'sd-ai-agent/get-plugins',
 						'sd-ai-agent/get-themes',
+						// Navigation finishing and verification are common first-run
+						// follow-ups; keep them direct so setup can complete in one pass.
+						...self::ONBOARDING_REQUIRED_TIER_1_TOOLS,
 						// Use a dedicated, confirmation-aware ability instead of the
 						// broad WP-CLI dispatcher when setup needs WooCommerce.
 						'sd-ai-agent/install-plugin',

--- a/includes/Models/Agent.php
+++ b/includes/Models/Agent.php
@@ -563,30 +563,28 @@ class Agent {
 		if ( null !== $agent->max_iterations ) {
 			$options['max_iterations'] = $agent->max_iterations;
 		}
-		if ( ! empty( $agent->tier_1_tools ) ) {
-			$tier_1_tools = $agent->tier_1_tools;
+		$tier_1_tools = $agent->tier_1_tools;
 
-			// Built-in onboarding records are seeded only once, so an upgraded
-			// site can retain the former direct WP-CLI entry. Keep the broad
-			// dispatcher out of Phase 0 even when the stored agent row predates
-			// the safer dedicated discovery tools.
-			if ( self::ONBOARDING_AGENT_SLUG === $agent->slug && $agent->is_builtin ) {
-				$tier_1_tools = array_values(
-					array_unique(
-						array_merge(
-							array_filter(
-								$tier_1_tools,
-								static fn( string $tool ): bool => 'wp-cli/execute' !== $tool
-							),
-							self::ONBOARDING_REQUIRED_TIER_1_TOOLS
-						)
+		// Built-in onboarding records are seeded only once, so an upgraded
+		// site can retain the former direct WP-CLI entry or an empty stored list.
+		// Keep the broad dispatcher out of Phase 0 while always restoring the
+		// safer dedicated discovery tools for the built-in onboarding agent.
+		if ( self::ONBOARDING_AGENT_SLUG === $agent->slug && $agent->is_builtin ) {
+			$tier_1_tools = array_values(
+				array_unique(
+					array_merge(
+						array_filter(
+							$tier_1_tools,
+							static fn( string $tool ): bool => 'wp-cli/execute' !== $tool
+						),
+						self::ONBOARDING_REQUIRED_TIER_1_TOOLS
 					)
-				);
-			}
+				)
+			);
+		}
 
-			if ( ! empty( $tier_1_tools ) ) {
-				$options['tier_1_tools'] = $tier_1_tools;
-			}
+		if ( ! empty( $tier_1_tools ) ) {
+			$options['tier_1_tools'] = $tier_1_tools;
 		}
 
 		return $options;

--- a/tests/SdAiAgent/Models/AgentTest.php
+++ b/tests/SdAiAgent/Models/AgentTest.php
@@ -601,6 +601,12 @@ class AgentTest extends WP_UnitTestCase {
 		$this->assertContains( 'sd-ai-agent/get-plugins', $tools );
 		$this->assertContains( 'sd-ai-agent/get-themes', $tools );
 		$this->assertContains( 'sd-ai-agent/install-plugin', $tools );
+		$this->assertContains( 'sd-ai-agent/create-menu', $tools );
+		$this->assertContains( 'sd-ai-agent/add-menu-item', $tools );
+		$this->assertContains( 'sd-ai-agent/list-menus', $tools );
+		$this->assertContains( 'sd-ai-agent/assign-menu-location', $tools );
+		$this->assertContains( 'sd-ai-agent/site-loopback-check', $tools );
+		$this->assertContains( 'sd-ai-agent/fetch-url', $tools );
 		$this->assertNotContains( 'wp-cli/execute', $tools );
 		$this->assertStringContainsString( 'Do not use the generic `wp-cli/execute` dispatcher for site title, tagline, active-plugin, or theme discovery', $prompt );
 	}
@@ -619,7 +625,14 @@ class AgentTest extends WP_UnitTestCase {
 
 		try {
 			$options = Agent::get_loop_options( $agent->id );
-			$this->assertSame( [ 'sd-ai-agent/get-option' ], $options['tier_1_tools'] );
+			$this->assertContains( 'sd-ai-agent/get-option', $options['tier_1_tools'] );
+			$this->assertContains( 'sd-ai-agent/create-menu', $options['tier_1_tools'] );
+			$this->assertContains( 'sd-ai-agent/add-menu-item', $options['tier_1_tools'] );
+			$this->assertContains( 'sd-ai-agent/list-menus', $options['tier_1_tools'] );
+			$this->assertContains( 'sd-ai-agent/assign-menu-location', $options['tier_1_tools'] );
+			$this->assertContains( 'sd-ai-agent/site-loopback-check', $options['tier_1_tools'] );
+			$this->assertContains( 'sd-ai-agent/fetch-url', $options['tier_1_tools'] );
+			$this->assertNotContains( 'wp-cli/execute', $options['tier_1_tools'] );
 		} finally {
 			Agent::update( $agent->id, [ 'tier_1_tools' => $original_tools ] );
 		}

--- a/tests/SdAiAgent/Models/AgentTest.php
+++ b/tests/SdAiAgent/Models/AgentTest.php
@@ -639,6 +639,33 @@ class AgentTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Empty stored onboarding tool lists should still receive the required direct
+	 * setup/verification tools at runtime.
+	 */
+	public function test_onboarding_loop_options_restore_required_tools_from_empty_existing_builtin(): void {
+		Agent::seed_defaults();
+		$agent = Agent::get_by_slug( 'onboarding' );
+		$this->assertNotNull( $agent );
+
+		$original_tools = $agent->tier_1_tools;
+		Agent::update( $agent->id, [ 'tier_1_tools' => [] ] );
+
+		try {
+			$options = Agent::get_loop_options( $agent->id );
+			$this->assertArrayHasKey( 'tier_1_tools', $options );
+			$this->assertContains( 'sd-ai-agent/create-menu', $options['tier_1_tools'] );
+			$this->assertContains( 'sd-ai-agent/add-menu-item', $options['tier_1_tools'] );
+			$this->assertContains( 'sd-ai-agent/list-menus', $options['tier_1_tools'] );
+			$this->assertContains( 'sd-ai-agent/assign-menu-location', $options['tier_1_tools'] );
+			$this->assertContains( 'sd-ai-agent/site-loopback-check', $options['tier_1_tools'] );
+			$this->assertContains( 'sd-ai-agent/fetch-url', $options['tier_1_tools'] );
+			$this->assertNotContains( 'wp-cli/execute', $options['tier_1_tools'] );
+		} finally {
+			Agent::update( $agent->id, [ 'tier_1_tools' => $original_tools ] );
+		}
+	}
+
+	/**
 	 * Every ability mentioned in a built-in agent's system prompt must be
 	 * present in that agent's tier_1_tools (or in the meta-tools that the
 	 * resolver always exposes). Catches drift between prompt and tool surface


### PR DESCRIPTION
## Summary
- Keep the Setup Assistant's common navigation-finishing and URL verification abilities directly available in Tier 1.
- Append those tools at runtime for existing seeded onboarding agents while still excluding the broad `wp-cli/execute` dispatcher.
- Extend `AgentTest` coverage so fresh defaults and upgraded stored onboarding rows both include the required direct tools.

## Context
Feedback report 42 showed the Setup Assistant discovering abilities through `ability-search`, then directly calling menu and URL-check tools. Those calls failed with `ability_not_allowed` before the model retried through `sd-ai-agent/ability-call`. The fix preserves the allowlist safety model and makes the expected first-run tools available on the first try.

## Worker self-verification
- PHPUnit: Tests: 3961, Assertions: 17437, Errors: 0, Failures: 0, Skipped: 126, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

## Commands run
- `composer install --no-interaction`
- `npm run test:php -- --filter=AgentTest`
- `npm run lint:php`
- `composer phpstan`
- `npm run test:php`
- `npm run lint:js`
- `npm run lint:css`
- `npm run build`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.188 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.5 spent 1d 5h and 576,965 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the onboarding assistant’s site discovery and menu setup capabilities.
  * Added dedicated tools for creating menus, adding items, listing menus, assigning locations, checking site connectivity, and fetching URLs.
  * Onboarding no longer relies on the broad command-execution tool for these tasks.

* **Bug Fixes**
  * Prevented duplicate onboarding tools while ensuring all required capabilities are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->