### PR TITLE
GH#2404: Improve floating widget muted-label contrast

### DIFF
--- a/src/components/chat-redesign/chat-redesign.css
+++ b/src/components/chat-redesign/chat-redesign.css
@@ -17,6 +17,7 @@
 	--sdaa-text-primary: #1d2327;
 	--sdaa-text-secondary: #50575e;
 	--sdaa-text-muted: #787c82;
+	--sdaa-text-muted-contrast: #71767b;
 	--sdaa-text-disabled: #a7aaad;
 	--sdaa-surface-page: #fff;
 	--sdaa-surface: #f6f7f7;
@@ -1478,7 +1479,7 @@ textarea.sdaa-cr-input-textarea {
 
 .sdaa-cr-model-chip-provider {
 	font-size: 11px;
-	color: var(--sdaa-text-muted);
+	color: var(--sdaa-text-muted-contrast);
 	padding-right: 6px;
 	border-right: 1px solid var(--sdaa-border-subtle);
 	margin-right: 2px;

--- a/src/components/chat-widget/widget.css
+++ b/src/components/chat-widget/widget.css
@@ -12,6 +12,7 @@
 	--sdaa-w-text-primary: #1d2327;
 	--sdaa-w-text-secondary: #50575e;
 	--sdaa-w-text-muted: #787c82;
+	--sdaa-w-text-muted-contrast: #71767b;
 	--sdaa-w-border-strong: #c3c4c7;
 	--sdaa-w-border-subtle: #dcdcde;
 	--sdaa-w-bubble-user-border: #c5d9ed;
@@ -419,7 +420,7 @@
 	gap: 4px;
 	margin-top: 1px;
 	font-size: 11px;
-	color: var(--sdaa-w-text-muted);
+	color: var(--sdaa-w-text-muted-contrast);
 }
 
 .sdaa-w-head-status.is-running {


### PR DESCRIPTION
## Summary

- Add dedicated WCAG AA muted-label tokens for the floating widget status and model-provider labels.
- Use `#71767b`, which has a 4.586:1 contrast ratio on the white widget surface.

## Testing

- Manual contrast calculation: `#71767b` on `#ffffff` is 4.586:1.
- `npm run test:js -- --runInBand src/components/chat-widget/__tests__/new-chat-actions.test.js src/components/chat-widget/__tests__/widget-message-list.test.js`
- `npm run verify`

## Runtime Testing

- Self-assessed: the configured local WordPress site was unavailable (`wordpress.local:8080` was not found), so the browser accessibility audit could not run.

## Worker self-verification

- PHPUnit: Tests: 4029, Assertions: 18001, Errors: 0, Failures: 0, Skipped: 134
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Resolves #2404

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.205 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 3m and 72,939 tokens on this as a headless worker.
