### PR TITLE
GH#2410: reject invalid calc length arithmetic

### DIFF
--- a/includes/Services/DesignTokenContract.php
+++ b/includes/Services/DesignTokenContract.php
@@ -1394,7 +1394,7 @@ final class DesignTokenContract {
 			return false;
 		}
 
-		return 1 === preg_match( '~^calc\(\s*' . $length . '(?:(?:\s*[+*/]\s*|\s+-\s+)' . $length . ')+\s*\)$~', $value )
+		return 1 === preg_match( '~^calc\(\s*' . $length . '(?:(?:\s*\+\s*|\s+-\s+)' . $length . ')+\s*\)$~', $value )
 			|| 1 === preg_match( '~^(?:min|max)\(\s*' . $length . '(?:\s*,\s*' . $length . ')+\s*\)$~', $value )
 			|| 1 === preg_match( '~^clamp\(\s*' . $length . '\s*,\s*' . $length . '\s*,\s*' . $length . '\s*\)$~', $value );
 	}

--- a/tests/SdAiAgent/Abilities/CompileDesignTokensAbilityTest.php
+++ b/tests/SdAiAgent/Abilities/CompileDesignTokensAbilityTest.php
@@ -98,7 +98,7 @@ class CompileDesignTokensAbilityTest extends WP_UnitTestCase {
 	 */
 	public function test_run_reports_invalid_css_primitive_path_and_expected_shape(): void {
 		$contract                                      = $this->valid_contract();
-		$contract['primitives']['font_sizes'][0]['size'] = 'calc(1rem 2rem)';
+		$contract['primitives']['font_sizes'][0]['size'] = 'calc(1rem * 2rem)';
 
 		$result = $this->ability()->run( [ 'contract' => $contract ] );
 


### PR DESCRIPTION
## Summary

- Restrict token-size `calc()` expressions to length-preserving addition and subtraction.
- Cover length-by-length multiplication as an invalid design-token primitive.

## Worker self-verification

- PHPUnit: Tests: 4034, Assertions: 18030, Errors: 0, Failures: 0, Skipped: 134, Incomplete: 4
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded

Additional focused verification: `npm run test:php -- --filter=CompileDesignTokensAbilityTest` — 5 tests, 34 assertions.

Resolves #2410

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.209 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra
