### PR TITLE
fix: allow configured loopback AI edge

### DIFF
--- a/includes/Bootstrap/SuperdavAiProviderHandler.php
+++ b/includes/Bootstrap/SuperdavAiProviderHandler.php
@@ -6,6 +6,7 @@ namespace SdAiAgent\Bootstrap;
 
 use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
 use XWP\DI\Decorators\Action;
+use XWP\DI\Decorators\Filter;
 use XWP\DI\Decorators\Handler;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -43,5 +44,80 @@ final class SuperdavAiProviderHandler {
 		} catch ( \Throwable $e ) {
 			return;
 		}
+	}
+
+	/**
+	 * Allow the explicitly configured loopback edge through WordPress safe HTTP validation.
+	 *
+	 * The AI Client SDK uses `wp_safe_remote_request()`, which rejects loopback
+	 * hosts by default. Local service development is an intentional exception,
+	 * but only for requests beneath the exact configured cloud base URL.
+	 *
+	 * @param bool   $is_external Whether WordPress already considers the host external.
+	 * @param string $host        Request host.
+	 * @param string $url         Full request URL.
+	 * @return bool Whether the host is allowed.
+	 */
+	#[Filter( tag: 'http_request_host_is_external', priority: 10, args: 3 )]
+	public function allow_configured_loopback_host( bool $is_external, string $host, string $url ): bool {
+		if ( $is_external ) {
+			return true;
+		}
+
+		return self::is_configured_loopback_url( $host, $url );
+	}
+
+	/**
+	 * Allow the configured loopback edge port through safe HTTP validation.
+	 *
+	 * @param int[]  $ports Allowed safe ports.
+	 * @param string $host  Request host.
+	 * @param string $url   Full request URL.
+	 * @return int[] Allowed safe ports.
+	 */
+	#[Filter( tag: 'http_allowed_safe_ports', priority: 10, args: 3 )]
+	public function allow_configured_loopback_port( array $ports, string $host, string $url ): array {
+		if ( ! self::is_configured_loopback_url( $host, $url ) ) {
+			return $ports;
+		}
+
+		$port = wp_parse_url( $url, PHP_URL_PORT );
+		if ( is_int( $port ) && ! in_array( $port, $ports, true ) ) {
+			$ports[] = $port;
+		}
+
+		return $ports;
+	}
+
+	/** Determine whether a request belongs to the exact configured loopback edge. */
+	private static function is_configured_loopback_url( string $host, string $url ): bool {
+		$base_parts    = wp_parse_url( SuperdavAiProvider::configured_base_url() );
+		$request_parts = wp_parse_url( $url );
+		if ( ! is_array( $base_parts ) || ! is_array( $request_parts ) ) {
+			return false;
+		}
+
+		$base_host    = strtolower( (string) ( $base_parts['host'] ?? '' ) );
+		$request_host = strtolower( (string) ( $request_parts['host'] ?? '' ) );
+		$filter_host  = strtolower( trim( $host, '.' ) );
+		if ( ! in_array( $base_host, array( '127.0.0.1', 'localhost' ), true )
+			|| $request_host !== $base_host
+			|| $filter_host !== $base_host
+		) {
+			return false;
+		}
+
+		$base_scheme    = strtolower( (string) ( $base_parts['scheme'] ?? '' ) );
+		$request_scheme = strtolower( (string) ( $request_parts['scheme'] ?? '' ) );
+		if ( $request_scheme !== $base_scheme
+			|| (int) ( $request_parts['port'] ?? 0 ) !== (int) ( $base_parts['port'] ?? 0 )
+		) {
+			return false;
+		}
+
+		$base_path    = '/' . trim( (string) ( $base_parts['path'] ?? '' ), '/' );
+		$request_path = '/' . trim( (string) ( $request_parts['path'] ?? '' ), '/' );
+
+		return $request_path === $base_path || str_starts_with( $request_path, rtrim( $base_path, '/' ) . '/' );
 	}
 }

--- a/includes/Bootstrap/SuperdavAiProviderHandler.php
+++ b/includes/Bootstrap/SuperdavAiProviderHandler.php
@@ -117,6 +117,9 @@ final class SuperdavAiProviderHandler {
 
 		$base_path    = '/' . trim( (string) ( $base_parts['path'] ?? '' ), '/' );
 		$request_path = '/' . trim( (string) ( $request_parts['path'] ?? '' ), '/' );
+		if ( 1 === preg_match( '#(?:^|/)\.{1,2}(?:/|$)#', rawurldecode( $request_path ) ) ) {
+			return false;
+		}
 
 		return $request_path === $base_path || str_starts_with( $request_path, rtrim( $base_path, '/' ) . '/' );
 	}

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
@@ -140,10 +140,19 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 			$handler->allow_configured_loopback_host( false, '127.0.0.1', 'http://127.0.0.1:3200/admin' )
 		);
 		$this->assertFalse(
+			$handler->allow_configured_loopback_host( false, '127.0.0.1', 'http://127.0.0.1:3200/v1/../admin' )
+		);
+		$this->assertFalse(
+			$handler->allow_configured_loopback_host( false, '127.0.0.1', 'http://127.0.0.1:3200/v1/%2e%2e/admin' )
+		);
+		$this->assertFalse(
 			$handler->allow_configured_loopback_host( false, 'localhost', 'http://localhost:3200/v1/models' )
 		);
 		$this->assertFalse(
 			$handler->allow_configured_loopback_host( false, '127.0.0.1', 'http://127.0.0.1:3300/v1/models' )
+		);
+		$this->assertFalse(
+			$handler->allow_configured_loopback_host( false, '127.0.0.1', 'https://127.0.0.1:3200/v1/models' )
 		);
 		$this->assertTrue(
 			$handler->allow_configured_loopback_host( true, 'unrelated.example', 'https://unrelated.example/models' )

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
@@ -124,6 +124,61 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Local development may use the configured loopback edge with the safe SDK transporter.
+	 */
+	public function test_handler_allows_only_the_configured_loopback_edge(): void {
+		add_filter(
+			'sd_ai_agent_cloud_base_url',
+			static fn(): string => 'http://127.0.0.1:3200/v1'
+		);
+		$handler = new SuperdavAiProviderHandler();
+
+		$this->assertTrue(
+			$handler->allow_configured_loopback_host( false, '127.0.0.1', 'http://127.0.0.1:3200/v1/models' )
+		);
+		$this->assertFalse(
+			$handler->allow_configured_loopback_host( false, '127.0.0.1', 'http://127.0.0.1:3200/admin' )
+		);
+		$this->assertFalse(
+			$handler->allow_configured_loopback_host( false, 'localhost', 'http://localhost:3200/v1/models' )
+		);
+		$this->assertFalse(
+			$handler->allow_configured_loopback_host( false, '127.0.0.1', 'http://127.0.0.1:3300/v1/models' )
+		);
+		$this->assertTrue(
+			$handler->allow_configured_loopback_host( true, 'unrelated.example', 'https://unrelated.example/models' )
+		);
+	}
+
+	/**
+	 * Only the configured loopback service port is added to WordPress's safe list.
+	 */
+	public function test_handler_allows_only_the_configured_loopback_port(): void {
+		add_filter(
+			'sd_ai_agent_cloud_base_url',
+			static fn(): string => 'http://127.0.0.1:3200/v1'
+		);
+		$handler = new SuperdavAiProviderHandler();
+
+		$this->assertSame(
+			array( 80, 443, 3200 ),
+			$handler->allow_configured_loopback_port(
+				array( 80, 443 ),
+				'127.0.0.1',
+				'http://127.0.0.1:3200/v1/chat/completions'
+			)
+		);
+		$this->assertSame(
+			array( 80, 443 ),
+			$handler->allow_configured_loopback_port(
+				array( 80, 443 ),
+				'127.0.0.1',
+				'http://127.0.0.1:3300/v1/chat/completions'
+			)
+		);
+	}
+
+	/**
 	 * The bundled provider defaults clean installs to the standard managed alias.
 	 */
 	public function test_default_model_is_managed_standard_alias(): void {


### PR DESCRIPTION
## Summary

- allow WordPress AI Client safe HTTP requests to an explicitly configured loopback Superdav edge
- scope the exception to the exact configured scheme, host, port, and base path
- cover allowed and rejected loopback host/port combinations with regression tests

## Problem

The documented local `SD_AI_AGENT_CLOUD_BASE_URL` setup could register a site but model discovery failed because the AI Client SDK uses `wp_safe_remote_request()`. WordPress rejected the loopback host and custom port before requests reached `/v1/models`, leaving chat models unavailable.

## Security

- production and other non-loopback endpoints retain WordPress's normal safe-URL validation
- only `127.0.0.1` or `localhost` can receive the exception
- request scheme, host, port, and path must match the configured cloud base URL

## Files

- `includes/Bootstrap/SuperdavAiProviderHandler.php`
- `tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php`

## Verification

- `vendor/bin/phpcs includes/Bootstrap/SuperdavAiProviderHandler.php tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php`
- `vendor/bin/phpunit tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php` — 34 tests, 106 assertions
- `vendor/bin/phpstan analyse includes/Bootstrap/SuperdavAiProviderHandler.php --memory-limit=2G`
- browser acceptance: managed models loaded, chat completed successfully, and usage was metered against the local edge

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.213 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connectivity with configured loopback AI service endpoints.
  * Requests are now allowed only when the host, scheme, port, and path match the configured endpoint.
  * Preserved access for valid unrelated external requests while rejecting mismatched loopback requests.

* **Tests**
  * Added coverage for valid and invalid loopback hosts, paths, schemes, and ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->