### PR TITLE
GH#2394: Preserve floating widget new chats

### DIFF
--- a/src/components/chat-widget/__tests__/new-chat-actions.test.js
+++ b/src/components/chat-widget/__tests__/new-chat-actions.test.js
@@ -1,0 +1,183 @@
+/**
+ * Regression coverage for floating-widget new-chat entry points.
+ */
+
+import { createElement } from '@wordpress/element';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+import { useDispatch, useSelect } from '@wordpress/data';
+
+import WidgetHeader from '../widget-header';
+import WidgetInput from '../widget-input';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+	useSelect: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text ) => text,
+	sprintf: ( format, value ) => format.replace( '%d', value ),
+} ) );
+
+jest.mock( '@wordpress/icons', () => ( {
+	Icon: () => null,
+	arrowUp: 'arrow-up',
+	chevronDown: 'chevron-down',
+	close: 'close',
+	commentContent: 'comment-content',
+	plus: 'plus',
+} ) );
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+jest.mock( '../../../store', () => 'sd-ai-agent' );
+jest.mock( '../../../utils/branding', () => ( {
+	getBranding: () => ( { agentName: 'SD AI Agent' } ),
+} ) );
+jest.mock( '../../use-speech-recognition', () => () => ( {
+	isListening: false,
+	isSupported: false,
+	toggleListening: jest.fn(),
+} ) );
+jest.mock( '../../feedback-consent-modal', () => () => null );
+jest.mock( '../../chat-redesign/ModelPicker', () => () => null );
+jest.mock( '../../chat-redesign/AgentPicker', () => () => null );
+jest.mock( '../../chat-redesign/icons', () => ( {
+	AiIcon: () => null,
+	Microphone: () => null,
+	Paperclip: () => null,
+	Stop: () => null,
+} ) );
+jest.mock(
+	'../../slash-command-menu',
+	() =>
+		( { onSelect } ) =>
+			require( '@wordpress/element' ).createElement(
+				'button',
+				{
+					type: 'button',
+					'data-slash-new': 'true',
+					onClick: () => onSelect( { action: 'new' } ),
+				},
+				'/new'
+			)
+);
+
+/**
+ * Build the selectors required by the tested widget components.
+ *
+ * @return {Object} Mocked store selectors.
+ */
+function selectors() {
+	return {
+		getCurrentSessionId: () => 7,
+		getMessageQueue: () => [],
+		getProviders: () => [],
+		getSelectedProviderId: () => '',
+		getSelectedModelId: () => '',
+		getSessionJobs: () => ( {} ),
+		getSessions: () => [],
+		isSending: () => false,
+	};
+}
+
+/**
+ * Build the actions required by the tested widget components.
+ *
+ * @return {Object} Mocked store actions.
+ */
+function actions() {
+	return {
+		clearCurrentSession: jest.fn(),
+		compactConversation: jest.fn(),
+		exportSession: jest.fn(),
+		fetchSessions: jest.fn(),
+		openSession: jest.fn(),
+		sendMessage: jest.fn(),
+		setFloatingOpen: jest.fn(),
+		stopGeneration: jest.fn(),
+	};
+}
+
+/**
+ * Render a component into an isolated DOM container.
+ *
+ * @param {JSX.Element} component Component to render.
+ * @return {Promise<{container: HTMLElement, root: import('@wordpress/element').Root}>} Mounted component.
+ */
+async function render( component ) {
+	const container = document.createElement( 'div' );
+	document.body.appendChild( container );
+	const root = createRoot( container );
+
+	await act( async () => {
+		root.render( component );
+	} );
+
+	return { container, root };
+}
+
+describe( 'floating-widget new-chat actions', () => {
+	let dispatch;
+	let mounted;
+
+	beforeEach( () => {
+		dispatch = actions();
+		useDispatch.mockReturnValue( dispatch );
+		useSelect.mockImplementation( ( select ) =>
+			select( () => selectors() )
+		);
+	} );
+
+	afterEach( async () => {
+		if ( mounted ) {
+			await act( async () => {
+				mounted.root.unmount();
+			} );
+			document.body.removeChild( mounted.container );
+			mounted = undefined;
+		}
+		jest.clearAllMocks();
+	} );
+
+	test( 'clears the current session from the header button', async () => {
+		mounted = await render(
+			createElement( WidgetHeader, {
+				isMinimized: false,
+				onToggleMinimize: jest.fn(),
+			} )
+		);
+
+		await act( async () => {
+			mounted.container
+				.querySelector( '.sdaa-w-new-btn' )
+				.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+		} );
+
+		expect( dispatch.clearCurrentSession ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'clears the current session when /new is selected', async () => {
+		mounted = await render( createElement( WidgetInput ) );
+		const textarea = mounted.container.querySelector( 'textarea' );
+		const setter = Object.getOwnPropertyDescriptor(
+			window.HTMLTextAreaElement.prototype,
+			'value'
+		).set;
+
+		await act( async () => {
+			setter.call( textarea, '/' );
+			textarea.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+		} );
+
+		await act( async () => {
+			mounted.container
+				.querySelector( '[data-slash-new="true"]' )
+				.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+		} );
+
+		expect( dispatch.clearCurrentSession ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/src/floating-widget/__tests__/frontend-onboarding.test.js
+++ b/src/floating-widget/__tests__/frontend-onboarding.test.js
@@ -3,6 +3,7 @@ import {
 	hasLiveSiteChangeActivity,
 	isFrontendOnboardingEnabled,
 	isMobileViewport,
+	shouldHydrateSession,
 	shouldStartFrontendOnboarding,
 	startOnboarding,
 } from '../frontend-onboarding';
@@ -116,6 +117,24 @@ describe( 'frontend onboarding helpers', () => {
 				}
 			)
 		).toBe( 12 );
+	} );
+
+	test( 'does not hydrate a persisted session after an explicit new chat', () => {
+		expect(
+			shouldHydrateSession( {
+				sessionCount: 1,
+				currentSessionId: null,
+				isNewChatPending: true,
+			} )
+		).toBe( false );
+
+		expect(
+			shouldHydrateSession( {
+				sessionCount: 1,
+				currentSessionId: null,
+				isNewChatPending: false,
+			} )
+		).toBe( true );
 	} );
 
 	test( 'starts frontend onboarding only after sessions load empty', () => {

--- a/src/floating-widget/frontend-onboarding.js
+++ b/src/floating-widget/frontend-onboarding.js
@@ -125,6 +125,28 @@ export function getHydrationSessionId( sessions, sessionJobs = {} ) {
 }
 
 /**
+ * Determine whether the widget should reopen a persisted conversation.
+ *
+ * An empty current session normally means the widget is mounting after a page
+ * load or navigation, so it should restore the active/latest conversation.
+ * An explicit new-chat action uses the same empty state but must retain it
+ * until the user sends the first message in the new conversation.
+ *
+ * @param {Object}  options
+ * @param {number}  options.sessionCount     Number of persisted sessions.
+ * @param {?number} options.currentSessionId Currently opened session ID.
+ * @param {boolean} options.isNewChatPending Whether the user started a new chat.
+ * @return {boolean} Whether persisted-session hydration should run.
+ */
+export function shouldHydrateSession( {
+	sessionCount,
+	currentSessionId,
+	isNewChatPending,
+} ) {
+	return sessionCount > 0 && ! currentSessionId && ! isNewChatPending;
+}
+
+/**
  * Determine whether first-run frontend onboarding may start.
  *
  * Onboarding must wait until sessions have loaded. Otherwise a reload during a

--- a/src/floating-widget/index.js
+++ b/src/floating-widget/index.js
@@ -66,6 +66,7 @@ function FloatingWidget() {
 		sessions,
 		sessionsLoaded,
 		currentSessionId,
+		isNewChatPending,
 		sessionJobs,
 	] = useSelect(
 		( select ) => [
@@ -77,6 +78,7 @@ function FloatingWidget() {
 			select( STORE_NAME ).getSessions(),
 			select( STORE_NAME ).getSessionsLoaded(),
 			select( STORE_NAME ).getCurrentSessionId(),
+			select( STORE_NAME ).isNewChatPending(),
 			select( STORE_NAME ).getSessionJobs(),
 		],
 		[]
@@ -140,7 +142,16 @@ function FloatingWidget() {
 			setFrontendOnboardingMode( null );
 			if ( sessions.length && ! currentSessionId ) {
 				import( './frontend-onboarding' ).then(
-					( { getHydrationSessionId } ) => {
+					( { getHydrationSessionId, shouldHydrateSession } ) => {
+						if (
+							! shouldHydrateSession( {
+								sessionCount: sessions.length,
+								currentSessionId,
+								isNewChatPending,
+							} )
+						) {
+							return;
+						}
 						const sessionId = getHydrationSessionId(
 							sessions,
 							sessionJobs
@@ -183,6 +194,7 @@ function FloatingWidget() {
 		sessions,
 		sessionJobs,
 		currentSessionId,
+		isNewChatPending,
 		openSession,
 		sendMessage,
 		setSelectedAgentId,

--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -85,6 +85,7 @@ const DEFAULT_STATE = {
 	currentSessionId: null,
 	currentSessionMessages: [],
 	currentSessionToolCalls: [],
+	isNewChatPending: false,
 	sending: false,
 	streamError: false,
 	streamErrorSessionId: null,
@@ -1434,6 +1435,7 @@ describe( 'reducer', () => {
 		expect( state.currentSessionId ).toBe( 7 );
 		expect( state.currentSessionMessages ).toEqual( [ { role: 'user' } ] );
 		expect( state.currentSessionToolCalls ).toEqual( [ { type: 'call' } ] );
+		expect( state.isNewChatPending ).toBe( false );
 	} );
 
 	test( 'SET_CURRENT_SESSION preserves per-turn model metadata during hydration', () => {
@@ -1487,6 +1489,7 @@ describe( 'reducer', () => {
 		expect( state.streamError ).toBe( false );
 		expect( state.streamErrorSessionId ).toBeNull();
 		expect( state.lastUserMessage ).toBe( '' );
+		expect( state.isNewChatPending ).toBe( true );
 	} );
 
 	test( 'SET_SENDING updates sending flag', () => {

--- a/src/store/slices/sessionsSlice.js
+++ b/src/store/slices/sessionsSlice.js
@@ -150,6 +150,9 @@ export const initialState = {
 	currentSessionId: null,
 	currentSessionMessages: [],
 	currentSessionToolCalls: [],
+	// Set only by an explicit new-chat action. The floating widget consumes this
+	// to distinguish a user-requested empty conversation from initial hydration.
+	isNewChatPending: false,
 	sending: false,
 
 	// Token usage (current session)
@@ -1545,6 +1548,17 @@ export const selectors = {
 	},
 
 	/**
+	 * Whether the user explicitly started a new chat and the UI should remain
+	 * empty until the next message creates its new session.
+	 *
+	 * @param {import('../../types').StoreState} state
+	 * @return {boolean} Whether a new chat is pending its first message.
+	 */
+	isNewChatPending( state ) {
+		return state.isNewChatPending;
+	},
+
+	/**
 	 * @param {import('../../types').StoreState} state
 	 * @return {boolean} Whether a message is in-flight.
 	 */
@@ -1725,6 +1739,7 @@ export function reducer( state, action ) {
 		case 'SET_CURRENT_SESSION':
 			return {
 				...state,
+				isNewChatPending: false,
 				currentSessionId:
 					typeof action.sessionId === 'string'
 						? parseInt( action.sessionId, 10 )
@@ -1738,6 +1753,7 @@ export function reducer( state, action ) {
 		case 'CLEAR_CURRENT_SESSION':
 			return {
 				...state,
+				isNewChatPending: true,
 				currentSessionId: null,
 				currentSessionMessages: [],
 				currentSessionToolCalls: [],


### PR DESCRIPTION
## Summary

Preserve explicit new-chat state across floating-widget hydration and clear it only when a new turn begins.

## Files Changed

src/components/chat-widget/__tests__/new-chat-actions.test.js, src/floating-widget/__tests__/frontend-onboarding.test.js, src/floating-widget/frontend-onboarding.js, src/floating-widget/index.js, src/store/__tests__/index.test.js, src/store/slices/sessionsSlice.js

## Runtime Testing

- **Risk level:** Critical
- **Verification:** runtime-verified — `npm run verify` passed with 4,029 PHPUnit tests and 18,001 assertions; PHP/JS/CSS lint, PHPStan, build, and bundle checks passed. GitHub E2E run https://github.com/Ultimate-Multisite/superdav-ai-agent/actions/runs/30664007056 passed all three WordPress trunk Playwright shards.

## Worker self-verification
- PHPUnit: Tests: 4029, Assertions: 18001, Errors: 0, Failures: 0, Skipped: 134
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Resolves #2394

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.201 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol spent 15h 9m and 1,143,906 tokens on this with the user in an interactive session.
