### PR TITLE
GH#2430: fix: require clarification before vague mutations

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -512,7 +512,8 @@ PROMPT;
 		// ToolPermissionResolver encapsulates yolo_mode and tool_permissions.
 		$this->permission_resolver = new ToolPermissionResolver(
 			$this->yolo_mode,
-			$this->tool_permissions
+			$this->tool_permissions,
+			SystemInstructionBuilder::requires_clarification_before_mutation( $this->user_message )
 		);
 
 		// SpinDetector tracks consecutive identical tool-call rounds.

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -1738,6 +1738,26 @@ PROMPT;
 				continue;
 			}
 
+			$confirm_needed = $this->permission_resolver->get_tools_needing_confirmation( $assistant_message );
+
+			if ( ! empty( $confirm_needed ) ) {
+				$this->approved_once_abilities = $this->extract_pending_ability_names( $confirm_needed );
+
+				return $this->with_paused_logs(
+					array(
+						'awaiting_confirmation'   => true,
+						'pending_tools'           => $confirm_needed,
+						'approved_once_abilities' => $this->approved_once_abilities,
+						'history'                 => $this->serialize_history(),
+						'tool_call_log'           => $this->tool_call_log,
+						'token_usage'             => $this->token_usage,
+						'iterations_remaining'    => $iterations,
+						'iterations_used'         => $this->iterations_used,
+						'model_id'                => $this->model_id,
+					)
+				);
+			}
+
 			// ── Client-side ability routing ───────────────────────────────
 			// Partition tool calls into PHP-executable and JS-pending sets.
 			// PHP calls execute inline; JS calls are returned as pending so
@@ -1811,26 +1831,6 @@ PROMPT;
 				}
 			}
 			// ── End client-side routing ───────────────────────────────────
-
-			$confirm_needed = $this->permission_resolver->get_tools_needing_confirmation( $assistant_message );
-
-			if ( ! empty( $confirm_needed ) ) {
-				$this->approved_once_abilities = $this->extract_pending_ability_names( $confirm_needed );
-
-				return $this->with_paused_logs(
-					array(
-						'awaiting_confirmation'   => true,
-						'pending_tools'           => $confirm_needed,
-						'approved_once_abilities' => $this->approved_once_abilities,
-						'history'                 => $this->serialize_history(),
-						'tool_call_log'           => $this->tool_call_log,
-						'token_usage'             => $this->token_usage,
-						'iterations_remaining'    => $iterations,
-						'iterations_used'         => $this->iterations_used,
-						'model_id'                => $this->model_id,
-					)
-				);
-			}
 
 			// Execute the ability calls and get the function response message.
 			$this->save_active_job_checkpoint( self::CHECKPOINT_TOOL_EXECUTION_STARTED, $iterations );

--- a/includes/Core/SystemInstructionBuilder.php
+++ b/includes/Core/SystemInstructionBuilder.php
@@ -112,6 +112,7 @@ class SystemInstructionBuilder {
 		$custom = $settings['system_prompt'] ?? '';
 		$base   = is_string( $custom ) && '' !== $custom ? $custom : self::default_system_instruction();
 		$base  .= "\n\n" . self::build_advanced_companion_section();
+		$base  .= "\n\n" . self::build_underspecified_request_section();
 
 		// Append memory section if memories exist.
 		$memory_text = Memory::get_formatted_for_prompt();
@@ -330,6 +331,52 @@ class SystemInstructionBuilder {
 			. 'For read-only diagnostic requests, call only inspection abilities, then summarize findings, severity, and recommended next steps. '
 			. 'Do not install or activate plugins, change security settings, write files, run privileged configuration commands, update options, execute remediation PHP/SQL/WP-CLI, or navigate to unrelated admin pages. '
 			. 'If remediation seems useful, ask for explicit approval and name the proposed changes before taking action.';
+	}
+
+	/**
+	 * Build the policy for prompts that do not name any useful objective.
+	 *
+	 * Read-only inspection is safe when it can help form a recommendation. Any
+	 * mutation needs a stated intent, target, and success criteria; otherwise a
+	 * model must ask a concise question or present a bounded proposal. AgentLoop
+	 * independently confirms a mutating call if a provider ignores this policy.
+	 *
+	 * @return string
+	 */
+	public static function build_underspecified_request_section(): string {
+		return "## Underspecified requests\n\n"
+			. 'A prompt with no stated intent, target, or success criteria (for example, "do anything") is not permission to invent a site change. '
+			. 'Do not publish, delete, install, activate, send, or otherwise mutate WordPress or an external service from such a prompt. '
+			. 'You may perform bounded read-only inspection when it will support a recommendation, then summarize the findings and offer a small, explicit set of next actions. '
+			. 'Otherwise ask one concise clarifying question. If the user intentionally wants a demonstration, make it a clearly labelled draft or proposal, never a public change.';
+	}
+
+	/**
+	 * Whether a user message has no actionable intent, target, or success
+	 * criteria and therefore needs clarification before any mutation.
+	 *
+	 * This deliberately recognizes only short, generic requests. More nuanced
+	 * prompts remain the model's responsibility, while these known no-objective
+	 * forms receive a deterministic server-side guard.
+	 *
+	 * @param string $user_message User message for the current turn.
+	 * @return bool
+	 */
+	public static function requires_clarification_before_mutation( string $user_message ): bool {
+		$normalized = strtolower( trim( preg_replace( '/\s+/', ' ', $user_message ) ?? '' ) );
+
+		return in_array(
+			$normalized,
+			array(
+				'anything',
+				'do anything',
+				'do something',
+				'whatever',
+				'something',
+				'surprise me',
+			),
+			true
+		);
 	}
 
 	/**

--- a/includes/Core/SystemInstructionBuilder.php
+++ b/includes/Core/SystemInstructionBuilder.php
@@ -359,11 +359,14 @@ class SystemInstructionBuilder {
 	 * prompts remain the model's responsibility, while these known no-objective
 	 * forms receive a deterministic server-side guard.
 	 *
-	 * @param string $user_message User message for the current turn.
+	 * @param string $userMessage User message for the current turn.
 	 * @return bool
 	 */
-	public static function requires_clarification_before_mutation( string $user_message ): bool {
-		$normalized = strtolower( trim( preg_replace( '/\s+/', ' ', $user_message ) ?? '' ) );
+	// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- Project variable naming guidance requires camelCase.
+	public static function requires_clarification_before_mutation( string $userMessage ): bool {
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- Project variable naming guidance requires camelCase.
+		$normalized = strtolower( trim( preg_replace( '/\s+/', ' ', $userMessage ) ?? '' ) );
+		$normalized = rtrim( $normalized, '.!?' );
 
 		return in_array(
 			$normalized,

--- a/includes/Core/ToolPermissionResolver.php
+++ b/includes/Core/ToolPermissionResolver.php
@@ -27,34 +27,39 @@ class ToolPermissionResolver {
 	/**
 	 * @param bool                     $yolo_mode        When true, skip all confirmations.
 	 * @param array<int|string, mixed> $tool_permissions Tool permission levels from settings.
+	 * @param bool                     $requires_mutation_clarification Whether the current prompt lacks an actionable objective.
 	 */
 	public function __construct(
 		private bool $yolo_mode = false,
-		private array $tool_permissions = array()
+		private array $tool_permissions = array(),
+		private bool $requires_mutation_clarification = false
 	) {}
 
 	/**
 	 * Check which tool calls in an assistant message require user confirmation.
 	 *
 	 * Permission resolution order (first match wins):
-	 * 1. YOLO mode → skip all confirmations.
-	 * 2. Explicit tool_permissions setting:
+	 * 1. An underspecified request → require confirmation for every mutation.
+	 * 2. YOLO mode → skip all other confirmations.
+	 * 3. Explicit tool_permissions setting:
 	 *    - confirm → require confirmation.
 	 *    - always_allow/disabled → do not pause here (disabled is enforced before execution).
 	 *    - auto or unset → continue to the default annotation policy.
-	 * 3. Annotation-based classification:
+	 * 4. Annotation-based classification:
 	 *    - readonly=true      → auto-execute (read-only, safe).
 	 *    - destructive=false  → auto-execute (non-destructive write).
 	 *    - destructive=true or unknown → require confirmation.
-	 * 4. For sd-ai-agent/ability-call, classify the nested target ability so the
+	 * 5. For sd-ai-agent/ability-call, classify the nested target ability so the
 	 *    meta-tool cannot bypass a target tool's confirmation policy.
 	 *
 	 * @param Message $message The assistant's tool-call message.
 	 * @return list<array<string, mixed>> Array of tool details needing confirmation (empty if none).
 	 */
 	public function get_tools_needing_confirmation( Message $message ): array {
-		// YOLO mode: skip all confirmations and execute immediately.
-		if ( $this->yolo_mode ) {
+		// YOLO mode: skip all confirmations and execute immediately. A prompt
+		// with no stated objective is the exception: it must not manufacture a
+		// mutation merely because a site-wide convenience setting is enabled.
+		if ( $this->yolo_mode && ! $this->requires_mutation_clarification ) {
 			return array();
 		}
 
@@ -88,12 +93,17 @@ class ToolPermissionResolver {
 			$ability                 = $all_abilities[ $confirmation_ability_id ] ?? null;
 			$ability                 = $ability instanceof \WP_Ability ? $ability : null;
 
-			if ( self::ability_needs_confirmation( $confirmation_ability_id, $ability, $this->tool_permissions ) ) {
+			$requires_clarification = $this->requires_mutation_clarification
+				&& $ability instanceof \WP_Ability
+				&& 'read' !== self::classify_ability( $ability );
+
+			if ( $requires_clarification || self::ability_needs_confirmation( $confirmation_ability_id, $ability, $this->tool_permissions ) ) {
 				$confirm[] = array(
 					'id'      => $call->getId(),
 					'name'    => $fn_name,
 					'ability' => $confirmation_ability_id,
 					'args'    => $call->getArgs(),
+					'reason'  => $requires_clarification ? 'underspecified_request' : 'tool_permission',
 				);
 			}
 		}

--- a/includes/Core/ToolPermissionResolver.php
+++ b/includes/Core/ToolPermissionResolver.php
@@ -27,12 +27,13 @@ class ToolPermissionResolver {
 	/**
 	 * @param bool                     $yolo_mode        When true, skip all confirmations.
 	 * @param array<int|string, mixed> $tool_permissions Tool permission levels from settings.
-	 * @param bool                     $requires_mutation_clarification Whether the current prompt lacks an actionable objective.
+	 * @param bool                     $requiresMutationClarification Whether the current prompt lacks an actionable objective.
 	 */
 	public function __construct(
 		private bool $yolo_mode = false,
 		private array $tool_permissions = array(),
-		private bool $requires_mutation_clarification = false
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase -- Project property naming guidance requires camelCase.
+		private bool $requiresMutationClarification = false
 	) {}
 
 	/**
@@ -59,7 +60,7 @@ class ToolPermissionResolver {
 		// YOLO mode: skip all confirmations and execute immediately. A prompt
 		// with no stated objective is the exception: it must not manufacture a
 		// mutation merely because a site-wide convenience setting is enabled.
-		if ( $this->yolo_mode && ! $this->requires_mutation_clarification ) {
+		if ( $this->yolo_mode && ! $this->requiresMutationClarification ) {
 			return array();
 		}
 
@@ -93,7 +94,7 @@ class ToolPermissionResolver {
 			$ability                 = $all_abilities[ $confirmation_ability_id ] ?? null;
 			$ability                 = $ability instanceof \WP_Ability ? $ability : null;
 
-			$requires_clarification = $this->requires_mutation_clarification
+			$requires_clarification = $this->requiresMutationClarification
 				&& $ability instanceof \WP_Ability
 				&& 'read' !== self::classify_ability( $ability );
 

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -3962,6 +3962,69 @@ class AgentLoopTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Mixed client and PHP calls must be classified before the PHP partition can
+	 * execute, so a generic prompt cannot publish while a read-only browser call
+	 * is pending.
+	 */
+	public function test_underspecified_prompt_confirms_before_mixed_client_and_publish_calls(): void {
+		$this->skip_if_sdk_unavailable();
+		if ( ! class_exists( 'WP_AI_Client_Ability_Function_Resolver' ) ) {
+			$this->markTestSkipped( 'WP_AI_Client_Ability_Function_Resolver not available.' );
+		}
+
+		Settings::instance()->update(
+			[
+				'tool_permissions' => [
+					'sd-ai-agent/create-post' => 'always_allow',
+				],
+			]
+		);
+
+		$this->mock_ai_response(
+			'',
+			[
+				[
+					'id'       => 'call_vague_navigate',
+					'type'     => 'function',
+					'function' => [
+						'name'      => 'wpab__sd-ai-agent-js__navigate-to',
+						'arguments' => wp_json_encode( [ 'path' => 'edit.php' ] ),
+					],
+				],
+				[
+					'id'       => 'call_vague_publish',
+					'type'     => 'function',
+					'function' => [
+						'name'      => 'wpab__sd-ai-agent__create-post',
+						'arguments' => wp_json_encode(
+							[
+								'title'   => 'Invented post',
+								'content' => 'This must not be published from a vague prompt.',
+								'status'  => 'publish',
+							]
+						),
+					],
+				],
+			]
+		);
+
+		$catalog = JsAbilityCatalog::get_descriptors_by_name();
+		$loop    = new AgentLoop(
+			'do anything',
+			array(),
+			array(),
+			array( 'client_abilities' => array( $catalog['sd-ai-agent-js/navigate-to'] ) )
+		);
+		$result  = $loop->run();
+
+		$this->assertTrue( $result['awaiting_confirmation'] ?? false );
+		$this->assertCount( 1, $result['pending_tools'] );
+		$this->assertSame( 'sd-ai-agent/create-post', $result['pending_tools'][0]['ability'] ?? '' );
+		$this->assertSame( 'underspecified_request', $result['pending_tools'][0]['reason'] ?? '' );
+		$this->assertArrayNotHasKey( 'pending_client_tool_calls', $result );
+	}
+
+	/**
 	 * The deterministic boundary remains covered without an authenticated AI
 	 * provider: an always-allowed create-post call from "do anything" is held
 	 * as an underspecified-request proposal before the resolver can execute it.

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -3962,6 +3962,44 @@ class AgentLoopTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The deterministic boundary remains covered without an authenticated AI
+	 * provider: an always-allowed create-post call from "do anything" is held
+	 * as an underspecified-request proposal before the resolver can execute it.
+	 */
+	public function test_underspecified_prompt_holds_always_allowed_create_post_at_permission_boundary(): void {
+		if ( ! function_exists( 'wp_get_abilities' ) || ! wp_has_ability( 'sd-ai-agent/create-post' ) ) {
+			$this->markTestSkipped( 'sd-ai-agent/create-post ability is not registered.' );
+		}
+
+		$resolver = new ToolPermissionResolver(
+			false,
+			[ 'sd-ai-agent/create-post' => 'always_allow' ],
+			SystemInstructionBuilder::requires_clarification_before_mutation( 'do anything' )
+		);
+		$message  = new ModelMessage(
+			[
+				new MessagePart(
+					new FunctionCall(
+						'call_vague_publish',
+						'wpab__sd-ai-agent__create-post',
+						[
+							'title'   => 'Invented post',
+							'content' => 'This must not be published from a vague prompt.',
+							'status'  => 'publish',
+						]
+					)
+				),
+			]
+		);
+
+		$pending = $resolver->get_tools_needing_confirmation( $message );
+
+		$this->assertCount( 1, $pending );
+		$this->assertSame( 'sd-ai-agent/create-post', $pending[0]['ability'] );
+		$this->assertSame( 'underspecified_request', $pending[0]['reason'] );
+	}
+
+	/**
 	 * Identical function calls in one model response should be dispatched once.
 	 */
 	public function test_run_deduplicates_identical_tool_calls_within_iteration(): void {

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -3914,6 +3914,54 @@ class AgentLoopTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A generic first prompt cannot use an always-allowed write tool to publish
+	 * invented content. The normal confirmation response gives the UI a proposal
+	 * boundary instead of executing the provider call or surfacing an error.
+	 */
+	public function test_underspecified_prompt_requires_confirmation_before_publishing(): void {
+		$this->skip_if_sdk_unavailable();
+		if ( ! class_exists( 'WP_AI_Client_Ability_Function_Resolver' ) ) {
+			$this->markTestSkipped( 'WP_AI_Client_Ability_Function_Resolver not available.' );
+		}
+
+		Settings::instance()->update(
+			[
+				'tool_permissions' => [
+					'sd-ai-agent/create-post' => 'always_allow',
+				],
+			]
+		);
+
+		$this->mock_ai_response(
+			'',
+			[
+				[
+					'id'       => 'call_underspecified_publish',
+					'type'     => 'function',
+					'function' => [
+						'name'      => 'wpab__sd-ai-agent__create-post',
+						'arguments' => wp_json_encode(
+							[
+								'title'   => 'Invented post',
+								'content' => 'This must not be published from a vague prompt.',
+								'status'  => 'publish',
+							]
+						),
+					],
+				],
+			]
+		);
+
+		$loop   = new AgentLoop( 'do anything' );
+		$result = $loop->run();
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['awaiting_confirmation'] ?? false );
+		$this->assertSame( 'sd-ai-agent/create-post', $result['pending_tools'][0]['ability'] ?? '' );
+		$this->assertSame( 'underspecified_request', $result['pending_tools'][0]['reason'] ?? '' );
+	}
+
+	/**
 	 * Identical function calls in one model response should be dispatched once.
 	 */
 	public function test_run_deduplicates_identical_tool_calls_within_iteration(): void {

--- a/tests/SdAiAgent/Core/SystemInstructionBuilderTest.php
+++ b/tests/SdAiAgent/Core/SystemInstructionBuilderTest.php
@@ -168,6 +168,18 @@ class SystemInstructionBuilderTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'update options', $section );
 	}
 
+	/** Underspecified prompts must not be treated as permission to mutate. */
+	public function test_underspecified_request_policy_requires_clarification_before_mutation(): void {
+		$section = SystemInstructionBuilder::build_underspecified_request_section();
+
+		$this->assertStringContainsString( 'no stated intent, target, or success criteria', $section );
+		$this->assertStringContainsString( 'bounded read-only inspection', $section );
+		$this->assertStringContainsString( 'never a public change', $section );
+		$this->assertTrue( SystemInstructionBuilder::requires_clarification_before_mutation( 'do anything' ) );
+		$this->assertTrue( SystemInstructionBuilder::requires_clarification_before_mutation( '  surprise   me ' ) );
+		$this->assertFalse( SystemInstructionBuilder::requires_clarification_before_mutation( 'Publish a post about gardening.' ) );
+	}
+
 	/**
 	 * Test that custom system prompt overrides the default.
 	 */

--- a/tests/SdAiAgent/Core/SystemInstructionBuilderTest.php
+++ b/tests/SdAiAgent/Core/SystemInstructionBuilderTest.php
@@ -176,7 +176,10 @@ class SystemInstructionBuilderTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'bounded read-only inspection', $section );
 		$this->assertStringContainsString( 'never a public change', $section );
 		$this->assertTrue( SystemInstructionBuilder::requires_clarification_before_mutation( 'do anything' ) );
+		$this->assertTrue( SystemInstructionBuilder::requires_clarification_before_mutation( 'do anything!' ) );
 		$this->assertTrue( SystemInstructionBuilder::requires_clarification_before_mutation( '  surprise   me ' ) );
+		$this->assertTrue( SystemInstructionBuilder::requires_clarification_before_mutation( 'surprise me?' ) );
+		$this->assertTrue( SystemInstructionBuilder::requires_clarification_before_mutation( 'whatever.' ) );
 		$this->assertFalse( SystemInstructionBuilder::requires_clarification_before_mutation( 'Publish a post about gardening.' ) );
 	}
 


### PR DESCRIPTION
## Summary

Added an underspecified-request policy and a server-side confirmation boundary so generic prompts cannot directly publish arbitrary content.

## Files Changed

includes/Core/AgentLoop.php, includes/Core/SystemInstructionBuilder.php, includes/Core/ToolPermissionResolver.php, tests/SdAiAgent/Core/AgentLoopTest.php, tests/SdAiAgent/Core/SystemInstructionBuilderTest.php

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — pnpm run test:php -- --filter='AgentLoopTest|SystemInstructionBuilderTest|PostAbilitiesTest' (blocked by the runner argument wrapper before PHPUnit); pre-commit PHPCS passed after Composer dependencies were installed.

Resolves #2430


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.264 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 5m and 140,409 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safeguards for vague or underspecified requests.
  * The assistant now asks for clarification before making changes when the requested action is unclear.
  * Initial handling of ambiguous requests is limited to read-only inspection.

* **Bug Fixes**
  * Prevented automatic publishing or other mutations based on invented interpretations of unclear instructions, even when automatic approval is enabled.

* **Tests**
  * Added coverage for clarification requirements and publishing safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->