### PR TITLE
GH#2354: feat: expose safe active-job failure diagnostics

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -188,6 +188,7 @@ System notices:
 - Reserve the red error surface for true failures that require troubleshooting.
 - Account-action notices (billing, connection, setup) should use `Surface Active` with `Border Accent`, `role="status"`, friendly action-oriented copy, and a single primary button-style link CTA when an action URL is available.
 - Avoid framing customer account actions as errors; do not surface provider phrases such as “rejected” or “insufficient” in the chat UI when a clearer next step is available.
+- Background-job failure cards use fixed, customer-safe copy with one next step, an optional safe last-completed phase, and a correlation ID for support. Never show provider errors, prompts, tool payloads, paths, or stack traces; only show a retry button when retry is the prescribed action.
 
 ### Cards (suggestion / template)
 

--- a/includes/Core/ActiveJobFailureDiagnostic.php
+++ b/includes/Core/ActiveJobFailureDiagnostic.php
@@ -1,0 +1,324 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Prompt-free terminal diagnostics for background agent jobs.
+ *
+ * @package SdAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Builds the compact, allowlisted diagnostic envelope stored for a failed job.
+ *
+ * Failure messages from providers and PHP exceptions are deliberately excluded:
+ * those values can echo prompts, tool input, credentials, paths, or stack traces.
+ */
+final class ActiveJobFailureDiagnostic {
+
+	/** Current persisted-envelope version. */
+	private const VERSION = 1;
+
+	/** Failure caused by the local request-size guard. */
+	public const REASON_LOCAL_PAYLOAD_GUARD = 'local_payload_guard';
+
+	/** Failure caused by an upstream request-size rejection. */
+	public const REASON_UPSTREAM_PAYLOAD_REJECTION = 'upstream_payload_rejection';
+
+	/** Failure caused by an upstream provider timeout. */
+	public const REASON_PROVIDER_TIMEOUT = 'provider_timeout';
+
+	/** Failure caused by a loopback request or worker terminating unexpectedly. */
+	public const REASON_WORKER_TERMINATED = 'worker_terminated';
+
+	/** Job is paused for an approval or client-side review. */
+	public const REASON_APPROVAL_WAIT = 'approval_wait';
+
+	/** Approval state expired before it could be completed safely. */
+	public const REASON_APPROVAL_EXPIRED = 'approval_expired';
+
+	/** Automatic resume budget was exhausted without a durable completion. */
+	public const REASON_RESUME_EXHAUSTED = 'resume_exhausted';
+
+	/** A caught loop exception left durable continuation state. */
+	public const REASON_LOOP_EXCEPTION = 'loop_exception';
+
+	/** Failure could not be classified without retaining unsafe detail. */
+	public const REASON_UNKNOWN = 'unknown';
+
+	/** @var list<string> Reasons that may be persisted or exposed to clients. */
+	private const REASONS = array(
+		self::REASON_LOCAL_PAYLOAD_GUARD,
+		self::REASON_UPSTREAM_PAYLOAD_REJECTION,
+		self::REASON_PROVIDER_TIMEOUT,
+		self::REASON_WORKER_TERMINATED,
+		self::REASON_APPROVAL_WAIT,
+		self::REASON_APPROVAL_EXPIRED,
+		self::REASON_RESUME_EXHAUSTED,
+		self::REASON_LOOP_EXCEPTION,
+		self::REASON_UNKNOWN,
+	);
+
+	/** @var list<string> Safe request-size classifications emitted by ProviderTraceLogger. */
+	private const REQUEST_SIZE_CLASSES = array( 'small', 'medium', 'large', 'very_large' );
+
+	/**
+	 * Build a safe diagnostic envelope from allowlisted metadata only.
+	 *
+	 * @param string               $job_id  Active-job UUID.
+	 * @param string               $reason  Normalized terminal reason.
+	 * @param array<string, mixed> $context Safe metadata supplied by the caller.
+	 * @return array<string, bool|int|string>
+	 */
+	public static function create( string $job_id, string $reason, array $context = array() ): array {
+		$reason = self::normalize_reason( $reason );
+
+		return array(
+			'version'            => self::VERSION,
+			'reason'             => $reason,
+			'last_safe_phase'    => self::sanitize_phase( (string) ( $context['last_safe_phase'] ?? '' ) ),
+			'resume_count'       => max( 0, (int) ( $context['resume_count'] ?? 0 ) ),
+			'provider_id'        => self::sanitize_identifier( (string) ( $context['provider_id'] ?? '' ) ),
+			'model_id'           => self::sanitize_identifier( (string) ( $context['model_id'] ?? '' ) ),
+			'request_size_class' => self::sanitize_request_size_class( (string) ( $context['request_size_class'] ?? '' ) ),
+			'retryable'          => self::is_retryable_reason( $reason ),
+			'next_action'        => self::next_action_for_reason( $reason ),
+			'correlation_id'     => self::correlation_id( $job_id ),
+		);
+	}
+
+	/**
+	 * Encode a diagnostic for the existing active_jobs.error column.
+	 *
+	 * @param string               $job_id     Active-job UUID.
+	 * @param array<string, mixed> $diagnostic Candidate diagnostic data.
+	 * @return string JSON envelope. Never returns unsafe caller-supplied detail.
+	 */
+	public static function encode( string $job_id, array $diagnostic ): string {
+		$normalized = self::create(
+			$job_id,
+			(string) ( $diagnostic['reason'] ?? self::REASON_UNKNOWN ),
+			$diagnostic
+		);
+		$encoded    = wp_json_encode( $normalized );
+
+		return is_string( $encoded ) ? $encoded : '';
+	}
+
+	/**
+	 * Decode a diagnostic envelope. Legacy free-text error rows intentionally
+	 * become an unknown diagnostic instead of exposing their historical content.
+	 *
+	 * @param string      $job_id Active-job UUID.
+	 * @param string|null $stored Stored active_jobs.error value.
+	 * @return array<string, bool|int|string>
+	 */
+	public static function from_stored( string $job_id, ?string $stored ): array {
+		$decoded = json_decode( (string) $stored, true );
+		if ( ! is_array( $decoded ) || self::VERSION !== (int) ( $decoded['version'] ?? 0 ) ) {
+			return self::create( $job_id, self::REASON_UNKNOWN );
+		}
+
+		return self::create( $job_id, (string) ( $decoded['reason'] ?? self::REASON_UNKNOWN ), $decoded );
+	}
+
+	/**
+	 * Classify a provider or loop WP_Error without retaining its message.
+	 *
+	 * Error messages are inspected only to recognize a timeout when an upstream
+	 * library does not supply a stable code. They are never returned, persisted,
+	 * or added to the diagnostic context.
+	 *
+	 * @param \WP_Error $error Provider or loop error.
+	 * @return string Normalized diagnostic reason.
+	 */
+	public static function reason_from_error( \WP_Error $error ): string {
+		$code = sanitize_key( (string) $error->get_error_code() );
+		$data = $error->get_error_data();
+		$data = is_array( $data ) ? $data : array();
+
+		if (
+			'sd_ai_agent_provider_payload_budget_exceeded' === $code ||
+			! empty( $data['local_rejection'] )
+		) {
+			return self::REASON_LOCAL_PAYLOAD_GUARD;
+		}
+
+		if ( 'sd_ai_agent_provider_payload_too_large' === $code || 413 === (int) ( $data['status_code'] ?? 0 ) ) {
+			return self::REASON_UPSTREAM_PAYLOAD_REJECTION;
+		}
+
+		if (
+			in_array( $code, array( 'sd_ai_agent_provider_timeout', 'sd_ai_agent_provider_retry_failed', 'timeout', 'timed_out', 'deadline_exceeded' ), true ) ||
+			in_array( (int) ( $data['status_code'] ?? 0 ), array( 408, 504, 524 ), true )
+		) {
+			return self::REASON_PROVIDER_TIMEOUT;
+		}
+
+		$message = strtolower( $error->get_error_message() );
+		if ( str_contains( $message, 'timed out' ) || str_contains( $message, 'timeout' ) || str_contains( $message, 'deadline exceeded' ) ) {
+			return self::REASON_PROVIDER_TIMEOUT;
+		}
+
+		return self::REASON_UNKNOWN;
+	}
+
+	/**
+	 * Extract allowlisted diagnostic context from a WP_Error data payload.
+	 *
+	 * @param array<string, mixed> $data Error data.
+	 * @return array<string, string>
+	 */
+	public static function context_from_error_data( array $data ): array {
+		$context = array(
+			'provider_id'        => (string) ( $data['provider_id'] ?? '' ),
+			'model_id'           => (string) ( $data['model_id'] ?? '' ),
+			'request_size_class' => (string) ( $data['request_size_class'] ?? '' ),
+		);
+
+		if ( '' === $context['request_size_class'] ) {
+			$request_bytes = max( 0, (int) ( $data['request_bytes'] ?? $data['request_bytes_estimate'] ?? 0 ) );
+			if ( $request_bytes > 0 ) {
+				$context['request_size_class'] = ProviderTraceLogger::classify_request_size( $request_bytes );
+			}
+		}
+
+		return $context;
+	}
+
+	/**
+	 * Build the safe REST DTO for a persisted diagnostic.
+	 *
+	 * @param array<string, bool|int|string> $diagnostic Diagnostic envelope.
+	 * @return array<string, bool|int|string>
+	 */
+	public static function to_rest( array $diagnostic ): array {
+		return array(
+			'reason'             => (string) $diagnostic['reason'],
+			'last_safe_phase'    => (string) $diagnostic['last_safe_phase'],
+			'resume_count'       => (int) $diagnostic['resume_count'],
+			'provider_id'        => (string) $diagnostic['provider_id'],
+			'model_id'           => (string) $diagnostic['model_id'],
+			'request_size_class' => (string) $diagnostic['request_size_class'],
+			'retryable'          => (bool) $diagnostic['retryable'],
+			'next_action'        => (string) $diagnostic['next_action'],
+			'correlation_id'     => (string) $diagnostic['correlation_id'],
+		);
+	}
+
+	/**
+	 * Return a customer-safe, fixed recovery message for a normalized reason.
+	 */
+	public static function message_for( string $reason ): string {
+		return match ( self::normalize_reason( $reason ) ) {
+			self::REASON_LOCAL_PAYLOAD_GUARD => __( 'This request is too large to send safely. Compact the conversation, shorten the latest message, or remove large attachments before retrying.', 'superdav-ai-agent' ),
+			self::REASON_UPSTREAM_PAYLOAD_REJECTION => __( 'The selected AI provider rejected this request because it exceeds its payload limit. Start a smaller continuation and retry.', 'superdav-ai-agent' ),
+			self::REASON_PROVIDER_TIMEOUT => __( 'The AI provider timed out before finishing. Retry the request shortly.', 'superdav-ai-agent' ),
+			self::REASON_WORKER_TERMINATED => __( 'The background worker stopped before the job could finish. Retry the job or start a continuation from the saved conversation.', 'superdav-ai-agent' ),
+			self::REASON_APPROVAL_WAIT => __( 'This job is waiting for approval before it can continue.', 'superdav-ai-agent' ),
+			self::REASON_APPROVAL_EXPIRED => __( 'The pending approval expired before it could be completed. Review the conversation and start a continuation.', 'superdav-ai-agent' ),
+			self::REASON_RESUME_EXHAUSTED => __( 'The job could not make progress after its automatic recovery attempts. Start a continuation from the saved conversation.', 'superdav-ai-agent' ),
+			self::REASON_LOOP_EXCEPTION => __( 'The background job stopped unexpectedly. Start a continuation from the saved conversation or contact support with the correlation ID.', 'superdav-ai-agent' ),
+			default => __( 'The background agent job could not finish. Retry the request, or contact support with the correlation ID if the problem continues.', 'superdav-ai-agent' ),
+		};
+	}
+
+	/**
+	 * Emit only prompt-free failure telemetry through the allowlisted event log.
+	 *
+	 * @param array<string, bool|int|string> $diagnostic Diagnostic envelope.
+	 * @param int                            $session_id Session identifier.
+	 */
+	public static function log( array $diagnostic, int $session_id ): void {
+		AgentEventLog::log(
+			'active_job_failure',
+			AgentEventLog::SEVERITY_ERROR,
+			array(
+				'session_id'         => max( 0, $session_id ),
+				'code'               => (string) $diagnostic['reason'],
+				'reason'             => (string) $diagnostic['reason'],
+				'phase'              => (string) $diagnostic['last_safe_phase'],
+				'resume_count'       => (int) $diagnostic['resume_count'],
+				'provider_id'        => (string) $diagnostic['provider_id'],
+				'model_id'           => (string) $diagnostic['model_id'],
+				'request_size_class' => (string) $diagnostic['request_size_class'],
+				'retryable'          => (bool) $diagnostic['retryable'],
+				'next_action'        => (string) $diagnostic['next_action'],
+				'correlation_id'     => (string) $diagnostic['correlation_id'],
+			)
+		);
+	}
+
+	/** Normalize a candidate failure reason against the shipped allowlist. */
+	private static function normalize_reason( string $reason ): string {
+		$reason = sanitize_key( $reason );
+
+		return in_array( $reason, self::REASONS, true ) ? $reason : self::REASON_UNKNOWN;
+	}
+
+	/** Return whether the reason is safe to retry without changing the request. */
+	private static function is_retryable_reason( string $reason ): bool {
+		return in_array(
+			$reason,
+			array(
+				self::REASON_PROVIDER_TIMEOUT,
+				self::REASON_WORKER_TERMINATED,
+				self::REASON_APPROVAL_WAIT,
+				self::REASON_UNKNOWN,
+			),
+			true
+		);
+	}
+
+	/** Return the next user action for a normalized failure reason. */
+	private static function next_action_for_reason( string $reason ): string {
+		return match ( $reason ) {
+			self::REASON_LOCAL_PAYLOAD_GUARD,
+			self::REASON_UPSTREAM_PAYLOAD_REJECTION => 'compact',
+			self::REASON_PROVIDER_TIMEOUT,
+			self::REASON_WORKER_TERMINATED => 'retry',
+			self::REASON_APPROVAL_WAIT => 'approve_review',
+			self::REASON_APPROVAL_EXPIRED,
+			self::REASON_RESUME_EXHAUSTED,
+			self::REASON_LOOP_EXCEPTION => 'continuation',
+			default => 'contact_support',
+		};
+	}
+
+	/** Keep a checkpoint phase to a short, machine-readable token. */
+	private static function sanitize_phase( string $phase ): string {
+		$phase = sanitize_key( $phase );
+
+		return substr( $phase, 0, 60 );
+	}
+
+	/** Keep provider and model identifiers free of free-text request content. */
+	private static function sanitize_identifier( string $identifier ): string {
+		$identifier = sanitize_text_field( $identifier );
+		$identifier = preg_replace( '/[^A-Za-z0-9._:-]/', '', $identifier );
+
+		return is_string( $identifier ) ? substr( $identifier, 0, 100 ) : '';
+	}
+
+	/** Normalize a request-size classification emitted by ProviderTraceLogger. */
+	private static function sanitize_request_size_class( string $size_class ): string {
+		$size_class = sanitize_key( $size_class );
+
+		return in_array( $size_class, self::REQUEST_SIZE_CLASSES, true ) ? $size_class : '';
+	}
+
+	/** Build a stable support correlation ID without exposing the raw job UUID. */
+	private static function correlation_id( string $job_id ): string {
+		if ( '' === $job_id ) {
+			return 'job-unknown';
+		}
+
+		return 'job-' . substr( hash( 'sha256', $job_id ), 0, 12 );
+	}
+}

--- a/includes/Core/ActiveJobsCleanupService.php
+++ b/includes/Core/ActiveJobsCleanupService.php
@@ -55,6 +55,9 @@ class ActiveJobsCleanupService {
 	 */
 	const DEFAULT_THRESHOLD_MINUTES = 15;
 
+	/** Default bounded retention window for undelivered terminal diagnostics. */
+	const DEFAULT_DIAGNOSTIC_RETENTION_DAYS = 7;
+
 	// ── Registration ─────────────────────────────────────────────────────
 
 	/**
@@ -112,6 +115,14 @@ class ActiveJobsCleanupService {
 		$threshold = max( 1, $threshold );
 
 		$count = ActiveJobRepository::cleanup_stale( $threshold );
+		/**
+		 * Filter the number of days to retain undelivered terminal job diagnostics.
+		 *
+		 * @param int $days Retention period in days.
+		 */
+		$retention_days = (int) apply_filters( 'sd_ai_agent_job_diagnostic_retention_days', self::DEFAULT_DIAGNOSTIC_RETENTION_DAYS );
+		$retention_days = max( 1, $retention_days );
+		$pruned         = ActiveJobRepository::cleanup_terminal_diagnostics( $retention_days );
 
 		if ( $count > 0 ) {
 			/**
@@ -120,6 +131,15 @@ class ActiveJobsCleanupService {
 			 * @param int $count Number of rows reaped.
 			 */
 			do_action( 'sd_ai_agent_stale_jobs_reaped', $count );
+		}
+
+		if ( $pruned > 0 ) {
+			/**
+			 * Fired after expired terminal active-job diagnostics are pruned.
+			 *
+			 * @param int $pruned Number of terminal rows deleted.
+			 */
+			do_action( 'sd_ai_agent_terminal_job_diagnostics_pruned', $pruned );
 		}
 	}
 }

--- a/includes/Core/AgentEventLog.php
+++ b/includes/Core/AgentEventLog.php
@@ -113,6 +113,10 @@ class AgentEventLog {
 		'local_rejection',
 		'fallback_attempted',
 		'payload_reduced',
+		'correlation_id',
+		'resume_count',
+		'retryable',
+		'next_action',
 	);
 
 	/**

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -223,9 +223,6 @@ class AgentLoop {
 	 */
 	private string $active_job_id = '';
 
-	/** @var float Unix timestamp when this active-job run started. */
-	private float $active_job_started_at = 0.0;
-
 	/** @var array<string, mixed> Resume metadata carried forward from a claimed checkpoint. */
 	private array $checkpoint_resume_metadata = array();
 
@@ -554,7 +551,6 @@ class AgentLoop {
 		// The handler is a no-op when the row is no longer 'processing'
 		// (i.e. the loop finished normally and updated the status first).
 		if ( '' !== $this->active_job_id ) {
-			$this->active_job_started_at = microtime( true );
 			register_shutdown_function( array( $this, 'handle_active_job_shutdown' ) );
 		}
 
@@ -606,7 +602,8 @@ class AgentLoop {
 	 * The database update is guarded by status='processing', so this method is a
 	 * no-op after normal completion/error persistence. When PHP terminates during
 	 * a provider call or ability execution, the row now records the last loop
-	 * phase and any fatal shutdown error instead of a generic interruption note.
+	 * phase and a normalized fatal error code instead of a generic interruption
+	 * note. Raw fatal messages, paths, and traces are never retained.
 	 *
 	 * @return void
 	 */
@@ -615,38 +612,17 @@ class AgentLoop {
 			return;
 		}
 
-		$connection_status = connection_status();
-		if ( CONNECTION_ABORTED === $connection_status ) {
-			$reason = 'shutdown handler — client disconnected before loop completion';
-		} elseif ( CONNECTION_TIMEOUT === $connection_status ) {
-			$reason = 'shutdown handler — PHP request timed out before loop completion';
-		} else {
-			$reason = 'shutdown handler — request terminated without loop completion';
-		}
-
-		$elapsed               = $this->active_job_started_at > 0
-			? max( 0, (int) round( microtime( true ) - $this->active_job_started_at ) )
-			: 0;
 		$interrupted_phase     = $this->last_loop_phase;
 		$this->last_loop_phase = 'shutdown';
-
-		$details = array(
-			'phase=' . $interrupted_phase,
-			'iteration=' . $this->iterations_used . '/' . (int) $this->max_iterations,
-			'elapsed_s=' . $elapsed,
-			'connection_status=' . $this->format_connection_status( $connection_status ),
-			'memory_peak=' . (int) memory_get_peak_usage( true ),
+		$context               = array(
+			'last_safe_phase' => $interrupted_phase,
+			'provider_id'     => (string) $this->provider_id,
+			'model_id'        => (string) $this->model_id,
 		);
 
 		$last_error = error_get_last();
 		if ( is_array( $last_error ) && $this->is_fatal_shutdown_error( $last_error ) ) {
-			$message   = (string) $last_error['message'];
-			$file      = (string) $last_error['file'];
-			$line      = (int) $last_error['line'];
-			$type      = (int) $last_error['type'];
-			$details[] = 'fatal_type=' . $type;
-			$details[] = 'fatal=redacted';
-			$details[] = 'fatal_code=php_shutdown_' . $type;
+			$type = (int) $last_error['type'];
 
 			AgentEventLog::log(
 				'active_job_shutdown_fatal',
@@ -655,36 +631,12 @@ class AgentLoop {
 					'session_id' => $this->session_id,
 					'code'       => 'php_shutdown_' . $type,
 					'reason'     => 'fatal_shutdown',
-					'message'    => $this->shorten_shutdown_detail( $message . ( '' !== $file ? ' in ' . $file . ':' . $line : '' ) ),
+					'phase'      => $interrupted_phase,
 				)
 			);
-		} else {
-			$details[] = 'fatal=none';
 		}
 
-		ActiveJobRepository::mark_interrupted( $this->active_job_id, $reason . '; ' . implode( '; ', $details ) );
-	}
-
-	/**
-	 * Format a PHP connection status bitmask for shutdown diagnostics.
-	 *
-	 * @param int $status PHP connection_status() bitmask.
-	 * @return string Human-readable status label.
-	 */
-	private function format_connection_status( int $status ): string {
-		if ( CONNECTION_NORMAL === $status ) {
-			return 'normal';
-		}
-
-		$labels = array();
-		if ( ( $status & CONNECTION_ABORTED ) === CONNECTION_ABORTED ) {
-			$labels[] = 'aborted';
-		}
-		if ( ( $status & CONNECTION_TIMEOUT ) === CONNECTION_TIMEOUT ) {
-			$labels[] = 'timeout';
-		}
-
-		return empty( $labels ) ? (string) $status : implode( '+', $labels );
+		ActiveJobRepository::mark_interrupted( $this->active_job_id, '', $context );
 	}
 
 	/**
@@ -701,22 +653,6 @@ class AgentLoop {
 			array( E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR ),
 			true
 		);
-	}
-
-	/**
-	 * Keep shutdown details compact enough for active_jobs.error.
-	 *
-	 * @param string $detail Raw shutdown detail.
-	 * @return string Trimmed detail.
-	 */
-	private function shorten_shutdown_detail( string $detail ): string {
-		$detail = trim( preg_replace( '/\s+/', ' ', $detail ) ?? $detail );
-
-		if ( strlen( $detail ) <= 220 ) {
-			return $detail;
-		}
-
-		return substr( $detail, 0, 217 ) . '...';
 	}
 
 	/**
@@ -809,7 +745,6 @@ class AgentLoop {
 			ProviderCredentialLoader::load();
 
 			if ( '' !== $this->active_job_id ) {
-				$this->active_job_started_at = microtime( true );
 				register_shutdown_function( array( $this, 'handle_active_job_shutdown' ) );
 			}
 

--- a/includes/Models/ActiveJobRepository.php
+++ b/includes/Models/ActiveJobRepository.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Models;
 
+use SdAiAgent\Core\ActiveJobFailureDiagnostic;
 use SdAiAgent\Models\DTO\ActiveJobRow;
 
 class ActiveJobRepository {
@@ -174,6 +175,15 @@ class ActiveJobRepository {
 
 		$allowed = [ 'pending_tools', 'tool_calls', 'checkpoint', 'checkpoint_phase', 'resume_attempts', 'error' ];
 		$data    = array_intersect_key( $extra, array_flip( $allowed ) );
+		if ( array_key_exists( 'error', $data ) ) {
+			$data['error'] = ActiveJobFailureDiagnostic::encode(
+				$job_id,
+				ActiveJobFailureDiagnostic::from_stored(
+					$job_id,
+					is_string( $data['error'] ) ? $data['error'] : null
+				)
+			);
+		}
 
 		$data['status']     = $status;
 		$data['updated_at'] = current_time( 'mysql', true );
@@ -190,6 +200,33 @@ class ActiveJobRepository {
 		);
 
 		return $result !== false;
+	}
+
+	/**
+	 * Persist a normalized, prompt-free terminal failure and emit safe telemetry.
+	 *
+	 * @param string               $job_id  Active-job UUID.
+	 * @param string               $status  Terminal status (error, interrupted, or abandoned).
+	 * @param string               $reason  Normalized terminal reason.
+	 * @param array<string, mixed> $context Safe diagnostic metadata.
+	 * @param array<string, mixed> $extra   Additional persisted active-job fields.
+	 * @return array<string, bool|int|string> Persisted diagnostic envelope.
+	 */
+	public static function record_failure( string $job_id, string $status, string $reason, array $context = array(), array $extra = array() ): array {
+		$row            = self::get_by_job_id( $job_id );
+		$diagnostic     = self::build_failure_diagnostic( $job_id, $reason, $row, $context );
+		$session_id     = null !== $row ? $row->session_id : 0;
+		$extra['error'] = ActiveJobFailureDiagnostic::encode( $job_id, $diagnostic );
+
+		if ( ! in_array( $status, array( 'error', 'interrupted', 'abandoned' ), true ) ) {
+			$status = 'error';
+		}
+
+		if ( self::update_status( $job_id, $status, $extra ) ) {
+			ActiveJobFailureDiagnostic::log( $diagnostic, $session_id );
+		}
+
+		return $diagnostic;
 	}
 
 	/**
@@ -305,29 +342,43 @@ class ActiveJobRepository {
 	 * updates the row when the status is still 'processing' so a normally-
 	 * completed job that finished just before shutdown is not overwritten.
 	 *
-	 * @param string $job_id The job UUID.
-	 * @param string $reason Human-readable reason for the interruption.
+	 * @param string               $job_id  The job UUID.
+	 * @param string               $reason  Retained for call-site compatibility; never persisted as free text.
+	 * @param array<string, mixed> $context Safe diagnostic metadata.
 	 * @return bool True on success, false on failure.
 	 */
-	public static function mark_interrupted( string $job_id, string $reason ): bool {
+	public static function mark_interrupted( string $job_id, string $reason = '', array $context = array() ): bool {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 
-		$now = current_time( 'mysql', true );
+		$row        = self::get_by_job_id( $job_id );
+		$diagnostic = self::build_failure_diagnostic(
+			$job_id,
+			ActiveJobFailureDiagnostic::REASON_WORKER_TERMINATED,
+			$row,
+			$context
+		);
+		$session_id = null !== $row ? $row->session_id : 0;
+		$now        = current_time( 'mysql', true );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
 		$result = $wpdb->query(
 			$wpdb->prepare(
 				"UPDATE %i SET status = 'interrupted', error = %s, interrupted_at = %s, updated_at = %s WHERE job_id = %s AND status = 'processing'",
 				self::table_name(),
-				$reason,
+				ActiveJobFailureDiagnostic::encode( $job_id, $diagnostic ),
 				$now,
 				$now,
 				$job_id
 			)
 		);
 
-		return $result !== false && $result > 0;
+		$updated = $result !== false && $result > 0;
+		if ( $updated ) {
+			ActiveJobFailureDiagnostic::log( $diagnostic, $session_id );
+		}
+
+		return $updated;
 	}
 
 	/**
@@ -343,16 +394,108 @@ class ActiveJobRepository {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 
+		$table = self::table_name();
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
-		$result = $wpdb->query(
+		$rows  = $wpdb->get_results(
 			$wpdb->prepare(
-				"UPDATE %i SET status = 'abandoned', updated_at = UTC_TIMESTAMP() WHERE status = 'processing' AND updated_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL %d MINUTE)",
-				self::table_name(),
+				"SELECT * FROM %i WHERE status = 'processing' AND updated_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL %d MINUTE)",
+				$table,
 				$threshold_minutes
 			)
 		);
+		$count = 0;
 
-		return (int) $result;
+		foreach ( $rows ?: array() as $raw_row ) {
+			$row        = ActiveJobRow::from_row( $raw_row );
+			$diagnostic = self::build_failure_diagnostic(
+				$row->job_id,
+				ActiveJobFailureDiagnostic::REASON_WORKER_TERMINATED,
+				$row
+			);
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Conditional custom-table state transition.
+			$result = $wpdb->query(
+				$wpdb->prepare(
+					"UPDATE %i SET status = 'abandoned', error = %s, updated_at = UTC_TIMESTAMP() WHERE job_id = %s AND status = 'processing'",
+					$table,
+					ActiveJobFailureDiagnostic::encode( $row->job_id, $diagnostic ),
+					$row->job_id
+				)
+			);
+
+			if ( $result !== false && $result > 0 ) {
+				++$count;
+				ActiveJobFailureDiagnostic::log( $diagnostic, $row->session_id );
+			}
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Replace exhausted auto-recovery state with a compact continuation hint.
+	 *
+	 * Clearing the checkpoint prevents stale prompt history from being retained
+	 * after it can no longer be resumed automatically.
+	 *
+	 * @param string $job_id Active-job UUID.
+	 */
+	public static function mark_resume_exhausted( string $job_id ): void {
+		$row = self::get_by_job_id( $job_id );
+		if ( null === $row ) {
+			return;
+		}
+
+		self::record_failure(
+			$job_id,
+			$row->status,
+			ActiveJobFailureDiagnostic::REASON_RESUME_EXHAUSTED,
+			array(
+				'last_safe_phase' => $row->checkpoint_phase,
+				'resume_count'    => $row->resume_attempts,
+			),
+			array( 'checkpoint' => '' )
+		);
+	}
+
+	/**
+	 * Delete terminal rows after the diagnostic retention window expires.
+	 *
+	 * @param int $retention_days Number of days to retain undelivered terminal diagnostics.
+	 * @return int Number of deleted rows.
+	 */
+	public static function cleanup_terminal_diagnostics( int $retention_days ): int {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$retention_days = max( 1, $retention_days );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom-table data-retention cleanup.
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM %i WHERE status IN ('complete', 'error', 'interrupted', 'abandoned') AND updated_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL %d DAY)",
+				self::table_name(),
+				$retention_days
+			)
+		);
+
+		return $result === false ? 0 : (int) $result;
+	}
+
+	/**
+	 * Build an allowlisted diagnostic using the row's durable metadata.
+	 *
+	 * @param string               $job_id  Active-job UUID.
+	 * @param string               $reason  Normalized failure reason.
+	 * @param ActiveJobRow|null    $row     Existing row, when available.
+	 * @param array<string, mixed> $context Caller-supplied safe metadata.
+	 * @return array<string, bool|int|string>
+	 */
+	private static function build_failure_diagnostic( string $job_id, string $reason, ?ActiveJobRow $row, array $context = array() ): array {
+		$defaults = array(
+			'last_safe_phase' => null !== $row ? $row->checkpoint_phase : '',
+			'resume_count'    => null !== $row ? $row->resume_attempts : 0,
+		);
+
+		return ActiveJobFailureDiagnostic::create( $job_id, $reason, array_merge( $defaults, $context ) );
 	}
 
 	/**

--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -30,6 +30,7 @@ namespace SdAiAgent\REST;
 
 use SdAiAgent\Core\AgentLoop;
 use SdAiAgent\Core\AgentEventLog;
+use SdAiAgent\Core\ActiveJobFailureDiagnostic;
 use SdAiAgent\Core\ClientAbilityRouter;
 use SdAiAgent\Core\ConversationSerializer;
 use SdAiAgent\Core\ConversationTrimmer;
@@ -621,7 +622,15 @@ Assistant: %s',
 			// pending client tool call. Without this, the transient still
 			// says 'awaiting_client_tools' and the next poll cycle produces
 			// an infinite 409 loop on /chat/tool-result.
-			self::mark_job_error_after_resume( $job_id, $result->get_error_message() );
+			self::mark_job_error_after_resume(
+				$job_id,
+				$result,
+				array(
+					'last_safe_phase' => 'client_tool_resume',
+					'provider_id'     => $options['provider_id'],
+					'model_id'        => $options['model_id'],
+				)
+			);
 
 			return $result;
 		}
@@ -824,21 +833,32 @@ Assistant: %s',
 	 * (paused_state was already consumed before resume_after_client_tools
 	 * ran).
 	 *
-	 * @param string $job_id        Job UUID supplied by the browser. No-op when empty.
-	 * @param string $error_message Human-readable error from the WP_Error.
+	 * @param string               $job_id  Job UUID supplied by the browser. No-op when empty.
+	 * @param WP_Error             $error   Error returned by the resumed loop.
+	 * @param array<string, mixed> $context Allowlisted diagnostic metadata.
 	 */
-	private static function mark_job_error_after_resume( string $job_id, string $error_message ): void {
+	private static function mark_job_error_after_resume( string $job_id, WP_Error $error, array $context = array() ): void {
 		if ( '' === $job_id ) {
 			return;
 		}
 
 		$transient_key = self::JOB_PREFIX . $job_id;
 		$job           = get_transient( $transient_key );
+		$error_data    = $error->get_error_data();
+		$error_data    = is_array( $error_data ) ? $error_data : array();
+		$context       = array_merge( ActiveJobFailureDiagnostic::context_from_error_data( $error_data ), $context );
+		$diagnostic    = ActiveJobRepository::record_failure(
+			$job_id,
+			'error',
+			ActiveJobFailureDiagnostic::reason_from_error( $error ),
+			$context
+		);
 
 		if ( is_array( $job ) ) {
-			unset( $job['token'] );
-			$job['status'] = 'error';
-			$job['error']  = $error_message;
+			unset( $job['token'], $job['tool_calls'], $job['messages'] );
+			$job['status']     = 'error';
+			$job['error']      = ActiveJobFailureDiagnostic::message_for( (string) $diagnostic['reason'] );
+			$job['diagnostic'] = ActiveJobFailureDiagnostic::to_rest( $diagnostic );
 
 			// Drop stale pending-call hints so a transient-served poll cannot
 			// re-emit 'awaiting_client_tools' for the next browser poll.
@@ -846,10 +866,6 @@ Assistant: %s',
 
 			set_transient( $transient_key, $job, self::JOB_TTL );
 		}
-
-		// Update the DB row so the transient-expiry fallback also serves
-		// 'error' rather than the stale 'awaiting_client_tools'.
-		ActiveJobRepository::update_status( $job_id, 'error', [ 'error' => $error_message ] );
 	}
 
 	/**
@@ -888,15 +904,18 @@ Assistant: %s',
 			// on 'complete' or 'error' that a prior POST already produced.
 			if ( 'awaiting_client_tools' === $current_status ) {
 				unset( $job['token'], $job['pending_client_tool_calls'] );
-				$job['status'] = 'error';
-				$job['error']  = __(
-					'Client tool result arrived after the agent state had already been resumed or expired.',
-					'superdav-ai-agent'
+				$diagnostic = ActiveJobRepository::record_failure(
+					$job_id,
+					'error',
+					ActiveJobFailureDiagnostic::REASON_APPROVAL_EXPIRED,
+					array( 'last_safe_phase' => 'awaiting_client_tools' )
 				);
+				unset( $job['tool_calls'], $job['messages'] );
+				$job['status']     = 'error';
+				$job['error']      = ActiveJobFailureDiagnostic::message_for( (string) $diagnostic['reason'] );
+				$job['diagnostic'] = ActiveJobFailureDiagnostic::to_rest( $diagnostic );
 
 				set_transient( $transient_key, $job, self::JOB_TTL );
-
-				ActiveJobRepository::update_status( $job_id, 'error', [ 'error' => (string) $job['error'] ] );
 			}
 
 			return;
@@ -906,12 +925,11 @@ Assistant: %s',
 		// advertises the stale 'awaiting_client_tools' status.
 		$db_row = ActiveJobRepository::get_by_job_id( $job_id );
 		if ( null !== $db_row && 'awaiting_client_tools' === $db_row->status ) {
-			ActiveJobRepository::update_status(
+			ActiveJobRepository::record_failure(
 				$job_id,
 				'error',
-				[
-					'error' => __( 'Client tool result arrived after the agent state had already been resumed or expired.', 'superdav-ai-agent' ),
-				]
+				ActiveJobFailureDiagnostic::REASON_APPROVAL_EXPIRED,
+				array( 'last_safe_phase' => 'awaiting_client_tools' )
 			);
 		}
 	}

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -14,13 +14,13 @@ namespace SdAiAgent\REST;
 use SdAiAgent\Abilities\Js\JsAbilityCatalog;
 use SdAiAgent\Core\AgentLoop;
 use SdAiAgent\Core\AgentEventLog;
+use SdAiAgent\Core\ActiveJobFailureDiagnostic;
 use SdAiAgent\Core\ConversationDisplaySanitizer;
 use SdAiAgent\Core\ConversationSerializer;
 use SdAiAgent\Core\ConversationTrimmer;
 use SdAiAgent\Core\CostCalculator;
 use SdAiAgent\Core\Database;
 use SdAiAgent\Core\Export;
-use SdAiAgent\Core\JobErrorSanitizer;
 use SdAiAgent\Core\Settings;
 use SdAiAgent\Core\ToolPermissionResolver;
 use SdAiAgent\Models\ActiveJobRepository;
@@ -57,9 +57,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 final class SessionController {
 
 	use PermissionTrait;
-
-	/** Maximum safe technical-detail length returned by job status polling. */
-	private const JOB_ERROR_DETAIL_MAX_LENGTH = 180;
 
 	/** Maximum automatic resume attempts for a crashed background job. */
 	private const JOB_AUTO_RESUME_MAX_ATTEMPTS = 2;
@@ -1235,17 +1232,10 @@ final class SessionController {
 				);
 			}
 			if ( $this->discard_expired_paused_job( $db_row ) ) {
-				// A paused job needs the transient's serialized loop state to resume.
-				// Never resurrect its DB-only tool list as a confirmation dialog: the
-				// subsequent confirm/reject request cannot safely execute it.
-				return new WP_REST_Response(
-					array(
-						'status'     => 'expired',
-						'from_db'    => true,
-						'session_id' => $db_row->session_id,
-					),
-					200
-				);
+				$expired_row = ActiveJobRepository::get_by_job_id( $job_id );
+				if ( null !== $expired_row ) {
+					return $this->job_status_from_db_row( $job_id, $expired_row );
+				}
 			}
 			return $this->job_status_from_db_row( $job_id, $db_row );
 		}
@@ -1327,13 +1317,9 @@ final class SessionController {
 			ActiveJobRepository::delete( $job_id );
 		}
 
-		if ( 'error' === $job['status'] && isset( $job['error'] ) ) {
+		if ( 'error' === $job['status'] ) {
 			$job_session_id = $this->get_job_session_id( $job );
-			$error_context  = array(
-				'job_id'        => $job_id,
-				'session_id'    => $job_session_id,
-				'error_context' => $job['error_context'] ?? null,
-			);
+			unset( $response['tool_calls'], $response['messages'] );
 
 			if ( $job_session_id > 0 ) {
 				$response['session_id'] = $job_session_id;
@@ -1341,34 +1327,7 @@ final class SessionController {
 			if ( ! empty( $job['recoverable'] ) ) {
 				$response['recoverable'] = true;
 			}
-
-			/**
-			 * Filter the error message returned to the chat client.
-			 *
-			 * Companion plugins that raise their own AI-related errors
-			 * (usage caps, billing, content-policy gates, etc.) can hook
-			 * here to rewrite the message into something more actionable
-			 * for the user — for example, by appending a Markdown link to
-			 * a checkout or settings page. The frontend renders the
-			 * returned string through its Markdown pipeline, so producers
-			 * may use Markdown syntax including links.
-			 *
-			 * @since 1.11.0
-			 *
-			 * @param string               $message       Raw error message from AgentLoop.
-			 * @param array<string, mixed> $error_context Context: job_id, session_id, error_context.
-			 */
-			$response['message'] = (string) apply_filters(
-				'sd_ai_agent_chat_error_message',
-				(string) $job['error'],
-				$error_context
-			);
-
-			// Forward backtrace context so the frontend can display
-			// actionable debugging details (file, line, abbreviated stack).
-			if ( ! empty( $job['error_context'] ) ) {
-				$response['error_context'] = $job['error_context'];
-			}
+			$this->add_transient_failure_response( $job_id, $job, $job_session_id, $response );
 
 			// Clean up.
 			delete_transient( RestController::JOB_PREFIX . $job_id );
@@ -1391,8 +1350,9 @@ final class SessionController {
 	 * @return WP_REST_Response
 	 */
 	private function job_status_from_db_row( string $job_id, ActiveJobRow $row ): WP_REST_Response {
-		$status   = $row->status;
-		$response = [
+		$original_status = $row->status;
+		$status          = $row->status;
+		$response        = [
 			'status'     => $status,
 			'from_db'    => true,
 			'session_id' => $row->session_id,
@@ -1419,6 +1379,14 @@ final class SessionController {
 			}
 		}
 
+		if ( in_array( $status, array( 'interrupted', 'abandoned' ), true ) ) {
+			$refreshed_row = ActiveJobRepository::get_by_job_id( $job_id );
+			if ( null !== $refreshed_row ) {
+				$row    = $refreshed_row;
+				$status = $row->status;
+			}
+		}
+
 		// Include tool-call progress when present.
 		$tool_calls = json_decode( $row->tool_calls, true );
 		if ( is_array( $tool_calls ) && ! empty( $tool_calls ) ) {
@@ -1440,28 +1408,19 @@ final class SessionController {
 			}
 		}
 
-		if ( 'error' === $status ) {
-			$error_detail        = $this->sanitize_job_error_detail( (string) $row->error );
-			$response['message'] = '' !== $error_detail
-				? $error_detail
-				: __( 'The background agent job failed before it could finish. Please retry the request.', 'superdav-ai-agent' );
+		if ( in_array( $status, array( 'error', 'interrupted', 'abandoned' ), true ) ) {
+			$diagnostic             = ActiveJobFailureDiagnostic::from_stored( $job_id, $row->error );
+			$response['diagnostic'] = ActiveJobFailureDiagnostic::to_rest( $diagnostic );
+			$response['message']    = $this->filter_failure_message( $diagnostic, $row->session_id );
 
 			if ( $this->session_has_recoverable_paused_state( $row->session_id ) ) {
 				$response['recoverable'] = true;
 			}
-		}
 
-		if ( in_array( $status, array( 'interrupted', 'abandoned' ), true ) ) {
-			$error_detail                = $this->sanitize_job_error_detail( (string) $row->error );
-			$response['status']          = 'error';
-			$response['original_status'] = $status;
-			$response['message']         = '' !== $error_detail
-				? sprintf(
-					/* translators: %s: technical interruption detail. */
-					__( 'The background agent job stopped before it could finish. Technical detail: %s', 'superdav-ai-agent' ),
-					$error_detail
-				)
-				: __( 'The background agent job stopped before it could finish. Please retry the request.', 'superdav-ai-agent' );
+			if ( 'error' !== $status ) {
+				$response['status']          = 'error';
+				$response['original_status'] = $original_status;
+			}
 		}
 
 		// Delete DB row on terminal-state delivery (mirrors the transient cleanup).
@@ -1848,9 +1807,17 @@ final class SessionController {
 	 */
 	private function terminal_checkpoint_resume( string $job_id, ActiveJobRow $row, string $reason, array $metadata, string $phase ): array {
 		$public_metadata = $this->checkpoint_resume_response_metadata( $metadata, $reason, $phase );
-		$detail          = sprintf( 'checkpoint_resume_%s; phase=%s; size_class=%s', $public_metadata['reason'], $public_metadata['phase'], $public_metadata['size_class'] );
 
-		ActiveJobRepository::update_status( $job_id, 'error', array( 'error' => $detail ) );
+		ActiveJobRepository::record_failure(
+			$job_id,
+			'error',
+			ActiveJobFailureDiagnostic::REASON_RESUME_EXHAUSTED,
+			array(
+				'last_safe_phase'    => $public_metadata['phase'],
+				'resume_count'       => $row->resume_attempts,
+				'request_size_class' => $public_metadata['size_class'],
+			)
+		);
 		AgentEventLog::log(
 			'checkpoint_resume_stopped',
 			AgentEventLog::SEVERITY_WARNING,
@@ -1875,6 +1842,18 @@ final class SessionController {
 	 * @return WP_REST_Response Terminal job-status response.
 	 */
 	private function checkpoint_resume_terminal_response( string $job_id, ActiveJobRow $row, array $metadata ): WP_REST_Response {
+		$stored_row = ActiveJobRepository::get_by_job_id( $job_id );
+		$diagnostic = null !== $stored_row
+			? ActiveJobFailureDiagnostic::from_stored( $job_id, $stored_row->error )
+			: ActiveJobFailureDiagnostic::create(
+				$job_id,
+				ActiveJobFailureDiagnostic::REASON_RESUME_EXHAUSTED,
+				array(
+					'last_safe_phase'    => $metadata['phase'],
+					'resume_count'       => $row->resume_attempts,
+					'request_size_class' => $metadata['size_class'],
+				)
+			);
 		ActiveJobRepository::delete( $job_id );
 
 		return new WP_REST_Response(
@@ -1883,7 +1862,8 @@ final class SessionController {
 				'from_db'           => true,
 				'session_id'        => $row->session_id,
 				'original_status'   => $row->status,
-				'message'           => __( 'The background job could not safely resume. Start a new request to continue.', 'superdav-ai-agent' ),
+				'message'           => $this->filter_failure_message( $diagnostic, $row->session_id ),
+				'diagnostic'        => ActiveJobFailureDiagnostic::to_rest( $diagnostic ),
 				'checkpoint_resume' => $metadata,
 			),
 			200
@@ -1908,17 +1888,74 @@ final class SessionController {
 	}
 
 	/**
-	 * Scrub active-job technical details before they are returned to REST clients.
+	 * Add a prompt-free diagnostic for a transient-backed failed job.
 	 *
-	 * Active-job rows may contain shutdown or provider details written from low-level
-	 * code paths. Keep the useful phase/status tokens but strip paths, stack traces,
-	 * credential-shaped fragments, and any known secret option names.
-	 *
-	 * @param string $detail Raw active_jobs.error value.
-	 * @return string Bounded, client-safe summary, or empty string when fully redacted.
+	 * @param string               $job_id     Active-job UUID.
+	 * @param array<string, mixed> $job        Job transient payload.
+	 * @param int                  $session_id Session identifier.
+	 * @param array<string, mixed> $response   REST response, updated by reference.
+	 * @return void
 	 */
-	private function sanitize_job_error_detail( string $detail ): string {
-		return JobErrorSanitizer::sanitize( $detail, self::JOB_ERROR_DETAIL_MAX_LENGTH );
+	private function add_transient_failure_response( string $job_id, array $job, int $session_id, array &$response ): void {
+		$stored_diagnostic = $job['diagnostic'] ?? array();
+		$stored_diagnostic = is_array( $stored_diagnostic ) ? $stored_diagnostic : array();
+		$diagnostic        = ActiveJobFailureDiagnostic::create(
+			$job_id,
+			(string) ( $stored_diagnostic['reason'] ?? ActiveJobFailureDiagnostic::REASON_UNKNOWN ),
+			$stored_diagnostic
+		);
+
+		$response['diagnostic'] = ActiveJobFailureDiagnostic::to_rest( $diagnostic );
+		$response['message']    = $this->filter_failure_message( $diagnostic, $session_id );
+	}
+
+	/**
+	 * Filter a fixed, prompt-free failure message with safe metadata only.
+	 *
+	 * @param array<string, bool|int|string> $diagnostic Safe diagnostic envelope.
+	 * @param int                            $session_id Session identifier.
+	 * @return string Customer-facing message.
+	 */
+	private function filter_failure_message( array $diagnostic, int $session_id ): string {
+		/**
+		 * Filter the prompt-free failure message returned to the chat client.
+		 *
+		 * @since 1.11.0
+		 *
+		 * @param string               $message    Fixed message for the normalized reason.
+		 * @param array<string, mixed> $context    Safe diagnostic and session context.
+		 */
+		$message = apply_filters(
+			'sd_ai_agent_chat_error_message',
+			ActiveJobFailureDiagnostic::message_for( (string) $diagnostic['reason'] ),
+			array(
+				'session_id' => $session_id,
+				'diagnostic' => ActiveJobFailureDiagnostic::to_rest( $diagnostic ),
+			)
+		);
+
+		return is_string( $message ) && '' !== $message
+			? $message
+			: ActiveJobFailureDiagnostic::message_for( (string) $diagnostic['reason'] );
+	}
+
+	/**
+	 * Persist a prompt-free terminal failure and replace transient error data.
+	 *
+	 * @param string               $job_id  Active-job UUID.
+	 * @param array<string, mixed> $job     Job transient payload, updated by reference.
+	 * @param string               $reason  Normalized diagnostic reason.
+	 * @param array<string, mixed> $context Allowlisted diagnostic metadata.
+	 * @return array<string, bool|int|string> Persisted diagnostic envelope.
+	 */
+	private function persist_active_job_failure( string $job_id, array &$job, string $reason, array $context = array() ): array {
+		$diagnostic        = ActiveJobRepository::record_failure( $job_id, 'error', $reason, $context );
+		$job['status']     = 'error';
+		$job['error']      = ActiveJobFailureDiagnostic::message_for( (string) $diagnostic['reason'] );
+		$job['diagnostic'] = ActiveJobFailureDiagnostic::to_rest( $diagnostic );
+		unset( $job['error_context'] );
+
+		return $diagnostic;
 	}
 
 	/**
@@ -2285,10 +2322,8 @@ final class SessionController {
 			delete_transient( RestController::JOB_PREFIX . $job_id );
 			ActiveJobRepository::delete( $job_id );
 		} elseif ( 'error' === ( $job['status'] ?? '' ) ) {
-			$response['message'] = $this->sanitize_job_error_detail( (string) ( $job['error'] ?? '' ) );
-			if ( '' === $response['message'] ) {
-				$response['message'] = __( 'The public chat request failed. Please try again later.', 'superdav-ai-agent' );
-			}
+			unset( $response['tool_calls'], $response['messages'] );
+			$this->add_transient_failure_response( $job_id, $job, 0, $response );
 			delete_transient( RestController::JOB_PREFIX . $job_id );
 			ActiveJobRepository::delete( $job_id );
 		}
@@ -2961,11 +2996,18 @@ final class SessionController {
 				// Same defensive strip for history passed directly in the request body.
 				$history = ConversationTrimmer::validate_tool_pairs( $history );
 			} catch ( \Exception $e ) {
-				$job['status'] = 'error';
-				$job['error']  = __( 'Invalid conversation history format.', 'superdav-ai-agent' );
+				$this->persist_active_job_failure(
+					$job_id,
+					$job,
+					ActiveJobFailureDiagnostic::REASON_LOOP_EXCEPTION,
+					array(
+						'last_safe_phase' => 'history_deserialization',
+						'provider_id'     => (string) ( $params['provider_id'] ?? '' ),
+						'model_id'        => (string) ( $params['model_id'] ?? '' ),
+					)
+				);
 				unset( $job['token'] );
 				set_transient( RestController::JOB_PREFIX . $job_id, $job, RestController::JOB_TTL );
-				ActiveJobRepository::update_status( $job_id, 'error', [ 'error' => $job['error'] ] );
 				return new WP_REST_Response( array( 'ok' => false ), 200 );
 			}
 		}
@@ -3166,34 +3208,21 @@ final class SessionController {
 				$result = $loop->run();
 			}
 		} catch ( \Throwable $e ) {
-			// Log the full exception so stdClass and similar runtime errors
-			// are visible in debug.log instead of silently swallowed.
-			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-			error_log( '[Superdav AI Agent] AgentLoop error: ' . $e->getMessage() . ' in ' . $e->getFile() . ':' . $e->getLine() . "\n" . $e->getTraceAsString() );
-
-			$job['status'] = 'error';
-			$job['error']  = $e->getMessage();
-
-			// Include backtrace context so the frontend can display
-			// actionable debugging info instead of a bare message.
-			$trace_frames = array();
-			foreach ( array_slice( $e->getTrace(), 0, 10 ) as $frame ) {
-				$trace_frames[] = ( $frame['file'] ?? '?' )
-					. ':' . ( $frame['line'] ?? '?' )
-					. ' ' . ( $frame['class'] ?? '' )
-					. ( $frame['type'] ?? '' )
-					. ( $frame['function'] ?? '' ) . '()';
-			}
-			$job['error_context'] = array(
-				'file'  => $e->getFile(),
-				'line'  => $e->getLine(),
-				'trace' => $trace_frames,
+			$diagnostic = $this->persist_active_job_failure(
+				$job_id,
+				$job,
+				ActiveJobFailureDiagnostic::REASON_LOOP_EXCEPTION,
+				array(
+					'last_safe_phase' => 'process_exception',
+					'provider_id'     => (string) ( $options['provider_id'] ?? $params['provider_id'] ?? '' ),
+					'model_id'        => (string) ( $options['model_id'] ?? $params['model_id'] ?? '' ),
+				)
 			);
 
 			if ( $session_id ) {
 				$recovery_error = new WP_Error(
 					'sd_ai_agent_loop_exception',
-					$e->getMessage(),
+					ActiveJobFailureDiagnostic::message_for( (string) $diagnostic['reason'] ),
 					array(
 						'history'     => $this->build_exception_recovery_history( array_values( $history ), $params ),
 						'tool_calls'  => is_array( $job['tool_calls'] ?? null )
@@ -3218,32 +3247,41 @@ final class SessionController {
 				);
 			}
 
-			unset( $job['token'] );
+			unset( $job['token'], $job['tool_calls'], $job['messages'] );
 			set_transient( RestController::JOB_PREFIX . $job_id, $job, RestController::JOB_TTL );
-
-			// Persist exception details to DB so status survives transient expiry.
-			ActiveJobRepository::update_status( $job_id, 'error', [ 'error' => $job['error'] ] );
 
 			return new WP_REST_Response( array( 'ok' => false ), 200 );
 		}
 
 		if ( is_wp_error( $result ) ) {
-			$job['status'] = 'error';
-			$job['error']  = $result->get_error_message();
-			$error_data    = $result->get_error_data();
-			if ( is_array( $error_data ) ) {
-				$job['tool_calls'] = $error_data['tool_calls'] ?? ( $job['tool_calls'] ?? array() );
-				$job['messages']   = $error_data['messages'] ?? ( $job['messages'] ?? array() );
-				if ( $session_id ) {
-					$this->persist_error_recovery_to_session(
-						$session_id,
-						$result,
-						$error_data,
-						$params,
-						$options,
-						$job
-					);
-				}
+			$error_data   = $result->get_error_data();
+			$error_data   = is_array( $error_data ) ? $error_data : array();
+			$failure_data = ActiveJobFailureDiagnostic::context_from_error_data( $error_data );
+
+			$failure_data['last_safe_phase'] = 'agent_loop';
+			if ( '' === $failure_data['provider_id'] ) {
+				$failure_data['provider_id'] = (string) ( $options['provider_id'] ?? $params['provider_id'] ?? '' );
+			}
+			if ( '' === $failure_data['model_id'] ) {
+				$failure_data['model_id'] = (string) ( $options['model_id'] ?? $params['model_id'] ?? '' );
+			}
+			$diagnostic        = $this->persist_active_job_failure(
+				$job_id,
+				$job,
+				ActiveJobFailureDiagnostic::reason_from_error( $result ),
+				$failure_data
+			);
+			$job['tool_calls'] = $error_data['tool_calls'] ?? ( $job['tool_calls'] ?? array() );
+			$job['messages']   = $error_data['messages'] ?? ( $job['messages'] ?? array() );
+			if ( $session_id ) {
+				$this->persist_error_recovery_to_session(
+					$session_id,
+					$result,
+					$error_data,
+					$params,
+					$options,
+					$job
+				);
 			}
 
 			// Log webhook execution failure.
@@ -3258,9 +3296,11 @@ final class SessionController {
 					0,
 					0,
 					$duration_ms,
-					$result->get_error_message()
+					ActiveJobFailureDiagnostic::message_for( (string) $diagnostic['reason'] )
 				);
 			}
+
+			unset( $job['tool_calls'], $job['messages'] );
 		} elseif ( is_array( $result ) && ! empty( $result['awaiting_confirmation'] ) ) {
 			/** @var array<string, mixed> $result */
 			$job['status']             = 'awaiting_confirmation';
@@ -3461,12 +3501,13 @@ final class SessionController {
 		// frontend to reload the session when needed.
 		// @phpstan-ignore-next-line -- status is set above in all paths (error or complete).
 		$db_status = (string) $job['status'];
-		if ( 'error' === $db_status ) {
-			$error_extra = [ 'error' => (string) ( $job['error'] ?? '' ) ];
-			if ( ! empty( $job['tool_calls'] ) && is_array( $job['tool_calls'] ) ) {
-				$error_extra['tool_calls'] = wp_json_encode( $job['tool_calls'] );
-			}
-			ActiveJobRepository::update_status( $job_id, 'error', $error_extra );
+		if ( 'error' === $db_status && empty( $job['diagnostic'] ) ) {
+			$this->persist_active_job_failure(
+				$job_id,
+				$job,
+				ActiveJobFailureDiagnostic::REASON_UNKNOWN,
+				array( 'last_safe_phase' => 'agent_loop' )
+			);
 		} elseif ( 'complete' === $db_status ) {
 			/** @var array<string, mixed> $complete_result */
 			$complete_result = $job['result'] ?? array();
@@ -3545,7 +3586,7 @@ final class SessionController {
 	}
 
 	/**
-	 * Remove a paused job whose transient has expired.
+	 * Convert a paused job whose transient has expired into a safe terminal failure.
 	 *
 	 * The active-jobs table deliberately stores summary data for polling
 	 * recovery, but does not contain the serialized loop state required to
@@ -3553,7 +3594,7 @@ final class SessionController {
 	 * transient expires makes the UI show an approval it can never submit.
 	 *
 	 * @param ActiveJobRow $row Persistent active-job row.
-	 * @return bool Whether an expired paused row was discarded.
+	 * @return bool Whether an expired paused row was converted to a failure.
 	 */
 	private function discard_expired_paused_job( ActiveJobRow $row ): bool {
 		if ( ! in_array( $row->status, array( 'awaiting_confirmation', 'awaiting_client_tools' ), true ) ) {
@@ -3565,7 +3606,13 @@ final class SessionController {
 			return false;
 		}
 
-		ActiveJobRepository::delete( $row->job_id );
+		ActiveJobRepository::record_failure(
+			$row->job_id,
+			'error',
+			ActiveJobFailureDiagnostic::REASON_APPROVAL_EXPIRED,
+			array( 'last_safe_phase' => $row->status ),
+			array( 'pending_tools' => '[]' )
+		);
 		return true;
 	}
 }

--- a/includes/Services/CustomerAgentRuntimeService.php
+++ b/includes/Services/CustomerAgentRuntimeService.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Services;
 
 use SdAiAgent\Contracts\CustomerAgentRuntimeInterface;
+use SdAiAgent\Core\ActiveJobFailureDiagnostic;
 use SdAiAgent\Core\AgentLoop;
 use SdAiAgent\Core\ConversationSerializer;
 use SdAiAgent\Core\ConversationTrimmer;
@@ -760,10 +761,11 @@ class CustomerAgentRuntimeService implements CustomerAgentRuntimeInterface {
 
 		$now = current_time( 'mysql', true );
 		if ( CustomerAgentRuntimeRepository::mark_cancelled( $job_id, $now ) ) {
-			ActiveJobRepository::update_status(
+			ActiveJobRepository::record_failure(
 				$job_id,
 				'error',
-				array( 'error' => 'Customer-agent runtime cancelled before result delivery.' )
+				ActiveJobFailureDiagnostic::REASON_UNKNOWN,
+				array( 'last_safe_phase' => 'customer_agent_cancellation' )
 			);
 			$cancelled = CustomerAgentRuntimeRepository::get_job( $job_id );
 			if ( null !== $cancelled ) {
@@ -928,7 +930,17 @@ class CustomerAgentRuntimeService implements CustomerAgentRuntimeInterface {
 
 		$result = $this->execute_turn( $job, $conversation, $profile );
 		if ( is_wp_error( $result ) ) {
-			$this->fail_job( $job, 'sd_ai_agent_customer_agent_execution_failed', $result->get_error_message() );
+			$error_data         = $result->get_error_data();
+			$diagnostic_context = is_array( $error_data )
+				? ActiveJobFailureDiagnostic::context_from_error_data( $error_data )
+				: array();
+			$this->fail_job(
+				$job,
+				'sd_ai_agent_customer_agent_execution_failed',
+				$result->get_error_message(),
+				ActiveJobFailureDiagnostic::reason_from_error( $result ),
+				$diagnostic_context
+			);
 			return;
 		}
 		if ( ! is_array( $result ) || ! empty( $result['awaiting_confirmation'] ) || ! empty( $result['pending_client_tool_calls'] ) ) {
@@ -1749,7 +1761,12 @@ class CustomerAgentRuntimeService implements CustomerAgentRuntimeInterface {
 		$job_id  = (string) $job['job_id'];
 		$message = __( 'The customer-agent request timed out before a reply was available.', 'superdav-ai-agent' );
 		if ( CustomerAgentRuntimeRepository::mark_timed_out( $job_id, current_time( 'mysql', true ), 'sd_ai_agent_customer_agent_timeout', $message ) ) {
-			ActiveJobRepository::update_status( $job_id, 'error', array( 'error' => $message ) );
+			ActiveJobRepository::record_failure(
+				$job_id,
+				'error',
+				ActiveJobFailureDiagnostic::REASON_PROVIDER_TIMEOUT,
+				array( 'last_safe_phase' => 'customer_agent_runtime' )
+			);
 			$timed_out = CustomerAgentRuntimeRepository::get_job( $job_id );
 			if ( null !== $timed_out ) {
 				$this->emit_lifecycle_event( 'failed', $timed_out );
@@ -1760,13 +1777,23 @@ class CustomerAgentRuntimeService implements CustomerAgentRuntimeInterface {
 	/**
 	 * Persist a sanitized failure only while cancellation has not already won.
 	 *
-	 * @param array<string,mixed> $job Durable job row.
+	 * @param array<string,mixed> $job                Durable job row.
+	 * @param string              $error_code         Customer-runtime error code.
+	 * @param string              $detail             Potentially unsafe failure detail.
+	 * @param string              $reason             Normalized terminal reason.
+	 * @param array<string,mixed> $diagnostic_context Allowlisted diagnostic metadata.
 	 */
-	private function fail_job( array $job, string $error_code, string $detail ): void {
-		$job_id  = (string) $job['job_id'];
-		$message = $this->customer_safe_error_message( $detail );
+	private function fail_job( array $job, string $error_code, string $detail, string $reason = ActiveJobFailureDiagnostic::REASON_UNKNOWN, array $diagnostic_context = array() ): void {
+		$job_id                                = (string) $job['job_id'];
+		$message                               = $this->customer_safe_error_message( $detail );
+		$diagnostic_context['last_safe_phase'] = 'customer_agent_runtime';
 		if ( CustomerAgentRuntimeRepository::mark_failed( $job_id, current_time( 'mysql', true ), $error_code, $message ) ) {
-			ActiveJobRepository::update_status( $job_id, 'error', array( 'error' => $message ) );
+			ActiveJobRepository::record_failure(
+				$job_id,
+				'error',
+				$reason,
+				$diagnostic_context
+			);
 			$failed = CustomerAgentRuntimeRepository::get_job( $job_id );
 			if ( null !== $failed ) {
 				$this->emit_lifecycle_event( 'failed', $failed );

--- a/src/components/action-card.js
+++ b/src/components/action-card.js
@@ -50,6 +50,56 @@ function describeToolCall( name, args ) {
 }
 
 /**
+ * Format the allowlisted checkpoint phase for a short user-facing label.
+ *
+ * @param {string} phase Checkpoint phase from the safe diagnostic DTO.
+ * @return {string} Human-readable phase label.
+ */
+function formatFailurePhase( phase ) {
+	if ( ! /^[a-z0-9_]{1,60}$/.test( phase ) ) {
+		return '';
+	}
+
+	return phase.replace( /_/g, ' ' );
+}
+
+/**
+ * Explain the specific recovery action without exposing implementation detail.
+ *
+ * @param {string} nextAction Normalized recovery action.
+ * @return {string} Customer-facing next-step guidance.
+ */
+function getFailureNextStep( nextAction ) {
+	switch ( nextAction ) {
+		case 'compact':
+			return __(
+				'Start a smaller continuation with a shorter recent message or fewer attachments.',
+				'superdav-ai-agent'
+			);
+		case 'retry':
+			return __(
+				'Retry the last message. Completed work in the conversation is preserved.',
+				'superdav-ai-agent'
+			);
+		case 'approve_review':
+			return __(
+				'Review the pending approval before continuing.',
+				'superdav-ai-agent'
+			);
+		case 'continuation':
+			return __(
+				'Start a continuation from the saved conversation.',
+				'superdav-ai-agent'
+			);
+		default:
+			return __(
+				'Contact support with the support ID below if the problem continues.',
+				'superdav-ai-agent'
+			);
+	}
+}
+
+/**
  * ActionCard — inline confirmation card rendered in the message list.
  *
  * Shown when the AI proposes a destructive or significant operation and
@@ -131,9 +181,96 @@ export default function ActionCard( { card, onConfirm, onCancel } ) {
 		);
 	}
 
+	if ( card?.type === 'active_job_failure' ) {
+		const diagnostic = card.diagnostic || {};
+		const nextAction =
+			typeof diagnostic.next_action === 'string'
+				? diagnostic.next_action
+				: 'contact_support';
+		const phase = formatFailurePhase( diagnostic.last_safe_phase || '' );
+		const correlationId =
+			typeof diagnostic.correlation_id === 'string' &&
+			/^job-(?:[a-f0-9]{12}|unknown)$/.test( diagnostic.correlation_id )
+				? diagnostic.correlation_id
+				: '';
+		const canRetry =
+			'retry' === nextAction && typeof onConfirm === 'function';
+
+		return (
+			<div
+				className="sdaa-action-card sdaa-action-card--failure"
+				role="region"
+				aria-label={ __(
+					'Background job recovery details',
+					'superdav-ai-agent'
+				) }
+			>
+				<div className="sdaa-action-card-header">
+					<span className="sdaa-action-card-heading">
+						{ __( 'Job needs attention', 'superdav-ai-agent' ) }
+					</span>
+				</div>
+				<div className="sdaa-action-card-body">
+					<p>
+						{ card.message ||
+							__(
+								'The background agent job could not finish.',
+								'superdav-ai-agent'
+							) }
+					</p>
+					<p className="sdaa-action-card-failure-next-step">
+						<strong>
+							{ __( 'Next step:', 'superdav-ai-agent' ) }
+						</strong>{ ' ' }
+						{ getFailureNextStep( nextAction ) }
+					</p>
+					{ phase && (
+						<p className="sdaa-action-card-failure-phase">
+							<strong>
+								{ __(
+									'Last completed step:',
+									'superdav-ai-agent'
+								) }
+							</strong>{ ' ' }
+							{ phase }
+						</p>
+					) }
+					{ correlationId && (
+						<p className="sdaa-action-card-failure-correlation">
+							<strong>
+								{ __( 'Support ID:', 'superdav-ai-agent' ) }
+							</strong>{ ' ' }
+							<code>{ correlationId }</code>
+						</p>
+					) }
+				</div>
+				<div className="sdaa-action-card-footer">
+					<button
+						type="button"
+						className="button sdaa-action-card-btn-cancel"
+						onClick={ onCancel }
+					>
+						{ __( 'Dismiss', 'superdav-ai-agent' ) }
+					</button>
+					{ canRetry && (
+						<button
+							type="button"
+							ref={ confirmRef }
+							className="button button-primary sdaa-action-card-btn-confirm"
+							onClick={ onConfirm }
+						>
+							{ __( 'Retry last message', 'superdav-ai-agent' ) }
+						</button>
+					) }
+				</div>
+			</div>
+		);
+	}
+
 	if ( card?.type === 'resume_recoverable_job' ) {
 		return (
 			<RecoverableJobActionCard
+				diagnostic={ card.diagnostic }
 				onConfirm={ onConfirm }
 				onCancel={ onCancel }
 			/>

--- a/src/components/chat-redesign/MessageList.js
+++ b/src/components/chat-redesign/MessageList.js
@@ -19,7 +19,7 @@ import { useRef, useEffect, useState, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 import STORE_NAME from '../../store';
-import RecoverableJobActionCard from '../recoverable-job-action-card';
+import ActionCard from '../action-card';
 import FeedbackConsentModal from '../feedback-consent-modal';
 import useTextToSpeech from '../use-text-to-speech';
 import {
@@ -250,6 +250,20 @@ export default function MessageList() {
 		setUnseenCount( 0 );
 	}, [] );
 
+	const confirmJobFailureAction = () => {
+		if ( pendingActionCard?.type === 'resume_recoverable_job' ) {
+			resumeRecoverableJob();
+			return;
+		}
+
+		if (
+			pendingActionCard?.type === 'active_job_failure' &&
+			pendingActionCard.diagnostic?.next_action === 'retry'
+		) {
+			retryLastMessage();
+		}
+	};
+
 	// ── Derived values ────────────────────────────────────────────────────────
 
 	const lastRunningJob = currentSessionId
@@ -354,11 +368,15 @@ export default function MessageList() {
 						</div>
 					) }
 
-					{ pendingActionCard?.type === 'resume_recoverable_job' &&
+					{ [
+						'resume_recoverable_job',
+						'active_job_failure',
+					].includes( pendingActionCard?.type ) &&
 						pendingActionCard.sessionId === currentSessionId &&
 						! sending && (
-							<RecoverableJobActionCard
-								onConfirm={ resumeRecoverableJob }
+							<ActionCard
+								card={ pendingActionCard }
+								onConfirm={ confirmJobFailureAction }
 								onCancel={ () => setPendingActionCard( null ) }
 							/>
 						) }

--- a/src/components/chat-redesign/__tests__/MessageList.test.js
+++ b/src/components/chat-redesign/__tests__/MessageList.test.js
@@ -192,4 +192,46 @@ describe( 'MessageList stream error banner', () => {
 
 		expect( resumeRecoverableJob ).toHaveBeenCalledTimes( 1 );
 	} );
+
+	test( 'shows a safe retry card for a terminal job diagnostic', async () => {
+		const setPendingActionCard = jest.fn();
+		( { container, root } = await renderMessageList( {
+			selectors: buildSelectors( {
+				hasStreamError: false,
+				pendingActionCard: {
+					type: 'active_job_failure',
+					sessionId: 123,
+					message:
+						'The AI provider timed out before finishing. Retry the request shortly.',
+					diagnostic: {
+						last_safe_phase: 'before_provider_call',
+						next_action: 'retry',
+						correlation_id: 'job-1234abcd5678',
+					},
+				},
+			} ),
+			dispatchMap: {
+				sendMessage: jest.fn(),
+				retryLastMessage,
+				resumeRecoverableJob: jest.fn(),
+				setPendingActionCard,
+			},
+		} ) );
+
+		const retryButton = container.querySelector(
+			'.sdaa-action-card-btn-confirm'
+		);
+		expect( retryButton ).not.toBeNull();
+		expect( container.textContent ).toContain( 'Last completed step:' );
+		expect( container.textContent ).toContain( 'before provider call' );
+		expect( container.textContent ).toContain( 'job-1234abcd5678' );
+
+		await act( async () => {
+			retryButton.dispatchEvent(
+				new MouseEvent( 'click', { bubbles: true } )
+			);
+		} );
+
+		expect( retryLastMessage ).toHaveBeenCalledTimes( 1 );
+	} );
 } );

--- a/src/components/recoverable-job-action-card.js
+++ b/src/components/recoverable-job-action-card.js
@@ -10,13 +10,28 @@ import { __ } from '@wordpress/i18n';
  * Kept separate from the broader confirmation ActionCard so the floating
  * widget does not need to include confirmation-only rendering code.
  *
- * @param {Object}   props
- * @param {Function} props.onConfirm Called to resume the failed job.
- * @param {Function} props.onCancel  Called to dismiss the action.
+ * @param {Object}   props            Component props.
+ * @param {Object}   props.diagnostic Safe active-job diagnostic DTO.
+ * @param {Function} props.onConfirm  Called to resume the failed job.
+ * @param {Function} props.onCancel   Called to dismiss the action.
  * @return {JSX.Element} Recovery action card.
  */
-export default function RecoverableJobActionCard( { onConfirm, onCancel } ) {
+export default function RecoverableJobActionCard( {
+	diagnostic = {},
+	onConfirm,
+	onCancel,
+} ) {
 	const confirmRef = useRef( null );
+	const phase =
+		typeof diagnostic.last_safe_phase === 'string' &&
+		/^[a-z0-9_]{1,60}$/.test( diagnostic.last_safe_phase )
+			? diagnostic.last_safe_phase.replace( /_/g, ' ' )
+			: '';
+	const correlationId =
+		typeof diagnostic.correlation_id === 'string' &&
+		/^job-(?:[a-f0-9]{12}|unknown)$/.test( diagnostic.correlation_id )
+			? diagnostic.correlation_id
+			: '';
 
 	useEffect( () => {
 		confirmRef.current?.focus();
@@ -46,6 +61,25 @@ export default function RecoverableJobActionCard( { onConfirm, onCancel } ) {
 						'superdav-ai-agent'
 					) }
 				</p>
+				{ phase && (
+					<p className="sdaa-action-card-failure-phase">
+						<strong>
+							{ __(
+								'Last completed step:',
+								'superdav-ai-agent'
+							) }
+						</strong>{ ' ' }
+						{ phase }
+					</p>
+				) }
+				{ correlationId && (
+					<p className="sdaa-action-card-failure-correlation">
+						<strong>
+							{ __( 'Support ID:', 'superdav-ai-agent' ) }
+						</strong>{ ' ' }
+						<code>{ correlationId }</code>
+					</p>
+				) }
 			</div>
 			<div className="sdaa-action-card-footer">
 				<button

--- a/src/components/shared.css
+++ b/src/components/shared.css
@@ -256,8 +256,31 @@
 	color: #d63638;
 }
 
+.sdaa-action-card--failure {
+	background: #fcf0f1;
+	border-color: #d63638;
+}
+
+.sdaa-action-card--failure .sdaa-action-card-header,
+.sdaa-action-card--failure .sdaa-action-card-footer {
+	background: #fcf0f1;
+	border-color: #d63638;
+}
+
 .sdaa-action-card-body {
 	padding: 10px 14px;
+}
+
+.sdaa-action-card-failure-next-step,
+.sdaa-action-card-failure-phase,
+.sdaa-action-card-failure-correlation {
+	margin: 8px 0 0;
+	color: #50575e;
+}
+
+.sdaa-action-card-failure-correlation code {
+	font-size: 12px;
+	word-break: break-word;
 }
 
 .sdaa-action-card-tool {

--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -67,6 +67,10 @@ const {
 	preserveRecoverableProviderModels,
 } = require( '../slices/providersSlice' );
 const { buildFailedJobActivityMessage } = require( '../slices/jobSlice' );
+const {
+	buildActiveJobFailureCard,
+	normalizeActiveJobFailureDiagnostic,
+} = require( '../slices/active-job-failure-diagnostic' );
 const apiFetch = require( '@wordpress/api-fetch' );
 const { executeClientAbility } = require( '../../abilities/registry' );
 
@@ -645,6 +649,53 @@ describe( 'actions', () => {
 		expect( buildFailedJobActivityMessage( [] ) ).toBeNull();
 	} );
 
+	test( 'buildActiveJobFailureCard keeps only the safe diagnostic contract', () => {
+		const card = buildActiveJobFailureCard( 17, {
+			reason: 'provider_timeout',
+			last_safe_phase: 'before_provider_call',
+			retryable: true,
+			next_action: 'retry',
+			correlation_id: 'job-1234abcd5678',
+			message: 'PRIVATE_PROVIDER_MESSAGE',
+			prompt: 'PRIVATE_PROMPT_CONTENT',
+			error_context: { trace: [ '/private/path.php:99' ] },
+		} );
+
+		expect( card ).toMatchObject( {
+			type: 'active_job_failure',
+			sessionId: 17,
+			diagnostic: {
+				reason: 'provider_timeout',
+				last_safe_phase: 'before_provider_call',
+				retryable: true,
+				next_action: 'retry',
+				correlation_id: 'job-1234abcd5678',
+			},
+		} );
+		expect( JSON.stringify( card ) ).not.toContain(
+			'PRIVATE_PROVIDER_MESSAGE'
+		);
+		expect( JSON.stringify( card ) ).not.toContain(
+			'PRIVATE_PROMPT_CONTENT'
+		);
+		expect( JSON.stringify( card ) ).not.toContain( '/private/path.php' );
+
+		expect(
+			normalizeActiveJobFailureDiagnostic( {
+				reason: 'not-a-shipped-reason',
+				next_action: 'unsafe-action',
+				last_safe_phase: 'unsafe phase',
+				correlation_id: 'private-correlation',
+			} )
+		).toEqual( {
+			reason: 'unknown',
+			last_safe_phase: '',
+			retryable: false,
+			next_action: 'contact_support',
+			correlation_id: '',
+		} );
+	} );
+
 	test( 'pollJob posts a timeout error when a client ability never resolves', async () => {
 		jest.useFakeTimers();
 		apiFetch.mockReset();
@@ -836,7 +887,72 @@ describe( 'actions', () => {
 		expect( dispatch.setPendingActionCard ).toHaveBeenCalledWith( {
 			type: 'resume_recoverable_job',
 			sessionId: 17,
+			diagnostic: null,
 		} );
+	} );
+
+	test( 'pollJob uses a safe diagnostic card instead of a raw provider error', async () => {
+		jest.useFakeTimers();
+		apiFetch.mockReset();
+		apiFetch.mockResolvedValue( {
+			status: 'error',
+			message: 'PRIVATE_PROVIDER_MESSAGE',
+			diagnostic: {
+				reason: 'local_payload_guard',
+				last_safe_phase: 'before_provider_call',
+				retryable: false,
+				next_action: 'compact',
+				correlation_id: 'job-1234abcd5678',
+			},
+			error_context: {
+				trace: [ '/private/path.php:99' ],
+			},
+		} );
+		const dispatch = {
+			appendMessage: jest.fn(),
+			setPendingConfirmation: jest.fn(),
+			setPendingActionCard: jest.fn(),
+			setStreamError: jest.fn(),
+			setSending: jest.fn(),
+			setLiveToolCalls: jest.fn(),
+			drainMessageQueue: jest.fn(),
+			setCurrentJobId: jest.fn(),
+			setSessionJob: jest.fn(),
+		};
+		const select = {
+			getCurrentSessionId: jest.fn( () => 17 ),
+			getCurrentJobId: jest.fn( () => 'failed-job' ),
+		};
+
+		try {
+			actions.pollJob( 'failed-job', 17 )( { dispatch, select } );
+			await jest.advanceTimersByTimeAsync( 2000 );
+		} finally {
+			jest.useRealTimers();
+		}
+
+		const cardCalls = dispatch.setPendingActionCard.mock.calls;
+		const card = cardCalls[ cardCalls.length - 1 ][ 0 ];
+
+		expect( card ).toMatchObject( {
+			type: 'active_job_failure',
+			sessionId: 17,
+			diagnostic: {
+				reason: 'local_payload_guard',
+				next_action: 'compact',
+			},
+		} );
+		expect( dispatch.setStreamError ).not.toHaveBeenCalled();
+		expect( JSON.stringify( card ) ).not.toContain(
+			'PRIVATE_PROVIDER_MESSAGE'
+		);
+		expect( JSON.stringify( card ) ).not.toContain( '/private/path.php' );
+		expect(
+			dispatch.appendMessage.mock.calls[ 0 ][ 0 ].parts[ 0 ].text
+		).not.toContain( 'PRIVATE_PROVIDER_MESSAGE' );
+		expect(
+			dispatch.appendMessage.mock.calls[ 0 ][ 0 ].parts[ 0 ].text
+		).not.toContain( '/private/path.php' );
 	} );
 } );
 

--- a/src/store/slices/active-job-failure-diagnostic.js
+++ b/src/store/slices/active-job-failure-diagnostic.js
@@ -1,0 +1,168 @@
+/**
+ * Safe active-job failure presentation helpers.
+ *
+ * This module is loaded only after a terminal job failure so the normal
+ * floating-widget launcher remains within its initial-download budget. Every
+ * value returned here is constrained to the public diagnostic contract.
+ */
+
+import { __ } from '@wordpress/i18n';
+
+const ACTIVE_JOB_FAILURE_REASONS = [
+	'local_payload_guard',
+	'upstream_payload_rejection',
+	'provider_timeout',
+	'worker_terminated',
+	'approval_wait',
+	'approval_expired',
+	'resume_exhausted',
+	'loop_exception',
+	'unknown',
+];
+
+const ACTIVE_JOB_FAILURE_ACTIONS = [
+	'compact',
+	'retry',
+	'approve_review',
+	'continuation',
+	'contact_support',
+];
+
+/**
+ * Keep a failed-job diagnostic limited to the REST contract's safe fields.
+ *
+ * This provides client-side defence in depth: a stale proxy or integration
+ * cannot repopulate the error card with a provider message, trace, or prompt.
+ *
+ * @param {Object} diagnostic Candidate job failure diagnostic.
+ * @return {Object} Safe diagnostic for rendering.
+ */
+export function normalizeActiveJobFailureDiagnostic( diagnostic ) {
+	const source =
+		diagnostic &&
+		typeof diagnostic === 'object' &&
+		! Array.isArray( diagnostic )
+			? diagnostic
+			: {};
+	const reason = ACTIVE_JOB_FAILURE_REASONS.includes( source.reason )
+		? source.reason
+		: 'unknown';
+	const nextAction = ACTIVE_JOB_FAILURE_ACTIONS.includes( source.next_action )
+		? source.next_action
+		: 'contact_support';
+	const phase =
+		typeof source.last_safe_phase === 'string' &&
+		/^[a-z0-9_]{1,60}$/.test( source.last_safe_phase )
+			? source.last_safe_phase
+			: '';
+	const correlationId =
+		typeof source.correlation_id === 'string' &&
+		/^job-(?:[a-f0-9]{12}|unknown)$/.test( source.correlation_id )
+			? source.correlation_id
+			: '';
+
+	return {
+		reason,
+		last_safe_phase: phase,
+		retryable: source.retryable === true,
+		next_action: nextAction,
+		correlation_id: correlationId,
+	};
+}
+
+/**
+ * Return a normalized diagnostic only when the REST response supplied one.
+ *
+ * @param {Object} diagnostic Candidate diagnostic from a job status response.
+ * @return {Object|null} Safe diagnostic, or null for legacy responses.
+ */
+export function getFailureDiagnostic( diagnostic ) {
+	if (
+		! diagnostic ||
+		typeof diagnostic !== 'object' ||
+		Array.isArray( diagnostic )
+	) {
+		return null;
+	}
+
+	return normalizeActiveJobFailureDiagnostic( diagnostic );
+}
+
+/**
+ * Return fixed customer copy for a normalized active-job failure reason.
+ *
+ * The API provides equivalent text, but keeping a fixed frontend mapping
+ * prevents accidental display of legacy free-text provider errors.
+ *
+ * @param {Object} diagnostic Safe job failure diagnostic.
+ * @return {string} Customer-safe failure message.
+ */
+export function getActiveJobFailureMessage( diagnostic ) {
+	const { reason } = normalizeActiveJobFailureDiagnostic( diagnostic );
+
+	switch ( reason ) {
+		case 'local_payload_guard':
+			return __(
+				'This request is too large to send safely. Compact the conversation, shorten the latest message, or remove large attachments before retrying.',
+				'superdav-ai-agent'
+			);
+		case 'upstream_payload_rejection':
+			return __(
+				'The selected AI provider rejected this request because it exceeds its payload limit. Start a smaller continuation and retry.',
+				'superdav-ai-agent'
+			);
+		case 'provider_timeout':
+			return __(
+				'The AI provider timed out before finishing. Retry the request shortly.',
+				'superdav-ai-agent'
+			);
+		case 'worker_terminated':
+			return __(
+				'The background worker stopped before the job could finish. Retry the job or start a continuation from the saved conversation.',
+				'superdav-ai-agent'
+			);
+		case 'approval_wait':
+			return __(
+				'This job is waiting for approval before it can continue.',
+				'superdav-ai-agent'
+			);
+		case 'approval_expired':
+			return __(
+				'The pending approval expired before it could be completed. Review the conversation and start a continuation.',
+				'superdav-ai-agent'
+			);
+		case 'resume_exhausted':
+			return __(
+				'The job could not make progress after its automatic recovery attempts. Start a continuation from the saved conversation.',
+				'superdav-ai-agent'
+			);
+		case 'loop_exception':
+			return __(
+				'The background job stopped unexpectedly. Start a continuation from the saved conversation or contact support with the correlation ID.',
+				'superdav-ai-agent'
+			);
+		default:
+			return __(
+				'The background agent job could not finish. Retry the request, or contact support with the correlation ID if the problem continues.',
+				'superdav-ai-agent'
+			);
+	}
+}
+
+/**
+ * Create the action-card payload for a terminal job failure.
+ *
+ * @param {number} sessionId  Session owning the failed job.
+ * @param {Object} diagnostic Candidate failure diagnostic.
+ * @return {Object} Safe card payload.
+ */
+export function buildActiveJobFailureCard( sessionId, diagnostic ) {
+	const safeDiagnostic = normalizeActiveJobFailureDiagnostic( diagnostic );
+
+	return {
+		type: 'active_job_failure',
+		sessionId,
+		diagnostic: safeDiagnostic,
+		message: getActiveJobFailureMessage( safeDiagnostic ),
+	};
+}

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -812,32 +812,45 @@ export const actions = {
 						const rawErrorMessage =
 							result.message ||
 							__( 'Unknown error', 'superdav-ai-agent' );
+						const hasFailureDiagnostic = !! result.diagnostic;
+						let failureDiagnostic = null;
+						let failureHelpers = null;
+						let errorMessage = rawErrorMessage;
+
+						if ( hasFailureDiagnostic ) {
+							try {
+								// Failure copy and validation are only needed after a
+								// terminal error, so keep them out of the launch bundle.
+								failureHelpers = await import(
+									/* webpackChunkName: "active-job-failure-diagnostic" */
+									'./active-job-failure-diagnostic'
+								);
+								failureDiagnostic =
+									failureHelpers.getFailureDiagnostic(
+										result.diagnostic
+									);
+								errorMessage =
+									failureHelpers.getActiveJobFailureMessage(
+										failureDiagnostic
+									);
+							} catch {
+								// A failed optional chunk must not surface raw provider
+								// errors or leave the terminal job cleanup incomplete.
+								errorMessage = __(
+									'Recovery details unavailable.',
+									'superdav-ai-agent'
+								);
+							}
+						}
 						const isCreditNotice =
+							! hasFailureDiagnostic &&
 							/superdav.*credit|credit.*superdav/i.test(
 								rawErrorMessage
 							);
-						let errorText = `${ __(
+						const errorText = `${ __(
 							'Error:',
 							'superdav-ai-agent'
-						) } ${ rawErrorMessage }`;
-						if ( ! isCreditNotice && result.error_context ) {
-							const ctx = result.error_context;
-							errorText += `\n\n**${ __(
-								'Location:',
-								'superdav-ai-agent'
-							) }** \`${ ctx.file }:${ ctx.line }\``;
-							if (
-								Array.isArray( ctx.trace ) &&
-								ctx.trace.length > 0
-							) {
-								errorText +=
-									'\n\n**' +
-									__( 'Stack trace:', 'superdav-ai-agent' ) +
-									'**\n```\n' +
-									ctx.trace.join( '\n' ) +
-									'\n```';
-							}
-						}
+						) } ${ errorMessage }`;
 
 						if ( select.getCurrentSessionId() === sessionId ) {
 							let sessionReloaded = false;
@@ -882,13 +895,21 @@ export const actions = {
 								dispatch.setPendingActionCard( {
 									type: 'resume_recoverable_job',
 									sessionId,
+									diagnostic: failureDiagnostic,
 								} );
+							} else if ( failureDiagnostic ) {
+								dispatch.setPendingActionCard(
+									failureHelpers.buildActiveJobFailureCard(
+										sessionId,
+										failureDiagnostic
+									)
+								);
 							}
-							if ( ! isCreditNotice ) {
+							if ( ! isCreditNotice && ! failureDiagnostic ) {
 								dispatch.setStreamError( true, sessionId );
 							}
 							// WP_Error max_iterations — show feedback banner (t183).
-							const errMsg = result.message || '';
+							const errMsg = errorMessage;
 							if ( /max.?iteration/i.test( errMsg ) ) {
 								dispatch.setFeedbackBanner( {
 									exitReason: 'max_iterations',

--- a/tests/SdAiAgent/Core/ActiveJobFailureDiagnosticTest.php
+++ b/tests/SdAiAgent/Core/ActiveJobFailureDiagnosticTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\ActiveJobFailureDiagnostic;
+use WP_UnitTestCase;
+
+/**
+ * Tests prompt-free active-job failure envelopes.
+ */
+class ActiveJobFailureDiagnosticTest extends WP_UnitTestCase {
+
+	public function test_encoded_diagnostic_keeps_only_allowlisted_metadata(): void {
+		$job_id      = '11111111-2222-3333-4444-555555555555';
+		$diagnostic  = ActiveJobFailureDiagnostic::create(
+			$job_id,
+			ActiveJobFailureDiagnostic::REASON_LOCAL_PAYLOAD_GUARD,
+			array(
+				'last_safe_phase'    => 'before_provider_call',
+				'resume_count'       => 2,
+				'provider_id'        => 'openai_compat',
+				'model_id'           => 'gpt-test',
+				'request_size_class' => 'large',
+				'prompt'             => 'PRIVATE_PROMPT_CONTENT',
+				'authorization'      => 'Bearer PRIVATE_TOKEN',
+				'trace'              => '/private/path.php:99',
+			)
+		);
+		$encoded     = ActiveJobFailureDiagnostic::encode( $job_id, $diagnostic );
+		$decoded     = ActiveJobFailureDiagnostic::from_stored( $job_id, $encoded );
+		$rest_result = ActiveJobFailureDiagnostic::to_rest( $decoded );
+
+		$this->assertStringNotContainsString( 'PRIVATE_PROMPT_CONTENT', $encoded );
+		$this->assertStringNotContainsString( 'PRIVATE_TOKEN', $encoded );
+		$this->assertStringNotContainsString( '/private/path.php', $encoded );
+		$this->assertSame( ActiveJobFailureDiagnostic::REASON_LOCAL_PAYLOAD_GUARD, $rest_result['reason'] );
+		$this->assertSame( 'before_provider_call', $rest_result['last_safe_phase'] );
+		$this->assertSame( 2, $rest_result['resume_count'] );
+		$this->assertSame( 'openai_compat', $rest_result['provider_id'] );
+		$this->assertSame( 'gpt-test', $rest_result['model_id'] );
+		$this->assertSame( 'large', $rest_result['request_size_class'] );
+		$this->assertFalse( $rest_result['retryable'] );
+		$this->assertSame( 'compact', $rest_result['next_action'] );
+		$this->assertMatchesRegularExpression( '/^job-[a-f0-9]{12}$/', $rest_result['correlation_id'] );
+	}
+
+	public function test_legacy_free_text_is_not_returned_as_a_diagnostic(): void {
+		$diagnostic = ActiveJobFailureDiagnostic::from_stored(
+			'66666666-7777-8888-9999-000000000000',
+			'Provider echoed PRIVATE_PROMPT_CONTENT with Authorization: Bearer PRIVATE_TOKEN'
+		);
+		$encoded    = ActiveJobFailureDiagnostic::encode( '66666666-7777-8888-9999-000000000000', $diagnostic );
+
+		$this->assertSame( ActiveJobFailureDiagnostic::REASON_UNKNOWN, $diagnostic['reason'] );
+		$this->assertStringNotContainsString( 'PRIVATE_PROMPT_CONTENT', $encoded );
+		$this->assertStringNotContainsString( 'PRIVATE_TOKEN', $encoded );
+	}
+
+	/**
+	 * @dataProvider provider_error_reason_provider
+	 *
+	 * @param \WP_Error $error           Provider error to classify.
+	 * @param string    $expected_reason Normalized failure reason.
+	 */
+	public function test_reason_from_error_classifies_provider_failures( \WP_Error $error, string $expected_reason ): void {
+		$this->assertSame( $expected_reason, ActiveJobFailureDiagnostic::reason_from_error( $error ) );
+	}
+
+	/**
+	 * Provider and transport errors carry many vendor-specific messages. The
+	 * classifier must normalize the failure without retaining those messages.
+	 *
+	 * @return array<string, array{0: \WP_Error, 1: string}>
+	 */
+	public function provider_error_reason_provider(): array {
+		return array(
+			'local payload guard'       => array(
+				new \WP_Error(
+					'sd_ai_agent_provider_payload_budget_exceeded',
+					'PRIVATE_PROMPT_CONTENT exceeded the local payload budget.',
+					array( 'local_rejection' => true )
+				),
+				ActiveJobFailureDiagnostic::REASON_LOCAL_PAYLOAD_GUARD,
+			),
+			'upstream payload rejection' => array(
+				new \WP_Error(
+					'provider_http_error',
+					'Provider returned 413 for PRIVATE_PROMPT_CONTENT.',
+					array( 'status_code' => 413 )
+				),
+				ActiveJobFailureDiagnostic::REASON_UPSTREAM_PAYLOAD_REJECTION,
+			),
+			'provider timeout'          => array(
+				new \WP_Error(
+					'provider_transport_error',
+					'Provider request timed out while processing PRIVATE_PROMPT_CONTENT.'
+				),
+				ActiveJobFailureDiagnostic::REASON_PROVIDER_TIMEOUT,
+			),
+			'unknown provider error'    => array(
+				new \WP_Error(
+					'provider_unexpected_error',
+					'Unexpected provider response containing PRIVATE_PROMPT_CONTENT.'
+				),
+				ActiveJobFailureDiagnostic::REASON_UNKNOWN,
+			),
+		);
+	}
+
+	public function test_all_normalized_reasons_have_safe_recovery_metadata(): void {
+		$expected = array(
+			ActiveJobFailureDiagnostic::REASON_LOCAL_PAYLOAD_GUARD        => array( 'compact', false ),
+			ActiveJobFailureDiagnostic::REASON_UPSTREAM_PAYLOAD_REJECTION => array( 'compact', false ),
+			ActiveJobFailureDiagnostic::REASON_PROVIDER_TIMEOUT           => array( 'retry', true ),
+			ActiveJobFailureDiagnostic::REASON_WORKER_TERMINATED          => array( 'retry', true ),
+			ActiveJobFailureDiagnostic::REASON_APPROVAL_WAIT              => array( 'approve_review', true ),
+			ActiveJobFailureDiagnostic::REASON_APPROVAL_EXPIRED           => array( 'continuation', false ),
+			ActiveJobFailureDiagnostic::REASON_RESUME_EXHAUSTED           => array( 'continuation', false ),
+			ActiveJobFailureDiagnostic::REASON_LOOP_EXCEPTION             => array( 'continuation', false ),
+			ActiveJobFailureDiagnostic::REASON_UNKNOWN                    => array( 'contact_support', true ),
+		);
+
+		foreach ( $expected as $reason => $metadata ) {
+			$diagnostic = ActiveJobFailureDiagnostic::create(
+				'77777777-8888-9999-0000-111111111111',
+				$reason,
+				array( 'last_safe_phase' => 'before_provider_call' )
+			);
+
+			$this->assertSame( $reason, $diagnostic['reason'] );
+			$this->assertSame( $metadata[0], $diagnostic['next_action'] );
+			$this->assertSame( $metadata[1], $diagnostic['retryable'] );
+		}
+	}
+}

--- a/tests/SdAiAgent/Core/ActiveJobsCleanupTest.php
+++ b/tests/SdAiAgent/Core/ActiveJobsCleanupTest.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 namespace SdAiAgent\Tests\Core;
 
 use SdAiAgent\Core\ActiveJobsCleanupService;
+use SdAiAgent\Core\ActiveJobFailureDiagnostic;
 use SdAiAgent\Models\ActiveJobRepository;
 use WP_UnitTestCase;
 
@@ -43,7 +44,9 @@ class ActiveJobsCleanupTest extends WP_UnitTestCase {
 		$wpdb->query( 'DELETE FROM ' . ActiveJobRepository::table_name() . " WHERE job_id LIKE 'test-%'" );
 		ActiveJobsCleanupService::unschedule();
 		remove_all_actions( 'sd_ai_agent_stale_jobs_reaped' );
+		remove_all_actions( 'sd_ai_agent_terminal_job_diagnostics_pruned' );
 		remove_all_filters( 'sd_ai_agent_stale_job_threshold_minutes' );
+		remove_all_filters( 'sd_ai_agent_job_diagnostic_retention_days' );
 
 		parent::tear_down();
 	}
@@ -151,7 +154,10 @@ class ActiveJobsCleanupTest extends WP_UnitTestCase {
 		$this->assertTrue( $result, 'mark_interrupted() should return true when it updated a row' );
 		$this->assertNotNull( $row );
 		$this->assertSame( 'interrupted', $row->status );
-		$this->assertSame( $reason, $row->error );
+		$diagnostic = ActiveJobFailureDiagnostic::from_stored( 'test-interrupted-1', (string) $row->error );
+
+		$this->assertSame( ActiveJobFailureDiagnostic::REASON_WORKER_TERMINATED, $diagnostic['reason'] );
+		$this->assertStringNotContainsString( $reason, (string) $row->error );
 		$this->assertNotEmpty( $row->interrupted_at );
 	}
 
@@ -249,6 +255,8 @@ class ActiveJobsCleanupTest extends WP_UnitTestCase {
 		$this->assertGreaterThanOrEqual( 1, $count, 'cleanup_stale() should report at least one reaped row' );
 		$this->assertNotNull( $row );
 		$this->assertSame( 'abandoned', $row->status );
+		$diagnostic = ActiveJobFailureDiagnostic::from_stored( 'test-stale-1', $row->error );
+		$this->assertSame( ActiveJobFailureDiagnostic::REASON_WORKER_TERMINATED, $diagnostic['reason'] );
 	}
 
 	/**
@@ -285,6 +293,23 @@ class ActiveJobsCleanupTest extends WP_UnitTestCase {
 	public function test_cleanup_stale_returns_zero_when_no_stale_rows(): void {
 		$count = ActiveJobRepository::cleanup_stale( 15 );
 		$this->assertSame( 0, $count );
+	}
+
+	/**
+	 * Terminal job diagnostics are retained only for their bounded support window.
+	 */
+	public function test_cleanup_terminal_diagnostics_removes_only_expired_terminal_rows(): void {
+		$expired_time = gmdate( 'Y-m-d H:i:s', time() - ( 2 * DAY_IN_SECONDS ) );
+		$this->insert_job( 'test-terminal-expired', 'error', $expired_time );
+		$this->insert_job( 'test-terminal-fresh', 'error' );
+		$this->insert_job( 'test-terminal-processing', 'processing', $expired_time );
+
+		$deleted = ActiveJobRepository::cleanup_terminal_diagnostics( 1 );
+
+		$this->assertSame( 1, $deleted );
+		$this->assertNull( $this->fetch_row( 'test-terminal-expired' ) );
+		$this->assertNotNull( $this->fetch_row( 'test-terminal-fresh' ) );
+		$this->assertNotNull( $this->fetch_row( 'test-terminal-processing' ) );
 	}
 
 	// ── ActiveJobsCleanupService scheduling ──────────────────────────────

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -23,6 +23,7 @@ namespace SdAiAgent\Tests\REST;
 
 use SdAiAgent\Core\AgentLoop;
 use SdAiAgent\Core\ConversationTrimmer;
+use SdAiAgent\Core\ActiveJobFailureDiagnostic;
 use SdAiAgent\Core\Database;
 use SdAiAgent\Core\Settings;
 use SdAiAgent\Automations\HumanApprovalGate;
@@ -1129,8 +1130,10 @@ class RestControllerTest extends WP_UnitTestCase {
 
 		$this->assertSame( 'error', $data['status'] );
 		$this->assertSame( 'interrupted', $data['original_status'] );
-		$this->assertStringContainsString( 'phase=provider_call', $data['message'] );
-		$this->assertStringNotContainsString( '/home/runner/work', $data['message'] );
+		$this->assertSame( ActiveJobFailureDiagnostic::REASON_WORKER_TERMINATED, $data['diagnostic']['reason'] );
+		$this->assertTrue( $data['diagnostic']['retryable'] );
+		$this->assertSame( 'retry', $data['diagnostic']['next_action'] );
+		$this->assertStringNotContainsString( '/home/runner/work', wp_json_encode( $data ) );
 		$this->assertStringNotContainsString( 'sk-test-secret-token', $data['message'] );
 		$this->assertNull(
 			ActiveJobRepository::get_by_job_id( $job_id ),
@@ -1373,7 +1376,8 @@ class RestControllerTest extends WP_UnitTestCase {
 
 		$this->assertSame( 'error', $data['status'] );
 		$this->assertTrue( $data['from_db'] );
-		$this->assertSame( $error_text, $data['message'] );
+		$this->assertSame( ActiveJobFailureDiagnostic::REASON_UNKNOWN, $data['diagnostic']['reason'] );
+		$this->assertSame( ActiveJobFailureDiagnostic::message_for( ActiveJobFailureDiagnostic::REASON_UNKNOWN ), $data['message'] );
 		$this->assertArrayNotHasKey( 'recoverable', $data );
 		$this->assertNull( ActiveJobRepository::get_by_job_id( $job_id ) );
 	}
@@ -1401,7 +1405,7 @@ class RestControllerTest extends WP_UnitTestCase {
 		$response = $this->dispatch( 'GET', "/sd-ai-agent/v1/job/{$job_id}" );
 
 		$this->assertStatus( 200, $response );
-		$this->assertSame( 'expired', $response->get_data()['status'] );
+		$this->assertSame( 'error', $response->get_data()['status'] );
 		$this->assertArrayNotHasKey( 'pending_tools', $response->get_data() );
 		$this->assertNull( ActiveJobRepository::get_by_job_id( $job_id ) );
 	}
@@ -1425,7 +1429,13 @@ class RestControllerTest extends WP_UnitTestCase {
 
 		$this->assertStatus( 200, $response );
 		$this->assertNotContains( $job_id, wp_list_pluck( $response->get_data(), 'job_id' ) );
-		$this->assertNull( ActiveJobRepository::get_by_job_id( $job_id ) );
+		$expired_job = ActiveJobRepository::get_by_job_id( $job_id );
+		$this->assertNotNull( $expired_job );
+		$this->assertSame( 'error', $expired_job->status );
+		$this->assertSame(
+			ActiveJobFailureDiagnostic::REASON_APPROVAL_EXPIRED,
+			ActiveJobFailureDiagnostic::from_stored( $job_id, $expired_job->error )['reason']
+		);
 	}
 
 	/**
@@ -1446,11 +1456,17 @@ class RestControllerTest extends WP_UnitTestCase {
 		$response = $this->dispatch( 'GET', "/sd-ai-agent/v1/sessions/{$session_id}/active-job" );
 
 		$this->assertStatus( 404, $response );
-		$this->assertNull( ActiveJobRepository::get_by_job_id( $job_id ) );
+		$expired_job = ActiveJobRepository::get_by_job_id( $job_id );
+		$this->assertNotNull( $expired_job );
+		$this->assertSame( 'error', $expired_job->status );
+		$this->assertSame(
+			ActiveJobFailureDiagnostic::REASON_APPROVAL_EXPIRED,
+			ActiveJobFailureDiagnostic::from_stored( $job_id, $expired_job->error )['reason']
+		);
 	}
 
 	/**
-	 * Test terminal DB error rows keep recoverable metadata when paused state exists.
+	 * Test terminal DB error rows keep recoverable metadata without returning legacy detail.
 	 */
 	public function test_job_status_from_db_error_row_includes_recoverable_when_paused_state_exists(): void {
 		wp_set_current_user( $this->admin_id );
@@ -1482,7 +1498,9 @@ class RestControllerTest extends WP_UnitTestCase {
 
 		$this->assertSame( 'error', $data['status'] );
 		$this->assertTrue( $data['from_db'] );
-		$this->assertSame( $error_text, $data['message'] );
+		$this->assertSame( ActiveJobFailureDiagnostic::REASON_UNKNOWN, $data['diagnostic']['reason'] );
+		$this->assertSame( ActiveJobFailureDiagnostic::message_for( ActiveJobFailureDiagnostic::REASON_UNKNOWN ), $data['message'] );
+		$this->assertStringNotContainsString( $error_text, wp_json_encode( $data ) );
 		$this->assertTrue( $data['recoverable'] );
 		$this->assertNull( ActiveJobRepository::get_by_job_id( $job_id ) );
 	}
@@ -1572,7 +1590,11 @@ class RestControllerTest extends WP_UnitTestCase {
 
 		$this->assertNotNull( $db_row );
 		$this->assertSame( 'error', $db_row->status );
-		$this->assertSame( 'Invalid conversation history format.', $db_row->error );
+		$this->assertSame(
+			ActiveJobFailureDiagnostic::REASON_LOOP_EXCEPTION,
+			ActiveJobFailureDiagnostic::from_stored( $job_id, $db_row->error )['reason']
+		);
+		$this->assertStringNotContainsString( 'Invalid conversation history format.', $db_row->error );
 	}
 
 	/**

--- a/tests/SdAiAgent/Services/CustomerAgentRuntimeServiceTest.php
+++ b/tests/SdAiAgent/Services/CustomerAgentRuntimeServiceTest.php
@@ -10,8 +10,10 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Tests\Services;
 
+use SdAiAgent\Core\ActiveJobFailureDiagnostic;
 use SdAiAgent\Core\Database;
 use SdAiAgent\Knowledge\KnowledgeDatabase;
+use SdAiAgent\Models\ActiveJobRepository;
 use SdAiAgent\Models\Agent;
 use SdAiAgent\Models\CustomerAgentRuntimeRepository;
 use SdAiAgent\Services\CustomerAgentRuntimeService;
@@ -371,6 +373,12 @@ class CustomerAgentRuntimeServiceTest extends WP_UnitTestCase {
 		$this->assertNotInstanceOf( WP_Error::class, $status );
 		$this->assertSame( 'cancelled', $status['status'] );
 		$this->assertArrayNotHasKey( 'reply', $status );
+		$active_job = ActiveJobRepository::get_by_job_id( $job['job_id'] );
+		$this->assertNotNull( $active_job );
+		$this->assertSame( 'error', $active_job->status );
+		$diagnostic = ActiveJobFailureDiagnostic::from_stored( $job['job_id'], $active_job->error );
+		$this->assertSame( ActiveJobFailureDiagnostic::REASON_UNKNOWN, $diagnostic['reason'] );
+		$this->assertSame( 'customer_agent_cancellation', $diagnostic['last_safe_phase'] );
 	}
 
 	/** Stuck jobs are converted to a stable timeout response during reconciliation. */
@@ -431,6 +439,43 @@ class CustomerAgentRuntimeServiceTest extends WP_UnitTestCase {
 		$stored = CustomerAgentRuntimeRepository::get_job( $job['job_id'] );
 		$this->assertNotNull( $stored );
 		$this->assertStringNotContainsString( 'test-only-secret-value', (string) $stored['error_message'] );
+		$active_job = ActiveJobRepository::get_by_job_id( $job['job_id'] );
+		$this->assertNotNull( $active_job );
+		$diagnostic = ActiveJobFailureDiagnostic::from_stored( $job['job_id'], $active_job->error );
+		$this->assertSame( ActiveJobFailureDiagnostic::REASON_UNKNOWN, $diagnostic['reason'] );
+		$this->assertSame( 'customer_agent_runtime', $diagnostic['last_safe_phase'] );
+		$this->assertStringNotContainsString( 'test-only-secret-value', $active_job->error );
+	}
+
+	/** Provider timeout failures retain only safe recovery metadata. */
+	public function test_classifies_timeout_executor_failures_for_active_job_recovery(): void {
+		$service = new CustomerAgentRuntimeService(
+			static function (): WP_Error {
+				return new WP_Error(
+					'timeout',
+					'Provider timeout: token=test-only-timeout-secret',
+					array(
+						'provider_id' => 'timeout-provider',
+						'model_id'    => 'timeout-model',
+					)
+				);
+			}
+		);
+		$job = $service->enqueue_turn( self::INTEGRATION, 'customer-session-timeout-diagnostic', 'message-1', 'Please help.' );
+		$this->assertNotInstanceOf( WP_Error::class, $job );
+
+		$service->process_job( $job['job_id'] );
+
+		$active_job = ActiveJobRepository::get_by_job_id( $job['job_id'] );
+		$this->assertNotNull( $active_job );
+		$diagnostic = ActiveJobFailureDiagnostic::from_stored( $job['job_id'], $active_job->error );
+		$this->assertSame( ActiveJobFailureDiagnostic::REASON_PROVIDER_TIMEOUT, $diagnostic['reason'] );
+		$this->assertSame( 'customer_agent_runtime', $diagnostic['last_safe_phase'] );
+		$this->assertTrue( $diagnostic['retryable'] );
+		$this->assertSame( 'retry', $diagnostic['next_action'] );
+		$this->assertSame( 'timeout-provider', $diagnostic['provider_id'] );
+		$this->assertSame( 'timeout-model', $diagnostic['model_id'] );
+		$this->assertStringNotContainsString( 'test-only-timeout-secret', $active_job->error );
 	}
 
 	/** Unknown or unsafe registrations fail before a conversation can be created. */


### PR DESCRIPTION
## Summary

Persist safe active-job failure diagnostics across worker persistence, REST polling, telemetry, and recovery UI.

## Files Changed

DESIGN.md, includes/Core/ActiveJobFailureDiagnostic.php, includes/Core/ActiveJobsCleanupService.php, includes/Core/AgentEventLog.php, includes/Core/AgentLoop.php, includes/Models/ActiveJobRepository.php, includes/REST/RestController.php, includes/REST/SessionController.php, includes/Services/CustomerAgentRuntimeService.php, src/components/action-card.js, src/components/chat-redesign/MessageList.js, src/components/chat-redesign/__tests__/MessageList.test.js, src/components/recoverable-job-action-card.js, src/components/shared.css, src/store/__tests__/index.test.js, src/store/slices/active-job-failure-diagnostic.js, src/store/slices/jobSlice.js, tests/SdAiAgent/Core/ActiveJobFailureDiagnosticTest.php, tests/SdAiAgent/Core/ActiveJobsCleanupTest.php, tests/SdAiAgent/REST/RestControllerTest.php, tests/SdAiAgent/Services/CustomerAgentRuntimeServiceTest.php

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — runtime-verified: activated this worktree in the shared WordPress runtime; wp eval-file persisted a provider_timeout diagnostic, safely projected its DTO, rejected a private marker, and cleaned its test records. npm run verify passed: PHPUnit 3989 tests, 17603 assertions, 0 errors/failures; PHP/JS/CSS lint, PHPStan, build, and bundle checks passed. npm run test:js passed: 412 tests.

Resolves #2354


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.192 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-terra spent 3h 31m and 2,066,980 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customer-safe failure cards for background jobs, with clear recovery guidance and optional retry actions.
  * Displays the last completed step and a support correlation ID when available.
  * Standardized failure messages and recovery states across job status and chat experiences.

* **Bug Fixes**
  * Prevents provider errors, prompts, paths, stack traces, and other sensitive technical details from appearing in customer-facing responses.
  * Preserves failed-job diagnostics safely for troubleshooting and recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->