### PR TITLE
GH#2409: Prevent stale chat attachments

### DIFF
--- a/src/components/chat-composer/__tests__/use-chat-composer.test.js
+++ b/src/components/chat-composer/__tests__/use-chat-composer.test.js
@@ -213,6 +213,63 @@ describe( 'useChatComposer', () => {
 		);
 	} );
 
+	test( 'does not restore an attachment after submitting while it is loading', async () => {
+		const originalFileReader = global.FileReader;
+		let pendingReader;
+
+		class DeferredFileReader {
+			readAsDataURL() {
+				pendingReader = this;
+			}
+		}
+
+		global.FileReader = DeferredFileReader;
+
+		try {
+			await act( async () => {
+				container
+					.querySelector( '[data-attach]' )
+					.dispatchEvent(
+						new MouseEvent( 'click', { bubbles: true } )
+					);
+			} );
+			expect( pendingReader ).toBeDefined();
+
+			await act( async () => {
+				setTextareaValue( container, 'Send before attachment loads' );
+				container
+					.querySelector( '[data-send]' )
+					.dispatchEvent(
+						new MouseEvent( 'click', { bubbles: true } )
+					);
+			} );
+
+			pendingReader.onload( {
+				target: { result: 'data:text/plain;base64,YnJpZWY=' },
+			} );
+			await act( async () => {
+				await Promise.resolve();
+			} );
+
+			await act( async () => {
+				setTextareaValue( container, 'Send after attachment loads' );
+				container
+					.querySelector( '[data-send]' )
+					.dispatchEvent(
+						new MouseEvent( 'click', { bubbles: true } )
+					);
+			} );
+
+			expect( dispatchers.sendMessage ).toHaveBeenNthCalledWith(
+				2,
+				'Send after attachment loads',
+				[]
+			);
+		} finally {
+			global.FileReader = originalFileReader;
+		}
+	} );
+
 	test( 'does not open issue reporting in simple customer mode', async () => {
 		await act( async () => {
 			root.render(

--- a/src/components/chat-composer/use-chat-composer.js
+++ b/src/components/chat-composer/use-chat-composer.js
@@ -85,6 +85,7 @@ export default function useChatComposer( {
 	} );
 	const textareaRef = useRef( null );
 	const fileInputRef = useRef( null );
+	const attachmentGenerationRef = useRef( 0 );
 
 	const focusTextarea = useCallback( () => {
 		setTimeout(
@@ -126,6 +127,7 @@ export default function useChatComposer( {
 	}, [ text, isSimpleMode ] );
 
 	const processFiles = useCallback( async ( files ) => {
+		const attachmentGeneration = attachmentGenerationRef.current;
 		const next = [];
 		const rejectedNames = [];
 		setAttachmentError( '' );
@@ -139,6 +141,9 @@ export default function useChatComposer( {
 			}
 			try {
 				const dataUrl = await readAsDataUrl( file );
+				if ( attachmentGeneration !== attachmentGenerationRef.current ) {
+					return;
+				}
 				next.push( {
 					name: file.name,
 					type: file.type,
@@ -146,8 +151,14 @@ export default function useChatComposer( {
 					isImage: ACCEPTED_IMAGE_TYPES.includes( file.type ),
 				} );
 			} catch {
+				if ( attachmentGeneration !== attachmentGenerationRef.current ) {
+					return;
+				}
 				rejectedNames.push( file.name );
 			}
+		}
+		if ( attachmentGeneration !== attachmentGenerationRef.current ) {
+			return;
 		}
 		if ( next.length ) {
 			setAttachments( ( previous ) => [ ...previous, ...next ] );
@@ -164,6 +175,7 @@ export default function useChatComposer( {
 	}, [] );
 
 	const clearComposer = useCallback( () => {
+		attachmentGenerationRef.current += 1;
 		setText( '' );
 		setAttachments( [] );
 		setAttachmentError( '' );

--- a/src/components/chat-composer/use-chat-composer.js
+++ b/src/components/chat-composer/use-chat-composer.js
@@ -141,7 +141,9 @@ export default function useChatComposer( {
 			}
 			try {
 				const dataUrl = await readAsDataUrl( file );
-				if ( attachmentGeneration !== attachmentGenerationRef.current ) {
+				if (
+					attachmentGeneration !== attachmentGenerationRef.current
+				) {
 					return;
 				}
 				next.push( {
@@ -151,7 +153,9 @@ export default function useChatComposer( {
 					isImage: ACCEPTED_IMAGE_TYPES.includes( file.type ),
 				} );
 			} catch {
-				if ( attachmentGeneration !== attachmentGenerationRef.current ) {
+				if (
+					attachmentGeneration !== attachmentGenerationRef.current
+				) {
 					return;
 				}
 				rejectedNames.push( file.name );


### PR DESCRIPTION
## Summary

- Invalidates in-flight attachment reads when the composer is cleared.
- Adds a regression test that proves a late FileReader completion cannot attach a file to the next message.

## Testing

- `npm run test:js -- src/components/chat-composer/__tests__/use-chat-composer.test.js --runInBand`
- `npm run verify`

## Worker self-verification

- PHPUnit: Tests: 4034, Assertions: 18030, Errors: 0, Failures: 0, Skipped: 134, Incomplete: 4
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded

## Runtime Testing

- Self-assessed: the regression test simulates the reported FileReader race.

Resolves #2409

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.209 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 3m and 97,416 tokens on this as a headless worker.
