### PR TITLE
GH#2368: exclude generated coverage assets from stylelint hooks

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,2 @@
+# PHPUnit HTML coverage output is generated locally and must never be linted.
+coverage-html/

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,2 +1,0 @@
-# PHPUnit HTML coverage output is generated locally and must never be linted.
-coverage-html/

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -11,6 +11,7 @@
 	},
 	"ignoreFiles": [
 		"build/**",
+		"coverage-html/**",
 		"node_modules/**",
 		"vendor/**"
 	]

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
 		"start": "wp-scripts start",
 		"lint:js": "wp-scripts lint-js src/",
 		"lint:js:fix": "wp-scripts lint-js src/ --fix",
-		"lint:css": "wp-scripts lint-style 'src/**/*.css'",
-		"lint:css:fix": "wp-scripts lint-style 'src/**/*.css' --fix",
+		"lint:css": "wp-scripts lint-style --config-basedir . 'src/**/*.css'",
+		"lint:css:fix": "wp-scripts lint-style --config-basedir . 'src/**/*.css' --fix",
 		"lint:php": "composer phpcs",
 		"lint:php:fix": "composer phpcbf",
 		"lint": "pnpm run lint:js && pnpm run lint:css && pnpm run lint:php",
@@ -120,7 +120,7 @@
 			"eslint --fix"
 		],
 		"src/**/*.css": [
-			"wp-scripts lint-style --fix"
+			"wp-scripts lint-style --config-basedir . --fix"
 		],
 		"**/*.php": [
 			"bash -c 'vendor/bin/phpcbf \"$@\"; ec=$?; [ $ec -le 1 ] || exit $ec' --",


### PR DESCRIPTION
## Summary

Configures Stylelint to ignore PHPUnit coverage reports and resolves the config from the active worktree for both package lint and lint-staged.

## Files Changed

.stylelintrc.json, package.json

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — pnpm run test:php (4082 tests, 18291 assertions); pnpm run lint:php; pnpm run lint:js; pnpm run lint:css; composer phpstan; pnpm run build; pnpm run check:bundle

Resolves #2368


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.258 plugin for [OpenCode](https://opencode.ai) v1.18.17 with gpt-5.6-terra spent 21m and 170,982 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CSS linting configuration to ignore generated coverage reports.
  * Improved consistency for direct CSS linting and staged-file autofixing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->