### PR TITLE
GH#2381: harden WordPress.org listing capture

### DIFF
--- a/docs/wordpress-org-submission.md
+++ b/docs/wordpress-org-submission.md
@@ -361,6 +361,7 @@ cp /path/to/superdav-ai-agent-repo/.wordpress-org/assets/screenshot-1.png assets
 # … repeat for each screenshot
 
 svn add --force assets
+svn status assets
 svn commit -m "Add plugin assets (banner, icon, screenshots)" \
     --username YOUR_WP_USERNAME
 ```

--- a/scripts/capture-wporg-screenshots.js
+++ b/scripts/capture-wporg-screenshots.js
@@ -36,13 +36,15 @@ if ( ! baseURL ) {
  * @return {Promise<void>} Resolves after the browser closes.
  */
 async function capture() {
-	const browser = await chromium.launch( { headless: true } );
-	const page = await browser.newPage( {
-		viewport: { width: 1440, height: 960 },
-		baseURL,
-	} );
+	let browser;
 
 	try {
+		browser = await chromium.launch( { headless: true } );
+		const page = await browser.newPage( {
+			viewport: { width: 1440, height: 960 },
+			baseURL,
+		} );
+
 		await loginToWordPress( page );
 
 		await goToAgentPage( page );
@@ -67,7 +69,9 @@ async function capture() {
 			path: path.join( outputDirectory, 'screenshot-3.png' ),
 		} );
 	} finally {
-		await browser.close();
+		if ( browser ) {
+			await browser.close();
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Make manual asset uploads repeatable and guarantee screenshot browser cleanup after page-creation failures.

## Files Changed

docs/wordpress-org-submission.md, scripts/capture-wporg-screenshots.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — node --check and all lint/PHPStan checks passed; full PHPUnit ran 4,025 tests but had three database-credential failures in isolated PluginBuilder sandbox tests.

Resolves #2381


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.194 plugin for [OpenCode](https://opencode.ai) v1.18.5 with gpt-5.6-terra spent 10m and 103,864 tokens on this as a headless worker.