### PR TITLE
feat: add verified account action SSO

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -204,6 +204,13 @@ System notices:
 - Hover: `border-color: --wp-admin-theme-color`, `box-shadow: 0 2px 8px rgba(0,0,0,.06)`
 - No transform or scale on hover — keep transitions to colour/border only
 
+### SD AI Account Card
+
+- Show the verified linked user's display name, masked email, and a concise “Email verified” status above wallet details.
+- Use **Link a different user** as a secondary action. Relinking must open the managed confirmation flow rather than accepting identity details in WordPress.
+- **Open account portal**, **Manage payment methods**, and **Add credits** are buttons that request a fresh one-time URL when clicked; do not render, inspect, or persist action tickets in the settings page.
+- Open account actions in a separate tab when the browser permits, clear `window.opener`, and show one neutral retry notice if URL minting fails.
+
 ### Tooltips
 
 Use `<Tooltip>` from `@wordpress/components` (or `showTooltip + label` on `<Button>`) for every icon-only button. Do not rely on the native `title` attribute — it has poor accessibility and inconsistent browser styling.

--- a/includes/Core/SuperdavSiteConnectionService.php
+++ b/includes/Core/SuperdavSiteConnectionService.php
@@ -491,7 +491,7 @@ final class SuperdavSiteConnectionService {
 		 */
 		$endpoint = apply_filters( 'sd_ai_agent_cloud_account_status_endpoint', $endpoint );
 
-		return is_string( $endpoint ) ? esc_url_raw( $endpoint ) : '';
+		return $this->sanitize_account_url( $endpoint );
 	}
 
 	/** Resolve the managed endpoint that mints fresh one-time account actions. */
@@ -505,7 +505,7 @@ final class SuperdavSiteConnectionService {
 		 */
 		$endpoint = apply_filters( 'sd_ai_agent_cloud_account_action_endpoint', $endpoint );
 
-		return is_string( $endpoint ) ? esc_url_raw( $endpoint ) : '';
+		return $this->sanitize_account_url( $endpoint );
 	}
 
 	/**

--- a/includes/Core/SuperdavSiteConnectionService.php
+++ b/includes/Core/SuperdavSiteConnectionService.php
@@ -29,6 +29,7 @@ final class SuperdavSiteConnectionService {
 	private const REGISTRATION_ENDPOINT_PATH              = 'site/installations';
 	private const REVOCATION_ENDPOINT_PATH                = 'site/token/revoke';
 	private const ACCOUNT_STATUS_ENDPOINT_PATH            = 'site/account';
+	private const ACCOUNT_ACTION_ENDPOINT_PATH            = 'site/account/action';
 	private const ACCOUNT_COUPON_REDEMPTION_ENDPOINT_PATH = 'portal/account/redeem-coupon';
 	private const ACCOUNT_COUPON_REDEMPTION_PATH          = '/v1/portal/account/redeem-coupon';
 
@@ -64,22 +65,28 @@ final class SuperdavSiteConnectionService {
 		$token    = $this->get_stored_token();
 		$metadata = $this->get_metadata();
 
-		$account_portal_url   = $this->get_account_portal_url( $metadata );
-		$purchase_credits_url = $this->get_account_action_url( $metadata, 'purchase_credits_url' );
-		$payment_methods_url  = $this->get_account_action_url( $metadata, 'payment_methods_url' );
+		$account_portal_available   = true === ( $metadata['account_portal_available'] ?? false );
+		$purchase_credits_available = true === ( $metadata['purchase_credits_available'] ?? false );
+		$payment_methods_available  = true === ( $metadata['payment_methods_available'] ?? false );
+		$link_account_available     = true === ( $metadata['link_account_available'] ?? false );
 
 		$status = array(
-			'configured'                => '' !== $token,
-			'provider'                  => SuperdavAiProvider::PROVIDER_ID,
-			'connection_mode'           => $metadata['connection_mode'] ?? ( '' !== $token ? 'site' : 'none' ),
-			'installation_id'           => $this->get_installation_id(),
-			'site_url'                  => $this->get_verified_site_url(),
-			'connected_at'              => $metadata['connected_at'] ?? null,
-			'account_connect_available' => '' !== $account_portal_url,
-			'account_connect_url'       => $account_portal_url,
-			'account_portal_url'        => $account_portal_url,
-			'purchase_credits_url'      => $purchase_credits_url,
-			'payment_methods_url'       => $payment_methods_url,
+			'configured'                 => '' !== $token,
+			'provider'                   => SuperdavAiProvider::PROVIDER_ID,
+			'connection_mode'            => $metadata['connection_mode'] ?? ( '' !== $token ? 'site' : 'none' ),
+			'installation_id'            => $this->get_installation_id(),
+			'site_url'                   => $this->get_verified_site_url(),
+			'connected_at'               => $metadata['connected_at'] ?? null,
+			'account_connect_available'  => $account_portal_available,
+			'account_connect_url'        => '',
+			'account_portal_url'         => '',
+			'purchase_credits_url'       => '',
+			'payment_methods_url'        => '',
+			'link_account_url'           => '',
+			'account_portal_available'   => $account_portal_available,
+			'purchase_credits_available' => $purchase_credits_available,
+			'payment_methods_available'  => $payment_methods_available,
+			'link_account_available'     => $link_account_available,
 		);
 
 		foreach ( array( 'tier', 'verified', 'request_id', 'refreshed_at', 'connection_notice_pending' ) as $key ) {
@@ -108,6 +115,10 @@ final class SuperdavSiteConnectionService {
 		if ( isset( $metadata['chat_sessions'] ) && is_array( $metadata['chat_sessions'] ) ) {
 			$status['chat_sessions'] = $this->sanitize_chat_session_metadata( $metadata['chat_sessions'] );
 		}
+
+		$status['linked_user'] = isset( $metadata['linked_user'] ) && is_array( $metadata['linked_user'] )
+			? $this->sanitize_linked_user_metadata( $metadata['linked_user'] )
+			: null;
 
 		$status['site_timezone'] = wp_timezone_string();
 
@@ -174,6 +185,14 @@ final class SuperdavSiteConnectionService {
 			$metadata['request_id'],
 			$metadata['refreshed_at'],
 			$metadata['account_portal_url'],
+			$metadata['purchase_credits_url'],
+			$metadata['payment_methods_url'],
+			$metadata['link_account_url'],
+			$metadata['account_portal_available'],
+			$metadata['purchase_credits_available'],
+			$metadata['payment_methods_available'],
+			$metadata['link_account_available'],
+			$metadata['linked_user'],
 			$metadata['usage'],
 			$metadata['verification'],
 			$metadata['wallet'],
@@ -184,6 +203,69 @@ final class SuperdavSiteConnectionService {
 		update_option( self::TOKEN_METADATA_OPTION, $metadata, false );
 
 		return $this->get_status();
+	}
+
+	/**
+	 * Request a fresh, one-time browser URL for an account action.
+	 *
+	 * @param string $action Documented account action name.
+	 * @return array{action:string,url:string}|WP_Error Safe action response or service error.
+	 */
+	public function request_account_action( string $action ): array|WP_Error {
+		$allowed_actions = array( 'account_portal', 'purchase_credits', 'payment_methods', 'link_account' );
+
+		if ( ! in_array( $action, $allowed_actions, true ) ) {
+			return new WP_Error( 'sd_ai_agent_account_action_invalid', __( 'That SD AI account action is invalid.', 'superdav-ai-agent' ), array( 'status' => 400 ) );
+		}
+
+		$token = $this->get_stored_token();
+		if ( '' === $token ) {
+			return new WP_Error( 'sd_ai_agent_cloud_account_unavailable', __( 'Connect SD AI before opening account actions.', 'superdav-ai-agent' ), array( 'status' => 412 ) );
+		}
+
+		$endpoint = $this->get_account_action_endpoint();
+		if ( '' === $endpoint ) {
+			return new WP_Error( 'sd_ai_agent_account_action_unavailable', __( 'SD AI account actions are temporarily unavailable.', 'superdav-ai-agent' ), array( 'status' => 503 ) );
+		}
+
+		$response = wp_remote_post(
+			$endpoint,
+			array(
+				'timeout'     => 15,
+				'redirection' => 0,
+				'headers'     => array(
+					'Authorization' => 'Bearer ' . $token,
+					'Content-Type'  => 'application/json',
+				),
+				'body'        => wp_json_encode(
+					array(
+						'installation_id' => $this->get_installation_id(),
+						'action'          => $action,
+					)
+				),
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			return new WP_Error( 'sd_ai_agent_account_action_unavailable', __( 'SD AI account actions are temporarily unavailable.', 'superdav-ai-agent' ), array( 'status' => 502 ) );
+		}
+
+		$status_code = (int) wp_remote_retrieve_response_code( $response );
+		$body        = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		if ( $status_code < 200 || $status_code >= 300 || ! is_array( $body ) || ( $body['action'] ?? null ) !== $action ) {
+			return new WP_Error( 'sd_ai_agent_account_action_unavailable', __( 'SD AI account actions are temporarily unavailable.', 'superdav-ai-agent' ), array( 'status' => 502 ) );
+		}
+
+		$url = $this->sanitize_account_url( $body['url'] ?? '' );
+		if ( '' === $url ) {
+			return new WP_Error( 'sd_ai_agent_account_action_invalid_response', __( 'The SD AI account action response was invalid.', 'superdav-ai-agent' ), array( 'status' => 502 ) );
+		}
+
+		return array(
+			'action' => $action,
+			'url'    => $url,
+		);
 	}
 
 	/**
@@ -394,39 +476,6 @@ final class SuperdavSiteConnectionService {
 	}
 
 	/**
-	 * Return the account portal URL when the service exposes one.
-	 *
-	 * @param array<string, mixed> $metadata Safe connection metadata.
-	 */
-	private function get_account_portal_url( array $metadata ): string {
-		/**
-		 * Filters the Superdav account connection URL for future paid-account flows.
-		 *
-		 * The URL is safe UI metadata and must not include bearer tokens.
-		 *
-		 * @param string $url             Account connect URL.
-		 * @param string $installation_id Durable site-installation identity.
-		 * @param string $site_url        Verified site URL.
-		 */
-		$default_url = $metadata['account_portal_url'] ?? '';
-		$default_url = is_string( $default_url ) ? $default_url : '';
-		$url         = apply_filters( 'sd_ai_agent_cloud_account_connect_url', $default_url, $this->get_installation_id(), $this->get_verified_site_url() );
-
-		return $this->sanitize_account_url( $url );
-	}
-
-	/**
-	 * Return a dedicated, service-issued billing action URL when available.
-	 *
-	 * @param array<string, mixed> $metadata Safe connection metadata.
-	 * @param string               $key      Dedicated action metadata key.
-	 * @return string Service-issued action URL, or empty when unavailable.
-	 */
-	private function get_account_action_url( array $metadata, string $key ): string {
-		return $this->sanitize_account_url( $metadata[ $key ] ?? '' );
-	}
-
-	/**
 	 * Resolve the managed service endpoint used to refresh safe wallet metadata.
 	 */
 	private function get_account_status_endpoint(): string {
@@ -441,6 +490,20 @@ final class SuperdavSiteConnectionService {
 		 * @param string $endpoint Account-status endpoint URL.
 		 */
 		$endpoint = apply_filters( 'sd_ai_agent_cloud_account_status_endpoint', $endpoint );
+
+		return is_string( $endpoint ) ? esc_url_raw( $endpoint ) : '';
+	}
+
+	/** Resolve the managed endpoint that mints fresh one-time account actions. */
+	private function get_account_action_endpoint(): string {
+		$endpoint = $this->configured_endpoint( 'SD_AI_AGENT_CLOUD_ACCOUNT_ACTION_ENDPOINT', self::ACCOUNT_ACTION_ENDPOINT_PATH );
+
+		/**
+		 * Filters the server-to-server account action endpoint.
+		 *
+		 * @param string $endpoint Account action endpoint URL.
+		 */
+		$endpoint = apply_filters( 'sd_ai_agent_cloud_account_action_endpoint', $endpoint );
 
 		return is_string( $endpoint ) ? esc_url_raw( $endpoint ) : '';
 	}
@@ -667,10 +730,11 @@ final class SuperdavSiteConnectionService {
 			'verified',
 			'connect_required',
 			'request_id',
-			'account_portal_url',
+			'account_portal_available',
+			'purchase_credits_available',
+			'payment_methods_available',
+			'link_account_available',
 			'refreshed_at',
-			'purchase_credits_url',
-			'payment_methods_url',
 		);
 		$safe         = array();
 
@@ -680,14 +744,14 @@ final class SuperdavSiteConnectionService {
 			}
 		}
 
-		foreach ( array( 'account_portal_url', 'purchase_credits_url', 'payment_methods_url' ) as $key ) {
-			if ( isset( $safe[ $key ] ) ) {
-				$url = $this->sanitize_account_url( $safe[ $key ] );
-				if ( '' === $url ) {
-					unset( $safe[ $key ] );
-				} else {
-					$safe[ $key ] = $url;
-				}
+		$billing_actions = isset( $metadata['billing_actions'] ) && is_array( $metadata['billing_actions'] )
+			? $metadata['billing_actions']
+			: array();
+
+		foreach ( array( 'account_portal', 'purchase_credits', 'payment_methods', 'link_account' ) as $action ) {
+			$key = $action . '_available';
+			if ( isset( $billing_actions[ $action ] ) && is_array( $billing_actions[ $action ] ) ) {
+				$safe[ $key ] = true === ( $billing_actions[ $action ]['available'] ?? false );
 			}
 		}
 
@@ -726,7 +790,38 @@ final class SuperdavSiteConnectionService {
 			$safe['chat_sessions'] = $this->sanitize_chat_session_metadata( $metadata['chat_sessions'] );
 		}
 
+		if ( isset( $metadata['linked_user'] ) && is_array( $metadata['linked_user'] ) ) {
+			$safe['linked_user'] = $this->sanitize_linked_user_metadata( $metadata['linked_user'] );
+		}
+
 		return $safe;
+	}
+
+	/**
+	 * Keep only display-safe identity fields returned by the managed service.
+	 *
+	 * @param array<string, mixed> $identity Remote linked-user metadata.
+	 * @return array<string, bool|string>|null Safe linked user, or null when invalid.
+	 */
+	private function sanitize_linked_user_metadata( array $identity ): ?array {
+		$display_name      = isset( $identity['display_name'] ) && is_string( $identity['display_name'] )
+			? substr( sanitize_text_field( $identity['display_name'] ), 0, 100 )
+			: '';
+		$masked_email      = isset( $identity['masked_email'] ) && is_string( $identity['masked_email'] )
+			? substr( sanitize_text_field( $identity['masked_email'] ), 0, 191 )
+			: '';
+		$email_verified_at = $this->sanitize_credit_activity_timestamp( $identity['email_verified_at'] ?? null );
+
+		if ( '' === $display_name || '' === $masked_email || true !== ( $identity['email_verified'] ?? false ) || null === $email_verified_at ) {
+			return null;
+		}
+
+		return array(
+			'display_name'      => $display_name,
+			'masked_email'      => $masked_email,
+			'email_verified'    => true,
+			'email_verified_at' => $email_verified_at,
+		);
 	}
 
 	/**

--- a/includes/REST/SettingsController.php
+++ b/includes/REST/SettingsController.php
@@ -149,6 +149,23 @@ final class SettingsController {
 
 		register_rest_route(
 			RestController::NAMESPACE,
+			'/superdav-account/action',
+			array(
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'handle_superdav_account_action' ),
+				'permission_callback' => array( __CLASS__, 'check_admin_permission' ),
+				'args'                => array(
+					'action' => array(
+						'required'          => true,
+						'type'              => 'string',
+						'validate_callback' => static fn( mixed $value ): bool => is_string( $value ) && in_array( $value, array( 'account_portal', 'purchase_credits', 'payment_methods', 'link_account' ), true ),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			RestController::NAMESPACE,
 			'/superdav-account/redeem-coupon',
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
@@ -558,6 +575,26 @@ final class SettingsController {
 		}
 
 		return new WP_REST_Response( $this->add_local_chat_session_details( $status ), 200 );
+	}
+
+	/**
+	 * Mint one fresh, action-specific browser URL without exposing the site token.
+	 *
+	 * @param WP_REST_Request $request Current administrator request.
+	 * @return WP_REST_Response|WP_Error Safe action URL or service error.
+	 */
+	public function handle_superdav_account_action( WP_REST_Request $request ): WP_REST_Response|WP_Error {
+		$action = $request->get_param( 'action' );
+		if ( ! is_string( $action ) ) {
+			return new WP_Error( 'sd_ai_agent_account_action_invalid', __( 'That SD AI account action is invalid.', 'superdav-ai-agent' ), array( 'status' => 400 ) );
+		}
+
+		$result = ( new SuperdavSiteConnectionService() )->request_account_action( $action );
+		if ( $result instanceof WP_Error ) {
+			return $result;
+		}
+
+		return new WP_REST_Response( $result, 200 );
 	}
 
 	/**

--- a/src/settings-page/__tests__/superdav-account-manager.test.js
+++ b/src/settings-page/__tests__/superdav-account-manager.test.js
@@ -293,14 +293,30 @@ describe( 'SuperdavAccountManager', () => {
 		).not.toBeNull();
 	} );
 
-	test( 'renders account actions in the requested header order with their service-issued URLs', async () => {
-		apiFetch.mockResolvedValueOnce( {
-			configured: true,
-			account_portal_url: 'https://account.example/portal',
-			purchase_credits_url: 'https://account.example/credits/purchase',
-			payment_methods_url:
-				'https://account.example/billing/payment-methods',
-		} );
+	test( 'shows the linked user and mints a fresh URL when an account action is clicked', async () => {
+		const portalWindow = {
+			location: { assign: jest.fn() },
+			close: jest.fn(),
+			opener: window,
+		};
+		window.open = jest.fn( () => portalWindow );
+		apiFetch
+			.mockResolvedValueOnce( {
+				configured: true,
+				account_portal_available: true,
+				purchase_credits_available: true,
+				payment_methods_available: true,
+				link_account_available: true,
+				linked_user: {
+					display_name: 'Verified Customer',
+					masked_email: 'v***@example.test',
+					email_verified: true,
+				},
+			} )
+			.mockResolvedValueOnce( {
+				action: 'account_portal',
+				url: 'https://account.example/fresh-account-action',
+			} );
 
 		await act( async () => {
 			root.render( createElement( SuperdavAccountManager, {} ) );
@@ -309,21 +325,9 @@ describe( 'SuperdavAccountManager', () => {
 			await Promise.resolve();
 		} );
 
-		expect(
-			container.querySelector(
-				'a[href="https://account.example/credits/purchase"]'
-			)
-		).not.toBeNull();
-		expect(
-			container.querySelector(
-				'a[href="https://account.example/billing/payment-methods"]'
-			)
-		).not.toBeNull();
-		expect(
-			container.querySelector(
-				'a[href="https://account.example/portal"]'
-			)
-		).not.toBeNull();
+		expect( container.textContent ).toContain( 'Verified Customer' );
+		expect( container.textContent ).toContain( 'v***@example.test' );
+		expect( findButton( 'Link a different user' ) ).toBeDefined();
 
 		const headerActions = container.querySelector(
 			'.sd-ai-agent-superdav-account-header-actions'
@@ -338,6 +342,21 @@ describe( 'SuperdavAccountManager', () => {
 			'Redeem Coupon',
 			'Add credits',
 		] );
+
+		await act( async () => {
+			findButton( 'Open account portal' ).click();
+			await Promise.resolve();
+		} );
+
+		expect( apiFetch ).toHaveBeenLastCalledWith( {
+			path: '/sd-ai-agent/v1/superdav-account/action',
+			method: 'POST',
+			data: { action: 'account_portal' },
+		} );
+		expect( portalWindow.opener ).toBeNull();
+		expect( portalWindow.location.assign ).toHaveBeenCalledWith(
+			'https://account.example/fresh-account-action'
+		);
 	} );
 
 	test( 'redeems a coupon, disables submission while pending, and updates the balance', async () => {

--- a/src/settings-page/style.css
+++ b/src/settings-page/style.css
@@ -552,12 +552,40 @@
 }
 
 .sd-ai-agent-superdav-account-overview,
+.sd-ai-agent-superdav-linked-user,
 .sd-ai-agent-superdav-session-usage,
 .sd-ai-agent-superdav-credit-activity {
 	padding: 24px;
 	border: 1px solid #dcdcde;
 	border-radius: 8px;
 	background: #fff;
+}
+
+.sd-ai-agent-superdav-linked-user {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 16px;
+}
+
+.sd-ai-agent-superdav-linked-user h4 {
+	margin: 0 0 8px;
+}
+
+.sd-ai-agent-superdav-linked-user strong,
+.sd-ai-agent-superdav-linked-user span {
+	display: block;
+}
+
+.sd-ai-agent-superdav-linked-user span {
+	margin-top: 3px;
+	color: #50575e;
+}
+
+.sd-ai-agent-superdav-linked-user .sd-ai-agent-superdav-linked-user-status {
+	color: #008a20;
+	font-size: 12px;
+	font-weight: 600;
 }
 
 .sd-ai-agent-superdav-account-overview {
@@ -816,9 +844,15 @@
 	}
 
 	.sd-ai-agent-superdav-account-overview,
+	.sd-ai-agent-superdav-linked-user,
 	.sd-ai-agent-superdav-session-usage,
 	.sd-ai-agent-superdav-credit-activity {
 		padding: 16px;
+	}
+
+	.sd-ai-agent-superdav-linked-user {
+		align-items: flex-start;
+		flex-direction: column;
 	}
 
 	.sd-ai-agent-superdav-session-usage-summary {

--- a/src/settings-page/superdav-account-manager.js
+++ b/src/settings-page/superdav-account-manager.js
@@ -483,7 +483,7 @@ export default function SuperdavAccountManager() {
 				}
 
 				setActionNotice( {
-					status: 'error',
+					status: 'info',
 					message: __(
 						'Unable to open that SD AI account action. Try again.',
 						'superdav-ai-agent'
@@ -725,7 +725,7 @@ export default function SuperdavAccountManager() {
 					</Button>
 					{ purchaseCreditsAvailable && (
 						<Button
-							variant="primary"
+							variant="secondary"
 							onClick={ () =>
 								openAccountAction( 'purchase_credits' )
 							}

--- a/src/settings-page/superdav-account-manager.js
+++ b/src/settings-page/superdav-account-manager.js
@@ -402,6 +402,8 @@ export default function SuperdavAccountManager() {
 	const [ couponCode, setCouponCode ] = useState( '' );
 	const [ redeeming, setRedeeming ] = useState( false );
 	const [ redemptionNotice, setRedemptionNotice ] = useState( null );
+	const [ actionNotice, setActionNotice ] = useState( null );
+	const [ openingAction, setOpeningAction ] = useState( '' );
 	const [ error, setError ] = useState( '' );
 	const [ hasLoadedAccount, setHasLoadedAccount ] = useState( false );
 
@@ -444,6 +446,55 @@ export default function SuperdavAccountManager() {
 		setRedemptionNotice( null );
 		setIsCouponModalOpen( false );
 	}, [ redeeming ] );
+
+	const openAccountAction = useCallback(
+		async ( action ) => {
+			if ( openingAction ) {
+				return;
+			}
+
+			const portalWindow = window.open( 'about:blank', '_blank' );
+			if ( portalWindow ) {
+				portalWindow.opener = null;
+			}
+
+			setOpeningAction( action );
+			setActionNotice( null );
+
+			try {
+				const result = await apiFetch( {
+					path: '/sd-ai-agent/v1/superdav-account/action',
+					method: 'POST',
+					data: { action },
+				} );
+
+				if ( ! result?.url ) {
+					throw new Error( 'invalid_account_action' );
+				}
+
+				if ( portalWindow ) {
+					portalWindow.location.assign( result.url );
+				} else {
+					window.location.assign( result.url );
+				}
+			} catch {
+				if ( portalWindow ) {
+					portalWindow.close();
+				}
+
+				setActionNotice( {
+					status: 'error',
+					message: __(
+						'Unable to open that SD AI account action. Try again.',
+						'superdav-ai-agent'
+					),
+				} );
+			} finally {
+				setOpeningAction( '' );
+			}
+		},
+		[ openingAction ]
+	);
 
 	const redeemCoupon = useCallback(
 		async ( event ) => {
@@ -520,11 +571,16 @@ export default function SuperdavAccountManager() {
 	}
 
 	const wallet = account?.wallet || {};
-	const accountUrl = account?.account_portal_url || '';
-	const purchaseCreditsUrl = account?.purchase_credits_url || '';
-	const paymentMethodsUrl = account?.payment_methods_url || '';
+	const accountPortalAvailable = !! account?.account_portal_available;
+	const purchaseCreditsAvailable = !! account?.purchase_credits_available;
+	const paymentMethodsAvailable = !! account?.payment_methods_available;
+	const linkAccountAvailable = !! account?.link_account_available;
+	const linkedUser = account?.linked_user || null;
 	const hasAccountActions =
-		purchaseCreditsUrl || paymentMethodsUrl || accountUrl;
+		purchaseCreditsAvailable ||
+		paymentMethodsAvailable ||
+		accountPortalAvailable ||
+		linkAccountAvailable;
 	const configured = !! account?.configured;
 	const tier = account?.tier || '';
 	const chatSessions = Array.isArray( account?.chat_sessions )
@@ -633,22 +689,26 @@ export default function SuperdavAccountManager() {
 					</p>
 				</div>
 				<div className="sd-ai-agent-superdav-account-header-actions">
-					{ accountUrl && (
+					{ accountPortalAvailable && (
 						<Button
 							variant="tertiary"
-							href={ accountUrl }
-							target="_blank"
-							rel="noopener noreferrer"
+							onClick={ () =>
+								openAccountAction( 'account_portal' )
+							}
+							isBusy={ openingAction === 'account_portal' }
+							disabled={ !! openingAction }
 						>
 							{ __( 'Open account portal', 'superdav-ai-agent' ) }
 						</Button>
 					) }
-					{ paymentMethodsUrl && (
+					{ paymentMethodsAvailable && (
 						<Button
 							variant="secondary"
-							href={ paymentMethodsUrl }
-							target="_blank"
-							rel="noopener noreferrer"
+							onClick={ () =>
+								openAccountAction( 'payment_methods' )
+							}
+							isBusy={ openingAction === 'payment_methods' }
+							disabled={ !! openingAction }
 						>
 							{ __(
 								'Manage payment methods',
@@ -663,12 +723,14 @@ export default function SuperdavAccountManager() {
 					>
 						{ __( 'Redeem Coupon', 'superdav-ai-agent' ) }
 					</Button>
-					{ purchaseCreditsUrl && (
+					{ purchaseCreditsAvailable && (
 						<Button
 							variant="primary"
-							href={ purchaseCreditsUrl }
-							target="_blank"
-							rel="noopener noreferrer"
+							onClick={ () =>
+								openAccountAction( 'purchase_credits' )
+							}
+							isBusy={ openingAction === 'purchase_credits' }
+							disabled={ !! openingAction }
 						>
 							{ __( 'Add credits', 'superdav-ai-agent' ) }
 						</Button>
@@ -689,6 +751,11 @@ export default function SuperdavAccountManager() {
 					{ redemptionNotice.message }
 				</Notice>
 			) }
+			{ actionNotice && (
+				<Notice status={ actionNotice.status } isDismissible={ false }>
+					{ actionNotice.message }
+				</Notice>
+			) }
 
 			{ hasLoadedAccount &&
 				( ! configured ? (
@@ -700,6 +767,50 @@ export default function SuperdavAccountManager() {
 					</Notice>
 				) : (
 					<>
+						<section className="sd-ai-agent-superdav-linked-user">
+							<div>
+								<h4>
+									{ __( 'Linked user', 'superdav-ai-agent' ) }
+								</h4>
+								{ linkedUser ? (
+									<>
+										<strong>
+											{ linkedUser.display_name }
+										</strong>
+										<span>{ linkedUser.masked_email }</span>
+										<span className="sd-ai-agent-superdav-linked-user-status">
+											{ __(
+												'Email verified',
+												'superdav-ai-agent'
+											) }
+										</span>
+									</>
+								) : (
+									<p className="description">
+										{ __(
+											'No verified user is linked to this site yet.',
+											'superdav-ai-agent'
+										) }
+									</p>
+								) }
+							</div>
+							{ linkAccountAvailable && (
+								<Button
+									variant="secondary"
+									onClick={ () =>
+										openAccountAction( 'link_account' )
+									}
+									isBusy={ openingAction === 'link_account' }
+									disabled={ !! openingAction }
+								>
+									{ __(
+										'Link a different user',
+										'superdav-ai-agent'
+									) }
+								</Button>
+							) }
+						</section>
+
 						<section
 							className="sd-ai-agent-superdav-account-overview"
 							aria-label={ __(

--- a/tests/SdAiAgent/REST/SettingsControllerTest.php
+++ b/tests/SdAiAgent/REST/SettingsControllerTest.php
@@ -46,6 +46,7 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		delete_option( SuperdavSiteConnectionService::TOKEN_METADATA_OPTION );
 		remove_all_filters( 'sd_ai_agent_cloud_base_url' );
 		remove_all_filters( 'sd_ai_agent_cloud_portal_signing_secret' );
+		remove_all_filters( 'sd_ai_agent_cloud_account_action_endpoint' );
 		remove_all_filters( 'sd_ai_agent_cloud_account_coupon_redemption_endpoint' );
 		remove_all_filters( 'sd_ai_agent_options_read_blocklist' );
 		remove_all_filters( 'pre_update_option_' . SuperdavSiteConnectionService::TOKEN_METADATA_OPTION );
@@ -498,6 +499,36 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( 'https://account.example/action?sdai_action_ticket=opaque-ticket', $response->get_data()['url'] );
 		$this->assertStringNotContainsString( $token, wp_json_encode( $response->get_data() ) ?: '' );
+	}
+
+	/** Account actions never send their bearer token to unsafe filtered endpoints. */
+	public function test_handle_superdav_account_action_rejects_unsafe_endpoint_overrides(): void {
+		$endpoints = array(
+			'http://service.example/v1/site/account/action',
+			'https://action-user:action-password@service.example/v1/site/account/action',
+			'https://service.example/v1/site/account/action?access_token=must-not-be-sent',
+		);
+
+		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, 'sdaist_action_endpoint_token', false );
+		add_filter(
+			'pre_http_request',
+			static function (): void {
+				self::fail( 'Unsafe account action endpoint must not receive an HTTP request.' );
+			},
+			10,
+			0
+		);
+
+		foreach ( $endpoints as $endpoint ) {
+			add_filter( 'sd_ai_agent_cloud_account_action_endpoint', static fn(): string => $endpoint );
+			$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/superdav-account/action' );
+			$request->set_param( 'action', 'account_portal' );
+			$response = ( new SettingsController( new Settings(), new Database() ) )->handle_superdav_account_action( $request );
+
+			$this->assertInstanceOf( \WP_Error::class, $response );
+			$this->assertSame( 'sd_ai_agent_account_action_unavailable', $response->get_error_code() );
+			remove_all_filters( 'sd_ai_agent_cloud_account_action_endpoint' );
+		}
 	}
 
 	/** Coupon redemption signs the documented request and returns only safe refreshed metadata. */

--- a/tests/SdAiAgent/REST/SettingsControllerTest.php
+++ b/tests/SdAiAgent/REST/SettingsControllerTest.php
@@ -297,9 +297,23 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 					'body'     => wp_json_encode(
 						array(
 							'tier'                 => 'pro',
-							'account_portal_url'   => 'https://account.example/billing',
-							'purchase_credits_url' => 'https://account.example/credits/purchase',
-							'payment_methods_url'  => 'https://account.example/billing/payment-methods',
+							'account_portal_url'   => 'https://account.example/action?sdai_action_ticket=opaque-action-ticket',
+							'purchase_credits_url' => 'https://account.example/action?sdai_action_ticket=opaque-action-ticket',
+							'payment_methods_url'  => 'https://account.example/action?sdai_action_ticket=opaque-action-ticket',
+							'link_account_url'     => 'https://account.example/action?sdai_action_ticket=opaque-action-ticket',
+							'billing_actions'      => array(
+								'account_portal'   => array( 'available' => true ),
+								'purchase_credits' => array( 'available' => true ),
+								'payment_methods'  => array( 'available' => true ),
+								'link_account'     => array( 'available' => true ),
+							),
+							'linked_user'          => array(
+								'display_name'      => 'Verified Customer',
+								'masked_email'      => 'v***@example.test',
+								'email_verified'    => true,
+								'email_verified_at' => '2026-08-05T12:00:00Z',
+								'raw_email'         => 'must-not-be-exposed',
+							),
 							'wallet'             => array(
 								'currency'         => 'USD',
 								'promo_usd_micros' => 2500000,
@@ -386,9 +400,23 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		$this->assertSame( 200, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertSame( 15000000, $data['wallet']['total_usd_micros'] );
-		$this->assertSame( 'https://account.example/billing', $data['account_portal_url'] );
-		$this->assertSame( 'https://account.example/credits/purchase', $data['purchase_credits_url'] );
-		$this->assertSame( 'https://account.example/billing/payment-methods', $data['payment_methods_url'] );
+		$this->assertSame( '', $data['account_portal_url'] );
+		$this->assertSame( '', $data['purchase_credits_url'] );
+		$this->assertSame( '', $data['payment_methods_url'] );
+		$this->assertSame( '', $data['link_account_url'] );
+		$this->assertTrue( $data['account_portal_available'] );
+		$this->assertTrue( $data['purchase_credits_available'] );
+		$this->assertTrue( $data['payment_methods_available'] );
+		$this->assertTrue( $data['link_account_available'] );
+		$this->assertSame(
+			array(
+				'display_name'      => 'Verified Customer',
+				'masked_email'      => 'v***@example.test',
+				'email_verified'    => true,
+				'email_verified_at' => '2026-08-05T12:00:00+00:00',
+			),
+			$data['linked_user']
+		);
 		$this->assertSame( '2026-07-16T00:00:00+00:00', $data['connected_at'] );
 		$this->assertSame( wp_timezone_string(), $data['site_timezone'] );
 		$this->assertCount( 2, $data['credit_activity'] );
@@ -408,6 +436,8 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'verification', $data );
 		$this->assertArrayNotHasKey( 'refreshed_at', $data );
 		$this->assertStringNotContainsString( $token, wp_json_encode( $data ) ?: '' );
+		$this->assertStringNotContainsString( 'opaque-action-ticket', wp_json_encode( $data ) ?: '' );
+		$this->assertStringNotContainsString( 'opaque-action-ticket', wp_json_encode( get_option( SuperdavSiteConnectionService::TOKEN_METADATA_OPTION ) ) ?: '' );
 		$this->assertStringNotContainsString( 'must-not-be-exposed', wp_json_encode( $data ) ?: '' );
 	}
 
@@ -419,6 +449,55 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 
 		wp_set_current_user( 0 );
 		$this->assertFalse( SettingsController::check_admin_permission() );
+	}
+
+	/** Account actions are minted on demand without exposing or persisting the site token. */
+	public function test_handle_superdav_account_action_returns_fresh_safe_url(): void {
+		$base_url   = 'https://service.example/v1';
+		$action_url = $base_url . '/site/account/action';
+		$token      = 'sdaist_fresh_account_action_token';
+
+		add_filter( 'sd_ai_agent_cloud_base_url', static fn(): string => $base_url );
+		add_filter(
+			'pre_http_request',
+			static function ( mixed $preempt, array $parsed_args, string $url ) use ( $action_url, $token ): mixed {
+				if ( $action_url !== $url ) {
+					return $preempt;
+				}
+
+				self::assertSame( 'Bearer ' . $token, self::authorization_header_from_args( $parsed_args ) );
+				self::assertSame( 0, $parsed_args['redirection'] ?? null );
+				self::assertSame(
+					'account_portal',
+					json_decode( (string) ( $parsed_args['body'] ?? '' ), true )['action'] ?? null
+				);
+
+				return array(
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'body'     => wp_json_encode(
+						array(
+							'action' => 'account_portal',
+							'url'    => 'https://account.example/action?sdai_action_ticket=opaque-ticket',
+						)
+					),
+				);
+			},
+			10,
+			3
+		);
+
+		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, $token, false );
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/superdav-account/action' );
+		$request->set_param( 'action', 'account_portal' );
+		$response = ( new SettingsController( new Settings(), new Database() ) )->handle_superdav_account_action( $request );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'https://account.example/action?sdai_action_ticket=opaque-ticket', $response->get_data()['url'] );
+		$this->assertStringNotContainsString( $token, wp_json_encode( $response->get_data() ) ?: '' );
 	}
 
 	/** Coupon redemption signs the documented request and returns only safe refreshed metadata. */


### PR DESCRIPTION
## Summary

- mint fresh, one-time managed-account URLs when administrators click account actions
- show the verified linked user and provide a secure relink action
- retain only action availability and display-safe identity metadata in WordPress

## Security

- account-action routes require `manage_options`
- site bearer tokens remain server-side
- one-time ticket URLs are returned directly and are not persisted in plugin metadata
- linked identity is limited to display name, masked email, and verification timestamp

## Worker self-verification

- PHPUnit: Tests: 4081, Assertions: 18279, Errors: 0, Failures: 0, Skipped: 134, Incomplete: 4
- Jest: 470 tests passed across 46 suites
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded
- Bundle: budgets passed

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.228 plugin for [OpenCode](https://opencode.ai) v1.18.9 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added linked-account details to the account settings panel.
  * Added secure, on-demand access to the account portal, credit purchases, payment methods, and account-linking actions.
  * Added action availability indicators and optional account-linking support.
  * Added responsive styling for the linked-account panel.

* **Bug Fixes**
  * Improved popup security and neutral error handling when account action links cannot be generated.
  * Prevented sensitive action tickets and service URLs from being exposed or stored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->