### PR TITLE
GH#2437: recover client tool provider continuation

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -83,10 +83,10 @@ class AgentLoop {
 	const MAX_TOOL_RESULT_CHARS = 40000;
 
 	/** Maximum provider-call attempts for retryable transient failures. */
-	private const PROVIDER_RETRY_MAX_ATTEMPTS = 4;
+	private const PROVIDER_RETRY_MAX_ATTEMPTS = 6;
 
 	/** Default exponential backoff schedule in seconds. */
-	private const PROVIDER_RETRY_DELAYS = array( 1, 2, 4 );
+	private const PROVIDER_RETRY_DELAYS = array( 1, 2, 4, 8, 16 );
 
 	/** Durable checkpoint phase saved before a provider call is attempted. */
 	public const CHECKPOINT_BEFORE_PROVIDER_CALL = 'before_provider_call';
@@ -2410,9 +2410,7 @@ PROMPT;
 			$delay = $this->get_provider_retry_delay( $attempt, $last_error );
 			$this->log_provider_retry_progress( $status_code, $attempt + 1, $delay );
 
-			if ( $delay > 0 ) {
-				sleep( $delay );
-			}
+			$this->wait_for_provider_retry( $delay );
 		}
 
 		$elapsed_seconds = max( 0, (int) round( microtime( true ) - $started_at ) );
@@ -2499,6 +2497,23 @@ PROMPT;
 
 		$index = max( 0, $attempt - 1 );
 		return (int) ( $this->provider_retry_delays[ $index ] ?? 60 );
+	}
+
+	/**
+	 * Wait between transient provider attempts while keeping the active job alive.
+	 *
+	 * A one-second heartbeat avoids marking a still-waiting continuation stale on
+	 * hosts where managed-provider backoff is longer than the normal job poll.
+	 *
+	 * @param int $delay Delay in seconds, already bounded by retry configuration.
+	 */
+	private function wait_for_provider_retry( int $delay ): void {
+		for ( $remaining = max( 0, $delay ); $remaining > 0; --$remaining ) {
+			if ( '' !== $this->active_job_id ) {
+				ActiveJobRepository::heartbeat( $this->active_job_id );
+			}
+			sleep( 1 );
+		}
 	}
 
 	/**

--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -607,6 +607,7 @@ Assistant: %s',
 			'session_id'       => $session_id,
 			'client_abilities' => $paused_state['client_abilities'] ?? array(),
 			'page_context'     => $paused_state['page_context'] ?? array(),
+			'active_job_id'    => $job_id,
 		);
 		$paused_provider_id = trim( (string) ( $paused_state['provider_id'] ?? '' ) );
 		$paused_model_id    = trim( (string) ( $paused_state['model_id'] ?? '' ) );
@@ -636,22 +637,40 @@ Assistant: %s',
 		$result             = $loop->resume_after_client_tools( $tool_results_typed, $iterations_remaining );
 
 		if ( is_wp_error( $result ) ) {
+			$is_recoverable_provider_failure = 'sd_ai_agent_provider_retry_failed' === $result->get_error_code();
 			// Sync the job transient/DB row to 'error' so the browser's poll
 			// loop sees a terminal state and stops re-issuing the same
 			// pending client tool call. Without this, the transient still
 			// says 'awaiting_client_tools' and the next poll cycle produces
 			// an infinite 409 loop on /chat/tool-result.
-			self::mark_job_error_after_resume(
+			$diagnostic = self::mark_job_error_after_resume(
 				$job_id,
 				$result,
 				array(
-					'last_safe_phase' => 'client_tool_resume',
+					'last_safe_phase' => 'client_tool_results_accepted',
 					'provider_id'     => (string) ( $options['provider_id'] ?? '' ),
 					'model_id'        => (string) ( $options['model_id'] ?? '' ),
 				)
 			);
 
-			return $result;
+			// Do not expose the raw WP_Error, which can contain a full conversation
+			// and tool log. A retry-exhausted provider continuation has already
+			// checkpointed the accepted results, so its client must resume that state
+			// rather than re-POSTing the browser result batch.
+			return new WP_REST_Response(
+				array(
+					'code'    => (string) $result->get_error_code(),
+					'message' => ActiveJobFailureDiagnostic::message_for( (string) $diagnostic['reason'] ),
+					'data'    => array(
+						'status'      => $is_recoverable_provider_failure ? 503 : 500,
+						'safe_phase'  => 'client_tool_results_accepted',
+						'recoverable' => $is_recoverable_provider_failure,
+						'diagnostic'  => ActiveJobFailureDiagnostic::to_rest( $diagnostic ),
+						'session_id'  => $session_id,
+					),
+				),
+				$is_recoverable_provider_failure ? 503 : 500
+			);
 		}
 
 		/** @var array<string, mixed> $result */
@@ -855,10 +874,19 @@ Assistant: %s',
 	 * @param string               $job_id  Job UUID supplied by the browser. No-op when empty.
 	 * @param WP_Error             $error   Error returned by the resumed loop.
 	 * @param array<string, mixed> $context Allowlisted diagnostic metadata.
+	 * @return array<string, bool|int|string> Persisted diagnostic metadata.
 	 */
-	private static function mark_job_error_after_resume( string $job_id, WP_Error $error, array $context = array() ): void {
+	private static function mark_job_error_after_resume( string $job_id, WP_Error $error, array $context = array() ): array {
 		if ( '' === $job_id ) {
-			return;
+			$error_data = $error->get_error_data();
+			$error_data = is_array( $error_data ) ? $error_data : array();
+			$context    = array_merge( ActiveJobFailureDiagnostic::context_from_error_data( $error_data ), $context );
+
+			return ActiveJobFailureDiagnostic::create(
+				'',
+				ActiveJobFailureDiagnostic::reason_from_error( $error ),
+				$context
+			);
 		}
 
 		$transient_key = self::JOB_PREFIX . $job_id;
@@ -885,6 +913,8 @@ Assistant: %s',
 
 			set_transient( $transient_key, $job, self::JOB_TTL );
 		}
+
+		return $diagnostic;
 	}
 
 	/**

--- a/src/components/chat-widget/__tests__/widget-message-list.test.js
+++ b/src/components/chat-widget/__tests__/widget-message-list.test.js
@@ -164,6 +164,65 @@ describe( 'WidgetMessageList recoverable-job action card', () => {
 			root.unmount();
 		} );
 	} );
+
+	test.each( [
+		[ 'retry_client_tools', 'retryClientToolSubmission' ],
+		[ 'resume_recoverable_job', 'resumeRecoverableJob' ],
+	] )(
+		'renders %s with its matching recovery action',
+		async ( type, actionName ) => {
+			const action = jest.fn();
+			const selectors = {
+				getCurrentSessionMessages: () => [],
+				isSending: () => false,
+				getCurrentSessionId: () => 123,
+				getLiveToolCalls: () => [],
+				getSessionJobs: () => ( {} ),
+				getSettings: () => ( {} ),
+				hasStreamError: () => true,
+				getPendingActionCard: () => ( {
+					type,
+					sessionId: 123,
+					toolNames: [ 'sd-ai-agent-js/screenshot-url' ],
+				} ),
+				getProviders: () => [],
+			};
+			useSelect.mockImplementation( ( fn ) => fn( () => selectors ) );
+			useDispatch.mockReturnValue( {
+				sendMessage: jest.fn(),
+				retryLastMessage: jest.fn(),
+				retryClientToolSubmission:
+					actionName === 'retryClientToolSubmission'
+						? action
+						: jest.fn(),
+				resumeRecoverableJob:
+					actionName === 'resumeRecoverableJob' ? action : jest.fn(),
+				setPendingActionCard: jest.fn(),
+			} );
+
+			const container = document.createElement( 'div' );
+			document.body.appendChild( container );
+			const root = createRoot( container );
+			await act( async () => {
+				root.render( createElement( WidgetMessageList ) );
+			} );
+
+			const confirmButton = container.querySelector(
+				'.sdaa-action-card-btn-confirm'
+			);
+			expect( confirmButton ).not.toBeNull();
+			await act( async () => {
+				confirmButton.dispatchEvent(
+					new MouseEvent( 'click', { bubbles: true } )
+				);
+			} );
+			expect( action ).toHaveBeenCalledTimes( 1 );
+
+			await act( async () => {
+				root.unmount();
+			} );
+		}
+	);
 } );
 
 describe( 'WidgetMessageList compact conversation action card', () => {

--- a/src/components/chat-widget/widget-message-list.js
+++ b/src/components/chat-widget/widget-message-list.js
@@ -58,6 +58,8 @@ export default function WidgetMessageList() {
 	const {
 		sendMessage,
 		retryLastMessage,
+		retryClientToolSubmission,
+		resumeRecoverableJob,
 		compactConversation,
 		setPendingActionCard,
 	} = useDispatch( STORE_NAME );
@@ -86,6 +88,24 @@ export default function WidgetMessageList() {
 		liveToolCalls,
 	} );
 	const runningStatus = useRunningStatus( sending && running.isFallback );
+	const confirmJobFailureAction = () => {
+		if ( pendingActionCard?.type === 'retry_client_tools' ) {
+			retryClientToolSubmission();
+			return;
+		}
+
+		if ( pendingActionCard?.type === 'resume_recoverable_job' ) {
+			resumeRecoverableJob();
+			return;
+		}
+
+		if (
+			pendingActionCard?.type === 'active_job_failure' &&
+			pendingActionCard.diagnostic?.next_action === 'retry'
+		) {
+			retryLastMessage();
+		}
+	};
 
 	return (
 		<>
@@ -114,7 +134,12 @@ export default function WidgetMessageList() {
 					{ hasStreamError &&
 						currentSessionId &&
 						! sending &&
-						pendingActionCard?.type !== 'compact_session' && (
+						! [
+							'retry_client_tools',
+							'resume_recoverable_job',
+							'active_job_failure',
+							'compact_session',
+						].includes( pendingActionCard?.type ) && (
 							<button
 								type="button"
 								className="button button-primary sdaa-w-retry-failed-step"
@@ -125,6 +150,43 @@ export default function WidgetMessageList() {
 									'superdav-ai-agent'
 								) }
 							</button>
+						) }
+
+					{ [
+						'retry_client_tools',
+						'resume_recoverable_job',
+						'active_job_failure',
+					].includes( pendingActionCard?.type ) &&
+						pendingActionCard.sessionId === currentSessionId &&
+						! sending && (
+							<div
+								className="sdaa-action-card"
+								role="region"
+								aria-label={ __(
+									'Recovery action',
+									'superdav-ai-agent'
+								) }
+							>
+								<button
+									type="button"
+									className="button button-primary sdaa-action-card-btn-confirm"
+									onClick={ confirmJobFailureAction }
+								>
+									{ __(
+										'Retry failed step',
+										'superdav-ai-agent'
+									) }
+								</button>
+								<button
+									type="button"
+									className="button sdaa-action-card-btn-cancel"
+									onClick={ () =>
+										setPendingActionCard( null )
+									}
+								>
+									{ __( 'Dismiss', 'superdav-ai-agent' ) }
+								</button>
+							</div>
 						) }
 
 					{ pendingActionCard?.type === 'compact_session' &&

--- a/src/store/__tests__/index.test.js
+++ b/src/store/__tests__/index.test.js
@@ -493,6 +493,26 @@ describe( 'actions', () => {
 		expect( dispatch.truncateMessagesTo ).not.toHaveBeenCalled();
 	} );
 
+	test( 'sendMessage treats a typed retry as durable recovery', async () => {
+		const dispatch = {
+			resumeRecoverableJob: jest.fn(),
+			streamMessage: jest.fn(),
+		};
+		const select = {
+			getPendingActionCard: jest.fn( () => ( {
+				type: 'resume_recoverable_job',
+				sessionId: 17,
+			} ) ),
+			isSending: jest.fn(),
+		};
+
+		await actions.sendMessage( ' retry ' )( { dispatch, select } );
+
+		expect( dispatch.resumeRecoverableJob ).toHaveBeenCalledTimes( 1 );
+		expect( select.isSending ).not.toHaveBeenCalled();
+		expect( dispatch.streamMessage ).not.toHaveBeenCalled();
+	} );
+
 	test( 'retryClientToolSubmission resubmits preserved results and resumes the same job once', async () => {
 		apiFetch.mockReset();
 		apiFetch.mockResolvedValue( {} );
@@ -595,6 +615,49 @@ describe( 'actions', () => {
 		);
 	} );
 
+	test( 'retryClientToolSubmission resumes after accepted results hit a provider timeout', async () => {
+		apiFetch.mockReset();
+		apiFetch.mockRejectedValue( {
+			data: {
+				recoverable: true,
+				safe_phase: 'client_tool_results_accepted',
+			},
+		} );
+		const retry = {
+			sessionId: 17,
+			jobId: 'client-tool-job',
+			toolResults: [
+				{
+					id: 'call-screenshot',
+					name: 'sd-ai-agent-js/screenshot-url',
+					result: { success: true },
+				},
+			],
+			toolNames: [ 'sd-ai-agent-js/screenshot-url' ],
+		};
+		const dispatch = {
+			setPendingToolResultRetry: jest.fn(),
+			setPendingActionCard: jest.fn(),
+			setSending: jest.fn(),
+			setCurrentJobId: jest.fn(),
+			setSessionJob: jest.fn(),
+			pollJob: jest.fn(),
+		};
+		const select = {
+			getPendingToolResultRetry: jest.fn( () => retry ),
+		};
+
+		await actions.retryClientToolSubmission()( { dispatch, select } );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( dispatch.setPendingActionCard ).toHaveBeenLastCalledWith( {
+			type: 'resume_recoverable_job',
+			sessionId: 17,
+		} );
+		expect( dispatch.pollJob ).not.toHaveBeenCalled();
+		expect( dispatch.setSending ).toHaveBeenLastCalledWith( false );
+	} );
+
 	test( 'retryClientToolSubmission preserves results after terminal POST failures', async () => {
 		apiFetch.mockReset();
 		apiFetch.mockRejectedValue( new Error( 'Network unavailable' ) );
@@ -638,6 +701,7 @@ describe( 'actions', () => {
 		);
 		expect( dispatch.setPendingActionCard ).toHaveBeenLastCalledWith( {
 			type: 'retry_client_tools',
+			sessionId: 17,
 			toolNames: retry.toolNames,
 		} );
 		expect( dispatch.appendMessage ).toHaveBeenCalledWith(

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -282,6 +282,7 @@ export const actions = {
 			dispatch.setSending( true );
 
 			let postSucceeded = false;
+			let serverAcceptedResults = false;
 			let lastErr = null;
 			for ( let attempt = 0; attempt < 3; attempt++ ) {
 				try {
@@ -297,6 +298,13 @@ export const actions = {
 					postSucceeded = true;
 					break;
 				} catch ( err ) {
+					if (
+						err?.data?.recoverable === true &&
+						err?.data?.safe_phase === 'client_tool_results_accepted'
+					) {
+						serverAcceptedResults = true;
+						break;
+					}
 					// 409: server already processed results (POST got through
 					// on a prior attempt but the response was lost) — resume.
 					if (
@@ -315,7 +323,13 @@ export const actions = {
 				}
 			}
 
-			if ( postSucceeded ) {
+			if ( serverAcceptedResults ) {
+				dispatch.setPendingActionCard( {
+					type: 'resume_recoverable_job',
+					sessionId,
+				} );
+				dispatch.setSending( false );
+			} else if ( postSucceeded ) {
 				// Re-register and resume polling the existing job.
 				setActiveJob( sessionId, jobId );
 				dispatch.setCurrentJobId( jobId );
@@ -330,6 +344,7 @@ export const actions = {
 				dispatch.setPendingToolResultRetry( retry );
 				dispatch.setPendingActionCard( {
 					type: 'retry_client_tools',
+					sessionId,
 					toolNames: retry.toolNames,
 				} );
 				dispatch.appendMessage( {
@@ -685,6 +700,7 @@ export const actions = {
 						// post-resume state, preventing an infinite 409 loop.
 						const currentSessionId = select.getCurrentSessionId();
 						let postSucceeded = false;
+						let serverAcceptedResults = false;
 						let postErr = null;
 						for ( let attempt = 0; attempt < 3; attempt++ ) {
 							try {
@@ -700,6 +716,14 @@ export const actions = {
 								postSucceeded = true;
 								break;
 							} catch ( err ) {
+								if (
+									err?.data?.recoverable === true &&
+									err?.data?.safe_phase ===
+										'client_tool_results_accepted'
+								) {
+									serverAcceptedResults = true;
+									break;
+								}
 								if (
 									err?.data?.status === 409 ||
 									err?.code ===
@@ -721,6 +745,21 @@ export const actions = {
 							}
 						}
 
+						if ( serverAcceptedResults ) {
+							if ( currentSessionId === sessionId ) {
+								dispatch.setPendingActionCard( {
+									type: 'resume_recoverable_job',
+									sessionId,
+								} );
+								dispatch.setSending( false );
+							}
+							unsubscribeVisibility();
+							clearActiveJob( sessionId );
+							dispatch.setCurrentJobId( null );
+							dispatch.setSessionJob( sessionId, null );
+							return;
+						}
+
 						if ( ! postSucceeded ) {
 							// All retries exhausted — preserve the tool results so
 							// the user can retry via the action card without
@@ -737,6 +776,7 @@ export const actions = {
 								} );
 								dispatch.setPendingActionCard( {
 									type: 'retry_client_tools',
+									sessionId,
 									toolNames,
 								} );
 								dispatch.appendMessage( {

--- a/src/store/slices/sessionsSlice.js
+++ b/src/store/slices/sessionsSlice.js
@@ -1304,6 +1304,15 @@ export const actions = {
 	 */
 	sendMessage( message, attachments = [], options = {} ) {
 		return ( { dispatch, select } ) => {
+			const pendingActionCard = select.getPendingActionCard?.();
+			if (
+				'retry' === String( message ).trim().toLowerCase() &&
+				pendingActionCard?.type === 'resume_recoverable_job'
+			) {
+				dispatch.resumeRecoverableJob();
+				return;
+			}
+
 			const isBusy = select.isSending();
 
 			if ( ! isBusy ) {

--- a/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
@@ -584,6 +584,19 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 		$this->assertSame( array( 'url' => 'https://example.test/' ), $state['page_context'] );
 	}
 
+	/** Managed-provider retries cover roughly thirty seconds before recovery. */
+	public function test_default_provider_retry_window_has_six_attempts(): void {
+		$loop       = new AgentLoop( 'test' );
+		$reflection = new \ReflectionClass( $loop );
+		$attempts   = $reflection->getProperty( 'provider_retry_max_attempts' );
+		$delays     = $reflection->getProperty( 'provider_retry_delays' );
+		$attempts->setAccessible( true );
+		$delays->setAccessible( true );
+
+		$this->assertSame( 6, $attempts->getValue( $loop ) );
+		$this->assertSame( array( 1, 2, 4, 8, 16 ), $delays->getValue( $loop ) );
+	}
+
 	/** An incomplete page-quality run must replace a model success claim. */
 	public function test_incomplete_page_quality_notice_replaces_model_success_reply(): void {
 		$loop = new AgentLoop(


### PR DESCRIPTION
## Summary

Checkpoint accepted client-tool results, return a bounded recoverable continuation response, and render floating-widget recovery actions.

## Files Changed

includes/Core/AgentLoop.php, includes/REST/RestController.php, src/components/chat-widget/__tests__/widget-message-list.test.js, src/components/chat-widget/widget-message-list.js, src/store/slices/jobSlice.js, src/store/slices/sessionsSlice.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — pnpm run test:js -- --runInBand src/components/chat-widget/__tests__/widget-message-list.test.js

Resolves #2437


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.264 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 6m and 155,307 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added recovery action cards for retrying client tools and resuming recoverable jobs.
  - Users can type “retry” to resume a pending recoverable job.
  - Recovery actions now provide confirmation and dismissal controls.

- **Bug Fixes**
  - Improved handling of failed job resumes with clearer, safer error responses and recovery details.
  - Extended provider retry attempts and added longer backoff delays.
  - Preserved job and session context during recovery actions.

- **Tests**
  - Added coverage for retry, resume, timeout recovery, and updated retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->