### PR TITLE
GH#2388: Align PHPUnit database configuration

### DIFF
--- a/bin/setup-wp-phpunit.php
+++ b/bin/setup-wp-phpunit.php
@@ -126,42 +126,36 @@ function sd_ai_agent_setup_shell_command(array $parts): string
 }
 
 /**
- * Read DB_PASSWORD from an existing wp-tests-config.php file.
+ * Read database connection values from an existing wp-tests-config.php file.
  *
- * When WP_TESTS_DB_PASS is not set in the environment, fall back to the
- * password already stored in wp-tests-config.php (written once by
- * install-wp-tests.sh and never overwritten). This prevents a subsequent
- * `npm run test:php:setup` run — without WP_TESTS_DB_PASS — from
- * regenerating wp-config.php with an empty password when the test
- * database was originally set up with a non-empty password.
- *
- * That mismatch caused Layer 2 (isolated include) in PluginSandbox to
- * fail: the WP-CLI subprocess reads wp-config.php (not wp-tests-config.php)
- * and the wrong password produces "Access denied" → sandbox reports
- * sd_ai_agent_sandbox_failed → PluginUpdaterTest / PluginBuilderIntegrationTest
- * failures on every clean run of npm run test:php.
+ * The test installer writes this configuration once and leaves it in place on
+ * later setup runs. Reusing every database setting keeps mysqladmin and the
+ * WP-CLI-compatible core config aligned with the parent PHPUnit bootstrap.
  *
  * @param string $tests_dir WordPress test library directory.
- * @return string|null Password extracted from the config file, or null if not found.
+ * @return array<string, string> Connection values keyed by DB constant name.
  */
-function sd_ai_agent_setup_read_config_password(string $tests_dir): ?string
+function sd_ai_agent_setup_read_config_database(string $tests_dir): array
 {
 	$config_file = rtrim($tests_dir, '/') . '/wp-tests-config.php';
 	if (! is_file($config_file)) {
-		return null;
+		return array();
 	}
 
 	$content = file_get_contents($config_file);
 	if (false === $content) {
-		return null;
+		return array();
 	}
 
-	// Match: define( 'DB_PASSWORD', 'value' );
-	if (preg_match("/define\s*\(\s*'DB_PASSWORD'\s*,\s*'([^']*)'\s*\)/", $content, $matches)) {
-		return $matches[1];
+	$database = array();
+	foreach (array('DB_NAME', 'DB_USER', 'DB_PASSWORD', 'DB_HOST') as $constant) {
+		$pattern = "/define\s*\(\s*'" . $constant . "'\s*,\s*'((?:\\\\.|[^'])*)'\s*\)/";
+		if (preg_match($pattern, $content, $matches)) {
+			$database[$constant] = stripcslashes($matches[1]);
+		}
 	}
 
-	return null;
+	return $database;
 }
 
 /**
@@ -229,13 +223,11 @@ $cache_root  = sd_ai_agent_setup_cache_root();
 $tests_dir   = sd_ai_agent_setup_env('WP_TESTS_DIR') ?? $cache_root . '/wordpress-tests-lib-' . $version_key;
 $core_dir    = sd_ai_agent_setup_env('WP_CORE_DIR') ?? $cache_root . '/wordpress-' . $version_key;
 
-$db_name     = sd_ai_agent_setup_env('WP_TESTS_DB_NAME') ?? 'sd_ai_agent_tests';
-$db_user     = sd_ai_agent_setup_env('WP_TESTS_DB_USER') ?? 'root';
-$db_pass_env = sd_ai_agent_setup_env('WP_TESTS_DB_PASS');
-$db_pass     = null !== $db_pass_env
-	? $db_pass_env
-	: (sd_ai_agent_setup_read_config_password($tests_dir) ?? '');
-$db_host     = sd_ai_agent_setup_env('WP_TESTS_DB_HOST') ?? 'localhost';
+$test_database = sd_ai_agent_setup_read_config_database($tests_dir);
+$db_name       = sd_ai_agent_setup_env('WP_TESTS_DB_NAME') ?? $test_database['DB_NAME'] ?? 'sd_ai_agent_tests';
+$db_user       = sd_ai_agent_setup_env('WP_TESTS_DB_USER') ?? $test_database['DB_USER'] ?? 'root';
+$db_pass       = sd_ai_agent_setup_env('WP_TESTS_DB_PASS') ?? $test_database['DB_PASSWORD'] ?? '';
+$db_host       = sd_ai_agent_setup_env('WP_TESTS_DB_HOST') ?? $test_database['DB_HOST'] ?? 'localhost';
 $skip_db = 'true' === strtolower(sd_ai_agent_setup_env('WP_TESTS_SKIP_DB_CREATE') ?? 'false');
 
 $installer = $plugin_dir . '/bin/install-wp-tests.sh';

--- a/bin/setup-wp-phpunit.php
+++ b/bin/setup-wp-phpunit.php
@@ -151,7 +151,7 @@ function sd_ai_agent_setup_read_config_database(string $tests_dir): array
 	foreach (array('DB_NAME', 'DB_USER', 'DB_PASSWORD', 'DB_HOST') as $constant) {
 		$pattern = "/define\s*\(\s*'" . $constant . "'\s*,\s*'((?:\\\\.|[^'])*)'\s*\)/";
 		if (preg_match($pattern, $content, $matches)) {
-			$database[$constant] = stripcslashes($matches[1]);
+			$database[$constant] = str_replace(array("\\'", "\\\\"), array("'", "\\"), $matches[1]);
 		}
 	}
 


### PR DESCRIPTION
Resolves #2388

## Summary

- Reuse all existing WordPress PHPUnit database connection settings when provisioning the shared test environment.
- Keep the generated WP-CLI configuration and `mysqladmin` aligned with the configuration used by the parent PHPUnit bootstrap.

## Testing

- `npm run test:php:setup`
- `npm run test:php -- --filter='PluginBuilderIntegrationTest::test_updater_happy_path_replaces_files|PluginUpdaterTest::test_test_staged_passes_for_valid_plugin|PluginUpdaterTest::test_update_replaces_live_plugin_files'`
- `npm run test:php`
- `npm run lint:php`
- `npm run lint:js`
- `npm run lint:css`
- `composer phpstan`
- `npm run build`

## Worker self-verification

- PHPUnit: Tests: 4026, Assertions: 17987, Errors: 0, Failures: 0, Skipped: 134, Incomplete: 4
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.200 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 3m and 104,581 tokens on this as a headless worker.
