### PR TITLE
GH#2361: require target-site WooCommerce activation

### DIFF
--- a/includes/Abilities/WooCommerceAbilities.php
+++ b/includes/Abilities/WooCommerceAbilities.php
@@ -24,12 +24,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 final class WooCommerceAbilities {
 
-	private const INSPECT_ABILITY = 'sd-ai-agent/commerce-inspect';
-	private const PLAN_ABILITY    = 'sd-ai-agent/commerce-plan';
-	private const EXECUTE_ABILITY = 'sd-ai-agent/commerce-execute-approved-plan';
-	private const APPROVAL_ACTION = 'commerce-site-plan';
-	private const PLAN_VERSION    = 1;
-	private const TAXONOMY        = 'product_cat';
+	private const INSPECT_ABILITY    = 'sd-ai-agent/commerce-inspect';
+	private const PLAN_ABILITY       = 'sd-ai-agent/commerce-plan';
+	private const EXECUTE_ABILITY    = 'sd-ai-agent/commerce-execute-approved-plan';
+	private const APPROVAL_ACTION    = 'commerce-site-plan';
+	private const PLAN_VERSION       = 1;
+	private const TAXONOMY           = 'product_cat';
+	private const WOOCOMMERCE_PLUGIN = 'woocommerce/woocommerce.php';
 
 	/**
 	 * The only WooCommerce options that this ability family may change.
@@ -266,6 +267,13 @@ final class WooCommerceAbilities {
 					return self::target_permission_error( $target_blog_id );
 				}
 
+				if ( ! self::is_woocommerce_active_on_current_site() ) {
+					return [
+						'operations'    => [],
+						'prerequisites' => [ self::woocommerce_activation_prerequisite( $target_blog_id ) ],
+					];
+				}
+
 				if ( ! self::is_woocommerce_runtime_available() ) {
 					return [
 						'operations'    => [],
@@ -398,6 +406,10 @@ final class WooCommerceAbilities {
 						return self::target_permission_error( $target_blog_id );
 					}
 
+					if ( ! self::is_woocommerce_active_on_current_site() ) {
+						return new WP_Error( 'sd_ai_agent_commerce_prerequisite_changed', __( 'WooCommerce is no longer active for the approved target site.', 'superdav-ai-agent' ), [ 'status' => 409 ] );
+					}
+
 					if ( ! self::is_woocommerce_runtime_available() ) {
 						return new WP_Error( 'sd_ai_agent_commerce_prerequisite_changed', __( 'WooCommerce is no longer loaded for the approved target site.', 'superdav-ai-agent' ), [ 'status' => 409 ] );
 					}
@@ -450,7 +462,7 @@ final class WooCommerceAbilities {
 		return [
 			'blog_id'                => get_current_blog_id(),
 			'woocommerce'            => [
-				'plugin_active'     => self::is_plugin_active_on_current_site( 'woocommerce/woocommerce.php' ),
+				'plugin_active'     => self::is_woocommerce_active_on_current_site(),
 				'runtime_available' => self::is_woocommerce_runtime_available(),
 				'version'           => defined( 'WC_VERSION' ) ? (string) constant( 'WC_VERSION' ) : '',
 			],
@@ -777,6 +789,11 @@ final class WooCommerceAbilities {
 		return class_exists( 'WooCommerce' ) && taxonomy_exists( self::TAXONOMY );
 	}
 
+	/** Return whether WooCommerce is active for the current site or network-wide. */
+	private static function is_woocommerce_active_on_current_site(): bool {
+		return self::is_plugin_active_on_current_site( self::WOOCOMMERCE_PLUGIN );
+	}
+
 	/**
 	 * Return active status for a plugin in the current site context.
 	 */
@@ -876,6 +893,19 @@ final class WooCommerceAbilities {
 	}
 
 	/**
+	 * Build a prerequisite when WooCommerce is inactive on the target site.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private static function woocommerce_activation_prerequisite( int $target_blog_id ): array {
+		return [
+			'code'           => 'woocommerce_plugin_inactive',
+			'target_blog_id' => $target_blog_id,
+			'message'        => __( 'WooCommerce must be activated for the requested site or network-activated before a commerce plan can be approved.', 'superdav-ai-agent' ),
+		];
+	}
+
+	/**
 	 * Build a prerequisite when WooCommerce is not loaded on the target site.
 	 *
 	 * @return array<string,mixed>
@@ -884,7 +914,7 @@ final class WooCommerceAbilities {
 		return [
 			'code'           => 'woocommerce_runtime_unavailable',
 			'target_blog_id' => $target_blog_id,
-			'message'        => __( 'WooCommerce must be active and loaded on the requested site before a commerce plan can be approved.', 'superdav-ai-agent' ),
+			'message'        => __( 'WooCommerce must be loaded for the requested site before a commerce plan can be approved.', 'superdav-ai-agent' ),
 		];
 	}
 

--- a/tests/SdAiAgent/Abilities/WooCommerceAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/WooCommerceAbilitiesTest.php
@@ -23,10 +23,15 @@ class WooCommerceAbilitiesTestDouble {
 
 class WooCommerceAbilitiesTest extends WP_UnitTestCase {
 
+	private const WOOCOMMERCE_PLUGIN = 'woocommerce/woocommerce.php';
+
 	private int $admin_id;
 	private int $target_blog_id;
 	private int $other_blog_id;
 	private bool $registered_product_taxonomy = false;
+	/** @var array<string, mixed> */
+	private array $original_network_active_plugins = [];
+	private bool $network_active_plugins_changed = false;
 
 	public function set_up(): void {
 		parent::set_up();
@@ -38,6 +43,7 @@ class WooCommerceAbilitiesTest extends WP_UnitTestCase {
 		$this->admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
 		grant_super_admin( $this->admin_id );
 		wp_set_current_user( $this->admin_id );
+		$this->original_network_active_plugins = (array) get_site_option( 'active_sitewide_plugins', [] );
 
 		if ( ! taxonomy_exists( 'product_cat' ) ) {
 			register_taxonomy( 'product_cat', [ 'post' ] );
@@ -52,6 +58,7 @@ class WooCommerceAbilitiesTest extends WP_UnitTestCase {
 		$this->other_blog_id  = self::factory()->blog->create();
 		add_user_to_blog( $this->target_blog_id, $this->admin_id, 'administrator' );
 		add_user_to_blog( $this->other_blog_id, $this->admin_id, 'administrator' );
+		$this->set_plugin_active_for_blog( $this->target_blog_id, self::WOOCOMMERCE_PLUGIN, true );
 		$this->install_changes_log_table_for_blog( $this->target_blog_id );
 
 		Database::install();
@@ -62,6 +69,9 @@ class WooCommerceAbilitiesTest extends WP_UnitTestCase {
 	public function tear_down(): void {
 		ChangeLogger::end();
 		HumanApprovalGate::clear_handlers();
+		if ( $this->network_active_plugins_changed ) {
+			update_site_option( 'active_sitewide_plugins', $this->original_network_active_plugins );
+		}
 
 		if ( $this->registered_product_taxonomy ) {
 			unregister_taxonomy( 'product_cat' );
@@ -154,6 +164,73 @@ class WooCommerceAbilitiesTest extends WP_UnitTestCase {
 		$this->assertSame( 'yes', $this->get_option_for_blog( $this->target_blog_id, 'woocommerce_enable_coupons' ) );
 	}
 
+	public function test_network_active_woocommerce_allows_target_site_plan_execution(): void {
+		$this->set_option_for_blog( $this->target_blog_id, 'woocommerce_enable_coupons', 'yes' );
+		$this->set_plugin_active_for_blog( $this->target_blog_id, self::WOOCOMMERCE_PLUGIN, false );
+		$this->set_network_plugin_active( self::WOOCOMMERCE_PLUGIN, true );
+
+		$plan = WooCommerceAbilities::handle_create_plan(
+			[
+				'target_blog_id' => $this->target_blog_id,
+				'operations'     => [
+					[
+						'operation'   => 'update_setting',
+						'setting_key' => 'woocommerce_enable_coupons',
+						'value'       => 'no',
+					],
+				],
+			]
+		);
+
+		$this->assertIsArray( $plan );
+		$this->assertSame( 'pending_approval', $plan['status'] );
+
+		$approved = HumanApprovalGate::approve( (int) $plan['approval_request_id'], $this->admin_id );
+
+		$this->assertIsArray( $approved );
+		$this->assertSame( HumanApprovalGate::STATUS_EXECUTED, $approved['status'] );
+		$this->assertSame( 'no', $this->get_option_for_blog( $this->target_blog_id, 'woocommerce_enable_coupons' ) );
+	}
+
+	public function test_approved_plan_fails_when_woocommerce_is_inactive_on_target_site(): void {
+		$initial_blog_id = get_current_blog_id();
+		$this->set_option_for_blog( $this->target_blog_id, 'woocommerce_enable_coupons', 'yes' );
+
+		$plan = WooCommerceAbilities::handle_create_plan(
+			[
+				'target_blog_id' => $this->target_blog_id,
+				'operations'     => [
+					[
+						'operation' => 'create_category',
+						'name'      => 'Inactive Target Category',
+						'slug'      => 'inactive-target-category',
+					],
+					[
+						'operation'   => 'update_setting',
+						'setting_key' => 'woocommerce_enable_coupons',
+						'value'       => 'no',
+					],
+				],
+			]
+		);
+
+		$this->assertIsArray( $plan );
+		$this->assertSame( 'pending_approval', $plan['status'] );
+		$this->assertTrue( class_exists( 'WooCommerce' ), 'WooCommerce remains globally loaded for this request.' );
+		$this->assertTrue( taxonomy_exists( 'product_cat' ), 'The WooCommerce taxonomy remains globally registered for this request.' );
+
+		$this->set_plugin_active_for_blog( $this->target_blog_id, self::WOOCOMMERCE_PLUGIN, false );
+		$this->set_network_plugin_active( self::WOOCOMMERCE_PLUGIN, false );
+		$approved = HumanApprovalGate::approve( (int) $plan['approval_request_id'], $this->admin_id );
+
+		$this->assertInstanceOf( WP_Error::class, $approved );
+		$this->assertSame( 'sd_ai_agent_commerce_prerequisite_changed', $approved->get_error_code() );
+		$this->assertSame( $initial_blog_id, get_current_blog_id(), 'Failed execution must restore the caller blog.' );
+		$this->assertFalse( $this->term_exists_for_blog( $this->target_blog_id, 'Inactive Target Category' ) );
+		$this->assertSame( 'yes', $this->get_option_for_blog( $this->target_blog_id, 'woocommerce_enable_coupons' ) );
+		$this->assertSame( 0, $this->change_log_count_for_blog( $this->target_blog_id ) );
+	}
+
 	public function test_approved_plan_changes_only_target_site_and_restores_blog_context(): void {
 		$initial_blog_id = get_current_blog_id();
 		$this->set_option_for_blog( $this->target_blog_id, 'woocommerce_enable_coupons', 'yes' );
@@ -232,6 +309,32 @@ class WooCommerceAbilitiesTest extends WP_UnitTestCase {
 		switch_to_blog( $blog_id );
 		update_option( $option, $value );
 		restore_current_blog();
+	}
+
+	private function set_plugin_active_for_blog( int $blog_id, string $plugin_file, bool $active ): void {
+		switch_to_blog( $blog_id );
+		$active_plugins = array_values(
+			array_filter(
+				(array) get_option( 'active_plugins', [] ),
+				static fn( mixed $active_plugin ): bool => $plugin_file !== $active_plugin
+			)
+		);
+		if ( $active ) {
+			$active_plugins[] = $plugin_file;
+		}
+		update_option( 'active_plugins', $active_plugins );
+		restore_current_blog();
+	}
+
+	private function set_network_plugin_active( string $plugin_file, bool $active ): void {
+		$active_plugins = (array) get_site_option( 'active_sitewide_plugins', [] );
+		if ( $active ) {
+			$active_plugins[ $plugin_file ] = time();
+		} else {
+			unset( $active_plugins[ $plugin_file ] );
+		}
+		update_site_option( 'active_sitewide_plugins', $active_plugins );
+		$this->network_active_plugins_changed = true;
 	}
 
 	private function get_option_for_blog( int $blog_id, string $option ): string {


### PR DESCRIPTION
## Summary

Require WooCommerce to remain active on the exact target site before an approved commerce plan executes. The plan builder now reports an actionable prerequisite when the target lacks WooCommerce, while approved execution rechecks target-site activation before any taxonomy or option write.

Network-active WooCommerce remains valid for the target site.

## Files Changed

- `includes/Abilities/WooCommerceAbilities.php`
- `tests/SdAiAgent/Abilities/WooCommerceAbilitiesTest.php`

## Runtime Testing

- **Risk level:** Medium
- **Verification:** runtime-verified — `WP_MULTISITE=1 npm run test:php -- --filter="WooCommerceAbilitiesTest"` passed (7 tests, 48 assertions).

## Worker self-verification

- PHPUnit: Tests: 3980, Assertions: 17524, Errors: 0, Failures: 0, Skipped: 133, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Verify:  `npm run verify` passed, including bundle-size checks

Resolves #2361
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.192 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-terra spent 24m and 193,390 tokens on this as a headless worker.