### PR TITLE
GH#2371: bound stale active-job reaping

### DIFF
--- a/includes/Models/ActiveJobRepository.php
+++ b/includes/Models/ActiveJobRepository.php
@@ -458,12 +458,13 @@ class ActiveJobRepository {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 
-		$table  = self::table_name();
-		$reaped = array();
+		$table     = self::table_name();
+		$reaped    = array();
+		$row_count = 0;
 
 		do {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded custom-table candidate discovery is followed by per-row conditional claims.
-			$rows = $wpdb->get_results(
+			$rows      = $wpdb->get_results(
 				$wpdb->prepare(
 					"SELECT id, session_id, job_id, user_id, checkpoint_phase, resume_attempts FROM %i WHERE status IN ('queued', 'processing') AND updated_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL %d MINUTE) LIMIT %d",
 					$table,
@@ -471,6 +472,7 @@ class ActiveJobRepository {
 					self::STALE_REAP_BATCH_SIZE
 				)
 			);
+			$row_count = count( $rows ?: array() );
 
 			foreach ( $rows ?: array() as $raw_row ) {
 				$row        = ActiveJobRow::from_row( $raw_row );
@@ -495,7 +497,7 @@ class ActiveJobRepository {
 					ActiveJobFailureDiagnostic::log( $diagnostic, $row->session_id );
 				}
 			}
-		} while ( count( $rows ?: array() ) === self::STALE_REAP_BATCH_SIZE );
+		} while ( $row_count === self::STALE_REAP_BATCH_SIZE );
 
 		return $reaped;
 	}

--- a/includes/Models/ActiveJobRepository.php
+++ b/includes/Models/ActiveJobRepository.php
@@ -32,6 +32,9 @@ class ActiveJobRepository {
 	 */
 	const STATUSES = [ 'queued', 'processing', 'awaiting_confirmation', 'awaiting_client_tools', 'complete', 'error', 'interrupted', 'abandoned' ];
 
+	/** Maximum stale jobs claimed per candidate-query batch. */
+	private const STALE_REAP_BATCH_SIZE = 500;
+
 	/**
 	 * Get the active jobs table name.
 	 */
@@ -455,40 +458,44 @@ class ActiveJobRepository {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 
-		$table = self::table_name();
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Candidate discovery is followed by per-row conditional claims.
-		$rows   = $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT * FROM %i WHERE status IN ('queued', 'processing') AND updated_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL %d MINUTE)",
-				$table,
-				$threshold_minutes
-			)
-		);
+		$table  = self::table_name();
 		$reaped = array();
 
-		foreach ( $rows ?: array() as $raw_row ) {
-			$row        = ActiveJobRow::from_row( $raw_row );
-			$diagnostic = self::build_failure_diagnostic(
-				$row->job_id,
-				ActiveJobFailureDiagnostic::REASON_WORKER_TERMINATED,
-				$row
-			);
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Conditional custom-table state transition prevents stale candidate races.
-			$result = $wpdb->query(
+		do {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded custom-table candidate discovery is followed by per-row conditional claims.
+			$rows = $wpdb->get_results(
 				$wpdb->prepare(
-					"UPDATE %i SET status = 'abandoned', error = %s, updated_at = UTC_TIMESTAMP() WHERE job_id = %s AND status IN ('queued', 'processing') AND updated_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL %d MINUTE)",
+					"SELECT id, session_id, job_id, user_id, checkpoint_phase, resume_attempts FROM %i WHERE status IN ('queued', 'processing') AND updated_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL %d MINUTE) LIMIT %d",
 					$table,
-					ActiveJobFailureDiagnostic::encode( $row->job_id, $diagnostic ),
-					$row->job_id,
-					$threshold_minutes
+					$threshold_minutes,
+					self::STALE_REAP_BATCH_SIZE
 				)
 			);
 
-			if ( $result !== false && $result > 0 ) {
-				$reaped[] = $row->job_id;
-				ActiveJobFailureDiagnostic::log( $diagnostic, $row->session_id );
+			foreach ( $rows ?: array() as $raw_row ) {
+				$row        = ActiveJobRow::from_row( $raw_row );
+				$diagnostic = self::build_failure_diagnostic(
+					$row->job_id,
+					ActiveJobFailureDiagnostic::REASON_WORKER_TERMINATED,
+					$row
+				);
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Conditional custom-table state transition prevents stale candidate races.
+				$result = $wpdb->query(
+					$wpdb->prepare(
+						"UPDATE %i SET status = 'abandoned', error = %s, updated_at = UTC_TIMESTAMP() WHERE job_id = %s AND status IN ('queued', 'processing') AND updated_at < DATE_SUB(UTC_TIMESTAMP(), INTERVAL %d MINUTE)",
+						$table,
+						ActiveJobFailureDiagnostic::encode( $row->job_id, $diagnostic ),
+						$row->job_id,
+						$threshold_minutes
+					)
+				);
+
+				if ( $result !== false && $result > 0 ) {
+					$reaped[] = $row->job_id;
+					ActiveJobFailureDiagnostic::log( $diagnostic, $row->session_id );
+				}
 			}
-		}
+		} while ( count( $rows ?: array() ) === self::STALE_REAP_BATCH_SIZE );
 
 		return $reaped;
 	}

--- a/tests/SdAiAgent/Core/ActiveJobsCleanupTest.php
+++ b/tests/SdAiAgent/Core/ActiveJobsCleanupTest.php
@@ -315,6 +315,25 @@ class ActiveJobsCleanupTest extends WP_UnitTestCase {
 		$this->assertSame( 'abandoned', $row->status );
 	}
 
+	/** cleanup_stale() continues through bounded candidate-query batches. */
+	public function test_cleanup_stale_reaps_more_than_one_candidate_batch(): void {
+		$stale_time = gmdate( 'Y-m-d H:i:s', time() - 1800 );
+
+		for ( $index = 1; $index <= 501; ++$index ) {
+			$this->insert_job( "test-stale-batch-{$index}", 'processing', $stale_time );
+		}
+
+		$count = ActiveJobRepository::cleanup_stale( 15 );
+		$first = $this->fetch_row( 'test-stale-batch-1' );
+		$last  = $this->fetch_row( 'test-stale-batch-501' );
+
+		$this->assertSame( 501, $count );
+		$this->assertNotNull( $first );
+		$this->assertNotNull( $last );
+		$this->assertSame( 'abandoned', $first->status );
+		$this->assertSame( 'abandoned', $last->status );
+	}
+
 	/**
 	 * cleanup_stale() does NOT touch rows whose updated_at is within the threshold.
 	 */


### PR DESCRIPTION
## Summary

- Bound stale active-job cleanup candidate queries to 500 rows per batch.
- Exclude serialized checkpoints from the cleanup query while retaining diagnostic metadata.
- Add coverage for processing more than one candidate-query batch.

## Testing

- `npm run verify`
- `npm run test:php -- --filter=ActiveJobsCleanupTest`

## Runtime Testing

- Runtime-verified against the WordPress PHPUnit database environment.

## Worker self-verification

- PHPUnit: Tests: 4024, Assertions: 17975, Errors: 0, Failures: 0, Skipped: 134
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Resolves #2371

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.194 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-terra spent 12m and 128,680 tokens on this as a headless worker. Overall, 29m since this issue was created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stale-job cleanup to process large numbers of abandoned jobs reliably.
  * Ensured cleanup continues across multiple batches and correctly marks all eligible jobs as abandoned.

* **Tests**
  * Added coverage for cleanup scenarios involving more than 500 stale jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->