### PR TITLE
fix: remediate production npm audit advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8747,6 +8747,19 @@
 				}
 			}
 		},
+		"node_modules/@wordpress/components/node_modules/uuid": {
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+			"integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
+			"license": "MIT",
+			"bin": {
+				"uuid": "dist/esm/bin/uuid"
+			}
+		},
 		"node_modules/@wordpress/compose": {
 			"version": "7.40.0",
 			"license": "GPL-2.0-or-later",
@@ -23984,11 +23997,17 @@
 			}
 		},
 		"node_modules/sockjs/node_modules/uuid": {
-			"version": "8.3.2",
+			"version": "11.1.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+			"integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
 			"dev": true,
+			"funding": [
+				"https://github.com/sponsors/broofa",
+				"https://github.com/sponsors/ctavan"
+			],
 			"license": "MIT",
 			"bin": {
-				"uuid": "dist/bin/uuid"
+				"uuid": "dist/esm/bin/uuid"
 			}
 		},
 		"node_modules/socks": {
@@ -26136,19 +26155,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"base64-arraybuffer": "^1.0.2"
-			}
-		},
-		"node_modules/uuid": {
-			"version": "14.0.1",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-			"integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"node_modules/v8-to-istanbul": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,14 +25,14 @@
 				"@codemirror/theme-one-dark": "^6.1.3",
 				"@codemirror/view": "^6.40.0",
 				"@wordpress/api-fetch": "^7.36.0",
-				"@wordpress/components": "^30.7.0",
+				"@wordpress/components": "^37.0.0",
 				"@wordpress/compose": "^7.34.0",
 				"@wordpress/data": "^10.34.0",
 				"@wordpress/dom-ready": "^4.38.0",
 				"@wordpress/element": "^6.34.0",
 				"@wordpress/i18n": "^6.7.0",
 				"@wordpress/icons": "^11.1.0",
-				"@wordpress/notices": "^5.35.0",
+				"@wordpress/notices": "^5.51.0",
 				"chart.js": "^4.5.1",
 				"html2canvas": "^1.4.1",
 				"morphdom": "^2.7.8",
@@ -64,15 +64,23 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/@ariakit/core": {
-			"version": "0.4.18",
-			"license": "MIT"
-		},
-		"node_modules/@ariakit/react": {
-			"version": "0.4.21",
+		"node_modules/@ariakit/components": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/@ariakit/components/-/components-0.1.8.tgz",
+			"integrity": "sha512-Lwqh7wCjgQxNPYP8fU4mAXXtEVoN6Zv5jwd+sRYlPf61l7SUbFCEnrXy3+M2FJYOx/3QWUOp/co/OQrDVPid4w==",
 			"license": "MIT",
 			"dependencies": {
-				"@ariakit/react-core": "0.4.21"
+				"@ariakit/store": "0.1.7",
+				"@ariakit/utils": "0.1.5"
+			}
+		},
+		"node_modules/@ariakit/react": {
+			"version": "0.4.35",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.35.tgz",
+			"integrity": "sha512-f/bCg+kw7YgBM5sElc5eHeACb8OxP54mN5w3igu6vg/JBFstDUBnhMeTWZU6NhOqMPUrZIgJYhry9i0Gl9TrVg==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/react-components": "0.3.4"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -83,18 +91,66 @@
 				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
-		"node_modules/@ariakit/react-core": {
-			"version": "0.4.21",
+		"node_modules/@ariakit/react-components": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-components/-/react-components-0.3.4.tgz",
+			"integrity": "sha512-jEfVkDQi99Zdv9SGnTRWGxfvhLXMHHuKXRw57D/uCA8ziKzMNH0+0ZhNDNKnskfPxBsZjbhtSsBXsCeMp1W1ag==",
 			"license": "MIT",
 			"dependencies": {
-				"@ariakit/core": "0.4.18",
-				"@floating-ui/dom": "^1.0.0",
-				"use-sync-external-store": "^1.2.0"
+				"@ariakit/components": "0.1.8",
+				"@ariakit/react-store": "0.1.8",
+				"@ariakit/react-utils": "0.2.3",
+				"@ariakit/store": "0.1.7",
+				"@ariakit/utils": "0.1.5",
+				"@floating-ui/dom": "^1.0.0"
 			},
 			"peerDependencies": {
 				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
 				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
+		},
+		"node_modules/@ariakit/react-store": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-store/-/react-store-0.1.8.tgz",
+			"integrity": "sha512-VYZ1LTUVMrNUi4jP37Npvhe3mcAzKdznqnBSVeh1Jjsbcgw0JlN88oy6UpdoJPvLKWOZHVYr62Sqn7xE0GrsqQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/react-utils": "0.2.3",
+				"@ariakit/store": "0.1.7",
+				"@ariakit/utils": "0.1.5",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@ariakit/react-utils": {
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-utils/-/react-utils-0.2.3.tgz",
+			"integrity": "sha512-fDaheb/7QEusanZb2oRT7mO55GTpQUyBOdjvQF5RPh3/CM15lm0TejLKN5bl1obmU5HRuByvckQmQvSyr8n/dw==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/store": "0.1.7",
+				"@ariakit/utils": "0.1.5"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@ariakit/store": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/@ariakit/store/-/store-0.1.7.tgz",
+			"integrity": "sha512-/GcxscA9QTo2F+IFbFPvoyj1N8hzXBnaYsQt9UxRiJgCFPQ2jIe4i6QgPXdOZEZUuqYdyuvjcQrg7MDm9vpvCA==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/utils": "0.1.5"
+			}
+		},
+		"node_modules/@ariakit/utils": {
+			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/@ariakit/utils/-/utils-0.1.5.tgz",
+			"integrity": "sha512-BQebYH9nV1VZttZwoq/fsxcxIJjc8oW2bNV6yJDHLZ8OF8UtM15drFN0JOL8Jwn7jeeD7Ev+tIC8pUijJEditQ==",
+			"license": "MIT"
 		},
 		"node_modules/@asamuzakjp/css-color": {
 			"version": "3.2.0",
@@ -1775,7 +1831,9 @@
 			}
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.28.6",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+			"integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -1820,6 +1878,66 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@base-ui/react": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/@base-ui/react/-/react-1.6.0.tgz",
+			"integrity": "sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.29.2",
+				"@base-ui/utils": "0.3.1",
+				"@floating-ui/react-dom": "^2.1.8",
+				"@floating-ui/utils": "^0.2.11",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/mui-org"
+			},
+			"peerDependencies": {
+				"@date-fns/tz": "^1.2.0",
+				"@types/react": "^17 || ^18 || ^19",
+				"date-fns": "^4.0.0",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@date-fns/tz": {
+					"optional": true
+				},
+				"@types/react": {
+					"optional": true
+				},
+				"date-fns": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@base-ui/utils": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@base-ui/utils/-/utils-0.3.1.tgz",
+			"integrity": "sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.29.2",
+				"@floating-ui/utils": "^0.2.11",
+				"reselect": "^5.2.0",
+				"use-sync-external-store": "^1.6.0"
+			},
+			"peerDependencies": {
+				"@types/react": "^17 || ^18 || ^19",
+				"react": "^17 || ^18 || ^19",
+				"react-dom": "^17 || ^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@bcoe/v8-coverage": {
 			"version": "0.2.3",
 			"dev": true,
@@ -1827,7 +1945,7 @@
 		},
 		"node_modules/@cacheable/memory": {
 			"version": "2.0.8",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cacheable/utils": "^2.4.0",
@@ -1838,7 +1956,7 @@
 		},
 		"node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
 			"version": "1.3.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"hashery": "^1.4.0",
@@ -1853,7 +1971,7 @@
 		},
 		"node_modules/@cacheable/memory/node_modules/keyv": {
 			"version": "5.6.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@keyv/serialize": "^1.1.1"
@@ -1861,7 +1979,7 @@
 		},
 		"node_modules/@cacheable/utils": {
 			"version": "2.4.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"hashery": "^1.5.0",
@@ -1870,7 +1988,7 @@
 		},
 		"node_modules/@cacheable/utils/node_modules/keyv": {
 			"version": "5.6.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@keyv/serialize": "^1.1.1"
@@ -2161,7 +2279,7 @@
 		},
 		"node_modules/@csstools/css-parser-algorithms": {
 			"version": "3.0.5",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2182,7 +2300,7 @@
 		},
 		"node_modules/@csstools/css-syntax-patches-for-csstree": {
 			"version": "1.1.1",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2205,7 +2323,7 @@
 		},
 		"node_modules/@csstools/css-tokenizer": {
 			"version": "3.0.4",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2261,7 +2379,7 @@
 		},
 		"node_modules/@dual-bundle/import-meta-resolve": {
 			"version": "4.2.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -2504,11 +2622,6 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/@eslint/eslintrc/node_modules/argparse": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "Python-2.0"
-		},
 		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
 			"version": "1.1.12",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -2518,17 +2631,6 @@
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-			"version": "4.1.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"argparse": "^2.0.1"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
@@ -2553,25 +2655,31 @@
 			}
 		},
 		"node_modules/@floating-ui/core": {
-			"version": "1.7.4",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz",
+			"integrity": "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@floating-ui/utils": "^0.2.10"
+				"@floating-ui/utils": "^0.2.12"
 			}
 		},
 		"node_modules/@floating-ui/dom": {
-			"version": "1.7.5",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
+			"integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
 			"license": "MIT",
 			"dependencies": {
-				"@floating-ui/core": "^1.7.4",
-				"@floating-ui/utils": "^0.2.10"
+				"@floating-ui/core": "^1.8.0",
+				"@floating-ui/utils": "^0.2.12"
 			}
 		},
 		"node_modules/@floating-ui/react-dom": {
-			"version": "2.0.8",
+			"version": "2.1.9",
+			"resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.9.tgz",
+			"integrity": "sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==",
 			"license": "MIT",
 			"dependencies": {
-				"@floating-ui/dom": "^1.6.1"
+				"@floating-ui/dom": "^1.8.0"
 			},
 			"peerDependencies": {
 				"react": ">=16.8.0",
@@ -2579,7 +2687,9 @@
 			}
 		},
 		"node_modules/@floating-ui/utils": {
-			"version": "0.2.10",
+			"version": "0.2.12",
+			"resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.12.tgz",
+			"integrity": "sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==",
 			"license": "MIT"
 		},
 		"node_modules/@formatjs/ecma402-abstract": {
@@ -3442,17 +3552,6 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/@jest/environment-jsdom-abstract/node_modules/picomatch": {
-			"version": "4.0.3",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/@jest/environment-jsdom-abstract/node_modules/pretty-format": {
 			"version": "30.2.0",
 			"dev": true,
@@ -4136,7 +4235,7 @@
 		},
 		"node_modules/@keyv/serialize": {
 			"version": "1.1.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/@kurkle/color": {
@@ -4325,7 +4424,7 @@
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.stat": "2.0.5",
@@ -4337,7 +4436,7 @@
 		},
 		"node_modules/@nodelib/fs.stat": {
 			"version": "2.0.5",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
@@ -4345,7 +4444,7 @@
 		},
 		"node_modules/@nodelib/fs.walk": {
 			"version": "1.2.8",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.scandir": "2.1.5",
@@ -5655,18 +5754,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
-			}
-		},
-		"node_modules/@parcel/watcher/node_modules/picomatch": {
-			"version": "4.0.3",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/@paulirish/trace_engine": {
@@ -8256,11 +8343,13 @@
 			}
 		},
 		"node_modules/@wordpress/a11y": {
-			"version": "4.40.0",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/a11y/-/a11y-4.51.0.tgz",
+			"integrity": "sha512-ophPwL3J31JOA46koDonBz7EL1dMfpKLEj8crD2uCK5IYzvqlYJrLA0o+RfPUUHrbXa51qGBSZ/+Bprb6nao+g==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/dom-ready": "^4.40.0",
-				"@wordpress/i18n": "^6.13.0"
+				"@wordpress/dom-ready": "^4.51.0",
+				"@wordpress/i18n": "^6.24.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -8483,6 +8572,7 @@
 		},
 		"node_modules/@wordpress/base-styles": {
 			"version": "6.17.0",
+			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -8499,64 +8589,162 @@
 			}
 		},
 		"node_modules/@wordpress/components": {
-			"version": "30.9.0",
+			"version": "37.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/components/-/components-37.0.0.tgz",
+			"integrity": "sha512-Lol3iUujNnn4uHxI4VARDVEJIFUKlBtZUMcSFWofiYRZc8aV5BplyKC+sRAhKm+KFNBQjZtqd4PdixtaOHuX6w==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.4.15",
+				"@ariakit/react": "^0.4.32",
 				"@date-fns/utc": "^2.1.1",
-				"@emotion/cache": "^11.7.1",
-				"@emotion/css": "^11.7.1",
-				"@emotion/react": "^11.7.1",
-				"@emotion/serialize": "^1.0.2",
-				"@emotion/styled": "^11.6.0",
-				"@emotion/utils": "^1.0.0",
-				"@floating-ui/react-dom": "2.0.8",
-				"@types/gradient-parser": "1.1.0",
-				"@types/highlight-words-core": "1.2.1",
+				"@emotion/cache": "^11.14.0",
+				"@emotion/css": "^11.13.5",
+				"@emotion/react": "^11.14.0",
+				"@emotion/serialize": "^1.3.3",
+				"@emotion/styled": "^11.14.1",
+				"@emotion/utils": "^1.4.2",
+				"@floating-ui/react-dom": "^2.0.8",
+				"@types/gradient-parser": "^1.1.0",
+				"@types/highlight-words-core": "^1.2.1",
 				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.36.0",
-				"@wordpress/base-styles": "^6.12.0",
-				"@wordpress/compose": "^7.36.0",
-				"@wordpress/date": "^5.36.0",
-				"@wordpress/deprecated": "^4.36.0",
-				"@wordpress/dom": "^4.36.0",
-				"@wordpress/element": "^6.36.0",
-				"@wordpress/escape-html": "^3.36.0",
-				"@wordpress/hooks": "^4.36.0",
-				"@wordpress/html-entities": "^4.36.0",
-				"@wordpress/i18n": "^6.9.0",
-				"@wordpress/icons": "^11.3.0",
-				"@wordpress/is-shallow-equal": "^5.36.0",
-				"@wordpress/keycodes": "^4.36.0",
-				"@wordpress/primitives": "^4.36.0",
-				"@wordpress/private-apis": "^1.36.0",
-				"@wordpress/rich-text": "^7.36.0",
-				"@wordpress/warning": "^3.36.0",
+				"@wordpress/a11y": "^4.51.0",
+				"@wordpress/base-styles": "^11.0.0",
+				"@wordpress/compose": "^8.4.0",
+				"@wordpress/date": "^5.51.0",
+				"@wordpress/deprecated": "^4.51.0",
+				"@wordpress/dom": "^4.51.0",
+				"@wordpress/element": "^8.3.0",
+				"@wordpress/escape-html": "^3.51.0",
+				"@wordpress/hooks": "^4.51.0",
+				"@wordpress/html-entities": "^4.51.0",
+				"@wordpress/i18n": "^6.24.0",
+				"@wordpress/icons": "^15.2.0",
+				"@wordpress/is-shallow-equal": "^5.51.0",
+				"@wordpress/keycodes": "^4.51.0",
+				"@wordpress/primitives": "^4.51.0",
+				"@wordpress/private-apis": "^1.51.0",
+				"@wordpress/rich-text": "^7.51.0",
+				"@wordpress/style-runtime": "^0.7.0",
+				"@wordpress/ui": "^0.18.0",
+				"@wordpress/warning": "^3.51.0",
 				"change-case": "^4.1.2",
 				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
-				"date-fns": "^3.6.0",
-				"deepmerge": "^4.3.0",
+				"colord": "^2.9.3",
+				"csstype": "^3.2.3",
+				"date-fns": "^4.1.0",
+				"deepmerge": "^4.3.1",
 				"fast-deep-equal": "^3.1.3",
 				"framer-motion": "^11.15.0",
-				"gradient-parser": "1.1.1",
+				"gradient-parser": "^1.1.1",
 				"highlight-words-core": "^1.2.2",
 				"is-plain-object": "^5.0.0",
 				"memize": "^2.1.0",
 				"path-to-regexp": "^6.2.1",
 				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.3.1",
+				"react-colorful": "^5.6.1",
 				"react-day-picker": "^9.7.0",
 				"remove-accents": "^0.5.0",
-				"uuid": "^9.0.1"
+				"uuid": "^14.0.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/base-styles": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-11.0.0.tgz",
+			"integrity": "sha512-w+n/AWSNfDx5RhPIpKCi7Iptn+8+Sll8uJhyx6X62zkkHDX51H2vZTU2XaXOQGx5U7xQcaVTbHjVDgYBwkU4Vg==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/compose": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.4.0.tgz",
+			"integrity": "sha512-oVmRQ05Rlzh+W7oFb6CGmNm9SDozd3VEVYhXO4CcTpz0vkn7bEcwIMIdaKq49X8vORW1htJa/myBbYJATpamNg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.51.0",
+				"@wordpress/dom": "^4.51.0",
+				"@wordpress/element": "^8.3.0",
+				"@wordpress/is-shallow-equal": "^5.51.0",
+				"@wordpress/keycodes": "^4.51.0",
+				"@wordpress/priority-queue": "^3.51.0",
+				"@wordpress/private-apis": "^1.51.0",
+				"@wordpress/undo-manager": "^1.51.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/element": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.3.0.tgz",
+			"integrity": "sha512-D6Oawyq9RNL01RbpmBkx5dcE2CawU7p2cPxfeNVZkh/zEV5w9pi7HAwvFFqQA1jRT0sV4B62JcAAzuILALcQQw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.51.0",
+				"@wordpress/escape-html": "^3.51.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/components/node_modules/@wordpress/icons": {
+			"version": "15.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-15.2.0.tgz",
+			"integrity": "sha512-g/1a4eTNH/mCluvmryNcYAg1GxsjY6xGjfGJRq3z44SEcB8jAZyEQtqdcGQ+o2kHelKhmmqS8WAowxif44ZgNQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.3.0",
+				"@wordpress/primitives": "^4.51.0",
+				"change-case": "^4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/compose": {
@@ -8585,17 +8773,19 @@
 			}
 		},
 		"node_modules/@wordpress/data": {
-			"version": "10.40.0",
+			"version": "10.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/data/-/data-10.51.0.tgz",
+			"integrity": "sha512-KwlrgU+PGd+l4QyrwuCvbHE5HUC1CU6pqD19WZr+yOD1XRmIWZ+LZNwrEdFlhCu8aOG9+e131k1zmAMZign/mA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/compose": "^7.40.0",
-				"@wordpress/deprecated": "^4.40.0",
-				"@wordpress/element": "^6.40.0",
-				"@wordpress/is-shallow-equal": "^5.40.0",
-				"@wordpress/priority-queue": "^3.40.0",
-				"@wordpress/private-apis": "^1.40.0",
-				"@wordpress/redux-routine": "^5.40.0",
-				"deepmerge": "^4.3.0",
+				"@wordpress/compose": "^8.4.0",
+				"@wordpress/deprecated": "^4.51.0",
+				"@wordpress/element": "^8.3.0",
+				"@wordpress/is-shallow-equal": "^5.51.0",
+				"@wordpress/priority-queue": "^3.51.0",
+				"@wordpress/private-apis": "^1.51.0",
+				"@wordpress/redux-routine": "^5.51.0",
+				"deepmerge": "^4.3.1",
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
 				"is-promise": "^4.0.0",
@@ -8608,14 +8798,75 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"react": "^18.0.0"
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/data/node_modules/@wordpress/compose": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.4.0.tgz",
+			"integrity": "sha512-oVmRQ05Rlzh+W7oFb6CGmNm9SDozd3VEVYhXO4CcTpz0vkn7bEcwIMIdaKq49X8vORW1htJa/myBbYJATpamNg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.51.0",
+				"@wordpress/dom": "^4.51.0",
+				"@wordpress/element": "^8.3.0",
+				"@wordpress/is-shallow-equal": "^5.51.0",
+				"@wordpress/keycodes": "^4.51.0",
+				"@wordpress/priority-queue": "^3.51.0",
+				"@wordpress/private-apis": "^1.51.0",
+				"@wordpress/undo-manager": "^1.51.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/data/node_modules/@wordpress/element": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.3.0.tgz",
+			"integrity": "sha512-D6Oawyq9RNL01RbpmBkx5dcE2CawU7p2cPxfeNVZkh/zEV5w9pi7HAwvFFqQA1jRT0sV4B62JcAAzuILALcQQw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.51.0",
+				"@wordpress/escape-html": "^3.51.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/date": {
-			"version": "5.40.0",
+			"version": "5.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/date/-/date-5.51.0.tgz",
+			"integrity": "sha512-clBSLSnP799BYGq97i9JX8oqNMAK37omFGig1+OFDxKqHj6iuM4UA9teOBlUFkHuldLc4I4MQcuLi/Ic6AF7fg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/deprecated": "^4.40.0",
+				"@wordpress/deprecated": "^4.51.0",
 				"moment": "^2.29.4",
 				"moment-timezone": "^0.5.40"
 			},
@@ -8645,10 +8896,12 @@
 			"license": "BSD"
 		},
 		"node_modules/@wordpress/deprecated": {
-			"version": "4.40.0",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/deprecated/-/deprecated-4.51.0.tgz",
+			"integrity": "sha512-6pgnUvz7oQRwpJh+aM/dPBs5GBPTyOj+XKGeyzKPKHqbaWeSzkHVI9bhgs+Ajamn/jERK5TgH+VAq/gwfvfO+g==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/hooks": "^4.40.0"
+				"@wordpress/hooks": "^4.51.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -8656,10 +8909,12 @@
 			}
 		},
 		"node_modules/@wordpress/dom": {
-			"version": "4.40.0",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom/-/dom-4.51.0.tgz",
+			"integrity": "sha512-POkQoNBzLFlHaVzJakgF5X/xj4nERsLa5uTAvt3i7YFr9tep3uLtOFCJiiZM1vzO5iVtYSBWxmWyDkJPsOSy6g==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/deprecated": "^4.40.0"
+				"@wordpress/deprecated": "^4.51.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -8667,7 +8922,9 @@
 			}
 		},
 		"node_modules/@wordpress/dom-ready": {
-			"version": "4.40.0",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-4.51.0.tgz",
+			"integrity": "sha512-O/ivmzG+o44CicTW+c17KBXlmjRoVp4VGIyyEQDD52H5YH+gX7i15FuEPk6G2e7Rqz4DCvCS5yD7eY9Zb3z1WA==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -8802,7 +9059,9 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "3.41.0",
+			"version": "3.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.51.0.tgz",
+			"integrity": "sha512-0jPCm9WqpB7S+mdhkjjikBzGo06xAgvmgwtSP1v44P5tKNGujcbsvKj+JW0m60FJxNBmaZPvGu2e/DlY4iljVQ==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -8869,7 +9128,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "4.40.0",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.51.0.tgz",
+			"integrity": "sha512-pTVZRT9mjEdrNNt7TyKw5hQhFUqntfTXVs/fboEDpmAi+PFWXoD8rPs3oZyRCVr/MDyE6OCv1mwEibI6AsRk3Q==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -8877,7 +9138,9 @@
 			}
 		},
 		"node_modules/@wordpress/html-entities": {
-			"version": "4.40.0",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-4.51.0.tgz",
+			"integrity": "sha512-rkWpUWbO7FlGzicae0tAlmDj6gTTh/SLXbuRKlPLvG4W8dokSuv+q491aes14VvDY9u4sFeRduQt+nXivfxpfQ==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -8885,11 +9148,13 @@
 			}
 		},
 		"node_modules/@wordpress/i18n": {
-			"version": "6.13.0",
+			"version": "6.24.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.24.0.tgz",
+			"integrity": "sha512-K4XmCyyyDOKH/5ea75P2L36ZiAvQTy4Hsa73Na3n6NzVjAwrrKZm4JJGf0t+OlThUG4D4GyfEv5szs5EeCA0lA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.40.0",
+				"@wordpress/hooks": "^4.51.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -8919,7 +9184,9 @@
 			}
 		},
 		"node_modules/@wordpress/is-shallow-equal": {
-			"version": "5.40.0",
+			"version": "5.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/is-shallow-equal/-/is-shallow-equal-5.51.0.tgz",
+			"integrity": "sha512-Ivyf85r9trFfl/rRaDMgghFZ+gzw8yIl7/vDPagYkvq9Xnqw8KecPy91BqIIvco1jIOh3RXPP6cbVu3dTqZDMA==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -8960,23 +9227,35 @@
 			}
 		},
 		"node_modules/@wordpress/keycodes": {
-			"version": "4.40.0",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/keycodes/-/keycodes-4.51.0.tgz",
+			"integrity": "sha512-C9CZq2WCWVacjsHhFgM0GVIQmTUxo/oX7U+Qj0kr3vWHZu6cmEDJ94PX+f02M3b+iHnCk4oHCvnXGANwKQwsSw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/i18n": "^6.13.0"
+				"@wordpress/i18n": "^6.24.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/notices": {
-			"version": "5.40.0",
+			"version": "5.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/notices/-/notices-5.51.0.tgz",
+			"integrity": "sha512-mOOPEnjmkvscs4gNEYNiowsSF371HnO5euFOmBRIcnuRjn/dW7VqUfGXUbsu3HGXqjMBWBWPW0hzEjaatEVhGA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/a11y": "^4.40.0",
-				"@wordpress/components": "^32.2.0",
-				"@wordpress/data": "^10.40.0",
+				"@wordpress/a11y": "^4.51.0",
+				"@wordpress/components": "^37.0.0",
+				"@wordpress/data": "^10.51.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -8984,70 +9263,13 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"react": "^18.0.0"
-			}
-		},
-		"node_modules/@wordpress/notices/node_modules/@wordpress/components": {
-			"version": "32.2.0",
-			"license": "GPL-2.0-or-later",
-			"dependencies": {
-				"@ariakit/react": "^0.4.21",
-				"@date-fns/utc": "^2.1.1",
-				"@emotion/cache": "^11.14.0",
-				"@emotion/css": "^11.13.5",
-				"@emotion/react": "^11.14.0",
-				"@emotion/serialize": "^1.3.3",
-				"@emotion/styled": "^11.14.1",
-				"@emotion/utils": "^1.4.2",
-				"@floating-ui/react-dom": "2.0.8",
-				"@types/gradient-parser": "1.1.0",
-				"@types/highlight-words-core": "1.2.1",
-				"@types/react": "^18.3.27",
-				"@use-gesture/react": "^10.3.1",
-				"@wordpress/a11y": "^4.40.0",
-				"@wordpress/base-styles": "^6.16.0",
-				"@wordpress/compose": "^7.40.0",
-				"@wordpress/date": "^5.40.0",
-				"@wordpress/deprecated": "^4.40.0",
-				"@wordpress/dom": "^4.40.0",
-				"@wordpress/element": "^6.40.0",
-				"@wordpress/escape-html": "^3.40.0",
-				"@wordpress/hooks": "^4.40.0",
-				"@wordpress/html-entities": "^4.40.0",
-				"@wordpress/i18n": "^6.13.0",
-				"@wordpress/icons": "^11.7.0",
-				"@wordpress/is-shallow-equal": "^5.40.0",
-				"@wordpress/keycodes": "^4.40.0",
-				"@wordpress/primitives": "^4.40.0",
-				"@wordpress/private-apis": "^1.40.0",
-				"@wordpress/rich-text": "^7.40.0",
-				"@wordpress/warning": "^3.40.0",
-				"change-case": "^4.1.2",
-				"clsx": "^2.1.1",
-				"colord": "^2.7.0",
-				"csstype": "^3.2.3",
-				"date-fns": "^3.6.0",
-				"deepmerge": "^4.3.0",
-				"fast-deep-equal": "^3.1.3",
-				"framer-motion": "^11.15.0",
-				"gradient-parser": "1.1.1",
-				"highlight-words-core": "^1.2.2",
-				"is-plain-object": "^5.0.0",
-				"memize": "^2.1.0",
-				"path-to-regexp": "^6.2.1",
-				"re-resizable": "^6.4.0",
-				"react-colorful": "^5.6.1",
-				"react-day-picker": "^9.7.0",
-				"remove-accents": "^0.5.0",
-				"uuid": "^9.0.1"
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
 			},
-			"engines": {
-				"node": ">=18.12.0",
-				"npm": ">=8.19.2"
-			},
-			"peerDependencies": {
-				"react": "^18.0.0",
-				"react-dom": "^18.0.0"
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/npm-package-json-lint-config": {
@@ -9092,10 +9314,12 @@
 			}
 		},
 		"node_modules/@wordpress/primitives": {
-			"version": "4.40.0",
+			"version": "4.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.51.0.tgz",
+			"integrity": "sha512-vSg8XYGyBL9+s1h67Fhx8vV718iM9jto8/Tx5tyEdPHXuvY9F8hi3FLZ8k/DQ7qGy+o3ljDsfl1dq9DHP/Fs0A==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/element": "^6.40.0",
+				"@wordpress/element": "^8.3.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {
@@ -9103,11 +9327,39 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"react": "^18.0.0"
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/primitives/node_modules/@wordpress/element": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.3.0.tgz",
+			"integrity": "sha512-D6Oawyq9RNL01RbpmBkx5dcE2CawU7p2cPxfeNVZkh/zEV5w9pi7HAwvFFqQA1jRT0sV4B62JcAAzuILALcQQw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.51.0",
+				"@wordpress/escape-html": "^3.51.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/priority-queue": {
-			"version": "3.40.0",
+			"version": "3.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/priority-queue/-/priority-queue-3.51.0.tgz",
+			"integrity": "sha512-Mgm6DFRW4ZqgkVTQNe6LdtWzah19u6531Uf1L5q1LwYd/eekKeRsNB9dJnqBg2Kn/jgfPbZnTaHToDvnOZQgcA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"requestidlecallback": "^0.3.0"
@@ -9118,7 +9370,9 @@
 			}
 		},
 		"node_modules/@wordpress/private-apis": {
-			"version": "1.41.0",
+			"version": "1.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.51.0.tgz",
+			"integrity": "sha512-x3FeBDGegBAKveYHNmgZgTbEwuwVMxGouTR2fKP94Myn5PzF5EkZK1CZJrDnfNjzTl73nCwsd4IXACdtYfnnAQ==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -9126,7 +9380,9 @@
 			}
 		},
 		"node_modules/@wordpress/redux-routine": {
-			"version": "5.40.0",
+			"version": "5.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/redux-routine/-/redux-routine-5.51.0.tgz",
+			"integrity": "sha512-L5wLAEMPXjE7HvyD2ErH7HL0vgAhXGN9if0yc/r42nnyt9Mq/5B7MOjGJL7qpBb0VoBsUvqPoLEIZmIPU+OF+A==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"is-plain-object": "^5.0.0",
@@ -9142,20 +9398,22 @@
 			}
 		},
 		"node_modules/@wordpress/rich-text": {
-			"version": "7.40.0",
+			"version": "7.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/rich-text/-/rich-text-7.51.0.tgz",
+			"integrity": "sha512-SYe7N6GMTZ3DMwNrC69EuFc/tv0KJNfWKoLJWOepIJuuseWj+JVrSAUO13Dv1c8Q0syr8zR2RJvS5G4jiMgAsA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/a11y": "^4.40.0",
-				"@wordpress/compose": "^7.40.0",
-				"@wordpress/data": "^10.40.0",
-				"@wordpress/deprecated": "^4.40.0",
-				"@wordpress/dom": "^4.40.0",
-				"@wordpress/element": "^6.40.0",
-				"@wordpress/escape-html": "^3.40.0",
-				"@wordpress/i18n": "^6.13.0",
-				"@wordpress/keycodes": "^4.40.0",
-				"@wordpress/private-apis": "^1.40.0",
-				"colord": "2.9.3",
+				"@wordpress/a11y": "^4.51.0",
+				"@wordpress/compose": "^8.4.0",
+				"@wordpress/data": "^10.51.0",
+				"@wordpress/deprecated": "^4.51.0",
+				"@wordpress/dom": "^4.51.0",
+				"@wordpress/element": "^8.3.0",
+				"@wordpress/escape-html": "^3.51.0",
+				"@wordpress/i18n": "^6.24.0",
+				"@wordpress/keycodes": "^4.51.0",
+				"@wordpress/private-apis": "^1.51.0",
+				"colord": "^2.9.3",
 				"memize": "^2.1.0"
 			},
 			"engines": {
@@ -9163,7 +9421,66 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"react": "^18.0.0"
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/rich-text/node_modules/@wordpress/compose": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.4.0.tgz",
+			"integrity": "sha512-oVmRQ05Rlzh+W7oFb6CGmNm9SDozd3VEVYhXO4CcTpz0vkn7bEcwIMIdaKq49X8vORW1htJa/myBbYJATpamNg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.51.0",
+				"@wordpress/dom": "^4.51.0",
+				"@wordpress/element": "^8.3.0",
+				"@wordpress/is-shallow-equal": "^5.51.0",
+				"@wordpress/keycodes": "^4.51.0",
+				"@wordpress/priority-queue": "^3.51.0",
+				"@wordpress/private-apis": "^1.51.0",
+				"@wordpress/undo-manager": "^1.51.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/rich-text/node_modules/@wordpress/element": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.3.0.tgz",
+			"integrity": "sha512-D6Oawyq9RNL01RbpmBkx5dcE2CawU7p2cPxfeNVZkh/zEV5w9pi7HAwvFFqQA1jRT0sV4B62JcAAzuILALcQQw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.51.0",
+				"@wordpress/escape-html": "^3.51.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
 			}
 		},
 		"node_modules/@wordpress/scripts": {
@@ -9250,6 +9567,16 @@
 				}
 			}
 		},
+		"node_modules/@wordpress/style-runtime": {
+			"version": "0.7.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/style-runtime/-/style-runtime-0.7.0.tgz",
+			"integrity": "sha512-PeAcF7qoIMg9ChS5SfkRrLLcUx9D7Te6weRcQmoKYgxE7jSzzXpoaiy3Z+Us+ChyisolF4xhTg5DblMBPL1iug==",
+			"license": "GPL-2.0-or-later",
+			"engines": {
+				"node": ">=20.10.0",
+				"npm": ">=10.2.3"
+			}
+		},
 		"node_modules/@wordpress/stylelint-config": {
 			"version": "23.33.0",
 			"dev": true,
@@ -9294,11 +9621,170 @@
 				}
 			}
 		},
-		"node_modules/@wordpress/undo-manager": {
-			"version": "1.40.0",
+		"node_modules/@wordpress/ui": {
+			"version": "0.18.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/ui/-/ui-0.18.0.tgz",
+			"integrity": "sha512-TIMsjaRl5/QJEjKbtoa0YAhzVdcvAk/FmA9rgJVR6oG/l6+s0WgoebGASEVyRyoOstq45xB7PzYMdjVs7iS0zg==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/is-shallow-equal": "^5.40.0"
+				"@base-ui/react": "^1.6.0",
+				"@wordpress/a11y": "^4.51.0",
+				"@wordpress/compose": "^8.4.0",
+				"@wordpress/element": "^8.3.0",
+				"@wordpress/i18n": "^6.24.0",
+				"@wordpress/icons": "^15.2.0",
+				"@wordpress/keycodes": "^4.51.0",
+				"@wordpress/primitives": "^4.51.0",
+				"@wordpress/private-apis": "^1.51.0",
+				"@wordpress/style-runtime": "^0.7.0",
+				"@wordpress/theme": "^1.0.0",
+				"clsx": "^2.1.1",
+				"tabbable": "^6.4.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.13.0",
+				"npm": ">=10.2.3"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/compose": {
+			"version": "8.4.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/compose/-/compose-8.4.0.tgz",
+			"integrity": "sha512-oVmRQ05Rlzh+W7oFb6CGmNm9SDozd3VEVYhXO4CcTpz0vkn7bEcwIMIdaKq49X8vORW1htJa/myBbYJATpamNg==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/mousetrap": "^1.6.8",
+				"@wordpress/deprecated": "^4.51.0",
+				"@wordpress/dom": "^4.51.0",
+				"@wordpress/element": "^8.3.0",
+				"@wordpress/is-shallow-equal": "^5.51.0",
+				"@wordpress/keycodes": "^4.51.0",
+				"@wordpress/priority-queue": "^3.51.0",
+				"@wordpress/private-apis": "^1.51.0",
+				"@wordpress/undo-manager": "^1.51.0",
+				"change-case": "^4.1.2",
+				"mousetrap": "^1.6.5",
+				"use-memo-one": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/element": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-8.3.0.tgz",
+			"integrity": "sha512-D6Oawyq9RNL01RbpmBkx5dcE2CawU7p2cPxfeNVZkh/zEV5w9pi7HAwvFFqQA1jRT0sV4B62JcAAzuILALcQQw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/deprecated": "^4.51.0",
+				"@wordpress/escape-html": "^3.51.0",
+				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
+				"react": "^18.3.1",
+				"react-dom": "^18.3.1"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/icons": {
+			"version": "15.2.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-15.2.0.tgz",
+			"integrity": "sha512-g/1a4eTNH/mCluvmryNcYAg1GxsjY6xGjfGJRq3z44SEcB8jAZyEQtqdcGQ+o2kHelKhmmqS8WAowxif44ZgNQ==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^8.3.0",
+				"@wordpress/primitives": "^4.51.0",
+				"change-case": "^4.1.2"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"react": "^18 || ^19"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/ui/node_modules/@wordpress/theme": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-1.0.0.tgz",
+			"integrity": "sha512-zPwDgv7xx3f4h+lLCq95szofMAMjSIlkIIfR7U2cxQws5J6XnnTsOxHWJTE6V4jPzS19vzFdQdZ9wiR/X3c0Lw==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/compose": "^8.4.0",
+				"@wordpress/deprecated": "^4.51.0",
+				"@wordpress/element": "^8.3.0",
+				"@wordpress/private-apis": "^1.51.0",
+				"@wordpress/style-runtime": "^0.7.0",
+				"colorjs.io": "^0.6.0",
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || >=22.13.0",
+				"npm": ">=10.2.3"
+			},
+			"peerDependencies": {
+				"@types/react": "^18 || ^19",
+				"esbuild": "^0.27.2",
+				"postcss": "^8.0.0",
+				"react": "^18 || ^19",
+				"react-dom": "^18 || ^19",
+				"stylelint": "^16.8.2",
+				"vite": "^7.3.2"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"esbuild": {
+					"optional": true
+				},
+				"postcss": {
+					"optional": true
+				},
+				"stylelint": {
+					"optional": true
+				},
+				"vite": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@wordpress/undo-manager": {
+			"version": "1.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/undo-manager/-/undo-manager-1.51.0.tgz",
+			"integrity": "sha512-w/vUyQX2m+X2xDYCdxu/ALHJdE5S0vkWbxFhUJJeBJG66IFs/DGk/NmLCOudUFLFMQYSXFyIm1XsIPT0UdjhCA==",
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/is-shallow-equal": "^5.51.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -9317,7 +9803,9 @@
 			}
 		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.41.0",
+			"version": "3.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.51.0.tgz",
+			"integrity": "sha512-wWeM6pjAWbMhdNfgCaxi5yhLzomj6/trcIjGPi2Q4kaIuxUula8Ybq0ZPn5lYuc19ICkcGYcAnWNYz/4mYCHdA==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -10249,7 +10737,7 @@
 		},
 		"node_modules/ansi-regex": {
 			"version": "5.0.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -10257,7 +10745,7 @@
 		},
 		"node_modules/ansi-styles": {
 			"version": "4.3.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^2.0.1"
@@ -10290,12 +10778,11 @@
 			}
 		},
 		"node_modules/argparse": {
-			"version": "1.0.10",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"sprintf-js": "~1.0.2"
-			}
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"devOptional": true,
+			"license": "Python-2.0"
 		},
 		"node_modules/aria-query": {
 			"version": "5.3.2",
@@ -10356,7 +10843,7 @@
 		},
 		"node_modules/array-union": {
 			"version": "2.1.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -10509,7 +10996,7 @@
 		},
 		"node_modules/astral-regex": {
 			"version": "2.0.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -11031,7 +11518,7 @@
 		},
 		"node_modules/braces": {
 			"version": "3.0.3",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"fill-range": "^7.1.1"
@@ -11179,7 +11666,7 @@
 		},
 		"node_modules/cacheable": {
 			"version": "2.3.3",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cacheable/memory": "^2.0.8",
@@ -11230,7 +11717,7 @@
 		},
 		"node_modules/cacheable/node_modules/keyv": {
 			"version": "5.6.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@keyv/serialize": "^1.1.1"
@@ -11810,7 +12297,7 @@
 		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-name": "~1.1.4"
@@ -11821,7 +12308,7 @@
 		},
 		"node_modules/color-name": {
 			"version": "1.1.4",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/colord": {
@@ -11835,7 +12322,6 @@
 		},
 		"node_modules/colorjs.io": {
 			"version": "0.6.1",
-			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
@@ -12177,22 +12663,6 @@
 				}
 			}
 		},
-		"node_modules/cosmiconfig/node_modules/argparse": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "Python-2.0"
-		},
-		"node_modules/cosmiconfig/node_modules/js-yaml": {
-			"version": "4.1.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"argparse": "^2.0.1"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
-			}
-		},
 		"node_modules/crc-32": {
 			"version": "1.2.2",
 			"dev": true,
@@ -12261,7 +12731,7 @@
 		},
 		"node_modules/css-functions-list": {
 			"version": "3.3.3",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -12338,7 +12808,7 @@
 		},
 		"node_modules/css-tree": {
 			"version": "3.2.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"mdn-data": "2.27.1",
@@ -12361,7 +12831,7 @@
 		},
 		"node_modules/cssesc": {
 			"version": "3.0.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"bin": {
 				"cssesc": "bin/cssesc"
@@ -12575,7 +13045,9 @@
 			}
 		},
 		"node_modules/date-fns": {
-			"version": "3.6.0",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+			"integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -12903,7 +13375,7 @@
 		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"path-type": "^4.0.0"
@@ -12932,20 +13404,6 @@
 			},
 			"engines": {
 				"node": ">= 6.0.0"
-			}
-		},
-		"node_modules/docker-compose/node_modules/yaml": {
-			"version": "2.8.2",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
 		"node_modules/doctrine": {
@@ -13168,7 +13626,7 @@
 		},
 		"node_modules/env-paths": {
 			"version": "2.2.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -14070,11 +14528,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/eslint/node_modules/argparse": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "Python-2.0"
-		},
 		"node_modules/eslint/node_modules/brace-expansion": {
 			"version": "1.1.12",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -14125,17 +14578,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/eslint/node_modules/js-yaml": {
-			"version": "4.1.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"argparse": "^2.0.1"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
 			}
 		},
 		"node_modules/eslint/node_modules/locate-path": {
@@ -14469,7 +14911,7 @@
 		},
 		"node_modules/fast-glob": {
 			"version": "3.3.3",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"@nodelib/fs.stat": "^2.0.2",
@@ -14484,7 +14926,7 @@
 		},
 		"node_modules/fast-glob/node_modules/glob-parent": {
 			"version": "5.1.2",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC",
 			"dependencies": {
 				"is-glob": "^4.0.1"
@@ -14504,10 +14946,10 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-			"dev": true,
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-4.1.1.tgz",
+			"integrity": "sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==",
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -14555,7 +14997,7 @@
 		},
 		"node_modules/fastest-levenshtein": {
 			"version": "1.0.16",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4.9.1"
@@ -14563,7 +15005,7 @@
 		},
 		"node_modules/fastq": {
 			"version": "1.20.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC",
 			"dependencies": {
 				"reusify": "^1.0.4"
@@ -14625,7 +15067,7 @@
 		},
 		"node_modules/fill-range": {
 			"version": "7.1.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
@@ -14758,8 +15200,10 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.4.1",
-			"dev": true,
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+			"integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
+			"devOptional": true,
 			"license": "ISC"
 		},
 		"node_modules/follow-redirects": {
@@ -15303,7 +15747,7 @@
 		},
 		"node_modules/globby": {
 			"version": "11.1.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"array-union": "^2.1.0",
@@ -15322,7 +15766,7 @@
 		},
 		"node_modules/globjoin": {
 			"version": "0.1.4",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/good-listener": {
@@ -15423,7 +15867,7 @@
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -15481,7 +15925,7 @@
 		},
 		"node_modules/hashery": {
 			"version": "1.5.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"hookified": "^1.14.0"
@@ -15568,7 +16012,7 @@
 		},
 		"node_modules/hookified": {
 			"version": "1.15.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/hosted-git-info": {
@@ -15674,7 +16118,7 @@
 		},
 		"node_modules/html-tags": {
 			"version": "3.3.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -15903,7 +16347,7 @@
 		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
@@ -16017,7 +16461,7 @@
 		},
 		"node_modules/imurmurhash": {
 			"version": "0.1.4",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.19"
@@ -16047,7 +16491,7 @@
 		},
 		"node_modules/ini": {
 			"version": "1.3.8",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC"
 		},
 		"node_modules/inline-style-parser": {
@@ -16333,7 +16777,7 @@
 		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -16355,7 +16799,7 @@
 		},
 		"node_modules/is-fullwidth-code-point": {
 			"version": "3.0.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -16389,7 +16833,7 @@
 		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-extglob": "^2.1.1"
@@ -16480,7 +16924,7 @@
 		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
@@ -16534,6 +16978,8 @@
 		},
 		"node_modules/is-promise": {
 			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+			"integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
 			"license": "MIT"
 		},
 		"node_modules/is-regex": {
@@ -16711,7 +17157,7 @@
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC"
 		},
 		"node_modules/isobject": {
@@ -17189,17 +17635,6 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/jest-environment-jsdom/node_modules/picomatch": {
-			"version": "4.0.3",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/jest-environment-jsdom/node_modules/pretty-format": {
 			"version": "30.2.0",
 			"dev": true,
@@ -17596,15 +18031,26 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "3.14.2",
-			"dev": true,
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+			"integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
+			"devOptional": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
+				"argparse": "^2.0.1"
 			},
 			"bin": {
-				"js-yaml": "bin/js-yaml.js"
+				"js-yaml": "bin/js-yaml.mjs"
 			}
 		},
 		"node_modules/jsdoc-type-pratt-parser": {
@@ -17818,7 +18264,7 @@
 		},
 		"node_modules/known-css-properties": {
 			"version": "0.37.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/language-subtag-registry": {
@@ -18107,35 +18553,6 @@
 				"node": ">=20"
 			}
 		},
-		"node_modules/lint-staged/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/lint-staged/node_modules/yaml": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-			"dev": true,
-			"license": "ISC",
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/eemeli"
-			}
-		},
 		"node_modules/listr2": {
 			"version": "9.0.5",
 			"resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
@@ -18344,7 +18761,7 @@
 		},
 		"node_modules/lodash.truncate": {
 			"version": "4.4.2",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash.uniq": {
@@ -18705,11 +19122,6 @@
 				"markdown-it": "bin/markdown-it.js"
 			}
 		},
-		"node_modules/markdown-it/node_modules/argparse": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "Python-2.0"
-		},
 		"node_modules/markdown-it/node_modules/entities": {
 			"version": "2.1.0",
 			"dev": true,
@@ -18760,11 +19172,6 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/markdownlint-cli/node_modules/argparse": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "Python-2.0"
-		},
 		"node_modules/markdownlint-cli/node_modules/brace-expansion": {
 			"version": "1.1.12",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -18790,17 +19197,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
-			}
-		},
-		"node_modules/markdownlint-cli/node_modules/js-yaml": {
-			"version": "4.1.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"argparse": "^2.0.1"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
 			}
 		},
 		"node_modules/markdownlint-cli/node_modules/minimatch": {
@@ -18836,7 +19232,7 @@
 		},
 		"node_modules/mathml-tag-names": {
 			"version": "2.1.3",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"funding": {
 				"type": "github",
@@ -19095,7 +19491,7 @@
 		},
 		"node_modules/mdn-data": {
 			"version": "2.27.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "CC0-1.0"
 		},
 		"node_modules/mdurl": {
@@ -19215,7 +19611,7 @@
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 8"
@@ -19743,7 +20139,7 @@
 		},
 		"node_modules/micromatch": {
 			"version": "4.0.8",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"braces": "^3.0.3",
@@ -19954,6 +20350,8 @@
 		},
 		"node_modules/moment": {
 			"version": "2.30.1",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+			"integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
 			"license": "MIT",
 			"engines": {
 				"node": "*"
@@ -19961,6 +20359,8 @@
 		},
 		"node_modules/moment-timezone": {
 			"version": "0.5.48",
+			"resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.48.tgz",
+			"integrity": "sha512-f22b8LV1gbTO2ms2j2z13MuPogNoh5UzxL3nzNAYKGraILnbGc9NEE6dyiiiLv46DGRb8A4kg8UKWLjPthxBHw==",
 			"license": "MIT",
 			"dependencies": {
 				"moment": "^2.29.4"
@@ -20028,8 +20428,10 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"dev": true,
+			"version": "3.3.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -20162,7 +20564,7 @@
 		},
 		"node_modules/normalize-path": {
 			"version": "3.0.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -20984,11 +21386,13 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"dev": true,
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=8.6"
+				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
@@ -21182,8 +21586,10 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.6",
-			"dev": true,
+			"version": "8.5.24",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+			"integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -21200,7 +21606,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.11",
+				"nanoid": "^3.3.16",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -21708,12 +22114,12 @@
 		},
 		"node_modules/postcss-resolve-nested-selector": {
 			"version": "0.1.6",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/postcss-safe-parser": {
 			"version": "7.0.1",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -21804,7 +22210,7 @@
 		},
 		"node_modules/postcss-value-parser": {
 			"version": "4.2.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/postgres-array": {
@@ -22075,7 +22481,7 @@
 		},
 		"node_modules/qified": {
 			"version": "0.6.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"hookified": "^1.14.0"
@@ -22100,7 +22506,7 @@
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -22202,14 +22608,6 @@
 			},
 			"peerDependencies": {
 				"react": ">=16.8.0"
-			}
-		},
-		"node_modules/react-day-picker/node_modules/date-fns": {
-			"version": "4.1.0",
-			"license": "MIT",
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/kossnocorp"
 			}
 		},
 		"node_modules/react-dom": {
@@ -22388,6 +22786,8 @@
 		},
 		"node_modules/redux": {
 			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
 			"license": "MIT"
 		},
 		"node_modules/reflect-metadata": {
@@ -22565,7 +22965,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -22595,6 +22995,12 @@
 		"node_modules/requires-port": {
 			"version": "1.0.0",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/reselect": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/reselect/-/reselect-5.2.0.tgz",
+			"integrity": "sha512-AgZ3UOZm3YndfrJ4OYjgrT7bmCm/1iqkjvEfH/oYjzh6PD2qw4QuT3jjnXIrpdt4MTpMXclMT3lXbmRY+XRakw==",
 			"license": "MIT"
 		},
 		"node_modules/resolve": {
@@ -22653,7 +23059,7 @@
 		},
 		"node_modules/resolve-from": {
 			"version": "5.0.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -22708,7 +23114,7 @@
 		},
 		"node_modules/reusify": {
 			"version": "1.1.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"iojs": ">=1.0.0",
@@ -22801,7 +23207,7 @@
 		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -22823,6 +23229,8 @@
 		},
 		"node_modules/rungen": {
 			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/rungen/-/rungen-0.3.2.tgz",
+			"integrity": "sha512-zWl10xu2D7zoR8zSC2U6bg5bYF6T/Wk7rxwp8IPaJH7f0Ge21G03kNHVgHR7tyVkSSfAOG0Rqf/Cl38JftSmtw==",
 			"license": "MIT"
 		},
 		"node_modules/rxjs": {
@@ -23526,7 +23934,7 @@
 		},
 		"node_modules/slash": {
 			"version": "3.0.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -23534,7 +23942,7 @@
 		},
 		"node_modules/slice-ansi": {
 			"version": "4.0.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
@@ -23618,7 +24026,7 @@
 		},
 		"node_modules/source-map-js": {
 			"version": "1.2.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.10.0"
@@ -23770,11 +24178,6 @@
 				"node": ">=8.0"
 			}
 		},
-		"node_modules/sprintf-js": {
-			"version": "1.0.3",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
 		"node_modules/stable-hash-x": {
 			"version": "0.2.0",
 			"dev": true,
@@ -23869,7 +24272,7 @@
 		},
 		"node_modules/string-width": {
 			"version": "4.2.3",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
@@ -23901,7 +24304,7 @@
 		},
 		"node_modules/string-width/node_modules/emoji-regex": {
 			"version": "8.0.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/string.prototype.includes": {
@@ -24019,7 +24422,7 @@
 		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -24163,7 +24566,7 @@
 		},
 		"node_modules/stylelint": {
 			"version": "16.26.1",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -24301,7 +24704,7 @@
 		},
 		"node_modules/stylelint/node_modules/@csstools/media-query-list-parser": {
 			"version": "4.0.3",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -24323,7 +24726,7 @@
 		},
 		"node_modules/stylelint/node_modules/@csstools/selector-specificity": {
 			"version": "5.0.0",
-			"dev": true,
+			"devOptional": true,
 			"funding": [
 				{
 					"type": "github",
@@ -24342,19 +24745,14 @@
 				"postcss-selector-parser": "^7.0.0"
 			}
 		},
-		"node_modules/stylelint/node_modules/argparse": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "Python-2.0"
-		},
 		"node_modules/stylelint/node_modules/balanced-match": {
 			"version": "2.0.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/stylelint/node_modules/cosmiconfig": {
 			"version": "9.0.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"env-paths": "^2.2.1",
@@ -24379,7 +24777,7 @@
 		},
 		"node_modules/stylelint/node_modules/file-entry-cache": {
 			"version": "11.1.2",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"flat-cache": "^6.1.20"
@@ -24387,7 +24785,7 @@
 		},
 		"node_modules/stylelint/node_modules/flat-cache": {
 			"version": "6.1.20",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"cacheable": "^2.3.2",
@@ -24397,7 +24795,7 @@
 		},
 		"node_modules/stylelint/node_modules/global-modules": {
 			"version": "2.0.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"global-prefix": "^3.0.0"
@@ -24408,7 +24806,7 @@
 		},
 		"node_modules/stylelint/node_modules/global-prefix": {
 			"version": "3.0.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"ini": "^1.3.5",
@@ -24421,26 +24819,15 @@
 		},
 		"node_modules/stylelint/node_modules/ignore": {
 			"version": "7.0.5",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
 			}
 		},
-		"node_modules/stylelint/node_modules/js-yaml": {
-			"version": "4.1.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"argparse": "^2.0.1"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
-			}
-		},
 		"node_modules/stylelint/node_modules/kind-of": {
 			"version": "6.0.3",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -24448,7 +24835,7 @@
 		},
 		"node_modules/stylelint/node_modules/meow": {
 			"version": "13.2.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -24459,7 +24846,7 @@
 		},
 		"node_modules/stylelint/node_modules/postcss-selector-parser": {
 			"version": "7.1.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"cssesc": "^3.0.0",
@@ -24471,7 +24858,7 @@
 		},
 		"node_modules/stylelint/node_modules/signal-exit": {
 			"version": "4.1.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=14"
@@ -24482,7 +24869,7 @@
 		},
 		"node_modules/stylelint/node_modules/which": {
 			"version": "1.3.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -24493,7 +24880,7 @@
 		},
 		"node_modules/stylelint/node_modules/write-file-atomic": {
 			"version": "5.0.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "ISC",
 			"dependencies": {
 				"imurmurhash": "^0.1.4",
@@ -24509,7 +24896,7 @@
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
@@ -24520,7 +24907,7 @@
 		},
 		"node_modules/supports-hyperlinks": {
 			"version": "3.2.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0",
@@ -24550,7 +24937,7 @@
 		},
 		"node_modules/svg-tags": {
 			"version": "1.0.0",
-			"dev": true
+			"devOptional": true
 		},
 		"node_modules/svgo": {
 			"version": "3.3.3",
@@ -24620,9 +25007,15 @@
 				"url": "https://opencollective.com/synckit"
 			}
 		},
+		"node_modules/tabbable": {
+			"version": "6.5.0",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.5.0.tgz",
+			"integrity": "sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==",
+			"license": "MIT"
+		},
 		"node_modules/table": {
 			"version": "6.9.0",
-			"dev": true,
+			"devOptional": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"ajv": "^8.0.1",
@@ -24639,7 +25032,7 @@
 			"version": "8.18.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
 			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.3",
@@ -24656,7 +25049,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
 			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/tannin": {
@@ -24996,17 +25389,6 @@
 				}
 			}
 		},
-		"node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.3",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
 		"node_modules/tldts": {
 			"version": "6.1.86",
 			"dev": true,
@@ -25072,7 +25454,7 @@
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
@@ -25727,6 +26109,8 @@
 		},
 		"node_modules/use-sync-external-store": {
 			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+			"integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
 			"license": "MIT",
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -25734,7 +26118,7 @@
 		},
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/utils-merge": {
@@ -25755,14 +26139,16 @@
 			}
 		},
 		"node_modules/uuid": {
-			"version": "9.0.1",
+			"version": "14.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+			"integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
 			"funding": [
 				"https://github.com/sponsors/broofa",
 				"https://github.com/sponsors/ctavan"
 			],
 			"license": "MIT",
 			"bin": {
-				"uuid": "dist/bin/uuid"
+				"uuid": "dist-node/bin/uuid"
 			}
 		},
 		"node_modules/v8-to-istanbul": {
@@ -26660,10 +27046,18 @@
 			"license": "ISC"
 		},
 		"node_modules/yaml": {
-			"version": "1.10.2",
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
 			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
 			"engines": {
-				"node": ">= 6"
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
 		"node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
 		"postcss": "^8.5.24",
 		"serialize-javascript": "^7.0.4",
 		"svgo": "^3.3.3",
+		"uuid": "^11.1.1",
 		"webpack-dev-server": "^5.2.3",
 		"yauzl": "^3.2.1",
 		"yaml": "^2.9.0"

--- a/package.json
+++ b/package.json
@@ -65,14 +65,14 @@
 		"@codemirror/theme-one-dark": "^6.1.3",
 		"@codemirror/view": "^6.40.0",
 		"@wordpress/api-fetch": "^7.36.0",
-		"@wordpress/components": "^30.7.0",
+		"@wordpress/components": "^37.0.0",
 		"@wordpress/compose": "^7.34.0",
 		"@wordpress/data": "^10.34.0",
 		"@wordpress/dom-ready": "^4.38.0",
 		"@wordpress/element": "^6.34.0",
 		"@wordpress/i18n": "^6.7.0",
 		"@wordpress/icons": "^11.1.0",
-		"@wordpress/notices": "^5.35.0",
+		"@wordpress/notices": "^5.51.0",
 		"chart.js": "^4.5.1",
 		"html2canvas": "^1.4.1",
 		"morphdom": "^2.7.8",
@@ -98,12 +98,17 @@
 		"markdownlint-cli": {
 			"minimatch": "^3.1.5"
 		},
-		"flatted": "^3.4.0",
+		"flatted": "^3.4.3",
+		"fast-uri": "^4.1.1",
 		"immutable": "^5.1.5",
+		"js-yaml": "^5.2.2",
+		"picomatch": "^4.0.5",
+		"postcss": "^8.5.24",
 		"serialize-javascript": "^7.0.4",
 		"svgo": "^3.3.3",
 		"webpack-dev-server": "^5.2.3",
-		"yauzl": "^3.2.1"
+		"yauzl": "^3.2.1",
+		"yaml": "^2.9.0"
 	},
 	"lint-staged": {
 		"src/**/*.{js,jsx}": [

--- a/src/settings-page/__tests__/calendar-sms-manager.test.js
+++ b/src/settings-page/__tests__/calendar-sms-manager.test.js
@@ -11,6 +11,76 @@ global.IS_REACT_ACT_ENVIRONMENT = true;
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
+jest.mock( '@wordpress/components', () => {
+	const React = require( 'react' );
+
+	return {
+		Button: ( { children, href, onClick, type = 'button', disabled } ) =>
+			href
+				? React.createElement( 'a', { href, onClick }, children )
+				: React.createElement(
+						'button',
+						{ type, disabled, onClick },
+						children
+				  ),
+		Notice: ( { children } ) =>
+			React.createElement( 'div', null, children ),
+		SelectControl: ( { label, value, onChange, options = [] } ) =>
+			React.createElement(
+				'label',
+				null,
+				label,
+				React.createElement(
+					'select',
+					{
+						value,
+						onChange: ( event ) => onChange( event.target.value ),
+					},
+					options.map( ( option ) =>
+						React.createElement(
+							'option',
+							{ key: option.value, value: option.value },
+							option.label
+						)
+					)
+				)
+			),
+		Spinner: () => React.createElement( 'div', { role: 'status' } ),
+		TextareaControl: ( { label, value, onChange } ) =>
+			React.createElement(
+				'label',
+				null,
+				label,
+				React.createElement( 'textarea', {
+					value,
+					onChange: ( event ) => onChange( event.target.value ),
+				} )
+			),
+		TextControl: ( { label, value, onChange, type = 'text' } ) =>
+			React.createElement(
+				'label',
+				null,
+				label,
+				React.createElement( 'input', {
+					value,
+					type,
+					onChange: ( event ) => onChange( event.target.value ),
+				} )
+			),
+		ToggleControl: ( { label, checked, onChange } ) =>
+			React.createElement(
+				'label',
+				null,
+				label,
+				React.createElement( 'input', {
+					checked,
+					type: 'checkbox',
+					onChange: ( event ) => onChange( event.target.checked ),
+				} )
+			),
+	};
+} );
+
 const routeResponses = {
 	'/sd-ai-agent/v1/settings/google-calendar': {
 		has_credentials: true,

--- a/src/settings-page/__tests__/superdav-account-manager.test.js
+++ b/src/settings-page/__tests__/superdav-account-manager.test.js
@@ -15,6 +15,36 @@ global.IS_REACT_ACT_ENVIRONMENT = true;
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
+jest.mock( '@wordpress/components', () => {
+	const React = require( 'react' );
+
+	return {
+		Button: ( { children, href, onClick, type = 'button', disabled } ) =>
+			href
+				? React.createElement( 'a', { href, onClick }, children )
+				: React.createElement(
+						'button',
+						{ type, disabled, onClick },
+						children
+				  ),
+		Notice: ( { children } ) =>
+			React.createElement( 'div', null, children ),
+		Spinner: () => React.createElement( 'div', { role: 'status' } ),
+		TextControl: ( { label, value, onChange, type = 'text', disabled } ) =>
+			React.createElement(
+				'label',
+				null,
+				label,
+				React.createElement( 'input', {
+					value,
+					type,
+					disabled,
+					onChange: ( event ) => onChange( event.target.value ),
+				} )
+			),
+	};
+} );
+
 describe( 'SuperdavAccountManager', () => {
 	let createRoot;
 	let act;


### PR DESCRIPTION
Resolves #2364

## Summary

- upgrade `@wordpress/components` to 37.0.0 and `@wordpress/notices` to 5.51.0
- add targeted npm overrides for every remaining production-audit dependency path
- retain the existing `Notice`, `SnackbarList`, and `core/notices` APIs after checking their current consumers

## Verification

- `npm audit --omit=dev --json` (0 vulnerabilities)
- `npm run lint:js`
- `npm run test:js -- --runInBand` (38 suites, 412 tests)
- `npm run verify` (PHP/JS/CSS lint, PHPStan, 3,989 PHPUnit tests with 0 errors/failures, build, and floating-widget bundle check)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.192 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-terra
