### PR TITLE
test: validate explicit image model fixture

### DIFF
--- a/tests/SdAiAgent/Abilities/AiImageAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/AiImageAbilitiesTest.php
@@ -226,6 +226,7 @@ class AiImageAbilitiesTest extends WP_UnitTestCase {
 				SuperdavAiProvider::PROVIDER_ID => [
 					SuperdavAiProvider::DEFAULT_MODEL_ID,
 					SuperdavAiProvider::IMAGE_MODEL_ID,
+					'custom-image-model',
 				],
 			];
 		};


### PR DESCRIPTION
## Summary

- Include the explicit custom image model in the validation fixture.
- Keep the preservation assertion meaningful when image model preferences resolve.

## Testing

- `npm run verify`

## Worker self-verification
- PHPUnit: Tests: 4034, Assertions: 18030, Errors: 0, Failures: 0, Skipped: 134
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

Resolves #2352

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.212 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated AI image preference test coverage to include an additional custom image model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->