### PR TITLE
Show credit usage by chat session

### DIFF
--- a/includes/Core/ProviderTraceLogger.php
+++ b/includes/Core/ProviderTraceLogger.php
@@ -140,6 +140,11 @@ class ProviderTraceLogger {
 		);
 	}
 
+	/** Return the non-secret chat session ID for the active provider request. */
+	public static function get_runtime_session_id(): int {
+		return self::$runtimeContext['session_id'];
+	}
+
 	/** Clear runtime provider attribution after a synchronous request. */
 	public static function clear_runtime_context(): void {
 		self::$runtimeContext = array(

--- a/includes/Core/SuperdavSiteConnectionService.php
+++ b/includes/Core/SuperdavSiteConnectionService.php
@@ -40,6 +40,10 @@ final class SuperdavSiteConnectionService {
 	 * billing ledger. The managed service must return only its newest page.
 	 */
 	public const MAX_CREDIT_ACTIVITY_EVENTS = 25;
+	public const MAX_CHAT_SESSION_EVENTS    = 25;
+
+	/** Maximum per-model breakdown rows retained for one chat session. */
+	private const MAX_CHAT_SESSION_MODELS = 10;
 
 	/** @var string[] Event types that are safe to render in the account UI. */
 	private const CREDIT_ACTIVITY_EVENT_TYPES = array(
@@ -101,6 +105,10 @@ final class SuperdavSiteConnectionService {
 			$status['credit_activity'] = $this->sanitize_credit_activity_metadata( $metadata['credit_activity'] );
 		}
 
+		if ( isset( $metadata['chat_sessions'] ) && is_array( $metadata['chat_sessions'] ) ) {
+			$status['chat_sessions'] = $this->sanitize_chat_session_metadata( $metadata['chat_sessions'] );
+		}
+
 		$status['site_timezone'] = wp_timezone_string();
 
 		return $status;
@@ -138,6 +146,7 @@ final class SuperdavSiteConnectionService {
 						'installation_id'       => $this->get_installation_id(),
 						'site_url'              => $this->get_verified_site_url(),
 						'credit_activity_limit' => self::MAX_CREDIT_ACTIVITY_EVENTS,
+						'chat_session_limit'    => self::MAX_CHAT_SESSION_EVENTS,
 					)
 				),
 			)
@@ -168,7 +177,8 @@ final class SuperdavSiteConnectionService {
 			$metadata['usage'],
 			$metadata['verification'],
 			$metadata['wallet'],
-			$metadata['credit_activity']
+			$metadata['credit_activity'],
+			$metadata['chat_sessions']
 		);
 		$metadata = array_merge( $metadata, $this->sanitize_remote_metadata( $body ) );
 		update_option( self::TOKEN_METADATA_OPTION, $metadata, false );
@@ -712,6 +722,10 @@ final class SuperdavSiteConnectionService {
 			$safe['credit_activity'] = $this->sanitize_credit_activity_metadata( $metadata['credit_activity'] );
 		}
 
+		if ( isset( $metadata['chat_sessions'] ) && is_array( $metadata['chat_sessions'] ) ) {
+			$safe['chat_sessions'] = $this->sanitize_chat_session_metadata( $metadata['chat_sessions'] );
+		}
+
 		return $safe;
 	}
 
@@ -838,6 +852,121 @@ final class SuperdavSiteConnectionService {
 		}
 
 		return new WP_Error( 'sd_ai_agent_coupon_redemption_unavailable', __( 'Coupon redemption is temporarily unavailable.', 'superdav-ai-agent' ), array( 'status' => $status_code >= 500 ? 502 : 503 ) );
+	}
+
+	/**
+	 * Keep only display-safe, authoritative usage grouped by local chat session.
+	 *
+	 * Request IDs, account identifiers, provider routing, prompts, tool arguments,
+	 * and arbitrary service metadata are never retained. The local REST layer adds
+	 * the current user's session title and tool-call count after ownership checks.
+	 *
+	 * @param array<mixed, mixed> $sessions Remote grouped chat usage rows.
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function sanitize_chat_session_metadata( array $sessions ): array {
+		$safe_sessions = array();
+
+		foreach ( array_slice( $sessions, 0, self::MAX_CHAT_SESSION_EVENTS ) as $session ) {
+			if ( ! is_array( $session ) ) {
+				continue;
+			}
+
+			$session_id   = filter_var( $session['session_id'] ?? null, FILTER_VALIDATE_INT, array( 'options' => array( 'min_range' => 1 ) ) );
+			$started_at   = $this->sanitize_credit_activity_timestamp( $session['started_at'] ?? null );
+			$last_used_at = $this->sanitize_credit_activity_timestamp( $session['last_used_at'] ?? null );
+			$models       = isset( $session['models'] ) && is_array( $session['models'] )
+				? $this->sanitize_chat_session_models( $session['models'] )
+				: array();
+
+			if ( false === $session_id || null === $started_at || null === $last_used_at || empty( $models ) ) {
+				continue;
+			}
+
+			$metric_keys = array(
+				'input_tokens',
+				'cached_input_tokens',
+				'output_tokens',
+				'total_tokens',
+				'cost_usd_micros',
+				'loop_count',
+			);
+			$metrics     = array();
+			foreach ( $metric_keys as $key ) {
+				$value = $session[ $key ] ?? null;
+				if ( ! is_int( $value ) || $value < 0 || ( 'loop_count' === $key && 0 === $value ) ) {
+					continue 2;
+				}
+				$metrics[ $key ] = $value;
+			}
+
+			$safe_sessions[] = array_merge(
+				array(
+					'session_id'   => (int) $session_id,
+					'started_at'   => $started_at,
+					'last_used_at' => $last_used_at,
+					'models'       => $models,
+				),
+				$metrics
+			);
+		}
+
+		usort(
+			$safe_sessions,
+			static function ( array $left, array $right ): int {
+				$left_date  = $left['last_used_at'];
+				$right_date = $right['last_used_at'];
+				if ( ! is_string( $left_date ) || ! is_string( $right_date ) ) {
+					return 0;
+				}
+
+				return strcmp( $right_date, $left_date );
+			}
+		);
+
+		return $safe_sessions;
+	}
+
+	/**
+	 * Sanitize a bounded per-model usage breakdown for one chat session.
+	 *
+	 * @param array<mixed, mixed> $models Remote model usage rows.
+	 * @return array<int, array<string, int|string>>
+	 */
+	private function sanitize_chat_session_models( array $models ): array {
+		$safe_models = array();
+
+		foreach ( array_slice( $models, 0, self::MAX_CHAT_SESSION_MODELS ) as $model ) {
+			if ( ! is_array( $model ) || ! isset( $model['model_id'] ) || ! is_string( $model['model_id'] ) ) {
+				continue;
+			}
+
+			$model_id = substr( sanitize_text_field( $model['model_id'] ), 0, 100 );
+			if ( '' === $model_id ) {
+				continue;
+			}
+
+			$safe_model  = array( 'model_id' => $model_id );
+			$metric_keys = array(
+				'input_tokens',
+				'cached_input_tokens',
+				'output_tokens',
+				'total_tokens',
+				'cost_usd_micros',
+				'loop_count',
+			);
+			foreach ( $metric_keys as $key ) {
+				$value = $model[ $key ] ?? null;
+				if ( ! is_int( $value ) || $value < 0 || ( 'loop_count' === $key && 0 === $value ) ) {
+					continue 2;
+				}
+				$safe_model[ $key ] = $value;
+			}
+
+			$safe_models[] = $safe_model;
+		}
+
+		return $safe_models;
 	}
 
 	/**

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiImageGenerationModel.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiImageGenerationModel.php
@@ -54,7 +54,7 @@ final class SuperdavAiImageGenerationModel extends AbstractOpenAiCompatibleImage
 	 * @return Request
 	 */
 	protected function createRequest( HttpMethodEnum $method, string $path, array $headers = array(), mixed $data = null ): Request {
-		return new Request( $method, SuperdavAiProvider::url( $path ), $headers, $data, $this->getRequestOptions() );
+		return new Request( $method, SuperdavAiProvider::url( $path ), SuperdavAiProvider::with_session_attribution( $headers ), $data, $this->getRequestOptions() );
 	}
 
 	/**

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Infrastructure\AiClient\Superdav;
 
+use SdAiAgent\Core\ProviderTraceLogger;
 use WordPress\AiClient\Providers\ApiBasedImplementation\AbstractApiProvider;
 use WordPress\AiClient\Providers\Contracts\ModelMetadataDirectoryInterface;
 use WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface;
@@ -23,13 +24,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 final class SuperdavAiProvider extends AbstractApiProvider {
 
-	public const PROVIDER_ID       = 'sd-ai-agent-cloud';
-	public const CREDENTIAL_OPTION = 'connectors_ai_sd_ai_agent_cloud_api_key';
-	public const DEFAULT_BASE_URL  = 'https://api.sdaiagent.com/v1';
-	public const FAST_MODEL_ID     = 'superdav-chat-fast';
-	public const DEFAULT_MODEL_ID  = 'superdav-chat-pro';
-	public const STRONG_MODEL_ID   = 'superdav-chat-strong';
-	public const IMAGE_MODEL_ID    = 'superdav-image';
+	public const PROVIDER_ID                = 'sd-ai-agent-cloud';
+	public const CREDENTIAL_OPTION          = 'connectors_ai_sd_ai_agent_cloud_api_key';
+	public const DEFAULT_BASE_URL           = 'https://api.sdaiagent.com/v1';
+	public const FAST_MODEL_ID              = 'superdav-chat-fast';
+	public const DEFAULT_MODEL_ID           = 'superdav-chat-pro';
+	public const STRONG_MODEL_ID            = 'superdav-chat-strong';
+	public const IMAGE_MODEL_ID             = 'superdav-image';
+	public const SESSION_ATTRIBUTION_HEADER = 'X-Superdav-Session-ID';
 
 	/**
 	 * Reasoning effort hints for managed Superdav model aliases.
@@ -46,6 +48,24 @@ final class SuperdavAiProvider extends AbstractApiProvider {
 		self::DEFAULT_MODEL_ID => 'medium',
 		self::STRONG_MODEL_ID  => 'high',
 	);
+
+	/**
+	 * Add non-secret local chat attribution to a managed inference request.
+	 *
+	 * The site-scoped service token remains the authorization boundary. The
+	 * numeric session ID is used only to group metered usage for the same site.
+	 *
+	 * @param array<string, string|list<string>> $headers Existing request headers.
+	 * @return array<string, string|list<string>> Headers with safe attribution.
+	 */
+	public static function with_session_attribution( array $headers ): array {
+		$session_id = ProviderTraceLogger::get_runtime_session_id();
+		if ( $session_id > 0 ) {
+			$headers[ self::SESSION_ATTRIBUTION_HEADER ] = (string) $session_id;
+		}
+
+		return $headers;
+	}
 
 	/**
 	 * Return the managed model that new Superdav-provider installs should prefer.

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiResponsesToolSearchTextGenerationModel.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiResponsesToolSearchTextGenerationModel.php
@@ -84,7 +84,7 @@ final class SuperdavAiResponsesToolSearchTextGenerationModel extends AbstractApi
 	 * @return Request
 	 */
 	protected function createRequest( HttpMethodEnum $method, string $path, array $headers = array(), mixed $data = null ): Request {
-		return new Request( $method, SuperdavAiProvider::url( $path ), $headers, $data, $this->getRequestOptions() );
+		return new Request( $method, SuperdavAiProvider::url( $path ), SuperdavAiProvider::with_session_attribution( $headers ), $data, $this->getRequestOptions() );
 	}
 
 	/**

--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiTextGenerationModel.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiTextGenerationModel.php
@@ -78,7 +78,7 @@ final class SuperdavAiTextGenerationModel extends AbstractOpenAiCompatibleTextGe
 			}
 		}
 
-		return new Request( $method, SuperdavAiProvider::url( $path ), $headers, $data, $this->getRequestOptions() );
+		return new Request( $method, SuperdavAiProvider::url( $path ), SuperdavAiProvider::with_session_attribution( $headers ), $data, $this->getRequestOptions() );
 	}
 
 	/**

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -541,7 +541,9 @@ final class SettingsController {
 	 * Return safe account metadata for the Superdav AI account manager.
 	 */
 	public function handle_get_superdav_account(): WP_REST_Response {
-		return new WP_REST_Response( ( new SuperdavSiteConnectionService() )->get_status(), 200 );
+		$status = ( new SuperdavSiteConnectionService() )->get_status();
+
+		return new WP_REST_Response( $this->add_local_chat_session_details( $status ), 200 );
 	}
 
 	/**
@@ -555,7 +557,7 @@ final class SettingsController {
 			return $status;
 		}
 
-		return new WP_REST_Response( $status, 200 );
+		return new WP_REST_Response( $this->add_local_chat_session_details( $status ), 200 );
 	}
 
 	/**
@@ -572,7 +574,57 @@ final class SettingsController {
 			return $status;
 		}
 
-		return new WP_REST_Response( $status, 200 );
+		return new WP_REST_Response( $this->add_local_chat_session_details( $status ), 200 );
+	}
+
+	/**
+	 * Add current-user-owned local details to safe cloud billing summaries.
+	 *
+	 * The managed service never receives chat titles, messages, or tool payloads.
+	 * Session ownership is re-checked locally before a reviewable row is exposed.
+	 *
+	 * @param array<string, mixed> $status Safe managed account status.
+	 * @return array<string, mixed> Status with safe local session details.
+	 */
+	private function add_local_chat_session_details( array $status ): array {
+		if ( ! isset( $status['chat_sessions'] ) || ! is_array( $status['chat_sessions'] ) ) {
+			return $status;
+		}
+
+		$user_id       = get_current_user_id();
+		$chat_sessions = array();
+		foreach ( $status['chat_sessions'] as $usage ) {
+			if ( ! is_array( $usage ) ) {
+				continue;
+			}
+
+			$session_id = absint( $usage['session_id'] ?? 0 );
+			$session    = $session_id > 0 ? $this->database->get_session( $session_id ) : null;
+			if ( ! is_object( $session ) || (int) ( $session->user_id ?? 0 ) !== $user_id ) {
+				continue;
+			}
+
+			$title = sanitize_text_field( (string) ( $session->title ?? '' ) );
+			if ( '' === $title ) {
+				$title = sprintf(
+					/* translators: %d: chat session ID. */
+					__( 'Chat session #%d', 'superdav-ai-agent' ),
+					$session_id
+				);
+			}
+
+			$tool_calls = json_decode( (string) ( $session->tool_calls ?? '[]' ), true );
+			$messages   = json_decode( (string) ( $session->messages ?? '[]' ), true );
+
+			$usage['title']           = $title;
+			$usage['tool_call_count'] = is_array( $tool_calls ) ? count( $tool_calls ) : 0;
+			$usage['message_count']   = is_array( $messages ) ? count( $messages ) : 0;
+			$chat_sessions[]          = $usage;
+		}
+
+		$status['chat_sessions'] = $chat_sessions;
+
+		return $status;
 	}
 
 	/**

--- a/src/admin-page/index.js
+++ b/src/admin-page/index.js
@@ -71,19 +71,23 @@ const ShortcutsHelp = lazy( () =>
  *
  * 3. After onboarding completes the full redesigned chat layout is shown.
  *
+ * @param {Object}      props                  Component props.
+ * @param {number|null} props.initialSessionId Session selected by a deep link.
  * @return {JSX.Element|null} Admin page app element, or null while settings are loading.
  */
-function AdminPageApp() {
+function AdminPageApp( { initialSessionId = null } ) {
 	const {
 		fetchProviders,
 		fetchSessions,
 		fetchSettings,
 		clearCurrentSession,
+		openSession,
 		restoreActiveJobs,
 		setShowShortcutsHelp,
 		appendMessage,
 	} = useDispatch( STORE_NAME );
 	const serviceNoticeDisplayedRef = useRef( false );
+	const initialSessionOpenedRef = useRef( false );
 	const [ serviceConnectionNotice, setServiceConnectionNotice ] =
 		useState( '' );
 	const [
@@ -114,7 +118,23 @@ function AdminPageApp() {
 		fetchSessions();
 		fetchSettings();
 		restoreActiveJobs();
-	}, [ fetchProviders, fetchSessions, fetchSettings, restoreActiveJobs ] );
+
+		if (
+			! initialSessionOpenedRef.current &&
+			Number.isInteger( initialSessionId ) &&
+			initialSessionId > 0
+		) {
+			initialSessionOpenedRef.current = true;
+			openSession( initialSessionId );
+		}
+	}, [
+		fetchProviders,
+		fetchSessions,
+		fetchSettings,
+		initialSessionId,
+		openSession,
+		restoreActiveJobs,
+	] );
 
 	const appendServiceConnectionNotice = useCallback(
 		( notice ) => {
@@ -291,12 +311,15 @@ function AdminPageApp() {
  * Called by the unified admin's ChatRoute via window.sdAiAgentChat.mount().
  * Returns a root instance so the caller can unmount cleanly.
  *
- * @param {HTMLElement} container - DOM element to mount into.
+ * @param {HTMLElement}          container DOM element to mount into.
+ * @param {{sessionId?: number}} options   Optional mount options.
  * @return {import('@wordpress/element').Root} React root.
  */
-function mountAdminPageApp( container ) {
+function mountAdminPageApp( container, options = {} ) {
 	const root = createRoot( container );
-	root.render( <AdminPageApp /> );
+	root.render(
+		<AdminPageApp initialSessionId={ options.sessionId ?? null } />
+	);
 	return root;
 }
 
@@ -313,14 +336,15 @@ window.sdAiAgentChat = {
 	/**
 	 * Mount the admin page app into the given container.
 	 *
-	 * @param {HTMLElement} container - Target DOM element.
+	 * @param {HTMLElement}          container Target DOM element.
+	 * @param {{sessionId?: number}} options   Optional mount options.
 	 */
-	mount( container ) {
+	mount( container, options = {} ) {
 		if ( ! container ) {
 			return;
 		}
 		// Store the root so unmount() can tear it down cleanly.
-		container.__sdAiRoot = mountAdminPageApp( container );
+		container.__sdAiRoot = mountAdminPageApp( container, options );
 	},
 
 	/**

--- a/src/settings-page/__tests__/superdav-account-manager.test.js
+++ b/src/settings-page/__tests__/superdav-account-manager.test.js
@@ -8,6 +8,9 @@ import apiFetch from '@wordpress/api-fetch';
 import SuperdavAccountManager, {
 	formatCreditActivityDate,
 	formatCreditActivityType,
+	formatManagedModelName,
+	formatTokenCount,
+	formatUsageCost,
 	formatWalletAmount,
 } from '../superdav-account-manager';
 
@@ -95,6 +98,7 @@ describe( 'SuperdavAccountManager', () => {
 		expect( formatWalletAmount( undefined ) ).toBe( '—' );
 		expect( formatWalletAmount( '' ) ).toBe( '—' );
 		expect( formatWalletAmount( 0 ) ).not.toBe( '—' );
+		expect( formatUsageCost( 1250 ) ).toMatch( /0[.,]00125/ );
 	} );
 
 	test( 'formats safe activity states and unavailable timestamps', () => {
@@ -107,6 +111,10 @@ describe( 'SuperdavAccountManager', () => {
 		expect( formatCreditActivityDate( 'invalid', 'UTC' ) ).toBe(
 			'Unavailable'
 		);
+		expect( formatManagedModelName( 'superdav-chat-pro' ) ).toBe(
+			'Standard'
+		);
+		expect( formatTokenCount( 1234 ) ).toMatch( /1.234|1,234/ );
 	} );
 
 	test( 'does not show a disconnected warning after a failed request', async () => {
@@ -184,8 +192,68 @@ describe( 'SuperdavAccountManager', () => {
 		} );
 
 		expect( container.textContent ).toContain(
-			'No recent credit activity is available.'
+			'No purchases, promotions, or adjustments are available.'
 		);
+	} );
+
+	test( 'expands actual usage grouped by chat session and links to the full chat', async () => {
+		apiFetch.mockResolvedValue( {
+			configured: true,
+			site_timezone: 'UTC',
+			chat_sessions: [
+				{
+					session_id: 42,
+					title: 'Build the landing page',
+					last_used_at: '2026-07-31T10:01:00+00:00',
+					input_tokens: 1200,
+					cached_input_tokens: 300,
+					output_tokens: 400,
+					total_tokens: 1600,
+					cost_usd_micros: 125000,
+					loop_count: 3,
+					tool_call_count: 7,
+					models: [
+						{
+							model_id: 'superdav-chat-pro',
+							total_tokens: 1400,
+							cost_usd_micros: 100000,
+							loop_count: 2,
+						},
+						{
+							model_id: 'superdav-chat-fast',
+							total_tokens: 200,
+							cost_usd_micros: 25000,
+							loop_count: 1,
+						},
+					],
+				},
+			],
+			credit_activity: [],
+		} );
+
+		await act( async () => {
+			root.render( createElement( SuperdavAccountManager, {} ) );
+		} );
+		await act( async () => {
+			await Promise.resolve();
+		} );
+
+		expect( container.textContent ).toContain( 'Build the landing page' );
+		expect( container.textContent ).toContain( 'Standard, Speedy' );
+		expect( container.textContent ).toContain( '$0.125' );
+		expect( container.textContent ).not.toContain( 'Agent loops' );
+
+		await act( async () => {
+			container
+				.querySelector( '.sd-ai-agent-superdav-session-usage-summary' )
+				.click();
+		} );
+
+		expect( container.textContent ).toContain( 'Agent loops3' );
+		expect( container.textContent ).toContain( 'Tool calls7' );
+		expect(
+			container.querySelector( 'a[href$="#/chat/42"]' )
+		).not.toBeNull();
 	} );
 
 	test( 'renders dedicated billing actions with their service-issued URLs', async () => {

--- a/src/settings-page/style.css
+++ b/src/settings-page/style.css
@@ -591,8 +591,137 @@
 	gap: 8px;
 }
 
+.sd-ai-agent-superdav-session-usage h4,
 .sd-ai-agent-superdav-credit-activity h4 {
 	margin: 0 0 8px;
+}
+
+.sd-ai-agent-superdav-session-usage > .description {
+	margin: -2px 0 10px;
+}
+
+.sd-ai-agent-superdav-session-usage-list {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	border: 1px solid #dcdcde;
+	border-radius: 4px;
+	background: #fff;
+	overflow: hidden;
+}
+
+.sd-ai-agent-superdav-session-usage-list > li {
+	margin: 0;
+	border-bottom: 1px solid #dcdcde;
+}
+
+.sd-ai-agent-superdav-session-usage-list > li:last-child {
+	border-bottom: 0;
+}
+
+.sd-ai-agent-superdav-session-usage-summary {
+	display: grid;
+	grid-template-columns: minmax(0, 1fr) auto;
+	align-items: center;
+	gap: 20px;
+	width: 100%;
+	padding: 14px 16px;
+	border: 0;
+	background: transparent;
+	color: #1d2327;
+	font: inherit;
+	text-align: left;
+	cursor: pointer;
+}
+
+.sd-ai-agent-superdav-session-usage-summary:hover,
+.sd-ai-agent-superdav-session-usage-summary[aria-expanded="true"] {
+	background: #f6f7f7;
+}
+
+.sd-ai-agent-superdav-session-usage-summary:focus-visible {
+	outline: 2px solid var(--wp-admin-theme-color, #2271b1);
+	outline-offset: -2px;
+}
+
+.sd-ai-agent-superdav-session-identity,
+.sd-ai-agent-superdav-session-identity > span,
+.sd-ai-agent-superdav-session-usage-totals > span {
+	display: block;
+}
+
+.sd-ai-agent-superdav-session-identity {
+	min-width: 0;
+}
+
+.sd-ai-agent-superdav-session-identity > strong {
+	display: block;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.sd-ai-agent-superdav-session-identity > span,
+.sd-ai-agent-superdav-session-usage-totals > span {
+	margin-top: 3px;
+	color: #50575e;
+	font-size: 12px;
+}
+
+.sd-ai-agent-superdav-session-usage-totals {
+	min-width: 110px;
+	text-align: right;
+}
+
+.sd-ai-agent-superdav-session-usage-totals > strong {
+	display: block;
+	margin-top: 3px;
+	font-size: 16px;
+}
+
+.sd-ai-agent-superdav-session-usage-details {
+	padding: 16px;
+	border-top: 1px solid #dcdcde;
+	background: #f6f7f7;
+}
+
+.sd-ai-agent-superdav-session-usage-details dl {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+	gap: 10px;
+	margin: 0 0 16px;
+}
+
+.sd-ai-agent-superdav-session-usage-details dl > div {
+	padding: 10px 12px;
+	border: 1px solid #dcdcde;
+	border-radius: 3px;
+	background: #fff;
+}
+
+.sd-ai-agent-superdav-session-usage-details dt {
+	color: #50575e;
+	font-size: 12px;
+}
+
+.sd-ai-agent-superdav-session-usage-details dd {
+	margin: 3px 0 0;
+	font-weight: 600;
+}
+
+.sd-ai-agent-superdav-session-models {
+	width: 100%;
+	margin: 0 0 16px;
+	border-collapse: collapse;
+	background: #fff;
+	font-size: 12px;
+}
+
+.sd-ai-agent-superdav-session-models th,
+.sd-ai-agent-superdav-session-models td {
+	padding: 7px 9px;
+	border: 1px solid #dcdcde;
+	text-align: left;
 }
 
 .sd-ai-agent-superdav-credit-activity-list {
@@ -631,6 +760,15 @@
 @media screen and (max-width: 600px) {
 	.sd-ai-agent-superdav-account-header {
 		flex-direction: column;
+	}
+
+	.sd-ai-agent-superdav-session-usage-summary {
+		grid-template-columns: 1fr;
+		gap: 8px;
+	}
+
+	.sd-ai-agent-superdav-session-usage-totals {
+		text-align: left;
 	}
 
 	.sd-ai-agent-superdav-credit-activity-list li {

--- a/src/settings-page/superdav-account-manager.js
+++ b/src/settings-page/superdav-account-manager.js
@@ -27,6 +27,30 @@ export function formatWalletAmount( micros ) {
 }
 
 /**
+ * Format an actual usage charge without rounding sub-cent costs to zero.
+ *
+ * @param {number|string|null|undefined} micros Amount in USD micros.
+ * @return {string} Localized usage cost.
+ */
+export function formatUsageCost( micros ) {
+	if ( micros === null || micros === undefined || micros === '' ) {
+		return '—';
+	}
+
+	const amount = Number( micros );
+	if ( ! Number.isFinite( amount ) ) {
+		return '—';
+	}
+
+	return new Intl.NumberFormat( undefined, {
+		style: 'currency',
+		currency: 'USD',
+		minimumFractionDigits: 2,
+		maximumFractionDigits: 6,
+	} ).format( amount / 1_000_000 );
+}
+
+/**
  * Format a service timestamp in the WordPress site's configured timezone.
  *
  * @param {string|null|undefined} timestamp ISO-8601 timestamp.
@@ -67,6 +91,294 @@ export function formatCreditActivityType( type ) {
 	};
 
 	return labels[ type ] || __( 'Credit activity', 'superdav-ai-agent' );
+}
+
+/**
+ * @param {number|string|null|undefined} tokens Token count.
+ * @return {string} Localized integer token count.
+ */
+export function formatTokenCount( tokens ) {
+	const count = Number( tokens );
+
+	return new Intl.NumberFormat().format(
+		Number.isFinite( count ) && count > 0 ? Math.floor( count ) : 0
+	);
+}
+
+/**
+ * @param {string} modelId Managed model identifier.
+ * @return {string} User-facing model name.
+ */
+export function formatManagedModelName( modelId ) {
+	const names = {
+		'superdav-chat-fast': __( 'Speedy', 'superdav-ai-agent' ),
+		'superdav-chat-pro': __( 'Standard', 'superdav-ai-agent' ),
+		'superdav-chat-strong': __( 'Strong', 'superdav-ai-agent' ),
+		'superdav-image': __( 'Image', 'superdav-ai-agent' ),
+	};
+
+	return (
+		names[ modelId ] ||
+		modelId ||
+		__( 'Unknown model', 'superdav-ai-agent' )
+	);
+}
+
+/**
+ * Build a same-origin deep link to one local chat session.
+ *
+ * @param {number} sessionId Local chat session ID.
+ * @return {string} Chat review URL.
+ */
+function getChatSessionUrl( sessionId ) {
+	return `${ window.location.href.split( '#' )[ 0 ] }#/chat/${ sessionId }`;
+}
+
+/**
+ * Render actual managed-service charges grouped by local chat session.
+ *
+ * @param {Object}     props          Component props.
+ * @param {Array|null} props.sessions Safe owned session summaries.
+ * @param {string}     props.timeZone Site timezone.
+ * @return {JSX.Element} Session usage content.
+ */
+function ChatSessionUsage( { sessions, timeZone } ) {
+	const [ expandedSessionId, setExpandedSessionId ] = useState( null );
+
+	if ( sessions === null ) {
+		return (
+			<p className="description">
+				{ __(
+					'Session-level usage is unavailable. Refresh your balance and try again.',
+					'superdav-ai-agent'
+				) }
+			</p>
+		);
+	}
+
+	if ( sessions.length === 0 ) {
+		return (
+			<p className="description">
+				{ __(
+					'No chat session usage is available yet.',
+					'superdav-ai-agent'
+				) }
+			</p>
+		);
+	}
+
+	return (
+		<ul className="sd-ai-agent-superdav-session-usage-list">
+			{ sessions.map( ( session ) => {
+				const sessionId = Number( session.session_id );
+				const expanded = expandedSessionId === sessionId;
+				const detailsId = `sd-ai-agent-session-usage-${ sessionId }`;
+				const models = Array.isArray( session.models )
+					? session.models
+					: [];
+				const modelNames = models
+					.map( ( model ) =>
+						formatManagedModelName( model.model_id )
+					)
+					.join( ', ' );
+
+				return (
+					<li key={ sessionId }>
+						<button
+							type="button"
+							className="sd-ai-agent-superdav-session-usage-summary"
+							aria-expanded={ expanded }
+							aria-controls={ detailsId }
+							onClick={ () =>
+								setExpandedSessionId(
+									expanded ? null : sessionId
+								)
+							}
+						>
+							<span className="sd-ai-agent-superdav-session-identity">
+								<strong>{ session.title }</strong>
+								<span>
+									{ modelNames ||
+										__(
+											'Unknown model',
+											'superdav-ai-agent'
+										) }
+									{ ' · ' }
+									{ formatCreditActivityDate(
+										session.last_used_at,
+										timeZone
+									) }
+								</span>
+							</span>
+							<span className="sd-ai-agent-superdav-session-usage-totals">
+								<span>
+									{ sprintf(
+										/* translators: %s: total number of tokens. */
+										__( '%s tokens', 'superdav-ai-agent' ),
+										formatTokenCount( session.total_tokens )
+									) }
+								</span>
+								<strong>
+									{ formatUsageCost(
+										session.cost_usd_micros
+									) }
+								</strong>
+							</span>
+						</button>
+
+						{ expanded && (
+							<div
+								id={ detailsId }
+								className="sd-ai-agent-superdav-session-usage-details"
+							>
+								<dl>
+									<div>
+										<dt>
+											{ __(
+												'Input tokens',
+												'superdav-ai-agent'
+											) }
+										</dt>
+										<dd>
+											{ formatTokenCount(
+												session.input_tokens
+											) }
+										</dd>
+									</div>
+									<div>
+										<dt>
+											{ __(
+												'Cached input tokens',
+												'superdav-ai-agent'
+											) }
+										</dt>
+										<dd>
+											{ formatTokenCount(
+												session.cached_input_tokens
+											) }
+										</dd>
+									</div>
+									<div>
+										<dt>
+											{ __(
+												'Output tokens',
+												'superdav-ai-agent'
+											) }
+										</dt>
+										<dd>
+											{ formatTokenCount(
+												session.output_tokens
+											) }
+										</dd>
+									</div>
+									<div>
+										<dt>
+											{ __(
+												'Agent loops',
+												'superdav-ai-agent'
+											) }
+										</dt>
+										<dd>{ session.loop_count || 0 }</dd>
+									</div>
+									<div>
+										<dt>
+											{ __(
+												'Tool calls',
+												'superdav-ai-agent'
+											) }
+										</dt>
+										<dd>
+											{ session.tool_call_count || 0 }
+										</dd>
+									</div>
+									<div>
+										<dt>
+											{ __(
+												'Actual cost',
+												'superdav-ai-agent'
+											) }
+										</dt>
+										<dd>
+											{ formatUsageCost(
+												session.cost_usd_micros
+											) }
+										</dd>
+									</div>
+								</dl>
+
+								{ models.length > 1 && (
+									<table className="sd-ai-agent-superdav-session-models">
+										<thead>
+											<tr>
+												<th>
+													{ __(
+														'Model',
+														'superdav-ai-agent'
+													) }
+												</th>
+												<th>
+													{ __(
+														'Tokens',
+														'superdav-ai-agent'
+													) }
+												</th>
+												<th>
+													{ __(
+														'Loops',
+														'superdav-ai-agent'
+													) }
+												</th>
+												<th>
+													{ __(
+														'Cost',
+														'superdav-ai-agent'
+													) }
+												</th>
+											</tr>
+										</thead>
+										<tbody>
+											{ models.map( ( model ) => (
+												<tr key={ model.model_id }>
+													<td>
+														{ formatManagedModelName(
+															model.model_id
+														) }
+													</td>
+													<td>
+														{ formatTokenCount(
+															model.total_tokens
+														) }
+													</td>
+													<td>
+														{ model.loop_count }
+													</td>
+													<td>
+														{ formatUsageCost(
+															model.cost_usd_micros
+														) }
+													</td>
+												</tr>
+											) ) }
+										</tbody>
+									</table>
+								) }
+
+								<Button
+									variant="secondary"
+									href={ getChatSessionUrl( sessionId ) }
+								>
+									{ __(
+										'Review full session',
+										'superdav-ai-agent'
+									) }
+								</Button>
+							</div>
+						) }
+					</li>
+				);
+			} ) }
+		</ul>
+	);
 }
 
 /**
@@ -197,14 +509,22 @@ export default function SuperdavAccountManager() {
 		purchaseCreditsUrl || paymentMethodsUrl || accountUrl;
 	const configured = !! account?.configured;
 	const tier = account?.tier || '';
+	const chatSessions = Array.isArray( account?.chat_sessions )
+		? account.chat_sessions
+		: null;
 	const creditActivity = Array.isArray( account?.credit_activity )
-		? account.credit_activity
+		? account.credit_activity.filter(
+				( event ) =>
+					event.type !== 'consumed' &&
+					( event.type !== 'pending' ||
+						event.label === 'Credit adjustment' )
+		  )
 		: null;
 	const siteTimezone = account?.site_timezone || '';
 	let creditActivityContent = (
 		<p className="description">
 			{ __(
-				'Recent credit activity is unavailable.',
+				'Other credit activity is unavailable.',
 				'superdav-ai-agent'
 			) }
 		</p>
@@ -214,7 +534,7 @@ export default function SuperdavAccountManager() {
 		creditActivityContent = (
 			<p className="description">
 				{ __(
-					'No recent credit activity is available.',
+					'No purchases, promotions, or adjustments are available.',
 					'superdav-ai-agent'
 				) }
 			</p>
@@ -407,11 +727,36 @@ export default function SuperdavAccountManager() {
 						</form>
 
 						<section
+							className="sd-ai-agent-superdav-session-usage"
+							aria-labelledby="sd-ai-agent-superdav-session-usage-heading"
+						>
+							<h4 id="sd-ai-agent-superdav-session-usage-heading">
+								{ __(
+									'Credit usage by chat session',
+									'superdav-ai-agent'
+								) }
+							</h4>
+							<p className="description">
+								{ __(
+									'Actual SD AI charges and tokens are grouped by the chat that created them.',
+									'superdav-ai-agent'
+								) }
+							</p>
+							<ChatSessionUsage
+								sessions={ chatSessions }
+								timeZone={ siteTimezone }
+							/>
+						</section>
+
+						<section
 							className="sd-ai-agent-superdav-credit-activity"
 							aria-labelledby="sd-ai-agent-superdav-credit-activity-heading"
 						>
 							<h4 id="sd-ai-agent-superdav-credit-activity-heading">
-								{ __( 'Credit activity', 'superdav-ai-agent' ) }
+								{ __(
+									'Other credit activity',
+									'superdav-ai-agent'
+								) }
 							</h4>
 							{ creditActivityContent }
 						</section>

--- a/src/unified-admin/router.js
+++ b/src/unified-admin/router.js
@@ -68,8 +68,12 @@ export default function Router( { route } ) {
 
 	switch ( mainRoute ) {
 		case 'chat':
-		case '':
-			return <ChatRoute />;
+		case '': {
+			const sessionId = /^\d+$/.test( subRoute || '' )
+				? Number( subRoute )
+				: null;
+			return <ChatRoute sessionId={ sessionId } />;
+		}
 
 		case 'abilities':
 			return <AbilitiesRoute />;

--- a/src/unified-admin/routes/chat.js
+++ b/src/unified-admin/routes/chat.js
@@ -18,9 +18,11 @@ import { useEffect, useRef } from '@wordpress/element';
  * which bypasses React's unmount hooks and leaks subscriptions and event
  * handlers.
  *
+ * @param {Object}      props           Component props.
+ * @param {number|null} props.sessionId Optional session to open after mount.
  * @return {JSX.Element} Chat route element.
  */
-export default function ChatRoute() {
+export default function ChatRoute( { sessionId = null } ) {
 	const containerRef = useRef( null );
 	// Track whether mount() has been called so we don't call it twice.
 	const mountedRef = useRef( false );
@@ -43,7 +45,7 @@ export default function ChatRoute() {
 				! mountedRef.current
 			) {
 				mountedRef.current = true;
-				window.sdAiAgentChat.mount( container );
+				window.sdAiAgentChat.mount( container, { sessionId } );
 				return true;
 			}
 			return false;
@@ -111,7 +113,7 @@ export default function ChatRoute() {
 				mountedRef.current = false;
 			}
 		};
-	}, [] );
+	}, [ sessionId ] );
 
 	return (
 		<div className="sdaa-route sdaa-route-chat">

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
@@ -13,6 +13,7 @@ namespace SdAiAgent\Tests\Infrastructure\AiClient\Superdav;
 use SdAiAgent\Bootstrap\SuperdavAiProviderHandler;
 use SdAiAgent\Core\ModelCapabilityRegistry;
 use SdAiAgent\Core\ProviderCredentialLoader;
+use SdAiAgent\Core\ProviderTraceLogger;
 use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiImageGenerationModel;
 use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiModelMetadataDirectory;
 use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
@@ -55,6 +56,7 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 		remove_all_filters( 'sd_ai_agent_superdav_default_model' );
 		remove_all_filters( 'sd_ai_agent_superdav_reasoning_effort' );
 		remove_all_filters( 'sd_ai_agent_openai_tool_search_enabled' );
+		ProviderTraceLogger::clear_runtime_context();
 		parent::tear_down();
 	}
 
@@ -165,6 +167,39 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 		$data = $request->getData();
 		$this->assertIsArray( $data );
 		$this->assertSame( $expected_effort, $data['reasoning_effort'] ?? '' );
+	}
+
+	/** Managed inference requests carry only the active local session ID. */
+	public function test_text_generation_request_includes_safe_session_attribution(): void {
+		$this->skip_if_sdk_unavailable();
+
+		$model = new SuperdavAiTextGenerationModel(
+			new ModelMetadata( 'example-model', 'Example Model', array(), array() ),
+			SuperdavAiProvider::metadata()
+		);
+		$method = new \ReflectionMethod( $model, 'createRequest' );
+		$method->setAccessible( true );
+
+		ProviderTraceLogger::set_runtime_context( SuperdavAiProvider::PROVIDER_ID, 'example-model', 42 );
+		$request = $method->invoke(
+			$model,
+			HttpMethodEnum::POST(),
+			'chat/completions',
+			array( 'Content-Type' => 'application/json' ),
+			array( 'model' => 'example-model' )
+		);
+		ProviderTraceLogger::clear_runtime_context();
+
+		$this->assertSame( '42', $request->getHeaderAsString( SuperdavAiProvider::SESSION_ATTRIBUTION_HEADER ) );
+
+		$unattributed_request = $method->invoke(
+			$model,
+			HttpMethodEnum::POST(),
+			'chat/completions',
+			array( 'Content-Type' => 'application/json' ),
+			array( 'model' => 'example-model' )
+		);
+		$this->assertNull( $unattributed_request->getHeaderAsString( SuperdavAiProvider::SESSION_ATTRIBUTION_HEADER ) );
 	}
 
 	/**

--- a/tests/SdAiAgent/REST/SettingsControllerTest.php
+++ b/tests/SdAiAgent/REST/SettingsControllerTest.php
@@ -253,6 +253,25 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 
 	/** Superdav account refresh returns safe wallet metadata without a bearer token. */
 	public function test_handle_refresh_superdav_account_returns_safe_wallet_metadata(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+		$session_id = Database::create_session(
+			array(
+				'user_id'     => $user_id,
+				'title'       => 'Build the landing page',
+				'provider_id' => SuperdavAiProvider::PROVIDER_ID,
+				'model_id'    => SuperdavAiProvider::DEFAULT_MODEL_ID,
+			)
+		);
+		$this->assertIsInt( $session_id );
+		Database::update_session(
+			$session_id,
+			array(
+				'messages'   => wp_json_encode( array( array( 'role' => 'user' ), array( 'role' => 'assistant' ) ) ),
+				'tool_calls' => wp_json_encode( array( array( 'name' => 'site-info' ), array( 'name' => 'update-post' ) ) ),
+			)
+		);
+
 		$base_url    = 'https://service.example/v1';
 		$account_url = $base_url . '/site/account';
 		$token       = 'sdaist_account_refresh_token';
@@ -260,12 +279,15 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		add_filter( 'sd_ai_agent_cloud_base_url', static fn(): string => $base_url );
 		add_filter(
 			'pre_http_request',
-			static function ( mixed $preempt, array $parsed_args, string $url ) use ( $account_url, $token ): mixed {
+			static function ( mixed $preempt, array $parsed_args, string $url ) use ( $account_url, $token, $session_id ): mixed {
 				if ( $account_url !== $url ) {
 					return $preempt;
 				}
 
 				self::assertSame( 'Bearer ' . $token, self::authorization_header_from_args( $parsed_args ) );
+				$request_body = json_decode( (string) ( $parsed_args['body'] ?? '' ), true );
+				self::assertSame( SuperdavSiteConnectionService::MAX_CREDIT_ACTIVITY_EVENTS, $request_body['credit_activity_limit'] ?? null );
+				self::assertSame( SuperdavSiteConnectionService::MAX_CHAT_SESSION_EVENTS, $request_body['chat_session_limit'] ?? null );
 
 				return array(
 					'response' => array(
@@ -284,6 +306,32 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 								'cash_usd_micros'  => 12500000,
 								'total_usd_micros' => 15000000,
 								'payment_token'    => 'must-not-be-exposed',
+							),
+							'chat_sessions' => array(
+								array(
+									'session_id'         => (string) $session_id,
+									'started_at'         => '2026-07-16T00:00:00Z',
+									'last_used_at'       => '2026-07-16T00:05:00Z',
+									'input_tokens'       => 1200,
+									'cached_input_tokens' => 300,
+									'output_tokens'      => 400,
+									'total_tokens'       => 1600,
+									'cost_usd_micros'    => 125000,
+									'loop_count'         => 3,
+									'models'             => array(
+										array(
+											'model_id'           => SuperdavAiProvider::DEFAULT_MODEL_ID,
+											'input_tokens'       => 1200,
+											'cached_input_tokens' => 300,
+											'output_tokens'      => 400,
+											'total_tokens'       => 1600,
+											'cost_usd_micros'    => 125000,
+											'loop_count'         => 3,
+											'upstream_request_id' => 'must-not-be-exposed',
+										),
+									),
+									'account_id'         => 'must-not-be-exposed',
+								),
 							),
 							'credit_activity' => array(
 								array(
@@ -348,6 +396,14 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		$this->assertSame( 2500000, $data['credit_activity'][0]['amount_usd_micros'] );
 		$this->assertSame( '2026-08-16T00:00:00+00:00', $data['credit_activity'][0]['expires_at'] );
 		$this->assertArrayNotHasKey( 'customer_id', $data['credit_activity'][0] );
+		$this->assertCount( 1, $data['chat_sessions'] );
+		$this->assertSame( $session_id, $data['chat_sessions'][0]['session_id'] );
+		$this->assertSame( 'Build the landing page', $data['chat_sessions'][0]['title'] );
+		$this->assertSame( 2, $data['chat_sessions'][0]['tool_call_count'] );
+		$this->assertSame( 2, $data['chat_sessions'][0]['message_count'] );
+		$this->assertSame( 125000, $data['chat_sessions'][0]['cost_usd_micros'] );
+		$this->assertSame( SuperdavAiProvider::DEFAULT_MODEL_ID, $data['chat_sessions'][0]['models'][0]['model_id'] );
+		$this->assertArrayNotHasKey( 'upstream_request_id', $data['chat_sessions'][0]['models'][0] );
 		$this->assertArrayNotHasKey( 'usage', $data );
 		$this->assertArrayNotHasKey( 'verification', $data );
 		$this->assertArrayNotHasKey( 'refreshed_at', $data );


### PR DESCRIPTION
## Summary

- replace request-level credit ledger noise with usage grouped by owned chat session
- show the model, exact managed-service USD charge, total/input/cached/output tokens, agent loops, and local tool-call count
- provide expandable per-model details and a “Review full session” action
- add `#/chat/{sessionId}` deep links that open the selected conversation in the chat interface
- send only the numeric local session ID to the managed service for billing attribution
- strictly allowlist service session summaries and re-check local WordPress session ownership before exposing titles or review links
- retain purchases, promotions, coupon redemptions, adjustments, and reversals under “Other credit activity”

## Service dependency

Requires the managed-service contract and migration from https://github.com/Ultimate-Multisite/superdav-ai-service/pull/77. Existing historical usage without session attribution cannot be retroactively grouped; new usage is grouped after both changes are deployed.

## Manual verification

- tested the settings page with a representative multi-model session fixture
- verified expandable token, loop, tool-call, and exact-cost details
- verified “Review full session” opens `#/chat/{sessionId}` and loads the conversation
- scoped axe audit on the collapsed and expanded session list: 0 violations

## Worker self-verification
- PHPUnit: Tests: 4034, Assertions: 18021, Errors: 0, Failures: 0, Skipped: 136
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.198
