### PR TITLE
Move SD AI account actions to the header

### DIFF
--- a/src/settings-page/__tests__/superdav-account-manager.test.js
+++ b/src/settings-page/__tests__/superdav-account-manager.test.js
@@ -293,9 +293,10 @@ describe( 'SuperdavAccountManager', () => {
 		).not.toBeNull();
 	} );
 
-	test( 'renders dedicated billing actions with their service-issued URLs', async () => {
+	test( 'renders account actions in the requested header order with their service-issued URLs', async () => {
 		apiFetch.mockResolvedValueOnce( {
 			configured: true,
+			account_portal_url: 'https://account.example/portal',
 			purchase_credits_url: 'https://account.example/credits/purchase',
 			payment_methods_url:
 				'https://account.example/billing/payment-methods',
@@ -318,6 +319,25 @@ describe( 'SuperdavAccountManager', () => {
 				'a[href="https://account.example/billing/payment-methods"]'
 			)
 		).not.toBeNull();
+		expect(
+			container.querySelector(
+				'a[href="https://account.example/portal"]'
+			)
+		).not.toBeNull();
+
+		const headerActions = container.querySelector(
+			'.sd-ai-agent-superdav-account-header-actions'
+		);
+		expect(
+			[ ...headerActions.querySelectorAll( 'a, button' ) ].map(
+				( action ) => action.textContent
+			)
+		).toEqual( [
+			'Open account portal',
+			'Manage payment methods',
+			'Redeem Coupon',
+			'Add credits',
+		] );
 	} );
 
 	test( 'redeems a coupon, disables submission while pending, and updates the balance', async () => {

--- a/src/settings-page/style.css
+++ b/src/settings-page/style.css
@@ -606,11 +606,12 @@
 	font-size: 16px;
 }
 
-.sd-ai-agent-superdav-account-actions {
+.sd-ai-agent-superdav-account-header-actions {
 	display: flex;
+	flex: 0 1 auto;
 	flex-wrap: wrap;
 	gap: 8px;
-	padding: 0 4px 4px;
+	justify-content: flex-end;
 }
 
 .sd-ai-agent-superdav-coupon-redemption {
@@ -803,6 +804,11 @@
 @media screen and (max-width: 600px) {
 	.sd-ai-agent-superdav-account-header {
 		flex-direction: column;
+	}
+
+	.sd-ai-agent-superdav-account-header-actions {
+		justify-content: flex-start;
+		width: 100%;
 	}
 
 	.sd-ai-agent-superdav-account-header .components-button {

--- a/src/settings-page/superdav-account-manager.js
+++ b/src/settings-page/superdav-account-manager.js
@@ -632,13 +632,48 @@ export default function SuperdavAccountManager() {
 						) }
 					</p>
 				</div>
-				<Button
-					variant="primary"
-					onClick={ openCouponModal }
-					disabled={ ! configured }
-				>
-					{ __( 'Redeem Coupon', 'superdav-ai-agent' ) }
-				</Button>
+				<div className="sd-ai-agent-superdav-account-header-actions">
+					{ accountUrl && (
+						<Button
+							variant="tertiary"
+							href={ accountUrl }
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							{ __( 'Open account portal', 'superdav-ai-agent' ) }
+						</Button>
+					) }
+					{ paymentMethodsUrl && (
+						<Button
+							variant="secondary"
+							href={ paymentMethodsUrl }
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							{ __(
+								'Manage payment methods',
+								'superdav-ai-agent'
+							) }
+						</Button>
+					) }
+					<Button
+						variant="primary"
+						onClick={ openCouponModal }
+						disabled={ ! configured }
+					>
+						{ __( 'Redeem Coupon', 'superdav-ai-agent' ) }
+					</Button>
+					{ purchaseCreditsUrl && (
+						<Button
+							variant="primary"
+							href={ purchaseCreditsUrl }
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							{ __( 'Add credits', 'superdav-ai-agent' ) }
+						</Button>
+					) }
+				</div>
 			</div>
 
 			{ error && (
@@ -763,49 +798,7 @@ export default function SuperdavAccountManager() {
 							{ creditActivityContent }
 						</section>
 
-						{ hasAccountActions ? (
-							<div className="sd-ai-agent-superdav-account-actions">
-								{ purchaseCreditsUrl && (
-									<Button
-										variant="primary"
-										href={ purchaseCreditsUrl }
-										target="_blank"
-										rel="noopener noreferrer"
-									>
-										{ __(
-											'Add credits',
-											'superdav-ai-agent'
-										) }
-									</Button>
-								) }
-								{ paymentMethodsUrl && (
-									<Button
-										variant="secondary"
-										href={ paymentMethodsUrl }
-										target="_blank"
-										rel="noopener noreferrer"
-									>
-										{ __(
-											'Manage payment methods',
-											'superdav-ai-agent'
-										) }
-									</Button>
-								) }
-								{ accountUrl && (
-									<Button
-										variant="tertiary"
-										href={ accountUrl }
-										target="_blank"
-										rel="noopener noreferrer"
-									>
-										{ __(
-											'Open account portal',
-											'superdav-ai-agent'
-										) }
-									</Button>
-								) }
-							</div>
-						) : (
+						{ ! hasAccountActions && (
 							<Notice status="info" isDismissible={ false }>
 								{ __(
 									'Account billing is managed by your SD AI service administrator.',


### PR DESCRIPTION
## Summary
- move the account portal, payment methods, coupon, and credit actions into the SD AI account header
- order actions left-to-right as Open account portal, Manage payment methods, Redeem Coupon, and Add credits
- preserve responsive wrapping and the administrator-managed billing notice
- add a component test that locks the requested action order and service-issued URLs

## Testing
- Targeted Jest: `src/settings-page/__tests__/superdav-account-manager.test.js` — 11 passed
- Manual browser verification at `/wp-admin/admin.php?page=sd-ai-agent#/settings` confirmed all four desktop actions share the header row in the requested order; mobile wrapping preserves DOM order and 44px action heights
- Bundle size check passed

## Worker self-verification
- PHPUnit: Tests: 4080, Assertions: 18261, Errors: 0, Failures: 0, Skipped: 136
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added account and billing actions directly to the account header, including portal access, payment methods, coupon redemption, and credit purchases.
  - Improved responsive layout so header actions wrap and align appropriately on smaller screens.

- **Bug Fixes**
  - Removed duplicate billing actions from the lower account section.
  - Billing notices now appear only when no account actions are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->