### PR TITLE
Fix retry-exhausted provider trace failures

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -248,6 +248,9 @@ PROMPT;
 	/** @var string Last coarse loop phase for shutdown diagnostics. */
 	private string $last_loop_phase = 'initializing';
 
+	/** @var string Safe provider trace phase for the current request scope. */
+	private string $provider_trace_phase = 'initial_provider_call';
+
 	/** @var int Maximum attempts for retryable provider failures. */
 	private int $provider_retry_max_attempts = self::PROVIDER_RETRY_MAX_ATTEMPTS;
 
@@ -964,8 +967,10 @@ PROMPT;
 		try {
 			$this->apply_anonymous_mode_context();
 			$this->apply_page_preview_context();
+			$this->provider_trace_phase = 'client_tool_resume';
 			return $this->run_loop( $remaining_iterations );
 		} finally {
+			$this->provider_trace_phase = 'initial_provider_call';
 			$this->clear_anonymous_mode_context();
 			$this->clear_page_preview_context();
 			AgentEventLog::clear_session();
@@ -2368,8 +2373,10 @@ PROMPT;
 			$builder->with_history( ...$this->history );
 		}
 
-		$started_at = microtime( true );
-		$last_error = null;
+		$started_at               = microtime( true );
+		$last_error               = null;
+		$last_retry_after_seconds = null;
+		$backoff_delays           = array();
 
 		for ( $attempt = 1; $attempt <= $this->provider_retry_max_attempts; ++$attempt ) {
 			$request_envelope = array();
@@ -2407,7 +2414,9 @@ PROMPT;
 				break;
 			}
 
-			$delay = $this->get_provider_retry_delay( $attempt, $last_error );
+			$delay                    = $this->get_provider_retry_delay( $attempt, $last_error );
+			$last_retry_after_seconds = $this->extract_retry_after_seconds( $last_error );
+			$backoff_delays[]         = $delay;
 			$this->log_provider_retry_progress( $status_code, $attempt + 1, $delay );
 
 			if ( $delay > 0 ) {
@@ -2416,7 +2425,32 @@ PROMPT;
 		}
 
 		$elapsed_seconds = max( 0, (int) round( microtime( true ) - $started_at ) );
+		ProviderTraceLogger::record_retry_exhausted_failure(
+			$provider_id,
+			$model_id,
+			$last_error,
+			$status_code,
+			$this->provider_retry_max_attempts,
+			(int) round( ( microtime( true ) - $started_at ) * 1000 ),
+			$last_retry_after_seconds,
+			$backoff_delays,
+			$this->get_provider_trace_phase(),
+			$this->session_id,
+			$this->active_job_id,
+			$request_envelope
+		);
 		return $this->build_provider_retry_failed_error( $last_error, $elapsed_seconds );
+	}
+
+	/** Return the bounded provider invocation phase stored in terminal traces. */
+	private function get_provider_trace_phase(): string {
+		if ( 'client_tool_resume' === $this->provider_trace_phase ) {
+			return 'client_tool_resume';
+		}
+
+		return 'provider_followup_call' === $this->last_loop_phase
+			? 'provider_followup_call'
+			: 'initial_provider_call';
 	}
 
 	/**

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -2377,6 +2377,8 @@ PROMPT;
 		$last_error               = null;
 		$last_retry_after_seconds = null;
 		$backoff_delays           = array();
+		$request_envelope         = array();
+		$status_code              = 0;
 
 		for ( $attempt = 1; $attempt <= $this->provider_retry_max_attempts; ++$attempt ) {
 			$request_envelope = array();

--- a/includes/Core/ProviderErrorClassifier.php
+++ b/includes/Core/ProviderErrorClassifier.php
@@ -139,6 +139,52 @@ final class ProviderErrorClassifier {
 	}
 
 	/**
+	 * Return a prompt-free error code suitable for persisted trace diagnostics.
+	 *
+	 * The source error message is used only to select a bounded code and must
+	 * never be written to a trace row: connector and transport libraries can
+	 * include request URLs, credentials, or provider response fragments.
+	 *
+	 * @param WP_Error|\Throwable|null $error       Provider error.
+	 * @param int                      $status_code HTTP status code, or 0 when unknown.
+	 * @return string Normalized safe diagnostic code.
+	 */
+	public static function get_safe_error_code( $error, int $status_code = 0 ): string {
+		if ( 0 === $status_code ) {
+			$status_code = self::extract_status_code( $error );
+		}
+
+		if ( 429 === $status_code ) {
+			return 'provider_rate_limited';
+		}
+		if ( 408 === $status_code ) {
+			return 'provider_timeout';
+		}
+		if ( $status_code >= 400 && $status_code <= 599 ) {
+			return 'provider_http_' . $status_code;
+		}
+
+		$message = self::get_message( $error );
+		if ( (bool) preg_match( '/\b(timeout|timed out|operation timed out)\b/i', $message ) ) {
+			return 'provider_timeout';
+		}
+		if ( (bool) preg_match( '/\b(could not resolve|name or service not known|dns)\b/i', $message ) ) {
+			return 'provider_dns_failure';
+		}
+		if ( (bool) preg_match( '/\b(connection reset|connection refused|could not connect|connect\(\)|network)\b/i', $message ) ) {
+			return 'provider_connection_failure';
+		}
+		if ( $error instanceof WP_Error ) {
+			return 'provider_wp_error';
+		}
+		if ( $error instanceof \Throwable ) {
+			return 'provider_exception';
+		}
+
+		return 'provider_error';
+	}
+
+	/**
 	 * Return the provider error message only for local classification.
 	 *
 	 * Callers must never return or log this value.

--- a/includes/Core/ProviderTraceLogger.php
+++ b/includes/Core/ProviderTraceLogger.php
@@ -619,6 +619,96 @@ class ProviderTraceLogger {
 		AgentEventLog::log( 'provider_model_discovery_failed', AgentEventLog::SEVERITY_ERROR, $context );
 	}
 
+	/**
+	 * Persist one bounded terminal trace for a retry-exhausted provider call.
+	 *
+	 * WordPress's HTTP response filter does not run when a transport returns a
+	 * WP_Error, and SDK exceptions do not dispatch an After event. This summary
+	 * deliberately records the invocation rather than another raw request: it
+	 * gives operators one correlated failure row without retaining a prompt,
+	 * provider error message, URL, header, or credential.
+	 *
+	 * @param string                    $provider_id         Runtime provider ID.
+	 * @param string                    $model_id            Runtime model ID.
+	 * @param \WP_Error|\Throwable|null $error               Last provider error.
+	 * @param int                       $status_code         HTTP status, or 0 when unavailable.
+	 * @param int                       $attempts            Total attempts in this invocation.
+	 * @param int                       $elapsed_ms          Total invocation elapsed time.
+	 * @param int|null                  $retry_after_seconds Retry-After from the last response, if available.
+	 * @param array<int>                $backoff_delays      Delays applied before retries.
+	 * @param string                    $phase               Safe invocation phase.
+	 * @param int                       $session_id          Correlating chat session, if any.
+	 * @param string                    $job_id              Correlating background job, if any.
+	 * @param array<string, int|string> $request_metrics     Prompt-free full-envelope measurements.
+	 */
+	public static function record_retry_exhausted_failure(
+		string $provider_id,
+		string $model_id,
+		$error,
+		int $status_code,
+		int $attempts,
+		int $elapsed_ms,
+		?int $retry_after_seconds,
+		array $backoff_delays,
+		string $phase,
+		int $session_id = 0,
+		string $job_id = '',
+		array $request_metrics = array()
+	): void {
+		if ( ! ProviderTrace::is_enabled() ) {
+			return;
+		}
+
+		$allowed_phases = array( 'initial_provider_call', 'client_tool_resume', 'provider_followup_call' );
+		if ( ! in_array( $phase, $allowed_phases, true ) ) {
+			$phase = 'initial_provider_call';
+		}
+
+		$metrics = array(
+			'request_size_class' => 'unknown',
+		);
+		foreach ( array( 'request_bytes', 'request_tokens_estimate', 'request_provider_limit_bytes', 'request_budget_bytes', 'request_safety_margin_bytes' ) as $key ) {
+			if ( isset( $request_metrics[ $key ] ) && is_numeric( $request_metrics[ $key ] ) ) {
+				$metrics[ $key ] = max( 0, (int) $request_metrics[ $key ] );
+			}
+		}
+		if ( isset( $request_metrics['request_size_class'] ) && is_string( $request_metrics['request_size_class'] ) ) {
+			$metrics['request_size_class'] = sanitize_key( $request_metrics['request_size_class'] );
+		}
+
+		$diagnostics = array(
+			'event'                  => 'provider_retry_exhausted',
+			'error_code'             => ProviderErrorClassifier::get_safe_error_code( $error, $status_code ),
+			'attempts'               => max( 1, $attempts ),
+			'elapsed_ms'             => max( 0, $elapsed_ms ),
+			'phase'                  => $phase,
+			'session_id'             => max( 0, $session_id ),
+			'backoff_delays_seconds' => array_values( array_map( static fn( $delay ): int => min( 60, max( 0, (int) $delay ) ), array_slice( $backoff_delays, 0, 10 ) ) ),
+		);
+		if ( null !== $retry_after_seconds ) {
+			$diagnostics['retry_after_seconds'] = min( 60, max( 0, $retry_after_seconds ) );
+		}
+		if ( '' !== $job_id ) {
+			$diagnostics['job_id'] = sanitize_text_field( $job_id );
+		}
+
+		ProviderTrace::insert(
+			array(
+				'provider_id'      => sanitize_key( $provider_id ),
+				'model_id'         => sanitize_text_field( $model_id ),
+				'url'              => '',
+				'method'           => 'SDK',
+				'status_code'      => max( 0, $status_code ),
+				'duration_ms'      => max( 0, $elapsed_ms ),
+				'request_headers'  => '{}',
+				'request_body'     => (string) wp_json_encode( $metrics ),
+				'response_headers' => '{}',
+				'response_body'    => (string) wp_json_encode( $diagnostics ),
+				'error'            => (string) $diagnostics['error_code'],
+			)
+		);
+	}
+
 	/** Classify request size without retaining request content. */
 	public static function classify_request_size( int $request_bytes ): string {
 		if ( $request_bytes < 65536 ) {

--- a/tests/SdAiAgent/Core/ProviderTraceLoggerResolveTest.php
+++ b/tests/SdAiAgent/Core/ProviderTraceLoggerResolveTest.php
@@ -18,6 +18,7 @@ namespace SdAiAgent\Tests\Core;
 
 use SdAiAgent\Core\ConversationTrimmer;
 use SdAiAgent\Core\ProviderTraceLogger;
+use SdAiAgent\Models\ProviderTrace;
 use WP_UnitTestCase;
 
 /**
@@ -28,6 +29,8 @@ class ProviderTraceLoggerResolveTest extends WP_UnitTestCase {
 
 	public function tear_down(): void {
 		ProviderTraceLogger::clear_runtime_context();
+		ProviderTrace::clear();
+		ProviderTrace::set_enabled( false );
 		remove_all_filters( 'sd_ai_agent_trace_match_provider' );
 		remove_all_filters( 'sd_ai_agent_trace_resolve_provider' );
 		remove_all_filters( 'sd_ai_agent_provider_trace_enabled' );
@@ -384,5 +387,45 @@ class ProviderTraceLoggerResolveTest extends WP_UnitTestCase {
 			)
 		);
 		$this->assertNull( $body_seen, 'Disabled tracing must not pass 413 prompt bodies to trace resolution filters.' );
+	}
+
+	/** Retry exhaustion has one prompt-free terminal trace even when transport callbacks never run. */
+	public function test_retry_exhaustion_writes_safe_terminal_trace(): void {
+		ProviderTrace::set_enabled( true );
+		ProviderTrace::clear();
+
+		ProviderTraceLogger::record_retry_exhausted_failure(
+			'openai_compat',
+			'gpt-test',
+			new \WP_Error( 'http_request_failed', 'cURL error: Could not resolve host: PRIVATE_HOST' ),
+			0,
+			4,
+			12000,
+			null,
+			array( 1, 2, 4 ),
+			'client_tool_resume',
+			73,
+			'job-123',
+			array(
+				'request_bytes'      => 2048,
+				'request_size_class' => 'small',
+			)
+		);
+
+		$rows = ProviderTrace::list( array( 'limit' => 1 ) );
+		$this->assertCount( 1, $rows );
+		$this->assertSame( 0, $rows[0]->status_code );
+		$this->assertSame( 'provider_dns_failure', $rows[0]->error );
+
+		$trace = ProviderTrace::get( $rows[0]->id );
+		$this->assertNotNull( $trace );
+		$diagnostics = json_decode( $trace->response_body, true );
+		$this->assertIsArray( $diagnostics );
+		$this->assertSame( 'provider_retry_exhausted', $diagnostics['event'] );
+		$this->assertSame( 4, $diagnostics['attempts'] );
+		$this->assertSame( 'client_tool_resume', $diagnostics['phase'] );
+		$this->assertSame( 73, $diagnostics['session_id'] );
+		$this->assertSame( 'job-123', $diagnostics['job_id'] );
+		$this->assertStringNotContainsString( 'PRIVATE_HOST', $trace->response_body );
 	}
 }

--- a/tests/SdAiAgent/Core/ProviderTraceLoggerResolveTest.php
+++ b/tests/SdAiAgent/Core/ProviderTraceLoggerResolveTest.php
@@ -428,4 +428,55 @@ class ProviderTraceLoggerResolveTest extends WP_UnitTestCase {
 		$this->assertSame( 'job-123', $diagnostics['job_id'] );
 		$this->assertStringNotContainsString( 'PRIVATE_HOST', $trace->response_body );
 	}
+
+	/** Timeout, connection, and rate-limit failures retain only bounded retry diagnostics. */
+	public function test_retry_exhaustion_classifies_transport_and_rate_limit_failures(): void {
+		ProviderTrace::set_enabled( true );
+		ProviderTrace::clear();
+
+		ProviderTraceLogger::record_retry_exhausted_failure(
+			'openai',
+			'gpt-test',
+			new \WP_Error( 'http_request_failed', 'cURL error: Operation timed out after 30000 milliseconds' ),
+			0,
+			2,
+			31000,
+			null,
+			array( 1 ),
+			'initial_provider_call'
+		);
+		ProviderTraceLogger::record_retry_exhausted_failure(
+			'openai',
+			'gpt-test',
+			new \WP_Error( 'http_request_failed', 'cURL error: Connection refused' ),
+			0,
+			2,
+			2000,
+			null,
+			array( 1 ),
+			'initial_provider_call'
+		);
+		ProviderTraceLogger::record_retry_exhausted_failure(
+			'openai',
+			'gpt-test',
+			new \WP_Error( '429', 'Rate limit response' ),
+			429,
+			4,
+			12000,
+			12,
+			array( 12, 12, 12 ),
+			'initial_provider_call'
+		);
+
+		$rows = ProviderTrace::list( array( 'limit' => 3 ) );
+		$this->assertCount( 3, $rows );
+		$errors = array_column( $rows, 'error' );
+		$this->assertContains( 'provider_timeout', $errors );
+		$this->assertContains( 'provider_connection_failure', $errors );
+		$this->assertContains( 'provider_rate_limited', $errors );
+
+		$rate_limit = ProviderTrace::get( $rows[0]->id );
+		$this->assertNotNull( $rate_limit );
+		$this->assertSame( 12, json_decode( $rate_limit->response_body, true )['retry_after_seconds'] );
+	}
 }


### PR DESCRIPTION
## Summary

- record one bounded terminal trace when retryable provider transport attempts are exhausted
- persist safe error classification, attempts, duration, backoff, request-size, phase, and session/job correlation without provider messages or prompt data
- identify client-tool continuations and cover DNS transport redaction

Resolves #2432

## Testing

- `vendor/bin/phpcs includes/Core/AgentLoop.php includes/Core/ProviderErrorClassifier.php includes/Core/ProviderTraceLogger.php tests/SdAiAgent/Core/ProviderTraceLoggerResolveTest.php`
- `php bin/run-wp-phpunit.php --filter='ProviderTraceLoggerResolveTest|AgentLoopTest'` (passed before shared test database contention)

<!-- aidevops:sig -->
