### PR TITLE
GH#2370: reserve checkpoint envelope capacity

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -1075,9 +1075,13 @@ PROMPT;
 		$request_tokens = ! empty( $history )
 			? ConversationTrimmer::estimate_total_tokens( $history )
 			: (int) ceil( $request_bytes / 4 );
-		$byte_budget    = ConversationTrimmer::get_request_byte_budget( $provider_id, $model_id );
-		$token_budget   = ConversationTrimmer::get_request_token_budget( $provider_id, $model_id );
-		$fingerprint    = hash(
+		// Checkpoint history shares the same full-envelope reserve as transport
+		// preflight. The provider body also contains system instructions, ability
+		// schemas, page context, model options, and framing that are not present
+		// in serialized history.
+		$byte_budget  = ConversationTrimmer::get_request_envelope_byte_budget( $provider_id, $model_id );
+		$token_budget = ConversationTrimmer::get_request_token_budget( $provider_id, $model_id );
+		$fingerprint  = hash(
 			'sha256',
 			(string) wp_json_encode(
 				array(

--- a/src/components/chat-redesign/__tests__/MessageList.test.js
+++ b/src/components/chat-redesign/__tests__/MessageList.test.js
@@ -256,7 +256,7 @@ describe( 'MessageList stream error banner', () => {
 
 		expect( container.querySelector( '.sdaa-cr-error-banner' ) ).toBeNull();
 		const compactButton = container.querySelector(
-			'.sdaa-action-card-btn-confirm'
+			'.sd-ai-agent-compact-conversation-action-card__confirm'
 		);
 		expect( compactButton.textContent ).toBe( 'Compact and continue' );
 
@@ -293,7 +293,9 @@ describe( 'MessageList stream error banner', () => {
 
 		await act( async () => {
 			container
-				.querySelector( '.sdaa-action-card-btn-confirm' )
+				.querySelector(
+					'.sd-ai-agent-compact-conversation-action-card__confirm'
+				)
 				.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
 		} );
 

--- a/src/components/compact-conversation-action-card.js
+++ b/src/components/compact-conversation-action-card.js
@@ -18,8 +18,8 @@ export default function CompactConversationActionCard( {
 	error = '',
 } ) {
 	return (
-		<div className="sdaa-action-card">
-			<div className="sdaa-action-card-body">
+		<div className="sd-ai-agent-compact-conversation-action-card">
+			<div className="sd-ai-agent-compact-conversation-action-card__body">
 				<p>
 					{ __(
 						'Too large to send. Compact it; your original chat stays available.',
@@ -28,17 +28,17 @@ export default function CompactConversationActionCard( {
 				</p>
 				{ error && <p role="alert">{ error }</p> }
 			</div>
-			<div className="sdaa-action-card-footer">
+			<div className="sd-ai-agent-compact-conversation-action-card__footer">
 				<button
 					type="button"
-					className="button sdaa-action-card-btn-cancel"
+					className="button sd-ai-agent-compact-conversation-action-card__cancel"
 					onClick={ onCancel }
 				>
 					{ __( 'Keep original', 'superdav-ai-agent' ) }
 				</button>
 				<button
 					type="button"
-					className="button button-primary sdaa-action-card-btn-confirm"
+					className="button button-primary sd-ai-agent-compact-conversation-action-card__confirm"
 					onClick={ onConfirm }
 				>
 					{ __( 'Compact and continue', 'superdav-ai-agent' ) }

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -1307,6 +1307,54 @@ class RestControllerTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Checkpoint compaction retains the full-envelope reserve used by transport
+	 * preflight so it does not dispatch a history that only fits in isolation.
+	 */
+	public function test_job_status_compacts_checkpoint_to_full_envelope_budget(): void {
+		wp_set_current_user( $this->admin_id );
+		$job_id  = 'a4444444-b555-c666-d777-e88888888888';
+		$history = array( array( 'role' => 'user', 'parts' => array( array( 'text' => str_repeat( 'envelope reserve context ', 500 ) ) ) ) );
+		$this->create_interrupted_checkpoint_job(
+			$job_id,
+			AgentLoop::CHECKPOINT_BEFORE_PROVIDER_CALL,
+			array(
+				'history'              => $history,
+				'provider_id'          => 'test-provider',
+				'model_id'             => 'test-model',
+				'iterations_remaining' => 3,
+			)
+		);
+
+		$byte_budget  = static fn(): int => 20000;
+		$safety_margin = static fn(): int => 18000;
+		add_filter( 'sd_ai_agent_provider_request_max_bytes', $byte_budget, 10, 3 );
+		add_filter( 'sd_ai_agent_provider_request_safety_margin_bytes', $safety_margin, 10, 4 );
+		try {
+			$response = $this->dispatch( 'GET', "/sd-ai-agent/v1/job/{$job_id}" );
+		} finally {
+			remove_filter( 'sd_ai_agent_provider_request_max_bytes', $byte_budget, 10 );
+			remove_filter( 'sd_ai_agent_provider_request_safety_margin_bytes', $safety_margin, 10 );
+		}
+
+		$this->assertStatus( 202, $response );
+		$row = ActiveJobRepository::get_by_job_id( $job_id );
+		$this->assertNotNull( $row );
+		$checkpoint = json_decode( (string) $row->checkpoint, true );
+		$this->assertIsArray( $checkpoint );
+		$metadata = AgentLoop::describe_checkpoint_request(
+			$checkpoint['history'],
+			AgentLoop::CHECKPOINT_BEFORE_PROVIDER_CALL,
+			'test-provider',
+			'test-model'
+		);
+		$this->assertSame( 2000, $metadata['request_budget_bytes'] );
+		$this->assertFalse( $metadata['locally_rejected'] );
+
+		ActiveJobRepository::delete( $job_id );
+		delete_transient( RestController::JOB_PREFIX . $job_id );
+	}
+
+	/**
 	 * A checkpoint saved immediately before tool execution remains terminal so
 	 * automatic recovery never repeats an ability call.
 	 */

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -1331,24 +1331,23 @@ class RestControllerTest extends WP_UnitTestCase {
 		add_filter( 'sd_ai_agent_provider_request_safety_margin_bytes', $safety_margin, 10, 4 );
 		try {
 			$response = $this->dispatch( 'GET', "/sd-ai-agent/v1/job/{$job_id}" );
+			$this->assertStatus( 202, $response );
+			$row = ActiveJobRepository::get_by_job_id( $job_id );
+			$this->assertNotNull( $row );
+			$checkpoint = json_decode( (string) $row->checkpoint, true );
+			$this->assertIsArray( $checkpoint );
+			$metadata = AgentLoop::describe_checkpoint_request(
+				$checkpoint['history'],
+				AgentLoop::CHECKPOINT_BEFORE_PROVIDER_CALL,
+				'test-provider',
+				'test-model'
+			);
+			$this->assertSame( 2000, $metadata['request_budget_bytes'] );
+			$this->assertFalse( $metadata['locally_rejected'] );
 		} finally {
 			remove_filter( 'sd_ai_agent_provider_request_max_bytes', $byte_budget, 10 );
 			remove_filter( 'sd_ai_agent_provider_request_safety_margin_bytes', $safety_margin, 10 );
 		}
-
-		$this->assertStatus( 202, $response );
-		$row = ActiveJobRepository::get_by_job_id( $job_id );
-		$this->assertNotNull( $row );
-		$checkpoint = json_decode( (string) $row->checkpoint, true );
-		$this->assertIsArray( $checkpoint );
-		$metadata = AgentLoop::describe_checkpoint_request(
-			$checkpoint['history'],
-			AgentLoop::CHECKPOINT_BEFORE_PROVIDER_CALL,
-			'test-provider',
-			'test-model'
-		);
-		$this->assertSame( 2000, $metadata['request_budget_bytes'] );
-		$this->assertFalse( $metadata['locally_rejected'] );
 
 		ActiveJobRepository::delete( $job_id );
 		delete_transient( RestController::JOB_PREFIX . $job_id );


### PR DESCRIPTION
## Summary

Reserve checkpoint history capacity for the complete provider envelope and namespace compact-conversation card classes.

## Files Changed

includes/Core/AgentLoop.php, src/components/chat-redesign/__tests__/MessageList.test.js, src/components/compact-conversation-action-card.js, tests/SdAiAgent/REST/RestControllerTest.php

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — Dependencies installed; targeted PHPUnit, Jest, and PHP/JS lint checks are running.

Resolves #2370


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.194 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-terra spent 6m and 135,897 tokens on this as a headless worker.