### PR TITLE
fix: preflight complete AI request envelopes

### DIFF
--- a/includes/Core/AgentEventLog.php
+++ b/includes/Core/AgentEventLog.php
@@ -107,7 +107,9 @@ class AgentEventLog {
 		'request_bytes',
 		'request_bytes_estimate',
 		'request_tokens_estimate',
+		'request_provider_limit_bytes',
 		'request_budget_bytes',
+		'request_safety_margin_bytes',
 		'request_size_class',
 		'request_size_source',
 		'local_rejection',
@@ -117,6 +119,7 @@ class AgentEventLog {
 		'resume_count',
 		'retryable',
 		'next_action',
+		'recovery_outcome',
 	);
 
 	/**

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -229,9 +229,6 @@ class AgentLoop {
 	/** @var int Full-envelope bytes from an upstream 413 eligible for one reduced retry. */
 	private int $provider_retry_baseline_envelope_bytes = 0;
 
-	/** @var float Unix timestamp when this active-job run started. */
-	private float $active_job_started_at = 0.0;
-
 	/** @var string Last coarse loop phase for shutdown diagnostics. */
 	private string $last_loop_phase = 'initializing';
 

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -226,6 +226,12 @@ class AgentLoop {
 	/** @var array<string, mixed> Resume metadata carried forward from a claimed checkpoint. */
 	private array $checkpoint_resume_metadata = array();
 
+	/** @var int Full-envelope bytes from an upstream 413 eligible for one reduced retry. */
+	private int $provider_retry_baseline_envelope_bytes = 0;
+
+	/** @var float Unix timestamp when this active-job run started. */
+	private float $active_job_started_at = 0.0;
+
 	/** @var string Last coarse loop phase for shutdown diagnostics. */
 	private string $last_loop_phase = 'initializing';
 
@@ -1866,7 +1872,7 @@ class AgentLoop {
 	private function send_prompt_with_payload_recovery(): GenerativeAiResult|WP_Error {
 		$provider_id  = $this->resolve_provider_id();
 		$model_id     = $this->resolve_effective_model_id( $provider_id );
-		$byte_budget  = ConversationTrimmer::get_request_byte_budget( $provider_id, $model_id );
+		$byte_budget  = ConversationTrimmer::get_request_envelope_byte_budget( $provider_id, $model_id );
 		$token_budget = ConversationTrimmer::get_request_token_budget( $provider_id, $model_id );
 
 		$this->history = ConversationTrimmer::trim_to_budget( $this->history, $byte_budget, $token_budget );
@@ -1874,6 +1880,9 @@ class AgentLoop {
 		$before_tokens = ConversationTrimmer::estimate_total_tokens( $this->history );
 
 		if ( ! ConversationTrimmer::fits_budget( $this->history, $byte_budget, $token_budget ) ) {
+			$recovery_outcome = $this->session_id > 0
+				? 'compact_session_available'
+				: 'compact_session_unavailable';
 			ProviderTraceLogger::record_payload_limit(
 				$provider_id,
 				$model_id,
@@ -1883,10 +1892,11 @@ class AgentLoop {
 				$byte_budget,
 				true,
 				false,
-				true
+				true,
+				$recovery_outcome
 			);
 
-			return new WP_Error(
+			$error = new WP_Error(
 				'sd_ai_agent_provider_payload_budget_exceeded',
 				__( 'This request is too large to send safely. Compact the conversation or shorten the latest message and remove large attachments before retrying.', 'superdav-ai-agent' ),
 				array(
@@ -1898,8 +1908,11 @@ class AgentLoop {
 					'request_budget_bytes'    => $byte_budget,
 					'local_rejection'         => true,
 					'fallback_attempted'      => false,
+					'recovery_outcome'        => $recovery_outcome,
 				)
 			);
+
+			return $this->with_payload_recovery_metadata( $error, $before_bytes, $before_tokens, false, false );
 		}
 
 		$result = $this->send_prompt( $provider_id, $model_id );
@@ -1907,18 +1920,34 @@ class AgentLoop {
 			return $result;
 		}
 
-		if ( ! $this->is_local_payload_limit_error( $result ) ) {
-			ProviderTraceLogger::record_payload_limit(
-				$provider_id,
-				$model_id,
-				413,
-				$before_bytes,
-				$before_tokens,
-				$byte_budget,
-				false,
-				false,
-				true
-			);
+		if ( $this->is_local_payload_limit_error( $result ) ) {
+			return $this->with_payload_recovery_metadata( $result, $before_bytes, $before_tokens, false, false );
+		}
+		$source_data              = $result->get_error_data();
+		$complete_envelope_bytes  = is_array( $source_data ) && 'complete_envelope' === ( $source_data['request_size_source'] ?? '' )
+			? max( 0, (int) ( $source_data['request_bytes'] ?? 0 ) )
+			: 0;
+		$complete_envelope_tokens = is_array( $source_data ) && 'complete_envelope' === ( $source_data['request_size_source'] ?? '' )
+			? max( 0, (int) ( $source_data['request_tokens_estimate'] ?? 0 ) )
+			: 0;
+		ProviderTraceLogger::record_payload_limit(
+			$provider_id,
+			$model_id,
+			413,
+			$complete_envelope_bytes > 0 ? $complete_envelope_bytes : $before_bytes,
+			$complete_envelope_tokens > 0 ? $complete_envelope_tokens : $before_tokens,
+			$byte_budget,
+			false,
+			false,
+			$complete_envelope_bytes <= 0,
+			'reduced_retry_attempted'
+		);
+
+		// Only a measured, complete request envelope can prove that the one
+		// reduced retry is materially smaller. Do not retry 413s from SDK layers
+		// that did not reach the HTTP preflight hook.
+		if ( $complete_envelope_bytes <= 0 ) {
+			return $this->with_payload_recovery_metadata( $result, $before_bytes, $before_tokens, false, false );
 		}
 
 		$target_bytes  = max( 1, (int) floor( $before_bytes * 0.6 ) );
@@ -1943,19 +1972,33 @@ class AgentLoop {
 		);
 		$this->fire_progress();
 
-		$retry_result = $this->send_prompt( $provider_id, $model_id );
+		$this->provider_retry_baseline_envelope_bytes = $complete_envelope_bytes;
+
+		try {
+			$retry_result = $this->send_prompt( $provider_id, $model_id );
+		} finally {
+			$this->provider_retry_baseline_envelope_bytes = 0;
+		}
 		if ( is_wp_error( $retry_result ) ) {
 			if ( $this->is_payload_limit_error( $retry_result ) && ! $this->is_local_payload_limit_error( $retry_result ) ) {
+				$retry_error_data      = $retry_result->get_error_data();
+				$retry_envelope_bytes  = is_array( $retry_error_data ) && 'complete_envelope' === ( $retry_error_data['request_size_source'] ?? '' )
+					? max( 0, (int) ( $retry_error_data['request_bytes'] ?? 0 ) )
+					: 0;
+				$retry_envelope_tokens = is_array( $retry_error_data ) && 'complete_envelope' === ( $retry_error_data['request_size_source'] ?? '' )
+					? max( 0, (int) ( $retry_error_data['request_tokens_estimate'] ?? 0 ) )
+					: 0;
 				ProviderTraceLogger::record_payload_limit(
 					$provider_id,
 					$model_id,
 					413,
-					$after_bytes,
-					$after_tokens,
+					$retry_envelope_bytes > 0 ? $retry_envelope_bytes : $after_bytes,
+					$retry_envelope_tokens > 0 ? $retry_envelope_tokens : $after_tokens,
 					$byte_budget,
 					false,
 					true,
-					true
+					$retry_envelope_bytes <= 0,
+					'reduced_retry_exhausted'
 				);
 			}
 
@@ -2001,6 +2044,12 @@ class AgentLoop {
 		$data['request_tokens_estimate'] = $request_tokens;
 		$data['fallback_attempted']      = $fallback_attempted;
 		$data['payload_reduced']         = $reduced;
+		if ( $this->is_local_payload_limit_error( $error ) && $this->session_id > 0 ) {
+			$data['recovery'] = array(
+				'action'            => 'compact_session',
+				'source_session_id' => $this->session_id,
+			);
+		}
 		$error->add_data( $data );
 
 		return $error;
@@ -2118,7 +2167,13 @@ class AgentLoop {
 		$last_error = null;
 
 		for ( $attempt = 1; $attempt <= $this->provider_retry_max_attempts; ++$attempt ) {
-			ProviderTraceLogger::set_runtime_context( $provider_id, $model_id );
+			$request_envelope = array();
+			ProviderTraceLogger::set_runtime_context(
+				$provider_id,
+				$model_id,
+				$this->session_id,
+				$this->provider_retry_baseline_envelope_bytes
+			);
 			try {
 				$result = $builder->generate_text_result();
 				if ( is_wp_error( $result ) ) {
@@ -2130,7 +2185,12 @@ class AgentLoop {
 			} catch ( \Throwable $e ) {
 				$last_error = $e;
 			} finally {
+				$request_envelope = ProviderTraceLogger::get_runtime_envelope_metrics();
 				ProviderTraceLogger::clear_runtime_context();
+			}
+
+			if ( $last_error instanceof WP_Error && ! empty( $request_envelope ) ) {
+				$last_error = $this->with_request_envelope_metadata( $last_error, $request_envelope );
 			}
 
 			$status_code = $this->extract_provider_error_status( $last_error );
@@ -2152,6 +2212,36 @@ class AgentLoop {
 
 		$elapsed_seconds = max( 0, (int) round( microtime( true ) - $started_at ) );
 		return $this->build_provider_retry_failed_error( $last_error, $elapsed_seconds );
+	}
+
+	/**
+	 * Copy full-envelope transport measurements onto a provider error.
+	 *
+	 * @param WP_Error                  $error   Provider error receiving the scalar measurements.
+	 * @param array<string, int|string> $metrics Prompt-free scalar measurements.
+	 */
+	private function with_request_envelope_metadata( WP_Error $error, array $metrics ): WP_Error {
+		$error_data = $error->get_error_data();
+		$data       = is_array( $error_data ) ? $error_data : array();
+
+		$safe_keys = array(
+			'request_bytes',
+			'request_tokens_estimate',
+			'request_provider_limit_bytes',
+			'request_budget_bytes',
+			'request_safety_margin_bytes',
+			'request_size_class',
+			'request_size_source',
+		);
+		foreach ( $safe_keys as $key ) {
+			if ( isset( $metrics[ $key ] ) && is_scalar( $metrics[ $key ] ) ) {
+				$data[ $key ] = $metrics[ $key ];
+			}
+		}
+
+		$error->add_data( $data );
+
+		return $error;
 	}
 
 	/**
@@ -2333,9 +2423,13 @@ class AgentLoop {
 						'model_id',
 						'request_bytes',
 						'request_tokens_estimate',
+						'request_provider_limit_bytes',
 						'request_budget_bytes',
+						'request_safety_margin_bytes',
 						'request_size_class',
+						'request_size_source',
 						'local_rejection',
+						'recovery_outcome',
 					);
 					foreach ( $safe_keys as $safe_key ) {
 						if ( isset( $source_data[ $safe_key ] ) && is_scalar( $source_data[ $safe_key ] ) ) {

--- a/includes/Core/ConversationTrimmer.php
+++ b/includes/Core/ConversationTrimmer.php
@@ -28,6 +28,9 @@ class ConversationTrimmer {
 	/** Default maximum serialized provider request body size (512 KiB). */
 	const DEFAULT_MAX_REQUEST_BYTES = 524288;
 
+	/** Default reserve below a provider's request limit for envelope variance. */
+	const DEFAULT_REQUEST_SAFETY_MARGIN_BYTES = 32768;
+
 	/** Default maximum estimated input tokens retained in conversation history. */
 	const DEFAULT_MAX_REQUEST_TOKENS = 100000;
 
@@ -467,6 +470,73 @@ class ConversationTrimmer {
 		$filtered = (int) apply_filters( 'sd_ai_agent_provider_request_max_bytes', $configured, $provider_id, $model_id );
 
 		return max( 1024, $filtered );
+	}
+
+	/**
+	 * Resolve the byte reserve retained below the provider's request limit.
+	 *
+	 * The final provider body contains more than conversation history: system
+	 * instructions, tool schemas, attachments, model options, and transport
+	 * framing are serialized after the history trimmer runs. Keep a configurable
+	 * reserve for those components while retaining a minimum usable request size.
+	 *
+	 * @param string $provider_id Runtime-selected provider ID.
+	 * @param string $model_id    Runtime-selected model ID.
+	 * @return int Effective safety-margin bytes.
+	 */
+	public static function get_request_safety_margin_bytes( string $provider_id = '', string $model_id = '' ): int {
+		$request_limit = self::get_request_byte_budget( $provider_id, $model_id );
+
+		return self::resolve_request_safety_margin_bytes( $request_limit, $provider_id, $model_id );
+	}
+
+	/**
+	 * Resolve the effective full-envelope byte budget.
+	 *
+	 * This budget applies to both history trimming and the final serialized HTTP
+	 * body guard. The latter remains authoritative because it sees provider-
+	 * specific serialization that is unavailable to the trimmer.
+	 *
+	 * @param string $provider_id Runtime-selected provider ID.
+	 * @param string $model_id    Runtime-selected model ID.
+	 * @return int Effective full-envelope byte budget.
+	 */
+	public static function get_request_envelope_byte_budget( string $provider_id = '', string $model_id = '' ): int {
+		$request_limit = self::get_request_byte_budget( $provider_id, $model_id );
+		$safety_margin = self::resolve_request_safety_margin_bytes( $request_limit, $provider_id, $model_id );
+
+		return max( 1024, $request_limit - $safety_margin );
+	}
+
+	/**
+	 * Apply the configurable request safety margin without reducing a request
+	 * below the minimum size supported by the local guard.
+	 *
+	 * @param int    $request_limit Provider request limit before the reserve.
+	 * @param string $provider_id   Runtime-selected provider ID.
+	 * @param string $model_id      Runtime-selected model ID.
+	 * @return int Effective safety-margin bytes.
+	 */
+	private static function resolve_request_safety_margin_bytes( int $request_limit, string $provider_id, string $model_id ): int {
+		$configured = self::DEFAULT_REQUEST_SAFETY_MARGIN_BYTES;
+
+		/**
+		 * Filter the reserve retained below a provider's request-size limit.
+		 *
+		 * @param int    $configured    Configured margin bytes.
+		 * @param string $provider_id   Runtime-selected provider ID.
+		 * @param string $model_id      Runtime-selected model ID.
+		 * @param int    $request_limit Provider request limit before the reserve.
+		 */
+		$filtered = (int) apply_filters(
+			'sd_ai_agent_provider_request_safety_margin_bytes',
+			$configured,
+			$provider_id,
+			$model_id,
+			$request_limit
+		);
+
+		return min( max( 0, $filtered ), max( 0, $request_limit - 1024 ) );
 	}
 
 	/**

--- a/includes/Core/ProviderTraceLogger.php
+++ b/includes/Core/ProviderTraceLogger.php
@@ -37,12 +37,29 @@ class ProviderTraceLogger {
 	/**
 	 * Runtime-selected provider/model for the synchronous SDK request in flight.
 	 *
-	 * @var array{provider_id:string,model_id:string}
+	 * @var array{
+	 *     provider_id:string,
+	 *     model_id:string,
+	 *     session_id:int,
+	 *     retry_baseline_request_bytes:int,
+	 *     request_bytes:int,
+	 *     request_tokens_estimate:int,
+	 *     request_provider_limit_bytes:int,
+	 *     request_budget_bytes:int,
+	 *     request_safety_margin_bytes:int
+	 * }
 	 */
 	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase -- Project property naming guidance requires camelCase.
 	private static array $runtimeContext = array(
-		'provider_id' => '',
-		'model_id'    => '',
+		'provider_id'                  => '',
+		'model_id'                     => '',
+		'session_id'                   => 0,
+		'retry_baseline_request_bytes' => 0,
+		'request_bytes'                => 0,
+		'request_tokens_estimate'      => 0,
+		'request_provider_limit_bytes' => 0,
+		'request_budget_bytes'         => 0,
+		'request_safety_margin_bytes'  => 0,
 	);
 
 	/**
@@ -104,21 +121,62 @@ class ProviderTraceLogger {
 	/**
 	 * Set safe runtime attribution for the next synchronous provider request.
 	 *
-	 * @param string $provider_id Runtime-selected provider ID.
-	 * @param string $model_id    Runtime-selected model ID.
+	 * @param string $provider_id                  Runtime-selected provider ID.
+	 * @param string $model_id                     Runtime-selected model ID.
+	 * @param int    $session_id                   Owning chat session, if any.
+	 * @param int    $retry_baseline_request_bytes Full-envelope bytes from an upstream 413 retry baseline.
 	 */
-	public static function set_runtime_context( string $provider_id, string $model_id ): void {
+	public static function set_runtime_context( string $provider_id, string $model_id, int $session_id = 0, int $retry_baseline_request_bytes = 0 ): void {
 		self::$runtimeContext = array(
-			'provider_id' => sanitize_key( $provider_id ),
-			'model_id'    => sanitize_text_field( $model_id ),
+			'provider_id'                  => sanitize_key( $provider_id ),
+			'model_id'                     => sanitize_text_field( $model_id ),
+			'session_id'                   => max( 0, $session_id ),
+			'retry_baseline_request_bytes' => max( 0, $retry_baseline_request_bytes ),
+			'request_bytes'                => 0,
+			'request_tokens_estimate'      => 0,
+			'request_provider_limit_bytes' => 0,
+			'request_budget_bytes'         => 0,
+			'request_safety_margin_bytes'  => 0,
 		);
 	}
 
 	/** Clear runtime provider attribution after a synchronous request. */
 	public static function clear_runtime_context(): void {
 		self::$runtimeContext = array(
-			'provider_id' => '',
-			'model_id'    => '',
+			'provider_id'                  => '',
+			'model_id'                     => '',
+			'session_id'                   => 0,
+			'retry_baseline_request_bytes' => 0,
+			'request_bytes'                => 0,
+			'request_tokens_estimate'      => 0,
+			'request_provider_limit_bytes' => 0,
+			'request_budget_bytes'         => 0,
+			'request_safety_margin_bytes'  => 0,
+		);
+	}
+
+	/**
+	 * Return only scalar measurements captured for the current full request envelope.
+	 *
+	 * The transport hook is the first provider-neutral point that sees the SDK's
+	 * complete serialized body. Never return the body, headers, URL, tool schema,
+	 * attachment, or prompt content from this method.
+	 *
+	 * @return array<string, int|string>
+	 */
+	public static function get_runtime_envelope_metrics(): array {
+		if ( self::$runtimeContext['request_bytes'] <= 0 ) {
+			return array();
+		}
+
+		return array(
+			'request_bytes'                => self::$runtimeContext['request_bytes'],
+			'request_tokens_estimate'      => self::$runtimeContext['request_tokens_estimate'],
+			'request_provider_limit_bytes' => self::$runtimeContext['request_provider_limit_bytes'],
+			'request_budget_bytes'         => self::$runtimeContext['request_budget_bytes'],
+			'request_safety_margin_bytes'  => self::$runtimeContext['request_safety_margin_bytes'],
+			'request_size_class'           => self::classify_request_size( self::$runtimeContext['request_bytes'] ),
+			'request_size_source'          => 'complete_envelope',
 		);
 	}
 
@@ -154,32 +212,88 @@ class ProviderTraceLogger {
 			$model_id = self::extract_model_id( $request_body );
 		}
 
-		$request_bytes = strlen( $request_body );
-		$byte_budget   = ConversationTrimmer::get_request_byte_budget( $provider_id, $model_id );
+		$request_bytes        = strlen( $request_body );
+		$request_tokens       = (int) ceil( $request_bytes / 4 );
+		$provider_limit_bytes = ConversationTrimmer::get_request_byte_budget( $provider_id, $model_id );
+		$byte_budget          = ConversationTrimmer::get_request_envelope_byte_budget( $provider_id, $model_id );
+		$safety_margin_bytes  = max( 0, $provider_limit_bytes - $byte_budget );
+
+		if ( $has_context ) {
+			self::$runtimeContext['request_bytes']                = $request_bytes;
+			self::$runtimeContext['request_tokens_estimate']      = $request_tokens;
+			self::$runtimeContext['request_provider_limit_bytes'] = $provider_limit_bytes;
+			self::$runtimeContext['request_budget_bytes']         = $byte_budget;
+			self::$runtimeContext['request_safety_margin_bytes']  = $safety_margin_bytes;
+		}
+
+		$fallback_attempted = $has_context && self::$runtimeContext['retry_baseline_request_bytes'] > 0;
+
 		if ( $has_context && $request_bytes > $byte_budget ) {
 			self::record_payload_limit(
 				$provider_id,
 				$model_id,
 				413,
 				$request_bytes,
-				(int) ceil( $request_bytes / 4 ),
+				$request_tokens,
 				$byte_budget,
 				true,
-				false
+				$fallback_attempted,
+				false,
+				self::local_payload_recovery_outcome()
 			);
 
 			return new \WP_Error(
 				'sd_ai_agent_provider_payload_budget_exceeded',
 				__( 'This request is too large to send safely. Compact the conversation or shorten the latest message and remove large attachments before retrying.', 'superdav-ai-agent' ),
 				array(
-					'status_code'             => 413,
-					'provider_id'             => $provider_id,
-					'model_id'                => $model_id,
-					'request_bytes'           => $request_bytes,
-					'request_tokens_estimate' => (int) ceil( $request_bytes / 4 ),
-					'request_budget_bytes'    => $byte_budget,
-					'request_size_class'      => self::classify_request_size( $request_bytes ),
-					'local_rejection'         => true,
+					'status_code'                  => 413,
+					'provider_id'                  => $provider_id,
+					'model_id'                     => $model_id,
+					'request_bytes'                => $request_bytes,
+					'request_tokens_estimate'      => $request_tokens,
+					'request_provider_limit_bytes' => $provider_limit_bytes,
+					'request_budget_bytes'         => $byte_budget,
+					'request_safety_margin_bytes'  => $safety_margin_bytes,
+					'request_size_class'           => self::classify_request_size( $request_bytes ),
+					'request_size_source'          => 'complete_envelope',
+					'local_rejection'              => true,
+					'fallback_attempted'           => $fallback_attempted,
+					'recovery_outcome'             => self::local_payload_recovery_outcome(),
+				)
+			);
+		}
+
+		$retry_baseline_bytes = self::$runtimeContext['retry_baseline_request_bytes'];
+		if ( $has_context && $retry_baseline_bytes > 0 && ! self::is_materially_smaller_envelope( $request_bytes, $retry_baseline_bytes ) ) {
+			self::record_payload_limit(
+				$provider_id,
+				$model_id,
+				413,
+				$request_bytes,
+				$request_tokens,
+				$byte_budget,
+				true,
+				true,
+				false,
+				'retry_not_materially_smaller'
+			);
+
+			return new \WP_Error(
+				'sd_ai_agent_provider_payload_budget_exceeded',
+				__( 'This request is too large to send safely. Compact the conversation or shorten the latest message and remove large attachments before retrying.', 'superdav-ai-agent' ),
+				array(
+					'status_code'                  => 413,
+					'provider_id'                  => $provider_id,
+					'model_id'                     => $model_id,
+					'request_bytes'                => $request_bytes,
+					'request_tokens_estimate'      => $request_tokens,
+					'request_provider_limit_bytes' => $provider_limit_bytes,
+					'request_budget_bytes'         => $byte_budget,
+					'request_safety_margin_bytes'  => $safety_margin_bytes,
+					'request_size_class'           => self::classify_request_size( $request_bytes ),
+					'request_size_source'          => 'complete_envelope',
+					'local_rejection'              => true,
+					'recovery_outcome'             => 'retry_not_materially_smaller',
 				)
 			);
 		}
@@ -249,7 +363,7 @@ class ProviderTraceLogger {
 					$model_id_for_log = self::extract_model_id( $request_body );
 				}
 				$request_bytes = strlen( $request_body );
-				$byte_budget   = ConversationTrimmer::get_request_byte_budget( $request_provider_id, $model_id_for_log );
+				$byte_budget   = ConversationTrimmer::get_request_envelope_byte_budget( $request_provider_id, $model_id_for_log );
 
 				if ( 413 === $status_code_for_log ) {
 					self::record_payload_limit(
@@ -260,7 +374,9 @@ class ProviderTraceLogger {
 						(int) ceil( $request_bytes / 4 ),
 						$byte_budget,
 						false,
-						false
+						false,
+						false,
+						'upstream_413'
 					);
 				} else {
 					AgentEventLog::log(
@@ -415,6 +531,7 @@ class ProviderTraceLogger {
 	 * @param bool   $local_rejection   Whether dispatch was blocked locally.
 	 * @param bool   $fallback_attempted Whether a reduced fallback was attempted.
 	 * @param bool   $bytes_estimated   Whether request_bytes is a history estimate.
+	 * @param string $recovery_outcome  Safe recovery outcome token.
 	 */
 	public static function record_payload_limit(
 		string $provider_id,
@@ -425,7 +542,8 @@ class ProviderTraceLogger {
 		int $request_budget,
 		bool $local_rejection,
 		bool $fallback_attempted,
-		bool $bytes_estimated = false
+		bool $bytes_estimated = false,
+		string $recovery_outcome = ''
 	): void {
 		$context               = array(
 			'provider_id'             => sanitize_key( $provider_id ),
@@ -434,14 +552,37 @@ class ProviderTraceLogger {
 			'request_tokens_estimate' => max( 0, $request_tokens ),
 			'request_budget_bytes'    => max( 0, $request_budget ),
 			'request_size_class'      => self::classify_request_size( $request_bytes ),
-			'request_size_source'     => $bytes_estimated ? 'history_estimate' : 'http_body',
+			'request_size_source'     => $bytes_estimated ? 'history_estimate' : 'complete_envelope',
 			'local_rejection'         => $local_rejection,
 			'fallback_attempted'      => $fallback_attempted,
 		);
 		$bytes_key             = $bytes_estimated ? 'request_bytes_estimate' : 'request_bytes';
 		$context[ $bytes_key ] = max( 0, $request_bytes );
+		if ( '' !== $recovery_outcome ) {
+			$context['recovery_outcome'] = sanitize_key( $recovery_outcome );
+		}
+		if ( ! $bytes_estimated && self::$runtimeContext['request_provider_limit_bytes'] > 0 ) {
+			$context['request_provider_limit_bytes'] = self::$runtimeContext['request_provider_limit_bytes'];
+			$context['request_safety_margin_bytes']  = self::$runtimeContext['request_safety_margin_bytes'];
+		}
 
 		AgentEventLog::log( 'provider_payload_limit', AgentEventLog::SEVERITY_ERROR, $context );
+	}
+
+	/** Whether a retried envelope is at least ten percent smaller than its upstream-413 baseline. */
+	private static function is_materially_smaller_envelope( int $request_bytes, int $baseline_bytes ): bool {
+		if ( $request_bytes >= $baseline_bytes || $baseline_bytes <= 0 ) {
+			return false;
+		}
+
+		return ( $baseline_bytes - $request_bytes ) >= (int) ceil( $baseline_bytes * 0.1 );
+	}
+
+	/** Return a safe local-rejection outcome without exposing request content. */
+	private static function local_payload_recovery_outcome(): string {
+		return self::$runtimeContext['session_id'] > 0
+			? 'compact_session_available'
+			: 'compact_session_unavailable';
 	}
 
 	/**

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -3369,7 +3369,6 @@ final class SessionController {
 					$job
 				);
 			}
-			}
 
 			// Log webhook execution failure.
 			if ( ! empty( $job['webhook_id'] ) ) {

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -929,8 +929,28 @@ final class SessionController {
 			);
 		}
 
-		$compacted     = ConversationTrimmer::compact_serialized_history( $source_messages );
-		$seed_messages = $compacted['messages'];
+		$provider_id = sanitize_text_field( (string) ( $request->get_param( 'provider_id' ) ?: $source_session->provider_id ) );
+		$model_id    = sanitize_text_field( (string) ( $request->get_param( 'model_id' ) ?: $source_session->model_id ) );
+
+		// Reserve half of the effective envelope for the next user turn, system
+		// instruction, tool declarations, attachments, and provider options. The
+		// transport preflight remains authoritative immediately before dispatch.
+		$request_byte_budget  = ConversationTrimmer::get_request_envelope_byte_budget( $provider_id, $model_id );
+		$request_token_budget = ConversationTrimmer::get_request_token_budget( $provider_id, $model_id );
+		$compact_byte_budget  = min(
+			ConversationTrimmer::COMPACT_MAX_BYTES,
+			max( 1024, (int) floor( $request_byte_budget / 2 ) )
+		);
+		$compact_token_budget = min(
+			ConversationTrimmer::COMPACT_MAX_TOKENS,
+			max( 256, (int) floor( $request_token_budget / 2 ) )
+		);
+		$compacted            = ConversationTrimmer::compact_serialized_history(
+			$source_messages,
+			$compact_byte_budget,
+			$compact_token_budget
+		);
+		$seed_messages        = $compacted['messages'];
 		if ( empty( $seed_messages ) ) {
 			return new WP_Error(
 				'sd_ai_agent_compact_failed',
@@ -939,16 +959,14 @@ final class SessionController {
 			);
 		}
 
-		$provider_id = (string) ( $request->get_param( 'provider_id' ) ?: $source_session->provider_id );
-		$model_id    = (string) ( $request->get_param( 'model_id' ) ?: $source_session->model_id );
-		$title       = $this->build_compacted_session_title( (string) $source_session->title );
+		$title = $this->build_compacted_session_title( (string) $source_session->title );
 
 		$new_session_id = $this->database->create_session(
 			array(
 				'user_id'     => get_current_user_id(),
 				'title'       => $title,
-				'provider_id' => sanitize_text_field( $provider_id ),
-				'model_id'    => sanitize_text_field( $model_id ),
+				'provider_id' => $provider_id,
+				'model_id'    => $model_id,
 			)
 		);
 
@@ -1328,6 +1346,13 @@ final class SessionController {
 				$response['recoverable'] = true;
 			}
 			$this->add_transient_failure_response( $job_id, $job, $job_session_id, $response );
+			$payload_recovery = $this->normalize_payload_recovery( $job['payload_recovery'] ?? null, $job_session_id );
+			if ( null === $payload_recovery ) {
+				$payload_recovery = $this->get_payload_recovery_from_paused_state( $job_session_id );
+			}
+			if ( null !== $payload_recovery ) {
+				$response['payload_recovery'] = $payload_recovery;
+			}
 
 			// Clean up.
 			delete_transient( RestController::JOB_PREFIX . $job_id );
@@ -1415,6 +1440,10 @@ final class SessionController {
 
 			if ( $this->session_has_recoverable_paused_state( $row->session_id ) ) {
 				$response['recoverable'] = true;
+			}
+			$payload_recovery = $this->get_payload_recovery_from_paused_state( $row->session_id );
+			if ( null !== $payload_recovery ) {
+				$response['payload_recovery'] = $payload_recovery;
 			}
 
 			if ( 'error' !== $status ) {
@@ -2606,6 +2635,59 @@ final class SessionController {
 	}
 
 	/**
+	 * Validate the compact-continuation metadata exposed to the chat client.
+	 *
+	 * Error data can originate in provider SDK layers, so reduce it to the two
+	 * identifiers the UI needs rather than forwarding arbitrary error fields.
+	 *
+	 * @param mixed $recovery   Candidate recovery payload.
+	 * @param int   $session_id Owning source session ID.
+	 * @return array{action:string,source_session_id:int}|null Safe action, or null.
+	 */
+	private function normalize_payload_recovery( mixed $recovery, int $session_id ): ?array {
+		if (
+			$session_id <= 0
+			|| ! is_array( $recovery )
+			|| 'compact_session' !== ( $recovery['action'] ?? '' )
+			|| $session_id !== (int) ( $recovery['source_session_id'] ?? 0 )
+		) {
+			return null;
+		}
+
+		return array(
+			'action'            => 'compact_session',
+			'source_session_id' => $session_id,
+		);
+	}
+
+	/**
+	 * Rebuild safe compaction recovery metadata after a terminal job transient expires.
+	 *
+	 * @param int $session_id Source session ID.
+	 * @return array{action:string,source_session_id:int}|null Safe action, or null.
+	 */
+	private function get_payload_recovery_from_paused_state( int $session_id ): ?array {
+		if ( $session_id <= 0 ) {
+			return null;
+		}
+
+		$session = $this->database->get_session( $session_id );
+		if ( ! $session || empty( $session->paused_state ) ) {
+			return null;
+		}
+
+		$paused_state = json_decode( (string) $session->paused_state, true );
+		if ( ! is_array( $paused_state ) || 'sd_ai_agent_provider_payload_budget_exceeded' !== ( $paused_state['exit_reason'] ?? '' ) ) {
+			return null;
+		}
+
+		return array(
+			'action'            => 'compact_session',
+			'source_session_id' => $session_id,
+		);
+	}
+
+	/**
 	 * Handle POST /job/{id}/confirm — user approves a pending tool call.
 	 *
 	 * @param WP_REST_Request $request The request object.
@@ -3273,6 +3355,10 @@ final class SessionController {
 			);
 			$job['tool_calls'] = $error_data['tool_calls'] ?? ( $job['tool_calls'] ?? array() );
 			$job['messages']   = $error_data['messages'] ?? ( $job['messages'] ?? array() );
+			$payload_recovery  = $this->normalize_payload_recovery( $error_data['recovery'] ?? null, $session_id );
+			if ( null !== $payload_recovery ) {
+				$job['payload_recovery'] = $payload_recovery;
+			}
 			if ( $session_id ) {
 				$this->persist_error_recovery_to_session(
 					$session_id,
@@ -3282,6 +3368,7 @@ final class SessionController {
 					$options,
 					$job
 				);
+			}
 			}
 
 			// Log webhook execution failure.

--- a/scripts/check-bundle-size.js
+++ b/scripts/check-bundle-size.js
@@ -10,7 +10,7 @@ const BUDGETS = [
 	{
 		name: 'floating-widget',
 		file: 'build/floating-widget.js',
-		minifiedBudgetKiB: 86,
+		minifiedBudgetKiB: 87,
 		gzipBudgetKiB: 28,
 	},
 	{

--- a/src/components/chat-redesign/MessageList.js
+++ b/src/components/chat-redesign/MessageList.js
@@ -20,6 +20,7 @@ import { __ } from '@wordpress/i18n';
 
 import STORE_NAME from '../../store';
 import ActionCard from '../action-card';
+import CompactConversationActionCard from '../compact-conversation-action-card';
 import FeedbackConsentModal from '../feedback-consent-modal';
 import useTextToSpeech from '../use-text-to-speech';
 import {
@@ -91,6 +92,7 @@ export default function MessageList() {
 		sendMessage,
 		retryLastMessage,
 		resumeRecoverableJob,
+		compactConversation,
 		setPendingActionCard,
 	} = useDispatch( STORE_NAME );
 	const ref = useRef( null );
@@ -264,6 +266,13 @@ export default function MessageList() {
 		}
 	};
 
+	const compactAndContinue = useCallback( async () => {
+		const compacted = await compactConversation();
+		if ( compacted ) {
+			setPendingActionCard( null );
+		}
+	}, [ compactConversation, setPendingActionCard ] );
+
 	// ── Derived values ────────────────────────────────────────────────────────
 
 	const lastRunningJob = currentSessionId
@@ -350,23 +359,26 @@ export default function MessageList() {
 						/>
 					) }
 
-					{ hasStreamError && currentSessionId && ! sending && (
-						<div className="sdaa-cr-error-banner" role="status">
-							<span className="sdaa-cr-error-banner__message">
-								{ __(
-									'Something went wrong while sending your message.',
-									'superdav-ai-agent'
-								) }
-							</span>
-							<button
-								type="button"
-								className="sdaa-cr-error-banner__retry"
-								onClick={ retryLastMessage }
-							>
-								{ __( 'Try again', 'superdav-ai-agent' ) }
-							</button>
-						</div>
-					) }
+					{ hasStreamError &&
+						currentSessionId &&
+						! sending &&
+						pendingActionCard?.type !== 'compact_session' && (
+							<div className="sdaa-cr-error-banner" role="status">
+								<span className="sdaa-cr-error-banner__message">
+									{ __(
+										'Something went wrong while sending your message.',
+										'superdav-ai-agent'
+									) }
+								</span>
+								<button
+									type="button"
+									className="sdaa-cr-error-banner__retry"
+									onClick={ retryLastMessage }
+								>
+									{ __( 'Try again', 'superdav-ai-agent' ) }
+								</button>
+							</div>
+						) }
 
 					{ [
 						'resume_recoverable_job',
@@ -377,6 +389,15 @@ export default function MessageList() {
 							<ActionCard
 								card={ pendingActionCard }
 								onConfirm={ confirmJobFailureAction }
+								onCancel={ () => setPendingActionCard( null ) }
+							/>
+						) }
+
+					{ pendingActionCard?.type === 'compact_session' &&
+						pendingActionCard.sessionId === currentSessionId &&
+						! sending && (
+							<CompactConversationActionCard
+								onConfirm={ compactAndContinue }
 								onCancel={ () => setPendingActionCard( null ) }
 							/>
 						) }

--- a/src/components/chat-redesign/MessageList.js
+++ b/src/components/chat-redesign/MessageList.js
@@ -111,6 +111,7 @@ export default function MessageList() {
 	const [ unseenCount, setUnseenCount ] = useState( 0 );
 	const [ thumbsDownMessageIndex, setThumbsDownMessageIndex ] =
 		useState( null );
+	const [ compactError, setCompactError ] = useState( '' );
 
 	// TTS hook — mirrors the old message-list.js TTS integration.
 	const { speak, cancel } = useTextToSpeech( {
@@ -267,10 +268,20 @@ export default function MessageList() {
 	};
 
 	const compactAndContinue = useCallback( async () => {
+		setCompactError( '' );
 		const compacted = await compactConversation();
-		if ( compacted ) {
+		if ( compacted === true ) {
 			setPendingActionCard( null );
+			return;
 		}
+
+		setCompactError(
+			compacted?.error ||
+				__(
+					'Unable to compact this conversation. Please try again.',
+					'superdav-ai-agent'
+				)
+		);
 	}, [ compactConversation, setPendingActionCard ] );
 
 	// ── Derived values ────────────────────────────────────────────────────────
@@ -397,6 +408,7 @@ export default function MessageList() {
 						pendingActionCard.sessionId === currentSessionId &&
 						! sending && (
 							<CompactConversationActionCard
+								error={ compactError }
 								onConfirm={ compactAndContinue }
 								onCancel={ () => setPendingActionCard( null ) }
 							/>

--- a/src/components/chat-redesign/__tests__/MessageList.test.js
+++ b/src/components/chat-redesign/__tests__/MessageList.test.js
@@ -234,4 +234,39 @@ describe( 'MessageList stream error banner', () => {
 
 		expect( retryLastMessage ).toHaveBeenCalledTimes( 1 );
 	} );
+
+	test( 'shows compact-and-continue for a locally oversized envelope', async () => {
+		const compactConversation = jest.fn().mockResolvedValue( true );
+		const setPendingActionCard = jest.fn();
+		( { container, root } = await renderMessageList( {
+			selectors: buildSelectors( {
+				hasStreamError: true,
+				pendingActionCard: {
+					type: 'compact_session',
+					sessionId: 123,
+				},
+			} ),
+			dispatchMap: {
+				sendMessage: jest.fn(),
+				retryLastMessage,
+				compactConversation,
+				setPendingActionCard,
+			},
+		} ) );
+
+		expect( container.querySelector( '.sdaa-cr-error-banner' ) ).toBeNull();
+		const compactButton = container.querySelector(
+			'.sdaa-action-card-btn-confirm'
+		);
+		expect( compactButton.textContent ).toBe( 'Compact and continue' );
+
+		await act( async () => {
+			compactButton.dispatchEvent(
+				new MouseEvent( 'click', { bubbles: true } )
+			);
+		} );
+
+		expect( compactConversation ).toHaveBeenCalledTimes( 1 );
+		expect( setPendingActionCard ).toHaveBeenCalledWith( null );
+	} );
 } );

--- a/src/components/chat-redesign/__tests__/MessageList.test.js
+++ b/src/components/chat-redesign/__tests__/MessageList.test.js
@@ -269,4 +269,37 @@ describe( 'MessageList stream error banner', () => {
 		expect( compactConversation ).toHaveBeenCalledTimes( 1 );
 		expect( setPendingActionCard ).toHaveBeenCalledWith( null );
 	} );
+
+	test( 'keeps the compact card and shows a compaction failure', async () => {
+		const compactConversation = jest.fn().mockResolvedValue( {
+			error: 'Compaction service unavailable',
+		} );
+		const setPendingActionCard = jest.fn();
+		( { container, root } = await renderMessageList( {
+			selectors: buildSelectors( {
+				hasStreamError: true,
+				pendingActionCard: {
+					type: 'compact_session',
+					sessionId: 123,
+				},
+			} ),
+			dispatchMap: {
+				sendMessage: jest.fn(),
+				retryLastMessage,
+				compactConversation,
+				setPendingActionCard,
+			},
+		} ) );
+
+		await act( async () => {
+			container
+				.querySelector( '.sdaa-action-card-btn-confirm' )
+				.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+		} );
+
+		expect( container.textContent ).toContain(
+			'Compaction service unavailable'
+		);
+		expect( setPendingActionCard ).not.toHaveBeenCalledWith( null );
+	} );
 } );

--- a/src/components/chat-widget/__tests__/widget-message-list.test.js
+++ b/src/components/chat-widget/__tests__/widget-message-list.test.js
@@ -226,4 +226,54 @@ describe( 'WidgetMessageList compact conversation action card', () => {
 			root.unmount();
 		} );
 	} );
+
+	test( 'keeps the compact card and shows a compaction failure', async () => {
+		const compactConversation = jest.fn().mockResolvedValue( {
+			error: 'Compaction service unavailable',
+		} );
+		const setPendingActionCard = jest.fn();
+		const selectors = {
+			getCurrentSessionMessages: () => [],
+			isSending: () => false,
+			getCurrentSessionId: () => 123,
+			getLiveToolCalls: () => [],
+			getSessionJobs: () => ( {} ),
+			getSettings: () => ( {} ),
+			hasStreamError: () => true,
+			getPendingActionCard: () => ( {
+				type: 'compact_session',
+				sessionId: 123,
+			} ),
+			getProviders: () => [],
+		};
+		useSelect.mockImplementation( ( fn ) => fn( () => selectors ) );
+		useDispatch.mockReturnValue( {
+			sendMessage: jest.fn(),
+			retryLastMessage: jest.fn(),
+			compactConversation,
+			setPendingActionCard,
+		} );
+
+		const container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		const root = createRoot( container );
+		await act( async () => {
+			root.render( createElement( WidgetMessageList ) );
+		} );
+
+		await act( async () => {
+			container
+				.querySelector( '.sdaa-action-card-btn-confirm' )
+				.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+		} );
+
+		expect( container.textContent ).toContain(
+			'Compaction service unavailable'
+		);
+		expect( setPendingActionCard ).not.toHaveBeenCalledWith( null );
+
+		await act( async () => {
+			root.unmount();
+		} );
+	} );
 } );

--- a/src/components/chat-widget/__tests__/widget-message-list.test.js
+++ b/src/components/chat-widget/__tests__/widget-message-list.test.js
@@ -57,6 +57,7 @@ async function renderCreditExhaustionMessage() {
 		getSessionJobs: () => ( {} ),
 		getSettings: () => ( {} ),
 		hasStreamError: () => false,
+		getPendingActionCard: () => null,
 		getProviders: () => [
 			{
 				id: 'sd-ai-agent-cloud',
@@ -70,6 +71,8 @@ async function renderCreditExhaustionMessage() {
 	useDispatch.mockReturnValue( {
 		sendMessage: jest.fn(),
 		retryLastMessage: jest.fn(),
+		compactConversation: jest.fn(),
+		setPendingActionCard: jest.fn(),
 	} );
 
 	const container = document.createElement( 'div' );
@@ -130,6 +133,7 @@ describe( 'WidgetMessageList recoverable-job action card', () => {
 			getSessionJobs: () => ( {} ),
 			getSettings: () => ( {} ),
 			hasStreamError: () => true,
+			getPendingActionCard: () => null,
 			getProviders: () => [],
 		};
 		useSelect.mockImplementation( ( fn ) => fn( () => selectors ) );
@@ -155,6 +159,68 @@ describe( 'WidgetMessageList recoverable-job action card', () => {
 			);
 		} );
 		expect( retryLastMessage ).toHaveBeenCalledTimes( 1 );
+
+		await act( async () => {
+			root.unmount();
+		} );
+	} );
+} );
+
+describe( 'WidgetMessageList compact conversation action card', () => {
+	afterEach( () => {
+		document.body.innerHTML = '';
+		jest.clearAllMocks();
+	} );
+
+	test( 'offers and completes compact-and-continue for the active session', async () => {
+		const compactConversation = jest.fn().mockResolvedValue( true );
+		const setPendingActionCard = jest.fn();
+		const selectors = {
+			getCurrentSessionMessages: () => [],
+			isSending: () => false,
+			getCurrentSessionId: () => 123,
+			getLiveToolCalls: () => [],
+			getSessionJobs: () => ( {} ),
+			getSettings: () => ( {} ),
+			hasStreamError: () => true,
+			getPendingActionCard: () => ( {
+				type: 'compact_session',
+				sessionId: 123,
+			} ),
+			getProviders: () => [],
+		};
+		useSelect.mockImplementation( ( fn ) => fn( () => selectors ) );
+		useDispatch.mockReturnValue( {
+			sendMessage: jest.fn(),
+			retryLastMessage: jest.fn(),
+			compactConversation,
+			setPendingActionCard,
+		} );
+
+		const container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		const root = createRoot( container );
+		await act( async () => {
+			root.render( createElement( WidgetMessageList ) );
+		} );
+
+		expect(
+			container.querySelector( '.sdaa-w-retry-failed-step' )
+		).toBeNull();
+		const compactButton = container.querySelector(
+			'.sdaa-action-card-btn-confirm'
+		);
+		expect( compactButton.textContent ).toBe( 'Compact and continue' );
+
+		await act( async () => {
+			compactButton.dispatchEvent(
+				new MouseEvent( 'click', { bubbles: true } )
+			);
+			await Promise.resolve();
+		} );
+
+		expect( compactConversation ).toHaveBeenCalledTimes( 1 );
+		expect( setPendingActionCard ).toHaveBeenCalledWith( null );
 
 		await act( async () => {
 			root.unmount();

--- a/src/components/chat-widget/widget-message-list.js
+++ b/src/components/chat-widget/widget-message-list.js
@@ -103,6 +103,7 @@ export default function WidgetMessageList() {
 	const [ unseenCount, setUnseenCount ] = useState( 0 );
 	const [ thumbsDownMessageIndex, setThumbsDownMessageIndex ] =
 		useState( null );
+	const [ compactError, setCompactError ] = useState( '' );
 
 	// ── Compute visible messages ──────────────────────────────────────────────
 	// Placed before effects so visibleCountRef is updated before they fire.
@@ -195,10 +196,20 @@ export default function WidgetMessageList() {
 	}, [] );
 
 	const compactAndContinue = useCallback( async () => {
+		setCompactError( '' );
 		const compacted = await compactConversation();
-		if ( compacted ) {
+		if ( compacted === true ) {
 			setPendingActionCard( null );
+			return;
 		}
+
+		setCompactError(
+			compacted?.error ||
+				__(
+					'Unable to compact this conversation. Please try again.',
+					'superdav-ai-agent'
+				)
+		);
 	}, [ compactConversation, setPendingActionCard ] );
 
 	// ── Derived values ────────────────────────────────────────────────────────
@@ -304,6 +315,7 @@ export default function WidgetMessageList() {
 						pendingActionCard.sessionId === currentSessionId &&
 						! sending && (
 							<CompactConversationActionCard
+								error={ compactError }
 								onConfirm={ compactAndContinue }
 								onCancel={ () => setPendingActionCard( null ) }
 							/>

--- a/src/components/chat-widget/widget-message-list.js
+++ b/src/components/chat-widget/widget-message-list.js
@@ -26,6 +26,7 @@ import {
 import { __ } from '@wordpress/i18n';
 
 import STORE_NAME from '../../store';
+import CompactConversationActionCard from '../compact-conversation-action-card';
 import FeedbackConsentModal from '../feedback-consent-modal';
 import {
 	extractText,
@@ -61,6 +62,7 @@ export default function WidgetMessageList() {
 		liveToolCalls,
 		sessionJobs,
 		hasStreamError,
+		pendingActionCard,
 		providers,
 		showToolCallDetails,
 	} = useSelect( ( sel ) => {
@@ -73,12 +75,18 @@ export default function WidgetMessageList() {
 			liveToolCalls: store.getLiveToolCalls(),
 			sessionJobs: store.getSessionJobs(),
 			hasStreamError: store.hasStreamError(),
+			pendingActionCard: store.getPendingActionCard(),
 			providers: store.getProviders(),
 			showToolCallDetails: settings?.show_tool_call_details === true,
 		};
 	}, [] );
 
-	const { sendMessage, retryLastMessage } = useDispatch( STORE_NAME );
+	const {
+		sendMessage,
+		retryLastMessage,
+		compactConversation,
+		setPendingActionCard,
+	} = useDispatch( STORE_NAME );
 	const ref = useRef( null );
 
 	/** True when the scroll container is within SCROLL_THRESHOLD px of the bottom. */
@@ -186,6 +194,13 @@ export default function WidgetMessageList() {
 		setUnseenCount( 0 );
 	}, [] );
 
+	const compactAndContinue = useCallback( async () => {
+		const compacted = await compactConversation();
+		if ( compacted ) {
+			setPendingActionCard( null );
+		}
+	}, [ compactConversation, setPendingActionCard ] );
+
 	// ── Derived values ────────────────────────────────────────────────────────
 
 	const lastRunningJob = currentSessionId
@@ -269,15 +284,30 @@ export default function WidgetMessageList() {
 						/>
 					) }
 
-					{ hasStreamError && currentSessionId && ! sending && (
-						<button
-							type="button"
-							className="button button-primary sdaa-w-retry-failed-step"
-							onClick={ retryLastMessage }
-						>
-							{ __( 'Retry failed step', 'superdav-ai-agent' ) }
-						</button>
-					) }
+					{ hasStreamError &&
+						currentSessionId &&
+						! sending &&
+						pendingActionCard?.type !== 'compact_session' && (
+							<button
+								type="button"
+								className="button button-primary sdaa-w-retry-failed-step"
+								onClick={ retryLastMessage }
+							>
+								{ __(
+									'Retry failed step',
+									'superdav-ai-agent'
+								) }
+							</button>
+						) }
+
+					{ pendingActionCard?.type === 'compact_session' &&
+						pendingActionCard.sessionId === currentSessionId &&
+						! sending && (
+							<CompactConversationActionCard
+								onConfirm={ compactAndContinue }
+								onCancel={ () => setPendingActionCard( null ) }
+							/>
+						) }
 				</div>
 			</div>
 

--- a/src/components/compact-conversation-action-card.js
+++ b/src/components/compact-conversation-action-card.js
@@ -9,11 +9,13 @@ import { __ } from '@wordpress/i18n';
  * @param {Object}   props
  * @param {Function} props.onConfirm Creates and opens the bounded continuation.
  * @param {Function} props.onCancel  Dismisses the action.
+ * @param {string}   props.error     Latest compaction failure message.
  * @return {JSX.Element} Compaction action card.
  */
 export default function CompactConversationActionCard( {
 	onConfirm,
 	onCancel,
+	error = '',
 } ) {
 	return (
 		<div className="sdaa-action-card">
@@ -24,6 +26,7 @@ export default function CompactConversationActionCard( {
 						'superdav-ai-agent'
 					) }
 				</p>
+				{ error && <p role="alert">{ error }</p> }
 			</div>
 			<div className="sdaa-action-card-footer">
 				<button

--- a/src/components/compact-conversation-action-card.js
+++ b/src/components/compact-conversation-action-card.js
@@ -1,0 +1,46 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Render the safe continuation action offered after a local envelope rejection.
+ *
+ * @param {Object}   props
+ * @param {Function} props.onConfirm Creates and opens the bounded continuation.
+ * @param {Function} props.onCancel  Dismisses the action.
+ * @return {JSX.Element} Compaction action card.
+ */
+export default function CompactConversationActionCard( {
+	onConfirm,
+	onCancel,
+} ) {
+	return (
+		<div className="sdaa-action-card">
+			<div className="sdaa-action-card-body">
+				<p>
+					{ __(
+						'Too large to send. Compact it; your original chat stays available.',
+						'superdav-ai-agent'
+					) }
+				</p>
+			</div>
+			<div className="sdaa-action-card-footer">
+				<button
+					type="button"
+					className="button sdaa-action-card-btn-cancel"
+					onClick={ onCancel }
+				>
+					{ __( 'Keep original', 'superdav-ai-agent' ) }
+				</button>
+				<button
+					type="button"
+					className="button button-primary sdaa-action-card-btn-confirm"
+					onClick={ onConfirm }
+				>
+					{ __( 'Compact and continue', 'superdav-ai-agent' ) }
+				</button>
+			</div>
+		</div>
+	);
+}

--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -402,6 +402,28 @@ describe( 'actions', () => {
 		expect( dispatch.sendMessage ).not.toHaveBeenCalled();
 	} );
 
+	test( 'compactConversation returns a display-safe failure message', async () => {
+		apiFetch.mockReset();
+		apiFetch.mockRejectedValue(
+			new Error( 'Compaction service unavailable' )
+		);
+		const dispatch = {};
+		const select = {
+			getCurrentSessionId: jest.fn( () => 12 ),
+			getSelectedProviderId: jest.fn( () => 'openai' ),
+			getSelectedModelId: jest.fn( () => 'gpt-test' ),
+		};
+
+		const result = await actions.compactConversation()( {
+			dispatch,
+			select,
+		} );
+
+		expect( result ).toEqual( {
+			error: 'Compaction service unavailable',
+		} );
+	} );
+
 	test( 'retryLastMessage rewinds to the last user message and resends it', async () => {
 		const dispatch = {
 			truncateMessagesTo: jest.fn(),
@@ -1030,7 +1052,10 @@ describe( 'actions', () => {
 		};
 
 		try {
-			actions.pollJob( 'mismatched-payload-job', 17 )( {
+			actions.pollJob(
+				'mismatched-payload-job',
+				17
+			)( {
 				dispatch,
 				select,
 			} );

--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -373,8 +373,12 @@ describe( 'actions', () => {
 			] ),
 		};
 
-		await actions.compactConversation()( { dispatch, select } );
+		const compacted = await actions.compactConversation()( {
+			dispatch,
+			select,
+		} );
 
+		expect( compacted ).toBe( true );
 		expect( apiFetch ).toHaveBeenCalledWith( {
 			path: '/sd-ai-agent/v1/sessions/12/compact',
 			method: 'POST',
@@ -953,6 +957,96 @@ describe( 'actions', () => {
 		expect(
 			dispatch.appendMessage.mock.calls[ 0 ][ 0 ].parts[ 0 ].text
 		).not.toContain( '/private/path.php' );
+	} );
+
+	test( 'pollJob prioritizes a compact continuation after a local envelope rejection', async () => {
+		jest.useFakeTimers();
+		apiFetch.mockReset();
+		apiFetch.mockResolvedValue( {
+			status: 'error',
+			message: 'This request is too large to send safely.',
+			recoverable: true,
+			payload_recovery: {
+				action: 'compact_session',
+				source_session_id: 17,
+			},
+		} );
+		const dispatch = {
+			appendMessage: jest.fn(),
+			setPendingConfirmation: jest.fn(),
+			setPendingActionCard: jest.fn(),
+			setStreamError: jest.fn(),
+			setSending: jest.fn(),
+			setLiveToolCalls: jest.fn(),
+			drainMessageQueue: jest.fn(),
+			setCurrentJobId: jest.fn(),
+			setSessionJob: jest.fn(),
+		};
+		const select = {
+			getCurrentSessionId: jest.fn( () => 17 ),
+			getCurrentJobId: jest.fn( () => 'payload-job' ),
+		};
+
+		try {
+			actions.pollJob( 'payload-job', 17 )( { dispatch, select } );
+			await jest.advanceTimersByTimeAsync( 2000 );
+		} finally {
+			jest.useRealTimers();
+		}
+
+		expect( dispatch.setPendingActionCard ).toHaveBeenCalledWith( {
+			type: 'compact_session',
+			sessionId: 17,
+			sourceSessionId: 17,
+		} );
+	} );
+
+	test( 'pollJob rejects compact recovery metadata for another session', async () => {
+		jest.useFakeTimers();
+		apiFetch.mockReset();
+		apiFetch.mockResolvedValue( {
+			status: 'error',
+			message: 'This request is too large to send safely.',
+			recoverable: true,
+			payload_recovery: {
+				action: 'compact_session',
+				source_session_id: 99,
+			},
+		} );
+		const dispatch = {
+			appendMessage: jest.fn(),
+			setPendingConfirmation: jest.fn(),
+			setPendingActionCard: jest.fn(),
+			setStreamError: jest.fn(),
+			setSending: jest.fn(),
+			setLiveToolCalls: jest.fn(),
+			drainMessageQueue: jest.fn(),
+			setCurrentJobId: jest.fn(),
+			setSessionJob: jest.fn(),
+		};
+		const select = {
+			getCurrentSessionId: jest.fn( () => 17 ),
+			getCurrentJobId: jest.fn( () => 'mismatched-payload-job' ),
+		};
+
+		try {
+			actions.pollJob( 'mismatched-payload-job', 17 )( {
+				dispatch,
+				select,
+			} );
+			await jest.advanceTimersByTimeAsync( 2000 );
+		} finally {
+			jest.useRealTimers();
+		}
+
+		expect( dispatch.setPendingActionCard ).toHaveBeenCalledWith( {
+			type: 'resume_recoverable_job',
+			sessionId: 17,
+			diagnostic: null,
+		} );
+		expect( dispatch.setPendingActionCard ).not.toHaveBeenCalledWith(
+			expect.objectContaining( { type: 'compact_session' } )
+		);
 	} );
 } );
 

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -854,6 +854,14 @@ export const actions = {
 
 						if ( select.getCurrentSessionId() === sessionId ) {
 							let sessionReloaded = false;
+							const payloadRecovery = result.payload_recovery;
+							const sourceSessionId = Number(
+								payloadRecovery?.source_session_id
+							);
+							const canCompactConversation =
+								payloadRecovery?.action === 'compact_session' &&
+								Number.isInteger( sourceSessionId ) &&
+								sourceSessionId === Number( sessionId );
 							if ( result.session_id ) {
 								try {
 									const session = await apiFetch( {
@@ -891,7 +899,13 @@ export const actions = {
 								role: 'system',
 								parts: [ { text: errorText } ],
 							} );
-							if ( result.recoverable ) {
+							if ( canCompactConversation ) {
+								dispatch.setPendingActionCard( {
+									type: 'compact_session',
+									sessionId,
+									sourceSessionId,
+								} );
+							} else if ( result.recoverable ) {
 								dispatch.setPendingActionCard( {
 									type: 'resume_recoverable_job',
 									sessionId,

--- a/src/store/slices/sessionsSlice.js
+++ b/src/store/slices/sessionsSlice.js
@@ -1423,8 +1423,16 @@ export const actions = {
 				dispatch.resetSessionTokens();
 				dispatch.fetchSessions();
 				return true;
-			} catch {
-				return false;
+			} catch ( error ) {
+				return {
+					error:
+						error instanceof Error
+							? error.message
+							: __(
+									'Unable to compact this conversation. Please try again.',
+									'superdav-ai-agent'
+							  ),
+				};
 			}
 		};
 	},

--- a/src/store/slices/sessionsSlice.js
+++ b/src/store/slices/sessionsSlice.js
@@ -1422,8 +1422,9 @@ export const actions = {
 				dispatch.setTokenUsage( { prompt: 0, completion: 0 } );
 				dispatch.resetSessionTokens();
 				dispatch.fetchSessions();
+				return true;
 			} catch {
-				// ignore
+				return false;
 			}
 		};
 	},

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -1120,9 +1120,9 @@ class AgentLoopTest extends WP_UnitTestCase {
 			$history,
 			$options,
 			array(
-				new WP_Error( 'sd_ai_agent_provider_payload_too_large', 'Payload too large.', array( 'status_code' => 413 ) ),
+				new WP_Error( 'sd_ai_agent_provider_payload_too_large', 'Payload too large.', array( 'status_code' => 413, 'request_bytes' => 131072, 'request_size_source' => 'complete_envelope' ) ),
 				$this->create_scripted_result( '' ),
-				new WP_Error( 'sd_ai_agent_provider_payload_too_large', 'Payload too large.', array( 'status_code' => 413 ) ),
+				new WP_Error( 'sd_ai_agent_provider_payload_too_large', 'Payload too large.', array( 'status_code' => 413, 'request_bytes' => 131072, 'request_size_source' => 'complete_envelope' ) ),
 				$this->create_scripted_result( 'Recovered after the follow-up retry.' ),
 			)
 		);
@@ -1165,8 +1165,8 @@ class AgentLoopTest extends WP_UnitTestCase {
 			$options,
 			array(
 				$this->create_scripted_result( '' ),
-				new WP_Error( 'sd_ai_agent_provider_payload_too_large', 'Payload too large.', array( 'status_code' => 413 ) ),
-				new WP_Error( 'sd_ai_agent_provider_payload_too_large', 'Payload too large.', array( 'status_code' => 413 ) ),
+				new WP_Error( 'sd_ai_agent_provider_payload_too_large', 'Payload too large.', array( 'status_code' => 413, 'request_bytes' => 131072, 'request_size_source' => 'complete_envelope' ) ),
+				new WP_Error( 'sd_ai_agent_provider_payload_too_large', 'Payload too large.', array( 'status_code' => 413, 'request_bytes' => 78643, 'request_size_source' => 'complete_envelope' ) ),
 			)
 		);
 		$result = $loop->run();
@@ -1201,6 +1201,7 @@ class AgentLoopTest extends WP_UnitTestCase {
 			array(
 				'provider_id' => 'scripted-provider',
 				'model_id'    => 'scripted-model',
+				'session_id'  => 47,
 			),
 			array( $this->create_scripted_result( 'Should not be sent.' ) )
 		);
@@ -1213,8 +1214,48 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertIsArray( $data );
 		$this->assertTrue( $data['local_rejection'] );
 		$this->assertFalse( $data['fallback_attempted'] );
+		$this->assertSame( 'compact_session_available', $data['recovery_outcome'] );
 		$this->assertTrue( $data['recoverable'] );
+		$this->assertSame( 'compact_session', $data['recovery']['action'] );
+		$this->assertSame( 47, $data['recovery']['source_session_id'] );
 		$this->assertStringContainsString( $current, (string) wp_json_encode( $data['history'] ) );
+	}
+
+	/** A local transport preflight rejection must not consume the one upstream-413 retry. */
+	public function test_local_transport_payload_rejection_skips_reduced_retry_and_offers_compaction(): void {
+		$loop = new ScriptedAgentLoop(
+			'Current request.',
+			array(),
+			array(),
+			array(
+				'provider_id' => 'scripted-provider',
+				'model_id'    => 'scripted-model',
+				'session_id'  => 48,
+			),
+			array(
+				new WP_Error(
+					'sd_ai_agent_provider_payload_budget_exceeded',
+					'Complete request envelope exceeded the local budget.',
+					array(
+						'status_code'         => 413,
+						'local_rejection'     => true,
+						'request_bytes'       => 8192,
+						'request_size_source' => 'complete_envelope',
+					)
+				),
+			)
+		);
+
+		$result = $loop->run();
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_provider_payload_budget_exceeded', $result->get_error_code() );
+		$this->assertCount( 1, $loop->requestSizes );
+		$data = $result->get_error_data();
+		$this->assertIsArray( $data );
+		$this->assertFalse( $data['fallback_attempted'] );
+		$this->assertSame( 'compact_session', $data['recovery']['action'] );
+		$this->assertSame( 48, $data['recovery']['source_session_id'] );
 	}
 
 	// -------------------------------------------------------------------------

--- a/tests/SdAiAgent/Core/ConversationTrimmerTest.php
+++ b/tests/SdAiAgent/Core/ConversationTrimmerTest.php
@@ -43,6 +43,14 @@ class ConversationTrimmerTest extends WP_UnitTestCase {
 		delete_option( 'sd_ai_agent_settings' );
 	}
 
+	/** Reset provider-budget filters registered by individual budget tests. */
+	public function tear_down(): void {
+		remove_all_filters( 'sd_ai_agent_provider_request_max_bytes' );
+		remove_all_filters( 'sd_ai_agent_provider_request_safety_margin_bytes' );
+		remove_all_filters( 'sd_ai_agent_provider_request_max_tokens' );
+		parent::tear_down();
+	}
+
 	/**
 	 * Create a mock user message.
 	 *
@@ -112,6 +120,16 @@ class ConversationTrimmerTest extends WP_UnitTestCase {
 	 */
 	public function test_default_max_turns_constant() {
 		$this->assertSame( 20, ConversationTrimmer::DEFAULT_MAX_TURNS );
+	}
+
+	/** The complete-envelope budget reserves a provider/model-configurable margin. */
+	public function test_request_envelope_budget_reserves_configurable_safety_margin(): void {
+		add_filter( 'sd_ai_agent_provider_request_max_bytes', static fn(): int => 8192 );
+		add_filter( 'sd_ai_agent_provider_request_safety_margin_bytes', static fn(): int => 2048 );
+
+		$this->assertSame( 8192, ConversationTrimmer::get_request_byte_budget( 'openai', 'gpt-test' ) );
+		$this->assertSame( 2048, ConversationTrimmer::get_request_safety_margin_bytes( 'openai', 'gpt-test' ) );
+		$this->assertSame( 6144, ConversationTrimmer::get_request_envelope_byte_budget( 'openai', 'gpt-test' ) );
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/ProviderTraceLoggerResolveTest.php
+++ b/tests/SdAiAgent/Core/ProviderTraceLoggerResolveTest.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Tests\Core;
 
+use SdAiAgent\Core\ConversationTrimmer;
 use SdAiAgent\Core\ProviderTraceLogger;
 use WP_UnitTestCase;
 
@@ -31,6 +32,7 @@ class ProviderTraceLoggerResolveTest extends WP_UnitTestCase {
 		remove_all_filters( 'sd_ai_agent_trace_resolve_provider' );
 		remove_all_filters( 'sd_ai_agent_provider_trace_enabled' );
 		remove_all_filters( 'sd_ai_agent_provider_request_max_bytes' );
+		remove_all_filters( 'sd_ai_agent_provider_request_safety_margin_bytes' );
 		parent::tear_down();
 	}
 
@@ -235,6 +237,109 @@ class ProviderTraceLoggerResolveTest extends WP_UnitTestCase {
 		$this->assertSame( 'sd_ai_agent_provider_payload_budget_exceeded', $result->get_error_code() );
 		$this->assertTrue( $result->get_error_data()['local_rejection'] );
 		$this->assertNull( $body_seen, 'Disabled tracing must not pass prompt bodies to trace resolution filters.' );
+	}
+
+	/**
+	 * The local guard measures the final serialized envelope rather than only the
+	 * history that fit before the SDK added system, tool, attachment, and option data.
+	 */
+	public function test_full_envelope_preflight_rejects_non_history_overhead_without_leaking_it(): void {
+		add_filter( 'sd_ai_agent_provider_request_max_bytes', static fn(): int => 4096 );
+		add_filter( 'sd_ai_agent_provider_request_safety_margin_bytes', static fn(): int => 512 );
+
+		$history = str_repeat( 'history ', 200 );
+		$history_body = (string) wp_json_encode(
+			array(
+				'messages' => array( array( 'content' => $history ) ),
+			)
+		);
+		$private_tool_argument = 'PRIVATE_TOOL_ARGUMENT_MUST_NOT_ESCAPE';
+		$request_body = (string) wp_json_encode(
+			array(
+				'messages'           => array( array( 'content' => $history ) ),
+				'system_instruction' => str_repeat( 'system ', 220 ),
+				'tools'              => array(
+					array(
+						'name'       => 'site-update',
+						'parameters' => str_repeat( 'schema ', 220 ) . $private_tool_argument,
+					)
+				),
+				'attachments'        => array( array( 'metadata' => str_repeat( 'attachment ', 120 ) ) ),
+				'model_options'      => array( 'response_format' => str_repeat( 'option ', 80 ) ),
+			)
+		);
+		$budget = ConversationTrimmer::get_request_envelope_byte_budget( 'openai', 'gpt-test' );
+
+		$this->assertLessThanOrEqual( $budget, strlen( $history_body ) );
+		$this->assertGreaterThan( $budget, strlen( $request_body ) );
+
+		ProviderTraceLogger::set_runtime_context( 'openai', 'gpt-test', 73 );
+		$result = ProviderTraceLogger::on_pre_http_request(
+			false,
+			array( 'body' => $request_body ),
+			'https://provider.example/v1/responses'
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$data = $result->get_error_data();
+		$this->assertIsArray( $data );
+		$this->assertSame( 'complete_envelope', $data['request_size_source'] );
+		$this->assertSame( strlen( $request_body ), $data['request_bytes'] );
+		$this->assertSame( $budget, $data['request_budget_bytes'] );
+		$this->assertSame( 512, $data['request_safety_margin_bytes'] );
+		$this->assertSame( 'compact_session_available', $data['recovery_outcome'] );
+		$this->assertStringNotContainsString( $private_tool_argument, (string) wp_json_encode( $data ) );
+	}
+
+	/** A reduced retry is blocked before dispatch unless its complete envelope is materially smaller. */
+	public function test_retry_preflight_rejects_envelope_that_is_not_materially_smaller(): void {
+		add_filter( 'sd_ai_agent_provider_request_max_bytes', static fn(): int => 4096 );
+		add_filter( 'sd_ai_agent_provider_request_safety_margin_bytes', static fn(): int => 0 );
+
+		$private_request_text = 'PRIVATE_RETRY_REQUEST_MUST_NOT_ESCAPE';
+		$request_body = (string) wp_json_encode(
+			array( 'messages' => array( array( 'content' => str_repeat( $private_request_text, 50 ) ) ) )
+		);
+		$baseline_bytes = (int) ceil( strlen( $request_body ) / 0.95 );
+
+		ProviderTraceLogger::set_runtime_context( 'openai', 'gpt-test', 73, $baseline_bytes );
+		$result = ProviderTraceLogger::on_pre_http_request(
+			false,
+			array( 'body' => $request_body ),
+			'https://provider.example/v1/responses'
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$data = $result->get_error_data();
+		$this->assertIsArray( $data );
+		$this->assertSame( 413, $data['status_code'] );
+		$this->assertSame( 'retry_not_materially_smaller', $data['recovery_outcome'] );
+		$this->assertTrue( $data['local_rejection'] );
+		$this->assertStringNotContainsString( $private_request_text, (string) wp_json_encode( $data ) );
+	}
+
+	/** A locally blocked reduced retry retains its fallback attribution in safe telemetry. */
+	public function test_retry_preflight_marks_local_rejection_as_fallback_attempted(): void {
+		add_filter( 'sd_ai_agent_provider_request_max_bytes', static fn(): int => 1024 );
+		add_filter( 'sd_ai_agent_provider_request_safety_margin_bytes', static fn(): int => 0 );
+
+		$request_body = (string) wp_json_encode(
+			array( 'messages' => array( array( 'content' => str_repeat( 'reduced request ', 100 ) ) ) )
+		);
+
+		ProviderTraceLogger::set_runtime_context( 'openai', 'gpt-test', 73, strlen( $request_body ) + 1024 );
+		$result = ProviderTraceLogger::on_pre_http_request(
+			false,
+			array( 'body' => $request_body ),
+			'https://provider.example/v1/responses'
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$data = $result->get_error_data();
+		$this->assertIsArray( $data );
+		$this->assertTrue( $data['local_rejection'] );
+		$this->assertTrue( $data['fallback_attempted'] );
+		$this->assertSame( 'compact_session_available', $data['recovery_outcome'] );
 	}
 
 	/** A traced provider context attributes 413 diagnostics without invoking trace filters when disabled. */

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -89,6 +89,8 @@ class RestControllerTest extends WP_UnitTestCase {
 		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Standard WordPress test global.
 		global $wp_rest_server;
 		$wp_rest_server = null;
+		remove_all_filters( 'sd_ai_agent_provider_request_max_bytes' );
+		remove_all_filters( 'sd_ai_agent_provider_request_safety_margin_bytes' );
 
 		parent::tear_down();
 	}
@@ -702,6 +704,9 @@ class RestControllerTest extends WP_UnitTestCase {
 			],
 		];
 		Database::append_to_session( (int) $session_id, $messages );
+		$source_messages_before = json_decode( (string) Database::get_session( (int) $session_id )->messages, true );
+		add_filter( 'sd_ai_agent_provider_request_max_bytes', static fn(): int => 4096 );
+		add_filter( 'sd_ai_agent_provider_request_safety_margin_bytes', static fn(): int => 512 );
 
 		$response = $this->dispatch(
 			'POST',
@@ -720,6 +725,7 @@ class RestControllerTest extends WP_UnitTestCase {
 		$this->assertSame( 'openai', $data['provider_id'] );
 		$this->assertSame( 'gpt-test', $data['model_id'] );
 		$this->assertCount( 1, $data['messages'] );
+		$this->assertSame( 1792, $data['compaction']['max_bytes'] );
 
 		$encoded_messages = (string) wp_json_encode( $data['messages'] );
 		$this->assertLessThanOrEqual( ConversationTrimmer::COMPACT_MAX_BYTES, strlen( $encoded_messages ) );
@@ -732,6 +738,8 @@ class RestControllerTest extends WP_UnitTestCase {
 		$stored_messages = json_decode( (string) $new_session->messages, true );
 		$this->assertIsArray( $stored_messages );
 		$this->assertCount( 1, $stored_messages );
+		$source_messages_after = json_decode( (string) Database::get_session( (int) $session_id )->messages, true );
+		$this->assertSame( $source_messages_before, $source_messages_after );
 	}
 
 	/**
@@ -1485,6 +1493,7 @@ class RestControllerTest extends WP_UnitTestCase {
 				'tool_call_log' => [],
 				'message_log'   => [],
 				'token_usage'   => [ 'prompt' => 0, 'completion' => 0 ],
+				'exit_reason'   => 'sd_ai_agent_provider_payload_budget_exceeded',
 			]
 		);
 		ActiveJobRepository::create( $session_id, $job_id, $this->admin_id, 'processing' );
@@ -1502,7 +1511,52 @@ class RestControllerTest extends WP_UnitTestCase {
 		$this->assertSame( ActiveJobFailureDiagnostic::message_for( ActiveJobFailureDiagnostic::REASON_UNKNOWN ), $data['message'] );
 		$this->assertStringNotContainsString( $error_text, wp_json_encode( $data ) );
 		$this->assertTrue( $data['recoverable'] );
+		$this->assertSame(
+			[
+				'action'            => 'compact_session',
+				'source_session_id' => $session_id,
+			],
+			$data['payload_recovery']
+		);
 		$this->assertNull( ActiveJobRepository::get_by_job_id( $job_id ) );
+	}
+
+	/** Error polling exposes only the validated continuation action metadata. */
+	public function test_job_status_exposes_safe_compact_continuation_recovery(): void {
+		wp_set_current_user( $this->admin_id );
+		$session_id = Database::create_session( [
+			'user_id' => $this->admin_id,
+			'title'   => 'Payload recovery status',
+		] );
+		$job_id     = '99999999-aaaa-bbbb-cccc-dddddddddddd';
+
+		set_transient(
+			RestController::JOB_PREFIX . $job_id,
+			[
+				'status'           => 'error',
+				'error'            => 'Request exceeded the local envelope budget.',
+				'params'           => [ 'session_id' => $session_id ],
+				'payload_recovery' => [
+					'action'            => 'compact_session',
+					'source_session_id' => $session_id,
+					'private_payload'   => 'MUST_NOT_ESCAPE',
+				],
+			],
+			RestController::JOB_TTL
+		);
+
+		$response = $this->dispatch( 'GET', "/sd-ai-agent/v1/job/{$job_id}" );
+
+		$this->assertStatus( 200, $response );
+		$data = $response->get_data();
+		$this->assertSame(
+			[
+				'action'            => 'compact_session',
+				'source_session_id' => $session_id,
+			],
+			$data['payload_recovery']
+		);
+		$this->assertStringNotContainsString( 'MUST_NOT_ESCAPE', (string) wp_json_encode( $data ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- measure the final serialized provider request envelope before dispatch and reject local oversize requests safely
- preserve the bounded upstream-413 retry only when the reduced full envelope is materially smaller
- add an explicit server-side compact-and-continue flow that preserves the source session and excludes raw tool and attachment payloads

Resolves #2356.

## Verification

- `npm run test:php -- --filter='AgentLoopTest|ConversationTrimmerTest|RestControllerTest|ProviderTraceLoggerResolveTest'`
- `npm run test:js -- --runInBand src/store/__tests__/index.test.js src/components/chat-redesign/__tests__/MessageList.test.js src/components/chat-widget/__tests__/widget-message-list.test.js`
- `npm run verify`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.191 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-terra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Compact and continue” recovery when provider payload limits are hit, with a dedicated compact session action card in the chat UI.
  * Added more detailed, validated recovery metadata surfaced during job error polling to support compact-session continuation.
* **Bug Fixes**
  * Improved 413/payload-rejection recovery and retry correctness using more accurate envelope byte budgeting.
  * Prevented reduced retries when the retried request isn’t materially smaller.
  * Preserved the source conversation content during compaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->