### PR TITLE
GH#2392: Keep the widget slash menu inside the viewport

### DIFF
--- a/src/admin-page/style.css
+++ b/src/admin-page/style.css
@@ -1337,53 +1337,6 @@ details[open] > .sdaa-tool-expandable-toggle::before {
 	gap: 6px;
 }
 
-/* Slash command menu */
-.sdaa-slash-menu {
-	position: absolute;
-	bottom: 100%;
-	left: 12px;
-	right: 12px;
-	background: #fff;
-	border: 1px solid #c3c4c7;
-	border-radius: 6px;
-	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
-	margin-bottom: 4px;
-	max-height: 240px;
-	overflow-y: auto;
-	z-index: 100;
-}
-
-.sdaa-slash-item {
-	display: flex;
-	align-items: center;
-	gap: 12px;
-	padding: 8px 14px;
-	cursor: pointer;
-	transition: background 0.1s;
-}
-
-.sdaa-slash-item:hover,
-.sdaa-slash-item.is-selected {
-	background: #f0f0f1;
-}
-
-.sdaa-slash-item:focus-visible {
-	outline: 2px solid var(--wp-admin-theme-color, #2271b1);
-	outline-offset: -2px;
-}
-
-.sdaa-slash-name {
-	font-weight: 600;
-	font-size: 13px;
-	color: var(--wp-admin-theme-color, #2271b1);
-	min-width: 80px;
-}
-
-.sdaa-slash-desc {
-	font-size: 13px;
-	color: #50575e;
-}
-
 /* Input row (wraps templates button + textarea + send/stop) */
 .sdaa-input-row {
 	display: flex;

--- a/src/components/chat-widget/widget.css
+++ b/src/components/chat-widget/widget.css
@@ -1137,6 +1137,7 @@
    ================================================================= */
 
 .sdaa-w-input {
+	position: relative;
 	flex-shrink: 0;
 	padding: 10px 12px;
 	border-top: 1px solid var(--sdaa-w-border-subtle);

--- a/src/components/shared.css
+++ b/src/components/shared.css
@@ -1,5 +1,52 @@
 /* Shared component styles — loaded by both admin-page and floating-widget bundles */
 
+/* ── Slash command menu ───────────────────────────────────────────────────── */
+.sdaa-slash-menu {
+	position: absolute;
+	bottom: 100%;
+	left: 12px;
+	right: 12px;
+	margin-bottom: 4px;
+	max-height: 240px;
+	overflow-y: auto;
+	z-index: 100;
+	border: 1px solid #c3c4c7;
+	border-radius: 6px;
+	background: #fff;
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+}
+
+.sdaa-slash-item {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 8px 14px;
+	cursor: pointer;
+	transition: background 0.1s;
+}
+
+.sdaa-slash-item:hover,
+.sdaa-slash-item.is-selected {
+	background: #f0f0f1;
+}
+
+.sdaa-slash-item:focus-visible {
+	outline: 2px solid var(--wp-admin-theme-color, #2271b1);
+	outline-offset: -2px;
+}
+
+.sdaa-slash-name {
+	min-width: 80px;
+	color: var(--wp-admin-theme-color, #2271b1);
+	font-size: 13px;
+	font-weight: 600;
+}
+
+.sdaa-slash-desc {
+	color: #50575e;
+	font-size: 13px;
+}
+
 /* ── AI Icon — unified mark + thinking animation ───────────────────────────── */
 .sdaa-ai-icon .sp {
 	transform-box: fill-box;

--- a/tests/e2e/floating-widget.spec.js
+++ b/tests/e2e/floating-widget.spec.js
@@ -204,4 +204,46 @@ test.describe( 'Floating Widget', () => {
 		// Input should be cleared after submission.
 		await expect( input ).toHaveValue( '' );
 	} );
+
+	test( 'slash command menu stays inside narrow viewports', async ( {
+		page,
+	} ) => {
+		const viewports = [
+			{ width: 390, height: 844 },
+			{ width: 320, height: 568 },
+		];
+
+		for ( const viewport of viewports ) {
+			await page.setViewportSize( viewport );
+
+			const fab = getFloatingButton( page );
+			await fab.click();
+
+			const panel = getFloatingPanel( page );
+			const input = panel.locator( '.sdaa-w-input-textarea' );
+			const slashMenu = panel.getByRole( 'listbox', {
+				name: 'Slash commands',
+			} );
+			const options = slashMenu.getByRole( 'option' );
+
+			await input.fill( '/' );
+			await expect( slashMenu ).toBeVisible();
+			await expect( options ).toHaveCount( 10 );
+
+			const menuBox = await slashMenu.boundingBox();
+			expect( menuBox ).not.toBeNull();
+			expect( menuBox.x ).toBeGreaterThanOrEqual( 0 );
+			expect( menuBox.y ).toBeGreaterThanOrEqual( 0 );
+			expect( menuBox.x + menuBox.width ).toBeLessThanOrEqual(
+				viewport.width
+			);
+			expect( menuBox.y + menuBox.height ).toBeLessThanOrEqual(
+				viewport.height
+			);
+
+			await options.last().scrollIntoViewIfNeeded();
+			await expect( options.last() ).toBeVisible();
+			await panel.getByLabel( 'Close' ).click();
+		}
+	} );
 } );


### PR DESCRIPTION
Resolves #2392

## Summary

- anchor the floating-widget slash-command menu to its input so it remains inside the panel viewport
- load the shared menu styles in both the admin chat and floating-widget bundles
- add mobile viewport coverage for menu containment and internal command scrolling

## Testing

- `npm run test:js -- --runInBand` — 38 suites / 425 tests passed
- `npm run test:php` — Tests: 4027, Assertions: 17994, Errors: 0, Failures: 0, Skipped: 134, Incomplete: 4
- `npm run lint:php`, `npm run lint:js`, `npm run lint:css`, and `composer phpstan` — passed
- `npm run build` — passed
- `npm run test:e2e:playwright -- tests/e2e/floating-widget.spec.js tests/e2e/chat-interactions.spec.js` — blocked locally because Docker's containerd snapshot is unavailable; remote Playwright checks are running

## Worker self-verification

- PHPUnit: Tests: 4027, Assertions: 17994, Errors: 0, Failures: 0, Skipped: 134
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.200 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 15m and 192,714 tokens on this as a headless worker.
