### PR TITLE
feat: rotate agent working statuses

### DIFF
--- a/src/components/chat-messages/__tests__/message-presentation.test.js
+++ b/src/components/chat-messages/__tests__/message-presentation.test.js
@@ -3,8 +3,10 @@
  */
 
 import {
+	getRunningStatusMessage,
 	getRunningJobPresentation,
 	getVisibleMessages,
+	RUNNING_STATUS_MESSAGES,
 	resolveSystemMessagePresentation,
 } from '../message-presentation';
 
@@ -77,7 +79,7 @@ describe( 'shared chat message presentation', () => {
 		} );
 	} );
 
-	test( 'uses the same running-job precedence and friendly fallback', () => {
+	test( 'uses the same running-job precedence and starts the fallback rotation', () => {
 		expect(
 			getRunningJobPresentation( {
 				currentSessionId: 7,
@@ -88,7 +90,17 @@ describe( 'shared chat message presentation', () => {
 			} )
 		).toEqual( {
 			toolCalls: [ { type: 'preamble', text: 'Working' } ],
-			step: 'Composing reply…',
+			isFallback: true,
+			step: 'Thinking…',
 		} );
+	} );
+
+	test( 'rotates 100 progressive fallback statuses in order and wraps', () => {
+		expect( RUNNING_STATUS_MESSAGES ).toHaveLength( 100 );
+		expect( getRunningStatusMessage( 0 ) ).toBe( 'Thinking…' );
+		expect( getRunningStatusMessage( 1 ) ).toBe( 'Working…' );
+		expect( getRunningStatusMessage( 77 ) ).toBe( 'Transmogrifying…' );
+		expect( getRunningStatusMessage( 78 ) ).toBe( 'Discombobulating…' );
+		expect( getRunningStatusMessage( 100 ) ).toBe( 'Thinking…' );
 	} );
 } );

--- a/src/components/chat-messages/__tests__/message-presentation.test.js
+++ b/src/components/chat-messages/__tests__/message-presentation.test.js
@@ -103,4 +103,22 @@ describe( 'shared chat message presentation', () => {
 		expect( getRunningStatusMessage( 78 ) ).toBe( 'Discombobulating…' );
 		expect( getRunningStatusMessage( 100 ) ).toBe( 'Thinking…' );
 	} );
+
+	test( 'keeps a concrete tool status instead of rotating fallback copy', () => {
+		expect(
+			getRunningJobPresentation( {
+				currentSessionId: 7,
+				sessionJobs: {},
+				liveToolCalls: [
+					{
+						type: 'call',
+						name: 'sd-ai-agent/get-site-info',
+					},
+				],
+			} )
+		).toMatchObject( {
+			isFallback: false,
+			step: 'Checking site info…',
+		} );
+	} );
 } );

--- a/src/components/chat-messages/__tests__/use-running-status.test.js
+++ b/src/components/chat-messages/__tests__/use-running-status.test.js
@@ -1,0 +1,68 @@
+/**
+ * Tests for fallback agent-status rotation.
+ */
+
+import { createElement } from '@wordpress/element';
+import { createRoot } from 'react-dom/client';
+import { act } from 'react';
+
+import useRunningStatus, {
+	RUNNING_STATUS_ROTATION_INTERVAL,
+} from '../use-running-status';
+
+global.IS_REACT_ACT_ENVIRONMENT = true;
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text ) => text,
+} ) );
+
+/**
+ * Render the currently rotated fallback status.
+ *
+ * @param {Object}  root0
+ * @param {boolean} root0.isRunning Whether fallback rotation is active.
+ * @return {JSX.Element} Status probe.
+ */
+function StatusProbe( { isRunning } ) {
+	return <output>{ useRunningStatus( isRunning ) }</output>;
+}
+
+describe( 'useRunningStatus', () => {
+	let container;
+	let root;
+
+	beforeEach( () => {
+		jest.useFakeTimers();
+		container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		root = createRoot( container );
+	} );
+
+	afterEach( async () => {
+		await act( async () => {
+			root.unmount();
+		} );
+		document.body.removeChild( container );
+		jest.useRealTimers();
+	} );
+
+	test( 'starts precisely, advances in order, and resets for the next request', async () => {
+		await act( async () => {
+			root.render( createElement( StatusProbe, { isRunning: true } ) );
+		} );
+		expect( container.textContent ).toBe( 'Thinking…' );
+
+		await act( async () => {
+			jest.advanceTimersByTime( RUNNING_STATUS_ROTATION_INTERVAL );
+		} );
+		expect( container.textContent ).toBe( 'Working…' );
+
+		await act( async () => {
+			root.render( createElement( StatusProbe, { isRunning: false } ) );
+		} );
+		await act( async () => {
+			root.render( createElement( StatusProbe, { isRunning: true } ) );
+		} );
+		expect( container.textContent ).toBe( 'Thinking…' );
+	} );
+} );

--- a/src/components/chat-messages/message-presentation.js
+++ b/src/components/chat-messages/message-presentation.js
@@ -15,6 +15,124 @@ import {
 } from '../chat-redesign/message-helpers';
 
 /**
+ * Ordered fallback copy for work that has not yet produced a concrete tool
+ * status. The first entries keep the status clear and precise; later entries
+ * become deliberately more playful for longer-running requests.
+ */
+export const RUNNING_STATUS_MESSAGES = [
+	__( 'Thinking…', 'superdav-ai-agent' ),
+	__( 'Working…', 'superdav-ai-agent' ),
+	__( 'Analyzing…', 'superdav-ai-agent' ),
+	__( 'Reviewing…', 'superdav-ai-agent' ),
+	__( 'Checking…', 'superdav-ai-agent' ),
+	__( 'Planning…', 'superdav-ai-agent' ),
+	__( 'Calculating…', 'superdav-ai-agent' ),
+	__( 'Organizing…', 'superdav-ai-agent' ),
+	__( 'Processing…', 'superdav-ai-agent' ),
+	__( 'Preparing…', 'superdav-ai-agent' ),
+	__( 'Drafting…', 'superdav-ai-agent' ),
+	__( 'Researching…', 'superdav-ai-agent' ),
+	__( 'Comparing…', 'superdav-ai-agent' ),
+	__( 'Validating…', 'superdav-ai-agent' ),
+	__( 'Refining…', 'superdav-ai-agent' ),
+	__( 'Synthesizing…', 'superdav-ai-agent' ),
+	__( 'Evaluating…', 'superdav-ai-agent' ),
+	__( 'Mapping…', 'superdav-ai-agent' ),
+	__( 'Parsing…', 'superdav-ai-agent' ),
+	__( 'Reasoning…', 'superdav-ai-agent' ),
+	__( 'Generating…', 'superdav-ai-agent' ),
+	__( 'Creating…', 'superdav-ai-agent' ),
+	__( 'Shaping…', 'superdav-ai-agent' ),
+	__( 'Assembling…', 'superdav-ai-agent' ),
+	__( 'Building…', 'superdav-ai-agent' ),
+	__( 'Composing…', 'superdav-ai-agent' ),
+	__( 'Formulating…', 'superdav-ai-agent' ),
+	__( 'Connecting…', 'superdav-ai-agent' ),
+	__( 'Exploring…', 'superdav-ai-agent' ),
+	__( 'Balancing…', 'superdav-ai-agent' ),
+	__( 'Polishing…', 'superdav-ai-agent' ),
+	__( 'Iterating…', 'superdav-ai-agent' ),
+	__( 'Arranging…', 'superdav-ai-agent' ),
+	__( 'Structuring…', 'superdav-ai-agent' ),
+	__( 'Reframing…', 'superdav-ai-agent' ),
+	__( 'Translating…', 'superdav-ai-agent' ),
+	__( 'Transforming…', 'superdav-ai-agent' ),
+	__( 'Transposing…', 'superdav-ai-agent' ),
+	__( 'Tuning…', 'superdav-ai-agent' ),
+	__( 'Aligning…', 'superdav-ai-agent' ),
+	__( 'Calibrating…', 'superdav-ai-agent' ),
+	__( 'Harmonizing…', 'superdav-ai-agent' ),
+	__( 'Sketching…', 'superdav-ai-agent' ),
+	__( 'Brainstorming…', 'superdav-ai-agent' ),
+	__( 'Weaving…', 'superdav-ai-agent' ),
+	__( 'Juggling…', 'superdav-ai-agent' ),
+	__( 'Wrangling…', 'superdav-ai-agent' ),
+	__( 'Untangling…', 'superdav-ai-agent' ),
+	__( 'Noodling…', 'superdav-ai-agent' ),
+	__( 'Pondering…', 'superdav-ai-agent' ),
+	__( 'Ruminating…', 'superdav-ai-agent' ),
+	__( 'Conjuring…', 'superdav-ai-agent' ),
+	__( 'Brewing…', 'superdav-ai-agent' ),
+	__( 'Cooking…', 'superdav-ai-agent' ),
+	__( 'Stirring…', 'superdav-ai-agent' ),
+	__( 'Whisking…', 'superdav-ai-agent' ),
+	__( 'Kneading…', 'superdav-ai-agent' ),
+	__( 'Sifting…', 'superdav-ai-agent' ),
+	__( 'Spinning…', 'superdav-ai-agent' ),
+	__( 'Twirling…', 'superdav-ai-agent' ),
+	__( 'Warming…', 'superdav-ai-agent' ),
+	__( 'Sparking…', 'superdav-ai-agent' ),
+	__( 'Igniting…', 'superdav-ai-agent' ),
+	__( 'Whirring…', 'superdav-ai-agent' ),
+	__( 'Humming…', 'superdav-ai-agent' ),
+	__( 'Buzzing…', 'superdav-ai-agent' ),
+	__( 'Percolating…', 'superdav-ai-agent' ),
+	__( 'Marinating…', 'superdav-ai-agent' ),
+	__( 'Fermenting…', 'superdav-ai-agent' ),
+	__( 'Moonwalking…', 'superdav-ai-agent' ),
+	__( 'Cartwheeling…', 'superdav-ai-agent' ),
+	__( 'Somersaulting…', 'superdav-ai-agent' ),
+	__( 'Gyrating…', 'superdav-ai-agent' ),
+	__( 'Orbiting…', 'superdav-ai-agent' ),
+	__( 'Time-traveling…', 'superdav-ai-agent' ),
+	__( 'Teleporting…', 'superdav-ai-agent' ),
+	__( 'Shape-shifting…', 'superdav-ai-agent' ),
+	__( 'Transmogrifying…', 'superdav-ai-agent' ),
+	__( 'Discombobulating…', 'superdav-ai-agent' ),
+	__( 'Bamboozling…', 'superdav-ai-agent' ),
+	__( 'Galvanizing…', 'superdav-ai-agent' ),
+	__( 'Pixelating…', 'superdav-ai-agent' ),
+	__( 'Jazz-handing…', 'superdav-ai-agent' ),
+	__( 'Spellcasting…', 'superdav-ai-agent' ),
+	__( 'Wizarding…', 'superdav-ai-agent' ),
+	__( 'Alchemizing…', 'superdav-ai-agent' ),
+	__( 'Enchanting…', 'superdav-ai-agent' ),
+	__( 'Bewitching…', 'superdav-ai-agent' ),
+	__( 'Sparkling…', 'superdav-ai-agent' ),
+	__( 'Glittering…', 'superdav-ai-agent' ),
+	__( 'Swooshing…', 'superdav-ai-agent' ),
+	__( 'Zooming…', 'superdav-ai-agent' ),
+	__( 'Scooting…', 'superdav-ai-agent' ),
+	__( 'Shimmying…', 'superdav-ai-agent' ),
+	__( 'Boogieing…', 'superdav-ai-agent' ),
+	__( 'Grooving…', 'superdav-ai-agent' ),
+	__( 'Vibing…', 'superdav-ai-agent' ),
+	__( 'High-fiving…', 'superdav-ai-agent' ),
+	__( 'Finessing…', 'superdav-ai-agent' ),
+	__( 'Finagling…', 'superdav-ai-agent' ),
+];
+
+/**
+ * Return a rotation status for an arbitrary counter value.
+ *
+ * @param {number} index Rotation counter.
+ * @return {string} Translated user-facing status.
+ */
+export function getRunningStatusMessage( index ) {
+	return RUNNING_STATUS_MESSAGES[ index % RUNNING_STATUS_MESSAGES.length ];
+}
+
+/**
  * Filter messages that have visible chat content.
  *
  * @param {Array} messages Store messages.
@@ -76,7 +194,7 @@ export function resolveSystemMessagePresentation( msg, providers ) {
  * @param {number|null} root0.currentSessionId Current session ID.
  * @param {Object}      root0.sessionJobs      Per-session job records.
  * @param {Array}       root0.liveToolCalls    Current live activity.
- * @return {{toolCalls: Array, step: string}} Running presentation.
+ * @return {{isFallback: boolean, toolCalls: Array, step: string}} Running presentation.
  */
 export function getRunningJobPresentation( {
 	currentSessionId,
@@ -94,8 +212,9 @@ export function getRunningJobPresentation( {
 
 	return {
 		toolCalls,
+		isFallback: ! runningToolName,
 		step: runningToolName
 			? `${ getFriendlyToolLabel( runningToolName ) }…`
-			: __( 'Composing reply…', 'superdav-ai-agent' ),
+			: getRunningStatusMessage( 0 ),
 	};
 }

--- a/src/components/chat-messages/use-running-status.js
+++ b/src/components/chat-messages/use-running-status.js
@@ -1,0 +1,34 @@
+/**
+ * Ordered fallback status rotation for agent work without a concrete tool step.
+ */
+
+import { useEffect, useState } from '@wordpress/element';
+
+import { getRunningStatusMessage } from './message-presentation';
+
+export const RUNNING_STATUS_ROTATION_INTERVAL = 3000;
+
+/**
+ * Rotate fallback work-status copy while an agent request is active.
+ *
+ * @param {boolean} isRunning Whether a request is running without tool status.
+ * @return {string} Current user-facing status.
+ */
+export default function useRunningStatus( isRunning ) {
+	const [ statusIndex, setStatusIndex ] = useState( 0 );
+
+	useEffect( () => {
+		setStatusIndex( 0 );
+		if ( ! isRunning ) {
+			return undefined;
+		}
+
+		const interval = setInterval( () => {
+			setStatusIndex( ( index ) => index + 1 );
+		}, RUNNING_STATUS_ROTATION_INTERVAL );
+
+		return () => clearInterval( interval );
+	}, [ isRunning ] );
+
+	return getRunningStatusMessage( statusIndex );
+}

--- a/src/components/chat-redesign/MessageList.js
+++ b/src/components/chat-redesign/MessageList.js
@@ -23,6 +23,7 @@ import {
 } from '../chat-messages/message-presentation';
 import useCompactConversationAction from '../chat-messages/use-compact-conversation-action';
 import useMessageListScroll from '../chat-messages/use-message-list-scroll';
+import useRunningStatus from '../chat-messages/use-running-status';
 import { extractText } from './message-helpers';
 import { RunningMessage } from './message-items';
 
@@ -105,6 +106,7 @@ export default function MessageList() {
 		sessionJobs,
 		liveToolCalls,
 	} );
+	const runningStatus = useRunningStatus( sending && running.isFallback );
 
 	const { speak, cancel } = useTextToSpeech( {
 		voiceURI: ttsVoiceURI,
@@ -175,7 +177,11 @@ export default function MessageList() {
 
 					{ sending && (
 						<RunningMessage
-							step={ running.step }
+							step={
+								running.isFallback
+									? runningStatus
+									: running.step
+							}
 							liveToolCalls={ running.toolCalls }
 							showToolCallDetails={ showToolCallDetails }
 						/>

--- a/src/components/chat-widget/widget-message-list.js
+++ b/src/components/chat-widget/widget-message-list.js
@@ -20,6 +20,7 @@ import {
 } from '../chat-messages/message-presentation';
 import useCompactConversationAction from '../chat-messages/use-compact-conversation-action';
 import useMessageListScroll from '../chat-messages/use-message-list-scroll';
+import useRunningStatus from '../chat-messages/use-running-status';
 import { RunningMessage } from '../chat-redesign/message-items';
 
 /**
@@ -84,6 +85,7 @@ export default function WidgetMessageList() {
 		sessionJobs,
 		liveToolCalls,
 	} );
+	const runningStatus = useRunningStatus( sending && running.isFallback );
 
 	return (
 		<>
@@ -99,7 +101,11 @@ export default function WidgetMessageList() {
 
 					{ sending && (
 						<RunningMessage
-							step={ running.step }
+							step={
+								running.isFallback
+									? runningStatus
+									: running.step
+							}
 							liveToolCalls={ running.toolCalls }
 							showToolCallDetails={ showToolCallDetails }
 						/>

--- a/tests/e2e/chat-interactions.spec.js
+++ b/tests/e2e/chat-interactions.spec.js
@@ -460,6 +460,20 @@ test.describe( 'Chat Input Interactions', () => {
 		await expect( stopButton ).toBeVisible( { timeout: 5_000 } );
 	} );
 
+	test( 'rotates the working status while the agent is processing', async ( {
+		page,
+	} ) => {
+		await interceptStream( page, { processingPolls: 2 } );
+
+		const input = getMessageInput( page );
+		await input.fill( 'Show the agent status' );
+		await input.press( 'Enter' );
+
+		const status = page.locator( '.sdaa-cr-progress-title' );
+		await expect( status ).toHaveText( 'Thinking…', { timeout: 5_000 } );
+		await expect( status ).toHaveText( 'Working…', { timeout: 5_000 } );
+	} );
+
 	test( 'rehydrated history keeps each turn model label', async ( { page } ) => {
 		const sessionId = 2393;
 		const sessionPath = `/sd-ai-agent/v1/sessions/${ sessionId }`;


### PR DESCRIPTION
## Summary

- Replace the static “Composing reply…” fallback with 100 ordered, present-progressive work statuses, progressing from precise to playful.
- Rotate fallback status copy every three seconds in both the main chat and floating widget, resetting for each request.
- Preserve concrete tool activity labels and add unit plus Playwright regression coverage.

## Worker self-verification

- PHPUnit: Tests: 4034, Assertions: 18030, Errors: 0, Failures: 0, Skipped: 134, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded

## Browser verification

- Added `tests/e2e/chat-interactions.spec.js` coverage for `Thinking…` → `Working…` while a mocked agent job remains processing.
- The new browser test could not run locally: `npx wp-env start` failed because Docker could not stat an overlay snapshot, leaving `http://localhost:8890` unavailable. `agent-browser` against the shared local service also encountered a redirect loop.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.212 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-terra spent 11h 44m and 344,164 tokens on this with the user in an interactive session.
