### PR TITLE
GH#2389: restore widget compact action-card tests

### DIFF
--- a/src/components/chat-widget/__tests__/widget-message-list.test.js
+++ b/src/components/chat-widget/__tests__/widget-message-list.test.js
@@ -208,8 +208,9 @@ describe( 'WidgetMessageList compact conversation action card', () => {
 			container.querySelector( '.sdaa-w-retry-failed-step' )
 		).toBeNull();
 		const compactButton = container.querySelector(
-			'.sdaa-action-card-btn-confirm'
+			'.sd-ai-agent-compact-conversation-action-card__confirm'
 		);
+		expect( compactButton ).not.toBeNull();
 		expect( compactButton.textContent ).toBe( 'Compact and continue' );
 
 		await act( async () => {
@@ -261,10 +262,15 @@ describe( 'WidgetMessageList compact conversation action card', () => {
 			root.render( createElement( WidgetMessageList ) );
 		} );
 
+		const compactButton = container.querySelector(
+			'.sd-ai-agent-compact-conversation-action-card__confirm'
+		);
+		expect( compactButton ).not.toBeNull();
+
 		await act( async () => {
-			container
-				.querySelector( '.sdaa-action-card-btn-confirm' )
-				.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+			compactButton.dispatchEvent(
+				new MouseEvent( 'click', { bubbles: true } )
+			);
 		} );
 
 		expect( container.textContent ).toContain(


### PR DESCRIPTION
## Summary

- Align widget compact-conversation tests with the shared action-card confirm selector.
- Assert the confirmation control exists before dispatching interactions.

## Testing

- `npm run test:js -- --runInBand src/components/chat-widget/__tests__/widget-message-list.test.js`
- `npm run lint:js -- --no-cache src/components/chat-widget/__tests__/widget-message-list.test.js`

Resolves #2389

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.200 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 13m and 103,340 tokens on this as a headless worker. Overall, 13h 59m since this issue was created.
