### PR TITLE
GH#2372: fix: retain raw max iteration failure reason

### DIFF
--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -1041,6 +1041,50 @@ describe( 'actions', () => {
 		).not.toContain( '/private/path.php' );
 	} );
 
+	test( 'pollJob shows max-iteration feedback from a raw diagnostic reason', async () => {
+		jest.useFakeTimers();
+		apiFetch.mockReset();
+		apiFetch.mockResolvedValue( {
+			status: 'error',
+			message: 'PRIVATE_PROVIDER_MESSAGE',
+			reason: 'max_iterations',
+			diagnostic: {
+				reason: 'provider_timeout',
+				last_safe_phase: 'before_provider_call',
+				retryable: false,
+				next_action: 'contact_support',
+				correlation_id: 'job-1234abcd5678',
+			},
+		} );
+		const dispatch = {
+			appendMessage: jest.fn(),
+			setFeedbackBanner: jest.fn(),
+			setPendingConfirmation: jest.fn(),
+			setPendingActionCard: jest.fn(),
+			setStreamError: jest.fn(),
+			setSending: jest.fn(),
+			setLiveToolCalls: jest.fn(),
+			drainMessageQueue: jest.fn(),
+			setCurrentJobId: jest.fn(),
+			setSessionJob: jest.fn(),
+		};
+		const select = {
+			getCurrentSessionId: jest.fn( () => 17 ),
+			getCurrentJobId: jest.fn( () => 'failed-job' ),
+		};
+
+		try {
+			actions.pollJob( 'failed-job', 17 )( { dispatch, select } );
+			await jest.advanceTimersByTimeAsync( 2000 );
+		} finally {
+			jest.useRealTimers();
+		}
+
+		expect( dispatch.setFeedbackBanner ).toHaveBeenCalledWith( {
+			exitReason: 'max_iterations',
+		} );
+	} );
+
 	test( 'pollJob prioritizes a compact continuation after a local envelope rejection', async () => {
 		jest.useFakeTimers();
 		apiFetch.mockReset();

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -946,7 +946,9 @@ export const actions = {
 								dispatch.setStreamError( true, sessionId );
 							}
 							// WP_Error max_iterations — show feedback banner (t183).
-							const errMsg = errorMessage;
+							const errMsg = `${ rawErrorMessage } ${
+								result.reason || ''
+							}`;
 							if ( /max.?iteration/i.test( errMsg ) ) {
 								dispatch.setFeedbackBanner( {
 									exitReason: 'max_iterations',


### PR DESCRIPTION
## Summary

Detect max_iterations from raw terminal reasons even when a diagnostic maps the customer-facing message.

## Files Changed

src/store/__tests__/index.test.js, src/store/slices/jobSlice.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — JS: 425 tests passed; lint JS/CSS/PHP, PHPStan, and build passed. PHP suite was attempted twice but encountered shared WordPress test-database deadlocks and sandbox database authentication failures unrelated to this JS-only diff.

Resolves #2372


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.194 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-terra spent 17m and 130,482 tokens on this as a headless worker.