### PR TITLE
fix: skip floating widget rendering in iframes

### DIFF
--- a/src/floating-widget/index.js
+++ b/src/floating-widget/index.js
@@ -376,14 +376,17 @@ function gatherPageContext() {
 	return context;
 }
 
-// Mount the floating widget.
-const wrapper = document.createElement( 'div' );
-wrapper.id = 'sdaa-floating-root';
-document.body.appendChild( wrapper );
+// Admin shell plugins can load WordPress screens in an iframe. The parent
+// screen owns the floating widget, so avoid rendering a duplicate in the frame.
+if ( window.self === window.top ) {
+	const wrapper = document.createElement( 'div' );
+	wrapper.id = 'sdaa-floating-root';
+	document.body.appendChild( wrapper );
 
-const root = createRoot( wrapper );
-root.render(
-	<ErrorBoundary label={ __( 'AI Agent widget', 'sd-ai-agent' ) }>
-		<FloatingWidget />
-	</ErrorBoundary>
-);
+	const root = createRoot( wrapper );
+	root.render(
+		<ErrorBoundary label={ __( 'AI Agent widget', 'sd-ai-agent' ) }>
+			<FloatingWidget />
+		</ErrorBoundary>
+	);
+}

--- a/src/floating-widget/index.js
+++ b/src/floating-widget/index.js
@@ -385,7 +385,7 @@ if ( window.self === window.top ) {
 
 	const root = createRoot( wrapper );
 	root.render(
-		<ErrorBoundary label={ __( 'AI Agent widget', 'sd-ai-agent' ) }>
+		<ErrorBoundary label={ __( 'AI Agent widget', 'superdav-ai-agent' ) }>
 			<FloatingWidget />
 		</ErrorBoundary>
 	);


### PR DESCRIPTION
## Summary

Prevent the floating AI Agent chat widget from mounting inside an iframe, so admin-shell integrations render only the parent-page widget.

## Implementation

- `src/floating-widget/index.js`: mount `#sdaa-floating-root` only when the current window is the top-level browsing context.

## Verification

- `npm run lint:js -- --no-cache`
- `npm run build`
- Production artifact contains `window.self===window.top`; the plugin is network-active and the public site returns HTTP 200.

## Review context

Review `src/floating-widget/index.js` at the entry-point mount. The guard must preserve normal top-level admin and frontend rendering while omitting the iframe root entirely.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.194 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-terra spent 12m and 113,546 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate floating widgets from appearing when screens are embedded in an iframe.
  * The widget now displays only in the top-level window and remains hidden within embedded frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->