### PR TITLE
GH#2355: add durable site-operation plans

### DIFF
--- a/includes/Core/ActiveJobsCleanupService.php
+++ b/includes/Core/ActiveJobsCleanupService.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 /**
  * Active Jobs Cleanup Service — hourly reaper for zombie processing rows.
  *
- * Rows in wp_sd_ai_agent_active_jobs become permanently stuck in
- * status='processing' when the PHP request running an AgentLoop terminates
+ * Rows in wp_sd_ai_agent_active_jobs become permanently stuck in queued or
+ * processing status when the PHP request running an AgentLoop terminates
  * abnormally (PHP fatal, FastCGI/nginx timeout, SIGKILL, OOM, FPM child exit).
  *
  * Two-tier cleanup strategy:
@@ -16,7 +16,7 @@ declare(strict_types=1);
  *
  * 2. Periodic reaper (this class, hourly cron):
  *    For cases where the shutdown handler itself could not run. Marks rows as
- *    'abandoned' when status='processing' and updated_at has not advanced
+ *    'abandoned' when status is queued or processing and updated_at has not advanced
  *    within the configured threshold (default 15 minutes, filterable via
  *    `sd_ai_agent_stale_job_threshold_minutes`).
  *
@@ -48,7 +48,7 @@ class ActiveJobsCleanupService {
 	/**
 	 * Default stale-job threshold in minutes.
 	 *
-	 * A row is considered stale when status='processing' and updated_at has
+	 * A row is considered stale when status is queued or processing and updated_at has
 	 * not advanced within this window. Must be longer than the longest
 	 * expected legitimate single loop iteration (image generation, large RAG
 	 * queries, etc. can legitimately take several minutes).
@@ -92,7 +92,7 @@ class ActiveJobsCleanupService {
 	 * Execute the stale-job reaper (called by WP-Cron).
 	 *
 	 * Marks rows as 'abandoned' when:
-	 *   - status = 'processing', AND
+	 *   - status is queued or processing, AND
 	 *   - updated_at < NOW() - INTERVAL {threshold} MINUTE
 	 *
 	 * The threshold is filterable via `sd_ai_agent_stale_job_threshold_minutes`.
@@ -103,7 +103,7 @@ class ActiveJobsCleanupService {
 	 */
 	public static function run(): void {
 		/**
-		 * Filter the number of minutes of inactivity before a processing row
+		 * Filter the number of minutes of inactivity before a queued or processing row
 		 * is considered stale and reaped by the hourly cron job.
 		 *
 		 * Must be longer than the longest expected legitimate single loop
@@ -114,7 +114,11 @@ class ActiveJobsCleanupService {
 		$threshold = (int) apply_filters( 'sd_ai_agent_stale_job_threshold_minutes', self::DEFAULT_THRESHOLD_MINUTES );
 		$threshold = max( 1, $threshold );
 
-		$count = ActiveJobRepository::cleanup_stale( $threshold );
+		$job_ids = ActiveJobRepository::reap_stale_jobs( $threshold );
+		foreach ( $job_ids as $job_id ) {
+			DurablePlanRunner::mark_phase_interrupted_by_job( $job_id );
+		}
+		$count = count( $job_ids );
 		/**
 		 * Filter the number of days to retain undelivered terminal job diagnostics.
 		 *

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -120,6 +120,21 @@ class AgentLoop {
 	/** Maximum serialized byte length of a provider or model identifier. */
 	private const CHECKPOINT_IDENTIFIER_MAX_BYTES = 191;
 
+	/**
+	 * Dedicated one-turn instruction for a durable-plan proposal.
+	 *
+	 * This mode deliberately has no abilities and returns only a narrow JSON
+	 * definition. The server still treats every resulting phase as untrusted
+	 * metadata and requires explicit approval before execution.
+	 */
+	private const DURABLE_PLAN_SYSTEM_INSTRUCTION = <<<'PROMPT'
+You prepare a compact durable site-operation plan. Do not call tools, browse, change the site, or claim that work has been performed.
+
+Return exactly one JSON object and nothing else: no Markdown fences, prose, comments, or extra fields.
+
+The root object must contain only "scope", "summary", and "steps". "steps" must be a non-empty array with at most 20 objects. Each step object must contain only "title", "instruction", "classification", "preconditions", "expected_evidence", and "rollback_guidance". Use one of "read", "write", or "destructive" for "classification". Include concise bounded instructions and expected evidence. Do not include credentials, tokens, passwords, authorization headers, raw tool payloads, or conversation history.
+PROMPT;
+
 	/** Format version for checkpoint resume metadata. */
 	public const CHECKPOINT_RESUME_METADATA_VERSION = 1;
 
@@ -253,6 +268,9 @@ class AgentLoop {
 	/** @var bool Whether an explicitly constrained customer-agent run is active, even with empty lists. */
 	private bool $customer_agent_mode = false;
 
+	/** @var bool Whether this is a no-tools, one-turn durable-plan proposal. */
+	private bool $durable_plan_mode = false;
+
 	/** @var bool Whether a request-scoped anonymous tool policy is active, even with an empty list. */
 	private bool $anonymous_policy_active = false;
 
@@ -315,16 +333,17 @@ class AgentLoop {
 	 * @param string               $user_message     The user's prompt.
 	 * @param string[]             $abilities         Ability names to enable (empty = all).
 	 * @param Message[]            $history           Prior messages for multi-turn.
-	 * @param array<string, mixed> $options           Optional overrides: system_instruction, max_iterations, provider_id, model_id, temperature, max_output_tokens, page_context.
+	 * @param array<string, mixed> $options           Optional overrides: system_instruction, max_iterations, provider_id, model_id, temperature, max_output_tokens, page_context, durable_plan_mode.
 	 * @param Settings|null        $settings_service  Injected Settings service (uses Settings::instance() when null).
 	 */
 	public function __construct( string $user_message, array $abilities = array(), array $history = array(), array $options = array(), ?Settings $settings_service = null ) {
-		$this->user_message     = $user_message;
-		$this->abilities        = $abilities;
-		$this->history          = $history;
-		$raw_page_ctx           = $options['page_context'] ?? null;
-		$this->page_context     = is_array( $raw_page_ctx ) ? $raw_page_ctx : array();
-		$this->settings_service = $settings_service ?? new Settings();
+		$this->user_message      = $user_message;
+		$this->abilities         = $abilities;
+		$this->history           = $history;
+		$this->durable_plan_mode = ! empty( $options['durable_plan_mode'] );
+		$raw_page_ctx            = $options['page_context'] ?? null;
+		$this->page_context      = is_array( $raw_page_ctx ) ? $raw_page_ctx : array();
+		$this->settings_service  = $settings_service ?? new Settings();
 
 		// Merge explicit options with saved settings as fallbacks.
 		$raw_settings = $this->settings_service->get();
@@ -407,7 +426,11 @@ class AgentLoop {
 		$raw_perms              = $options['tool_permissions'] ?? ( $settings['tool_permissions'] ?? null );
 		$this->tool_permissions = is_array( $raw_perms ) ? $raw_perms : array();
 		// @phpstan-ignore-next-line
-		$this->yolo_mode         = (bool) ( $options['yolo_mode'] ?? ( $settings['yolo_mode'] ?? false ) );
+		$this->yolo_mode = (bool) ( $options['yolo_mode'] ?? ( $settings['yolo_mode'] ?? false ) );
+		if ( $this->durable_plan_mode ) {
+			$this->max_iterations = 1;
+			$this->yolo_mode      = false;
+		}
 		$this->tool_call_log     = self::normalize_activity_log( $options['tool_call_log'] ?? array() );
 		$this->message_log       = self::normalize_activity_log( $options['message_log'] ?? array() );
 		$this->activity_sequence = $this->get_max_activity_sequence( $this->tool_call_log, $this->message_log );
@@ -488,7 +511,7 @@ class AgentLoop {
 
 		// ClientAbilityRouter validates and routes client-side ability calls.
 		// @phpstan-ignore-next-line
-		$raw_client_abilities = $this->customer_agent_mode ? array() : ( $options['client_abilities'] ?? array() );
+		$raw_client_abilities = ( $this->customer_agent_mode || $this->durable_plan_mode ) ? array() : ( $options['client_abilities'] ?? array() );
 		if ( is_array( $raw_client_abilities ) ) {
 			$this->client_router    = ClientAbilityRouter::from_raw( $raw_client_abilities );
 			$this->client_abilities = $this->client_router->get_descriptors();
@@ -503,7 +526,10 @@ class AgentLoop {
 		$this->generated_theme_completion_gate->replay_tool_call_log( $this->tool_call_log );
 
 		// Build or lock the initial system instruction.
-		if ( isset( $options['system_instruction'] ) ) {
+		if ( $this->durable_plan_mode ) {
+			$this->system_instruction        = self::DURABLE_PLAN_SYSTEM_INSTRUCTION;
+			$this->system_instruction_locked = true;
+		} elseif ( isset( $options['system_instruction'] ) ) {
 			// @phpstan-ignore-next-line
 			$this->system_instruction        = $options['system_instruction'];
 			$this->system_instruction_locked = true;
@@ -1443,6 +1469,29 @@ class AgentLoop {
 			// so an unrelated later truncation doesn't inherit prior state.
 			$this->preamble_truncation_retries = 0;
 
+			// Durable-plan proposal turns never execute or pause for tools. Keep the
+			// raw model response out of conversation history and accept only the
+			// narrow parsed definition returned by the planning prompt.
+			if ( $this->durable_plan_mode ) {
+				if ( $this->message_has_function_calls( $assistant_message ) ) {
+					return $this->with_error_recovery_data(
+						new WP_Error(
+							'sd_ai_agent_durable_plan_tool_call',
+							__( 'The planning response attempted to use a tool and was discarded. Please try again.', 'superdav-ai-agent' )
+						),
+						$recovery_history
+					);
+				}
+
+				try {
+					$reply = $result->toText();
+				} catch ( \RuntimeException $e ) {
+					$reply = '';
+				}
+
+				return $this->complete_durable_plan_response( $reply, $recovery_history );
+			}
+
 			// Some providers/models emit the same function call more than once in
 			// a single assistant response when they are hedging. Unless there is an
 			// explicit parallel identifier, execute only the first identical
@@ -1857,6 +1906,41 @@ class AgentLoop {
 					'model_id'        => $this->model_id,
 					'history'         => $this->serialize_history(),
 				)
+			)
+		);
+	}
+
+	/**
+	 * Convert a one-turn planning response into a safe persisted-plan handoff.
+	 *
+	 * The raw provider text is intentionally not appended to history. Only a
+	 * generic confirmation is retained alongside the validated compact shape.
+	 *
+	 * @param string                     $reply            Raw planning-only provider text.
+	 * @param array<int|string, Message> $recovery_history Safe pre-provider history.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	private function complete_durable_plan_response( string $reply, array $recovery_history ) {
+		$definition = DurablePlanDefinitionParser::parse( $reply );
+		if ( is_wp_error( $definition ) ) {
+			$this->last_loop_phase = 'durable_plan_response_invalid';
+			return $this->with_error_recovery_data( $definition, $recovery_history );
+		}
+
+		$safe_reply = __( 'I prepared a durable plan. Review each phase before continuing.', 'superdav-ai-agent' );
+
+		$this->history[]       = new ModelMessage( array( new MessagePart( $safe_reply ) ) );
+		$this->last_loop_phase = 'durable_plan_response_validated';
+
+		return $this->with_result_logs(
+			array(
+				'reply'                   => $safe_reply,
+				'history'                 => $this->serialize_history(),
+				'tool_calls'              => $this->tool_call_log,
+				'token_usage'             => $this->token_usage,
+				'iterations_used'         => $this->iterations_used,
+				'model_id'                => $this->model_id,
+				'durable_plan_definition' => $definition,
 			)
 		);
 	}
@@ -3116,6 +3200,10 @@ class AgentLoop {
 	 * @return \WP_Ability[]
 	 */
 	private function resolve_abilities(): array {
+		if ( $this->durable_plan_mode ) {
+			return array();
+		}
+
 		if ( ! function_exists( 'wp_get_abilities' ) ) {
 			return array();
 		}

--- a/includes/Core/Database.php
+++ b/includes/Core/Database.php
@@ -36,7 +36,7 @@ use SdAiAgent\Tools\CustomTools;
 class Database {
 
 	const DB_VERSION_OPTION = 'sd_ai_agent_db_version';
-	const DB_VERSION        = '19.8.0';
+	const DB_VERSION        = '19.9.1';
 
 	// ─── Table Name Registry ──────────────────────────────────────────────────
 
@@ -235,6 +235,24 @@ class Database {
 	}
 
 	/**
+	 * Get the durable operation plans table name.
+	 */
+	public static function durable_plans_table_name(): string {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+		return $wpdb->prefix . 'sd_ai_agent_durable_plans';
+	}
+
+	/**
+	 * Get the durable operation plan phases table name.
+	 */
+	public static function durable_plan_steps_table_name(): string {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+		return $wpdb->prefix . 'sd_ai_agent_durable_plan_steps';
+	}
+
+	/**
 	 * Get the durable customer-agent runtime conversations table name.
 	 */
 	public static function customer_agent_conversations_table_name(): string {
@@ -312,6 +330,8 @@ class Database {
 		$provider_trace_table               = self::provider_trace_table_name();
 		$generated_plugins_table            = self::generated_plugins_table_name();
 		$active_jobs_table                  = self::active_jobs_table_name();
+		$durable_plans_table                = self::durable_plans_table_name();
+		$durable_plan_steps_table           = self::durable_plan_steps_table_name();
 		$customer_agent_conversations_table = self::customer_agent_conversations_table_name();
 		$customer_agent_jobs_table          = self::customer_agent_jobs_table_name();
 		$skill_usage_table                  = self::skill_usage_table_name();
@@ -732,6 +752,61 @@ class Database {
 			KEY session_id (session_id),
 			KEY user_id_status (user_id, status),
 			KEY status_updated_at (status, updated_at)
+		) {$charset};
+
+		CREATE TABLE {$durable_plans_table} (
+			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+			plan_id varchar(36) NOT NULL,
+			session_id bigint(20) unsigned NOT NULL,
+			user_id bigint(20) unsigned NOT NULL,
+			scope longtext NOT NULL,
+			scope_hash char(64) NOT NULL,
+			pending_scope longtext NOT NULL,
+			pending_scope_hash char(64) NOT NULL,
+			summary text NOT NULL,
+			status varchar(30) NOT NULL DEFAULT 'pending',
+			current_step int(10) unsigned NOT NULL DEFAULT 0,
+			approval_request_id bigint(20) unsigned NOT NULL DEFAULT 0,
+			created_at datetime NOT NULL,
+			updated_at datetime NOT NULL,
+			completed_at datetime NULL,
+			cancelled_at datetime NULL,
+			PRIMARY KEY  (id),
+			UNIQUE KEY plan_id (plan_id),
+			KEY session_user_updated (session_id, user_id, updated_at),
+			KEY user_status_updated (user_id, status, updated_at),
+			KEY approval_request_id (approval_request_id)
+		) {$charset};
+
+		CREATE TABLE {$durable_plan_steps_table} (
+			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+			plan_db_id bigint(20) unsigned NOT NULL,
+			step_key varchar(100) NOT NULL,
+			position int(10) unsigned NOT NULL,
+			title varchar(255) NOT NULL,
+			instruction text NOT NULL,
+			classification varchar(20) NOT NULL DEFAULT 'read',
+			requires_approval tinyint(1) NOT NULL DEFAULT 1,
+			safe_to_resume tinyint(1) NOT NULL DEFAULT 0,
+			idempotency_key varchar(64) NOT NULL,
+			preconditions text NOT NULL,
+			expected_evidence text NOT NULL,
+			rollback_guidance text NOT NULL,
+			status varchar(30) NOT NULL DEFAULT 'pending',
+			approval_request_id bigint(20) unsigned NOT NULL DEFAULT 0,
+			job_id varchar(36) NOT NULL,
+			evidence longtext NOT NULL,
+			failure_message text NOT NULL,
+			attempts int(10) unsigned NOT NULL DEFAULT 0,
+			created_at datetime NOT NULL,
+			updated_at datetime NOT NULL,
+			completed_at datetime NULL,
+			PRIMARY KEY  (id),
+			UNIQUE KEY plan_step_key (plan_db_id, step_key),
+			UNIQUE KEY plan_position (plan_db_id, position),
+			KEY plan_status_position (plan_db_id, status, position),
+			KEY job_id (job_id),
+			KEY approval_request_id (approval_request_id)
 		) {$charset};
 
 		CREATE TABLE {$customer_agent_conversations_table} (

--- a/includes/Core/DurablePlanDefinitionParser.php
+++ b/includes/Core/DurablePlanDefinitionParser.php
@@ -27,7 +27,7 @@ final class DurablePlanDefinitionParser {
 	 *
 	 * @return array<string, mixed>|WP_Error
 	 */
-	public static function parse( string $response ) {
+	public static function parse( string $response ): array|WP_Error {
 		$response = trim( $response );
 		if ( '' === $response || strlen( $response ) > self::MAX_RESPONSE_BYTES ) {
 			return self::invalid_response();
@@ -117,7 +117,7 @@ final class DurablePlanDefinitionParser {
 	 * @param bool                 $required Whether the field is required and non-empty.
 	 * @return string|WP_Error
 	 */
-	private static function read_text( array $value, string $key, int $max_size, bool $required ) {
+	private static function read_text( array $value, string $key, int $max_size, bool $required ): string|WP_Error {
 		if ( ! array_key_exists( $key, $value ) ) {
 			return $required ? self::invalid_response() : '';
 		}

--- a/includes/Core/DurablePlanDefinitionParser.php
+++ b/includes/Core/DurablePlanDefinitionParser.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Validates the compact durable-plan shape returned by a planning-only model turn.
+ *
+ * @package SdAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Core;
+
+use SdAiAgent\Models\DurablePlanRepository;
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class DurablePlanDefinitionParser {
+
+	private const MAX_RESPONSE_BYTES = 48000;
+
+	/**
+	 * Parse a planning-only model response into the narrow durable-plan definition
+	 * accepted by DurablePlanRepository.
+	 *
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function parse( string $response ) {
+		$response = trim( $response );
+		if ( '' === $response || strlen( $response ) > self::MAX_RESPONSE_BYTES ) {
+			return self::invalid_response();
+		}
+
+		try {
+			$decoded = json_decode( $response, true, 32, JSON_THROW_ON_ERROR );
+		} catch ( \JsonException $e ) {
+			return self::invalid_response();
+		}
+
+		if ( ! is_array( $decoded ) || array_is_list( $decoded ) || ! self::has_only_keys( $decoded, array( 'scope', 'summary', 'steps' ) ) ) {
+			return self::invalid_response();
+		}
+
+		$scope = self::read_text( $decoded, 'scope', 1200, true );
+		if ( is_wp_error( $scope ) ) {
+			return $scope;
+		}
+		$summary = self::read_text( $decoded, 'summary', 600, false );
+		if ( is_wp_error( $summary ) ) {
+			return $summary;
+		}
+
+		$raw_steps = $decoded['steps'] ?? null;
+		if ( ! is_array( $raw_steps ) || ! array_is_list( $raw_steps ) || empty( $raw_steps ) || count( $raw_steps ) > 20 ) {
+			return self::invalid_response();
+		}
+
+		$steps = array();
+		foreach ( $raw_steps as $raw_step ) {
+			if ( ! is_array( $raw_step ) || array_is_list( $raw_step ) || ! self::has_only_keys( $raw_step, array( 'title', 'instruction', 'classification', 'preconditions', 'expected_evidence', 'rollback_guidance' ) ) ) {
+				return self::invalid_response();
+			}
+
+			$title             = self::read_text( $raw_step, 'title', 255, true );
+			$instruction       = self::read_text( $raw_step, 'instruction', 1600, true );
+			$classification    = self::read_text( $raw_step, 'classification', 32, true );
+			$preconditions     = self::read_text( $raw_step, 'preconditions', 600, false );
+			$expected_evidence = self::read_text( $raw_step, 'expected_evidence', 600, false );
+			$rollback_guidance = self::read_text( $raw_step, 'rollback_guidance', 600, false );
+			if (
+				is_wp_error( $title )
+				|| is_wp_error( $instruction )
+				|| is_wp_error( $classification )
+				|| is_wp_error( $preconditions )
+				|| is_wp_error( $expected_evidence )
+				|| is_wp_error( $rollback_guidance )
+				|| ! in_array( $classification, DurablePlanRepository::CLASSIFICATIONS, true )
+			) {
+				return self::invalid_response();
+			}
+
+			$steps[] = array(
+				'title'             => $title,
+				'instruction'       => $instruction,
+				'classification'    => $classification,
+				'preconditions'     => $preconditions,
+				'expected_evidence' => $expected_evidence,
+				'rollback_guidance' => $rollback_guidance,
+			);
+		}
+
+		return array(
+			'scope'   => $scope,
+			'summary' => $summary,
+			'steps'   => $steps,
+		);
+	}
+
+	/**
+	 * Ensure a JSON object contains no fields outside its narrow accepted schema.
+	 *
+	 * @param array<string, mixed> $value JSON object.
+	 * @param array<string>        $keys  Allowed keys.
+	 */
+	private static function has_only_keys( array $value, array $keys ): bool {
+		return empty( array_diff( array_keys( $value ), $keys ) );
+	}
+
+	/**
+	 * Read a bounded scalar text field without retaining unknown JSON structures.
+	 *
+	 * @param array<string, mixed> $value    JSON object.
+	 * @param string               $key      Field name.
+	 * @param int                  $max_size Maximum byte length.
+	 * @param bool                 $required Whether the field is required and non-empty.
+	 * @return string|WP_Error
+	 */
+	private static function read_text( array $value, string $key, int $max_size, bool $required ) {
+		if ( ! array_key_exists( $key, $value ) ) {
+			return $required ? self::invalid_response() : '';
+		}
+		if ( ! is_string( $value[ $key ] ) ) {
+			return self::invalid_response();
+		}
+
+		$text = trim( $value[ $key ] );
+		if ( ( $required && '' === $text ) || strlen( $text ) > $max_size ) {
+			return self::invalid_response();
+		}
+
+		return $text;
+	}
+
+	/**
+	 * Return a generic error without reflecting untrusted model output.
+	 */
+	private static function invalid_response(): WP_Error {
+		return new WP_Error(
+			'sd_ai_agent_durable_plan_invalid_response',
+			__( 'The planning response was not a valid compact plan. Please try again.', 'superdav-ai-agent' )
+		);
+	}
+}

--- a/includes/Core/DurablePlanRunner.php
+++ b/includes/Core/DurablePlanRunner.php
@@ -419,7 +419,7 @@ final class DurablePlanRunner {
 	public static function fail_phase( string $plan_id, int $step_id, string $message ): ?array {
 		$plan = DurablePlanRepository::get_by_plan_id( $plan_id );
 		$step = DurablePlanRepository::get_step( $step_id );
-		if ( null === $plan || null === $step || (int) $step['plan_db_id'] !== (int) $plan['id'] ) {
+		if ( null === $plan || null === $step || (int) $step['plan_db_id'] !== (int) $plan['id'] || 'running' !== $step['status'] ) {
 			return null;
 		}
 

--- a/includes/Core/DurablePlanRunner.php
+++ b/includes/Core/DurablePlanRunner.php
@@ -1,0 +1,746 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Bounded execution coordinator for durable multi-phase site-operation plans.
+ *
+ * The runner supplies one compact phase context at a time. It never treats a
+ * plan as a blanket tool permission and never replays a consequential phase
+ * after an interruption without a new explicit approval.
+ *
+ * @package SdAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Core;
+
+use SdAiAgent\Automations\HumanApprovalGate;
+use SdAiAgent\Models\DurablePlanRepository;
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class DurablePlanRunner {
+
+	private const CONTEXT_MAX_CHARS      = 6000;
+	private const CONTEXT_EVIDENCE_LIMIT = 3;
+
+	/**
+	 * Create a compact durable plan for a session.
+	 *
+	 * @param int                  $session_id Session ID.
+	 * @param int                  $user_id    Current authenticated user ID.
+	 * @param array<string, mixed> $definition Reviewed compact definition.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function create( int $session_id, int $user_id, array $definition ) {
+		return DurablePlanRepository::create( $session_id, $user_id, $definition );
+	}
+
+	/**
+	 * Create a durable plan from browser-controlled compact metadata.
+	 *
+	 * Browser-supplied classifications are preserved for display, but the
+	 * repository persists a fail-closed approval and resume policy.
+	 *
+	 * @param int                  $session_id Session ID.
+	 * @param int                  $user_id    Current authenticated user ID.
+	 * @param array<string, mixed> $definition Compact plan definition.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function create_from_client( int $session_id, int $user_id, array $definition ) {
+		return DurablePlanRepository::create_from_client( $session_id, $user_id, $definition );
+	}
+
+	/**
+	 * Resolve the next phase into an approval pause or bounded provider context.
+	 *
+	 * @param string $plan_id Plan UUID.
+	 * @param int    $user_id Current authenticated user ID.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function prepare_next( string $plan_id, int $user_id ) {
+		$plan = self::get_owned_plan( $plan_id, $user_id );
+		if ( is_wp_error( $plan ) ) {
+			return $plan;
+		}
+
+		if ( in_array( $plan['status'], [ 'completed', 'cancelled', 'failed', 'blocked' ], true ) ) {
+			return new WP_Error(
+				'sd_ai_agent_plan_not_runnable',
+				__( 'This durable plan has no runnable phase.', 'superdav-ai-agent' ),
+				[
+					'status' => 409,
+					'plan'   => DurablePlanRepository::to_public( $plan ),
+				]
+			);
+		}
+
+		// A requested scope change must be decided before any phase can start.
+		// Without this guard, a browser could call /continue while the scope
+		// approval is pending and execute the next phase against unapproved scope.
+		if ( '' !== (string) $plan['pending_scope'] ) {
+			return [
+				'status' => 'awaiting_approval',
+				'plan'   => DurablePlanRepository::to_public( $plan ),
+			];
+		}
+
+		$step = DurablePlanRepository::get_current_step( (int) $plan['id'] );
+		if ( null === $step ) {
+			DurablePlanRepository::update_plan_status( (int) $plan['id'], 'completed', [ 'completed_at' => current_time( 'mysql', true ) ] );
+			return [
+				'status' => 'completed',
+				'plan'   => self::public_plan( $plan_id ),
+			];
+		}
+
+		if ( 'running' === $step['status'] ) {
+			return [
+				'status' => 'running',
+				'plan'   => DurablePlanRepository::to_public( $plan ),
+			];
+		}
+
+		if ( 'interrupted' === $step['status'] && ! self::is_safe_to_resume( $step ) ) {
+			DurablePlanRepository::update_plan_status( (int) $plan['id'], 'blocked', [ 'current_step' => (int) $step['position'] ] );
+			return new WP_Error(
+				'sd_ai_agent_plan_manual_retry_required',
+				__( 'This phase may have changed the site and needs a new explicit confirmation before retrying.', 'superdav-ai-agent' ),
+				[
+					'status' => 409,
+					'plan'   => self::public_plan( $plan_id ),
+				]
+			);
+		}
+
+		if ( self::requires_approval( $step ) ) {
+			$approval = self::ensure_phase_approval( $plan, $step, $user_id );
+			if ( is_wp_error( $approval ) ) {
+				return $approval;
+			}
+
+			if ( HumanApprovalGate::STATUS_APPROVED !== $approval['status'] && HumanApprovalGate::STATUS_EXECUTED !== $approval['status'] ) {
+				return [
+					'status' => 'awaiting_approval',
+					'plan'   => self::public_plan( $plan_id ),
+				];
+			}
+		}
+
+		if ( ! DurablePlanRepository::claim_step_and_start_plan( (int) $plan['id'], (int) $step['id'], (int) $step['position'] ) ) {
+			$current_plan = DurablePlanRepository::get_by_plan_id( $plan_id );
+			if ( null !== $current_plan && '' !== (string) $current_plan['pending_scope'] ) {
+				return [
+					'status' => 'awaiting_approval',
+					'plan'   => DurablePlanRepository::to_public( $current_plan ),
+				];
+			}
+			if ( null !== $current_plan && 'running' === $current_plan['status'] ) {
+				return [
+					'status' => 'running',
+					'plan'   => DurablePlanRepository::to_public( $current_plan ),
+				];
+			}
+
+			return new WP_Error( 'sd_ai_agent_plan_claim_failed', __( 'This plan phase was changed by another request. Refresh the plan status and continue.', 'superdav-ai-agent' ), [ 'status' => 409 ] );
+		}
+
+		$plan = DurablePlanRepository::get_by_plan_id( $plan_id );
+		$step = DurablePlanRepository::get_step( (int) $step['id'] );
+		if ( null === $plan || null === $step ) {
+			return new WP_Error( 'sd_ai_agent_plan_missing_after_claim', __( 'The durable plan could not be loaded after starting its phase.', 'superdav-ai-agent' ), [ 'status' => 500 ] );
+		}
+
+		return [
+			'status'           => 'ready',
+			'plan'             => DurablePlanRepository::to_public( $plan ),
+			'step'             => $step,
+			'provider_context' => self::build_provider_context( $plan, $step ),
+		];
+	}
+
+	/**
+	 * Approve the current phase using the durable, server-side approval record.
+	 *
+	 * @param string $plan_id             Plan UUID.
+	 * @param int    $approval_request_id Durable approval record ID.
+	 * @param int    $user_id             Current authenticated user ID.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function approve( string $plan_id, int $approval_request_id, int $user_id ) {
+		$plan = self::get_owned_plan( $plan_id, $user_id );
+		if ( is_wp_error( $plan ) ) {
+			return $plan;
+		}
+
+		$approval = HumanApprovalGate::get( $approval_request_id );
+		if ( null === $approval || (int) $approval['requested_by'] !== $user_id ) {
+			return new WP_Error( 'sd_ai_agent_plan_approval_not_found', __( 'The requested plan approval was not found.', 'superdav-ai-agent' ), [ 'status' => 404 ] );
+		}
+
+		if ( 'durable-plan-scope' === $approval['action_type'] ) {
+			return self::approve_scope_change( $plan, $approval, $user_id );
+		}
+
+		$step = DurablePlanRepository::get_current_step( (int) $plan['id'] );
+		if ( null === $step || (int) $step['approval_request_id'] !== $approval_request_id || ! self::approval_matches_phase( $approval, $plan, $step ) ) {
+			return new WP_Error( 'sd_ai_agent_plan_approval_mismatch', __( 'This approval does not match the current durable plan phase.', 'superdav-ai-agent' ), [ 'status' => 409 ] );
+		}
+
+		$approved = HumanApprovalGate::approve( $approval_request_id, $user_id, false );
+		if ( is_wp_error( $approved ) ) {
+			return $approved;
+		}
+
+		return self::prepare_next( $plan_id, $user_id );
+	}
+
+	/**
+	 * Reject a pending phase and cancel the remaining plan safely.
+	 *
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function reject( string $plan_id, int $approval_request_id, int $user_id ) {
+		$plan = self::get_owned_plan( $plan_id, $user_id );
+		if ( is_wp_error( $plan ) ) {
+			return $plan;
+		}
+
+		$approval = HumanApprovalGate::get( $approval_request_id );
+		if ( null === $approval || (int) $approval['requested_by'] !== $user_id ) {
+			return new WP_Error( 'sd_ai_agent_plan_approval_not_found', __( 'The requested plan approval was not found.', 'superdav-ai-agent' ), [ 'status' => 404 ] );
+		}
+		if ( 'durable-plan-scope' === $approval['action_type'] ) {
+			return self::reject_scope_change( $plan, $approval, $user_id );
+		}
+
+		$step = DurablePlanRepository::get_current_step( (int) $plan['id'] );
+		if ( null === $step || (int) $step['approval_request_id'] !== $approval_request_id ) {
+			return new WP_Error( 'sd_ai_agent_plan_approval_mismatch', __( 'This approval does not match the current durable plan phase.', 'superdav-ai-agent' ), [ 'status' => 409 ] );
+		}
+
+		$rejected = HumanApprovalGate::reject( $approval_request_id, $user_id );
+		if ( is_wp_error( $rejected ) ) {
+			return $rejected;
+		}
+
+		DurablePlanRepository::update_step_status( (int) $step['id'], 'cancelled', [ 'failure_message' => __( 'The phase was declined by the user.', 'superdav-ai-agent' ) ] );
+		DurablePlanRepository::update_plan_status( (int) $plan['id'], 'cancelled', [ 'cancelled_at' => current_time( 'mysql', true ) ] );
+
+		return [
+			'status' => 'cancelled',
+			'plan'   => self::public_plan( $plan_id ),
+		];
+	}
+
+	/**
+	 * Cancel a plan without executing any unstarted phase.
+	 *
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function cancel( string $plan_id, int $user_id ) {
+		$plan = self::get_owned_plan( $plan_id, $user_id );
+		if ( is_wp_error( $plan ) ) {
+			return $plan;
+		}
+
+		if ( 'running' === $plan['status'] ) {
+			return new WP_Error( 'sd_ai_agent_plan_cancel_running', __( 'A running phase must finish or fail before this plan can be cancelled.', 'superdav-ai-agent' ), [ 'status' => 409 ] );
+		}
+
+		$step = DurablePlanRepository::get_current_step( (int) $plan['id'] );
+		if ( null !== $step && in_array( $step['status'], [ 'pending', 'awaiting_approval', 'interrupted' ], true ) ) {
+			DurablePlanRepository::update_step_status( (int) $step['id'], 'cancelled' );
+		}
+		DurablePlanRepository::update_plan_status( (int) $plan['id'], 'cancelled', [ 'cancelled_at' => current_time( 'mysql', true ) ] );
+
+		return [
+			'status' => 'cancelled',
+			'plan'   => self::public_plan( $plan_id ),
+		];
+	}
+
+	/**
+	 * Retry a failed or interrupted phase only after a new explicit user action.
+	 *
+	 * Write and destructive phases are reset to pending and then pass through
+	 * prepare_next(), which creates a fresh HumanApprovalGate record. Read-only
+	 * idempotent phases may continue directly, but are still never auto-retried.
+	 *
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function retry( string $plan_id, int $user_id ) {
+		$plan = self::get_owned_plan( $plan_id, $user_id );
+		if ( is_wp_error( $plan ) ) {
+			return $plan;
+		}
+		if ( ! in_array( $plan['status'], [ 'failed', 'blocked' ], true ) ) {
+			return new WP_Error( 'sd_ai_agent_plan_retry_unavailable', __( 'This durable plan phase is not available for retry.', 'superdav-ai-agent' ), [ 'status' => 409 ] );
+		}
+
+		$step = DurablePlanRepository::get_step_at_position( (int) $plan['id'], (int) $plan['current_step'] );
+		if ( null === $step || ! in_array( $step['status'], [ 'failed', 'interrupted' ], true ) ) {
+			return new WP_Error( 'sd_ai_agent_plan_retry_unavailable', __( 'The failed durable plan phase is no longer available for retry.', 'superdav-ai-agent' ), [ 'status' => 409 ] );
+		}
+
+		if ( ! DurablePlanRepository::update_step_status(
+			(int) $step['id'],
+			'pending',
+			[
+				'approval_request_id' => 0,
+				'job_id'              => '',
+				'failure_message'     => '',
+			]
+		) ) {
+			return new WP_Error( 'sd_ai_agent_plan_retry_failed', __( 'The durable plan phase could not be prepared for retry.', 'superdav-ai-agent' ), [ 'status' => 500 ] );
+		}
+
+		DurablePlanRepository::update_plan_status(
+			(int) $plan['id'],
+			'pending',
+			[ 'approval_request_id' => 0 ]
+		);
+
+		return self::prepare_next( $plan_id, $user_id );
+	}
+
+	/**
+	 * Require a fresh approval before changing a stored plan's compact scope.
+	 *
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function request_scope_change( string $plan_id, int $user_id, string $scope ) {
+		$plan = self::get_owned_plan( $plan_id, $user_id );
+		if ( is_wp_error( $plan ) ) {
+			return $plan;
+		}
+		if ( 'pending' !== $plan['status'] ) {
+			return new WP_Error( 'sd_ai_agent_plan_scope_unavailable', __( 'Change the plan scope only between phases before starting the next phase.', 'superdav-ai-agent' ), [ 'status' => 409 ] );
+		}
+
+		$scope = self::safe_text( $scope, 1200 );
+		if ( '' === $scope ) {
+			return new WP_Error( 'sd_ai_agent_plan_scope_invalid', __( 'A changed plan scope is required.', 'superdav-ai-agent' ), [ 'status' => 400 ] );
+		}
+
+		$scope_hash = hash( 'sha256', $scope );
+		if ( hash_equals( (string) $plan['scope_hash'], $scope_hash ) ) {
+			return [
+				'status' => $plan['status'],
+				'plan'   => DurablePlanRepository::to_public( $plan ),
+			];
+		}
+
+		$approval = HumanApprovalGate::create_pending(
+			[
+				'source_type'  => 'durable-plan',
+				'source_id'    => (int) $plan['id'],
+				'action_type'  => 'durable-plan-scope',
+				'requested_by' => $user_id,
+				'payload'      => [
+					'plan_id'    => $plan['plan_id'],
+					'scope'      => $scope,
+					'scope_hash' => $scope_hash,
+				],
+			]
+		);
+		if ( is_wp_error( $approval ) ) {
+			return $approval;
+		}
+
+		if ( ! DurablePlanRepository::claim_scope_change( (int) $plan['id'], $scope, $scope_hash, (int) $approval['id'] ) ) {
+			return new WP_Error( 'sd_ai_agent_plan_scope_changed', __( 'This durable plan changed before the scope request could be saved. Refresh the plan status and try again.', 'superdav-ai-agent' ), [ 'status' => 409 ] );
+		}
+
+		return [
+			'status' => 'awaiting_approval',
+			'plan'   => self::public_plan( $plan_id ),
+		];
+	}
+
+	/**
+	 * Attach a queued background job to the currently running phase.
+	 */
+	public static function assign_job( string $plan_id, int $step_id, string $job_id ): bool {
+		$plan = DurablePlanRepository::get_by_plan_id( $plan_id );
+		$step = DurablePlanRepository::get_step( $step_id );
+		if ( null === $plan || null === $step || (int) $step['plan_db_id'] !== (int) $plan['id'] ) {
+			return false;
+		}
+
+		return DurablePlanRepository::assign_job( $step_id, $job_id );
+	}
+
+	/**
+	 * Mark a completed bounded phase and persist only compact safe evidence.
+	 *
+	 * @param string               $plan_id Plan UUID.
+	 * @param int                  $step_id Phase ID.
+	 * @param array<string, mixed> $result  Agent-loop result.
+	 * @return array<string, mixed>|null
+	 */
+	public static function complete_phase( string $plan_id, int $step_id, array $result ): ?array {
+		$plan = DurablePlanRepository::get_by_plan_id( $plan_id );
+		$step = DurablePlanRepository::get_step( $step_id );
+		if ( null === $plan || null === $step || (int) $step['plan_db_id'] !== (int) $plan['id'] || 'running' !== $step['status'] ) {
+			return null;
+		}
+
+		$evidence = wp_json_encode( self::safe_evidence( $result ) );
+		if ( false === $evidence ) {
+			$evidence = '{}';
+		}
+
+		DurablePlanRepository::update_step_status(
+			$step_id,
+			'completed',
+			[
+				'evidence'     => $evidence,
+				'completed_at' => current_time( 'mysql', true ),
+			]
+		);
+
+		$next = DurablePlanRepository::get_current_step( (int) $plan['id'] );
+		DurablePlanRepository::update_plan_status(
+			(int) $plan['id'],
+			null === $next ? 'completed' : 'pending',
+			null === $next ? [ 'completed_at' => current_time( 'mysql', true ) ] : [ 'current_step' => (int) $next['position'] ]
+		);
+
+		return self::public_plan( $plan_id );
+	}
+
+	/**
+	 * Mark a normal phase failure and expose an actionable, redacted state.
+	 */
+	public static function fail_phase( string $plan_id, int $step_id, string $message ): ?array {
+		$plan = DurablePlanRepository::get_by_plan_id( $plan_id );
+		$step = DurablePlanRepository::get_step( $step_id );
+		if ( null === $plan || null === $step || (int) $step['plan_db_id'] !== (int) $plan['id'] ) {
+			return null;
+		}
+
+		$message = self::safe_text( $message, 500 );
+		DurablePlanRepository::update_step_status( $step_id, 'failed', [ 'failure_message' => $message ] );
+		DurablePlanRepository::update_plan_status( (int) $plan['id'], 'failed', [ 'current_step' => (int) $step['position'] ] );
+		return self::public_plan( $plan_id );
+	}
+
+	/**
+	 * Convert an interrupted phase into a safe retry or manual-retry block.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public static function mark_phase_interrupted_by_job( string $job_id ): ?array {
+		$step = DurablePlanRepository::get_step_by_job_id( $job_id );
+		if ( null === $step ) {
+			return null;
+		}
+
+		$plan = self::get_plan_by_internal_id( (int) $step['plan_db_id'] );
+		if ( null === $plan || ! in_array( $step['status'], [ 'running', 'interrupted' ], true ) ) {
+			return null;
+		}
+
+		if ( self::is_safe_to_resume( $step ) ) {
+			DurablePlanRepository::update_step_status( (int) $step['id'], 'interrupted', [ 'failure_message' => __( 'The safe read-only phase was interrupted and can be continued.', 'superdav-ai-agent' ) ] );
+			DurablePlanRepository::update_plan_status( (int) $plan['id'], 'pending', [ 'current_step' => (int) $step['position'] ] );
+		} else {
+			DurablePlanRepository::update_step_status( (int) $step['id'], 'failed', [ 'failure_message' => __( 'This consequential phase was interrupted. Review the site state and request a new confirmation before retrying.', 'superdav-ai-agent' ) ] );
+			DurablePlanRepository::update_plan_status( (int) $plan['id'], 'blocked', [ 'current_step' => (int) $step['position'] ] );
+		}
+
+		return self::public_plan( (string) $plan['plan_id'] );
+	}
+
+	/**
+	 * Build the compact provider message for one active phase.
+	 *
+	 * @param array<string, mixed> $plan Plan record.
+	 * @param array<string, mixed> $step Phase record.
+	 */
+	public static function build_provider_context( array $plan, array $step ): string {
+		$evidence_lines = [];
+		$plan_steps     = $plan['steps'] ?? [];
+		if ( ! is_array( $plan_steps ) ) {
+			$plan_steps = [];
+		}
+		$completed = array_filter(
+			$plan_steps,
+			static fn( mixed $candidate ): bool => is_array( $candidate ) && 'completed' === ( $candidate['status'] ?? '' )
+		);
+		$completed = array_slice( $completed, -self::CONTEXT_EVIDENCE_LIMIT );
+		foreach ( $completed as $completed_step ) {
+			$summary = is_array( $completed_step['evidence'] ?? null ) ? (string) ( $completed_step['evidence']['summary'] ?? '' ) : '';
+			if ( '' !== $summary ) {
+				$evidence_lines[] = '- ' . self::safe_text( (string) $completed_step['title'], 120 ) . ': ' . self::safe_text( $summary, 360 );
+			}
+		}
+
+		$sections = [
+			'Execute only the active phase of this durable site operation. Do not infer blanket permission for tools or later phases.',
+			'Scope: ' . self::safe_text( (string) $plan['scope'], 1200 ),
+			'Active phase ' . (int) $step['position'] . ': ' . self::safe_text( (string) $step['title'], 255 ),
+			'Instruction: ' . self::safe_text( (string) $step['instruction'], 1600 ),
+			'Classification: ' . self::safe_text( (string) $step['classification'], 32 ),
+			'Preconditions: ' . self::safe_text( (string) $step['preconditions'], 600 ),
+			'Expected evidence: ' . self::safe_text( (string) $step['expected_evidence'], 600 ),
+			'Rollback guidance: ' . self::safe_text( (string) $step['rollback_guidance'], 600 ),
+		];
+		if ( ! empty( $evidence_lines ) ) {
+			$sections[] = "Completed phase evidence:\n" . implode( "\n", $evidence_lines );
+		}
+		$sections[] = 'Return a concise completion summary and evidence. Do not include credentials, raw tool payloads, or the full prior conversation.';
+
+		$context = implode( "\n\n", $sections );
+		return function_exists( 'mb_substr' ) ? mb_substr( $context, 0, self::CONTEXT_MAX_CHARS ) : substr( $context, 0, self::CONTEXT_MAX_CHARS );
+	}
+
+	/**
+	 * Get a browser-safe plan record or null.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public static function public_plan( string $plan_id ): ?array {
+		$plan = DurablePlanRepository::get_by_plan_id( $plan_id );
+		return null === $plan ? null : DurablePlanRepository::to_public( $plan );
+	}
+
+	/**
+	 * Get a browser-safe plan by its active or completed phase job ID.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public static function public_plan_for_job( string $job_id ): ?array {
+		$step = DurablePlanRepository::get_step_by_job_id( $job_id );
+		if ( null === $step ) {
+			return null;
+		}
+
+		$plan = DurablePlanRepository::get_by_id( (int) $step['plan_db_id'] );
+		return null === $plan ? null : DurablePlanRepository::to_public( $plan );
+	}
+
+	/**
+	 * Check ownership against a server-side persisted plan row.
+	 *
+	 * @return array<string, mixed>|WP_Error
+	 */
+	private static function get_owned_plan( string $plan_id, int $user_id ) {
+		$plan = DurablePlanRepository::get_by_plan_id( $plan_id );
+		if ( null === $plan ) {
+			return new WP_Error( 'sd_ai_agent_plan_not_found', __( 'Durable plan not found.', 'superdav-ai-agent' ), [ 'status' => 404 ] );
+		}
+		if ( $user_id <= 0 || (int) $plan['user_id'] !== $user_id ) {
+			return new WP_Error( 'sd_ai_agent_plan_forbidden', __( 'You are not authorized to change this durable plan.', 'superdav-ai-agent' ), [ 'status' => 403 ] );
+		}
+
+		return $plan;
+	}
+
+	/**
+	 * Load a plan by internal ID for a job-to-phase state transition.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	private static function get_plan_by_internal_id( int $plan_db_id ): ?array {
+		return DurablePlanRepository::get_by_id( $plan_db_id );
+	}
+
+	/**
+	 * A server-owned policy determines whether a phase needs approval.
+	 *
+	 * @param array<string, mixed> $step Phase record.
+	 */
+	private static function requires_approval( array $step ): bool {
+		return 1 === (int) ( $step['requires_approval'] ?? 1 );
+	}
+
+	/**
+	 * Only server-reviewed read-only phases with a stable key may resume.
+	 *
+	 * @param array<string, mixed> $step Phase record.
+	 */
+	private static function is_safe_to_resume( array $step ): bool {
+		return ! self::requires_approval( $step )
+			&& 'read' === (string) ( $step['classification'] ?? '' )
+			&& 1 === (int) ( $step['safe_to_resume'] ?? 0 )
+			&& '' !== (string) ( $step['idempotency_key'] ?? '' );
+	}
+
+	/**
+	 * Find or create the approval request protecting a consequential phase.
+	 *
+	 * @param array<string, mixed> $plan Plan record.
+	 * @param array<string, mixed> $step Phase record.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	private static function ensure_phase_approval( array $plan, array $step, int $user_id ) {
+		if ( (int) $step['approval_request_id'] > 0 ) {
+			$existing = HumanApprovalGate::get( (int) $step['approval_request_id'] );
+			if ( null !== $existing && self::approval_matches_phase( $existing, $plan, $step ) ) {
+				if ( in_array( $existing['status'], [ HumanApprovalGate::STATUS_PENDING, HumanApprovalGate::STATUS_APPROVED, HumanApprovalGate::STATUS_EXECUTED ], true ) ) {
+					return $existing;
+				}
+
+				return new WP_Error( 'sd_ai_agent_plan_approval_unavailable', __( 'The required plan approval is no longer available. Review the phase and request a new plan.', 'superdav-ai-agent' ), [ 'status' => 409 ] );
+			}
+		}
+
+		$approval = HumanApprovalGate::create_pending(
+			[
+				'source_type'  => 'durable-plan',
+				'source_id'    => (int) $plan['id'],
+				'action_type'  => 'durable-plan-phase',
+				'requested_by' => $user_id,
+				'payload'      => [
+					'plan_id'        => $plan['plan_id'],
+					'step_id'        => (int) $step['id'],
+					'step_key'       => $step['step_key'],
+					'step_title'     => $step['title'],
+					'classification' => $step['classification'],
+					'scope_hash'     => $plan['scope_hash'],
+				],
+			]
+		);
+		if ( is_wp_error( $approval ) ) {
+			return $approval;
+		}
+
+		DurablePlanRepository::update_step_status(
+			(int) $step['id'],
+			'awaiting_approval',
+			[ 'approval_request_id' => (int) $approval['id'] ]
+		);
+		DurablePlanRepository::update_plan_status(
+			(int) $plan['id'],
+			'awaiting_approval',
+			[
+				'current_step'        => (int) $step['position'],
+				'approval_request_id' => (int) $approval['id'],
+			]
+		);
+		return $approval;
+	}
+
+	/**
+	 * Verify the server-side approval payload still describes this exact phase.
+	 *
+	 * @param array<string, mixed> $approval Approval record.
+	 * @param array<string, mixed> $plan     Plan record.
+	 * @param array<string, mixed> $step     Phase record.
+	 */
+	private static function approval_matches_phase( array $approval, array $plan, array $step ): bool {
+		$payload = is_array( $approval['payload'] ?? null ) ? $approval['payload'] : [];
+		return 'durable-plan-phase' === $approval['action_type']
+			&& (string) ( $payload['plan_id'] ?? '' ) === (string) $plan['plan_id']
+			&& (int) ( $payload['step_id'] ?? 0 ) === (int) $step['id']
+			&& hash_equals( (string) $plan['scope_hash'], (string) ( $payload['scope_hash'] ?? '' ) );
+	}
+
+	/**
+	 * Apply an approved scope change only after matching the persisted approval.
+	 *
+	 * @param array<string, mixed> $plan     Plan record.
+	 * @param array<string, mixed> $approval Approval record.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	private static function approve_scope_change( array $plan, array $approval, int $user_id ) {
+		$payload = is_array( $approval['payload'] ?? null ) ? $approval['payload'] : [];
+		if (
+			(string) ( $payload['plan_id'] ?? '' ) !== (string) $plan['plan_id']
+			|| (string) ( $payload['scope_hash'] ?? '' ) !== (string) $plan['pending_scope_hash']
+			|| '' === (string) $plan['pending_scope']
+		) {
+			return new WP_Error( 'sd_ai_agent_plan_scope_mismatch', __( 'This approval no longer matches the pending plan scope.', 'superdav-ai-agent' ), [ 'status' => 409 ] );
+		}
+
+		$approved = HumanApprovalGate::approve( (int) $approval['id'], $user_id, false );
+		if ( is_wp_error( $approved ) ) {
+			return $approved;
+		}
+
+		DurablePlanRepository::update_plan_status(
+			(int) $plan['id'],
+			'pending',
+			[
+				'scope'               => $plan['pending_scope'],
+				'scope_hash'          => $plan['pending_scope_hash'],
+				'pending_scope'       => '',
+				'pending_scope_hash'  => '',
+				'approval_request_id' => 0,
+			]
+		);
+
+		return [
+			'status' => 'pending',
+			'plan'   => self::public_plan( (string) $plan['plan_id'] ),
+		];
+	}
+
+	/**
+	 * Reject a pending scope change and retain the previously approved scope.
+	 *
+	 * @param array<string, mixed> $plan     Plan record.
+	 * @param array<string, mixed> $approval Approval record.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	private static function reject_scope_change( array $plan, array $approval, int $user_id ) {
+		$payload = is_array( $approval['payload'] ?? null ) ? $approval['payload'] : [];
+		if (
+			(string) ( $payload['plan_id'] ?? '' ) !== (string) $plan['plan_id']
+			|| (string) ( $payload['scope_hash'] ?? '' ) !== (string) $plan['pending_scope_hash']
+			|| '' === (string) $plan['pending_scope']
+		) {
+			return new WP_Error( 'sd_ai_agent_plan_scope_mismatch', __( 'This approval no longer matches the pending plan scope.', 'superdav-ai-agent' ), [ 'status' => 409 ] );
+		}
+
+		$rejected = HumanApprovalGate::reject( (int) $approval['id'], $user_id );
+		if ( is_wp_error( $rejected ) ) {
+			return $rejected;
+		}
+
+		DurablePlanRepository::update_plan_status(
+			(int) $plan['id'],
+			'pending',
+			[
+				'pending_scope'       => '',
+				'pending_scope_hash'  => '',
+				'approval_request_id' => 0,
+			]
+		);
+
+		return [
+			'status' => 'pending',
+			'plan'   => self::public_plan( (string) $plan['plan_id'] ),
+		];
+	}
+
+	/**
+	 * Persist a compact, redacted completion record rather than raw provider data.
+	 *
+	 * @param array<string, mixed> $result Agent-loop result.
+	 * @return array<string, mixed>
+	 */
+	private static function safe_evidence( array $result ): array {
+		$reply       = self::safe_text( (string) ( $result['reply'] ?? '' ), 900 );
+		$token_usage = is_array( $result['token_usage'] ?? null ) ? $result['token_usage'] : [];
+		return [
+			'summary'           => '' !== $reply ? $reply : __( 'Phase completed without a provider summary.', 'superdav-ai-agent' ),
+			'exit_reason'       => self::safe_text( (string) ( $result['exit_reason'] ?? 'complete' ), 80 ),
+			'completed_at'      => current_time( 'mysql', true ),
+			'prompt_tokens'     => max( 0, (int) ( $token_usage['prompt'] ?? 0 ) ),
+			'completion_tokens' => max( 0, (int) ( $token_usage['completion'] ?? 0 ) ),
+		];
+	}
+
+	/**
+	 * Redact common secret values and cap any operator-facing text.
+	 */
+	private static function safe_text( string $value, int $max_length ): string {
+		return DurablePlanTextSanitizer::sanitize( $value, $max_length );
+	}
+}

--- a/includes/Core/DurablePlanTextSanitizer.php
+++ b/includes/Core/DurablePlanTextSanitizer.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Shared secret scrubber for compact durable-plan records and evidence.
+ *
+ * @package SdAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Core;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class DurablePlanTextSanitizer {
+
+	public const REDACTED_PLACEHOLDER = '[redacted]';
+
+	/**
+	 * Strip markup, redact common credentials, and cap stored plan text.
+	 */
+	public static function sanitize( string $value, int $max_length ): string {
+		$value = sanitize_textarea_field( wp_strip_all_tags( $value ) );
+
+		$decoded = json_decode( $value, true );
+		if ( is_array( $decoded ) ) {
+			$encoded = wp_json_encode( self::redact_array( $decoded ) );
+			if ( is_string( $encoded ) ) {
+				$value = $encoded;
+			}
+		}
+
+		// Preserve a consistently redacted JSON authorization field before the
+		// generic text rules process the remaining credential labels.
+		$value = (string) preg_replace( '/"authorization"\s*:\s*"(?:\\\\.|[^"\\\\])*"/i', '"authorization": "[redacted]"', $value );
+		$value = (string) preg_replace( '/\b(authorization)\b\s*[:=]\s*(?:bearer\s+)?[^\s,;}\]]+/i', '$1: [redacted]', $value );
+		$value = (string) preg_replace(
+			'/(?:"|\')?(api[_-]?key|apikey|access[_-]?token|client[_-]?secret|credential(?:s)?|private[_-]?key|password|secret|token)(?:"|\')?\s*[:=]\s*(?:"(?:\\\\.|[^"\\\\])*"|\'(?:\\\\.|[^\'\\\\])*\'|[^\s,;}\]]+)/i',
+			'$1: [redacted]',
+			$value
+		);
+		$value = (string) preg_replace( '/\bBearer\s+[A-Za-z0-9._~+\/=:-]+/i', 'Bearer [redacted]', $value );
+
+		return function_exists( 'mb_substr' ) ? mb_substr( $value, 0, $max_length ) : substr( $value, 0, $max_length );
+	}
+
+	/**
+	 * Recursively redact secret-bearing keys in a JSON document.
+	 *
+	 * @param array<string|int, mixed> $value JSON-decoded map.
+	 * @return array<string|int, mixed>
+	 */
+	private static function redact_array( array $value ): array {
+		foreach ( $value as $key => $item ) {
+			if ( self::is_sensitive_key( (string) $key ) ) {
+				$value[ $key ] = self::REDACTED_PLACEHOLDER;
+				continue;
+			}
+
+			if ( is_array( $item ) ) {
+				$value[ $key ] = self::redact_array( $item );
+			} elseif ( is_string( $item ) ) {
+				$value[ $key ] = (string) preg_replace( '/\bBearer\s+[A-Za-z0-9._~+\/=:-]+/i', 'Bearer [redacted]', $item );
+			}
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Identify an exact key or a conventional compound key that holds a secret.
+	 */
+	private static function is_sensitive_key( string $key ): bool {
+		return 1 === preg_match(
+			'/(?:^|[_-])(?:api[_-]?key|apikey|access[_-]?token|authorization|auth|bearer|client[_-]?secret|credential(?:s)?|private[_-]?key|password|secret|token)(?:$|[_-])/i',
+			$key
+		);
+	}
+}

--- a/includes/Models/ActiveJobRepository.php
+++ b/includes/Models/ActiveJobRepository.php
@@ -103,6 +103,29 @@ class ActiveJobRepository {
 	}
 
 	/**
+	 * Atomically return a durable confirmation pause to the queue for one new claim.
+	 *
+	 * A stale confirmation must never overwrite a worker that has already
+	 * resumed or completed the job under a newer token.
+	 */
+	public static function requeue_paused_job( string $job_id ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Conditional confirmation transition prevents stale confirmations from reviving a newer job state.
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE %i SET status = 'queued', updated_at = %s WHERE job_id = %s AND status = 'awaiting_confirmation'",
+				self::table_name(),
+				current_time( 'mysql', true ),
+				$job_id
+			)
+		);
+
+		return false !== $result && $result > 0;
+	}
+
+	/**
 	 * Get an active job row by its UUID.
 	 *
 	 * @param string $job_id The job UUID.

--- a/includes/Models/ActiveJobRepository.php
+++ b/includes/Models/ActiveJobRepository.php
@@ -21,6 +21,7 @@ class ActiveJobRepository {
 	/**
 	 * Valid job status values.
 	 *
+	 * - queued                — durable phase is awaiting its one worker claim.
 	 * - processing            — loop is actively running.
 	 * - awaiting_confirmation — paused waiting for user confirmation.
 	 * - awaiting_client_tools — paused waiting for browser to execute JS tools.
@@ -29,7 +30,7 @@ class ActiveJobRepository {
 	 * - interrupted           — PHP request terminated before loop completion (shutdown handler fired).
 	 * - abandoned             — row reaped by the hourly cron because updated_at is stale.
 	 */
-	const STATUSES = [ 'processing', 'awaiting_confirmation', 'awaiting_client_tools', 'complete', 'error', 'interrupted', 'abandoned' ];
+	const STATUSES = [ 'queued', 'processing', 'awaiting_confirmation', 'awaiting_client_tools', 'complete', 'error', 'interrupted', 'abandoned' ];
 
 	/**
 	 * Get the active jobs table name.
@@ -78,6 +79,30 @@ class ActiveJobRepository {
 	}
 
 	/**
+	 * Atomically claim a queued durable-plan job for one worker.
+	 *
+	 * A loopback request can be retried or delivered more than once. Only the
+	 * request that changes this row from queued to processing may execute the
+	 * phase, preventing duplicated site operations.
+	 */
+	public static function claim_queued_job( string $job_id ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Conditional status transition is the durable worker claim.
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE %i SET status = 'processing', updated_at = %s WHERE job_id = %s AND status = 'queued'",
+				self::table_name(),
+				current_time( 'mysql', true ),
+				$job_id
+			)
+		);
+
+		return false !== $result && $result > 0;
+	}
+
+	/**
 	 * Get an active job row by its UUID.
 	 *
 	 * @param string $job_id The job UUID.
@@ -108,7 +133,7 @@ class ActiveJobRepository {
 	 * Get the active (non-terminal) job for a session.
 	 *
 	 * Returns the most-recently-created job that is still in a non-terminal
-	 * state (processing or awaiting_confirmation).
+	 * state (queued, processing, or awaiting_confirmation).
 	 *
 	 * @param int $session_id Session ID.
 	 * @return ActiveJobRow|null Row DTO or null if no active job exists.
@@ -121,7 +146,7 @@ class ActiveJobRepository {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
 		$row = $wpdb->get_row(
 			$wpdb->prepare(
-				"SELECT * FROM %i WHERE session_id = %d AND status IN ('processing', 'awaiting_confirmation', 'awaiting_client_tools') ORDER BY created_at DESC LIMIT 1",
+				"SELECT * FROM %i WHERE session_id = %d AND status IN ('queued', 'processing', 'awaiting_confirmation', 'awaiting_client_tools') ORDER BY created_at DESC LIMIT 1",
 				$table,
 				$session_id
 			)
@@ -148,7 +173,7 @@ class ActiveJobRepository {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
 		$rows = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT * FROM %i WHERE user_id = %d AND status IN ('processing', 'awaiting_confirmation', 'awaiting_client_tools') ORDER BY created_at DESC",
+				"SELECT * FROM %i WHERE user_id = %d AND status IN ('queued', 'processing', 'awaiting_confirmation', 'awaiting_client_tools') ORDER BY created_at DESC",
 				$table,
 				$user_id
 			)
@@ -382,28 +407,41 @@ class ActiveJobRepository {
 	}
 
 	/**
-	 * Reap stale processing rows by marking them as 'abandoned'.
+	 * Reap stale queued or processing rows by marking them as 'abandoned'.
 	 *
-	 * Rows are considered stale when status='processing' and updated_at has
+	 * Rows are considered stale when their status is queued or processing and updated_at has
 	 * not advanced within the given threshold. Called by the hourly cron job.
 	 *
 	 * @param int $threshold_minutes Number of minutes of inactivity before a row is considered stale.
 	 * @return int Number of rows updated.
 	 */
 	public static function cleanup_stale( int $threshold_minutes ): int {
+		return count( self::reap_stale_jobs( $threshold_minutes ) );
+	}
+
+	/**
+	 * Reap stale queued or processing jobs and return only the rows this call won.
+	 *
+	 * Each candidate is conditionally transitioned so a concurrent heartbeat or
+	 * queued-worker claim can prevent a stale cleanup from overwriting it.
+	 *
+	 * @param int $threshold_minutes Number of minutes of inactivity before a row is considered stale.
+	 * @return list<string> Reaped job UUIDs.
+	 */
+	public static function reap_stale_jobs( int $threshold_minutes ): array {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 
 		$table = self::table_name();
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom table query; caching not applicable.
-		$rows  = $wpdb->get_results(
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Candidate discovery is followed by per-row conditional claims.
+		$rows   = $wpdb->get_results(
 			$wpdb->prepare(
-				"SELECT * FROM %i WHERE status = 'processing' AND updated_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL %d MINUTE)",
+				"SELECT * FROM %i WHERE status IN ('queued', 'processing') AND updated_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL %d MINUTE)",
 				$table,
 				$threshold_minutes
 			)
 		);
-		$count = 0;
+		$reaped = array();
 
 		foreach ( $rows ?: array() as $raw_row ) {
 			$row        = ActiveJobRow::from_row( $raw_row );
@@ -412,23 +450,24 @@ class ActiveJobRepository {
 				ActiveJobFailureDiagnostic::REASON_WORKER_TERMINATED,
 				$row
 			);
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Conditional custom-table state transition.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Conditional custom-table state transition prevents stale candidate races.
 			$result = $wpdb->query(
 				$wpdb->prepare(
-					"UPDATE %i SET status = 'abandoned', error = %s, updated_at = UTC_TIMESTAMP() WHERE job_id = %s AND status = 'processing'",
+					"UPDATE %i SET status = 'abandoned', error = %s, updated_at = UTC_TIMESTAMP() WHERE job_id = %s AND status IN ('queued', 'processing') AND updated_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL %d MINUTE)",
 					$table,
 					ActiveJobFailureDiagnostic::encode( $row->job_id, $diagnostic ),
-					$row->job_id
+					$row->job_id,
+					$threshold_minutes
 				)
 			);
 
 			if ( $result !== false && $result > 0 ) {
-				++$count;
+				$reaped[] = $row->job_id;
 				ActiveJobFailureDiagnostic::log( $diagnostic, $row->session_id );
 			}
 		}
 
-		return $count;
+		return $reaped;
 	}
 
 	/**

--- a/includes/Models/DurablePlanRepository.php
+++ b/includes/Models/DurablePlanRepository.php
@@ -1,0 +1,623 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Durable storage for bounded multi-phase site-operation plans.
+ *
+ * Plan rows deliberately contain compact operational summaries rather than
+ * conversation transcripts, provider prompts, or raw tool payloads.
+ *
+ * @package SdAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Models;
+
+use SdAiAgent\Core\Database;
+use SdAiAgent\Core\DurablePlanTextSanitizer;
+use WP_Error;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+final class DurablePlanRepository {
+
+	/** @var list<string> Valid durable-plan lifecycle states. */
+	public const PLAN_STATUSES = [ 'pending', 'running', 'awaiting_approval', 'completed', 'failed', 'blocked', 'cancelled' ];
+
+	/** @var list<string> Valid durable-plan phase lifecycle states. */
+	public const STEP_STATUSES = [ 'pending', 'running', 'awaiting_approval', 'completed', 'failed', 'interrupted', 'cancelled' ];
+
+	/** @var list<string> Supported phase risk classifications. */
+	public const CLASSIFICATIONS = [ 'read', 'write', 'destructive' ];
+
+	/**
+	 * Get the durable plans table name.
+	 */
+	public static function table_name(): string {
+		return Database::durable_plans_table_name();
+	}
+
+	/**
+	 * Get the durable plan steps table name.
+	 */
+	public static function steps_table_name(): string {
+		return Database::durable_plan_steps_table_name();
+	}
+
+	/**
+	 * Create a plan and its compact phase records from server-reviewed input.
+	 *
+	 * Only server-side planning code may use this method. Browser requests must use
+	 * create_from_client() so they cannot label a consequential phase as safe.
+	 *
+	 * @param int                  $session_id Session that owns the plan.
+	 * @param int                  $user_id    User that created the plan.
+	 * @param array<string, mixed> $definition Compact plan definition.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function create( int $session_id, int $user_id, array $definition ) {
+		return self::create_with_policy( $session_id, $user_id, $definition, true );
+	}
+
+	/**
+	 * Create a plan from browser-controlled compact metadata.
+	 *
+	 * Client classifications remain descriptive only. Every client-created phase
+	 * requires an approval and cannot automatically resume after interruption.
+	 *
+	 * @param int                  $session_id Session that owns the plan.
+	 * @param int                  $user_id    User that created the plan.
+	 * @param array<string, mixed> $definition Compact plan definition.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function create_from_client( int $session_id, int $user_id, array $definition ) {
+		return self::create_with_policy( $session_id, $user_id, $definition, false );
+	}
+
+	/**
+	 * Persist a reviewed compact definition and its execution policy.
+	 *
+	 * The accepted definition intentionally has no raw_prompt, history, tool_result,
+	 * or credential field. Callers must pass a reviewed scope and compact phase
+	 * instructions instead of copying chat state into this storage.
+	 *
+	 * @param int                  $session_id       Session that owns the plan.
+	 * @param int                  $user_id          User that created the plan.
+	 * @param array<string, mixed> $definition       Compact plan definition.
+	 * @param bool                 $server_reviewed Whether server-side planning reviewed phase safety.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	private static function create_with_policy( int $session_id, int $user_id, array $definition, bool $server_reviewed ) {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$scope = self::sanitize_text( (string) ( $definition['scope'] ?? '' ), 1200 );
+		$steps = $definition['steps'] ?? [];
+		if ( $session_id <= 0 || $user_id <= 0 || '' === $scope || ! is_array( $steps ) || empty( $steps ) ) {
+			return new WP_Error( 'sd_ai_agent_plan_invalid', __( 'A session, scope, and at least one phase are required.', 'superdav-ai-agent' ), [ 'status' => 400 ] );
+		}
+
+		if ( count( $steps ) > 20 ) {
+			return new WP_Error( 'sd_ai_agent_plan_too_many_steps', __( 'A durable plan can contain at most 20 phases.', 'superdav-ai-agent' ), [ 'status' => 400 ] );
+		}
+
+		$plan_id = wp_generate_uuid4();
+		$now     = current_time( 'mysql', true );
+		$summary = self::sanitize_text( (string) ( $definition['summary'] ?? '' ), 600 );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Custom durable-plan table.
+		$inserted = $wpdb->insert(
+			self::table_name(),
+			[
+				'plan_id'             => $plan_id,
+				'session_id'          => $session_id,
+				'user_id'             => $user_id,
+				'scope'               => $scope,
+				'scope_hash'          => hash( 'sha256', $scope ),
+				'pending_scope'       => '',
+				'pending_scope_hash'  => '',
+				'summary'             => $summary,
+				'status'              => 'pending',
+				'current_step'        => 0,
+				'approval_request_id' => 0,
+				'created_at'          => $now,
+				'updated_at'          => $now,
+			],
+			[ '%s', '%d', '%d', '%s', '%s', '%s', '%s', '%s', '%s', '%d', '%d', '%s', '%s' ]
+		);
+
+		if ( false === $inserted ) {
+			return new WP_Error( 'sd_ai_agent_plan_create_failed', __( 'The durable plan could not be saved.', 'superdav-ai-agent' ), [ 'status' => 500 ] );
+		}
+
+		$plan_db_id = (int) $wpdb->insert_id;
+		foreach ( array_values( $steps ) as $position => $raw_step ) {
+			if ( ! is_array( $raw_step ) ) {
+				self::delete_by_id( $plan_db_id );
+				return new WP_Error( 'sd_ai_agent_plan_invalid_step', __( 'Each durable plan phase must be an object.', 'superdav-ai-agent' ), [ 'status' => 400 ] );
+			}
+
+			$step = self::normalize_step( $raw_step, $position + 1, $plan_id, $server_reviewed );
+			if ( is_wp_error( $step ) ) {
+				self::delete_by_id( $plan_db_id );
+				return $step;
+			}
+
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Custom durable-plan table.
+			$step_inserted = $wpdb->insert(
+				self::steps_table_name(),
+				[
+					'plan_db_id'          => $plan_db_id,
+					'step_key'            => $step['step_key'],
+					'position'            => $step['position'],
+					'title'               => $step['title'],
+					'instruction'         => $step['instruction'],
+					'classification'      => $step['classification'],
+					'requires_approval'   => $step['requires_approval'],
+					'safe_to_resume'      => $step['safe_to_resume'],
+					'idempotency_key'     => $step['idempotency_key'],
+					'preconditions'       => $step['preconditions'],
+					'expected_evidence'   => $step['expected_evidence'],
+					'rollback_guidance'   => $step['rollback_guidance'],
+					'status'              => 'pending',
+					'approval_request_id' => 0,
+					'job_id'              => '',
+					'evidence'            => '',
+					'failure_message'     => '',
+					'attempts'            => 0,
+					'created_at'          => $now,
+					'updated_at'          => $now,
+				],
+				[ '%d', '%s', '%d', '%s', '%s', '%s', '%d', '%d', '%s', '%s', '%s', '%s', '%s', '%d', '%s', '%s', '%s', '%d', '%s', '%s' ]
+			);
+
+			if ( false === $step_inserted ) {
+				self::delete_by_id( $plan_db_id );
+				return new WP_Error( 'sd_ai_agent_plan_step_create_failed', __( 'A durable plan phase could not be saved.', 'superdav-ai-agent' ), [ 'status' => 500 ] );
+			}
+		}
+
+		$plan = self::get_by_plan_id( $plan_id );
+		return $plan ?? new WP_Error( 'sd_ai_agent_plan_create_failed', __( 'The durable plan could not be loaded after saving.', 'superdav-ai-agent' ), [ 'status' => 500 ] );
+	}
+
+	/**
+	 * Get a plan with all phase records by public UUID.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public static function get_by_plan_id( string $plan_id ): ?array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom durable-plan table.
+		$row = $wpdb->get_row(
+			$wpdb->prepare( 'SELECT * FROM %i WHERE plan_id = %s LIMIT 1', self::table_name(), $plan_id )
+		);
+
+		return $row ? self::decode_plan_row( $row ) : null;
+	}
+
+	/**
+	 * Get a plan with all phase records by its internal database ID.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public static function get_by_id( int $plan_db_id ): ?array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom durable-plan table.
+		$row = $wpdb->get_row(
+			$wpdb->prepare( 'SELECT * FROM %i WHERE id = %d LIMIT 1', self::table_name(), $plan_db_id )
+		);
+
+		return $row ? self::decode_plan_row( $row ) : null;
+	}
+
+	/**
+	 * Get the latest plan visible to a session owner.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public static function get_latest_for_session( int $session_id, int $user_id ): ?array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom durable-plan table.
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE session_id = %d AND user_id = %d ORDER BY updated_at DESC, id DESC LIMIT 1',
+				self::table_name(),
+				$session_id,
+				$user_id
+			)
+		);
+
+		return $row ? self::decode_plan_row( $row ) : null;
+	}
+
+	/**
+	 * Get the next phase that has not reached a terminal state.
+	 *
+	 * @param int $plan_db_id Internal plan ID.
+	 * @return array<string, mixed>|null
+	 */
+	public static function get_current_step( int $plan_db_id ): ?array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom durable-plan table.
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT * FROM %i WHERE plan_db_id = %d AND status IN ('pending', 'running', 'awaiting_approval', 'interrupted') ORDER BY position ASC LIMIT 1",
+				self::steps_table_name(),
+				$plan_db_id
+			)
+		);
+
+		return $row ? self::decode_step_row( $row ) : null;
+	}
+
+	/**
+	 * Get a phase by its internal ID.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public static function get_step( int $step_id ): ?array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom durable-plan table.
+		$row = $wpdb->get_row( $wpdb->prepare( 'SELECT * FROM %i WHERE id = %d LIMIT 1', self::steps_table_name(), $step_id ) );
+		return $row ? self::decode_step_row( $row ) : null;
+	}
+
+	/**
+	 * Get a phase at its immutable one-based plan position.
+	 *
+	 * This is used for an explicit retry after a phase has reached a terminal
+	 * failure state and is therefore intentionally absent from get_current_step().
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public static function get_step_at_position( int $plan_db_id, int $position ): ?array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom durable-plan table.
+		$row = $wpdb->get_row(
+			$wpdb->prepare(
+				'SELECT * FROM %i WHERE plan_db_id = %d AND position = %d LIMIT 1',
+				self::steps_table_name(),
+				$plan_db_id,
+				$position
+			)
+		);
+
+		return $row ? self::decode_step_row( $row ) : null;
+	}
+
+	/**
+	 * Get a phase by the background job that is executing it.
+	 *
+	 * @return array<string, mixed>|null
+	 */
+	public static function get_step_by_job_id( string $job_id ): ?array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom durable-plan table.
+		$row = $wpdb->get_row( $wpdb->prepare( 'SELECT * FROM %i WHERE job_id = %s LIMIT 1', self::steps_table_name(), $job_id ) );
+		return $row ? self::decode_step_row( $row ) : null;
+	}
+
+	/**
+	 * Set durable plan lifecycle data using a fixed allowlist.
+	 *
+	 * @param int                  $plan_db_id Plan ID.
+	 * @param string               $status     New status.
+	 * @param array<string, mixed> $extra      Additional safe columns.
+	 */
+	public static function update_plan_status( int $plan_db_id, string $status, array $extra = [] ): bool {
+		if ( ! in_array( $status, self::PLAN_STATUSES, true ) ) {
+			return false;
+		}
+
+		$allowed            = [ 'scope', 'scope_hash', 'pending_scope', 'pending_scope_hash', 'summary', 'current_step', 'approval_request_id', 'completed_at', 'cancelled_at' ];
+		$data               = array_intersect_key( $extra, array_flip( $allowed ) );
+		$data['status']     = $status;
+		$data['updated_at'] = current_time( 'mysql', true );
+
+		return self::update_row( self::table_name(), $data, [ 'id' => $plan_db_id ], [ 'current_step', 'approval_request_id' ] );
+	}
+
+	/**
+	 * Set durable phase lifecycle data using a fixed allowlist.
+	 *
+	 * @param int                  $step_id Phase ID.
+	 * @param string               $status  New status.
+	 * @param array<string, mixed> $extra   Additional safe columns.
+	 */
+	public static function update_step_status( int $step_id, string $status, array $extra = [] ): bool {
+		if ( ! in_array( $status, self::STEP_STATUSES, true ) ) {
+			return false;
+		}
+
+		$allowed            = [ 'approval_request_id', 'job_id', 'evidence', 'failure_message', 'completed_at' ];
+		$data               = array_intersect_key( $extra, array_flip( $allowed ) );
+		$data['status']     = $status;
+		$data['updated_at'] = current_time( 'mysql', true );
+
+		return self::update_row( self::steps_table_name(), $data, [ 'id' => $step_id ], [ 'approval_request_id' ] );
+	}
+
+	/**
+	 * Atomically claim a phase and transition its plan to running.
+	 *
+	 * Claiming both records in one conditional update prevents a scope-change
+	 * request from winning between a phase claim and its plan-state update.
+	 */
+	public static function claim_step_and_start_plan( int $plan_db_id, int $step_id, int $position ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$now = current_time( 'mysql', true );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Joined conditional update makes the plan/phase transition atomic.
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE %i AS plan INNER JOIN %i AS step ON step.plan_db_id = plan.id SET plan.status = 'running', plan.current_step = %d, plan.approval_request_id = 0, plan.updated_at = %s, step.status = 'running', step.attempts = step.attempts + 1, step.updated_at = %s WHERE plan.id = %d AND plan.status IN ('pending', 'awaiting_approval') AND plan.pending_scope = '' AND step.id = %d AND step.status IN ('pending', 'interrupted', 'awaiting_approval')",
+				self::table_name(),
+				self::steps_table_name(),
+				$position,
+				$now,
+				$now,
+				$plan_db_id,
+				$step_id
+			)
+		);
+
+		return false !== $result && $result > 0;
+	}
+
+	/**
+	 * Atomically reserve a pending plan for a scope-change approval.
+	 *
+	 * A phase can claim the same plan only while it has no pending scope, so
+	 * this conditional transition prevents either operation from overriding the
+	 * other after it has won the race.
+	 */
+	public static function claim_scope_change( int $plan_db_id, string $scope, string $scope_hash, int $approval_request_id ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Conditional scope reservation prevents concurrent plan execution.
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"UPDATE %i SET status = 'awaiting_approval', pending_scope = %s, pending_scope_hash = %s, approval_request_id = %d, updated_at = %s WHERE id = %d AND status = 'pending' AND pending_scope = ''",
+				self::table_name(),
+				$scope,
+				$scope_hash,
+				$approval_request_id,
+				current_time( 'mysql', true ),
+				$plan_db_id
+			)
+		);
+
+		return false !== $result && $result > 0;
+	}
+
+	/**
+	 * Associate a background job with an already claimed phase.
+	 */
+	public static function assign_job( int $step_id, string $job_id ): bool {
+		return self::update_step_status( $step_id, 'running', [ 'job_id' => sanitize_text_field( $job_id ) ] );
+	}
+
+	/**
+	 * Remove plan records after a failed create operation or test teardown.
+	 */
+	public static function delete_by_id( int $plan_db_id ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Custom durable-plan table cleanup.
+		$wpdb->delete( self::steps_table_name(), [ 'plan_db_id' => $plan_db_id ], [ '%d' ] );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Custom durable-plan table cleanup.
+		$result = $wpdb->delete( self::table_name(), [ 'id' => $plan_db_id ], [ '%d' ] );
+		return false !== $result;
+	}
+
+	/**
+	 * Convert an internal plan row into a browser-safe response payload.
+	 *
+	 * @param array<string, mixed> $plan Plan record.
+	 * @return array<string, mixed>
+	 */
+	public static function to_public( array $plan ): array {
+		$steps = [];
+		foreach ( $plan['steps'] as $step ) {
+			if ( ! is_array( $step ) ) {
+				continue;
+			}
+			$steps[] = [
+				'key'                 => $step['step_key'],
+				'position'            => $step['position'],
+				'title'               => $step['title'],
+				'instruction'         => $step['instruction'],
+				'classification'      => $step['classification'],
+				'preconditions'       => $step['preconditions'],
+				'expected_evidence'   => $step['expected_evidence'],
+				'rollback_guidance'   => $step['rollback_guidance'],
+				'status'              => $step['status'],
+				'approval_request_id' => $step['approval_request_id'],
+				'evidence'            => $step['evidence'],
+				'failure_message'     => $step['failure_message'],
+			];
+		}
+
+		return [
+			'plan_id'             => $plan['plan_id'],
+			'session_id'          => $plan['session_id'],
+			'scope'               => $plan['scope'],
+			'pending_scope'       => $plan['pending_scope'],
+			'summary'             => $plan['summary'],
+			'status'              => $plan['status'],
+			'current_step'        => $plan['current_step'],
+			'approval_request_id' => $plan['approval_request_id'],
+			'created_at'          => $plan['created_at'],
+			'updated_at'          => $plan['updated_at'],
+			'completed_at'        => $plan['completed_at'],
+			'cancelled_at'        => $plan['cancelled_at'],
+			'steps'               => $steps,
+		];
+	}
+
+	/**
+	 * Normalize a compact phase definition and derive server-owned execution policy.
+	 *
+	 * @param array<string, mixed> $raw             Phase input.
+	 * @param int                  $position        One-based phase position.
+	 * @param string               $plan_id         Plan UUID.
+	 * @param bool                 $server_reviewed Whether server-side planning reviewed phase safety.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	private static function normalize_step( array $raw, int $position, string $plan_id, bool $server_reviewed ) {
+		$title       = self::sanitize_text( (string) ( $raw['title'] ?? '' ), 255 );
+		$instruction = self::sanitize_text( (string) ( $raw['instruction'] ?? '' ), 1600 );
+		if ( '' === $title || '' === $instruction ) {
+			return new WP_Error( 'sd_ai_agent_plan_invalid_step', __( 'Every durable plan phase needs a title and instruction.', 'superdav-ai-agent' ), [ 'status' => 400 ] );
+		}
+
+		$step_key = sanitize_key( (string) ( $raw['key'] ?? '' ) );
+		if ( '' === $step_key ) {
+			$step_key = 'phase-' . $position;
+		}
+
+		$classification = sanitize_key( (string) ( $raw['classification'] ?? 'read' ) );
+		if ( ! in_array( $classification, self::CLASSIFICATIONS, true ) ) {
+			return new WP_Error( 'sd_ai_agent_plan_invalid_classification', __( 'Each durable plan phase must be read, write, or destructive.', 'superdav-ai-agent' ), [ 'status' => 400 ] );
+		}
+
+		// Keep this opaque and server-generated so plan records never retain a
+		// browser or model-provided token under the guise of an idempotency key.
+		$idempotency_key = hash( 'sha256', $plan_id . ':' . $position . ':' . $instruction );
+
+		$requires_approval = ! $server_reviewed || 'read' !== $classification;
+		$safe_to_resume    = $server_reviewed && ! $requires_approval;
+
+		return [
+			'step_key'          => $step_key,
+			'position'          => $position,
+			'title'             => $title,
+			'instruction'       => $instruction,
+			'classification'    => $classification,
+			'requires_approval' => $requires_approval ? 1 : 0,
+			'safe_to_resume'    => $safe_to_resume ? 1 : 0,
+			'idempotency_key'   => $idempotency_key,
+			'preconditions'     => self::sanitize_text( (string) ( $raw['preconditions'] ?? '' ), 600 ),
+			'expected_evidence' => self::sanitize_text( (string) ( $raw['expected_evidence'] ?? '' ), 600 ),
+			'rollback_guidance' => self::sanitize_text( (string) ( $raw['rollback_guidance'] ?? '' ), 600 ),
+		];
+	}
+
+	/**
+	 * Load and decode a plan's phase records.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function decode_plan_row( object $row ): array {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom durable-plan table.
+		$step_rows = $wpdb->get_results(
+			$wpdb->prepare( 'SELECT * FROM %i WHERE plan_db_id = %d ORDER BY position ASC', self::steps_table_name(), (int) $row->id )
+		);
+
+		return [
+			'id'                  => (int) $row->id,
+			'plan_id'             => (string) $row->plan_id,
+			'session_id'          => (int) $row->session_id,
+			'user_id'             => (int) $row->user_id,
+			'scope'               => (string) $row->scope,
+			'scope_hash'          => (string) $row->scope_hash,
+			'pending_scope'       => (string) $row->pending_scope,
+			'pending_scope_hash'  => (string) $row->pending_scope_hash,
+			'summary'             => (string) $row->summary,
+			'status'              => (string) $row->status,
+			'current_step'        => (int) $row->current_step,
+			'approval_request_id' => (int) $row->approval_request_id,
+			'created_at'          => (string) $row->created_at,
+			'updated_at'          => (string) $row->updated_at,
+			'completed_at'        => $row->completed_at ? (string) $row->completed_at : '',
+			'cancelled_at'        => $row->cancelled_at ? (string) $row->cancelled_at : '',
+			'steps'               => array_map( [ self::class, 'decode_step_row' ], $step_rows ?: [] ),
+		];
+	}
+
+	/**
+	 * Decode a plan phase row.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function decode_step_row( object $row ): array {
+		$evidence = json_decode( (string) $row->evidence, true );
+
+		return [
+			'id'                  => (int) $row->id,
+			'plan_db_id'          => (int) $row->plan_db_id,
+			'step_key'            => (string) $row->step_key,
+			'position'            => (int) $row->position,
+			'title'               => (string) $row->title,
+			'instruction'         => (string) $row->instruction,
+			'classification'      => (string) $row->classification,
+			'requires_approval'   => isset( $row->requires_approval ) ? (int) $row->requires_approval : 1,
+			'safe_to_resume'      => isset( $row->safe_to_resume ) ? (int) $row->safe_to_resume : 0,
+			'idempotency_key'     => (string) $row->idempotency_key,
+			'preconditions'       => (string) $row->preconditions,
+			'expected_evidence'   => (string) $row->expected_evidence,
+			'rollback_guidance'   => (string) $row->rollback_guidance,
+			'status'              => (string) $row->status,
+			'approval_request_id' => (int) $row->approval_request_id,
+			'job_id'              => (string) $row->job_id,
+			'evidence'            => is_array( $evidence ) ? $evidence : [],
+			'failure_message'     => (string) $row->failure_message,
+			'attempts'            => (int) $row->attempts,
+			'created_at'          => (string) $row->created_at,
+			'updated_at'          => (string) $row->updated_at,
+			'completed_at'        => $row->completed_at ? (string) $row->completed_at : '',
+		];
+	}
+
+	/**
+	 * Update a custom-table row with explicit integer format columns.
+	 *
+	 * @param string               $table        Table name.
+	 * @param array<string, mixed> $data         Data to store.
+	 * @param array<string, mixed> $where        Row selector.
+	 * @param array<string>        $integer_keys Data keys that are integers.
+	 */
+	private static function update_row( string $table, array $data, array $where, array $integer_keys ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		$formats = [];
+		foreach ( array_keys( $data ) as $key ) {
+			$formats[] = in_array( $key, $integer_keys, true ) ? '%d' : '%s';
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Custom durable-plan table.
+		$result = $wpdb->update( $table, $data, $where, $formats, [ '%d' ] );
+		return false !== $result;
+	}
+
+	/**
+	 * Strip markup, cap stored plan fields, and redact common credential forms.
+	 */
+	private static function sanitize_text( string $value, int $max_length ): string {
+		return DurablePlanTextSanitizer::sanitize( $value, $max_length );
+	}
+}

--- a/includes/Models/DurablePlanRepository.php
+++ b/includes/Models/DurablePlanRepository.php
@@ -32,6 +32,9 @@ final class DurablePlanRepository {
 	/** @var list<string> Supported phase risk classifications. */
 	public const CLASSIFICATIONS = [ 'read', 'write', 'destructive' ];
 
+	/** Maximum database-backed phase key length. */
+	private const MAX_STEP_KEY_LENGTH = 100;
+
 	/**
 	 * Get the durable plans table name.
 	 */
@@ -57,7 +60,7 @@ final class DurablePlanRepository {
 	 * @param array<string, mixed> $definition Compact plan definition.
 	 * @return array<string, mixed>|WP_Error
 	 */
-	public static function create( int $session_id, int $user_id, array $definition ) {
+	public static function create( int $session_id, int $user_id, array $definition ): array|WP_Error {
 		return self::create_with_policy( $session_id, $user_id, $definition, true );
 	}
 
@@ -72,7 +75,7 @@ final class DurablePlanRepository {
 	 * @param array<string, mixed> $definition Compact plan definition.
 	 * @return array<string, mixed>|WP_Error
 	 */
-	public static function create_from_client( int $session_id, int $user_id, array $definition ) {
+	public static function create_from_client( int $session_id, int $user_id, array $definition ): array|WP_Error {
 		return self::create_with_policy( $session_id, $user_id, $definition, false );
 	}
 
@@ -89,7 +92,7 @@ final class DurablePlanRepository {
 	 * @param bool                 $server_reviewed Whether server-side planning reviewed phase safety.
 	 * @return array<string, mixed>|WP_Error
 	 */
-	private static function create_with_policy( int $session_id, int $user_id, array $definition, bool $server_reviewed ) {
+	private static function create_with_policy( int $session_id, int $user_id, array $definition, bool $server_reviewed ): array|WP_Error {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 
@@ -132,7 +135,8 @@ final class DurablePlanRepository {
 			return new WP_Error( 'sd_ai_agent_plan_create_failed', __( 'The durable plan could not be saved.', 'superdav-ai-agent' ), [ 'status' => 500 ] );
 		}
 
-		$plan_db_id = (int) $wpdb->insert_id;
+		$plan_db_id     = (int) $wpdb->insert_id;
+		$seen_step_keys = [];
 		foreach ( array_values( $steps ) as $position => $raw_step ) {
 			if ( ! is_array( $raw_step ) ) {
 				self::delete_by_id( $plan_db_id );
@@ -144,6 +148,12 @@ final class DurablePlanRepository {
 				self::delete_by_id( $plan_db_id );
 				return $step;
 			}
+			$step_key = (string) $step['step_key'];
+			if ( isset( $seen_step_keys[ $step_key ] ) ) {
+				self::delete_by_id( $plan_db_id );
+				return new WP_Error( 'sd_ai_agent_plan_duplicate_step_key', __( 'Each durable plan phase needs a unique key.', 'superdav-ai-agent' ), [ 'status' => 400 ] );
+			}
+			$seen_step_keys[ $step_key ] = true;
 
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Custom durable-plan table.
 			$step_inserted = $wpdb->insert(
@@ -306,6 +316,10 @@ final class DurablePlanRepository {
 	 * @return array<string, mixed>|null
 	 */
 	public static function get_step_by_job_id( string $job_id ): ?array {
+		if ( '' === $job_id ) {
+			return null;
+		}
+
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 
@@ -484,7 +498,7 @@ final class DurablePlanRepository {
 	 * @param bool                 $server_reviewed Whether server-side planning reviewed phase safety.
 	 * @return array<string, mixed>|WP_Error
 	 */
-	private static function normalize_step( array $raw, int $position, string $plan_id, bool $server_reviewed ) {
+	private static function normalize_step( array $raw, int $position, string $plan_id, bool $server_reviewed ): array|WP_Error {
 		$title       = self::sanitize_text( (string) ( $raw['title'] ?? '' ), 255 );
 		$instruction = self::sanitize_text( (string) ( $raw['instruction'] ?? '' ), 1600 );
 		if ( '' === $title || '' === $instruction ) {
@@ -494,6 +508,9 @@ final class DurablePlanRepository {
 		$step_key = sanitize_key( (string) ( $raw['key'] ?? '' ) );
 		if ( '' === $step_key ) {
 			$step_key = 'phase-' . $position;
+		}
+		if ( strlen( $step_key ) > self::MAX_STEP_KEY_LENGTH ) {
+			return new WP_Error( 'sd_ai_agent_plan_invalid_step_key', __( 'Each durable plan phase key must be 100 characters or fewer.', 'superdav-ai-agent' ), [ 'status' => 400 ] );
 		}
 
 		$classification = sanitize_key( (string) ( $raw['classification'] ?? 'read' ) );

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -1388,9 +1388,9 @@ final class SessionController {
 		}
 
 		$response = array( 'status' => $job['status'] );
-		if ( is_array( $job['durable_plan']['plan'] ?? null ) ) {
+		if ( self::can_current_user_view_durable_job( $db_row ) && is_array( $job['durable_plan']['plan'] ?? null ) ) {
 			$response['durable_plan'] = $job['durable_plan']['plan'];
-		} else {
+		} elseif ( self::can_current_user_view_durable_job( $db_row ) ) {
 			$durable_plan = DurablePlanRunner::public_plan_for_job( $job_id );
 			if ( null !== $durable_plan ) {
 				$response['durable_plan'] = $durable_plan;
@@ -1544,7 +1544,7 @@ final class SessionController {
 		}
 
 		$durable_plan = $durable_plan ?? DurablePlanRunner::public_plan_for_job( $job_id );
-		if ( null !== $durable_plan ) {
+		if ( self::can_current_user_view_durable_job( $row ) && null !== $durable_plan ) {
 			$response['durable_plan'] = $durable_plan;
 		}
 
@@ -1594,6 +1594,16 @@ final class SessionController {
 		}
 
 		return new WP_REST_Response( $response, 200 );
+	}
+
+	/**
+	 * Durable plan state is visible only to the active job's owning user.
+	 *
+	 * Shared session viewers may inspect ordinary conversation activity, but a
+	 * persisted plan can contain owner-scoped operation details and approvals.
+	 */
+	private static function can_current_user_view_durable_job( ?ActiveJobRow $row ): bool {
+		return null !== $row && (int) $row->user_id === get_current_user_id();
 	}
 
 	/**
@@ -3029,14 +3039,22 @@ final class SessionController {
 	 * @param string               $job_id Job identifier.
 	 * @param array<string, mixed> $job    Job transient data.
 	 * @param string               $action 'confirm' or 'reject'.
-	 * @return WP_REST_Response
+	 * @return WP_REST_Response|WP_Error
 	 */
-	private static function resume_job( string $job_id, array $job, string $action ): WP_REST_Response {
+	private static function resume_job( string $job_id, array $job, string $action ): WP_REST_Response|WP_Error {
 		$token                 = wp_generate_password( 40, false );
 		$params                = is_array( $job['params'] ?? null ) ? $job['params'] : array();
 		$phase                 = is_array( $params['durable_plan_phase'] ?? null ) ? $params['durable_plan_phase'] : array();
 		$is_durable_plan_phase = '' !== (string) ( $phase['plan_id'] ?? '' )
 			&& (int) ( $phase['step_id'] ?? 0 ) > 0;
+
+		if ( $is_durable_plan_phase && ! ActiveJobRepository::requeue_paused_job( $job_id ) ) {
+			return new WP_Error(
+				'sd_ai_agent_job_not_resumable',
+				__( 'This durable plan job is no longer waiting for confirmation.', 'superdav-ai-agent' ),
+				array( 'status' => 409 )
+			);
+		}
 
 		$job['status'] = 'processing';
 		$job['token']  = $token;
@@ -3044,9 +3062,11 @@ final class SessionController {
 
 		set_transient( RestController::JOB_PREFIX . $job_id, $job, RestController::JOB_TTL );
 
-		// Durable jobs return to queued so exactly one loopback worker can claim
-		// them. Other jobs retain their established processing transition.
-		ActiveJobRepository::update_status( $job_id, $is_durable_plan_phase ? 'queued' : 'processing' );
+		// Durable jobs are atomically queued above so exactly one loopback worker
+		// can claim them. Other jobs retain their established processing transition.
+		if ( ! $is_durable_plan_phase ) {
+			ActiveJobRepository::update_status( $job_id, 'processing' );
+		}
 
 		// Spawn background worker.
 		wp_remote_post(

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -20,12 +20,14 @@ use SdAiAgent\Core\ConversationSerializer;
 use SdAiAgent\Core\ConversationTrimmer;
 use SdAiAgent\Core\CostCalculator;
 use SdAiAgent\Core\Database;
+use SdAiAgent\Core\DurablePlanRunner;
 use SdAiAgent\Core\Export;
 use SdAiAgent\Core\Settings;
 use SdAiAgent\Core\ToolPermissionResolver;
 use SdAiAgent\Models\ActiveJobRepository;
 use SdAiAgent\Models\Agent;
 use SdAiAgent\Models\DTO\ActiveJobRow;
+use SdAiAgent\Models\DurablePlanRepository;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Response;
@@ -488,6 +490,11 @@ final class SessionController {
 						'type'     => 'array',
 						'default'  => array(),
 					),
+					'durable_plan'       => array(
+						'required' => false,
+						'type'     => 'boolean',
+						'default'  => false,
+					),
 				),
 			)
 		);
@@ -656,6 +663,118 @@ final class SessionController {
 				),
 			)
 		);
+
+		// Durable phased-operation plans. Lifecycle actions accept only a plan ID
+		// and explicit user action; plan creation treats browser metadata as untrusted.
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/sessions/(?P<id>\d+)/plan',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'handle_durable_plan_status' ),
+					'permission_callback' => array( $this, 'check_session_permission' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'handle_create_durable_plan' ),
+					'permission_callback' => array( $this, 'check_session_owner_permission' ),
+					'args'                => array(
+						'scope'   => array(
+							'required'          => true,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_textarea_field',
+						),
+						'summary' => array(
+							'required'          => false,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_textarea_field',
+						),
+						'steps'   => array(
+							'required' => true,
+							'type'     => 'array',
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			RestController::NAMESPACE,
+			'/sessions/(?P<id>\d+)/plan/status',
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'handle_durable_plan_status' ),
+				'permission_callback' => array( $this, 'check_session_permission' ),
+			)
+		);
+
+		foreach (
+			array(
+				'continue' => array(
+					'callback' => 'handle_continue_durable_plan',
+					'args'     => array(),
+				),
+				'approve'  => array(
+					'callback' => 'handle_approve_durable_plan',
+					'args'     => array(
+						'approval_request_id' => array(
+							'required'          => true,
+							'type'              => 'integer',
+							'sanitize_callback' => 'absint',
+						),
+					),
+				),
+				'reject'   => array(
+					'callback' => 'handle_reject_durable_plan',
+					'args'     => array(
+						'approval_request_id' => array(
+							'required'          => true,
+							'type'              => 'integer',
+							'sanitize_callback' => 'absint',
+						),
+					),
+				),
+				'retry'    => array(
+					'callback' => 'handle_retry_durable_plan',
+					'args'     => array(),
+				),
+				'cancel'   => array(
+					'callback' => 'handle_cancel_durable_plan',
+					'args'     => array(),
+				),
+				'scope'    => array(
+					'callback' => 'handle_durable_plan_scope_change',
+					'args'     => array(
+						'scope' => array(
+							'required'          => true,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_textarea_field',
+						),
+					),
+				),
+			) as $operation => $route
+		) {
+			register_rest_route(
+				RestController::NAMESPACE,
+				'/sessions/(?P<id>\d+)/plan/' . $operation,
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, $route['callback'] ),
+					'permission_callback' => array( $this, 'check_session_owner_permission' ),
+					'args'                => array_merge(
+						array(
+							'plan_id' => array(
+								'required'          => true,
+								'type'              => 'string',
+								'sanitize_callback' => 'sanitize_text_field',
+							),
+						),
+						$route['args']
+					),
+				)
+			);
+		}
 
 		// Public customer chat config for static documentation embeds.
 		register_rest_route(
@@ -1269,6 +1388,14 @@ final class SessionController {
 		}
 
 		$response = array( 'status' => $job['status'] );
+		if ( is_array( $job['durable_plan']['plan'] ?? null ) ) {
+			$response['durable_plan'] = $job['durable_plan']['plan'];
+		} else {
+			$durable_plan = DurablePlanRunner::public_plan_for_job( $job_id );
+			if ( null !== $durable_plan ) {
+				$response['durable_plan'] = $durable_plan;
+			}
+		}
 
 		// Include live tool call progress for all statuses that have it.
 		if ( ! empty( $job['tool_calls'] ) ) {
@@ -1376,31 +1503,35 @@ final class SessionController {
 	 */
 	private function job_status_from_db_row( string $job_id, ActiveJobRow $row ): WP_REST_Response {
 		$original_status = $row->status;
-		$status          = $row->status;
+		$status          = 'queued' === $row->status ? 'processing' : $row->status;
 		$response        = [
 			'status'     => $status,
 			'from_db'    => true,
 			'session_id' => $row->session_id,
 		];
+		$durable_plan    = null;
 
 		if ( in_array( $status, array( 'interrupted', 'abandoned' ), true ) ) {
-			$resume_outcome = $this->maybe_dispatch_checkpoint_resume( $job_id, $row );
-			if ( $resume_outcome['dispatched'] ) {
-				return new WP_REST_Response(
-					array(
-						'status'            => 'processing',
-						'from_db'           => true,
-						'auto_resumed'      => true,
-						'original_status'   => $status,
-						'session_id'        => $row->session_id,
-						'checkpoint_resume' => $resume_outcome['metadata'],
-					),
-					202
-				);
-			}
+			$durable_plan = DurablePlanRunner::mark_phase_interrupted_by_job( $job_id );
+			if ( null === $durable_plan ) {
+				$resume_outcome = $this->maybe_dispatch_checkpoint_resume( $job_id, $row );
+				if ( $resume_outcome['dispatched'] ) {
+					return new WP_REST_Response(
+						array(
+							'status'            => 'processing',
+							'from_db'           => true,
+							'auto_resumed'      => true,
+							'original_status'   => $status,
+							'session_id'        => $row->session_id,
+							'checkpoint_resume' => $resume_outcome['metadata'],
+						),
+						202
+					);
+				}
 
-			if ( $resume_outcome['terminal'] ) {
-				return $this->checkpoint_resume_terminal_response( $job_id, $row, $resume_outcome['metadata'] );
+				if ( $resume_outcome['terminal'] ) {
+					return $this->checkpoint_resume_terminal_response( $job_id, $row, $resume_outcome['metadata'] );
+				}
 			}
 		}
 
@@ -1410,6 +1541,11 @@ final class SessionController {
 				$row    = $refreshed_row;
 				$status = $row->status;
 			}
+		}
+
+		$durable_plan = $durable_plan ?? DurablePlanRunner::public_plan_for_job( $job_id );
+		if ( null !== $durable_plan ) {
+			$response['durable_plan'] = $durable_plan;
 		}
 
 		// Include tool-call progress when present.
@@ -2896,7 +3032,11 @@ final class SessionController {
 	 * @return WP_REST_Response
 	 */
 	private static function resume_job( string $job_id, array $job, string $action ): WP_REST_Response {
-		$token = wp_generate_password( 40, false );
+		$token                 = wp_generate_password( 40, false );
+		$params                = is_array( $job['params'] ?? null ) ? $job['params'] : array();
+		$phase                 = is_array( $params['durable_plan_phase'] ?? null ) ? $params['durable_plan_phase'] : array();
+		$is_durable_plan_phase = '' !== (string) ( $phase['plan_id'] ?? '' )
+			&& (int) ( $phase['step_id'] ?? 0 ) > 0;
 
 		$job['status'] = 'processing';
 		$job['token']  = $token;
@@ -2904,8 +3044,9 @@ final class SessionController {
 
 		set_transient( RestController::JOB_PREFIX . $job_id, $job, RestController::JOB_TTL );
 
-		// Keep DB in sync — job is back to processing after confirmation/rejection.
-		ActiveJobRepository::update_status( $job_id, 'processing' );
+		// Durable jobs return to queued so exactly one loopback worker can claim
+		// them. Other jobs retain their established processing transition.
+		ActiveJobRepository::update_status( $job_id, $is_durable_plan_phase ? 'queued' : 'processing' );
 
 		// Spawn background worker.
 		wp_remote_post(
@@ -2940,15 +3081,27 @@ final class SessionController {
 	 * Creates a job, spawns a background worker, and returns immediately.
 	 *
 	 * @param WP_REST_Request $request The request object.
-	 * @return WP_REST_Response
+	 * @return WP_REST_Response|WP_Error
 	 */
-	public function handle_run( WP_REST_Request $request ): WP_REST_Response {
+	public function handle_run( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$durable_plan_requested = true === $request->get_param( 'durable_plan' );
+		$session_id             = self::get_int_param( $request, 'session_id' );
+		if ( $durable_plan_requested ) {
+			$session = $this->database->get_session( $session_id );
+			if ( ! $session ) {
+				return new WP_Error( 'sd_ai_agent_session_not_found', __( 'A durable plan requires an existing session.', 'superdav-ai-agent' ), [ 'status' => 404 ] );
+			}
+			if ( (int) $session->user_id !== get_current_user_id() ) {
+				return new WP_Error( 'sd_ai_agent_plan_forbidden', __( 'Only the session owner can create a durable plan.', 'superdav-ai-agent' ), [ 'status' => 403 ] );
+			}
+		}
+
 		$job_id = wp_generate_uuid4();
 		$token  = wp_generate_password( 40, false );
 
 		// Upload attachments to the media library NOW (in the browser-facing
 		// request that has auth cookies) so the loopback worker doesn't need to.
-		$raw_attachments = $request->get_param( 'attachments' ) ?? array();
+		$raw_attachments = $durable_plan_requested ? array() : ( $request->get_param( 'attachments' ) ?? array() );
 		/** @var array<int, array{name: string, type: string, data_url: string, is_image: bool}> $raw_attachments_typed */
 		$raw_attachments_typed = is_array( $raw_attachments ) ? $raw_attachments : array();
 		$attachments           = RestController::upload_attachments_to_media_library( $raw_attachments_typed );
@@ -2966,13 +3119,14 @@ final class SessionController {
 				'system_instruction' => $request->get_param( 'system_instruction' ),
 				'bootstrap_prompt'   => $request->get_param( 'bootstrap_prompt' ),
 				'max_iterations'     => $request->get_param( 'max_iterations' ),
-				'session_id'         => $request->get_param( 'session_id' ),
+				'session_id'         => $session_id,
 				'provider_id'        => $request->get_param( 'provider_id' ),
 				'model_id'           => $request->get_param( 'model_id' ),
 				'page_context'       => $request->get_param( 'page_context' ),
 				'agent_id'           => $request->get_param( 'agent_id' ),
 				'attachments'        => $attachments,
 				'client_abilities'   => $request->get_param( 'client_abilities' ) ?? array(),
+				'durable_plan'       => $durable_plan_requested,
 			),
 		);
 
@@ -2980,8 +3134,13 @@ final class SessionController {
 
 		// Persist to DB so the job survives transient expiry (source of truth).
 		// @phpstan-ignore-next-line
-		$db_session_id = isset( $job['params']['session_id'] ) ? (int) $job['params']['session_id'] : 0;
-		ActiveJobRepository::create( $db_session_id, $job_id, (int) ( $job['user_id'] ?? 0 ) );
+		$db_session_id = $session_id;
+		ActiveJobRepository::create(
+			$db_session_id,
+			$job_id,
+			(int) ( $job['user_id'] ?? 0 ),
+			$durable_plan_requested ? 'queued' : 'processing'
+		);
 
 		// Spawn background worker via non-blocking loopback.
 		wp_remote_post(
@@ -3048,11 +3207,23 @@ final class SessionController {
 		$params = $job['params'];
 		/** @var array<string, mixed> $params */
 		// @phpstan-ignore-next-line
-		$session_id = ! empty( $params['session_id'] ) ? (int) $params['session_id'] : 0;
+		$session_id              = ! empty( $params['session_id'] ) ? (int) $params['session_id'] : 0;
+		$durable_plan_phase      = $params['durable_plan_phase'] ?? null;
+		$is_durable_plan_phase   = is_array( $durable_plan_phase )
+			&& '' !== (string) ( $durable_plan_phase['plan_id'] ?? '' )
+			&& (int) ( $durable_plan_phase['step_id'] ?? 0 ) > 0;
+		$is_durable_plan_request = ! $is_durable_plan_phase && ! empty( $params['durable_plan'] );
+		if ( ( $is_durable_plan_phase || $is_durable_plan_request ) && ! ActiveJobRepository::claim_queued_job( $job_id ) ) {
+			return new WP_REST_Response( array( 'ok' => false ), 200 );
+		}
 
-		// Load history from session if session_id is provided.
+		// Durable plans deliberately start every provider turn with only the compact
+		// active-phase context. They must not grow provider context by reloading the
+		// session transcript after every completed phase.
 		$history = array();
-		if ( $session_id ) {
+		if ( $is_durable_plan_phase || $is_durable_plan_request ) {
+			$history = array();
+		} elseif ( $session_id ) {
 			$session = $this->database->get_session( $session_id );
 			if ( $session ) {
 				$session_messages = json_decode( $session->messages, true ) ?: array();
@@ -3172,6 +3343,14 @@ final class SessionController {
 			// @phpstan-ignore-next-line
 			$agent_options = Agent::get_loop_options( (int) $params['agent_id'] );
 			$options       = array_merge( $options, $agent_options );
+		}
+
+		if ( $is_durable_plan_request ) {
+			// A planning request is a no-tools, one-turn proposal. Do not allow
+			// a selected agent or browser descriptor to restore normal tool access.
+			$options['durable_plan_mode'] = true;
+			$options['client_abilities']  = array();
+			$options['yolo_mode']         = false;
 		}
 
 		/*
@@ -3301,7 +3480,7 @@ final class SessionController {
 				)
 			);
 
-			if ( $session_id ) {
+			if ( $session_id && ! $is_durable_plan_phase ) {
 				$recovery_error = new WP_Error(
 					'sd_ai_agent_loop_exception',
 					ActiveJobFailureDiagnostic::message_for( (string) $diagnostic['reason'] ),
@@ -3330,9 +3509,14 @@ final class SessionController {
 			}
 
 			unset( $job['token'], $job['tool_calls'], $job['messages'] );
+			$this->finalize_durable_plan_phase( $job );
 			set_transient( RestController::JOB_PREFIX . $job_id, $job, RestController::JOB_TTL );
 
 			return new WP_REST_Response( array( 'ok' => false ), 200 );
+		}
+
+		if ( $is_durable_plan_request && is_array( $result ) ) {
+			$result = $this->attach_durable_plan_to_result( $job, $session_id, $result );
 		}
 
 		if ( is_wp_error( $result ) ) {
@@ -3359,7 +3543,7 @@ final class SessionController {
 			if ( null !== $payload_recovery ) {
 				$job['payload_recovery'] = $payload_recovery;
 			}
-			if ( $session_id ) {
+			if ( $session_id && ! $is_durable_plan_phase ) {
 				$this->persist_error_recovery_to_session(
 					$session_id,
 					$result,
@@ -3488,7 +3672,7 @@ final class SessionController {
 
 				$full_history = $result['history'] ?? array();
 				/** @var array<mixed> $full_history */
-				$appended = array_slice( $full_history, $existing_count );
+				$appended = ( $is_durable_plan_phase || $is_durable_plan_request ) ? $full_history : array_slice( $full_history, $existing_count );
 				/** @var list<array<string, mixed>> $tool_calls_result */
 				$tool_calls_result = $result['tool_calls'] ?? array();
 				$this->database->append_to_session( $session_id, array_values( $appended ), $tool_calls_result );
@@ -3577,6 +3761,8 @@ final class SessionController {
 			}
 		}
 
+		$this->finalize_durable_plan_phase( $job );
+
 		// Clear the token — no longer needed.
 		unset( $job['token'] );
 		set_transient( RestController::JOB_PREFIX . $job_id, $job, RestController::JOB_TTL );
@@ -3632,7 +3818,7 @@ final class SessionController {
 
 		$response = array(
 			'job_id' => $db_row->job_id,
-			'status' => $db_row->status,
+			'status' => 'queued' === $db_row->status ? 'processing' : $db_row->status,
 		);
 
 		$response['tool_calls'] = json_decode( $db_row->tool_calls, true ) ?: [];
@@ -3659,7 +3845,7 @@ final class SessionController {
 				return array(
 					'session_id' => $row->session_id,
 					'job_id'     => $row->job_id,
-					'status'     => $row->status,
+					'status'     => 'queued' === $row->status ? 'processing' : $row->status,
 				);
 			},
 			array_filter(
@@ -3669,6 +3855,351 @@ final class SessionController {
 		);
 
 		return new WP_REST_Response( array_values( $data ), 200 );
+	}
+
+	/**
+	 * Handle GET /sessions/{id}/plan and return only the current user's plan.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function handle_durable_plan_status( WP_REST_Request $request ) {
+		$session_id = self::get_int_param( $request, 'id' );
+		$plan       = DurablePlanRepository::get_latest_for_session( $session_id, get_current_user_id() );
+		if ( null === $plan ) {
+			return new WP_Error( 'sd_ai_agent_plan_not_found', __( 'No durable plan was found for this session.', 'superdav-ai-agent' ), [ 'status' => 404 ] );
+		}
+
+		return new WP_REST_Response( [ 'plan' => DurablePlanRepository::to_public( $plan ) ], 200 );
+	}
+
+	/**
+	 * Handle POST /sessions/{id}/plan.
+	 *
+	 * Only a session owner may create a durable plan. Shared-session viewers must
+	 * not be able to create a plan that later runs under the owner-owned session.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function handle_create_durable_plan( WP_REST_Request $request ) {
+		$session_id = self::get_int_param( $request, 'id' );
+		$session    = $this->database->get_session( $session_id );
+		$user_id    = get_current_user_id();
+		if ( ! $session ) {
+			return new WP_Error( 'sd_ai_agent_session_not_found', __( 'Session not found.', 'superdav-ai-agent' ), [ 'status' => 404 ] );
+		}
+		if ( (int) $session->user_id !== $user_id ) {
+			return new WP_Error( 'sd_ai_agent_plan_forbidden', __( 'Only the session owner can create a durable plan.', 'superdav-ai-agent' ), [ 'status' => 403 ] );
+		}
+
+		$plan = DurablePlanRunner::create_from_client(
+			$session_id,
+			$user_id,
+			[
+				'scope'   => (string) $request->get_param( 'scope' ),
+				'summary' => (string) $request->get_param( 'summary' ),
+				'steps'   => $request->get_param( 'steps' ),
+			]
+		);
+		if ( is_wp_error( $plan ) ) {
+			return $plan;
+		}
+
+		return new WP_REST_Response( [ 'plan' => DurablePlanRepository::to_public( $plan ) ], 201 );
+	}
+
+	/**
+	 * Handle POST /sessions/{id}/plan/continue.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function handle_continue_durable_plan( WP_REST_Request $request ) {
+		$plan_id = self::get_string_param( $request, 'plan_id' );
+		$valid   = $this->validate_durable_plan_request( $plan_id, self::get_int_param( $request, 'id' ) );
+		if ( is_wp_error( $valid ) ) {
+			return $valid;
+		}
+
+		$outcome = DurablePlanRunner::prepare_next( $plan_id, get_current_user_id() );
+		return $this->respond_to_durable_plan_outcome( $outcome );
+	}
+
+	/**
+	 * Handle POST /sessions/{id}/plan/approve.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function handle_approve_durable_plan( WP_REST_Request $request ) {
+		$plan_id = self::get_string_param( $request, 'plan_id' );
+		$valid   = $this->validate_durable_plan_request( $plan_id, self::get_int_param( $request, 'id' ) );
+		if ( is_wp_error( $valid ) ) {
+			return $valid;
+		}
+
+		$outcome = DurablePlanRunner::approve( $plan_id, self::get_int_param( $request, 'approval_request_id' ), get_current_user_id() );
+		return $this->respond_to_durable_plan_outcome( $outcome );
+	}
+
+	/**
+	 * Handle POST /sessions/{id}/plan/reject.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function handle_reject_durable_plan( WP_REST_Request $request ) {
+		$plan_id = self::get_string_param( $request, 'plan_id' );
+		$valid   = $this->validate_durable_plan_request( $plan_id, self::get_int_param( $request, 'id' ) );
+		if ( is_wp_error( $valid ) ) {
+			return $valid;
+		}
+
+		$outcome = DurablePlanRunner::reject( $plan_id, self::get_int_param( $request, 'approval_request_id' ), get_current_user_id() );
+		return $this->respond_to_durable_plan_outcome( $outcome );
+	}
+
+	/**
+	 * Handle POST /sessions/{id}/plan/retry.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function handle_retry_durable_plan( WP_REST_Request $request ) {
+		$plan_id = self::get_string_param( $request, 'plan_id' );
+		$valid   = $this->validate_durable_plan_request( $plan_id, self::get_int_param( $request, 'id' ) );
+		if ( is_wp_error( $valid ) ) {
+			return $valid;
+		}
+
+		$outcome = DurablePlanRunner::retry( $plan_id, get_current_user_id() );
+		return $this->respond_to_durable_plan_outcome( $outcome );
+	}
+
+	/**
+	 * Handle POST /sessions/{id}/plan/cancel.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function handle_cancel_durable_plan( WP_REST_Request $request ) {
+		$plan_id = self::get_string_param( $request, 'plan_id' );
+		$valid   = $this->validate_durable_plan_request( $plan_id, self::get_int_param( $request, 'id' ) );
+		if ( is_wp_error( $valid ) ) {
+			return $valid;
+		}
+
+		$outcome = DurablePlanRunner::cancel( $plan_id, get_current_user_id() );
+		return $this->respond_to_durable_plan_outcome( $outcome );
+	}
+
+	/**
+	 * Handle POST /sessions/{id}/plan/scope.
+	 *
+	 * A browser can request a scope change but cannot apply it. The persisted
+	 * approval record binds the change to this exact plan and owner.
+	 *
+	 * @param WP_REST_Request $request REST request.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function handle_durable_plan_scope_change( WP_REST_Request $request ) {
+		$plan_id = self::get_string_param( $request, 'plan_id' );
+		$valid   = $this->validate_durable_plan_request( $plan_id, self::get_int_param( $request, 'id' ) );
+		if ( is_wp_error( $valid ) ) {
+			return $valid;
+		}
+
+		$outcome = DurablePlanRunner::request_scope_change( $plan_id, get_current_user_id(), self::get_string_param( $request, 'scope' ) );
+		return $this->respond_to_durable_plan_outcome( $outcome );
+	}
+
+	/**
+	 * Check both user ownership and route-session ownership against durable state.
+	 *
+	 * @return array<string, mixed>|WP_Error
+	 */
+	private function validate_durable_plan_request( string $plan_id, int $session_id ) {
+		$plan = DurablePlanRepository::get_by_plan_id( $plan_id );
+		if ( null === $plan ) {
+			return new WP_Error( 'sd_ai_agent_plan_not_found', __( 'Durable plan not found.', 'superdav-ai-agent' ), [ 'status' => 404 ] );
+		}
+		if ( (int) $plan['session_id'] !== $session_id || (int) $plan['user_id'] !== get_current_user_id() ) {
+			return new WP_Error( 'sd_ai_agent_plan_forbidden', __( 'You are not authorized to change this durable plan.', 'superdav-ai-agent' ), [ 'status' => 403 ] );
+		}
+
+		return $plan;
+	}
+
+	/**
+	 * Persist a planning-only model result using the fail-closed client policy.
+	 *
+	 * The model response is intentionally treated like untrusted browser metadata:
+	 * classifications remain descriptive, every phase requires approval, and no
+	 * phase can automatically resume after an interruption.
+	 *
+	 * @param array<string, mixed> $job    Background job state.
+	 * @param int                  $session_id Session that owns the request.
+	 * @param array<string, mixed> $result Agent-loop result.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	private function attach_durable_plan_to_result( array &$job, int $session_id, array $result ) {
+		$definition = $result['durable_plan_definition'] ?? null;
+		$user_id    = (int) ( $job['user_id'] ?? 0 );
+		$session    = $this->database->get_session( $session_id );
+		if ( ! is_array( $definition ) || $session_id <= 0 || $user_id <= 0 || ! $session || (int) $session->user_id !== $user_id || get_current_user_id() !== $user_id ) {
+			return new WP_Error( 'sd_ai_agent_plan_forbidden', __( 'The durable plan could not be saved for this session.', 'superdav-ai-agent' ) );
+		}
+
+		$plan = DurablePlanRunner::create_from_client( $session_id, $user_id, $definition );
+		if ( is_wp_error( $plan ) ) {
+			return $plan;
+		}
+
+		unset( $result['durable_plan_definition'] );
+		$public_plan         = DurablePlanRepository::to_public( $plan );
+		$job['durable_plan'] = array(
+			'plan_id' => (string) $public_plan['plan_id'],
+			'plan'    => $public_plan,
+		);
+
+		return $result;
+	}
+
+	/**
+	 * Queue a bounded provider turn only when the runner has claimed a phase.
+	 *
+	 * @param array<string, mixed>|WP_Error $outcome Runner result.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	private function respond_to_durable_plan_outcome( array|WP_Error $outcome ) {
+		if ( is_wp_error( $outcome ) ) {
+			return $outcome;
+		}
+		if ( 'ready' !== ( $outcome['status'] ?? '' ) ) {
+			return new WP_REST_Response( $outcome, 200 );
+		}
+
+		$plan    = is_array( $outcome['plan'] ?? null ) ? $outcome['plan'] : [];
+		$step    = is_array( $outcome['step'] ?? null ) ? $outcome['step'] : [];
+		$context = (string) ( $outcome['provider_context'] ?? '' );
+		$queued  = $this->enqueue_durable_plan_phase( $plan, $step, $context );
+		if ( is_wp_error( $queued ) ) {
+			return $queued;
+		}
+
+		return new WP_REST_Response( $queued, 202 );
+	}
+
+	/**
+	 * Create a plan-phase job without loading the full session transcript.
+	 *
+	 * @param array<string, mixed> $plan             Browser-safe plan payload.
+	 * @param array<string, mixed> $step             Internal claimed phase record.
+	 * @param string               $provider_context Bounded active-phase context.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	private function enqueue_durable_plan_phase( array $plan, array $step, string $provider_context ) {
+		$plan_id    = (string) ( $plan['plan_id'] ?? '' );
+		$session_id = (int) ( $plan['session_id'] ?? 0 );
+		$step_id    = (int) ( $step['id'] ?? 0 );
+		$session    = $this->database->get_session( $session_id );
+		if ( '' === $plan_id || $step_id <= 0 || '' === $provider_context || ! $session ) {
+			return new WP_Error( 'sd_ai_agent_plan_enqueue_invalid', __( 'The durable plan phase could not be prepared for execution.', 'superdav-ai-agent' ), [ 'status' => 500 ] );
+		}
+
+		$job_id = wp_generate_uuid4();
+		$token  = wp_generate_password( 40, false );
+		$job    = array(
+			'status'       => 'processing',
+			'token'        => $token,
+			'user_id'      => get_current_user_id(),
+			'tool_calls'   => array(),
+			'messages'     => array(),
+			'durable_plan' => array(
+				'plan_id' => $plan_id,
+				'step_id' => $step_id,
+				'plan'    => $plan,
+			),
+			'params'       => array(
+				'message'            => $provider_context,
+				'history'            => array(),
+				'abilities'          => array(),
+				'system_instruction' => '',
+				'bootstrap_prompt'   => '',
+				'max_iterations'     => null,
+				'session_id'         => $session_id,
+				'provider_id'        => (string) $session->provider_id,
+				'model_id'           => (string) $session->model_id,
+				'page_context'       => array(),
+				'agent_id'           => 0,
+				'attachments'        => array(),
+				'client_abilities'   => array(),
+				'durable_plan_phase' => array(
+					'plan_id' => $plan_id,
+					'step_id' => $step_id,
+				),
+			),
+		);
+
+		set_transient( RestController::JOB_PREFIX . $job_id, $job, RestController::JOB_TTL );
+		if ( false === ActiveJobRepository::create( $session_id, $job_id, get_current_user_id(), 'queued' ) || ! DurablePlanRunner::assign_job( $plan_id, $step_id, $job_id ) ) {
+			delete_transient( RestController::JOB_PREFIX . $job_id );
+			ActiveJobRepository::delete( $job_id );
+			DurablePlanRunner::fail_phase( $plan_id, $step_id, __( 'The phase job could not be queued.', 'superdav-ai-agent' ) );
+			return new WP_Error( 'sd_ai_agent_plan_enqueue_failed', __( 'The durable plan phase could not be queued.', 'superdav-ai-agent' ), [ 'status' => 500 ] );
+		}
+
+		wp_remote_post(
+			rest_url( RestController::NAMESPACE . '/process' ),
+			array(
+				'timeout'  => 0.01,
+				'blocking' => false,
+				'body'     => (string) wp_json_encode(
+					array(
+						'job_id' => $job_id,
+						'token'  => $token,
+					)
+				),
+				'headers'  => array( 'Content-Type' => 'application/json' ),
+			)
+		);
+
+		return array(
+			'status' => 'processing',
+			'job_id' => $job_id,
+			'plan'   => DurablePlanRunner::public_plan( $plan_id ),
+		);
+	}
+
+	/**
+	 * Persist terminal plan-phase state without copying raw history or tool data.
+	 *
+	 * @param array<string, mixed> $job Background job state.
+	 */
+	private function finalize_durable_plan_phase( array &$job ): void {
+		$params  = is_array( $job['params'] ?? null ) ? $job['params'] : array();
+		$phase   = is_array( $params['durable_plan_phase'] ?? null ) ? $params['durable_plan_phase'] : array();
+		$plan_id = (string) ( $phase['plan_id'] ?? '' );
+		$step_id = (int) ( $phase['step_id'] ?? 0 );
+		if ( '' === $plan_id || $step_id <= 0 ) {
+			return;
+		}
+
+		$plan = null;
+		if ( 'complete' === ( $job['status'] ?? '' ) && is_array( $job['result'] ?? null ) ) {
+			$plan = DurablePlanRunner::complete_phase( $plan_id, $step_id, $job['result'] );
+		} elseif ( 'error' === ( $job['status'] ?? '' ) ) {
+			$plan = DurablePlanRunner::fail_phase( $plan_id, $step_id, (string) ( $job['error'] ?? __( 'The plan phase failed.', 'superdav-ai-agent' ) ) );
+		}
+
+		if ( null !== $plan ) {
+			$job['durable_plan'] = array(
+				'plan_id' => $plan_id,
+				'step_id' => $step_id,
+				'plan'    => $plan,
+			);
+		}
 	}
 
 	/**
@@ -3690,6 +4221,14 @@ final class SessionController {
 		$job = get_transient( RestController::JOB_PREFIX . $row->job_id );
 		if ( is_array( $job ) ) {
 			return false;
+		}
+
+		// Durable phases retain their actionable state in the plan tables, so the
+		// expired active-job row can be removed after that state is updated. Normal
+		// jobs retain the existing prompt-free diagnostic for recovery guidance.
+		if ( null !== DurablePlanRunner::mark_phase_interrupted_by_job( $row->job_id ) ) {
+			ActiveJobRepository::delete( $row->job_id );
+			return true;
 		}
 
 		ActiveJobRepository::record_failure(

--- a/src/components/action-card.js
+++ b/src/components/action-card.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useEffect, useRef } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 import RecoverableJobActionCard from './recoverable-job-action-card';
 
@@ -97,6 +97,83 @@ function getFailureNextStep( nextAction ) {
 				'superdav-ai-agent'
 			);
 	}
+}
+
+/**
+ * Return the active or next unfinished phase for a durable plan.
+ *
+ * @param {Object} plan Browser-safe durable plan payload.
+ * @return {Object|null} Current plan phase.
+ */
+function getCurrentPlanStep( plan ) {
+	const steps = Array.isArray( plan?.steps ) ? plan.steps : [];
+	const current = steps.find(
+		( step ) => Number( step.position ) === Number( plan.current_step )
+	);
+	if (
+		current &&
+		! [ 'completed', 'cancelled' ].includes( current.status )
+	) {
+		return current;
+	}
+
+	return (
+		steps.find(
+			( step ) => ! [ 'completed', 'cancelled' ].includes( step.status )
+		) || null
+	);
+}
+
+/**
+ * Build the user-facing controls for a durable plan lifecycle state.
+ *
+ * @param {Object}  root0                 State flags.
+ * @param {boolean} root0.isScopeApproval Whether a scope change is pending.
+ * @param {boolean} root0.isApproval      Whether any plan approval is pending.
+ * @param {boolean} root0.isRetry         Whether an explicit retry is needed.
+ * @param {boolean} root0.isRunning       Whether a phase is executing.
+ * @return {{heading: string, confirmLabel: string, cancelLabel: string}} Labels.
+ */
+function getDurablePlanLabels( {
+	isScopeApproval,
+	isApproval,
+	isRetry,
+	isRunning,
+} ) {
+	if ( isScopeApproval ) {
+		return {
+			heading: __( 'Approve plan scope change', 'superdav-ai-agent' ),
+			confirmLabel: __( 'Approve scope change', 'superdav-ai-agent' ),
+			cancelLabel: __( 'Keep current scope', 'superdav-ai-agent' ),
+		};
+	}
+	if ( isApproval ) {
+		return {
+			heading: __( 'Approve plan phase', 'superdav-ai-agent' ),
+			confirmLabel: __( 'Approve phase', 'superdav-ai-agent' ),
+			cancelLabel: __( 'Decline plan', 'superdav-ai-agent' ),
+		};
+	}
+	if ( isRetry ) {
+		return {
+			heading: __( 'Plan phase needs review', 'superdav-ai-agent' ),
+			confirmLabel: __( 'Retry phase', 'superdav-ai-agent' ),
+			cancelLabel: __( 'Cancel plan', 'superdav-ai-agent' ),
+		};
+	}
+	if ( isRunning ) {
+		return {
+			heading: __( 'Plan phase in progress', 'superdav-ai-agent' ),
+			confirmLabel: '',
+			cancelLabel: __( 'Cancel plan', 'superdav-ai-agent' ),
+		};
+	}
+
+	return {
+		heading: __( 'Site operation plan', 'superdav-ai-agent' ),
+		confirmLabel: __( 'Start next phase', 'superdav-ai-agent' ),
+		cancelLabel: __( 'Cancel plan', 'superdav-ai-agent' ),
+	};
 }
 
 /**
@@ -274,6 +351,167 @@ export default function ActionCard( { card, onConfirm, onCancel } ) {
 				onConfirm={ onConfirm }
 				onCancel={ onCancel }
 			/>
+		);
+	}
+
+	if ( card?.type === 'durable_plan' && card.plan ) {
+		const plan = card.plan;
+		const currentStep = getCurrentPlanStep( plan );
+		const isScopeApproval =
+			plan.status === 'awaiting_approval' &&
+			Boolean( plan.pending_scope );
+		const isApproval = plan.status === 'awaiting_approval';
+		const isRetry = [ 'failed', 'blocked' ].includes( plan.status );
+		const isRunning = plan.status === 'running';
+		const canContinue = plan.status === 'pending';
+		const hasAction = isApproval || isRetry || canContinue;
+		const { heading, confirmLabel, cancelLabel } = getDurablePlanLabels( {
+			isScopeApproval,
+			isApproval,
+			isRetry,
+			isRunning,
+		} );
+
+		return (
+			<div
+				className="sdaa-action-card sd-ai-agent-durable-plan-card"
+				role="region"
+				aria-label={ __(
+					'Durable site operation plan',
+					'superdav-ai-agent'
+				) }
+			>
+				<div className="sdaa-action-card-header">
+					<span className="sdaa-action-card-icon" aria-hidden="true">
+						&#9776;
+					</span>
+					<span className="sdaa-action-card-heading">
+						{ heading }
+					</span>
+				</div>
+				<div className="sdaa-action-card-body">
+					{ plan.summary && (
+						<p className="sd-ai-agent-durable-plan-summary">
+							{ plan.summary }
+						</p>
+					) }
+					<p className="sd-ai-agent-durable-plan-scope">
+						<strong>
+							{ __( 'Approved scope:', 'superdav-ai-agent' ) }
+						</strong>{ ' ' }
+						{ plan.scope }
+					</p>
+					{ isScopeApproval && (
+						<p className="sd-ai-agent-durable-plan-scope-change">
+							<strong>
+								{ __(
+									'Requested scope:',
+									'superdav-ai-agent'
+								) }
+							</strong>{ ' ' }
+							{ plan.pending_scope }
+						</p>
+					) }
+					{ currentStep && (
+						<details
+							className="sd-ai-agent-durable-plan-phase"
+							open={ isApproval || isRetry }
+						>
+							<summary>
+								{ sprintf(
+									/* translators: 1: phase number, 2: phase title, 3: phase status. */
+									__(
+										'Phase %1$d: %2$s (%3$s)',
+										'superdav-ai-agent'
+									),
+									Number( currentStep.position ),
+									currentStep.title,
+									currentStep.status
+								) }
+							</summary>
+							{ currentStep.instruction && (
+								<p>{ currentStep.instruction }</p>
+							) }
+							{ currentStep.preconditions && (
+								<p>
+									<strong>
+										{ __(
+											'Preconditions:',
+											'superdav-ai-agent'
+										) }
+									</strong>{ ' ' }
+									{ currentStep.preconditions }
+								</p>
+							) }
+							{ currentStep.expected_evidence && (
+								<p>
+									<strong>
+										{ __(
+											'Expected evidence:',
+											'superdav-ai-agent'
+										) }
+									</strong>{ ' ' }
+									{ currentStep.expected_evidence }
+								</p>
+							) }
+							{ currentStep.rollback_guidance && (
+								<p>
+									<strong>
+										{ __(
+											'Rollback:',
+											'superdav-ai-agent'
+										) }
+									</strong>{ ' ' }
+									{ currentStep.rollback_guidance }
+								</p>
+							) }
+							{ currentStep.failure_message && (
+								<p className="sd-ai-agent-durable-plan-failure">
+									{ currentStep.failure_message }
+								</p>
+							) }
+						</details>
+					) }
+					<ol className="sd-ai-agent-durable-plan-steps">
+						{ ( plan.steps || [] ).map( ( step ) => (
+							<li key={ step.key || step.position }>
+								<span className="sd-ai-agent-durable-plan-step-details">
+									<span>{ step.title }</span>
+									{ step.evidence?.summary && (
+										<span className="sd-ai-agent-durable-plan-evidence">
+											{ step.evidence.summary }
+										</span>
+									) }
+								</span>
+								<small>{ step.status }</small>
+							</li>
+						) ) }
+					</ol>
+				</div>
+				{ ( hasAction || ! isRunning ) && (
+					<div className="sdaa-action-card-footer">
+						{ ! isRunning && (
+							<button
+								type="button"
+								className="button sdaa-action-card-btn-cancel"
+								onClick={ onCancel }
+							>
+								{ cancelLabel }
+							</button>
+						) }
+						{ hasAction && (
+							<button
+								type="button"
+								ref={ confirmRef }
+								className="button button-primary sdaa-action-card-btn-confirm"
+								onClick={ onConfirm }
+							>
+								{ confirmLabel }
+							</button>
+						) }
+					</div>
+				) }
+			</div>
 		);
 	}
 

--- a/src/components/action-card.js
+++ b/src/components/action-card.js
@@ -488,17 +488,15 @@ export default function ActionCard( { card, onConfirm, onCancel } ) {
 						) ) }
 					</ol>
 				</div>
-				{ ( hasAction || ! isRunning ) && (
+				{ ( hasAction || isRunning ) && (
 					<div className="sdaa-action-card-footer">
-						{ ! isRunning && (
-							<button
-								type="button"
-								className="button sdaa-action-card-btn-cancel"
-								onClick={ onCancel }
-							>
-								{ cancelLabel }
-							</button>
-						) }
+						<button
+							type="button"
+							className="button sdaa-action-card-btn-cancel"
+							onClick={ onCancel }
+						>
+							{ cancelLabel }
+						</button>
 						{ hasAction && (
 							<button
 								type="button"

--- a/src/components/chat-redesign/InputArea.js
+++ b/src/components/chat-redesign/InputArea.js
@@ -190,6 +190,26 @@ export default function InputArea( { isSimpleMode = false } = {} ) {
 			return;
 		}
 
+		// /plan <site operation>
+		if (
+			! isSimpleMode &&
+			( trimmed === '/plan' || trimmed.startsWith( '/plan ' ) )
+		) {
+			const request = trimmed.slice( 5 ).trim();
+			if ( ! request ) {
+				setText( '/plan ' );
+				return;
+			}
+			sendMessage( request, [], { durablePlan: true } );
+			setText( '' );
+			setAttachments( [] );
+			setTimeout(
+				() => taRef.current?.focus( { preventScroll: true } ),
+				0
+			);
+			return;
+		}
+
 		sendMessage( trimmed, attachments );
 		setText( '' );
 		setAttachments( [] );
@@ -238,6 +258,13 @@ export default function InputArea( { isSimpleMode = false } = {} ) {
 					return;
 				case 'report-issue':
 					setText( '/report-issue ' );
+					setTimeout(
+						() => taRef.current?.focus( { preventScroll: true } ),
+						0
+					);
+					return;
+				case 'plan':
+					setText( '/plan ' );
 					setTimeout(
 						() => taRef.current?.focus( { preventScroll: true } ),
 						0

--- a/src/components/chat-redesign/__tests__/ActionCard.test.js
+++ b/src/components/chat-redesign/__tests__/ActionCard.test.js
@@ -4,6 +4,7 @@
 
 import { createElement } from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react';
 
@@ -18,6 +19,14 @@ jest.mock( '@wordpress/data', () => ( {
 
 jest.mock( '@wordpress/i18n', () => ( {
 	__: ( string ) => string,
+	sprintf: ( string, ...values ) =>
+		values.reduce(
+			( text, value, index ) =>
+				text
+					.replace( `%${ index + 1 }$d`, value )
+					.replace( `%${ index + 1 }$s`, value ),
+			string
+		),
 } ) );
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
@@ -39,16 +48,14 @@ jest.mock( '../InputArea', () => () => null );
 /**
  * Build the store selector map required by ChatRedesign.
  *
+ * @param {Object} pendingActionCard Pending action-card state.
  * @return {Object} Selector map.
  */
-function buildSelectors() {
+function buildSelectors( pendingActionCard ) {
 	return {
-		getCurrentSessionId: () => null,
+		getCurrentSessionId: () => pendingActionCard?.sessionId || null,
 		getPendingConfirmation: () => null,
-		getPendingActionCard: () => ( {
-			type: 'retry_client_tools',
-			toolNames: [ 'sd-ai-agent-js/validate-theme-completion' ],
-		} ),
+		getPendingActionCard: () => pendingActionCard,
 		isYoloMode: () => false,
 		isSending: () => false,
 	};
@@ -58,16 +65,28 @@ describe( 'ChatRedesign retry action card', () => {
 	let container;
 	let root;
 	let retryClientToolSubmission;
+	let pendingActionCard;
 
 	beforeEach( () => {
 		retryClientToolSubmission = jest.fn();
+		apiFetch.mockReset();
+		apiFetch.mockResolvedValue( {} );
+		pendingActionCard = {
+			type: 'retry_client_tools',
+			toolNames: [ 'sd-ai-agent-js/validate-theme-completion' ],
+		};
 		useSelect.mockImplementation( ( select ) =>
-			select( () => buildSelectors() )
+			select( () => buildSelectors( pendingActionCard ) )
 		);
 		useDispatch.mockReturnValue( {
 			confirmToolCall: jest.fn(),
 			rejectToolCall: jest.fn(),
 			retryClientToolSubmission,
+			appendMessage: jest.fn(),
+			setCurrentJobId: jest.fn(),
+			setSending: jest.fn(),
+			setSessionJob: jest.fn(),
+			pollJob: jest.fn(),
 			setPendingActionCard: jest.fn(),
 		} );
 	} );
@@ -108,5 +127,63 @@ describe( 'ChatRedesign retry action card', () => {
 		} );
 
 		expect( retryClientToolSubmission ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'shows completed evidence and posts the explicit phase approval', async () => {
+		pendingActionCard = {
+			type: 'durable_plan',
+			sessionId: 42,
+			plan: {
+				plan_id: '00000000-0000-0000-0000-000000000042',
+				status: 'awaiting_approval',
+				current_step: 2,
+				approval_request_id: 12,
+				scope: 'Update the site navigation.',
+				steps: [
+					{
+						key: 'inspect',
+						position: 1,
+						title: 'Inspect navigation',
+						status: 'completed',
+						evidence: { summary: 'Inventory captured.' },
+					},
+					{
+						key: 'configure',
+						position: 2,
+						title: 'Configure navigation',
+						instruction: 'Apply the reviewed changes.',
+						status: 'awaiting_approval',
+					},
+				],
+			},
+		};
+		apiFetch.mockResolvedValue( { plan: pendingActionCard.plan } );
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		root = createRoot( container );
+
+		await act( async () => {
+			root.render( createElement( ChatRedesign, { uiMode: 'admin' } ) );
+		} );
+
+		expect( container.textContent ).toContain( 'Inventory captured.' );
+		expect( container.textContent ).toContain( 'Approve phase' );
+
+		await act( async () => {
+			container
+				.querySelector( '.sdaa-action-card-btn-confirm' )
+				.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+			await Promise.resolve();
+			await Promise.resolve();
+		} );
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/sd-ai-agent/v1/sessions/42/plan/approve',
+			method: 'POST',
+			data: {
+				plan_id: '00000000-0000-0000-0000-000000000042',
+				approval_request_id: 12,
+			},
+		} );
 	} );
 } );

--- a/src/components/chat-redesign/__tests__/ActionCard.test.js
+++ b/src/components/chat-redesign/__tests__/ActionCard.test.js
@@ -66,6 +66,7 @@ describe( 'ChatRedesign retry action card', () => {
 	let root;
 	let retryClientToolSubmission;
 	let pendingActionCard;
+	let dispatch;
 
 	beforeEach( () => {
 		retryClientToolSubmission = jest.fn();
@@ -78,7 +79,7 @@ describe( 'ChatRedesign retry action card', () => {
 		useSelect.mockImplementation( ( select ) =>
 			select( () => buildSelectors( pendingActionCard ) )
 		);
-		useDispatch.mockReturnValue( {
+		dispatch = {
 			confirmToolCall: jest.fn(),
 			rejectToolCall: jest.fn(),
 			retryClientToolSubmission,
@@ -88,7 +89,8 @@ describe( 'ChatRedesign retry action card', () => {
 			setSessionJob: jest.fn(),
 			pollJob: jest.fn(),
 			setPendingActionCard: jest.fn(),
-		} );
+		};
+		useDispatch.mockReturnValue( dispatch );
 	} );
 
 	afterEach( async () => {
@@ -185,5 +187,108 @@ describe( 'ChatRedesign retry action card', () => {
 				approval_request_id: 12,
 			},
 		} );
+	} );
+
+	test( 'keeps Cancel plan available while a durable phase is running', async () => {
+		pendingActionCard = {
+			type: 'durable_plan',
+			sessionId: 42,
+			plan: {
+				plan_id: '00000000-0000-0000-0000-000000000042',
+				status: 'running',
+				current_step: 1,
+				scope: 'Update the site navigation.',
+				steps: [
+					{
+						key: 'inspect',
+						position: 1,
+						title: 'Inspect navigation',
+						status: 'running',
+					},
+				],
+			},
+		};
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		root = createRoot( container );
+
+		await act( async () => {
+			root.render( createElement( ChatRedesign, { uiMode: 'admin' } ) );
+		} );
+
+		const cancelButton = container.querySelector(
+			'.sdaa-action-card-btn-cancel'
+		);
+		expect( cancelButton ).not.toBeNull();
+		expect( cancelButton.textContent ).toBe( 'Cancel plan' );
+
+		await act( async () => {
+			cancelButton.dispatchEvent(
+				new MouseEvent( 'click', { bubbles: true } )
+			);
+			await Promise.resolve();
+			await Promise.resolve();
+		} );
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/sd-ai-agent/v1/sessions/42/plan/cancel',
+			method: 'POST',
+			data: {
+				plan_id: '00000000-0000-0000-0000-000000000042',
+			},
+		} );
+	} );
+
+	test( 'reports stale approval cards instead of silently ignoring them', async () => {
+		pendingActionCard = {
+			type: 'durable_plan',
+			sessionId: 42,
+			plan: {
+				plan_id: '00000000-0000-0000-0000-000000000042',
+				status: 'awaiting_approval',
+				current_step: 1,
+				scope: 'Update the site navigation.',
+				steps: [
+					{
+						key: 'configure',
+						position: 1,
+						title: 'Configure navigation',
+						status: 'awaiting_approval',
+					},
+				],
+			},
+		};
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		root = createRoot( container );
+
+		await act( async () => {
+			root.render( createElement( ChatRedesign, { uiMode: 'admin' } ) );
+		} );
+
+		await act( async () => {
+			container
+				.querySelector( '.sdaa-action-card-btn-confirm' )
+				.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+			await Promise.resolve();
+		} );
+
+		expect( apiFetch ).not.toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: '/sd-ai-agent/v1/sessions/42/plan/approve',
+			} )
+		);
+		expect( dispatch.appendMessage ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				role: 'system',
+				parts: [
+					expect.objectContaining( {
+						text: expect.stringContaining(
+							'The plan approval is no longer available.'
+						),
+					} ),
+				],
+			} )
+		);
 	} );
 } );

--- a/src/components/chat-redesign/index.js
+++ b/src/components/chat-redesign/index.js
@@ -77,12 +77,13 @@ export default function ChatRedesign( { uiMode = getChatUiMode() } = {} ) {
 		[]
 	);
 
+	const durablePlanDispatchers = useDispatch( STORE_NAME );
 	const {
 		confirmToolCall,
 		rejectToolCall,
 		retryClientToolSubmission,
 		setPendingActionCard,
-	} = useDispatch( STORE_NAME );
+	} = durablePlanDispatchers;
 
 	// Auto-confirm pending tool calls when YOLO is on.
 	useEffect( () => {
@@ -132,6 +133,116 @@ export default function ChatRedesign( { uiMode = getChatUiMode() } = {} ) {
 			refreshChangesCount();
 		}
 	}, [ sending, currentSessionId, refreshChangesCount ] );
+
+	useEffect( () => {
+		let active = true;
+		if (
+			! currentSessionId ||
+			isSimpleMode ||
+			( pendingActionCard &&
+				pendingActionCard.type !== 'durable_plan' ) ||
+			( pendingActionCard?.type === 'durable_plan' &&
+				pendingActionCard.sessionId === currentSessionId )
+		) {
+			return () => {
+				active = false;
+			};
+		}
+
+		if ( pendingActionCard?.type === 'durable_plan' ) {
+			setPendingActionCard( null );
+		}
+
+		import(
+			/* webpackChunkName: "durable-plan-actions" */
+			'../../store/slices/durable-plan-actions'
+		)
+			.then( ( { loadDurablePlan } ) =>
+				loadDurablePlan( currentSessionId )
+			)
+			.then( ( plan ) => {
+				if (
+					! active ||
+					! plan ||
+					[ 'completed', 'cancelled' ].includes( plan.status )
+				) {
+					return;
+				}
+				setPendingActionCard( {
+					type: 'durable_plan',
+					sessionId: currentSessionId,
+					plan,
+				} );
+			} )
+			.catch( () => undefined );
+
+		return () => {
+			active = false;
+		};
+	}, [
+		currentSessionId,
+		isSimpleMode,
+		pendingActionCard,
+		setPendingActionCard,
+	] );
+
+	const runDurablePlanAction = useCallback(
+		( actionName ) => {
+			import(
+				/* webpackChunkName: "durable-plan-actions" */
+				'../../store/slices/durable-plan-actions'
+			)
+				.then( ( { runDurablePlanAction: runAction } ) =>
+					runAction( actionName, {
+						dispatch: durablePlanDispatchers,
+						card: pendingActionCard,
+					} )
+				)
+				.catch( ( error ) => {
+					durablePlanDispatchers.appendMessage( {
+						role: 'system',
+						parts: [
+							{
+								text: `${ __(
+									'Error:',
+									'superdav-ai-agent'
+								) } ${
+									error instanceof Error
+										? error.message
+										: __(
+												'Unable to load the durable plan action.',
+												'superdav-ai-agent'
+										  )
+								}`,
+							},
+						],
+					} );
+					durablePlanDispatchers.setSending( false );
+				} );
+		},
+		[ durablePlanDispatchers, pendingActionCard ]
+	);
+
+	const handleDurablePlanConfirm = useCallback( () => {
+		const status = pendingActionCard?.plan?.status;
+		if ( status === 'awaiting_approval' ) {
+			runDurablePlanAction( 'approve' );
+			return;
+		}
+		if ( [ 'failed', 'blocked' ].includes( status ) ) {
+			runDurablePlanAction( 'retry' );
+			return;
+		}
+		runDurablePlanAction( 'continue' );
+	}, [ pendingActionCard, runDurablePlanAction ] );
+
+	const handleDurablePlanCancel = useCallback( () => {
+		if ( pendingActionCard?.plan?.status === 'awaiting_approval' ) {
+			runDurablePlanAction( 'reject' );
+			return;
+		}
+		runDurablePlanAction( 'cancel' );
+	}, [ pendingActionCard, runDurablePlanAction ] );
 
 	return (
 		<div
@@ -200,6 +311,23 @@ export default function ChatRedesign( { uiMode = getChatUiMode() } = {} ) {
 									onCancel={ () =>
 										setPendingActionCard( null )
 									}
+								/>
+							</ErrorBoundary>
+						) }
+
+					{ pendingActionCard?.type === 'durable_plan' &&
+						pendingActionCard.sessionId === currentSessionId &&
+						! isSimpleMode && (
+							<ErrorBoundary
+								label={ __(
+									'Durable site operation plan',
+									'superdav-ai-agent'
+								) }
+							>
+								<ActionCard
+									card={ pendingActionCard }
+									onConfirm={ handleDurablePlanConfirm }
+									onCancel={ handleDurablePlanCancel }
 								/>
 							</ErrorBoundary>
 						) }

--- a/src/components/shared.css
+++ b/src/components/shared.css
@@ -351,6 +351,83 @@
 	min-width: 80px;
 }
 
+.sd-ai-agent-durable-plan-card {
+	border-left-color: #2271b1;
+	max-width: 620px;
+}
+
+.sd-ai-agent-durable-plan-card .sdaa-action-card-header,
+.sd-ai-agent-durable-plan-card .sdaa-action-card-footer {
+	border-color: #8cbedc;
+	background: #f0f6fc;
+}
+
+.sd-ai-agent-durable-plan-card .sdaa-action-card-icon,
+.sd-ai-agent-durable-plan-card .sdaa-action-card-heading {
+	color: #135e96;
+}
+
+.sd-ai-agent-durable-plan-summary,
+.sd-ai-agent-durable-plan-scope,
+.sd-ai-agent-durable-plan-scope-change,
+.sd-ai-agent-durable-plan-phase p {
+	margin: 0 0 8px;
+}
+
+.sd-ai-agent-durable-plan-scope-change,
+.sd-ai-agent-durable-plan-failure {
+	padding: 8px;
+	border-radius: 3px;
+	background: #fff8e5;
+}
+
+.sd-ai-agent-durable-plan-failure {
+	color: #8a2424;
+}
+
+.sd-ai-agent-durable-plan-phase {
+	margin: 10px 0;
+	padding: 8px;
+	border: 1px solid #c3c4c7;
+	border-radius: 4px;
+}
+
+.sd-ai-agent-durable-plan-phase summary {
+	font-weight: 600;
+	cursor: pointer;
+}
+
+.sd-ai-agent-durable-plan-steps {
+	margin: 10px 0 0 20px;
+}
+
+.sd-ai-agent-durable-plan-steps li {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: 12px;
+	margin: 4px 0;
+}
+
+.sd-ai-agent-durable-plan-step-details {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+}
+
+.sd-ai-agent-durable-plan-evidence {
+	margin-top: 2px;
+	color: #50575e;
+	font-size: 12px;
+	line-height: 1.4;
+}
+
+.sd-ai-agent-durable-plan-steps small {
+	flex-shrink: 0;
+	color: #50575e;
+	text-transform: capitalize;
+}
+
 /* ── Chart blocks (Chart.js) ───────────────────────────────────────────────── */
 .sdaa-chart-block {
 	margin: 0.75em 0;

--- a/src/components/slash-command-menu.js
+++ b/src/components/slash-command-menu.js
@@ -62,6 +62,14 @@ const COMMANDS = [
 		action: 'compact',
 	},
 	{
+		name: '/plan',
+		description: __(
+			'Prepare a phased site-operation plan (type request after)',
+			'superdav-ai-agent'
+		),
+		action: 'plan',
+	},
+	{
 		name: '/help',
 		description: __( 'Show keyboard shortcuts', 'superdav-ai-agent' ),
 		action: 'help',

--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -877,6 +877,66 @@ describe( 'actions', () => {
 		expect( dispatch.setPendingActionCard ).toHaveBeenCalledWith( null );
 	} );
 
+	test( 'pollJob preserves a durable plan card while handling its terminal error', async () => {
+		jest.useFakeTimers();
+		apiFetch.mockReset();
+		const plan = {
+			plan_id: '00000000-0000-0000-0000-000000000017',
+			status: 'failed',
+		};
+		apiFetch
+			.mockResolvedValueOnce( {
+				status: 'error',
+				message: 'The provider interrupted this phase.',
+				session_id: 17,
+				durable_plan: plan,
+			} )
+			.mockResolvedValueOnce( {
+				id: 17,
+				messages: [],
+				tool_calls: [],
+			} );
+		const dispatch = {
+			appendMessage: jest.fn(),
+			setCurrentSession: jest.fn(),
+			setPendingConfirmation: jest.fn(),
+			setPendingActionCard: jest.fn(),
+			setStreamError: jest.fn(),
+			setSending: jest.fn(),
+			setLiveToolCalls: jest.fn(),
+			drainMessageQueue: jest.fn(),
+			setCurrentJobId: jest.fn(),
+			setSessionJob: jest.fn(),
+		};
+		const select = {
+			getCurrentSessionId: jest.fn( () => 17 ),
+			getCurrentJobId: jest.fn( () => 'durable-failed-job' ),
+		};
+
+		try {
+			actions.pollJob( 'durable-failed-job', 17 )( { dispatch, select } );
+			await jest.advanceTimersByTimeAsync( 2000 );
+			await Promise.resolve();
+			await Promise.resolve();
+		} finally {
+			jest.useRealTimers();
+		}
+
+		expect( dispatch.setCurrentSession ).toHaveBeenCalledWith( 17, [], [] );
+		expect( dispatch.appendMessage ).toHaveBeenCalledWith(
+			expect.objectContaining( { role: 'system' } )
+		);
+		expect( dispatch.setStreamError ).toHaveBeenCalledWith( true, 17 );
+		expect( dispatch.setPendingActionCard ).toHaveBeenCalledWith( {
+			type: 'durable_plan',
+			sessionId: 17,
+			plan,
+		} );
+		expect( dispatch.setPendingActionCard ).not.toHaveBeenCalledWith(
+			null
+		);
+	} );
+
 	test( 'pollJob preserves a recoverable error as a resume action card', async () => {
 		jest.useFakeTimers();
 		apiFetch.mockReset();
@@ -1573,6 +1633,22 @@ describe( 'reducer', () => {
 			confirmation,
 		} );
 		expect( state.pendingConfirmation ).toEqual( confirmation );
+	} );
+
+	test( 'ENQUEUE_MESSAGE preserves deferred message options', () => {
+		const options = { durable_plan: true };
+		const state = reducer(
+			{ ...DEFAULT_STATE, messageQueue: [] },
+			actions.enqueueMessage( 'Prepare a plan.', [], options )
+		);
+
+		expect( state.messageQueue ).toEqual( [
+			expect.objectContaining( {
+				text: 'Prepare a plan.',
+				attachments: [],
+				options,
+			} ),
+		] );
 	} );
 
 	test( 'TRUNCATE_MESSAGES_TO slices messages to given index', () => {

--- a/src/store/slices/durable-plan-actions.js
+++ b/src/store/slices/durable-plan-actions.js
@@ -182,12 +182,18 @@ export async function runDurablePlanAction( actionName, context ) {
 	const sessionId = card?.sessionId;
 	const planId = card?.plan?.plan_id;
 	const approvalRequestId = card?.plan?.approval_request_id;
-	if (
-		card?.type !== 'durable_plan' ||
-		! sessionId ||
-		! planId ||
-		( action.requiresApproval && ! approvalRequestId )
-	) {
+	if ( card?.type !== 'durable_plan' || ! sessionId || ! planId ) {
+		return;
+	}
+	if ( action.requiresApproval && ! approvalRequestId ) {
+		appendPlanError(
+			dispatch,
+			null,
+			__(
+				'The plan approval is no longer available. Refresh the plan before trying again.',
+				'superdav-ai-agent'
+			)
+		);
 		return;
 	}
 

--- a/src/store/slices/durable-plan-actions.js
+++ b/src/store/slices/durable-plan-actions.js
@@ -1,0 +1,215 @@
+/**
+ * Lazy-loaded client actions for durable site-operation plans.
+ *
+ * The floating widget initializes the shared job slice on every frontend page.
+ * Keep plan actions in their own chunk so code needed only after an operator
+ * opens a durable-plan card does not consume the widget's startup budget.
+ */
+
+import apiFetch from '@wordpress/api-fetch';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Add a user-visible error from a durable-plan action.
+ *
+ * @param {Object} dispatch Store dispatchers.
+ * @param {Object} error    Request or action error.
+ * @param {string} fallback Localized fallback message.
+ */
+function appendPlanError( dispatch, error, fallback ) {
+	dispatch.appendMessage( {
+		role: 'system',
+		parts: [
+			{
+				text: `${ __( 'Error:', 'superdav-ai-agent' ) } ${
+					error?.message || fallback
+				}`,
+			},
+		],
+	} );
+}
+
+/**
+ * Reconcile a durable-plan action or polling response with UI state.
+ *
+ * @param {Object} dispatch  Store dispatchers.
+ * @param {Object} result    REST response.
+ * @param {number} sessionId Session identifier.
+ */
+function handleDurablePlanResponse( dispatch, result, sessionId ) {
+	const plan = result?.plan || result?.durable_plan;
+	if ( plan ) {
+		if ( [ 'completed', 'cancelled' ].includes( plan.status ) ) {
+			dispatch.setPendingActionCard( null );
+		} else {
+			dispatch.setPendingActionCard( {
+				type: 'durable_plan',
+				sessionId,
+				plan,
+			} );
+		}
+	}
+
+	if ( result?.job_id ) {
+		dispatch.setCurrentJobId( result.job_id );
+		dispatch.setSessionJob( sessionId, {
+			jobId: result.job_id,
+			toolCalls: [],
+			status: 'processing',
+		} );
+		dispatch.pollJob( result.job_id, sessionId );
+		return;
+	}
+
+	dispatch.setSending( false );
+}
+
+/**
+ * Reconcile a durable-plan polling result with the current action card.
+ *
+ * @param {Object} context          Client action context.
+ * @param {Object} context.dispatch Store dispatchers.
+ * @param {Object} context.select   Store selectors.
+ * @param {Object} plan             Browser-safe durable plan payload.
+ * @param {number} sessionId        Session identifier.
+ * @param {string} jobStatus        Background job status.
+ */
+export function syncDurablePlanCard(
+	{ dispatch, select },
+	plan,
+	sessionId,
+	jobStatus
+) {
+	if (
+		! plan?.plan_id ||
+		select.getCurrentSessionId() !== sessionId ||
+		[ 'awaiting_confirmation', 'awaiting_client_tools' ].includes(
+			jobStatus
+		)
+	) {
+		return;
+	}
+
+	if ( [ 'completed', 'cancelled' ].includes( plan.status ) ) {
+		if ( select.getPendingActionCard()?.type === 'durable_plan' ) {
+			dispatch.setPendingActionCard( null );
+		}
+		return;
+	}
+
+	dispatch.setPendingActionCard( {
+		type: 'durable_plan',
+		sessionId,
+		plan,
+	} );
+}
+
+const DURABLE_PLAN_ACTIONS = {
+	continue: {
+		path: 'continue',
+		failureMessage: __(
+			'Unable to continue the durable plan.',
+			'superdav-ai-agent'
+		),
+		setsSending: true,
+	},
+	approve: {
+		path: 'approve',
+		failureMessage: __(
+			'Unable to approve the durable plan phase.',
+			'superdav-ai-agent'
+		),
+		requiresApproval: true,
+		setsSending: true,
+	},
+	reject: {
+		path: 'reject',
+		failureMessage: __(
+			'Unable to reject the durable plan phase.',
+			'superdav-ai-agent'
+		),
+		requiresApproval: true,
+	},
+	retry: {
+		path: 'retry',
+		failureMessage: __(
+			'Unable to retry the durable plan phase.',
+			'superdav-ai-agent'
+		),
+		setsSending: true,
+	},
+	cancel: {
+		path: 'cancel',
+		failureMessage: __(
+			'Unable to cancel the durable plan.',
+			'superdav-ai-agent'
+		),
+	},
+};
+
+/**
+ * Fetch the latest durable plan for a chat session.
+ *
+ * @param {number} sessionId Session identifier.
+ * @return {Promise<Object|null>} Browser-safe plan payload or null.
+ */
+export async function loadDurablePlan( sessionId ) {
+	try {
+		const result = await apiFetch( {
+			path: `/sd-ai-agent/v1/sessions/${ sessionId }/plan`,
+		} );
+		return result?.plan || null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Execute one operator-selected durable-plan action.
+ *
+ * The server remains authoritative for phase ordering, fresh approval records,
+ * scope checks, and retry eligibility.
+ *
+ * @param {string} actionName Action name.
+ * @param {Object} context    Client action context.
+ */
+export async function runDurablePlanAction( actionName, context ) {
+	const { dispatch, card } = context;
+	const action = DURABLE_PLAN_ACTIONS[ actionName ];
+	if ( ! action ) {
+		return;
+	}
+	const sessionId = card?.sessionId;
+	const planId = card?.plan?.plan_id;
+	const approvalRequestId = card?.plan?.approval_request_id;
+	if (
+		card?.type !== 'durable_plan' ||
+		! sessionId ||
+		! planId ||
+		( action.requiresApproval && ! approvalRequestId )
+	) {
+		return;
+	}
+
+	const data = { plan_id: planId };
+	if ( action.requiresApproval ) {
+		data.approval_request_id = approvalRequestId;
+	}
+
+	if ( action.setsSending ) {
+		dispatch.setSending( true );
+	}
+	try {
+		const result = await apiFetch( {
+			path: `/sd-ai-agent/v1/sessions/${ sessionId }/plan/${ action.path }`,
+			method: 'POST',
+			data,
+		} );
+		handleDurablePlanResponse( dispatch, result, sessionId );
+	} catch ( error ) {
+		appendPlanError( dispatch, error, action.failureMessage );
+		if ( action.setsSending ) {
+			dispatch.setSending( false );
+		}
+	}
+}

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -458,6 +458,22 @@ export const actions = {
 					if ( liveActivity.length ) {
 						lastLiveActivity = liveActivity;
 					}
+					const durablePlan = result?.durable_plan;
+					if ( durablePlan?.plan_id ) {
+						import(
+							/* webpackChunkName: "durable-plan-actions" */
+							'./durable-plan-actions'
+						)
+							.then( ( { syncDurablePlanCard } ) =>
+								syncDurablePlanCard(
+									{ dispatch, select },
+									durablePlan,
+									sessionId,
+									result.status
+								)
+							)
+							.catch( () => undefined );
+					}
 
 					if ( result.status === 'processing' ) {
 						// Update per-session job state for ALL sessions.
@@ -804,9 +820,14 @@ export const actions = {
 						// previous tool call). Clear the card before rendering the
 						// terminal error so the UI cannot submit a confirmation for a
 						// job that has already been closed.
-						if ( select.getCurrentSessionId() === sessionId ) {
+						const isDurablePlan = durablePlan?.plan_id;
+						const isCurrentSession =
+							select.getCurrentSessionId() === sessionId;
+						if ( isCurrentSession ) {
 							dispatch.setPendingConfirmation?.( null );
-							dispatch.setPendingActionCard?.( null );
+							if ( ! isDurablePlan ) {
+								dispatch.setPendingActionCard?.( null );
+							}
 							clearNotification( jobId );
 						}
 						const rawErrorMessage =
@@ -852,7 +873,7 @@ export const actions = {
 							'superdav-ai-agent'
 						) } ${ errorMessage }`;
 
-						if ( select.getCurrentSessionId() === sessionId ) {
+						if ( ! isDurablePlan && isCurrentSession ) {
 							let sessionReloaded = false;
 							const payloadRecovery = result.payload_recovery;
 							const sourceSessionId = Number(

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -873,7 +873,7 @@ export const actions = {
 							'superdav-ai-agent'
 						) } ${ errorMessage }`;
 
-						if ( ! isDurablePlan && isCurrentSession ) {
+						if ( isCurrentSession ) {
 							let sessionReloaded = false;
 							const payloadRecovery = result.payload_recovery;
 							const sourceSessionId = Number(
@@ -920,25 +920,27 @@ export const actions = {
 								role: 'system',
 								parts: [ { text: errorText } ],
 							} );
-							if ( canCompactConversation ) {
-								dispatch.setPendingActionCard( {
-									type: 'compact_session',
-									sessionId,
-									sourceSessionId,
-								} );
-							} else if ( result.recoverable ) {
-								dispatch.setPendingActionCard( {
-									type: 'resume_recoverable_job',
-									sessionId,
-									diagnostic: failureDiagnostic,
-								} );
-							} else if ( failureDiagnostic ) {
-								dispatch.setPendingActionCard(
-									failureHelpers.buildActiveJobFailureCard(
+							if ( ! isDurablePlan ) {
+								if ( canCompactConversation ) {
+									dispatch.setPendingActionCard( {
+										type: 'compact_session',
 										sessionId,
-										failureDiagnostic
-									)
-								);
+										sourceSessionId,
+									} );
+								} else if ( result.recoverable ) {
+									dispatch.setPendingActionCard( {
+										type: 'resume_recoverable_job',
+										sessionId,
+										diagnostic: failureDiagnostic,
+									} );
+								} else if ( failureDiagnostic ) {
+									dispatch.setPendingActionCard(
+										failureHelpers.buildActiveJobFailureCard(
+											sessionId,
+											failureDiagnostic
+										)
+									);
+								}
 							}
 							if ( ! isCreditNotice && ! failureDiagnostic ) {
 								dispatch.setStreamError( true, sessionId );

--- a/src/store/slices/sessionsSlice.js
+++ b/src/store/slices/sessionsSlice.js
@@ -421,13 +421,15 @@ export const actions = {
 	 *
 	 * @param {string} text        - Message text.
 	 * @param {Array}  attachments - Optional attachment objects.
+	 * @param {Object} options     - Optional message options.
 	 * @return {Object} Redux action.
 	 */
-	enqueueMessage( text, attachments ) {
+	enqueueMessage( text, attachments, options = {} ) {
 		return {
 			type: 'ENQUEUE_MESSAGE',
 			text,
 			attachments: attachments || [],
+			options,
 			timestamp: Date.now(),
 		};
 	},
@@ -1098,6 +1100,9 @@ export const actions = {
 			if ( options.systemInstruction ) {
 				body.system_instruction = options.systemInstruction;
 			}
+			if ( options.durablePlan ) {
+				body.durable_plan = true;
+			}
 
 			// Include client-side ability descriptors so the server can route
 			// JS tool calls back to the browser instead of executing them
@@ -1295,7 +1300,7 @@ export const actions = {
 				dispatch.streamMessage( message, attachments, options );
 			} else {
 				// Enqueue the message for later processing.
-				dispatch.enqueueMessage( message, attachments );
+				dispatch.enqueueMessage( message, attachments, options );
 
 				// Show the user message in the chat immediately with a
 				// "queued" marker so the user sees their message was accepted.
@@ -1342,6 +1347,7 @@ export const actions = {
 			// Pass fromQueue: true so streamMessage doesn't re-append
 			// the user message that was already shown when enqueued.
 			dispatch.streamMessage( next.text, next.attachments, {
+				...( next.options || {} ),
 				fromQueue: true,
 			} );
 		};

--- a/src/store/slices/sessionsSlice.js
+++ b/src/store/slices/sessionsSlice.js
@@ -1870,6 +1870,7 @@ export function reducer( state, action ) {
 					{
 						text: action.text,
 						attachments: action.attachments,
+						options: action.options,
 						timestamp: action.timestamp,
 					},
 				],

--- a/tests/SdAiAgent/Core/ActiveJobsCleanupTest.php
+++ b/tests/SdAiAgent/Core/ActiveJobsCleanupTest.php
@@ -259,6 +259,28 @@ class ActiveJobsCleanupTest extends WP_UnitTestCase {
 		$this->assertFalse( ActiveJobRepository::claim_queued_job( 'test-queued-paused-1' ) );
 	}
 
+	/** A durable confirmation can be requeued once without reviving a newer job state. */
+	public function test_requeue_paused_job_transitions_only_confirmation_rows(): void {
+		$this->insert_job( 'test-requeue-confirmation-1', 'awaiting_confirmation' );
+		$this->assertTrue( ActiveJobRepository::requeue_paused_job( 'test-requeue-confirmation-1' ) );
+		$this->assertFalse( ActiveJobRepository::requeue_paused_job( 'test-requeue-confirmation-1' ) );
+		$confirmation = $this->fetch_row( 'test-requeue-confirmation-1' );
+		$this->assertNotNull( $confirmation );
+		$this->assertSame( 'queued', $confirmation->status );
+
+		$this->insert_job( 'test-requeue-client-tools-1', 'awaiting_client_tools' );
+		$this->assertFalse( ActiveJobRepository::requeue_paused_job( 'test-requeue-client-tools-1' ) );
+		$client_tools = $this->fetch_row( 'test-requeue-client-tools-1' );
+		$this->assertNotNull( $client_tools );
+		$this->assertSame( 'awaiting_client_tools', $client_tools->status );
+
+		$this->insert_job( 'test-requeue-processing-1', 'processing' );
+		$this->assertFalse( ActiveJobRepository::requeue_paused_job( 'test-requeue-processing-1' ) );
+		$processing = $this->fetch_row( 'test-requeue-processing-1' );
+		$this->assertNotNull( $processing );
+		$this->assertSame( 'processing', $processing->status );
+	}
+
 	// ── cleanup_stale() ──────────────────────────────────────────────────
 
 	/**

--- a/tests/SdAiAgent/Core/ActiveJobsCleanupTest.php
+++ b/tests/SdAiAgent/Core/ActiveJobsCleanupTest.php
@@ -238,6 +238,27 @@ class ActiveJobsCleanupTest extends WP_UnitTestCase {
 		$this->assertSame( $checkpoint, json_decode( (string) $row->checkpoint, true ) );
 	}
 
+	/** A queued durable worker may be claimed exactly once. */
+	public function test_claim_queued_job_has_one_winner(): void {
+		$this->insert_job( 'test-queued-claim-1', 'queued' );
+
+		$this->assertTrue( ActiveJobRepository::claim_queued_job( 'test-queued-claim-1' ) );
+		$this->assertFalse( ActiveJobRepository::claim_queued_job( 'test-queued-claim-1' ) );
+
+		$row = $this->fetch_row( 'test-queued-claim-1' );
+		$this->assertNotNull( $row );
+		$this->assertSame( 'processing', $row->status );
+	}
+
+	/** Processing and paused jobs cannot be claimed as new durable workers. */
+	public function test_claim_queued_job_rejects_nonqueued_jobs(): void {
+		$this->insert_job( 'test-queued-processing-1', 'processing' );
+		$this->insert_job( 'test-queued-paused-1', 'awaiting_confirmation' );
+
+		$this->assertFalse( ActiveJobRepository::claim_queued_job( 'test-queued-processing-1' ) );
+		$this->assertFalse( ActiveJobRepository::claim_queued_job( 'test-queued-paused-1' ) );
+	}
+
 	// ── cleanup_stale() ──────────────────────────────────────────────────
 
 	/**
@@ -257,6 +278,19 @@ class ActiveJobsCleanupTest extends WP_UnitTestCase {
 		$this->assertSame( 'abandoned', $row->status );
 		$diagnostic = ActiveJobFailureDiagnostic::from_stored( 'test-stale-1', $row->error );
 		$this->assertSame( ActiveJobFailureDiagnostic::REASON_WORKER_TERMINATED, $diagnostic['reason'] );
+	}
+
+	/** cleanup_stale() also reaps queued workers that never receive a loopback delivery. */
+	public function test_cleanup_stale_marks_old_queued_rows_as_abandoned(): void {
+		$stale_time = gmdate( 'Y-m-d H:i:s', time() - 1800 );
+		$this->insert_job( 'test-stale-queued-1', 'queued', $stale_time );
+
+		$count = ActiveJobRepository::cleanup_stale( 15 );
+		$row   = $this->fetch_row( 'test-stale-queued-1' );
+
+		$this->assertGreaterThanOrEqual( 1, $count );
+		$this->assertNotNull( $row );
+		$this->assertSame( 'abandoned', $row->status );
 	}
 
 	/**
@@ -409,12 +443,17 @@ class ActiveJobsCleanupTest extends WP_UnitTestCase {
 	// ── STATUSES constant ─────────────────────────────────────────────────
 
 	/**
-	 * 'interrupted' and 'abandoned' are valid status values accepted by update_status().
+	 * 'queued', 'interrupted', and 'abandoned' are valid status values accepted by update_status().
 	 */
 	public function test_interrupted_and_abandoned_are_valid_statuses(): void {
+		$this->insert_job( 'test-status-queued', 'processing' );
 		$this->insert_job( 'test-status-interrupted', 'processing' );
 		$this->insert_job( 'test-status-abandoned', 'processing' );
 
+		$this->assertTrue(
+			ActiveJobRepository::update_status( 'test-status-queued', 'queued' ),
+			"'queued' should be a valid status"
+		);
 		$this->assertTrue(
 			ActiveJobRepository::update_status( 'test-status-interrupted', 'interrupted' ),
 			"'interrupted' should be a valid status"
@@ -424,9 +463,11 @@ class ActiveJobsCleanupTest extends WP_UnitTestCase {
 			"'abandoned' should be a valid status"
 		);
 
+		$row0 = $this->fetch_row( 'test-status-queued' );
 		$row1 = $this->fetch_row( 'test-status-interrupted' );
 		$row2 = $this->fetch_row( 'test-status-abandoned' );
 
+		$this->assertSame( 'queued', $row0->status ?? '' );
 		$this->assertSame( 'interrupted', $row1->status ?? '' );
 		$this->assertSame( 'abandoned', $row2->status ?? '' );
 	}

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -570,7 +570,7 @@ class AgentLoopTest extends WP_UnitTestCase {
 	}
 
 	/** Build a deterministic SDK result for scripted provider recovery tests. */
-	private function create_scripted_result( string $reply ): GenerativeAiResult {
+	private function create_scripted_result( string $reply, ?FunctionCall $function_call = null ): GenerativeAiResult {
 		$provider_metadata = new ProviderMetadata(
 			'scripted-provider',
 			'Scripted Provider',
@@ -585,7 +585,7 @@ class AgentLoopTest extends WP_UnitTestCase {
 			array()
 		);
 		$candidate         = new Candidate(
-			new ModelMessage( array( new MessagePart( $reply ) ) ),
+			new ModelMessage( array( new MessagePart( $function_call ?? $reply ) ) ),
 			FinishReasonEnum::stop()
 		);
 
@@ -713,6 +713,109 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'token_usage', $result );
 		$this->assertSame( 100, $result['token_usage']['prompt'] );
 		$this->assertSame( 50, $result['token_usage']['completion'] );
+	}
+
+	/** Durable planning accepts only a compact JSON shape and never saves raw model JSON to history. */
+	public function test_durable_plan_mode_returns_a_compact_definition_without_raw_history(): void {
+		$raw_response = (string) wp_json_encode(
+			[
+				'scope'   => 'MODEL-ONLY-SCOPE-MARKER',
+				'summary' => 'MODEL-ONLY-SUMMARY-MARKER',
+				'steps'   => [
+					[
+						'title'             => 'Inspect the current configuration',
+						'instruction'       => 'Inspect the current configuration without changing the site.',
+						'classification'    => 'read',
+						'preconditions'     => 'An administrator session is active.',
+						'expected_evidence' => 'A concise configuration inventory.',
+						'rollback_guidance' => 'No rollback is required.',
+					],
+				],
+			]
+		);
+		$loop         = new ScriptedAgentLoop(
+			'Prepare a safe plan for the current site operation.',
+			[],
+			[],
+			[
+				'durable_plan_mode' => true,
+				'provider_id'       => 'scripted-provider',
+				'model_id'          => 'scripted-model',
+			],
+			[ $this->create_scripted_result( $raw_response ) ]
+		);
+		$result       = $loop->run();
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'I prepared a durable plan. Review each phase before continuing.', $result['reply'] );
+		$this->assertSame( 'MODEL-ONLY-SCOPE-MARKER', $result['durable_plan_definition']['scope'] );
+		$this->assertSame( 'read', $result['durable_plan_definition']['steps'][0]['classification'] );
+		$this->assertSame( [], $result['tool_calls'] );
+		$this->assertStringNotContainsString( 'MODEL-ONLY-SCOPE-MARKER', (string) wp_json_encode( $result['history'] ) );
+		$this->assertStringNotContainsString( 'MODEL-ONLY-SUMMARY-MARKER', (string) wp_json_encode( $result['history'] ) );
+	}
+
+	/** Planner-only turns reject a provider tool call before it can execute or pause. */
+	public function test_durable_plan_mode_rejects_model_tool_calls_without_recording_them(): void {
+		$tool_name = 'wpab__sd-ai-agent__site-info';
+		$loop      = new ScriptedAgentLoop(
+			'Prepare a safe plan for the current site operation.',
+			array(),
+			array(),
+			array(
+				'durable_plan_mode' => true,
+				'provider_id'       => 'scripted-provider',
+				'model_id'          => 'scripted-model',
+			),
+			array( $this->create_scripted_result( '', new FunctionCall( 'plan_tool_call', $tool_name, array() ) ) )
+		);
+		$result    = $loop->run();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_durable_plan_tool_call', $result->get_error_code() );
+		$error_data = $result->get_error_data();
+		$this->assertIsArray( $error_data );
+		$this->assertSame( array(), $error_data['tool_calls'] ?? array() );
+		$this->assertStringNotContainsString( $tool_name, (string) wp_json_encode( $error_data['history'] ?? array() ) );
+	}
+
+	/** Planner-only turns reject unknown model fields without reflecting their raw response into history. */
+	public function test_durable_plan_mode_rejects_unknown_model_fields_without_raw_history(): void {
+		$raw_response = (string) wp_json_encode(
+			[
+				'scope'           => 'Review the site configuration.',
+				'summary'         => 'Create a reviewed plan.',
+				'idempotency_key' => 'MODEL-ONLY-UNTRUSTED-KEY-MARKER',
+				'steps'           => [
+					[
+						'title'             => 'Inspect configuration',
+						'instruction'       => 'Inspect the current configuration.',
+						'classification'    => 'read',
+						'preconditions'     => '',
+						'expected_evidence' => 'Configuration inventory.',
+						'rollback_guidance' => '',
+					],
+				],
+			]
+		);
+		$loop         = new ScriptedAgentLoop(
+			'Prepare a safe plan for the current site operation.',
+			[],
+			[],
+			[
+				'durable_plan_mode' => true,
+				'provider_id'       => 'scripted-provider',
+				'model_id'          => 'scripted-model',
+			],
+			[ $this->create_scripted_result( $raw_response ) ]
+		);
+		$result       = $loop->run();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_durable_plan_invalid_response', $result->get_error_code() );
+		$error_data = $result->get_error_data();
+		$this->assertIsArray( $error_data );
+		$this->assertStringNotContainsString( 'MODEL-ONLY-UNTRUSTED-KEY-MARKER', (string) wp_json_encode( $error_data['history'] ?? [] ) );
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/DatabaseSchemaTest.php
+++ b/tests/SdAiAgent/Core/DatabaseSchemaTest.php
@@ -65,6 +65,8 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 		'sd_ai_agent_provider_trace',
 		'sd_ai_agent_generated_plugins',
 		'sd_ai_agent_active_jobs',
+		'sd_ai_agent_durable_plans',
+		'sd_ai_agent_durable_plan_steps',
 		'sd_ai_agent_customer_agent_conversations',
 		'sd_ai_agent_customer_agent_jobs',
 		'sd_ai_agent_skill_usage',
@@ -419,6 +421,21 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 				$columns,
 				"active_jobs table missing column '{$col}' — see GH#2026."
 			);
+		}
+	}
+
+	/** Durable plans and their phases retain compact state outside chat history. */
+	public function test_durable_plan_tables_have_required_columns(): void {
+		Database::install();
+
+		$plan_columns = $this->get_column_names( Database::durable_plans_table_name() );
+		foreach ( [ 'plan_id', 'session_id', 'user_id', 'scope', 'scope_hash', 'pending_scope', 'pending_scope_hash', 'summary', 'status', 'current_step', 'approval_request_id', 'completed_at', 'cancelled_at' ] as $column ) {
+			$this->assertContains( $column, $plan_columns, "durable_plans table missing column '{$column}'." );
+		}
+
+		$step_columns = $this->get_column_names( Database::durable_plan_steps_table_name() );
+		foreach ( [ 'plan_db_id', 'step_key', 'position', 'title', 'instruction', 'classification', 'requires_approval', 'safe_to_resume', 'idempotency_key', 'preconditions', 'expected_evidence', 'rollback_guidance', 'status', 'approval_request_id', 'job_id', 'evidence', 'failure_message', 'attempts', 'completed_at' ] as $column ) {
+			$this->assertContains( $column, $step_columns, "durable_plan_steps table missing column '{$column}'." );
 		}
 	}
 

--- a/tests/SdAiAgent/Core/DatabaseSchemaTest.php
+++ b/tests/SdAiAgent/Core/DatabaseSchemaTest.php
@@ -437,6 +437,13 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 		foreach ( [ 'plan_db_id', 'step_key', 'position', 'title', 'instruction', 'classification', 'requires_approval', 'safe_to_resume', 'idempotency_key', 'preconditions', 'expected_evidence', 'rollback_guidance', 'status', 'approval_request_id', 'job_id', 'evidence', 'failure_message', 'attempts', 'completed_at' ] as $column ) {
 			$this->assertContains( $column, $step_columns, "durable_plan_steps table missing column '{$column}'." );
 		}
+
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+		$steps_table = Database::durable_plan_steps_table_name();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test-only schema index introspection.
+		$unique_index = $wpdb->get_var( "SHOW INDEX FROM {$steps_table} WHERE Key_name = 'plan_step_key' AND Non_unique = 0" );
+		$this->assertNotNull( $unique_index, 'Durable plan phase keys must be unique within a plan.' );
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/DurablePlanRunnerTest.php
+++ b/tests/SdAiAgent/Core/DurablePlanRunnerTest.php
@@ -164,6 +164,42 @@ class DurablePlanRunnerTest extends WP_UnitTestCase {
 		$this->assertNotSame( $first_approval, (int) $retry['plan']['approval_request_id'] );
 	}
 
+	/** Invalid phase keys are rejected before they can trip a database constraint. */
+	public function test_invalid_step_keys_are_rejected_and_empty_job_lookups_are_safe(): void {
+		$plan = $this->create_plan();
+		$this->assertNull( DurablePlanRepository::get_step_by_job_id( '' ) );
+
+		$duplicate_steps         = $this->steps();
+		$duplicate_steps[1]['key'] = $duplicate_steps[0]['key'];
+		$duplicate               = DurablePlanRunner::create(
+			(int) $plan['session_id'],
+			$this->admin_id,
+			[
+				'scope' => 'Reject duplicate durable plan phase keys.',
+				'steps' => $duplicate_steps,
+			]
+		);
+		$this->assertTrue( is_wp_error( $duplicate ) );
+		if ( is_wp_error( $duplicate ) ) {
+			$this->assertSame( 'sd_ai_agent_plan_duplicate_step_key', $duplicate->get_error_code() );
+		}
+
+		$long_key_steps         = $this->steps();
+		$long_key_steps[0]['key'] = str_repeat( 'phase-key-', 12 );
+		$long_key               = DurablePlanRunner::create(
+			(int) $plan['session_id'],
+			$this->admin_id,
+			[
+				'scope' => 'Reject oversized durable plan phase keys.',
+				'steps' => $long_key_steps,
+			]
+		);
+		$this->assertTrue( is_wp_error( $long_key ) );
+		if ( is_wp_error( $long_key ) ) {
+			$this->assertSame( 'sd_ai_agent_plan_invalid_step_key', $long_key->get_error_code() );
+		}
+	}
+
 	/** Pending scope approval cannot be bypassed with a direct continue call. */
 	public function test_scope_change_requires_approval_before_a_phase_can_start(): void {
 		$plan    = $this->create_plan();
@@ -429,6 +465,27 @@ class DurablePlanRunnerTest extends WP_UnitTestCase {
 		$this->assertSame( 'interrupted', $this->step( $updated_plan, 'inspect' )['status'] );
 
 		ActiveJobRepository::delete( $job_id );
+	}
+
+	/** A late worker error cannot overwrite a phase that already completed. */
+	public function test_late_failure_cannot_overwrite_a_completed_phase(): void {
+		$plan    = $this->create_plan();
+		$plan_id = (string) $plan['plan_id'];
+		$phase   = $this->prepare( $plan_id );
+
+		$this->complete( $plan_id, $phase, 'Inspection completed before the late failure.' );
+		$this->assertNull(
+			DurablePlanRunner::fail_phase(
+				$plan_id,
+				(int) $phase['step']['id'],
+				'A stale worker reported an error after completion.'
+			)
+		);
+
+		$updated = DurablePlanRunner::public_plan( $plan_id );
+		$this->assertIsArray( $updated );
+		$this->assertSame( 'pending', $updated['status'] );
+		$this->assertSame( 'completed', $this->step( $updated, 'inspect' )['status'] );
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/DurablePlanRunnerTest.php
+++ b/tests/SdAiAgent/Core/DurablePlanRunnerTest.php
@@ -1,0 +1,574 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Integration tests for durable phased site-operation plans.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests\Core
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Automations\HumanApprovalGate;
+use SdAiAgent\Core\ActiveJobsCleanupService;
+use SdAiAgent\Core\Database;
+use SdAiAgent\Core\DurablePlanRunner;
+use SdAiAgent\Models\ActiveJobRepository;
+use SdAiAgent\Models\DurablePlanRepository;
+use WP_UnitTestCase;
+
+class DurablePlanRunnerTest extends WP_UnitTestCase {
+
+	private int $admin_id;
+
+	public function set_up(): void {
+		parent::set_up();
+
+		Database::install();
+		HumanApprovalGate::clear_handlers();
+		$this->admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $this->admin_id );
+
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test cleanup for custom plan tables.
+		$wpdb->query( $wpdb->prepare( 'DELETE FROM %i', DurablePlanRepository::steps_table_name() ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test cleanup for custom plan tables.
+		$wpdb->query( $wpdb->prepare( 'DELETE FROM %i', DurablePlanRepository::table_name() ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test cleanup for plan approval records.
+		$wpdb->query( $wpdb->prepare( 'DELETE FROM %i WHERE source_type = %s', HumanApprovalGate::table_name(), 'durable-plan' ) );
+	}
+
+	public function tear_down(): void {
+		HumanApprovalGate::clear_handlers();
+		parent::tear_down();
+	}
+
+	/**
+	 * Four phases demonstrate normal completion, a consequential interruption
+	 * requiring a fresh approval, and a safe idempotent interruption resume.
+	 */
+	public function test_four_phase_plan_requires_fresh_approval_after_write_interruption(): void {
+		$plan    = $this->create_plan();
+		$plan_id = (string) $plan['plan_id'];
+
+		$first = $this->prepare( $plan_id );
+		$this->assertSame( 'inspect', $first['step']['step_key'] );
+		$this->assign_job( $plan_id, $first, '10000000-0000-0000-0000-000000000001' );
+		$after_first = $this->complete( $plan_id, $first, 'Inventory captured.' );
+		$this->assertSame( 'pending', $after_first['status'] );
+		$this->assertSame( 2, $after_first['current_step'] );
+		$this->assertSame( 'completed', $this->step( $after_first, 'inspect' )['status'] );
+
+		$awaiting_write = DurablePlanRunner::prepare_next( $plan_id, $this->admin_id );
+		$this->assertIsArray( $awaiting_write );
+		$this->assertSame( 'awaiting_approval', $awaiting_write['status'] );
+		$first_approval = (int) $awaiting_write['plan']['approval_request_id'];
+		$this->assertGreaterThan( 0, $first_approval );
+
+		$write = $this->approve_and_prepare( $plan_id, $first_approval );
+		$this->assertSame( 'configure', $write['step']['step_key'] );
+		$this->assign_job( $plan_id, $write, '10000000-0000-0000-0000-000000000002' );
+		$blocked = DurablePlanRunner::mark_phase_interrupted_by_job( '10000000-0000-0000-0000-000000000002' );
+		$this->assertIsArray( $blocked );
+		$this->assertSame( 'blocked', $blocked['status'] );
+		$this->assertSame( 'failed', $this->step( $blocked, 'configure' )['status'] );
+
+		$retry_approval = DurablePlanRunner::retry( $plan_id, $this->admin_id );
+		$this->assertIsArray( $retry_approval );
+		$this->assertSame( 'awaiting_approval', $retry_approval['status'] );
+		$second_approval = (int) $retry_approval['plan']['approval_request_id'];
+		$this->assertGreaterThan( 0, $second_approval );
+		$this->assertNotSame( $first_approval, $second_approval );
+
+		$write_retry = $this->approve_and_prepare( $plan_id, $second_approval );
+		$this->complete( $plan_id, $write_retry, 'Configuration applied.' );
+
+		$verify = $this->prepare( $plan_id );
+		$this->assertSame( 'verify', $verify['step']['step_key'] );
+		$this->assign_job( $plan_id, $verify, '10000000-0000-0000-0000-000000000003' );
+		$safe_interruption = DurablePlanRunner::mark_phase_interrupted_by_job( '10000000-0000-0000-0000-000000000003' );
+		$this->assertIsArray( $safe_interruption );
+		$this->assertSame( 'pending', $safe_interruption['status'] );
+		$this->assertSame( 'interrupted', $this->step( $safe_interruption, 'verify' )['status'] );
+
+		$verify_resume = $this->prepare( $plan_id );
+		$this->assertSame( 'verify', $verify_resume['step']['step_key'] );
+		$this->complete( $plan_id, $verify_resume, 'Verification succeeded.' );
+
+		$awaiting_destructive = DurablePlanRunner::prepare_next( $plan_id, $this->admin_id );
+		$this->assertIsArray( $awaiting_destructive );
+		$this->assertSame( 'awaiting_approval', $awaiting_destructive['status'] );
+		$cancelled = DurablePlanRunner::reject(
+			$plan_id,
+			(int) $awaiting_destructive['plan']['approval_request_id'],
+			$this->admin_id
+		);
+		$this->assertIsArray( $cancelled );
+		$this->assertSame( 'cancelled', $cancelled['status'] );
+	}
+
+	/** Client phase metadata must not weaken approval or interruption handling. */
+	public function test_client_phase_metadata_cannot_bypass_approval_or_safe_resume(): void {
+		$session_id = Database::create_session(
+			[
+				'user_id'     => $this->admin_id,
+				'title'       => 'Untrusted durable plan test',
+				'provider_id' => 'test-provider',
+				'model_id'    => 'test-model',
+			]
+		);
+		$this->assertIsInt( $session_id );
+
+		$plan = DurablePlanRunner::create_from_client(
+			(int) $session_id,
+			$this->admin_id,
+			[
+				'scope' => 'Inspect the site configuration.',
+				'steps' => [
+					[
+						'key'               => 'browser-read',
+						'title'             => 'Browser-labelled read phase',
+						'instruction'       => 'Inspect the site configuration without changes.',
+						'classification'    => 'read',
+						'idempotency_key'   => 'browser-controlled-key',
+						'requires_approval' => false,
+						'safe_to_resume'    => true,
+					],
+				],
+			]
+		);
+		$this->assertIsArray( $plan );
+		$stored_step = $plan['steps'][0];
+		$this->assertSame( 1, $stored_step['requires_approval'] );
+		$this->assertSame( 0, $stored_step['safe_to_resume'] );
+		$this->assertNotSame( 'browser-controlled-key', $stored_step['idempotency_key'] );
+
+		$awaiting = DurablePlanRunner::prepare_next( (string) $plan['plan_id'], $this->admin_id );
+		$this->assertIsArray( $awaiting );
+		$this->assertSame( 'awaiting_approval', $awaiting['status'] );
+		$first_approval = (int) $awaiting['plan']['approval_request_id'];
+
+		$ready = $this->approve_and_prepare( (string) $plan['plan_id'], $first_approval );
+		$this->assign_job( (string) $plan['plan_id'], $ready, '10000000-0000-0000-0000-000000000005' );
+		$interrupted = DurablePlanRunner::mark_phase_interrupted_by_job( '10000000-0000-0000-0000-000000000005' );
+		$this->assertIsArray( $interrupted );
+		$this->assertSame( 'blocked', $interrupted['status'] );
+		$this->assertSame( 'failed', $this->step( $interrupted, 'browser-read' )['status'] );
+
+		$retry = DurablePlanRunner::retry( (string) $plan['plan_id'], $this->admin_id );
+		$this->assertIsArray( $retry );
+		$this->assertSame( 'awaiting_approval', $retry['status'] );
+		$this->assertNotSame( $first_approval, (int) $retry['plan']['approval_request_id'] );
+	}
+
+	/** Pending scope approval cannot be bypassed with a direct continue call. */
+	public function test_scope_change_requires_approval_before_a_phase_can_start(): void {
+		$plan    = $this->create_plan();
+		$plan_id = (string) $plan['plan_id'];
+
+		$requested = DurablePlanRunner::request_scope_change( $plan_id, $this->admin_id, 'Include the production landing page.' );
+		$this->assertIsArray( $requested );
+		$this->assertSame( 'awaiting_approval', $requested['status'] );
+		$this->assertSame( 'Include the production landing page.', $requested['plan']['pending_scope'] );
+
+		$blocked_continue = DurablePlanRunner::prepare_next( $plan_id, $this->admin_id );
+		$this->assertIsArray( $blocked_continue );
+		$this->assertSame( 'awaiting_approval', $blocked_continue['status'] );
+		$this->assertSame( 'pending', $this->step( $blocked_continue['plan'], 'inspect' )['status'] );
+
+		$approved = DurablePlanRunner::approve(
+			$plan_id,
+			(int) $requested['plan']['approval_request_id'],
+			$this->admin_id
+		);
+		$this->assertIsArray( $approved );
+		$this->assertSame( 'pending', $approved['status'] );
+		$this->assertSame( 'Include the production landing page.', $approved['plan']['scope'] );
+		$this->assertSame( '', $approved['plan']['pending_scope'] );
+
+		$second_request = DurablePlanRunner::request_scope_change( $plan_id, $this->admin_id, 'Replace the approved scope.' );
+		$this->assertIsArray( $second_request );
+		$rejected = DurablePlanRunner::reject(
+			$plan_id,
+			(int) $second_request['plan']['approval_request_id'],
+			$this->admin_id
+		);
+		$this->assertIsArray( $rejected );
+		$this->assertSame( 'Include the production landing page.', $rejected['plan']['scope'] );
+		$this->assertSame( '', $rejected['plan']['pending_scope'] );
+	}
+
+	/** Provider context omits the session transcript and remains bounded. */
+	public function test_provider_context_uses_only_compact_plan_state(): void {
+		$session_id = Database::create_session(
+			[
+				'user_id' => $this->admin_id,
+				'title'   => 'Durable context test',
+			]
+		);
+		$this->assertIsInt( $session_id );
+		Database::append_to_session(
+			(int) $session_id,
+			[
+				[
+					'role'  => 'user',
+					'parts' => [ [ 'text' => 'RAW SESSION TRANSCRIPT MUST NOT REACH THE PROVIDER CONTEXT.' ] ],
+				],
+			]
+		);
+
+		$created = DurablePlanRunner::create(
+			$session_id,
+			$this->admin_id,
+			[
+				'scope' => 'api_key=do-not-store Authorization: Bearer repository-bearer-token {"authorization":"Bearer repository-json-bearer-token"} ' . str_repeat( 'bounded scope ', 200 ),
+				'steps' => $this->steps(),
+			]
+		);
+		$this->assertIsArray( $created );
+		$stored = DurablePlanRepository::get_by_plan_id( (string) $created['plan_id'] );
+		$this->assertIsArray( $stored );
+
+		$context = DurablePlanRunner::build_provider_context( $stored, $stored['steps'][0] );
+		$this->assertLessThanOrEqual( 6000, strlen( $context ) );
+		$this->assertStringNotContainsString( 'RAW SESSION TRANSCRIPT', $context );
+		$this->assertStringNotContainsString( 'do-not-store', $context );
+		$this->assertStringNotContainsString( 'repository-bearer-token', $context );
+		$this->assertStringNotContainsString( 'repository-json-bearer-token', $context );
+		$this->assertStringContainsString( 'api_key: [redacted]', $context );
+		$this->assertStringContainsString( 'Authorization: [redacted]', $context );
+		$this->assertStringContainsString( '"authorization": "[redacted]"', $context );
+
+		$stored['steps'] = array_map(
+			static function ( int $position ): array {
+				return [
+					'position' => $position,
+					'title'    => "Completed phase {$position}",
+					'status'   => 'completed',
+					'evidence' => [ 'summary' => "Evidence from phase {$position}." ],
+				];
+			},
+			range( 1, 5 )
+		);
+		$evidence_context = DurablePlanRunner::build_provider_context(
+			$stored,
+			[
+				'position'          => 6,
+				'title'             => 'Current phase',
+				'instruction'       => 'Perform only the current read-only phase.',
+				'classification'    => 'read',
+				'preconditions'     => '',
+				'expected_evidence' => '',
+				'rollback_guidance' => '',
+			]
+		);
+		$this->assertStringNotContainsString( 'Evidence from phase 1.', $evidence_context );
+		$this->assertStringNotContainsString( 'Evidence from phase 2.', $evidence_context );
+		$this->assertStringContainsString( 'Evidence from phase 3.', $evidence_context );
+		$this->assertStringContainsString( 'Evidence from phase 4.', $evidence_context );
+		$this->assertStringContainsString( 'Evidence from phase 5.', $evidence_context );
+	}
+
+	/** Structured credentials are redacted from every compact plan field. */
+	public function test_plan_fields_redact_structured_credentials(): void {
+		$session_id = Database::create_session(
+			[
+				'user_id' => $this->admin_id,
+				'title'   => 'Structured credential plan test',
+			]
+		);
+		$this->assertIsInt( $session_id );
+
+		$markers = [
+			'plan-scope-json-secret',
+			'plan-summary-json-secret',
+			'plan-title-json-secret',
+			'plan-instruction-json-secret',
+			'plan-precondition-json-secret',
+			'plan-evidence-json-secret',
+			'plan-rollback-json-secret',
+		];
+		$plan = DurablePlanRunner::create(
+			(int) $session_id,
+			$this->admin_id,
+			[
+				'scope'   => '{"credentials":{"api_key":"plan-scope-json-secret with spaces"}}',
+				'summary' => '{"access_token":"plan-summary-json-secret with spaces"}',
+				'steps'   => [
+					[
+						'key'               => 'structured-redaction',
+						'title'             => '{"password":"plan-title-json-secret with spaces"}',
+						'instruction'       => '{"client_secret":"plan-instruction-json-secret with spaces"}',
+						'classification'    => 'read',
+						'preconditions'     => '{"credential":"plan-precondition-json-secret with spaces"}',
+						'expected_evidence' => '{"token":"plan-evidence-json-secret with spaces"}',
+						'rollback_guidance' => '{"private_key":"plan-rollback-json-secret with spaces"}',
+					],
+				],
+			]
+		);
+		$this->assertIsArray( $plan );
+		$stored = DurablePlanRepository::get_by_plan_id( (string) $plan['plan_id'] );
+		$this->assertIsArray( $stored );
+		$step = $stored['steps'][0];
+		$fields = implode(
+			"\n",
+			[
+				(string) $stored['scope'],
+				(string) $stored['summary'],
+				(string) $step['title'],
+				(string) $step['instruction'],
+				(string) $step['preconditions'],
+				(string) $step['expected_evidence'],
+				(string) $step['rollback_guidance'],
+			]
+		);
+		foreach ( $markers as $marker ) {
+			$this->assertStringNotContainsString( $marker, $fields );
+		}
+		$this->assertStringContainsString( '[redacted]', $fields );
+	}
+
+	/** Completion evidence never persists a bearer credential from provider output. */
+	public function test_phase_evidence_redacts_bearer_credentials(): void {
+		$plan    = $this->create_plan();
+		$plan_id = (string) $plan['plan_id'];
+		$phase   = $this->prepare( $plan_id );
+
+		$this->assign_job( $plan_id, $phase, '10000000-0000-0000-0000-000000000004' );
+		$completed = $this->complete( $plan_id, $phase, 'Authorization: Bearer evidence-bearer-token {"authorization":"Bearer evidence-json-bearer-token","credentials":{"api_key":"evidence-json-secret with spaces"}}' );
+		$step      = $this->step( $completed, 'inspect' );
+
+		$this->assertStringNotContainsString( 'evidence-bearer-token', (string) $step['evidence']['summary'] );
+		$this->assertStringNotContainsString( 'evidence-json-bearer-token', (string) $step['evidence']['summary'] );
+		$this->assertStringNotContainsString( 'evidence-json-secret', (string) $step['evidence']['summary'] );
+		$this->assertStringContainsString( 'Authorization: [redacted]', (string) $step['evidence']['summary'] );
+		$this->assertStringContainsString( '"authorization": "[redacted]"', (string) $step['evidence']['summary'] );
+	}
+
+	/** Scope and phase claims cannot overwrite one another after either wins. */
+	public function test_scope_and_phase_claims_are_mutually_exclusive(): void {
+		$plan      = $this->create_plan();
+		$first_step = $plan['steps'][0];
+		$scope     = 'Add the production footer to the reviewed scope.';
+
+		$this->assertTrue(
+			DurablePlanRepository::claim_scope_change(
+				(int) $plan['id'],
+				$scope,
+				hash( 'sha256', $scope ),
+				99
+			)
+		);
+		$this->assertFalse(
+			DurablePlanRepository::claim_step_and_start_plan(
+				(int) $plan['id'],
+				(int) $first_step['id'],
+				(int) $first_step['position']
+			)
+		);
+
+		$after_scope_claim = DurablePlanRepository::get_by_plan_id( (string) $plan['plan_id'] );
+		$this->assertIsArray( $after_scope_claim );
+		$this->assertSame( 'awaiting_approval', $after_scope_claim['status'] );
+		$this->assertSame( 'pending', $after_scope_claim['steps'][0]['status'] );
+
+		$second_plan = $this->create_plan();
+		$second_step = $second_plan['steps'][0];
+		$this->assertTrue(
+			DurablePlanRepository::claim_step_and_start_plan(
+				(int) $second_plan['id'],
+				(int) $second_step['id'],
+				(int) $second_step['position']
+			)
+		);
+		$this->assertFalse(
+			DurablePlanRepository::claim_scope_change(
+				(int) $second_plan['id'],
+				'Change the scope after the phase has started.',
+				hash( 'sha256', 'Change the scope after the phase has started.' ),
+				100
+			)
+		);
+	}
+
+	/** The cron reaper converts a stale durable worker into a safe resume state. */
+	public function test_stale_durable_worker_marks_safe_phase_interrupted(): void {
+		$plan    = $this->create_plan();
+		$plan_id = (string) $plan['plan_id'];
+		$phase   = $this->prepare( $plan_id );
+		$job_id  = 'test-durable-stale-worker';
+
+		$this->assertNotFalse(
+			ActiveJobRepository::create( (int) $plan['session_id'], $job_id, $this->admin_id, 'queued' )
+		);
+		$this->assign_job( $plan_id, $phase, $job_id );
+
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Set up a deterministic stale-worker fixture.
+		$wpdb->update(
+			ActiveJobRepository::table_name(),
+			[ 'updated_at' => gmdate( 'Y-m-d H:i:s', time() - 1800 ) ],
+			[ 'job_id' => $job_id ],
+			[ '%s' ],
+			[ '%s' ]
+		);
+
+		ActiveJobsCleanupService::run();
+
+		$job = ActiveJobRepository::get_by_job_id( $job_id );
+		$this->assertNotNull( $job );
+		$this->assertSame( 'abandoned', $job->status );
+		$updated_plan = DurablePlanRunner::public_plan( $plan_id );
+		$this->assertIsArray( $updated_plan );
+		$this->assertSame( 'pending', $updated_plan['status'] );
+		$this->assertSame( 'interrupted', $this->step( $updated_plan, 'inspect' )['status'] );
+
+		ActiveJobRepository::delete( $job_id );
+	}
+
+	/**
+	 * Create a plan owned by the current administrator.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function create_plan(): array {
+		$session_id = Database::create_session(
+			[
+				'user_id'     => $this->admin_id,
+				'title'       => 'Durable plan test',
+				'provider_id' => 'test-provider',
+				'model_id'    => 'test-model',
+			]
+		);
+		$this->assertIsInt( $session_id );
+		$plan       = DurablePlanRunner::create(
+			(int) $session_id,
+			$this->admin_id,
+			[
+				'scope'   => 'Safely update the site navigation.',
+				'summary' => 'Four bounded phases.',
+				'steps'   => $this->steps(),
+			]
+		);
+		$this->assertIsArray( $plan );
+
+		return $plan;
+	}
+
+	/**
+	 * @return list<array<string, string>>
+	 */
+	private function steps(): array {
+		return [
+			[
+				'key'               => 'inspect',
+				'title'             => 'Inspect current navigation',
+				'instruction'       => 'Inspect the current navigation configuration only.',
+				'classification'    => 'read',
+				'idempotency_key'   => 'inspect-navigation',
+				'preconditions'     => 'Administrator session available.',
+				'expected_evidence' => 'A summary of existing navigation.',
+				'rollback_guidance' => 'No rollback is required.',
+			],
+			[
+				'key'               => 'configure',
+				'title'             => 'Configure navigation',
+				'instruction'       => 'Apply the reviewed navigation configuration.',
+				'classification'    => 'write',
+				'idempotency_key'   => 'configure-navigation',
+				'preconditions'     => 'Inspection evidence reviewed.',
+				'expected_evidence' => 'Configuration change confirmation.',
+				'rollback_guidance' => 'Restore the prior navigation configuration.',
+			],
+			[
+				'key'               => 'verify',
+				'title'             => 'Verify navigation',
+				'instruction'       => 'Verify the navigation output without modifying the site.',
+				'classification'    => 'read',
+				'idempotency_key'   => 'verify-navigation',
+				'preconditions'     => 'Configuration phase completed.',
+				'expected_evidence' => 'Verification result.',
+				'rollback_guidance' => 'No rollback is required.',
+			],
+			[
+				'key'               => 'publish',
+				'title'             => 'Publish navigation',
+				'instruction'       => 'Publish the reviewed navigation changes.',
+				'classification'    => 'destructive',
+				'idempotency_key'   => 'publish-navigation',
+				'preconditions'     => 'Verification evidence reviewed.',
+				'expected_evidence' => 'Publication confirmation.',
+				'rollback_guidance' => 'Restore the previously published navigation.',
+			],
+		];
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	private function prepare( string $plan_id ): array {
+		$outcome = DurablePlanRunner::prepare_next( $plan_id, $this->admin_id );
+		$this->assertIsArray( $outcome );
+		$this->assertSame( 'ready', $outcome['status'] );
+
+		return $outcome;
+	}
+
+	/**
+	 * @param array<string, mixed> $outcome Ready phase outcome.
+	 */
+	private function assign_job( string $plan_id, array $outcome, string $job_id ): void {
+		$this->assertTrue( DurablePlanRunner::assign_job( $plan_id, (int) $outcome['step']['id'], $job_id ) );
+	}
+
+	/**
+	 * @param array<string, mixed> $outcome Ready phase outcome.
+	 * @return array<string, mixed>
+	 */
+	private function complete( string $plan_id, array $outcome, string $summary ): array {
+		$plan = DurablePlanRunner::complete_phase(
+			$plan_id,
+			(int) $outcome['step']['id'],
+			[
+				'reply'       => $summary,
+				'exit_reason' => 'complete',
+				'token_usage' => [ 'prompt' => 4, 'completion' => 2 ],
+			]
+		);
+		$this->assertIsArray( $plan );
+
+		return $plan;
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	private function approve_and_prepare( string $plan_id, int $approval_id ): array {
+		$outcome = DurablePlanRunner::approve( $plan_id, $approval_id, $this->admin_id );
+		$this->assertIsArray( $outcome );
+		$this->assertSame( 'ready', $outcome['status'] );
+
+		return $outcome;
+	}
+
+	/**
+	 * @param array<string, mixed> $plan Public plan record.
+	 * @return array<string, mixed>
+	 */
+	private function step( array $plan, string $key ): array {
+		foreach ( $plan['steps'] as $step ) {
+			if ( is_array( $step ) && $key === (string) ( $step['key'] ?? $step['step_key'] ?? '' ) ) {
+				return $step;
+			}
+		}
+
+		$this->fail( "Missing durable plan step '{$key}'." );
+
+		return [];
+	}
+}

--- a/tests/SdAiAgent/REST/SessionControllerTest.php
+++ b/tests/SdAiAgent/REST/SessionControllerTest.php
@@ -323,6 +323,86 @@ class SessionControllerTest extends WP_UnitTestCase {
 		$this->assertSame( 'processing', $active_job->get_data()['status'] );
 	}
 
+	/** Job polling keeps durable plan details scoped to the job owner. */
+	public function test_job_status_hides_durable_plan_details_from_other_administrators(): void {
+		$session_id = $this->create_session();
+		$plan       = DurablePlanRunner::create( $session_id, $this->admin_id, $this->plan_definition() );
+		$this->assertIsArray( $plan );
+		$next = DurablePlanRunner::prepare_next( (string) $plan['plan_id'], $this->admin_id );
+		$this->assertIsArray( $next );
+		$this->assertSame( 'ready', $next['status'] );
+
+		$job_id = '00000000-0000-4000-8000-000000000101';
+		$this->assertNotFalse( ActiveJobRepository::create( $session_id, $job_id, $this->admin_id, 'queued' ) );
+		$this->assertTrue( DurablePlanRunner::assign_job( (string) $plan['plan_id'], (int) $next['step']['id'], $job_id ) );
+		$public_plan = DurablePlanRunner::public_plan( (string) $plan['plan_id'] );
+		$this->assertIsArray( $public_plan );
+
+		set_transient(
+			RestController::JOB_PREFIX . $job_id,
+			[
+				'status'       => 'processing',
+				'user_id'      => $this->admin_id,
+				'durable_plan' => [ 'plan' => $public_plan ],
+			],
+			RestController::JOB_TTL
+		);
+
+		$owner_inline = $this->dispatch( 'GET', "/sd-ai-agent/v1/job/{$job_id}" );
+		$this->assert_status( 200, $owner_inline );
+		$this->assertArrayHasKey( 'durable_plan', $owner_inline->get_data() );
+
+		wp_set_current_user( $this->other_admin_id );
+		$other_inline = $this->dispatch( 'GET', "/sd-ai-agent/v1/job/{$job_id}" );
+		$this->assert_status( 200, $other_inline );
+		$this->assertArrayNotHasKey( 'durable_plan', $other_inline->get_data() );
+
+		delete_transient( RestController::JOB_PREFIX . $job_id );
+		wp_set_current_user( $this->admin_id );
+		$owner_fallback = $this->dispatch( 'GET', "/sd-ai-agent/v1/job/{$job_id}" );
+		$this->assert_status( 200, $owner_fallback );
+		$this->assertArrayHasKey( 'durable_plan', $owner_fallback->get_data() );
+
+		wp_set_current_user( $this->other_admin_id );
+		$other_fallback = $this->dispatch( 'GET', "/sd-ai-agent/v1/job/{$job_id}" );
+		$this->assert_status( 200, $other_fallback );
+		$this->assertArrayNotHasKey( 'durable_plan', $other_fallback->get_data() );
+
+		ActiveJobRepository::delete( $job_id );
+	}
+
+	/** A stale confirmation cannot return a claimed durable worker to the queue. */
+	public function test_stale_durable_confirmation_does_not_requeue_an_active_worker(): void {
+		$job_id = '00000000-0000-4000-8000-000000000102';
+		$this->assertNotFalse( ActiveJobRepository::create( $this->create_session(), $job_id, $this->admin_id, 'processing' ) );
+		set_transient(
+			RestController::JOB_PREFIX . $job_id,
+			[
+				'status'  => 'awaiting_confirmation',
+				'user_id' => $this->admin_id,
+				'params'  => [
+					'durable_plan_phase' => [
+						'plan_id' => '00000000-0000-0000-0000-000000000001',
+						'step_id' => 1,
+					],
+				],
+			],
+			RestController::JOB_TTL
+		);
+
+		$response = $this->dispatch( 'POST', "/sd-ai-agent/v1/job/{$job_id}/confirm" );
+		$this->assert_status( 409, $response );
+		if ( is_wp_error( $response ) ) {
+			$this->assertSame( 'sd_ai_agent_job_not_resumable', $response->get_error_code() );
+		}
+
+		$row = ActiveJobRepository::get_by_job_id( $job_id );
+		$this->assertNotNull( $row );
+		$this->assertSame( 'processing', $row->status );
+		delete_transient( RestController::JOB_PREFIX . $job_id );
+		ActiveJobRepository::delete( $job_id );
+	}
+
 	/** Expired durable confirmation pauses update their associated plan state. */
 	public function test_expired_paused_durable_job_updates_its_plan_state(): void {
 		$session_id = $this->create_session();

--- a/tests/SdAiAgent/REST/SessionControllerTest.php
+++ b/tests/SdAiAgent/REST/SessionControllerTest.php
@@ -1,0 +1,448 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Integration tests for session-scoped durable plan REST endpoints.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests\REST
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\REST;
+
+use SdAiAgent\Core\Database;
+use SdAiAgent\Core\DurablePlanRunner;
+use SdAiAgent\Models\ActiveJobRepository;
+use SdAiAgent\Models\DurablePlanRepository;
+use SdAiAgent\REST\RestController;
+use WP_REST_Request;
+use WP_REST_Server;
+use WP_UnitTestCase;
+
+class SessionControllerTest extends WP_UnitTestCase {
+
+	protected WP_REST_Server $server;
+
+	private int $admin_id;
+
+	private int $other_admin_id;
+
+	public function set_up(): void {
+		// REST registration must happen before parent::set_up() snapshots hooks.
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Standard WordPress test global.
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Standard WordPress REST action.
+		do_action( 'rest_api_init' );
+
+		parent::set_up();
+		Database::install();
+		$this->admin_id       = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		$this->other_admin_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $this->admin_id );
+
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test cleanup for custom plan tables.
+		$wpdb->query( $wpdb->prepare( 'DELETE FROM %i', DurablePlanRepository::steps_table_name() ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test cleanup for custom plan tables.
+		$wpdb->query( $wpdb->prepare( 'DELETE FROM %i', DurablePlanRepository::table_name() ) );
+	}
+
+	public function tear_down(): void {
+		// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Standard WordPress test global.
+		global $wp_rest_server;
+		$wp_rest_server = null;
+
+		parent::tear_down();
+	}
+
+	/** Durable-plan routes remain private session endpoints. */
+	public function test_durable_plan_routes_are_registered(): void {
+		$routes = $this->server->get_routes();
+		foreach (
+			[
+				'/sd-ai-agent/v1/sessions/(?P<id>\d+)/plan',
+				'/sd-ai-agent/v1/sessions/(?P<id>\d+)/plan/status',
+				'/sd-ai-agent/v1/sessions/(?P<id>\d+)/plan/continue',
+				'/sd-ai-agent/v1/sessions/(?P<id>\d+)/plan/approve',
+				'/sd-ai-agent/v1/sessions/(?P<id>\d+)/plan/reject',
+				'/sd-ai-agent/v1/sessions/(?P<id>\d+)/plan/retry',
+				'/sd-ai-agent/v1/sessions/(?P<id>\d+)/plan/cancel',
+				'/sd-ai-agent/v1/sessions/(?P<id>\d+)/plan/scope',
+			] as $route
+		) {
+			$this->assertArrayHasKey( $route, $routes, "Route {$route} should be registered." );
+		}
+	}
+
+	/** A plan remains outside session messages and a pending scope blocks continue. */
+	public function test_create_status_and_scope_approval_are_session_bound(): void {
+		$session_id = $this->create_session();
+		$created    = $this->dispatch(
+			'POST',
+			"/sd-ai-agent/v1/sessions/{$session_id}/plan",
+			$this->plan_definition()
+		);
+		$this->assert_status( 201, $created );
+		$plan = $created->get_data()['plan'];
+		$this->assertSame( 'pending', $plan['status'] );
+		$this->assertCount( 2, $plan['steps'] );
+		$this->assertArrayNotHasKey( 'idempotency_key', $plan['steps'][0] );
+
+		$session = Database::get_session( $session_id );
+		$this->assertNotNull( $session );
+		$this->assertSame( '[]', $session->messages );
+
+		$status = $this->dispatch( 'GET', "/sd-ai-agent/v1/sessions/{$session_id}/plan" );
+		$this->assert_status( 200, $status );
+		$this->assertSame( $plan['plan_id'], $status->get_data()['plan']['plan_id'] );
+
+		$scope = $this->dispatch(
+			'POST',
+			"/sd-ai-agent/v1/sessions/{$session_id}/plan/scope",
+			[
+				'plan_id' => $plan['plan_id'],
+				'scope'   => 'Also update the production footer.',
+			]
+		);
+		$this->assert_status( 200, $scope );
+		$this->assertSame( 'awaiting_approval', $scope->get_data()['status'] );
+
+		$continue = $this->dispatch(
+			'POST',
+			"/sd-ai-agent/v1/sessions/{$session_id}/plan/continue",
+			[ 'plan_id' => $plan['plan_id'] ]
+		);
+		$this->assert_status( 200, $continue );
+		$this->assertSame( 'awaiting_approval', $continue->get_data()['status'] );
+		$this->assertSame( 'pending', $continue->get_data()['plan']['steps'][0]['status'] );
+
+		$approved = $this->dispatch(
+			'POST',
+			"/sd-ai-agent/v1/sessions/{$session_id}/plan/approve",
+			[
+				'plan_id'             => $plan['plan_id'],
+				'approval_request_id' => $scope->get_data()['plan']['approval_request_id'],
+			]
+		);
+		$this->assert_status( 200, $approved );
+		$this->assertSame( 'pending', $approved->get_data()['status'] );
+		$this->assertSame( 'Also update the production footer.', $approved->get_data()['plan']['scope'] );
+	}
+
+	/** Shared-session permissions do not allow another administrator to create a plan. */
+	public function test_other_administrator_cannot_create_plan_for_session_owner(): void {
+		$session_id = $this->create_session();
+		wp_set_current_user( $this->other_admin_id );
+
+		$response = $this->dispatch(
+			'POST',
+			"/sd-ai-agent/v1/sessions/{$session_id}/plan",
+			$this->plan_definition()
+		);
+
+		$this->assert_status( 403, $response );
+	}
+
+	/** Shared-session access never grants another administrator plan mutation rights. */
+	public function test_shared_administrator_cannot_mutate_durable_plan(): void {
+		$session_id = $this->create_session();
+		$created    = $this->dispatch(
+			'POST',
+			"/sd-ai-agent/v1/sessions/{$session_id}/plan",
+			$this->plan_definition()
+		);
+		$this->assert_status( 201, $created );
+		$plan_id = (string) $created->get_data()['plan']['plan_id'];
+		$this->assertTrue( Database::share_session( $session_id, $this->admin_id ) );
+
+		wp_set_current_user( $this->other_admin_id );
+		$requests = [
+			[ 'plan', $this->plan_definition() ],
+			[ 'plan/continue', [ 'plan_id' => $plan_id ] ],
+			[ 'plan/approve', [ 'plan_id' => $plan_id, 'approval_request_id' => 1 ] ],
+			[ 'plan/reject', [ 'plan_id' => $plan_id, 'approval_request_id' => 1 ] ],
+			[ 'plan/retry', [ 'plan_id' => $plan_id ] ],
+			[ 'plan/cancel', [ 'plan_id' => $plan_id ] ],
+			[ 'plan/scope', [ 'plan_id' => $plan_id, 'scope' => 'Change the approved scope.' ] ],
+		];
+
+		foreach ( $requests as [ $suffix, $params ] ) {
+			$response = $this->dispatch( 'POST', "/sd-ai-agent/v1/sessions/{$session_id}/{$suffix}", $params );
+			$this->assert_status( 403, $response );
+		}
+	}
+
+	/** Browser-supplied phase metadata cannot disable durable approval safeguards. */
+	public function test_client_plan_metadata_cannot_disable_approval_or_safe_resume(): void {
+		$session_id = $this->create_session();
+		$definition = $this->plan_definition();
+		$definition['steps'][0]['classification']      = 'read';
+		$definition['steps'][0]['idempotency_key']     = 'browser-controlled-key';
+		$definition['steps'][0]['requires_approval']   = false;
+		$definition['steps'][0]['safe_to_resume']      = true;
+
+		$created = $this->dispatch(
+			'POST',
+			"/sd-ai-agent/v1/sessions/{$session_id}/plan",
+			$definition
+		);
+		$this->assert_status( 201, $created );
+		$plan = $created->get_data()['plan'];
+
+		$stored = DurablePlanRepository::get_by_plan_id( (string) $plan['plan_id'] );
+		$this->assertIsArray( $stored );
+		$this->assertSame( 1, $stored['steps'][0]['requires_approval'] );
+		$this->assertSame( 0, $stored['steps'][0]['safe_to_resume'] );
+		$this->assertNotSame( 'browser-controlled-key', $stored['steps'][0]['idempotency_key'] );
+
+		$continue = $this->dispatch(
+			'POST',
+			"/sd-ai-agent/v1/sessions/{$session_id}/plan/continue",
+			[ 'plan_id' => $plan['plan_id'] ]
+		);
+		$this->assert_status( 200, $continue );
+		$this->assertSame( 'awaiting_approval', $continue->get_data()['status'] );
+	}
+
+	/** Planning jobs are session-owner-only and carry the server-recognised planning flag. */
+	public function test_durable_plan_run_is_session_owner_only_and_marks_the_job(): void {
+		$session_id     = $this->create_session();
+		$block_loopback = static function () {
+			return [
+				'headers'  => [],
+				'body'     => '',
+				'response' => [ 'code' => 200, 'message' => 'OK' ],
+				'cookies'  => [],
+				'filename' => null,
+			];
+		};
+		add_filter( 'pre_http_request', $block_loopback, 10, 3 );
+		try {
+			$response = $this->dispatch(
+				'POST',
+				'/sd-ai-agent/v1/run',
+				[
+					'message'      => 'Prepare a phased plan to review site navigation.',
+					'session_id'   => $session_id,
+					'durable_plan' => true,
+					'attachments'  => [
+						[
+							'name'     => 'planner-attachment.txt',
+							'type'     => 'text/plain',
+							'data_url' => 'data:text/plain;base64,cGxhbm5lciBhdHRhY2htZW50',
+							'is_image' => false,
+						],
+					],
+				]
+			);
+		} finally {
+			remove_filter( 'pre_http_request', $block_loopback, 10 );
+		}
+
+		$this->assert_status( 202, $response );
+		$job_id = (string) $response->get_data()['job_id'];
+		$job    = get_transient( RestController::JOB_PREFIX . $job_id );
+		$this->assertIsArray( $job );
+		$this->assertTrue( $job['params']['durable_plan'] );
+		$this->assertSame( [], $job['params']['attachments'] );
+		$active_job = ActiveJobRepository::get_by_job_id( $job_id );
+		$this->assertNotNull( $active_job );
+		$this->assertSame( 'queued', $active_job->status );
+
+		delete_transient( RestController::JOB_PREFIX . $job_id );
+		ActiveJobRepository::delete( $job_id );
+
+		wp_set_current_user( $this->other_admin_id );
+		$forbidden = $this->dispatch(
+			'POST',
+			'/sd-ai-agent/v1/run',
+			[
+				'message'      => 'Prepare a phased plan to review site navigation.',
+				'session_id'   => $session_id,
+				'durable_plan' => true,
+			]
+		);
+		$this->assert_status( 403, $forbidden );
+	}
+
+	/** A durable phase remains queued in storage until its worker claims it. */
+	public function test_durable_plan_continue_queues_the_worker_until_process_claims_it(): void {
+		$session_id = $this->create_session();
+		$created    = $this->dispatch(
+			'POST',
+			"/sd-ai-agent/v1/sessions/{$session_id}/plan",
+			$this->plan_definition()
+		);
+		$this->assert_status( 201, $created );
+		$plan_id = (string) $created->get_data()['plan']['plan_id'];
+		$awaiting = $this->dispatch(
+			'POST',
+			"/sd-ai-agent/v1/sessions/{$session_id}/plan/continue",
+			[ 'plan_id' => $plan_id ]
+		);
+		$this->assert_status( 200, $awaiting );
+		$this->assertSame( 'awaiting_approval', $awaiting->get_data()['status'] );
+
+		$block_loopback = static function () {
+			return [
+				'headers'  => [],
+				'body'     => '',
+				'response' => [ 'code' => 200, 'message' => 'OK' ],
+				'cookies'  => [],
+				'filename' => null,
+			];
+		};
+		add_filter( 'pre_http_request', $block_loopback, 10, 3 );
+		try {
+			$response = $this->dispatch(
+				'POST',
+				"/sd-ai-agent/v1/sessions/{$session_id}/plan/approve",
+				[
+					'plan_id'             => $plan_id,
+					'approval_request_id' => $awaiting->get_data()['plan']['approval_request_id'],
+				]
+			);
+		} finally {
+			remove_filter( 'pre_http_request', $block_loopback, 10 );
+		}
+
+		$this->assert_status( 202, $response );
+		$this->assertSame( 'processing', $response->get_data()['status'] );
+		$job_id = (string) $response->get_data()['job_id'];
+		$job    = ActiveJobRepository::get_by_job_id( $job_id );
+
+		$this->assertNotNull( $job );
+		$this->assertSame( 'queued', $job->status );
+
+		$active_job = $this->dispatch( 'GET', "/sd-ai-agent/v1/sessions/{$session_id}/active-job" );
+		$this->assert_status( 200, $active_job );
+		$this->assertSame( 'processing', $active_job->get_data()['status'] );
+	}
+
+	/** Expired durable confirmation pauses update their associated plan state. */
+	public function test_expired_paused_durable_job_updates_its_plan_state(): void {
+		$session_id = $this->create_session();
+		$cases      = [
+			[ 'classification' => 'read', 'plan_status' => 'pending', 'step_status' => 'interrupted' ],
+			[ 'classification' => 'write', 'plan_status' => 'blocked', 'step_status' => 'failed' ],
+		];
+
+		foreach ( $cases as $index => $case ) {
+			$plan = DurablePlanRunner::create(
+				$session_id,
+				$this->admin_id,
+				[
+					'scope' => 'Test expired paused durable job recovery.',
+					'steps' => [
+						[
+							'key'            => 'paused-' . $case['classification'],
+							'title'          => 'Paused ' . $case['classification'] . ' phase',
+							'instruction'    => 'Execute only this bounded test phase.',
+							'classification' => $case['classification'],
+						],
+					],
+				]
+			);
+			$this->assertIsArray( $plan );
+			$next = DurablePlanRunner::prepare_next( (string) $plan['plan_id'], $this->admin_id );
+			$this->assertIsArray( $next );
+			if ( 'awaiting_approval' === $next['status'] ) {
+				$next = DurablePlanRunner::approve( (string) $plan['plan_id'], (int) $next['plan']['approval_request_id'], $this->admin_id );
+				$this->assertIsArray( $next );
+			}
+			$this->assertSame( 'ready', $next['status'] );
+
+			$job_id = 'test-expired-paused-plan-' . $index;
+			$this->assertNotFalse( ActiveJobRepository::create( $session_id, $job_id, $this->admin_id, 'awaiting_confirmation' ) );
+			$this->assertTrue( DurablePlanRunner::assign_job( (string) $plan['plan_id'], (int) $next['step']['id'], $job_id ) );
+
+			$expired = $this->dispatch( 'GET', "/sd-ai-agent/v1/sessions/{$session_id}/active-job" );
+			$this->assert_status( 404, $expired );
+			$this->assertNull( ActiveJobRepository::get_by_job_id( $job_id ) );
+
+			$updated = DurablePlanRepository::get_by_plan_id( (string) $plan['plan_id'] );
+			$this->assertIsArray( $updated );
+			$this->assertSame( $case['plan_status'], $updated['status'] );
+			$this->assertSame( $case['step_status'], $updated['steps'][0]['status'] );
+		}
+	}
+
+	/**
+	 * @return \WP_REST_Response|\WP_Error
+	 */
+	private function dispatch( string $method, string $route, array $params = [] ) {
+		$request = new WP_REST_Request( $method, $route );
+		if ( in_array( $method, [ 'POST', 'PATCH', 'PUT' ], true ) ) {
+			$request->set_body( wp_json_encode( $params ) );
+			$request->set_header( 'Content-Type', 'application/json' );
+		} else {
+			$request->set_query_params( $params );
+		}
+
+		return $this->server->dispatch( $request );
+	}
+
+	/**
+	 * @param \WP_REST_Response|\WP_Error $response REST response.
+	 */
+	private function assert_status( int $expected, $response ): void {
+		if ( is_wp_error( $response ) ) {
+			$data   = $response->get_error_data();
+			$status = is_array( $data ) ? (int) ( $data['status'] ?? 0 ) : 0;
+		} else {
+			$status = $response->get_status();
+		}
+
+		$this->assertSame( $expected, $status, "Expected HTTP {$expected}, got {$status}." );
+	}
+
+	private function create_session(): int {
+		$session_id = Database::create_session(
+			[
+				'user_id'     => $this->admin_id,
+				'title'       => 'Durable REST plan test',
+				'provider_id' => 'test-provider',
+				'model_id'    => 'test-model',
+			]
+		);
+		$this->assertIsInt( $session_id );
+
+		return (int) $session_id;
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	private function plan_definition(): array {
+		return [
+			'scope'   => 'Review and update the site navigation.',
+			'summary' => 'Inspect before applying the reviewed update.',
+			'steps'   => [
+				[
+					'key'               => 'inspect',
+					'title'             => 'Inspect navigation',
+					'instruction'       => 'Inspect the current navigation without making changes.',
+					'classification'    => 'read',
+					'idempotency_key'   => 'rest-inspect-navigation',
+					'preconditions'     => 'Administrator session available.',
+					'expected_evidence' => 'Navigation inventory.',
+					'rollback_guidance' => 'No rollback required.',
+				],
+				[
+					'key'               => 'configure',
+					'title'             => 'Configure navigation',
+					'instruction'       => 'Apply the reviewed navigation update.',
+					'classification'    => 'write',
+					'idempotency_key'   => 'rest-configure-navigation',
+					'preconditions'     => 'Inspection evidence reviewed.',
+					'expected_evidence' => 'Configuration confirmation.',
+					'rollback_guidance' => 'Restore the prior navigation.',
+				],
+			],
+		];
+	}
+}


### PR DESCRIPTION
## Summary

- Adds an opt-in durable runner for phased site operations with persisted plan and phase state.
- Stores compact, redacted evidence independently of chat transcripts and raw tool payloads.
- Adds explicit first-phase and scope-expansion approvals plus pause, resume, cancel, retry, expiry, and safe recovery paths.
- Exposes durable-plan lifecycle actions through the session REST API and chat action cards.
- Hardens review findings for phase-key validation, owner-scoped plan polling, conditional confirmation requeue, terminal error cleanup, and deferred-message options.

## Risk and decisions

- **Runtime risk:** High — introduces persisted state-machine and REST lifecycle behaviour.
- **Safety:** Consequential phases and expanded scopes always require explicit user confirmation.
- **Data handling:** Durable records retain structured outputs and evidence only; raw transcripts and tool payloads are excluded.

## Worker self-verification

- PHPUnit: Tests: 4023, Assertions: 17970, Errors: 0, Failures: 0, Skipped: 134, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Runtime: Full WordPress PHPUnit suite passed; `wp-env start` browser-smoke setup was attempted but blocked by a local Docker overlayfs snapshot error.

Resolves #2355

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.192 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-terra spent 32m and 455,874 tokens on this as a headless worker. Overall, 9h 51m since this issue was created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added phased site-operation plans through the `/plan` command.
  * Plans now display summaries, scopes, phases, evidence, rollback guidance, and current status.
  * Added controls to approve, reject, continue, retry, cancel, and request scope changes.
  * Added durable plan status and action endpoints with session ownership protections.

* **Bug Fixes**
  * Improved handling of queued and interrupted jobs, including safer recovery of stale work.
  * Sensitive credentials are redacted from stored plan details and execution evidence.

* **Tests**
  * Added coverage for plan workflows, approvals, authorization, recovery, and UI actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
