### PR TITLE
GH#2427: scope feedback tool logs to message context

### DIFF
--- a/includes/Feedback/ReportBuilder.php
+++ b/includes/Feedback/ReportBuilder.php
@@ -37,6 +37,59 @@ class ReportBuilder {
 	}
 
 	/**
+	 * Keep only logged tool entries referenced by the scoped message context.
+	 *
+	 * Function-call and function-response parts share the same ID as their
+	 * corresponding tool log entries. Matching by ID keeps each call/response
+	 * pair together without leaking unrelated activity from the wider session.
+	 * If the scoped messages contain no tool IDs, the targeted report omits the
+	 * session-wide tool log rather than attaching misleading history.
+	 *
+	 * @param array<int, array<string, mixed>> $tool_calls Logged session tool entries.
+	 * @param array<int, array<string, mixed>> $messages   Scoped messages array.
+	 * @return array<int, array<string, mixed>> Matching tool entries, re-indexed.
+	 */
+	private static function scope_tool_calls_to_messages( array $tool_calls, array $messages ): array {
+		$tool_ids = array();
+
+		foreach ( $messages as $message ) {
+			$parts = $message['parts'] ?? $message['content'] ?? array();
+			if ( ! is_array( $parts ) ) {
+				continue;
+			}
+
+			foreach ( $parts as $part ) {
+				if ( ! is_array( $part ) ) {
+					continue;
+				}
+
+				foreach ( array( 'functionCall', 'function_call', 'functionResponse', 'function_response' ) as $key ) {
+					$tool_part = $part[ $key ] ?? null;
+					if ( ! is_array( $tool_part ) || ! isset( $tool_part['id'] ) ) {
+						continue;
+					}
+
+					$id = (string) $tool_part['id'];
+					if ( '' !== $id ) {
+						$tool_ids[ $id ] = true;
+					}
+				}
+			}
+		}
+
+		return array_values(
+			array_filter(
+				$tool_calls,
+				static function ( array $entry ) use ( $tool_ids ): bool {
+					$id = isset( $entry['id'] ) ? (string) $entry['id'] : '';
+
+					return '' !== $id && isset( $tool_ids[ $id ] );
+				}
+			)
+		);
+	}
+
+	/**
 	 * Build a feedback report payload from a session.
 	 *
 	 * @param int    $session_id        Session to report on.
@@ -72,11 +125,10 @@ class ReportBuilder {
 		/** @var array<int, array<string, mixed>> $tool_calls */
 		$tool_calls = is_array( $decoded_tool_calls ) ? $decoded_tool_calls : [];
 
-		// Tool logs do not record their originating message index, so they cannot be
-		// safely correlated with a targeted message window.
+		// Scope to a context window around the target message when requested (t186).
 		if ( $message_index >= 0 ) {
 			$messages   = self::slice_message_context( $messages, $message_index );
-			$tool_calls = array();
+			$tool_calls = self::scope_tool_calls_to_messages( $tool_calls, $messages );
 		}
 
 		if ( $strip_tool_results ) {
@@ -133,11 +185,10 @@ class ReportBuilder {
 		$messages           = is_array( $decoded_messages ) ? $decoded_messages : [];
 		$tool_calls         = is_array( $decoded_tool_calls ) ? $decoded_tool_calls : [];
 
-		// Tool logs do not record their originating message index, so omit them from
-		// targeted summaries rather than reporting an unrelated session-wide count.
+		// Scope both counts to the same context window used by the report payload.
 		if ( $message_index >= 0 ) {
 			$messages   = self::slice_message_context( $messages, $message_index );
-			$tool_calls = array();
+			$tool_calls = self::scope_tool_calls_to_messages( $tool_calls, $messages );
 		}
 
 		return array(

--- a/includes/Feedback/ReportBuilder.php
+++ b/includes/Feedback/ReportBuilder.php
@@ -72,9 +72,11 @@ class ReportBuilder {
 		/** @var array<int, array<string, mixed>> $tool_calls */
 		$tool_calls = is_array( $decoded_tool_calls ) ? $decoded_tool_calls : [];
 
-		// Scope to a context window around the target message when requested (t186).
+		// Tool logs do not record their originating message index, so they cannot be
+		// safely correlated with a targeted message window.
 		if ( $message_index >= 0 ) {
-			$messages = self::slice_message_context( $messages, $message_index );
+			$messages   = self::slice_message_context( $messages, $message_index );
+			$tool_calls = array();
 		}
 
 		if ( $strip_tool_results ) {
@@ -131,9 +133,11 @@ class ReportBuilder {
 		$messages           = is_array( $decoded_messages ) ? $decoded_messages : [];
 		$tool_calls         = is_array( $decoded_tool_calls ) ? $decoded_tool_calls : [];
 
-		// Scope message count to the context window when a specific message is targeted.
+		// Tool logs do not record their originating message index, so omit them from
+		// targeted summaries rather than reporting an unrelated session-wide count.
 		if ( $message_index >= 0 ) {
-			$messages = self::slice_message_context( $messages, $message_index );
+			$messages   = self::slice_message_context( $messages, $message_index );
+			$tool_calls = array();
 		}
 
 		return array(

--- a/includes/Feedback/ReportBuilder.php
+++ b/includes/Feedback/ReportBuilder.php
@@ -37,6 +37,59 @@ class ReportBuilder {
 	}
 
 	/**
+	 * Keep only logged tool entries referenced by the scoped message context.
+	 *
+	 * Function-call and function-response parts share the same ID as their
+	 * corresponding tool log entries. Matching by ID keeps each call/response
+	 * pair together without leaking unrelated activity from the wider session.
+	 * If the scoped messages contain no tool IDs, the targeted report omits the
+	 * session-wide tool log rather than attaching misleading history.
+	 *
+	 * @param array<int, array<string, mixed>> $tool_calls Logged session tool entries.
+	 * @param array<int, array<string, mixed>> $messages   Scoped messages array.
+	 * @return array<int, array<string, mixed>> Matching tool entries, re-indexed.
+	 */
+	private static function scope_tool_calls_to_messages( array $tool_calls, array $messages ): array {
+		$tool_ids = array();
+
+		foreach ( $messages as $message ) {
+			$parts = $message['parts'] ?? $message['content'] ?? array();
+			if ( ! is_array( $parts ) ) {
+				continue;
+			}
+
+			foreach ( $parts as $part ) {
+				if ( ! is_array( $part ) ) {
+					continue;
+				}
+
+				foreach ( array( 'functionCall', 'function_call', 'functionResponse', 'function_response' ) as $key ) {
+					$tool_part = $part[ $key ] ?? null;
+					if ( ! is_array( $tool_part ) || ! isset( $tool_part['id'] ) ) {
+						continue;
+					}
+
+					$id = (string) $tool_part['id'];
+					if ( '' !== $id ) {
+						$tool_ids[ $id ] = true;
+					}
+				}
+			}
+		}
+
+		return array_values(
+			array_filter(
+				$tool_calls,
+				static function ( array $entry ) use ( $tool_ids ): bool {
+					$id = isset( $entry['id'] ) ? (string) $entry['id'] : '';
+
+					return '' !== $id && isset( $tool_ids[ $id ] );
+				}
+			)
+		);
+	}
+
+	/**
 	 * Build a feedback report payload from a session.
 	 *
 	 * @param int    $session_id        Session to report on.
@@ -74,7 +127,8 @@ class ReportBuilder {
 
 		// Scope to a context window around the target message when requested (t186).
 		if ( $message_index >= 0 ) {
-			$messages = self::slice_message_context( $messages, $message_index );
+			$messages   = self::slice_message_context( $messages, $message_index );
+			$tool_calls = self::scope_tool_calls_to_messages( $tool_calls, $messages );
 		}
 
 		if ( $strip_tool_results ) {
@@ -131,9 +185,10 @@ class ReportBuilder {
 		$messages           = is_array( $decoded_messages ) ? $decoded_messages : [];
 		$tool_calls         = is_array( $decoded_tool_calls ) ? $decoded_tool_calls : [];
 
-		// Scope message count to the context window when a specific message is targeted.
+		// Scope both counts to the same context window used by the report payload.
 		if ( $message_index >= 0 ) {
-			$messages = self::slice_message_context( $messages, $message_index );
+			$messages   = self::slice_message_context( $messages, $message_index );
+			$tool_calls = self::scope_tool_calls_to_messages( $tool_calls, $messages );
 		}
 
 		return array(

--- a/tests/SdAiAgent/Feedback/ReportBuilderTest.php
+++ b/tests/SdAiAgent/Feedback/ReportBuilderTest.php
@@ -16,41 +16,108 @@ use SdAiAgent\Feedback\ReportBuilder;
 use WP_UnitTestCase;
 
 /**
- * Test targeted feedback report context.
+ * Test feedback message and tool-log context scoping.
  */
 class ReportBuilderTest extends WP_UnitTestCase {
 
-	/**
-	 * Targeted feedback reports omit tool logs that cannot be mapped to the selected message window.
-	 */
-	public function test_targeted_report_omits_unmappable_tool_calls_and_summary_matches(): void {
-		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
-		wp_set_current_user( $user_id );
+	private int $user_id;
 
+	public function set_up(): void {
+		parent::set_up();
+		$this->user_id = self::factory()->user->create();
+		wp_set_current_user( $this->user_id );
+	}
+
+	/**
+	 * Targeted reports include only tool pairs referenced by scoped messages.
+	 */
+	public function test_targeted_report_scopes_tool_calls_to_message_context(): void {
+		$session_id = $this->create_session_with_tool_history();
+
+		$report  = ReportBuilder::build( $session_id, 'thumbs_down', '', false, 5 );
+		$summary = ReportBuilder::build_summary( $session_id, false, 5 );
+
+		$this->assertNotNull( $report );
+		$this->assertNotNull( $summary );
+		$this->assertSame( array( 'target-call', 'target-call' ), array_column( $report['session_data']['tool_calls'], 'id' ) );
+		$this->assertSame( array( 'call', 'response' ), array_column( $report['session_data']['tool_calls'], 'type' ) );
+		$this->assertSame( 2, $report['session_data']['tool_call_count'] );
+		$this->assertSame( 2, $summary['tool_call_count'] );
+	}
+
+	/**
+	 * Full-session reports preserve the complete tool log.
+	 */
+	public function test_full_report_preserves_all_tool_calls(): void {
+		$session_id = $this->create_session_with_tool_history();
+
+		$report = ReportBuilder::build( $session_id, 'user_reported' );
+
+		$this->assertNotNull( $report );
+		$this->assertSame( 6, $report['session_data']['tool_call_count'] );
+		$this->assertSame(
+			array( 'before-call', 'before-call', 'target-call', 'target-call', 'after-call', 'after-call' ),
+			array_column( $report['session_data']['tool_calls'], 'id' )
+		);
+	}
+
+	/**
+	 * Targeted text-only context omits unrelated session-wide tool history.
+	 */
+	public function test_targeted_report_without_tool_ids_omits_tool_log(): void {
+		$session_id = $this->create_session_with_tool_history();
+		$this->assertTrue(
+			Database::update_session(
+				$session_id,
+				array(
+					'messages' => wp_json_encode(
+						array(
+							array( 'role' => 'user', 'parts' => array( array( 'type' => 'text', 'text' => 'Text only' ) ) ),
+							array( 'role' => 'model', 'parts' => array( array( 'type' => 'text', 'text' => 'No tools here' ) ) ),
+						)
+					),
+				)
+			)
+		);
+
+		$report = ReportBuilder::build( $session_id, 'thumbs_down', '', false, 1 );
+
+		$this->assertNotNull( $report );
+		$this->assertSame( array(), $report['session_data']['tool_calls'] );
+		$this->assertSame( 0, $report['session_data']['tool_call_count'] );
+	}
+
+	private function create_session_with_tool_history(): int {
 		$session_id = Database::create_session(
 			array(
-				'user_id' => $user_id,
-				'title'   => 'Targeted feedback context',
+				'user_id'     => $this->user_id,
+				'title'       => 'Scoped feedback',
+				'provider_id' => 'test-provider',
+				'model_id'    => 'test-model',
 			)
 		);
 		$this->assertIsInt( $session_id );
 
 		$messages = array(
-			array( 'role' => 'user', 'content' => 'Before the first tool call.' ),
-			array( 'role' => 'assistant', 'content' => 'First response.' ),
-			array( 'role' => 'user', 'content' => 'Context before the selected message.' ),
-			array( 'role' => 'assistant', 'content' => 'Context response.' ),
-			array( 'role' => 'user', 'content' => 'Selected feedback message.' ),
-			array( 'role' => 'assistant', 'content' => 'Context after the selected message.' ),
-			array( 'role' => 'user', 'content' => 'After the selected message.' ),
+			array( 'role' => 'user', 'parts' => array( array( 'type' => 'text', 'text' => 'Earlier task' ) ) ),
+			$this->function_message( 'model', 'functionCall', 'before-call' ),
+			$this->function_message( 'user', 'functionResponse', 'before-call' ),
+			array( 'role' => 'model', 'parts' => array( array( 'type' => 'text', 'text' => 'Earlier answer' ) ) ),
+			array( 'role' => 'user', 'parts' => array( array( 'type' => 'text', 'text' => 'Target task' ) ) ),
+			$this->function_message( 'model', 'functionCall', 'target-call' ),
+			$this->function_message( 'user', 'functionResponse', 'target-call' ),
+			array( 'role' => 'model', 'parts' => array( array( 'type' => 'text', 'text' => 'Target answer' ) ) ),
+			$this->function_message( 'model', 'functionCall', 'after-call' ),
+			$this->function_message( 'user', 'functionResponse', 'after-call' ),
 		);
+
 		$tool_calls = array(
-			array( 'type' => 'call', 'id' => 'before-call', 'name' => 'site-info' ),
-			array( 'type' => 'response', 'id' => 'before-call', 'name' => 'site-info' ),
-			array( 'type' => 'call', 'id' => 'within-call', 'name' => 'list-posts' ),
-			array( 'type' => 'response', 'id' => 'within-call', 'name' => 'list-posts' ),
-			array( 'type' => 'call', 'id' => 'after-call', 'name' => 'update-post' ),
-			array( 'type' => 'response', 'id' => 'after-call', 'name' => 'update-post' ),
+			array( 'type' => 'call', 'id' => 'before-call', 'name' => 'before-tool', 'args' => array() ),
+			array( 'type' => 'response', 'id' => 'before-call', 'name' => 'before-tool', 'response' => array( 'ok' => true ) ),
+			array( 'type' => 'call', 'id' => 'target-call', 'name' => 'target-tool', 'args' => array() ),
+			array( 'type' => 'response', 'id' => 'target-call', 'name' => 'target-tool', 'response' => array( 'ok' => true ) ),
+			array( 'type' => 'call', 'id' => 'after-call', 'name' => 'after-tool', 'args' => array() ),
+			array( 'type' => 'response', 'id' => 'after-call', 'name' => 'after-tool', 'response' => array( 'ok' => true ) ),
 		);
 
 		$this->assertTrue(
@@ -63,23 +130,26 @@ class ReportBuilderTest extends WP_UnitTestCase {
 			)
 		);
 
-		$payload = ReportBuilder::build( $session_id, 'user_reported', '', false, 4 );
-		$summary = ReportBuilder::build_summary( $session_id, false, 4 );
+		return $session_id;
+	}
 
-		$this->assertIsArray( $payload );
-		$this->assertIsArray( $summary );
-		$this->assertCount( 5, $payload['session_data']['messages'] );
-		$this->assertSame( array(), $payload['session_data']['tool_calls'] );
-		$this->assertSame( 0, $payload['session_data']['tool_call_count'] );
-		$this->assertSame( 0, $summary['tool_call_count'] );
-		$this->assertSame( $payload['session_data']['message_count'], $summary['message_count'] );
-
-		$complete_payload = ReportBuilder::build( $session_id, 'user_reported' );
-		$complete_summary = ReportBuilder::build_summary( $session_id );
-		$this->assertIsArray( $complete_payload );
-		$this->assertIsArray( $complete_summary );
-		$this->assertSame( $tool_calls, $complete_payload['session_data']['tool_calls'] );
-		$this->assertSame( count( $tool_calls ), $complete_payload['session_data']['tool_call_count'] );
-		$this->assertSame( count( $tool_calls ), $complete_summary['tool_call_count'] );
+	/**
+	 * Build a serialized SDK-style function message.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function function_message( string $role, string $key, string $id ): array {
+		return array(
+			'role'  => $role,
+			'parts' => array(
+				array(
+					'type'   => 'functionCall' === $key ? 'function_call' : 'function_response',
+					$key     => array(
+						'id'   => $id,
+						'name' => 'test-tool',
+					),
+				),
+			),
+		);
 	}
 }

--- a/tests/SdAiAgent/Feedback/ReportBuilderTest.php
+++ b/tests/SdAiAgent/Feedback/ReportBuilderTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Test case for feedback report construction.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Feedback;
+
+use SdAiAgent\Core\Database;
+use SdAiAgent\Feedback\ReportBuilder;
+use WP_UnitTestCase;
+
+/**
+ * Test targeted feedback report context.
+ */
+class ReportBuilderTest extends WP_UnitTestCase {
+
+	/**
+	 * Targeted feedback reports omit tool logs that cannot be mapped to the selected message window.
+	 */
+	public function test_targeted_report_omits_unmappable_tool_calls_and_summary_matches(): void {
+		$user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		$session_id = Database::create_session(
+			array(
+				'user_id' => $user_id,
+				'title'   => 'Targeted feedback context',
+			)
+		);
+		$this->assertIsInt( $session_id );
+
+		$messages = array(
+			array( 'role' => 'user', 'content' => 'Before the first tool call.' ),
+			array( 'role' => 'assistant', 'content' => 'First response.' ),
+			array( 'role' => 'user', 'content' => 'Context before the selected message.' ),
+			array( 'role' => 'assistant', 'content' => 'Context response.' ),
+			array( 'role' => 'user', 'content' => 'Selected feedback message.' ),
+			array( 'role' => 'assistant', 'content' => 'Context after the selected message.' ),
+			array( 'role' => 'user', 'content' => 'After the selected message.' ),
+		);
+		$tool_calls = array(
+			array( 'type' => 'call', 'id' => 'before-call', 'name' => 'site-info' ),
+			array( 'type' => 'response', 'id' => 'before-call', 'name' => 'site-info' ),
+			array( 'type' => 'call', 'id' => 'within-call', 'name' => 'list-posts' ),
+			array( 'type' => 'response', 'id' => 'within-call', 'name' => 'list-posts' ),
+			array( 'type' => 'call', 'id' => 'after-call', 'name' => 'update-post' ),
+			array( 'type' => 'response', 'id' => 'after-call', 'name' => 'update-post' ),
+		);
+
+		$this->assertTrue(
+			Database::update_session(
+				$session_id,
+				array(
+					'messages'   => wp_json_encode( $messages ),
+					'tool_calls' => wp_json_encode( $tool_calls ),
+				)
+			)
+		);
+
+		$payload = ReportBuilder::build( $session_id, 'user_reported', '', false, 4 );
+		$summary = ReportBuilder::build_summary( $session_id, false, 4 );
+
+		$this->assertIsArray( $payload );
+		$this->assertIsArray( $summary );
+		$this->assertCount( 5, $payload['session_data']['messages'] );
+		$this->assertSame( array(), $payload['session_data']['tool_calls'] );
+		$this->assertSame( 0, $payload['session_data']['tool_call_count'] );
+		$this->assertSame( 0, $summary['tool_call_count'] );
+		$this->assertSame( $payload['session_data']['message_count'], $summary['message_count'] );
+
+		$complete_payload = ReportBuilder::build( $session_id, 'user_reported' );
+		$complete_summary = ReportBuilder::build_summary( $session_id );
+		$this->assertIsArray( $complete_payload );
+		$this->assertIsArray( $complete_summary );
+		$this->assertSame( $tool_calls, $complete_payload['session_data']['tool_calls'] );
+		$this->assertSame( count( $tool_calls ), $complete_payload['session_data']['tool_call_count'] );
+		$this->assertSame( count( $tool_calls ), $complete_summary['tool_call_count'] );
+	}
+}

--- a/tests/SdAiAgent/Feedback/ReportBuilderTest.php
+++ b/tests/SdAiAgent/Feedback/ReportBuilderTest.php
@@ -20,22 +20,22 @@ use WP_UnitTestCase;
  */
 class ReportBuilderTest extends WP_UnitTestCase {
 
-	private int $user_id;
+	private int $userId;
 
 	public function set_up(): void {
 		parent::set_up();
-		$this->user_id = self::factory()->user->create();
-		wp_set_current_user( $this->user_id );
+		$this->userId = self::factory()->user->create();
+		wp_set_current_user( $this->userId );
 	}
 
 	/**
 	 * Targeted reports include only tool pairs referenced by scoped messages.
 	 */
 	public function test_targeted_report_scopes_tool_calls_to_message_context(): void {
-		$session_id = $this->create_session_with_tool_history();
+		$sessionId = $this->create_session_with_tool_history();
 
-		$report  = ReportBuilder::build( $session_id, 'thumbs_down', '', false, 5 );
-		$summary = ReportBuilder::build_summary( $session_id, false, 5 );
+		$report  = ReportBuilder::build( $sessionId, 'thumbs_down', '', false, 5 );
+		$summary = ReportBuilder::build_summary( $sessionId, false, 5 );
 
 		$this->assertNotNull( $report );
 		$this->assertNotNull( $summary );
@@ -49,9 +49,9 @@ class ReportBuilderTest extends WP_UnitTestCase {
 	 * Full-session reports preserve the complete tool log.
 	 */
 	public function test_full_report_preserves_all_tool_calls(): void {
-		$session_id = $this->create_session_with_tool_history();
+		$sessionId = $this->create_session_with_tool_history();
 
-		$report = ReportBuilder::build( $session_id, 'user_reported' );
+		$report = ReportBuilder::build( $sessionId, 'user_reported' );
 
 		$this->assertNotNull( $report );
 		$this->assertSame( 6, $report['session_data']['tool_call_count'] );
@@ -65,10 +65,10 @@ class ReportBuilderTest extends WP_UnitTestCase {
 	 * Targeted text-only context omits unrelated session-wide tool history.
 	 */
 	public function test_targeted_report_without_tool_ids_omits_tool_log(): void {
-		$session_id = $this->create_session_with_tool_history();
+		$sessionId = $this->create_session_with_tool_history();
 		$this->assertTrue(
 			Database::update_session(
-				$session_id,
+				$sessionId,
 				array(
 					'messages' => wp_json_encode(
 						array(
@@ -80,7 +80,7 @@ class ReportBuilderTest extends WP_UnitTestCase {
 			)
 		);
 
-		$report = ReportBuilder::build( $session_id, 'thumbs_down', '', false, 1 );
+		$report = ReportBuilder::build( $sessionId, 'thumbs_down', '', false, 1 );
 
 		$this->assertNotNull( $report );
 		$this->assertSame( array(), $report['session_data']['tool_calls'] );
@@ -88,15 +88,15 @@ class ReportBuilderTest extends WP_UnitTestCase {
 	}
 
 	private function create_session_with_tool_history(): int {
-		$session_id = Database::create_session(
+		$sessionId = Database::create_session(
 			array(
-				'user_id'     => $this->user_id,
+				'user_id'     => $this->userId,
 				'title'       => 'Scoped feedback',
 				'provider_id' => 'test-provider',
 				'model_id'    => 'test-model',
 			)
 		);
-		$this->assertIsInt( $session_id );
+		$this->assertIsInt( $sessionId );
 
 		$messages = array(
 			array( 'role' => 'user', 'parts' => array( array( 'type' => 'text', 'text' => 'Earlier task' ) ) ),
@@ -111,7 +111,7 @@ class ReportBuilderTest extends WP_UnitTestCase {
 			$this->function_message( 'user', 'functionResponse', 'after-call' ),
 		);
 
-		$tool_calls = array(
+		$toolCalls = array(
 			array( 'type' => 'call', 'id' => 'before-call', 'name' => 'before-tool', 'args' => array() ),
 			array( 'type' => 'response', 'id' => 'before-call', 'name' => 'before-tool', 'response' => array( 'ok' => true ) ),
 			array( 'type' => 'call', 'id' => 'target-call', 'name' => 'target-tool', 'args' => array() ),
@@ -122,15 +122,15 @@ class ReportBuilderTest extends WP_UnitTestCase {
 
 		$this->assertTrue(
 			Database::update_session(
-				$session_id,
+				$sessionId,
 				array(
 					'messages'   => wp_json_encode( $messages ),
-					'tool_calls' => wp_json_encode( $tool_calls ),
+					'tool_calls' => wp_json_encode( $toolCalls ),
 				)
 			)
 		);
 
-		return $session_id;
+		return $sessionId;
 	}
 
 	/**

--- a/tests/SdAiAgent/Feedback/ReportBuilderTest.php
+++ b/tests/SdAiAgent/Feedback/ReportBuilderTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Test case for feedback report construction.
+ *
+ * @package SdAiAgent
+ * @subpackage Tests
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Tests\Feedback;
+
+use SdAiAgent\Core\Database;
+use SdAiAgent\Feedback\ReportBuilder;
+use WP_UnitTestCase;
+
+/**
+ * Test feedback message and tool-log context scoping.
+ */
+class ReportBuilderTest extends WP_UnitTestCase {
+
+	private int $user_id;
+
+	public function set_up(): void {
+		parent::set_up();
+		$this->user_id = self::factory()->user->create();
+		wp_set_current_user( $this->user_id );
+	}
+
+	/**
+	 * Targeted reports include only tool pairs referenced by scoped messages.
+	 */
+	public function test_targeted_report_scopes_tool_calls_to_message_context(): void {
+		$session_id = $this->create_session_with_tool_history();
+
+		$report  = ReportBuilder::build( $session_id, 'thumbs_down', '', false, 5 );
+		$summary = ReportBuilder::build_summary( $session_id, false, 5 );
+
+		$this->assertNotNull( $report );
+		$this->assertNotNull( $summary );
+		$this->assertSame( array( 'target-call', 'target-call' ), array_column( $report['session_data']['tool_calls'], 'id' ) );
+		$this->assertSame( array( 'call', 'response' ), array_column( $report['session_data']['tool_calls'], 'type' ) );
+		$this->assertSame( 2, $report['session_data']['tool_call_count'] );
+		$this->assertSame( 2, $summary['tool_call_count'] );
+	}
+
+	/**
+	 * Full-session reports preserve the complete tool log.
+	 */
+	public function test_full_report_preserves_all_tool_calls(): void {
+		$session_id = $this->create_session_with_tool_history();
+
+		$report = ReportBuilder::build( $session_id, 'user_reported' );
+
+		$this->assertNotNull( $report );
+		$this->assertSame( 6, $report['session_data']['tool_call_count'] );
+		$this->assertSame(
+			array( 'before-call', 'before-call', 'target-call', 'target-call', 'after-call', 'after-call' ),
+			array_column( $report['session_data']['tool_calls'], 'id' )
+		);
+	}
+
+	/**
+	 * Targeted text-only context omits unrelated session-wide tool history.
+	 */
+	public function test_targeted_report_without_tool_ids_omits_tool_log(): void {
+		$session_id = $this->create_session_with_tool_history();
+		$this->assertTrue(
+			Database::update_session(
+				$session_id,
+				array(
+					'messages' => wp_json_encode(
+						array(
+							array( 'role' => 'user', 'parts' => array( array( 'type' => 'text', 'text' => 'Text only' ) ) ),
+							array( 'role' => 'model', 'parts' => array( array( 'type' => 'text', 'text' => 'No tools here' ) ) ),
+						)
+					),
+				)
+			)
+		);
+
+		$report = ReportBuilder::build( $session_id, 'thumbs_down', '', false, 1 );
+
+		$this->assertNotNull( $report );
+		$this->assertSame( array(), $report['session_data']['tool_calls'] );
+		$this->assertSame( 0, $report['session_data']['tool_call_count'] );
+	}
+
+	private function create_session_with_tool_history(): int {
+		$session_id = Database::create_session(
+			array(
+				'user_id'     => $this->user_id,
+				'title'       => 'Scoped feedback',
+				'provider_id' => 'test-provider',
+				'model_id'    => 'test-model',
+			)
+		);
+		$this->assertIsInt( $session_id );
+
+		$messages = array(
+			array( 'role' => 'user', 'parts' => array( array( 'type' => 'text', 'text' => 'Earlier task' ) ) ),
+			$this->function_message( 'model', 'functionCall', 'before-call' ),
+			$this->function_message( 'user', 'functionResponse', 'before-call' ),
+			array( 'role' => 'model', 'parts' => array( array( 'type' => 'text', 'text' => 'Earlier answer' ) ) ),
+			array( 'role' => 'user', 'parts' => array( array( 'type' => 'text', 'text' => 'Target task' ) ) ),
+			$this->function_message( 'model', 'functionCall', 'target-call' ),
+			$this->function_message( 'user', 'functionResponse', 'target-call' ),
+			array( 'role' => 'model', 'parts' => array( array( 'type' => 'text', 'text' => 'Target answer' ) ) ),
+			$this->function_message( 'model', 'functionCall', 'after-call' ),
+			$this->function_message( 'user', 'functionResponse', 'after-call' ),
+		);
+
+		$tool_calls = array(
+			array( 'type' => 'call', 'id' => 'before-call', 'name' => 'before-tool', 'args' => array() ),
+			array( 'type' => 'response', 'id' => 'before-call', 'name' => 'before-tool', 'response' => array( 'ok' => true ) ),
+			array( 'type' => 'call', 'id' => 'target-call', 'name' => 'target-tool', 'args' => array() ),
+			array( 'type' => 'response', 'id' => 'target-call', 'name' => 'target-tool', 'response' => array( 'ok' => true ) ),
+			array( 'type' => 'call', 'id' => 'after-call', 'name' => 'after-tool', 'args' => array() ),
+			array( 'type' => 'response', 'id' => 'after-call', 'name' => 'after-tool', 'response' => array( 'ok' => true ) ),
+		);
+
+		$this->assertTrue(
+			Database::update_session(
+				$session_id,
+				array(
+					'messages'   => wp_json_encode( $messages ),
+					'tool_calls' => wp_json_encode( $tool_calls ),
+				)
+			)
+		);
+
+		return $session_id;
+	}
+
+	/**
+	 * Build a serialized SDK-style function message.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function function_message( string $role, string $key, string $id ): array {
+		return array(
+			'role'  => $role,
+			'parts' => array(
+				array(
+					'type'   => 'functionCall' === $key ? 'function_call' : 'function_response',
+					$key     => array(
+						'id'   => $id,
+						'name' => 'test-tool',
+					),
+				),
+			),
+		);
+	}
+}


### PR DESCRIPTION
## Summary
- scope targeted feedback tool logs by function call/response IDs found in the selected message window
- keep matching call/response pairs while excluding unrelated historical session activity
- make feedback preview summaries report the same scoped tool-entry count as the payload
- preserve the complete tool log for full-session reports

## Tests
- added `ReportBuilderTest` coverage for targeted pair matching, text-only omission, and full-session preservation
- ran the complete repository verification gate
- deployed the focused PHP change to the reporting production multisite after a backup and syntax check
- re-sent the original plugin-audit prompt successfully; its final response covered both unused and outdated plugins
- verified the new live session had 10 total tool entries while final-response feedback contained only the matching call/response pair; summary and payload both reported 2 entries

## Worker self-verification
- PHPUnit: Tests: 4085, Assertions: 18310, Errors: 0, Failures: 0, Skipped: 134, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

Resolves #2427

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.262 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Targeted feedback reports now include only tool calls related to the selected message context.
  * Summary counts now accurately reflect the filtered tool calls.
  * Text-only targeted reports no longer include unrelated tool history.
  * Full-session reports continue to preserve the complete tool-call history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->