### PR TITLE
GH#2378: stop stale reaper after write failure

### DIFF
--- a/includes/Models/ActiveJobRepository.php
+++ b/includes/Models/ActiveJobRepository.php
@@ -458,9 +458,10 @@ class ActiveJobRepository {
 		global $wpdb;
 		/** @var \wpdb $wpdb */
 
-		$table     = self::table_name();
-		$reaped    = array();
-		$row_count = 0;
+		$table        = self::table_name();
+		$reaped       = array();
+		$row_count    = 0;
+		$write_failed = false;
 
 		do {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Bounded custom-table candidate discovery is followed by per-row conditional claims.
@@ -492,12 +493,17 @@ class ActiveJobRepository {
 					)
 				);
 
-				if ( $result !== false && $result > 0 ) {
+				if ( false === $result ) {
+					$write_failed = true;
+					break;
+				}
+
+				if ( $result > 0 ) {
 					$reaped[] = $row->job_id;
 					ActiveJobFailureDiagnostic::log( $diagnostic, $row->session_id );
 				}
 			}
-		} while ( $row_count === self::STALE_REAP_BATCH_SIZE );
+		} while ( $row_count === self::STALE_REAP_BATCH_SIZE && ! $write_failed );
 
 		return $reaped;
 	}

--- a/includes/Models/ActiveJobRepository.php
+++ b/includes/Models/ActiveJobRepository.php
@@ -450,6 +450,7 @@ class ActiveJobRepository {
 	 *
 	 * Each candidate is conditionally transitioned so a concurrent heartbeat or
 	 * queued-worker claim can prevent a stale cleanup from overwriting it.
+	 * A database write failure stops the batch so the next cron run can retry it.
 	 *
 	 * @param int $threshold_minutes Number of minutes of inactivity before a row is considered stale.
 	 * @return list<string> Reaped job UUIDs.


### PR DESCRIPTION
## Summary

- stop stale active-job cleanup after its first database write failure
- retain the failed candidate for a future scheduled cleanup instead of reselecting it indefinitely

## Worker self-verification

- PHPUnit: targeted `ActiveJobsCleanupTest` passed — Tests: 23, Assertions: 84, Errors: 0, Failures: 0
- PHPUnit: full suite ran 4,025 tests; 3 pre-existing PluginBuilder sandbox failures could not connect to local MySQL as `root` and are outside this change
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded (existing webpack asset-size warnings only)

Resolves #2378
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.194 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-terra spent 13m and 142,280 tokens on this as a headless worker.