### PR TITLE
fix: stop unchanged checkpoint retries (#2357)

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -99,6 +99,30 @@ class AgentLoop {
 	/** Durable checkpoint phase saved after tool responses are appended. */
 	public const CHECKPOINT_TOOL_RESPONSE_RECORDED = 'tool_response_recorded';
 
+	/** Maximum serialized history retained in one automatic-resume checkpoint. */
+	private const CHECKPOINT_HISTORY_MAX_BYTES = ConversationTrimmer::COMPACT_MAX_BYTES;
+
+	/** Maximum estimated tokens retained in one automatic-resume checkpoint. */
+	private const CHECKPOINT_HISTORY_MAX_TOKENS = ConversationTrimmer::COMPACT_MAX_TOKENS;
+
+	/** Maximum serialized page context retained in one automatic-resume checkpoint. */
+	private const CHECKPOINT_PAGE_CONTEXT_MAX_BYTES = 8192;
+
+	/** Maximum serialized scalar page-context value retained in one checkpoint. */
+	private const CHECKPOINT_PAGE_CONTEXT_VALUE_MAX_BYTES = 2048;
+
+	/** Maximum durable ability names retained for one automatic resume. */
+	private const CHECKPOINT_ABILITY_NAME_MAX_COUNT = 32;
+
+	/** Maximum serialized byte length of one durable ability name. */
+	private const CHECKPOINT_ABILITY_NAME_MAX_BYTES = 128;
+
+	/** Maximum serialized byte length of a provider or model identifier. */
+	private const CHECKPOINT_IDENTIFIER_MAX_BYTES = 191;
+
+	/** Format version for checkpoint resume metadata. */
+	public const CHECKPOINT_RESUME_METADATA_VERSION = 1;
+
 	/**
 	 * Maximum consecutive preamble-only truncations before we abort the loop.
 	 *
@@ -201,6 +225,9 @@ class AgentLoop {
 
 	/** @var float Unix timestamp when this active-job run started. */
 	private float $active_job_started_at = 0.0;
+
+	/** @var array<string, mixed> Resume metadata carried forward from a claimed checkpoint. */
+	private array $checkpoint_resume_metadata = array();
 
 	/** @var string Last coarse loop phase for shutdown diagnostics. */
 	private string $last_loop_phase = 'initializing';
@@ -404,6 +431,9 @@ class AgentLoop {
 		// Empty string when the loop is not running under a background job.
 		// @phpstan-ignore-next-line
 		$this->active_job_id = (string) ( $options['active_job_id'] ?? '' );
+		// @phpstan-ignore-next-line -- Resume metadata is an internal checkpoint payload.
+		$checkpoint_resume_metadata       = $options['checkpoint_resume_metadata'] ?? array();
+		$this->checkpoint_resume_metadata = is_array( $checkpoint_resume_metadata ) ? $checkpoint_resume_metadata : array();
 		// @phpstan-ignore-next-line -- Test/job callers may lower attempts or delays; production defaults remain four attempts.
 		$this->provider_retry_max_attempts = max( 1, (int) ( $options['provider_retry_max_attempts'] ?? self::PROVIDER_RETRY_MAX_ATTEMPTS ) );
 		// @phpstan-ignore-next-line -- Values are normalised below to non-negative integer seconds.
@@ -957,24 +987,333 @@ class AgentLoop {
 			return;
 		}
 
+		$history              = $this->serialize_history();
+		$original_history_len = count( $history );
+		$resolved_provider_id = $this->resolve_provider_id();
+		$resolved_model_id    = $this->resolve_effective_model_id( $resolved_provider_id );
+		$provider_id          = self::checkpoint_identifier( (string) $resolved_provider_id );
+		$model_id             = self::checkpoint_identifier( (string) $resolved_model_id );
+		$metadata             = self::describe_checkpoint_request( $history, $phase, $provider_id, $model_id );
+		$compaction           = array();
+		$recovery_transformation = '';
+
+		// Checkpoints are a recovery boundary, not a second unbounded transcript.
+		// A session remains the durable source for the full conversation; this copy
+		// only needs to be sufficient for one safe provider continuation.
+		if ( $this->checkpoint_requires_compaction( $metadata ) ) {
+			$compacted_history = ConversationTrimmer::compact_serialized_history(
+				$history,
+				self::checkpoint_compaction_byte_budget( (int) $metadata['request_budget_bytes'] ),
+				self::checkpoint_compaction_token_budget( (int) $metadata['request_budget_tokens'] )
+			);
+			$compact_metadata  = self::describe_checkpoint_request(
+				$compacted_history['messages'],
+				$phase,
+				$provider_id,
+				$model_id
+			);
+
+			if (
+				(int) $compact_metadata['request_bytes'] < (int) $metadata['request_bytes']
+				&& ! self::checkpoint_request_requires_compaction( $compact_metadata )
+			) {
+				$history                 = $compacted_history['messages'];
+				$metadata                = $compact_metadata;
+				$compaction              = $compacted_history['meta'];
+				$recovery_transformation = 'compact_checkpoint_history';
+			} else {
+				// Do not leave an oversized request behind when a deterministic
+				// compact representation cannot safely fit. An empty history makes
+				// this checkpoint deliberately non-resumable rather than replaying
+				// the same rejected request on the next status poll.
+				$history                 = array();
+				$metadata                = self::describe_checkpoint_request( $history, $phase, $provider_id, $model_id );
+				$compaction              = array( 'source_message_count' => $original_history_len );
+				$recovery_transformation = 'discard_uncompactable_checkpoint_history';
+			}
+		}
+
+		$resume_metadata = array(
+			'version'      => self::CHECKPOINT_RESUME_METADATA_VERSION,
+			'next_request' => $metadata,
+		);
+
+		if ( isset( $this->checkpoint_resume_metadata['last_attempt'] ) && is_array( $this->checkpoint_resume_metadata['last_attempt'] ) ) {
+			$last_attempt = self::checkpoint_attempt_metadata( $this->checkpoint_resume_metadata['last_attempt'] );
+			if ( ! empty( $last_attempt ) ) {
+				$resume_metadata['last_attempt'] = $last_attempt;
+			}
+		}
+
+		if ( '' !== $recovery_transformation ) {
+			$resume_metadata['recovery_transformation'] = $recovery_transformation;
+			$resume_metadata['compaction']              = self::checkpoint_compaction_metadata( $compaction );
+		} elseif ( isset( $this->checkpoint_resume_metadata['recovery_transformation'] ) ) {
+			$existing_transformation = self::checkpoint_recovery_transformation( (string) $this->checkpoint_resume_metadata['recovery_transformation'] );
+			if ( '' !== $existing_transformation ) {
+				$resume_metadata['recovery_transformation'] = $existing_transformation;
+			}
+			if ( isset( $this->checkpoint_resume_metadata['compaction'] ) && is_array( $this->checkpoint_resume_metadata['compaction'] ) ) {
+				$existing_compaction = self::checkpoint_compaction_metadata( $this->checkpoint_resume_metadata['compaction'] );
+				if ( ! empty( $existing_compaction ) ) {
+					$resume_metadata['compaction'] = $existing_compaction;
+				}
+			}
+		}
+
 		ActiveJobRepository::save_checkpoint(
 			$this->active_job_id,
 			$phase,
 			array(
-				'history'                       => $this->serialize_history(),
-				'tool_call_log'                 => $this->tool_call_log,
-				'message_log'                   => $this->message_log,
-				'token_usage'                   => $this->token_usage,
+				'history'                       => $history,
+				'checkpoint_resume_metadata'    => $resume_metadata,
+				'activity'                      => array(
+					'tool_call_count' => count( $this->tool_call_log ),
+					'message_count'   => count( $this->message_log ),
+				),
+				'token_usage'                   => $this->checkpoint_token_usage(),
 				'iterations_remaining'          => max( 1, $iterations_remaining ),
-				'model_id'                      => $this->model_id,
-				'provider_id'                   => $this->provider_id,
-				'client_abilities'              => $this->client_abilities,
-				'page_context'                  => $this->page_context,
-				'anonymous_allowed_abilities'   => $this->anonymous_allowed_abilities,
-				'anonymous_allowed_collections' => $this->anonymous_allowed_collections,
+				'model_id'                      => $model_id,
+				'provider_id'                   => $provider_id,
+				'client_ability_names'          => self::checkpoint_ability_names( $this->client_router->get_names() ),
+				'page_context'                  => $this->checkpoint_page_context(),
+				'anonymous_allowed_abilities'   => self::checkpoint_ability_names( $this->anonymous_allowed_abilities ),
+				'anonymous_allowed_collections' => self::checkpoint_ability_names( $this->anonymous_allowed_collections ),
 				'anonymous_policy_active'       => $this->anonymous_policy_active,
 			)
 		);
+	}
+
+	/**
+	 * Describe the next provider request without retaining its source content.
+	 *
+	 * This public helper is shared with the checkpoint dispatcher so legacy rows
+	 * without metadata can be upgraded safely before their first resume claim.
+	 *
+	 * @param array<int, array<string, mixed>> $serialized_history Serializable provider history.
+	 * @param string                            $phase              Durable checkpoint phase.
+	 * @param string                            $provider_id        Provider selected for the request.
+	 * @param string                            $model_id           Model selected for the request.
+	 * @return array{fingerprint:string,request_bytes:int,request_tokens:int,request_budget_bytes:int,request_budget_tokens:int,size_class:string,phase:string,locally_rejected:bool}
+	 */
+	public static function describe_checkpoint_request( array $serialized_history, string $phase, string $provider_id = '', string $model_id = '' ): array {
+		$history = array();
+		try {
+			$history = ConversationSerializer::deserialize( array_values( $serialized_history ) );
+			$history = ConversationTrimmer::validate_tool_pairs( $history );
+		} catch ( \Throwable $e ) {
+			// The dispatcher will reject an unreadable checkpoint before it can run.
+			$history = array();
+		}
+
+		$request_bytes  = ! empty( $history )
+			? ConversationTrimmer::estimate_total_bytes( $history )
+			: strlen( (string) wp_json_encode( $serialized_history ) );
+		$request_tokens = ! empty( $history )
+			? ConversationTrimmer::estimate_total_tokens( $history )
+			: (int) ceil( $request_bytes / 4 );
+		$byte_budget    = ConversationTrimmer::get_request_byte_budget( $provider_id, $model_id );
+		$token_budget   = ConversationTrimmer::get_request_token_budget( $provider_id, $model_id );
+		$fingerprint    = hash(
+			'sha256',
+			(string) wp_json_encode(
+				array(
+					'history'     => $serialized_history,
+					'provider_id' => $provider_id,
+					'model_id'    => $model_id,
+				)
+			)
+		);
+
+		return array(
+			'fingerprint'            => $fingerprint,
+			'request_bytes'          => max( 0, $request_bytes ),
+			'request_tokens'         => max( 0, $request_tokens ),
+			'request_budget_bytes'   => max( 0, $byte_budget ),
+			'request_budget_tokens'  => max( 0, $token_budget ),
+			'size_class'             => ProviderTraceLogger::classify_request_size( max( 0, $request_bytes ) ),
+			'phase'                  => $phase,
+			'locally_rejected'       => ! empty( $history ) && ! ConversationTrimmer::fits_budget( $history, $byte_budget, $token_budget ),
+		);
+	}
+
+	/**
+	 * Whether a checkpoint must use its bounded recovery representation.
+	 *
+	 * @param array<string, mixed> $metadata Next-request metadata.
+	 */
+	private function checkpoint_requires_compaction( array $metadata ): bool {
+		return self::checkpoint_request_requires_compaction( $metadata );
+	}
+
+	/** @param array<string, mixed> $metadata Next-request metadata. */
+	private static function checkpoint_request_requires_compaction( array $metadata ): bool {
+		return (int) ( $metadata['request_bytes'] ?? 0 ) > self::CHECKPOINT_HISTORY_MAX_BYTES
+			|| (int) ( $metadata['request_tokens'] ?? 0 ) > self::CHECKPOINT_HISTORY_MAX_TOKENS
+			|| ! empty( $metadata['locally_rejected'] );
+	}
+
+	/** Get a bounded byte budget for deterministic checkpoint compaction. */
+	private static function checkpoint_compaction_byte_budget( int $request_budget ): int {
+		if ( $request_budget <= 0 ) {
+			return self::CHECKPOINT_HISTORY_MAX_BYTES;
+		}
+
+		return max( 1024, min( self::CHECKPOINT_HISTORY_MAX_BYTES, $request_budget ) );
+	}
+
+	/** Get a bounded token budget for deterministic checkpoint compaction. */
+	private static function checkpoint_compaction_token_budget( int $request_budget ): int {
+		if ( $request_budget <= 0 ) {
+			return self::CHECKPOINT_HISTORY_MAX_TOKENS;
+		}
+
+		return max( 256, min( self::CHECKPOINT_HISTORY_MAX_TOKENS, $request_budget ) );
+	}
+
+	/** Keep one identifier inside the fixed checkpoint storage budget. */
+	private static function checkpoint_identifier( string $value ): string {
+		return self::checkpoint_json_fits_budget( $value, self::CHECKPOINT_IDENTIFIER_MAX_BYTES ) ? $value : '';
+	}
+
+	/**
+	 * Keep only a bounded, canonical list of ability names in checkpoint state.
+	 *
+	 * @param array<int, mixed> $names Candidate ability names.
+	 * @return list<string>
+	 */
+	private static function checkpoint_ability_names( array $names ): array {
+		$bounded = array();
+		foreach ( $names as $name ) {
+			if ( ! is_string( $name ) ) {
+				continue;
+			}
+
+			$name = trim( $name );
+			if ( '' === $name || ! self::checkpoint_json_fits_budget( $name, self::CHECKPOINT_ABILITY_NAME_MAX_BYTES ) ) {
+				continue;
+			}
+
+			$bounded[ $name ] = true;
+			if ( count( $bounded ) >= self::CHECKPOINT_ABILITY_NAME_MAX_COUNT ) {
+				break;
+			}
+		}
+
+		return array_keys( $bounded );
+	}
+
+	/** @return array<string, int> */
+	private function checkpoint_token_usage(): array {
+		$usage = is_array( $this->token_usage ) ? $this->token_usage : array();
+
+		return array(
+			'prompt'     => max( 0, (int) ( $usage['prompt'] ?? 0 ) ),
+			'completion' => max( 0, (int) ( $usage['completion'] ?? 0 ) ),
+		);
+	}
+
+	/** @return array<string, mixed> */
+	private function checkpoint_page_context(): array {
+		$context = array();
+		foreach ( array( 'summary', 'url', 'surface', 'is_frontend', 'page_title', 'post_id', 'post_type', 'admin_page', 'screen_id', 'public_chat' ) as $key ) {
+			if ( ! array_key_exists( $key, $this->page_context ) || ! is_scalar( $this->page_context[ $key ] ) ) {
+				continue;
+			}
+
+			self::checkpoint_append_context_value( $context, $key, $this->page_context[ $key ] );
+		}
+
+		$live_preview = $this->page_context['live_preview'] ?? null;
+		if ( is_array( $live_preview ) ) {
+			$preview = array();
+			foreach ( array( 'affected_descriptor_supported', 'requires_refresh_when_missing_affected', 'refresh_tool' ) as $key ) {
+				if ( isset( $live_preview[ $key ] ) && is_scalar( $live_preview[ $key ] ) ) {
+					self::checkpoint_append_context_value( $preview, $key, $live_preview[ $key ] );
+				}
+			}
+			if ( ! empty( $preview ) ) {
+				self::checkpoint_append_context_value( $context, 'live_preview', $preview );
+			}
+		}
+
+		return $context;
+	}
+
+	/** @param array<string, mixed> $context */
+	private static function checkpoint_append_context_value( array &$context, string $key, mixed $value ): void {
+		if ( ! self::checkpoint_json_fits_budget( $value, self::CHECKPOINT_PAGE_CONTEXT_VALUE_MAX_BYTES ) ) {
+			return;
+		}
+
+		$candidate         = $context;
+		$candidate[ $key ] = $value;
+		if ( self::checkpoint_json_fits_budget( $candidate, self::CHECKPOINT_PAGE_CONTEXT_MAX_BYTES ) ) {
+			$context = $candidate;
+		}
+	}
+
+	/** @param mixed $value */
+	private static function checkpoint_json_fits_budget( $value, int $maximum_bytes ): bool {
+		$encoded = wp_json_encode( $value );
+		return is_string( $encoded ) && strlen( $encoded ) <= $maximum_bytes;
+	}
+
+	/**
+	 * Keep only the fields needed to compare a prior resume candidate.
+	 *
+	 * @param array<string, mixed> $metadata Candidate metadata.
+	 * @return array<string, int|string>
+	 */
+	private static function checkpoint_attempt_metadata( array $metadata ): array {
+		$fingerprint = (string) ( $metadata['fingerprint'] ?? '' );
+		if ( 1 !== preg_match( '/^[a-f0-9]{64}$/', $fingerprint ) ) {
+			return array();
+		}
+
+		$size_class = (string) ( $metadata['size_class'] ?? '' );
+		if ( ! in_array( $size_class, array( 'small', 'medium', 'large', 'very_large' ), true ) ) {
+			$size_class = 'unknown';
+		}
+
+		return array(
+			'fingerprint'    => $fingerprint,
+			'request_bytes'  => max( 0, (int) ( $metadata['request_bytes'] ?? 0 ) ),
+			'request_tokens' => max( 0, (int) ( $metadata['request_tokens'] ?? 0 ) ),
+			'size_class'     => $size_class,
+			'phase'          => sanitize_key( (string) ( $metadata['phase'] ?? '' ) ),
+		);
+	}
+
+	/** @return string Allowed checkpoint transformation name, or empty when unknown. */
+	private static function checkpoint_recovery_transformation( string $transformation ): string {
+		return in_array(
+			$transformation,
+			array( 'compact_checkpoint_history', 'compact_checkpoint_resume', 'discard_uncompactable_checkpoint_history' ),
+			true
+		) ? $transformation : '';
+	}
+
+	/**
+	 * Keep only numeric/boolean compaction diagnostics in persisted metadata.
+	 *
+	 * @param array<string, mixed> $metadata Compaction metadata.
+	 * @return array<string, int|bool>
+	 */
+	private static function checkpoint_compaction_metadata( array $metadata ): array {
+		$bounded = array();
+		foreach ( array( 'source_message_count', 'retained_excerpt_count', 'boundary_omitted_count', 'estimated_bytes', 'estimated_tokens', 'max_bytes', 'max_tokens' ) as $key ) {
+			if ( isset( $metadata[ $key ] ) && is_numeric( $metadata[ $key ] ) ) {
+				$bounded[ $key ] = max( 0, (int) $metadata[ $key ] );
+			}
+		}
+		foreach ( array( 'attachments_omitted', 'tool_payloads_omitted' ) as $key ) {
+			if ( isset( $metadata[ $key ] ) ) {
+				$bounded[ $key ] = (bool) $metadata[ $key ];
+			}
+		}
+
+		return $bounded;
 	}
 
 	/**

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -987,14 +987,14 @@ class AgentLoop {
 			return;
 		}
 
-		$history              = $this->serialize_history();
-		$original_history_len = count( $history );
-		$resolved_provider_id = $this->resolve_provider_id();
-		$resolved_model_id    = $this->resolve_effective_model_id( $resolved_provider_id );
-		$provider_id          = self::checkpoint_identifier( (string) $resolved_provider_id );
-		$model_id             = self::checkpoint_identifier( (string) $resolved_model_id );
-		$metadata             = self::describe_checkpoint_request( $history, $phase, $provider_id, $model_id );
-		$compaction           = array();
+		$history                 = $this->serialize_history();
+		$original_history_len    = count( $history );
+		$resolved_provider_id    = $this->resolve_provider_id();
+		$resolved_model_id       = $this->resolve_effective_model_id( $resolved_provider_id );
+		$provider_id             = self::checkpoint_identifier( (string) $resolved_provider_id );
+		$model_id                = self::checkpoint_identifier( (string) $resolved_model_id );
+		$metadata                = self::describe_checkpoint_request( $history, $phase, $provider_id, $model_id );
+		$compaction              = array();
 		$recovery_transformation = '';
 
 		// Checkpoints are a recovery boundary, not a second unbounded transcript.
@@ -1091,9 +1091,9 @@ class AgentLoop {
 	 * without metadata can be upgraded safely before their first resume claim.
 	 *
 	 * @param array<int, array<string, mixed>> $serialized_history Serializable provider history.
-	 * @param string                            $phase              Durable checkpoint phase.
-	 * @param string                            $provider_id        Provider selected for the request.
-	 * @param string                            $model_id           Model selected for the request.
+	 * @param string                           $phase              Durable checkpoint phase.
+	 * @param string                           $provider_id        Provider selected for the request.
+	 * @param string                           $model_id           Model selected for the request.
 	 * @return array{fingerprint:string,request_bytes:int,request_tokens:int,request_budget_bytes:int,request_budget_tokens:int,size_class:string,phase:string,locally_rejected:bool}
 	 */
 	public static function describe_checkpoint_request( array $serialized_history, string $phase, string $provider_id = '', string $model_id = '' ): array {
@@ -1126,14 +1126,14 @@ class AgentLoop {
 		);
 
 		return array(
-			'fingerprint'            => $fingerprint,
-			'request_bytes'          => max( 0, $request_bytes ),
-			'request_tokens'         => max( 0, $request_tokens ),
-			'request_budget_bytes'   => max( 0, $byte_budget ),
-			'request_budget_tokens'  => max( 0, $token_budget ),
-			'size_class'             => ProviderTraceLogger::classify_request_size( max( 0, $request_bytes ) ),
-			'phase'                  => $phase,
-			'locally_rejected'       => ! empty( $history ) && ! ConversationTrimmer::fits_budget( $history, $byte_budget, $token_budget ),
+			'fingerprint'           => $fingerprint,
+			'request_bytes'         => max( 0, $request_bytes ),
+			'request_tokens'        => max( 0, $request_tokens ),
+			'request_budget_bytes'  => max( 0, $byte_budget ),
+			'request_budget_tokens' => max( 0, $token_budget ),
+			'size_class'            => ProviderTraceLogger::classify_request_size( max( 0, $request_bytes ) ),
+			'phase'                 => $phase,
+			'locally_rejected'      => ! empty( $history ) && ! ConversationTrimmer::fits_budget( $history, $byte_budget, $token_budget ),
 		);
 	}
 
@@ -1146,7 +1146,10 @@ class AgentLoop {
 		return self::checkpoint_request_requires_compaction( $metadata );
 	}
 
-	/** @param array<string, mixed> $metadata Next-request metadata. */
+	/**
+	 * @param array<string, mixed> $metadata Next-request metadata.
+	 * @return bool True when the checkpoint needs compaction.
+	 */
 	private static function checkpoint_request_requires_compaction( array $metadata ): bool {
 		return (int) ( $metadata['request_bytes'] ?? 0 ) > self::CHECKPOINT_HISTORY_MAX_BYTES
 			|| (int) ( $metadata['request_tokens'] ?? 0 ) > self::CHECKPOINT_HISTORY_MAX_TOKENS

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -431,6 +431,7 @@ class AgentLoop {
 		// Empty string when the loop is not running under a background job.
 		// @phpstan-ignore-next-line
 		$this->active_job_id = (string) ( $options['active_job_id'] ?? '' );
+
 		$this->checkpoint_resume_metadata = self::checkpoint_resume_metadata_from_candidate( $options['checkpoint_resume_metadata'] ?? array() );
 		// @phpstan-ignore-next-line -- Test/job callers may lower attempts or delays; production defaults remain four attempts.
 		$this->provider_retry_max_attempts = max( 1, (int) ( $options['provider_retry_max_attempts'] ?? self::PROVIDER_RETRY_MAX_ATTEMPTS ) );

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -431,9 +431,7 @@ class AgentLoop {
 		// Empty string when the loop is not running under a background job.
 		// @phpstan-ignore-next-line
 		$this->active_job_id = (string) ( $options['active_job_id'] ?? '' );
-		// @phpstan-ignore-next-line -- Resume metadata is an internal checkpoint payload.
-		$checkpoint_resume_metadata       = $options['checkpoint_resume_metadata'] ?? array();
-		$this->checkpoint_resume_metadata = is_array( $checkpoint_resume_metadata ) ? $checkpoint_resume_metadata : array();
+		$this->checkpoint_resume_metadata = self::checkpoint_resume_metadata_from_candidate( $options['checkpoint_resume_metadata'] ?? array() );
 		// @phpstan-ignore-next-line -- Test/job callers may lower attempts or delays; production defaults remain four attempts.
 		$this->provider_retry_max_attempts = max( 1, (int) ( $options['provider_retry_max_attempts'] ?? self::PROVIDER_RETRY_MAX_ATTEMPTS ) );
 		// @phpstan-ignore-next-line -- Values are normalised below to non-negative integer seconds.
@@ -1154,6 +1152,27 @@ class AgentLoop {
 		return (int) ( $metadata['request_bytes'] ?? 0 ) > self::CHECKPOINT_HISTORY_MAX_BYTES
 			|| (int) ( $metadata['request_tokens'] ?? 0 ) > self::CHECKPOINT_HISTORY_MAX_TOKENS
 			|| ! empty( $metadata['locally_rejected'] );
+	}
+
+	/**
+	 * Normalize checkpoint metadata from an untyped resume payload.
+	 *
+	 * @param mixed $candidate Candidate checkpoint metadata.
+	 * @return array<string, mixed> String-keyed checkpoint metadata.
+	 */
+	private static function checkpoint_resume_metadata_from_candidate( mixed $candidate ): array {
+		if ( ! is_array( $candidate ) ) {
+			return array();
+		}
+
+		$metadata = array();
+		foreach ( $candidate as $key => $value ) {
+			if ( is_string( $key ) ) {
+				$metadata[ $key ] = $value;
+			}
+		}
+
+		return $metadata;
 	}
 
 	/** Get a bounded byte budget for deterministic checkpoint compaction. */

--- a/includes/Models/ActiveJobRepository.php
+++ b/includes/Models/ActiveJobRepository.php
@@ -228,8 +228,8 @@ class ActiveJobRepository {
 	/**
 	 * Claim one automatic resume attempt by returning the row to processing.
 	 *
-	 * @param string               $job_id       The job UUID.
-	 * @param int                  $max_attempts Maximum permitted attempts.
+	 * @param string                    $job_id       The job UUID.
+	 * @param int                       $max_attempts Maximum permitted attempts.
 	 * @param array<string, mixed>|null $checkpoint Updated checkpoint to persist atomically with the claim.
 	 * @return bool True when an attempt was claimed.
 	 */

--- a/includes/Models/ActiveJobRepository.php
+++ b/includes/Models/ActiveJobRepository.php
@@ -228,15 +228,37 @@ class ActiveJobRepository {
 	/**
 	 * Claim one automatic resume attempt by returning the row to processing.
 	 *
-	 * @param string $job_id       The job UUID.
-	 * @param int    $max_attempts Maximum permitted attempts.
+	 * @param string               $job_id       The job UUID.
+	 * @param int                  $max_attempts Maximum permitted attempts.
+	 * @param array<string, mixed>|null $checkpoint Updated checkpoint to persist atomically with the claim.
 	 * @return bool True when an attempt was claimed.
 	 */
-	public static function claim_resume_attempt( string $job_id, int $max_attempts ): bool {
+	public static function claim_resume_attempt( string $job_id, int $max_attempts, ?array $checkpoint = null ): bool {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 
 		$now = current_time( 'mysql', true );
+		if ( null !== $checkpoint ) {
+			$encoded = wp_json_encode( $checkpoint );
+			if ( false === $encoded ) {
+				return false;
+			}
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; claim and checkpoint snapshot must be atomic.
+			$result = $wpdb->query(
+				$wpdb->prepare(
+					"UPDATE %i SET status = 'processing', error = NULL, interrupted_at = NULL, checkpoint = %s, resume_attempts = resume_attempts + 1, updated_at = %s WHERE job_id = %s AND status IN ('interrupted', 'abandoned') AND resume_attempts < %d",
+					self::table_name(),
+					$encoded,
+					$now,
+					$job_id,
+					$max_attempts
+				)
+			);
+
+			return $result !== false && $result > 0;
+		}
+
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
 		$result = $wpdb->query(
 			$wpdb->prepare(

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -43,6 +43,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * Uses #[Handler] + #[Action] because this controller serves multiple
  * basenames (/sessions, /run, /process, /job).
+ *
+ * @phpstan-type SerializedHistory list<array<string, mixed>>
+ * @phpstan-type CheckpointRequest array{fingerprint:string,request_bytes:int,request_tokens:int,request_budget_bytes:int,request_budget_tokens:int,size_class:string,phase:string,locally_rejected:bool}
+ * @phpstan-type ResumeAttempt array{fingerprint:string,request_bytes:int,request_tokens:int,size_class:string,phase:string}
+ * @phpstan-type CheckpointResumeOutcome array{dispatched:bool,terminal:bool,metadata:array{phase:string,reason:string,size_class:string}}
  */
 #[Handler(
 	container: 'sd-ai-agent',
@@ -1475,10 +1480,15 @@ final class SessionController {
 	 * @return array{dispatched:bool,terminal:bool,metadata:array{phase:string,reason:string,size_class:string}}
 	 */
 	private function maybe_dispatch_checkpoint_resume( string $job_id, ActiveJobRow $row ): array {
-		$checkpoint = json_decode( (string) $row->checkpoint, true );
-		if ( ! is_array( $checkpoint ) || ! $this->checkpoint_has_resume_history( $checkpoint ) ) {
+		$checkpoint = $this->checkpoint_array( json_decode( (string) $row->checkpoint, true ) );
+		if ( null === $checkpoint ) {
 			// Legacy interrupted rows without a checkpoint retain the existing
 			// sanitized interruption response instead of pretending they resumed.
+			return $this->checkpoint_resume_outcome( false, false, 'unavailable', array(), $row->checkpoint_phase );
+		}
+
+		$history = $this->checkpoint_resume_history( $checkpoint );
+		if ( null === $history ) {
 			return $this->checkpoint_resume_outcome( false, false, 'unavailable', array(), $row->checkpoint_phase );
 		}
 
@@ -1492,14 +1502,14 @@ final class SessionController {
 		}
 
 		$metadata = AgentLoop::describe_checkpoint_request(
-			$checkpoint['history'],
+			$history,
 			$phase,
 			(string) ( $checkpoint['provider_id'] ?? '' ),
 			(string) ( $checkpoint['model_id'] ?? '' )
 		);
 
 		if ( $this->checkpoint_resume_requires_compaction( $metadata ) ) {
-			$compacted = $this->compact_checkpoint_resume_history( $checkpoint, $metadata, $phase );
+			$compacted = $this->compact_checkpoint_resume_history( $checkpoint, $history, $metadata, $phase );
 			if ( null === $compacted ) {
 				return $this->terminal_checkpoint_resume( $job_id, $row, 'not_compactable', $metadata, $phase );
 			}
@@ -1572,24 +1582,61 @@ final class SessionController {
 	}
 
 	/**
-	 * @param array<string, mixed> $checkpoint Decoded checkpoint payload.
-	 * @return bool True when the checkpoint contains resumable history.
+	 * Normalize one decoded JSON object to a string-keyed checkpoint array.
+	 *
+	 * @param mixed $candidate Decoded JSON value.
+	 * @return array<string, mixed>|null Normalized checkpoint array, if valid.
 	 */
-	private function checkpoint_has_resume_history( array $checkpoint ): bool {
-		if ( empty( $checkpoint['history'] ) || ! is_array( $checkpoint['history'] ) ) {
-			return false;
+	private function checkpoint_array( mixed $candidate ): ?array {
+		if ( ! is_array( $candidate ) ) {
+			return null;
+		}
+
+		$normalized = array();
+		foreach ( $candidate as $key => $value ) {
+			if ( ! is_string( $key ) ) {
+				return null;
+			}
+			$normalized[ $key ] = $value;
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Decode and validate serialized checkpoint history before it can resume.
+	 *
+	 * @param array<string, mixed> $checkpoint Decoded checkpoint payload.
+	 * @return list<array<string, mixed>>|null Validated serialized history, if available.
+	 */
+	private function checkpoint_resume_history( array $checkpoint ): ?array {
+		$raw_history = $checkpoint['history'] ?? null;
+		if ( ! is_array( $raw_history ) || empty( $raw_history ) ) {
+			return null;
+		}
+
+		/** @var list<array<string, mixed>> $history */
+		$history = array();
+		foreach ( $raw_history as $message ) {
+			$serialized_message = $this->checkpoint_array( $message );
+			if ( null === $serialized_message ) {
+				return null;
+			}
+			$history[] = $serialized_message;
 		}
 
 		try {
-			ConversationSerializer::deserialize( array_values( $checkpoint['history'] ) );
-			return true;
+			ConversationSerializer::deserialize( $history );
 		} catch ( \Throwable $e ) {
-			return false;
+			return null;
 		}
+
+		return $history;
 	}
 
 	/**
 	 * @param array<string, mixed> $metadata Candidate request metadata.
+	 * @phpstan-param CheckpointRequest $metadata
 	 * @return bool True when the request requires compaction.
 	 */
 	private function checkpoint_resume_requires_compaction( array $metadata ): bool {
@@ -1602,15 +1649,17 @@ final class SessionController {
 	 * Replace an oversized persisted state with a smaller deterministic resume input.
 	 *
 	 * @param array<string, mixed> $checkpoint Decoded checkpoint payload.
+	 * @param list<array<string, mixed>> $history Validated serialized history.
 	 * @param array<string, mixed> $metadata Candidate request metadata.
-	 * @return array{checkpoint:array<string,mixed>,metadata:array<string,mixed>}|null
+	 * @phpstan-param CheckpointRequest $metadata
+	 * @return array{checkpoint:array<string,mixed>,metadata:CheckpointRequest}|null
 	 */
-	private function compact_checkpoint_resume_history( array $checkpoint, array $metadata, string $phase ): ?array {
+	private function compact_checkpoint_resume_history( array $checkpoint, array $history, array $metadata, string $phase ): ?array {
 		$byte_budget  = (int) ( $metadata['request_budget_bytes'] ?? 0 );
 		$token_budget = (int) ( $metadata['request_budget_tokens'] ?? 0 );
 		$byte_budget  = $byte_budget > 0 ? max( 1024, min( ConversationTrimmer::COMPACT_MAX_BYTES, $byte_budget ) ) : ConversationTrimmer::COMPACT_MAX_BYTES;
 		$token_budget = $token_budget > 0 ? max( 256, min( ConversationTrimmer::COMPACT_MAX_TOKENS, $token_budget ) ) : ConversationTrimmer::COMPACT_MAX_TOKENS;
-		$compacted    = ConversationTrimmer::compact_serialized_history( $checkpoint['history'], $byte_budget, $token_budget );
+		$compacted    = ConversationTrimmer::compact_serialized_history( $history, $byte_budget, $token_budget );
 		$next         = AgentLoop::describe_checkpoint_request(
 			$compacted['messages'],
 			$phase,
@@ -1640,13 +1689,15 @@ final class SessionController {
 
 	/**
 	 * @param array<string, mixed> $checkpoint Decoded checkpoint payload.
-	 * @return array<string, mixed> Last resume-attempt metadata.
+	 * @return ResumeAttempt Last resume-attempt metadata.
 	 */
 	private function checkpoint_resume_last_attempt( array $checkpoint ): array {
-		$resume_metadata = $checkpoint['checkpoint_resume_metadata'] ?? array();
-		return is_array( $resume_metadata ) && isset( $resume_metadata['last_attempt'] ) && is_array( $resume_metadata['last_attempt'] )
-			? $resume_metadata['last_attempt']
-			: array();
+		$resume_metadata = $this->checkpoint_array( $checkpoint['checkpoint_resume_metadata'] ?? null );
+		$last_attempt    = null === $resume_metadata
+			? null
+			: $this->checkpoint_array( $resume_metadata['last_attempt'] ?? null );
+
+		return $this->checkpoint_resume_attempt_metadata( $last_attempt ?? array() );
 	}
 
 	/**
@@ -1655,6 +1706,7 @@ final class SessionController {
 	 *
 	 * @param array<string, mixed> $checkpoint Decoded checkpoint payload.
 	 * @param array<string, mixed> $request_metadata Candidate request metadata.
+	 * @phpstan-param CheckpointRequest $request_metadata
 	 * @return array<string, mixed>
 	 */
 	private function checkpoint_resume_metadata( array $checkpoint, array $request_metadata ): array {
@@ -1720,6 +1772,8 @@ final class SessionController {
 	/**
 	 * @param array<string, mixed> $candidate Candidate request metadata.
 	 * @param array<string, mixed> $previous Previous attempted metadata.
+	 * @phpstan-param CheckpointRequest $candidate
+	 * @phpstan-param ResumeAttempt $previous
 	 * @return bool True when the candidate is unchanged.
 	 */
 	private function checkpoint_resume_is_unchanged( array $candidate, array $previous ): bool {
@@ -1737,7 +1791,7 @@ final class SessionController {
 
 	/**
 	 * @param array<string, mixed> $metadata Candidate request metadata.
-	 * @return array<string, mixed> Sanitized attempt metadata.
+	 * @return ResumeAttempt Sanitized attempt metadata.
 	 */
 	private function checkpoint_resume_attempt_metadata( array $metadata ): array {
 		return array(
@@ -1753,7 +1807,7 @@ final class SessionController {
 	 * @param array<string, mixed> $metadata Candidate request metadata.
 	 * @param string               $reason Recovery reason.
 	 * @param string               $phase Durable checkpoint phase.
-	 * @return array<string, string> Sanitized public response metadata.
+	 * @return array{phase:string,reason:string,size_class:string} Sanitized public response metadata.
 	 */
 	private function checkpoint_resume_response_metadata( array $metadata, string $reason, string $phase ): array {
 		$size_class = (string) ( $metadata['size_class'] ?? 'unknown' );
@@ -1774,7 +1828,7 @@ final class SessionController {
 	 * @param string               $reason The recovery reason.
 	 * @param array<string, mixed> $metadata Candidate request metadata.
 	 * @param string               $phase The durable checkpoint phase.
-	 * @return array<string, mixed> Resume outcome.
+	 * @return CheckpointResumeOutcome Resume outcome.
 	 */
 	private function checkpoint_resume_outcome( bool $dispatched, bool $terminal, string $reason, array $metadata, string $phase ): array {
 		return array(
@@ -1790,7 +1844,7 @@ final class SessionController {
 	 * @param string               $reason The terminal recovery reason.
 	 * @param array<string, mixed> $metadata Candidate request metadata.
 	 * @param string               $phase The durable checkpoint phase.
-	 * @return array<string, mixed> Terminal resume outcome.
+	 * @return CheckpointResumeOutcome Terminal resume outcome.
 	 */
 	private function terminal_checkpoint_resume( string $job_id, ActiveJobRow $row, string $reason, array $metadata, string $phase ): array {
 		$public_metadata = $this->checkpoint_resume_response_metadata( $metadata, $reason, $phase );
@@ -1816,7 +1870,7 @@ final class SessionController {
 	/**
 	 * @param string                $job_id The job UUID.
 	 * @param ActiveJobRow          $row The persisted active-job row.
-	 * @param array<string, string> $metadata Sanitized resume metadata.
+	 * @param array{phase:string,reason:string,size_class:string} $metadata Sanitized resume metadata.
 	 * @return WP_REST_Response Terminal job-status response.
 	 */
 	private function checkpoint_resume_terminal_response( string $job_id, ActiveJobRow $row, array $metadata ): WP_REST_Response {

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -1571,7 +1571,10 @@ final class SessionController {
 		return $this->checkpoint_resume_outcome( true, false, 'resumed', $metadata, $phase );
 	}
 
-	/** @param array<string, mixed> $checkpoint Decoded checkpoint payload. */
+	/**
+	 * @param array<string, mixed> $checkpoint Decoded checkpoint payload.
+	 * @return bool True when the checkpoint contains resumable history.
+	 */
 	private function checkpoint_has_resume_history( array $checkpoint ): bool {
 		if ( empty( $checkpoint['history'] ) || ! is_array( $checkpoint['history'] ) ) {
 			return false;
@@ -1585,7 +1588,10 @@ final class SessionController {
 		}
 	}
 
-	/** @param array<string, mixed> $metadata Candidate request metadata. */
+	/**
+	 * @param array<string, mixed> $metadata Candidate request metadata.
+	 * @return bool True when the request requires compaction.
+	 */
 	private function checkpoint_resume_requires_compaction( array $metadata ): bool {
 		return (int) ( $metadata['request_bytes'] ?? 0 ) > ConversationTrimmer::COMPACT_MAX_BYTES
 			|| (int) ( $metadata['request_tokens'] ?? 0 ) > ConversationTrimmer::COMPACT_MAX_TOKENS
@@ -1626,10 +1632,16 @@ final class SessionController {
 		$checkpoint['checkpoint_resume_metadata']['recovery_transformation'] = 'compact_checkpoint_resume';
 		$checkpoint['checkpoint_resume_metadata']['compaction']              = $compacted['meta'];
 
-		return array( 'checkpoint' => $checkpoint, 'metadata' => $next );
+		return array(
+			'checkpoint' => $checkpoint,
+			'metadata'   => $next,
+		);
 	}
 
-	/** @param array<string, mixed> $checkpoint Decoded checkpoint payload. @return array<string, mixed> */
+	/**
+	 * @param array<string, mixed> $checkpoint Decoded checkpoint payload.
+	 * @return array<string, mixed> Last resume-attempt metadata.
+	 */
 	private function checkpoint_resume_last_attempt( array $checkpoint ): array {
 		$resume_metadata = $checkpoint['checkpoint_resume_metadata'] ?? array();
 		return is_array( $resume_metadata ) && isset( $resume_metadata['last_attempt'] ) && is_array( $resume_metadata['last_attempt'] )
@@ -1705,7 +1717,11 @@ final class SessionController {
 		return array_values( $descriptors );
 	}
 
-	/** @param array<string, mixed> $candidate Candidate request metadata. @param array<string, mixed> $previous Previous attempted metadata. */
+	/**
+	 * @param array<string, mixed> $candidate Candidate request metadata.
+	 * @param array<string, mixed> $previous Previous attempted metadata.
+	 * @return bool True when the candidate is unchanged.
+	 */
 	private function checkpoint_resume_is_unchanged( array $candidate, array $previous ): bool {
 		$fingerprint = (string) ( $candidate['fingerprint'] ?? '' );
 		$prior       = (string) ( $previous['fingerprint'] ?? '' );
@@ -1719,7 +1735,10 @@ final class SessionController {
 			&& (string) ( $previous['phase'] ?? '' ) === (string) ( $candidate['phase'] ?? '' );
 	}
 
-	/** @param array<string, mixed> $metadata Candidate request metadata. @return array<string, mixed> */
+	/**
+	 * @param array<string, mixed> $metadata Candidate request metadata.
+	 * @return array<string, mixed> Sanitized attempt metadata.
+	 */
 	private function checkpoint_resume_attempt_metadata( array $metadata ): array {
 		return array(
 			'fingerprint'    => (string) ( $metadata['fingerprint'] ?? '' ),
@@ -1730,7 +1749,12 @@ final class SessionController {
 		);
 	}
 
-	/** @param array<string, mixed> $metadata Candidate request metadata. @return array{phase:string,reason:string,size_class:string} */
+	/**
+	 * @param array<string, mixed> $metadata Candidate request metadata.
+	 * @param string               $reason Recovery reason.
+	 * @param string               $phase Durable checkpoint phase.
+	 * @return array<string, string> Sanitized public response metadata.
+	 */
 	private function checkpoint_resume_response_metadata( array $metadata, string $reason, string $phase ): array {
 		$size_class = (string) ( $metadata['size_class'] ?? 'unknown' );
 		if ( ! in_array( $size_class, array( 'small', 'medium', 'large', 'very_large' ), true ) ) {
@@ -1744,7 +1768,14 @@ final class SessionController {
 		);
 	}
 
-	/** @param array<string, mixed> $metadata Candidate request metadata. @return array{dispatched:bool,terminal:bool,metadata:array{phase:string,reason:string,size_class:string}} */
+	/**
+	 * @param bool                 $dispatched Whether a resume was dispatched.
+	 * @param bool                 $terminal Whether the outcome is terminal.
+	 * @param string               $reason The recovery reason.
+	 * @param array<string, mixed> $metadata Candidate request metadata.
+	 * @param string               $phase The durable checkpoint phase.
+	 * @return array<string, mixed> Resume outcome.
+	 */
 	private function checkpoint_resume_outcome( bool $dispatched, bool $terminal, string $reason, array $metadata, string $phase ): array {
 		return array(
 			'dispatched' => $dispatched,
@@ -1753,7 +1784,14 @@ final class SessionController {
 		);
 	}
 
-	/** @param array<string, mixed> $metadata Candidate request metadata. @return array{dispatched:bool,terminal:bool,metadata:array{phase:string,reason:string,size_class:string}} */
+	/**
+	 * @param string               $job_id The job UUID.
+	 * @param ActiveJobRow         $row The persisted active-job row.
+	 * @param string               $reason The terminal recovery reason.
+	 * @param array<string, mixed> $metadata Candidate request metadata.
+	 * @param string               $phase The durable checkpoint phase.
+	 * @return array<string, mixed> Terminal resume outcome.
+	 */
 	private function terminal_checkpoint_resume( string $job_id, ActiveJobRow $row, string $reason, array $metadata, string $phase ): array {
 		$public_metadata = $this->checkpoint_resume_response_metadata( $metadata, $reason, $phase );
 		$detail          = sprintf( 'checkpoint_resume_%s; phase=%s; size_class=%s', $public_metadata['reason'], $public_metadata['phase'], $public_metadata['size_class'] );
@@ -1775,7 +1813,12 @@ final class SessionController {
 		return $this->checkpoint_resume_outcome( false, true, $reason, $metadata, $phase );
 	}
 
-	/** @param array{phase:string,reason:string,size_class:string} $metadata Sanitized resume metadata. */
+	/**
+	 * @param string                $job_id The job UUID.
+	 * @param ActiveJobRow          $row The persisted active-job row.
+	 * @param array<string, string> $metadata Sanitized resume metadata.
+	 * @return WP_REST_Response Terminal job-status response.
+	 */
 	private function checkpoint_resume_terminal_response( string $job_id, ActiveJobRow $row, array $metadata ): WP_REST_Response {
 		ActiveJobRepository::delete( $job_id );
 
@@ -3014,6 +3057,7 @@ final class SessionController {
 				$resume_history = ConversationSerializer::deserialize( array_values( $state_history ) );
 
 				$resume_options = $options;
+
 				$resume_options['checkpoint_resume_metadata'] = is_array( $state ) && is_array( $state['checkpoint_resume_metadata'] ?? null )
 					? $state['checkpoint_resume_metadata']
 					: array();

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -11,7 +11,9 @@ declare(strict_types=1);
 
 namespace SdAiAgent\REST;
 
+use SdAiAgent\Abilities\Js\JsAbilityCatalog;
 use SdAiAgent\Core\AgentLoop;
+use SdAiAgent\Core\AgentEventLog;
 use SdAiAgent\Core\ConversationDisplaySanitizer;
 use SdAiAgent\Core\ConversationSerializer;
 use SdAiAgent\Core\ConversationTrimmer;
@@ -1391,17 +1393,25 @@ final class SessionController {
 			'session_id' => $row->session_id,
 		];
 
-		if ( in_array( $status, array( 'interrupted', 'abandoned' ), true ) && $this->maybe_dispatch_checkpoint_resume( $job_id, $row ) ) {
-			return new WP_REST_Response(
-				array(
-					'status'          => 'processing',
-					'from_db'         => true,
-					'auto_resumed'    => true,
-					'original_status' => $status,
-					'session_id'      => $row->session_id,
-				),
-				202
-			);
+		if ( in_array( $status, array( 'interrupted', 'abandoned' ), true ) ) {
+			$resume_outcome = $this->maybe_dispatch_checkpoint_resume( $job_id, $row );
+			if ( $resume_outcome['dispatched'] ) {
+				return new WP_REST_Response(
+					array(
+						'status'            => 'processing',
+						'from_db'           => true,
+						'auto_resumed'      => true,
+						'original_status'   => $status,
+						'session_id'        => $row->session_id,
+						'checkpoint_resume' => $resume_outcome['metadata'],
+					),
+					202
+				);
+			}
+
+			if ( $resume_outcome['terminal'] ) {
+				return $this->checkpoint_resume_terminal_response( $job_id, $row, $resume_outcome['metadata'] );
+			}
 		}
 
 		// Include tool-call progress when present.
@@ -1462,17 +1472,47 @@ final class SessionController {
 	 *
 	 * @param string       $job_id Job UUID.
 	 * @param ActiveJobRow $row    Active-job row.
-	 * @return bool True when a resume worker was dispatched.
+	 * @return array{dispatched:bool,terminal:bool,metadata:array{phase:string,reason:string,size_class:string}}
 	 */
-	private function maybe_dispatch_checkpoint_resume( string $job_id, ActiveJobRow $row ): bool {
-		if ( $row->resume_attempts >= self::JOB_AUTO_RESUME_MAX_ATTEMPTS || ! $this->is_auto_resumable_checkpoint_phase( $row->checkpoint_phase ) ) {
-			return false;
+	private function maybe_dispatch_checkpoint_resume( string $job_id, ActiveJobRow $row ): array {
+		$checkpoint = json_decode( (string) $row->checkpoint, true );
+		if ( ! is_array( $checkpoint ) || ! $this->checkpoint_has_resume_history( $checkpoint ) ) {
+			// Legacy interrupted rows without a checkpoint retain the existing
+			// sanitized interruption response instead of pretending they resumed.
+			return $this->checkpoint_resume_outcome( false, false, 'unavailable', array(), $row->checkpoint_phase );
 		}
 
-		$checkpoint = json_decode( (string) $row->checkpoint, true );
-		if ( ! is_array( $checkpoint ) || empty( $checkpoint['history'] ) || ! is_array( $checkpoint['history'] ) ) {
-			return false;
+		$phase = (string) $row->checkpoint_phase;
+		if ( ! $this->is_auto_resumable_checkpoint_phase( $phase ) ) {
+			return $this->terminal_checkpoint_resume( $job_id, $row, 'unsafe_phase', array(), $phase );
 		}
+
+		if ( $row->resume_attempts >= self::JOB_AUTO_RESUME_MAX_ATTEMPTS ) {
+			return $this->terminal_checkpoint_resume( $job_id, $row, 'retry_budget_exhausted', array(), $phase );
+		}
+
+		$metadata = AgentLoop::describe_checkpoint_request(
+			$checkpoint['history'],
+			$phase,
+			(string) ( $checkpoint['provider_id'] ?? '' ),
+			(string) ( $checkpoint['model_id'] ?? '' )
+		);
+
+		if ( $this->checkpoint_resume_requires_compaction( $metadata ) ) {
+			$compacted = $this->compact_checkpoint_resume_history( $checkpoint, $metadata, $phase );
+			if ( null === $compacted ) {
+				return $this->terminal_checkpoint_resume( $job_id, $row, 'not_compactable', $metadata, $phase );
+			}
+
+			$checkpoint = $compacted['checkpoint'];
+			$metadata   = $compacted['metadata'];
+		}
+
+		if ( $this->checkpoint_resume_is_unchanged( $metadata, $this->checkpoint_resume_last_attempt( $checkpoint ) ) ) {
+			return $this->terminal_checkpoint_resume( $job_id, $row, 'no_progress', $metadata, $phase );
+		}
+
+		$checkpoint['checkpoint_resume_metadata'] = $this->checkpoint_resume_metadata( $checkpoint, $metadata );
 
 		$token = wp_generate_password( 40, false );
 		$job   = array(
@@ -1480,7 +1520,7 @@ final class SessionController {
 			'token'             => $token,
 			'user_id'           => $row->user_id,
 			'tool_calls'        => json_decode( $row->tool_calls, true ) ?: array(),
-			'messages'          => $checkpoint['message_log'] ?? array(),
+			'messages'          => array(),
 			'checkpoint_resume' => true,
 			'checkpoint_state'  => $checkpoint,
 			'params'            => array(
@@ -1496,15 +1536,20 @@ final class SessionController {
 				'page_context'                  => $checkpoint['page_context'] ?? array(),
 				'agent_id'                      => 0,
 				'attachments'                   => array(),
-				'client_abilities'              => $checkpoint['client_abilities'] ?? array(),
+				'client_abilities'              => $this->checkpoint_client_abilities( $checkpoint ),
 				'anonymous_allowed_abilities'   => $checkpoint['anonymous_allowed_abilities'] ?? array(),
 				'anonymous_allowed_collections' => $checkpoint['anonymous_allowed_collections'] ?? array(),
 				'anonymous_policy_active'       => ! empty( $checkpoint['anonymous_policy_active'] ),
 			),
 		);
 
-		if ( ! ActiveJobRepository::claim_resume_attempt( $job_id, self::JOB_AUTO_RESUME_MAX_ATTEMPTS ) ) {
-			return false;
+		if ( ! ActiveJobRepository::claim_resume_attempt( $job_id, self::JOB_AUTO_RESUME_MAX_ATTEMPTS, $checkpoint ) ) {
+			$current = ActiveJobRepository::get_by_job_id( $job_id );
+			if ( null !== $current && 'processing' === $current->status ) {
+				return $this->checkpoint_resume_outcome( true, false, 'resumed', $metadata, $phase );
+			}
+
+			return $this->terminal_checkpoint_resume( $job_id, $row, 'claim_failed', $metadata, $phase );
 		}
 
 		set_transient( RestController::JOB_PREFIX . $job_id, $job, RestController::JOB_TTL );
@@ -1523,7 +1568,228 @@ final class SessionController {
 			)
 		);
 
-		return true;
+		return $this->checkpoint_resume_outcome( true, false, 'resumed', $metadata, $phase );
+	}
+
+	/** @param array<string, mixed> $checkpoint Decoded checkpoint payload. */
+	private function checkpoint_has_resume_history( array $checkpoint ): bool {
+		if ( empty( $checkpoint['history'] ) || ! is_array( $checkpoint['history'] ) ) {
+			return false;
+		}
+
+		try {
+			ConversationSerializer::deserialize( array_values( $checkpoint['history'] ) );
+			return true;
+		} catch ( \Throwable $e ) {
+			return false;
+		}
+	}
+
+	/** @param array<string, mixed> $metadata Candidate request metadata. */
+	private function checkpoint_resume_requires_compaction( array $metadata ): bool {
+		return (int) ( $metadata['request_bytes'] ?? 0 ) > ConversationTrimmer::COMPACT_MAX_BYTES
+			|| (int) ( $metadata['request_tokens'] ?? 0 ) > ConversationTrimmer::COMPACT_MAX_TOKENS
+			|| ! empty( $metadata['locally_rejected'] );
+	}
+
+	/**
+	 * Replace an oversized persisted state with a smaller deterministic resume input.
+	 *
+	 * @param array<string, mixed> $checkpoint Decoded checkpoint payload.
+	 * @param array<string, mixed> $metadata Candidate request metadata.
+	 * @return array{checkpoint:array<string,mixed>,metadata:array<string,mixed>}|null
+	 */
+	private function compact_checkpoint_resume_history( array $checkpoint, array $metadata, string $phase ): ?array {
+		$byte_budget  = (int) ( $metadata['request_budget_bytes'] ?? 0 );
+		$token_budget = (int) ( $metadata['request_budget_tokens'] ?? 0 );
+		$byte_budget  = $byte_budget > 0 ? max( 1024, min( ConversationTrimmer::COMPACT_MAX_BYTES, $byte_budget ) ) : ConversationTrimmer::COMPACT_MAX_BYTES;
+		$token_budget = $token_budget > 0 ? max( 256, min( ConversationTrimmer::COMPACT_MAX_TOKENS, $token_budget ) ) : ConversationTrimmer::COMPACT_MAX_TOKENS;
+		$compacted    = ConversationTrimmer::compact_serialized_history( $checkpoint['history'], $byte_budget, $token_budget );
+		$next         = AgentLoop::describe_checkpoint_request(
+			$compacted['messages'],
+			$phase,
+			(string) ( $checkpoint['provider_id'] ?? '' ),
+			(string) ( $checkpoint['model_id'] ?? '' )
+		);
+
+		if (
+			(int) $next['request_bytes'] >= (int) $metadata['request_bytes']
+			|| $this->checkpoint_resume_requires_compaction( $next )
+		) {
+			return null;
+		}
+
+		$checkpoint['history']                    = $compacted['messages'];
+		$checkpoint['checkpoint_resume_metadata'] = is_array( $checkpoint['checkpoint_resume_metadata'] ?? null )
+			? $checkpoint['checkpoint_resume_metadata']
+			: array();
+		$checkpoint['checkpoint_resume_metadata']['recovery_transformation'] = 'compact_checkpoint_resume';
+		$checkpoint['checkpoint_resume_metadata']['compaction']              = $compacted['meta'];
+
+		return array( 'checkpoint' => $checkpoint, 'metadata' => $next );
+	}
+
+	/** @param array<string, mixed> $checkpoint Decoded checkpoint payload. @return array<string, mixed> */
+	private function checkpoint_resume_last_attempt( array $checkpoint ): array {
+		$resume_metadata = $checkpoint['checkpoint_resume_metadata'] ?? array();
+		return is_array( $resume_metadata ) && isset( $resume_metadata['last_attempt'] ) && is_array( $resume_metadata['last_attempt'] )
+			? $resume_metadata['last_attempt']
+			: array();
+	}
+
+	/**
+	 * Rebuild bounded metadata at the dispatcher boundary so legacy checkpoint
+	 * rows cannot carry arbitrary metadata forward into a new resume attempt.
+	 *
+	 * @param array<string, mixed> $checkpoint Decoded checkpoint payload.
+	 * @param array<string, mixed> $request_metadata Candidate request metadata.
+	 * @return array<string, mixed>
+	 */
+	private function checkpoint_resume_metadata( array $checkpoint, array $request_metadata ): array {
+		$resume_metadata = array(
+			'version'      => AgentLoop::CHECKPOINT_RESUME_METADATA_VERSION,
+			'next_request' => $request_metadata,
+			'last_attempt' => $this->checkpoint_resume_attempt_metadata( $request_metadata ),
+		);
+		$existing        = $checkpoint['checkpoint_resume_metadata'] ?? array();
+		if ( ! is_array( $existing ) ) {
+			return $resume_metadata;
+		}
+
+		$transformation = (string) ( $existing['recovery_transformation'] ?? '' );
+		if ( in_array( $transformation, array( 'compact_checkpoint_history', 'compact_checkpoint_resume', 'discard_uncompactable_checkpoint_history' ), true ) ) {
+			$resume_metadata['recovery_transformation'] = $transformation;
+		}
+
+		if ( isset( $existing['compaction'] ) && is_array( $existing['compaction'] ) ) {
+			$compaction = array();
+			foreach ( array( 'source_message_count', 'retained_excerpt_count', 'boundary_omitted_count', 'estimated_bytes', 'estimated_tokens', 'max_bytes', 'max_tokens' ) as $key ) {
+				if ( isset( $existing['compaction'][ $key ] ) && is_numeric( $existing['compaction'][ $key ] ) ) {
+					$compaction[ $key ] = max( 0, (int) $existing['compaction'][ $key ] );
+				}
+			}
+			foreach ( array( 'attachments_omitted', 'tool_payloads_omitted' ) as $key ) {
+				if ( isset( $existing['compaction'][ $key ] ) ) {
+					$compaction[ $key ] = (bool) $existing['compaction'][ $key ];
+				}
+			}
+			if ( ! empty( $compaction ) ) {
+				$resume_metadata['compaction'] = $compaction;
+			}
+		}
+
+		return $resume_metadata;
+	}
+
+	/**
+	 * Rehydrate only catalog-backed client ability descriptors for a checkpoint.
+	 *
+	 * @param array<string, mixed> $checkpoint Decoded checkpoint payload.
+	 * @return list<array<string, mixed>>
+	 */
+	private function checkpoint_client_abilities( array $checkpoint ): array {
+		$raw_names = $checkpoint['client_ability_names'] ?? $checkpoint['client_abilities'] ?? array();
+		if ( ! is_array( $raw_names ) ) {
+			return array();
+		}
+
+		$catalog     = JsAbilityCatalog::get_descriptors_by_name();
+		$descriptors = array();
+		foreach ( $raw_names as $raw_name ) {
+			$name = is_array( $raw_name ) ? (string) ( $raw_name['name'] ?? '' ) : (string) $raw_name;
+			if ( '' !== $name && isset( $catalog[ $name ] ) ) {
+				$descriptors[ $name ] = $catalog[ $name ];
+			}
+		}
+
+		return array_values( $descriptors );
+	}
+
+	/** @param array<string, mixed> $candidate Candidate request metadata. @param array<string, mixed> $previous Previous attempted metadata. */
+	private function checkpoint_resume_is_unchanged( array $candidate, array $previous ): bool {
+		$fingerprint = (string) ( $candidate['fingerprint'] ?? '' );
+		$prior       = (string) ( $previous['fingerprint'] ?? '' );
+
+		return 64 === strlen( $fingerprint )
+			&& 64 === strlen( $prior )
+			&& hash_equals( $prior, $fingerprint )
+			&& (int) ( $previous['request_bytes'] ?? -1 ) === (int) ( $candidate['request_bytes'] ?? -2 )
+			&& (int) ( $previous['request_tokens'] ?? -1 ) === (int) ( $candidate['request_tokens'] ?? -2 )
+			&& (string) ( $previous['size_class'] ?? '' ) === (string) ( $candidate['size_class'] ?? '' )
+			&& (string) ( $previous['phase'] ?? '' ) === (string) ( $candidate['phase'] ?? '' );
+	}
+
+	/** @param array<string, mixed> $metadata Candidate request metadata. @return array<string, mixed> */
+	private function checkpoint_resume_attempt_metadata( array $metadata ): array {
+		return array(
+			'fingerprint'    => (string) ( $metadata['fingerprint'] ?? '' ),
+			'request_bytes'  => (int) ( $metadata['request_bytes'] ?? 0 ),
+			'request_tokens' => (int) ( $metadata['request_tokens'] ?? 0 ),
+			'size_class'     => (string) ( $metadata['size_class'] ?? 'unknown' ),
+			'phase'          => (string) ( $metadata['phase'] ?? '' ),
+		);
+	}
+
+	/** @param array<string, mixed> $metadata Candidate request metadata. @return array{phase:string,reason:string,size_class:string} */
+	private function checkpoint_resume_response_metadata( array $metadata, string $reason, string $phase ): array {
+		$size_class = (string) ( $metadata['size_class'] ?? 'unknown' );
+		if ( ! in_array( $size_class, array( 'small', 'medium', 'large', 'very_large' ), true ) ) {
+			$size_class = 'unknown';
+		}
+
+		return array(
+			'phase'      => sanitize_key( $phase ),
+			'reason'     => sanitize_key( $reason ),
+			'size_class' => $size_class,
+		);
+	}
+
+	/** @param array<string, mixed> $metadata Candidate request metadata. @return array{dispatched:bool,terminal:bool,metadata:array{phase:string,reason:string,size_class:string}} */
+	private function checkpoint_resume_outcome( bool $dispatched, bool $terminal, string $reason, array $metadata, string $phase ): array {
+		return array(
+			'dispatched' => $dispatched,
+			'terminal'   => $terminal,
+			'metadata'   => $this->checkpoint_resume_response_metadata( $metadata, $reason, $phase ),
+		);
+	}
+
+	/** @param array<string, mixed> $metadata Candidate request metadata. @return array{dispatched:bool,terminal:bool,metadata:array{phase:string,reason:string,size_class:string}} */
+	private function terminal_checkpoint_resume( string $job_id, ActiveJobRow $row, string $reason, array $metadata, string $phase ): array {
+		$public_metadata = $this->checkpoint_resume_response_metadata( $metadata, $reason, $phase );
+		$detail          = sprintf( 'checkpoint_resume_%s; phase=%s; size_class=%s', $public_metadata['reason'], $public_metadata['phase'], $public_metadata['size_class'] );
+
+		ActiveJobRepository::update_status( $job_id, 'error', array( 'error' => $detail ) );
+		AgentEventLog::log(
+			'checkpoint_resume_stopped',
+			AgentEventLog::SEVERITY_WARNING,
+			array(
+				'session_id'         => $row->session_id,
+				'job_id'             => $job_id,
+				'phase'              => $public_metadata['phase'],
+				'reason'             => $public_metadata['reason'],
+				'attempts'           => $row->resume_attempts,
+				'request_size_class' => $public_metadata['size_class'],
+			)
+		);
+
+		return $this->checkpoint_resume_outcome( false, true, $reason, $metadata, $phase );
+	}
+
+	/** @param array{phase:string,reason:string,size_class:string} $metadata Sanitized resume metadata. */
+	private function checkpoint_resume_terminal_response( string $job_id, ActiveJobRow $row, array $metadata ): WP_REST_Response {
+		ActiveJobRepository::delete( $job_id );
+
+		return new WP_REST_Response(
+			array(
+				'status'            => 'error',
+				'from_db'           => true,
+				'session_id'        => $row->session_id,
+				'original_status'   => $row->status,
+				'message'           => __( 'The background job could not safely resume. Start a new request to continue.', 'superdav-ai-agent' ),
+				'checkpoint_resume' => $metadata,
+			),
+			200
+		);
 	}
 
 	/**
@@ -2748,6 +3014,9 @@ final class SessionController {
 				$resume_history = ConversationSerializer::deserialize( array_values( $state_history ) );
 
 				$resume_options = $options;
+				$resume_options['checkpoint_resume_metadata'] = is_array( $state ) && is_array( $state['checkpoint_resume_metadata'] ?? null )
+					? $state['checkpoint_resume_metadata']
+					: array();
 				// @phpstan-ignore-next-line
 				$resume_options['tool_call_log'] = is_array( $state ) ? ( $state['tool_call_log'] ?? array() ) : array();
 				// @phpstan-ignore-next-line

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -1648,9 +1648,9 @@ final class SessionController {
 	/**
 	 * Replace an oversized persisted state with a smaller deterministic resume input.
 	 *
-	 * @param array<string, mixed> $checkpoint Decoded checkpoint payload.
+	 * @param array<string, mixed>       $checkpoint Decoded checkpoint payload.
 	 * @param list<array<string, mixed>> $history Validated serialized history.
-	 * @param array<string, mixed> $metadata Candidate request metadata.
+	 * @param array<string, mixed>       $metadata Candidate request metadata.
 	 * @phpstan-param CheckpointRequest $metadata
 	 * @return array{checkpoint:array<string,mixed>,metadata:CheckpointRequest}|null
 	 */
@@ -1870,7 +1870,8 @@ final class SessionController {
 	/**
 	 * @param string                $job_id The job UUID.
 	 * @param ActiveJobRow          $row The persisted active-job row.
-	 * @param array{phase:string,reason:string,size_class:string} $metadata Sanitized resume metadata.
+	 * @param array<string, string> $metadata Sanitized resume metadata.
+	 * @phpstan-param array{phase:string,reason:string,size_class:string} $metadata
 	 * @return WP_REST_Response Terminal job-status response.
 	 */
 	private function checkpoint_resume_terminal_response( string $job_id, ActiveJobRow $row, array $metadata ): WP_REST_Response {

--- a/tests/SdAiAgent/Core/ActiveJobsCleanupTest.php
+++ b/tests/SdAiAgent/Core/ActiveJobsCleanupTest.php
@@ -210,6 +210,28 @@ class ActiveJobsCleanupTest extends WP_UnitTestCase {
 		$this->assertFalse( ActiveJobRepository::claim_resume_attempt( 'test-resume-1', 1 ) );
 	}
 
+	/**
+	 * A claimed resume atomically stores its compact checkpoint metadata.
+	 */
+	public function test_claim_resume_attempt_persists_checkpoint_with_claim(): void {
+		$this->insert_job( 'test-resume-checkpoint-1', 'interrupted' );
+		$checkpoint = array(
+			'history'                    => array( array( 'role' => 'user', 'parts' => array( array( 'text' => 'Resume safely.' ) ) ) ),
+			'checkpoint_resume_metadata' => array(
+				'version'      => 1,
+				'next_request' => array( 'fingerprint' => str_repeat( 'a', 64 ) ),
+			),
+		);
+
+		$this->assertTrue( ActiveJobRepository::claim_resume_attempt( 'test-resume-checkpoint-1', 2, $checkpoint ) );
+		$row = $this->fetch_row( 'test-resume-checkpoint-1' );
+
+		$this->assertNotNull( $row );
+		$this->assertSame( 'processing', $row->status );
+		$this->assertSame( '1', (string) $row->resume_attempts );
+		$this->assertSame( $checkpoint, json_decode( (string) $row->checkpoint, true ) );
+	}
+
 	// ── cleanup_stale() ──────────────────────────────────────────────────
 
 	/**

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -39,6 +39,7 @@ use SdAiAgent\Core\ProviderCredentialLoader;
 use SdAiAgent\Core\Settings;
 use SdAiAgent\Core\SystemInstructionBuilder;
 use SdAiAgent\Core\ToolPermissionResolver;
+use SdAiAgent\Models\ActiveJobRepository;
 use SdAiAgent\Tools\ToolDiscovery;
 use WordPress\AiClient\Messages\DTO\Message;
 use WordPress\AiClient\Messages\DTO\MessagePart;
@@ -1945,6 +1946,71 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$result = ConversationSerializer::deserialize( [] );
 		$this->assertIsArray( $result );
 		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Durable checkpoints retain a compact request snapshot rather than growing
+	 * with page context, activity logs, or raw client-ability descriptors.
+	 */
+	public function test_checkpoint_save_bounds_resume_state(): void {
+		$job_id = 'test-bounded-checkpoint-1';
+		$this->assertNotFalse( ActiveJobRepository::create( 1, $job_id, 1 ) );
+
+		try {
+			$history = array();
+			for ( $i = 0; $i < 12; ++$i ) {
+				$history[] = new UserMessage( array( new MessagePart( str_repeat( 'checkpoint context ', 500 ) ) ) );
+			}
+
+			$catalog = JsAbilityCatalog::get_descriptors_by_name();
+			$loop    = new AgentLoop(
+				'',
+				array(),
+				$history,
+				array(
+					'active_job_id'    => $job_id,
+					'provider_id'      => 'openai_compat',
+					'model_id'         => 'test-model',
+					'page_context'     => array(
+						'summary' => str_repeat( 'too-large-context ', 300 ),
+						'url'     => 'https://example.test/wp-admin/',
+						'unknown' => str_repeat( 'not-needed ', 300 ),
+					),
+					'client_abilities' => array( $catalog['sd-ai-agent-js/navigate-to'] ),
+					'tool_call_log'    => array( array( 'details' => str_repeat( 'tool-log ', 300 ) ) ),
+					'message_log'      => array( array( 'text' => str_repeat( 'message-log ', 300 ) ) ),
+				)
+			);
+
+			$method = new \ReflectionMethod( AgentLoop::class, 'save_active_job_checkpoint' );
+			$method->setAccessible( true );
+			$method->invoke( $loop, AgentLoop::CHECKPOINT_BEFORE_PROVIDER_CALL, 3 );
+
+			$row = ActiveJobRepository::get_by_job_id( $job_id );
+			$this->assertNotNull( $row );
+			$checkpoint = json_decode( (string) $row->checkpoint, true );
+			$this->assertIsArray( $checkpoint );
+			$this->assertArrayHasKey( 'history', $checkpoint );
+			$this->assertArrayHasKey( 'checkpoint_resume_metadata', $checkpoint );
+			$this->assertArrayNotHasKey( 'tool_call_log', $checkpoint );
+			$this->assertArrayNotHasKey( 'message_log', $checkpoint );
+			$this->assertArrayNotHasKey( 'client_abilities', $checkpoint );
+			$this->assertSame( array( 'sd-ai-agent-js/navigate-to' ), $checkpoint['client_ability_names'] );
+			$this->assertSame( 'https://example.test/wp-admin/', $checkpoint['page_context']['url'] );
+			$this->assertArrayNotHasKey( 'summary', $checkpoint['page_context'] );
+
+			$request = AgentLoop::describe_checkpoint_request(
+				$checkpoint['history'],
+				AgentLoop::CHECKPOINT_BEFORE_PROVIDER_CALL,
+				$checkpoint['provider_id'],
+				$checkpoint['model_id']
+			);
+			$this->assertLessThanOrEqual( ConversationTrimmer::COMPACT_MAX_BYTES, $request['request_bytes'] );
+			$this->assertMatchesRegularExpression( '/^[a-f0-9]{64}$/', $checkpoint['checkpoint_resume_metadata']['next_request']['fingerprint'] );
+			$this->assertLessThan( ConversationTrimmer::COMPACT_MAX_BYTES + 20000, strlen( (string) $row->checkpoint ) );
+		} finally {
+			ActiveJobRepository::delete( $job_id );
+		}
 	}
 
 	// -------------------------------------------------------------------------

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Tests\REST;
 
+use SdAiAgent\Core\AgentLoop;
 use SdAiAgent\Core\ConversationTrimmer;
 use SdAiAgent\Core\Database;
 use SdAiAgent\Core\Settings;
@@ -130,6 +131,25 @@ class RestControllerTest extends WP_UnitTestCase {
 			$status = $response->get_status();
 		}
 		$this->assertSame( $expected, $status, "Expected HTTP {$expected}, got {$status}." );
+	}
+
+	/**
+	 * Create an interrupted database-only job with its durable checkpoint.
+	 *
+	 * @param array<string, mixed> $checkpoint Serializable checkpoint state.
+	 */
+	private function create_interrupted_checkpoint_job( string $job_id, string $phase, array $checkpoint ): int {
+		$session_id = Database::create_session( array(
+			'user_id' => $this->admin_id,
+			'title'   => 'Checkpoint resume test',
+		) );
+
+		ActiveJobRepository::create( $session_id, $job_id, $this->admin_id, 'processing' );
+		ActiveJobRepository::save_checkpoint( $job_id, $phase, $checkpoint );
+		ActiveJobRepository::mark_interrupted( $job_id, 'checkpoint resume test interruption' );
+		delete_transient( RestController::JOB_PREFIX . $job_id );
+
+		return $session_id;
 	}
 
 	// ─── Route Registration ───────────────────────────────────────────────────
@@ -1116,6 +1136,184 @@ class RestControllerTest extends WP_UnitTestCase {
 			ActiveJobRepository::get_by_job_id( $job_id ),
 			'Terminal interrupted row should be deleted after delivery.'
 		);
+	}
+
+	/**
+	 * An identical failed request is terminalized rather than retried forever,
+	 * and its REST metadata remains deliberately minimal.
+	 */
+	public function test_job_status_stops_unchanged_checkpoint_resume(): void {
+		wp_set_current_user( $this->admin_id );
+		$job_id  = 'a1111111-b222-c333-d444-e55555555555';
+		$history = array( array( 'role' => 'user', 'parts' => array( array( 'text' => 'Resume this safely.' ) ) ) );
+		$request = AgentLoop::describe_checkpoint_request( $history, AgentLoop::CHECKPOINT_BEFORE_PROVIDER_CALL, 'test-provider', 'test-model' );
+		$attempt = array(
+			'fingerprint'    => $request['fingerprint'],
+			'request_bytes'  => $request['request_bytes'],
+			'request_tokens' => $request['request_tokens'],
+			'size_class'     => $request['size_class'],
+			'phase'          => $request['phase'],
+		);
+
+		$this->create_interrupted_checkpoint_job(
+			$job_id,
+			AgentLoop::CHECKPOINT_BEFORE_PROVIDER_CALL,
+			array(
+				'history'                    => $history,
+				'provider_id'                => 'test-provider',
+				'model_id'                   => 'test-model',
+				'iterations_remaining'       => 3,
+				'checkpoint_resume_metadata' => array( 'version' => AgentLoop::CHECKPOINT_RESUME_METADATA_VERSION, 'last_attempt' => $attempt ),
+			)
+		);
+
+		$response = $this->dispatch( 'GET', "/sd-ai-agent/v1/job/{$job_id}" );
+
+		$this->assertStatus( 200, $response );
+		$data = $response->get_data();
+		$this->assertSame( 'error', $data['status'] );
+		$this->assertSame( 'no_progress', $data['checkpoint_resume']['reason'] );
+		$this->assertSame( array( 'phase', 'reason', 'size_class' ), array_keys( $data['checkpoint_resume'] ) );
+		$this->assertArrayNotHasKey( 'fingerprint', $data['checkpoint_resume'] );
+		$this->assertNull( ActiveJobRepository::get_by_job_id( $job_id ) );
+	}
+
+	/**
+	 * Legacy/mixed-version checkpoints are compacted once, atomically saved, and
+	 * resumed with a changed request fingerprint and catalog-backed client tools.
+	 */
+	public function test_job_status_compacts_legacy_checkpoint_before_resume_claim(): void {
+		wp_set_current_user( $this->admin_id );
+		$job_id  = 'a2222222-b333-c444-d555-e66666666666';
+		$history = array( array( 'role' => 'user', 'parts' => array( array( 'text' => str_repeat( 'legacy checkpoint context ', 4000 ) ) ) ) );
+		$before  = AgentLoop::describe_checkpoint_request( $history, AgentLoop::CHECKPOINT_BEFORE_PROVIDER_CALL, 'test-provider', 'test-model' );
+
+		$this->create_interrupted_checkpoint_job(
+			$job_id,
+			AgentLoop::CHECKPOINT_BEFORE_PROVIDER_CALL,
+			array(
+				'history'                    => $history,
+				'provider_id'                => 'test-provider',
+				'model_id'                   => 'test-model',
+				'iterations_remaining'       => 3,
+				'client_abilities'           => array(
+					array( 'name' => 'sd-ai-agent-js/navigate-to', 'description' => str_repeat( 'legacy descriptor ', 300 ) ),
+					array( 'name' => 'sd-ai-agent-js/unknown-ability' ),
+				),
+				'checkpoint_resume_metadata' => array(
+					'version'                 => 99,
+					'recovery_transformation' => str_repeat( 'unknown-transformation-', 100 ),
+					'compaction'              => array( 'unbounded' => str_repeat( 'legacy metadata ', 500 ) ),
+				),
+			)
+		);
+
+		$loopback = static function (): array {
+			return array(
+				'headers'  => array(),
+				'body'     => '',
+				'response' => array( 'code' => 200, 'message' => 'OK' ),
+				'cookies'  => array(),
+			);
+		};
+		add_filter( 'pre_http_request', $loopback, 10, 3 );
+		try {
+			$response = $this->dispatch( 'GET', "/sd-ai-agent/v1/job/{$job_id}" );
+		} finally {
+			remove_filter( 'pre_http_request', $loopback, 10 );
+		}
+
+		$this->assertStatus( 202, $response );
+		$data = $response->get_data();
+		$this->assertTrue( $data['auto_resumed'] );
+		$this->assertSame( array( 'phase', 'reason', 'size_class' ), array_keys( $data['checkpoint_resume'] ) );
+		$dispatched = get_transient( RestController::JOB_PREFIX . $job_id );
+		$this->assertIsArray( $dispatched );
+		$this->assertSame( array( 'sd-ai-agent-js/navigate-to' ), array_column( $dispatched['params']['client_abilities'], 'name' ) );
+		$this->assertSame( 'Navigate to Admin Page', $dispatched['params']['client_abilities'][0]['label'] );
+
+		$row = ActiveJobRepository::get_by_job_id( $job_id );
+		$this->assertNotNull( $row );
+		$this->assertSame( 'processing', $row->status );
+		$this->assertSame( 1, $row->resume_attempts );
+		$checkpoint = json_decode( (string) $row->checkpoint, true );
+		$this->assertIsArray( $checkpoint );
+		$this->assertSame( AgentLoop::CHECKPOINT_RESUME_METADATA_VERSION, $checkpoint['checkpoint_resume_metadata']['version'] );
+		$this->assertSame( 'compact_checkpoint_resume', $checkpoint['checkpoint_resume_metadata']['recovery_transformation'] );
+		$this->assertArrayNotHasKey( 'unbounded', $checkpoint['checkpoint_resume_metadata']['compaction'] );
+		$this->assertNotSame( $before['fingerprint'], $checkpoint['checkpoint_resume_metadata']['last_attempt']['fingerprint'] );
+		$this->assertSame(
+			$checkpoint['checkpoint_resume_metadata']['last_attempt']['fingerprint'],
+			AgentLoop::describe_checkpoint_request( $checkpoint['history'], AgentLoop::CHECKPOINT_BEFORE_PROVIDER_CALL, 'test-provider', 'test-model' )['fingerprint']
+		);
+
+		ActiveJobRepository::delete( $job_id );
+		delete_transient( RestController::JOB_PREFIX . $job_id );
+	}
+
+	/**
+	 * A checkpoint whose compact representation still exceeds the active budget
+	 * must stop instead of dispatching an unchanged rejected request.
+	 */
+	public function test_job_status_stops_noncompactable_checkpoint(): void {
+		wp_set_current_user( $this->admin_id );
+		$job_id  = 'a3333333-b444-c555-d666-e77777777777';
+		$history = array( array( 'role' => 'user', 'parts' => array( array( 'text' => str_repeat( 'strict provider budget ', 500 ) ) ) ) );
+		$this->create_interrupted_checkpoint_job(
+			$job_id,
+			AgentLoop::CHECKPOINT_BEFORE_PROVIDER_CALL,
+			array(
+				'history'              => $history,
+				'provider_id'          => 'test-provider',
+				'model_id'             => 'test-model',
+				'iterations_remaining' => 3,
+			)
+		);
+
+		$byte_budget  = static fn(): int => 128;
+		$token_budget = static fn(): int => 32;
+		add_filter( 'sd_ai_agent_provider_request_max_bytes', $byte_budget, 10, 3 );
+		add_filter( 'sd_ai_agent_provider_request_max_tokens', $token_budget, 10, 3 );
+		try {
+			$response = $this->dispatch( 'GET', "/sd-ai-agent/v1/job/{$job_id}" );
+		} finally {
+			remove_filter( 'sd_ai_agent_provider_request_max_bytes', $byte_budget, 10 );
+			remove_filter( 'sd_ai_agent_provider_request_max_tokens', $token_budget, 10 );
+		}
+
+		$this->assertStatus( 200, $response );
+		$data = $response->get_data();
+		$this->assertSame( 'not_compactable', $data['checkpoint_resume']['reason'] );
+		$this->assertFalse( get_transient( RestController::JOB_PREFIX . $job_id ) );
+		$this->assertNull( ActiveJobRepository::get_by_job_id( $job_id ) );
+	}
+
+	/**
+	 * A checkpoint saved immediately before tool execution remains terminal so
+	 * automatic recovery never repeats an ability call.
+	 */
+	public function test_job_status_rejects_tool_execution_checkpoint(): void {
+		wp_set_current_user( $this->admin_id );
+		$job_id  = 'a4444444-b555-c666-d777-e88888888888';
+		$history = array( array( 'role' => 'user', 'parts' => array( array( 'text' => 'Never repeat this tool.' ) ) ) );
+		$this->create_interrupted_checkpoint_job(
+			$job_id,
+			AgentLoop::CHECKPOINT_TOOL_EXECUTION_STARTED,
+			array(
+				'history'              => $history,
+				'provider_id'          => 'test-provider',
+				'model_id'             => 'test-model',
+				'iterations_remaining' => 3,
+			)
+		);
+
+		$response = $this->dispatch( 'GET', "/sd-ai-agent/v1/job/{$job_id}" );
+
+		$this->assertStatus( 200, $response );
+		$data = $response->get_data();
+		$this->assertSame( 'unsafe_phase', $data['checkpoint_resume']['reason'] );
+		$this->assertFalse( get_transient( RestController::JOB_PREFIX . $job_id ) );
+		$this->assertNull( ActiveJobRepository::get_by_job_id( $job_id ) );
 	}
 
 	/**

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -1252,10 +1252,10 @@ class RestControllerTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A checkpoint whose compact representation still exceeds the active budget
-	 * must stop instead of dispatching an unchanged rejected request.
+	 * The supported minimum request budget allows a compactable checkpoint to
+	 * resume once after its persisted state is reduced to that budget.
 	 */
-	public function test_job_status_stops_noncompactable_checkpoint(): void {
+	public function test_job_status_compacts_checkpoint_at_minimum_effective_budget(): void {
 		wp_set_current_user( $this->admin_id );
 		$job_id  = 'a3333333-b444-c555-d666-e77777777777';
 		$history = array( array( 'role' => 'user', 'parts' => array( array( 'text' => str_repeat( 'strict provider budget ', 500 ) ) ) ) );
@@ -1270,8 +1270,8 @@ class RestControllerTest extends WP_UnitTestCase {
 			)
 		);
 
-		$byte_budget  = static fn(): int => 128;
-		$token_budget = static fn(): int => 32;
+		$byte_budget  = static fn(): int => 1024;
+		$token_budget = static fn(): int => 256;
 		add_filter( 'sd_ai_agent_provider_request_max_bytes', $byte_budget, 10, 3 );
 		add_filter( 'sd_ai_agent_provider_request_max_tokens', $token_budget, 10, 3 );
 		try {
@@ -1281,11 +1281,18 @@ class RestControllerTest extends WP_UnitTestCase {
 			remove_filter( 'sd_ai_agent_provider_request_max_tokens', $token_budget, 10 );
 		}
 
-		$this->assertStatus( 200, $response );
+		$this->assertStatus( 202, $response );
 		$data = $response->get_data();
-		$this->assertSame( 'not_compactable', $data['checkpoint_resume']['reason'] );
-		$this->assertFalse( get_transient( RestController::JOB_PREFIX . $job_id ) );
-		$this->assertNull( ActiveJobRepository::get_by_job_id( $job_id ) );
+		$this->assertTrue( $data['auto_resumed'] );
+		$this->assertSame( 'resumed', $data['checkpoint_resume']['reason'] );
+		$this->assertIsArray( get_transient( RestController::JOB_PREFIX . $job_id ) );
+		$row = ActiveJobRepository::get_by_job_id( $job_id );
+		$this->assertNotNull( $row );
+		$this->assertSame( 'processing', $row->status );
+		$this->assertSame( 1, $row->resume_attempts );
+
+		ActiveJobRepository::delete( $job_id );
+		delete_transient( RestController::JOB_PREFIX . $job_id );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2357

## Summary

- Bounds persisted checkpoint history, page context, identifiers, metadata, and client ability state.
- Normalizes persisted checkpoint payloads, atomically saves compacted resume metadata with the resume claim, and rejects unchanged recovery attempts.
- Keeps unsafe tool-execution phases terminal and rehydrates client abilities only from the canonical catalog.
- Corrects compacted checkpoint coverage at the effective minimum request budget.

## Verification

- Runtime-verified: a WordPress 7.0.2 `wp eval-file` smoke test compacted a 17,071-byte / 4,251-token checkpoint to 616 bytes / 135 tokens under effective 1,024-byte / 256-token limits.
- `php -l` passed for all changed PHP files.
- CI passed: PHPUnit, PHPCS + PHPStan, ESLint + Stylelint, build, canonical identifiers, and all three Playwright E2E shards.
- Local PHPUnit, PHPStan, PHPCS, and ESLint commands remain unavailable because their project dependencies are absent.

## Worker self-verification

- Runtime smoke: passed in WordPress 7.0.2.
- PHP syntax: all changed PHP files passed.
- Full local suite: blocked by missing project dependencies.
- CI: all checks passed, including PHPUnit, static analysis, build, lint, and three Playwright E2E shards.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.191 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-terra spent 1h 33m and 966,675 tokens on this as a headless worker.
