### PR TITLE
Improve account balance and coupon redemption UI

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -262,6 +262,13 @@ Base unit: **4px**
 
 Err toward more whitespace. Padding should feel generous inside panels. List items can be compact (7px vertical padding) because the sidebar is a dense navigation element — the chat area should breathe more.
 
+### Account settings surfaces
+
+- Separate account overview, usage, and activity surfaces with a `24px` vertical gap.
+- Give each account surface `24px` desktop padding, reducing to `16px` on mobile, with an `8px` radius and the standard subtle border.
+- Keep the account header focused on one primary action. Coupon redemption opens in a modal rather than placing a persistent form between account sections.
+- Refresh managed account data automatically when the account screen mounts; do not require a manual refresh control for current balances.
+
 ---
 
 ## 6. Depth & Elevation

--- a/src/settings-page/__tests__/superdav-account-manager.test.js
+++ b/src/settings-page/__tests__/superdav-account-manager.test.js
@@ -32,6 +32,13 @@ jest.mock( '@wordpress/components', () => {
 				  ),
 		Notice: ( { children } ) =>
 			React.createElement( 'div', null, children ),
+		Modal: ( { children, title } ) =>
+			React.createElement(
+				'div',
+				{ role: 'dialog', 'aria-label': title },
+				React.createElement( 'h2', null, title ),
+				children
+			),
 		Spinner: () => React.createElement( 'div', { role: 'status' } ),
 		TextControl: ( { label, value, onChange, type = 'text', disabled } ) =>
 			React.createElement(
@@ -93,6 +100,18 @@ describe( 'SuperdavAccountManager', () => {
 		} );
 	}
 
+	/**
+	 * Find a rendered button by its exact visible label.
+	 *
+	 * @param {string} label Button label.
+	 * @return {HTMLButtonElement|undefined} Matching button.
+	 */
+	function findButton( label ) {
+		return [ ...container.querySelectorAll( 'button' ) ].find(
+			( button ) => button.textContent === label
+		);
+	}
+
 	test( 'treats absent wallet amounts as unknown', () => {
 		expect( formatWalletAmount( null ) ).toBe( '—' );
 		expect( formatWalletAmount( undefined ) ).toBe( '—' );
@@ -149,6 +168,24 @@ describe( 'SuperdavAccountManager', () => {
 		expect(
 			container.querySelector( '.sd-ai-agent-superdav-account' )
 		).not.toBeNull();
+	} );
+
+	test( 'refreshes the balance on page visit and replaces the manual refresh action', async () => {
+		apiFetch.mockResolvedValue( { configured: true } );
+
+		await act( async () => {
+			root.render( createElement( SuperdavAccountManager, {} ) );
+		} );
+		await act( async () => {
+			await Promise.resolve();
+		} );
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/sd-ai-agent/v1/superdav-account',
+			method: 'POST',
+		} );
+		expect( findButton( 'Redeem Coupon' ) ).toBeDefined();
+		expect( container.textContent ).not.toContain( 'Refresh balance' );
 	} );
 
 	test( 'renders credit activity and labels missing promotional expiry as unavailable', async () => {
@@ -304,7 +341,12 @@ describe( 'SuperdavAccountManager', () => {
 			await Promise.resolve();
 		} );
 
-		const input = container.querySelector( 'input' );
+		await act( async () => {
+			findButton( 'Redeem Coupon' ).click();
+		} );
+
+		const dialog = container.querySelector( '[role="dialog"]' );
+		const input = dialog.querySelector( 'input' );
 		await setInputValue( input, ' test-coupon-code ' );
 		await act( async () => {
 			container
@@ -327,11 +369,11 @@ describe( 'SuperdavAccountManager', () => {
 			await Promise.resolve();
 		} );
 
-		expect( input.value ).toBe( '' );
 		expect( container.textContent ).toContain(
 			'Coupon redeemed. Your balance has been updated.'
 		);
 		expect( container.textContent ).toContain( '$6.00' );
+		expect( container.querySelector( '[role="dialog"]' ) ).toBeNull();
 		expect( apiFetch ).toHaveBeenLastCalledWith( {
 			path: '/sd-ai-agent/v1/superdav-account/redeem-coupon',
 			method: 'POST',
@@ -339,7 +381,7 @@ describe( 'SuperdavAccountManager', () => {
 		} );
 	} );
 
-	test( 'clears a failed coupon and renders only its stable error message', async () => {
+	test( 'keeps a failed coupon available for correction and renders only its stable error message', async () => {
 		apiFetch
 			.mockResolvedValueOnce( { configured: true } )
 			.mockRejectedValueOnce( {
@@ -354,7 +396,11 @@ describe( 'SuperdavAccountManager', () => {
 			await Promise.resolve();
 		} );
 
-		const input = container.querySelector( 'input' );
+		await act( async () => {
+			findButton( 'Redeem Coupon' ).click();
+		} );
+
+		const input = container.querySelector( '[role="dialog"] input' );
 		await setInputValue( input, 'test-coupon-code' );
 		await act( async () => {
 			container
@@ -365,7 +411,8 @@ describe( 'SuperdavAccountManager', () => {
 			await Promise.resolve();
 		} );
 
-		expect( input.value ).toBe( '' );
+		expect( input.value ).toBe( 'test-coupon-code' );
+		expect( container.querySelector( '[role="dialog"]' ) ).not.toBeNull();
 		expect( container.textContent ).toContain( 'The coupon has expired.' );
 		expect( container.textContent ).not.toContain(
 			'test-coupon-code must not be rendered'

--- a/src/settings-page/style.css
+++ b/src/settings-page/style.css
@@ -524,6 +524,12 @@
 }
 
 /* Superdav AI account manager */
+.sd-ai-agent-superdav-account {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+}
+
 .sd-ai-agent-superdav-account-loading {
 	padding: 40px;
 	text-align: center;
@@ -543,6 +549,21 @@
 
 .sd-ai-agent-superdav-account-header .description {
 	margin: 0;
+}
+
+.sd-ai-agent-superdav-account-overview,
+.sd-ai-agent-superdav-session-usage,
+.sd-ai-agent-superdav-credit-activity {
+	padding: 24px;
+	border: 1px solid #dcdcde;
+	border-radius: 8px;
+	background: #fff;
+}
+
+.sd-ai-agent-superdav-account-overview {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
 }
 
 .sd-ai-agent-superdav-account-balance {
@@ -589,6 +610,28 @@
 	display: flex;
 	flex-wrap: wrap;
 	gap: 8px;
+	padding: 0 4px 4px;
+}
+
+.sd-ai-agent-superdav-coupon-redemption {
+	display: flex;
+	flex-direction: column;
+	gap: 20px;
+}
+
+.sd-ai-agent-superdav-coupon-modal {
+	width: min(480px, calc(100% - 32px));
+}
+
+.sd-ai-agent-superdav-coupon-redemption > .description {
+	margin: 0;
+}
+
+.sd-ai-agent-superdav-coupon-modal-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	padding-top: 4px;
 }
 
 .sd-ai-agent-superdav-session-usage h4,
@@ -760,6 +803,16 @@
 @media screen and (max-width: 600px) {
 	.sd-ai-agent-superdav-account-header {
 		flex-direction: column;
+	}
+
+	.sd-ai-agent-superdav-account-header .components-button {
+		min-height: 44px;
+	}
+
+	.sd-ai-agent-superdav-account-overview,
+	.sd-ai-agent-superdav-session-usage,
+	.sd-ai-agent-superdav-credit-activity {
+		padding: 16px;
 	}
 
 	.sd-ai-agent-superdav-session-usage-summary {

--- a/src/settings-page/superdav-account-manager.js
+++ b/src/settings-page/superdav-account-manager.js
@@ -2,7 +2,13 @@
  * WordPress dependencies
  */
 import { useCallback, useEffect, useState } from '@wordpress/element';
-import { Button, Notice, Spinner, TextControl } from '@wordpress/components';
+import {
+	Button,
+	Modal,
+	Notice,
+	Spinner,
+	TextControl,
+} from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
 
@@ -149,7 +155,7 @@ function ChatSessionUsage( { sessions, timeZone } ) {
 		return (
 			<p className="description">
 				{ __(
-					'Session-level usage is unavailable. Refresh your balance and try again.',
+					'Session-level usage is unavailable. Reload the page and try again.',
 					'superdav-ai-agent'
 				) }
 			</p>
@@ -392,25 +398,21 @@ function ChatSessionUsage( { sessions, timeZone } ) {
 export default function SuperdavAccountManager() {
 	const [ account, setAccount ] = useState( null );
 	const [ loading, setLoading ] = useState( true );
-	const [ refreshing, setRefreshing ] = useState( false );
+	const [ isCouponModalOpen, setIsCouponModalOpen ] = useState( false );
 	const [ couponCode, setCouponCode ] = useState( '' );
 	const [ redeeming, setRedeeming ] = useState( false );
 	const [ redemptionNotice, setRedemptionNotice ] = useState( null );
 	const [ error, setError ] = useState( '' );
 	const [ hasLoadedAccount, setHasLoadedAccount ] = useState( false );
 
-	const loadAccount = useCallback( async ( refresh = false ) => {
-		if ( refresh ) {
-			setRefreshing( true );
-		} else {
-			setLoading( true );
-		}
+	const loadAccount = useCallback( async () => {
+		setLoading( true );
 		setError( '' );
 
 		try {
 			const result = await apiFetch( {
 				path: '/sd-ai-agent/v1/superdav-account',
-				method: refresh ? 'POST' : 'GET',
+				method: 'POST',
 			} );
 			setAccount( result );
 			setHasLoadedAccount( true );
@@ -424,9 +426,24 @@ export default function SuperdavAccountManager() {
 			);
 		} finally {
 			setLoading( false );
-			setRefreshing( false );
 		}
 	}, [] );
+
+	const openCouponModal = useCallback( () => {
+		setCouponCode( '' );
+		setRedemptionNotice( null );
+		setIsCouponModalOpen( true );
+	}, [] );
+
+	const closeCouponModal = useCallback( () => {
+		if ( redeeming ) {
+			return;
+		}
+
+		setCouponCode( '' );
+		setRedemptionNotice( null );
+		setIsCouponModalOpen( false );
+	}, [ redeeming ] );
 
 	const redeemCoupon = useCallback(
 		async ( event ) => {
@@ -453,6 +470,8 @@ export default function SuperdavAccountManager() {
 						'superdav-ai-agent'
 					),
 				} );
+				setCouponCode( '' );
+				setIsCouponModalOpen( false );
 			} catch ( err ) {
 				const messages = {
 					sd_ai_agent_coupon_invalid: __(
@@ -482,7 +501,6 @@ export default function SuperdavAccountManager() {
 						),
 				} );
 			} finally {
-				setCouponCode( '' );
 				setRedeeming( false );
 			}
 		},
@@ -615,12 +633,11 @@ export default function SuperdavAccountManager() {
 					</p>
 				</div>
 				<Button
-					variant="secondary"
-					onClick={ () => loadAccount( true ) }
-					isBusy={ refreshing }
-					disabled={ refreshing || ! configured }
+					variant="primary"
+					onClick={ openCouponModal }
+					disabled={ ! configured }
 				>
-					{ __( 'Refresh balance', 'superdav-ai-agent' ) }
+					{ __( 'Redeem Coupon', 'superdav-ai-agent' ) }
 				</Button>
 			</div>
 
@@ -629,7 +646,7 @@ export default function SuperdavAccountManager() {
 					{ error }
 				</Notice>
 			) }
-			{ redemptionNotice && (
+			{ redemptionNotice && ! isCouponModalOpen && (
 				<Notice
 					status={ redemptionNotice.status }
 					isDismissible={ false }
@@ -648,83 +665,68 @@ export default function SuperdavAccountManager() {
 					</Notice>
 				) : (
 					<>
-						<div className="sd-ai-agent-superdav-account-balance">
-							<div className="sd-ai-agent-superdav-account-balance-label">
-								{ __(
-									'Available balance',
-									'superdav-ai-agent'
-								) }
-							</div>
-							<div className="sd-ai-agent-superdav-account-balance-value">
-								{ formatWalletAmount(
-									wallet.total_usd_micros
-								) }
-							</div>
-							{ tier && (
-								<div className="sd-ai-agent-superdav-account-tier">
-									{ sprintf(
-										/* translators: %s: Superdav AI service tier. */
-										__( 'Plan: %s', 'superdav-ai-agent' ),
-										tier
+						<section
+							className="sd-ai-agent-superdav-account-overview"
+							aria-label={ __(
+								'Available credits',
+								'superdav-ai-agent'
+							) }
+						>
+							<div className="sd-ai-agent-superdav-account-balance">
+								<div className="sd-ai-agent-superdav-account-balance-label">
+									{ __(
+										'Available balance',
+										'superdav-ai-agent'
 									) }
 								</div>
-							) }
-						</div>
-
-						<div className="sd-ai-agent-superdav-account-breakdown">
-							<div>
-								<span>
-									{ __(
-										'Purchased credits',
-										'superdav-ai-agent'
-									) }
-								</span>
-								<strong>
+								<div className="sd-ai-agent-superdav-account-balance-value">
 									{ formatWalletAmount(
-										wallet.cash_usd_micros
+										wallet.total_usd_micros
 									) }
-								</strong>
-							</div>
-							<div>
-								<span>
-									{ __(
-										'Promotional credits',
-										'superdav-ai-agent'
-									) }
-								</span>
-								<strong>
-									{ formatWalletAmount(
-										wallet.promo_usd_micros
-									) }
-								</strong>
-							</div>
-						</div>
-
-						<form
-							className="sd-ai-agent-superdav-coupon-redemption"
-							onSubmit={ redeemCoupon }
-						>
-							<TextControl
-								label={ __(
-									'Coupon code',
-									'superdav-ai-agent'
+								</div>
+								{ tier && (
+									<div className="sd-ai-agent-superdav-account-tier">
+										{ sprintf(
+											/* translators: %s: Superdav AI service tier. */
+											__(
+												'Plan: %s',
+												'superdav-ai-agent'
+											),
+											tier
+										) }
+									</div>
 								) }
-								value={ couponCode }
-								onChange={ setCouponCode }
-								autoComplete="off"
-								disabled={ redeeming }
-								__next40pxDefaultSize
-								__nextHasNoMarginBottom
-							/>
-							<Button
-								variant="secondary"
-								type="submit"
-								isBusy={ redeeming }
-								disabled={ redeeming || ! couponCode.trim() }
-							>
-								{ __( 'Redeem coupon', 'superdav-ai-agent' ) }
-							</Button>
-						</form>
+							</div>
+
+							<div className="sd-ai-agent-superdav-account-breakdown">
+								<div>
+									<span>
+										{ __(
+											'Purchased credits',
+											'superdav-ai-agent'
+										) }
+									</span>
+									<strong>
+										{ formatWalletAmount(
+											wallet.cash_usd_micros
+										) }
+									</strong>
+								</div>
+								<div>
+									<span>
+										{ __(
+											'Promotional credits',
+											'superdav-ai-agent'
+										) }
+									</span>
+									<strong>
+										{ formatWalletAmount(
+											wallet.promo_usd_micros
+										) }
+									</strong>
+								</div>
+							</div>
+						</section>
 
 						<section
 							className="sd-ai-agent-superdav-session-usage"
@@ -813,6 +815,60 @@ export default function SuperdavAccountManager() {
 						) }
 					</>
 				) ) }
+
+			{ isCouponModalOpen && (
+				<Modal
+					title={ __( 'Redeem coupon', 'superdav-ai-agent' ) }
+					onRequestClose={ closeCouponModal }
+					className="sd-ai-agent-superdav-coupon-modal"
+				>
+					<form
+						className="sd-ai-agent-superdav-coupon-redemption"
+						onSubmit={ redeemCoupon }
+					>
+						<p className="description">
+							{ __(
+								'Enter your coupon code to verify it and add the credit to this account.',
+								'superdav-ai-agent'
+							) }
+						</p>
+						<TextControl
+							label={ __( 'Coupon code', 'superdav-ai-agent' ) }
+							value={ couponCode }
+							onChange={ setCouponCode }
+							autoComplete="off"
+							disabled={ redeeming }
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+						/>
+						{ redemptionNotice && (
+							<Notice
+								status={ redemptionNotice.status }
+								isDismissible={ false }
+							>
+								{ redemptionNotice.message }
+							</Notice>
+						) }
+						<div className="sd-ai-agent-superdav-coupon-modal-actions">
+							<Button
+								variant="tertiary"
+								onClick={ closeCouponModal }
+								disabled={ redeeming }
+							>
+								{ __( 'Cancel', 'superdav-ai-agent' ) }
+							</Button>
+							<Button
+								variant="primary"
+								type="submit"
+								isBusy={ redeeming }
+								disabled={ redeeming || ! couponCode.trim() }
+							>
+								{ __( 'Redeem coupon', 'superdav-ai-agent' ) }
+							</Button>
+						</div>
+					</form>
+				</Modal>
+			) }
 		</div>
 	);
 }


### PR DESCRIPTION
## Summary

- refresh SD AI account data automatically whenever the account screen mounts
- replace the manual balance refresh control with a primary **Redeem Coupon** action and focused coupon modal
- keep stable coupon validation feedback in the modal, apply successful credit responses immediately, and retain failed codes for correction
- add 24px separation and padded, responsive surfaces for the balance overview, session usage, and credit activity
- document the account-screen layout decisions in `DESIGN.md`

## Tests

- `npm run test:js -- --runInBand` — 470 tests passed
- `npm run test:php -- --filter=SettingsControllerTest` — 19 tests, 150 assertions
- `npm run verify`

## Worker self-verification
- PHPUnit: Tests: 4080, Assertions: 18270, Errors: 0, Failures: 0, Skipped: 134, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded (bundle budgets passed)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.221 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a coupon redemption dialog accessible from account actions.
  * Account data now refreshes automatically when the page loads.
  * Added an accessible “Available credits” account overview section.
* **Bug Fixes**
  * Successful coupon redemption now clears the code and closes the dialog.
  * Failed redemption keeps the dialog open with the entered code for correction.
* **Style**
  * Improved account card layouts, spacing, borders, and responsive mobile action buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->