### PR TITLE
GH#2434: Convert heading-only Markdown

### DIFF
--- a/includes/Abilities/PostAbilities.php
+++ b/includes/Abilities/PostAbilities.php
@@ -124,7 +124,7 @@ class PostAbilities {
 						],
 						'content'           => [
 							'type'        => 'string',
-							'description' => 'The post content. Write in markdown (headings with ##, lists with -, bold with **) or HTML — markdown is automatically converted to Gutenberg blocks.',
+							'description' => 'The post content. Write in markdown (headings with ##, lists with -, bold with **) or HTML — markdown is automatically converted to Gutenberg blocks. A single Markdown heading with plain paragraphs is supported.',
 						],
 						'excerpt'           => [
 							'type'        => 'string',
@@ -216,7 +216,7 @@ class PostAbilities {
 						],
 						'content'               => [
 							'type'        => 'string',
-							'description' => 'New post content.',
+							'description' => 'New post content. Markdown, including a single heading with plain paragraphs, is automatically converted to Gutenberg blocks.',
 						],
 						'excerpt'               => [
 							'type'        => 'string',
@@ -2179,7 +2179,7 @@ class PostAbilities {
 		// Check for markdown signals.
 		$markdown_signals = self::count_markdown_signals( $content );
 
-		if ( $markdown_signals < 2 ) {
+		if ( $markdown_signals < 2 && ! self::has_atx_heading( $content ) ) {
 			return $content;
 		}
 
@@ -2195,7 +2195,7 @@ class PostAbilities {
 	private static function count_markdown_signals( string $text ): int {
 		$signals = 0;
 
-		if ( preg_match( '/^#{1,6}\s+\S/m', $text ) ) {
+		if ( self::has_atx_heading( $text ) ) {
 			++$signals;
 		}
 		if ( preg_match( '/\*{1,2}[^*\n]+\*{1,2}/', $text ) || preg_match( '/_{1,2}[^_\n]+_{1,2}/', $text ) ) {
@@ -2215,6 +2215,16 @@ class PostAbilities {
 		}
 
 		return $signals;
+	}
+
+	/**
+	 * Determine whether text contains an ATX heading at the start of a line.
+	 *
+	 * @param string $text Text to check for a Markdown heading.
+	 * @return bool Whether the text contains an ATX heading.
+	 */
+	private static function has_atx_heading( string $text ): bool {
+		return 1 === preg_match( '/^#{1,6}\s+\S/m', $text );
 	}
 
 	/**

--- a/includes/Models/skills/gutenberg-blocks.md
+++ b/includes/Models/skills/gutenberg-blocks.md
@@ -12,6 +12,11 @@ Content passed to `sd-ai-agent/create-post` or `sd-ai-agent/update-post` must be
 
 **NEVER mix raw markdown with block markup.** Mixed content renders incorrectly.
 
+An ATX heading at the start of a line (for example, `## Section heading`) is
+enough to identify Markdown content. Pass heading-only outlines and a single
+heading followed by plain paragraphs directly to the post abilities; they are
+converted to `core/heading` and `core/paragraph` blocks.
+
 ## Quick diagnostic — symptom → fix
 
 | Symptom or error | Fix |

--- a/tests/SdAiAgent/Abilities/PostAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/PostAbilitiesTest.php
@@ -477,6 +477,26 @@ class PostAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Heading-only Markdown must be converted when updating post content.
+	 */
+	public function test_handle_update_post_converts_heading_only_markdown(): void {
+		$post_id = $this->factory->post->create( [ 'post_status' => 'draft' ] );
+		$content = "## Updated section\n\nUpdated paragraph.";
+
+		$result = PostAbilities::handle_update_post(
+			[
+				'post_id' => $post_id,
+				'content' => $content,
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['block_validation']['isValid'] );
+		$this->assertStringContainsString( '<!-- wp:heading', get_post( $post_id )->post_content );
+		$this->assertStringNotContainsString( '## Updated section', get_post( $post_id )->post_content );
+	}
+
+	/**
 	 * Provider-filled empty optional fields must not erase a published page.
 	 */
 	public function test_handle_update_post_blocks_empty_published_page_replacement(): void {
@@ -807,17 +827,17 @@ class PostAbilitiesTest extends WP_UnitTestCase {
 	// ─── block_validation save-time gate (GH#1584 follow-up) ────────
 
 	/**
-	 * Content without block markup should omit the block_validation key — the
-	 * helper short-circuits when `<!-- wp:` is not present.
+	 * A single heading with plain paragraphs is converted and validated as blocks.
 	 */
-	public function test_handle_create_post_omits_block_validation_for_markdown() {
+	public function test_handle_create_post_validates_single_heading_markdown() {
 		$result = PostAbilities::handle_create_post( [
 			'title'   => 'Markdown post',
 			'content' => "## Heading\n\nParagraph.",
 		] );
 
 		$this->assertIsArray( $result );
-		$this->assertArrayNotHasKey( 'block_validation', $result );
+		$this->assertArrayHasKey( 'block_validation', $result );
+		$this->assertTrue( $result['block_validation']['isValid'] );
 	}
 
 	/**
@@ -1499,6 +1519,50 @@ class PostAbilitiesTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '<!-- wp:', $result );
 		// Must not contain the raw markdown heading.
 		$this->assertStringNotContainsString( '## Introduction', $result );
+	}
+
+	/**
+	 * Test that headings are converted without a second Markdown construct.
+	 */
+	public function test_maybe_convert_markdown_heading_only_converted() {
+		$markdown = "Intro paragraph.\n\n## First section\n\nBody.\n\n### Second section\n\nMore body.";
+		$result   = $this->call_maybe_convert_markdown( $markdown );
+
+		$this->assertStringContainsString( '<!-- wp:heading', $result );
+		$this->assertStringContainsString( '<!-- wp:paragraph', $result );
+		$this->assertStringNotContainsString( '## First section', $result );
+		$this->assertStringNotContainsString( '### Second section', $result );
+	}
+
+	/**
+	 * Test that prose using hash characters is not mistaken for an ATX heading.
+	 */
+	public function test_maybe_convert_markdown_ignores_non_heading_hash_characters() {
+		$prose  = "#not a heading\nC# is a programming language.";
+		$result = $this->call_maybe_convert_markdown( $prose );
+
+		$this->assertSame( $prose, $result );
+	}
+
+	/**
+	 * Create-post saves heading-only Markdown as valid Gutenberg blocks.
+	 */
+	public function test_handle_create_post_converts_heading_only_markdown_to_valid_blocks(): void {
+		$result = PostAbilities::handle_create_post(
+			[
+				'title'   => 'Heading-only markdown',
+				'content' => "Intro paragraph.\n\n## First section\n\nBody.\n\n## Second section\n\nMore body.",
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['block_validation']['isValid'] );
+
+		$saved_content = get_post( $result['post_id'] )->post_content;
+		$this->assertStringContainsString( '<!-- wp:heading', $saved_content );
+		$this->assertStringContainsString( '<!-- wp:paragraph', $saved_content );
+		$this->assertStringNotContainsString( '## First section', $saved_content );
+		$this->assertStringNotContainsString( '## Second section', $saved_content );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Convert recognized heading-only Markdown to serialized Gutenberg blocks in create and update post flows.
- Document the single-heading Markdown contract in ability schemas and Gutenberg guidance.
- Cover saved blocks, update behavior, validation, and hash-character false positives.

Resolves #2434

## Testing

- `php bin/run-wp-phpunit.php --filter='PostAbilitiesTest|BlockAbilitiesTest'`
- `vendor/bin/phpcs includes/Abilities/PostAbilities.php tests/SdAiAgent/Abilities/PostAbilitiesTest.php`

## Runtime Testing

- self-assessed: conversion is covered by WordPress PHPUnit integration tests.

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.264 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 6m and 104,145 tokens on this as a headless worker. Overall, 56m since this issue was created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for converting Markdown with a single heading and paragraphs into properly formatted heading and paragraph blocks.
  * Heading-only Markdown content is now supported for creating and updating posts.

* **Bug Fixes**
  * Improved Markdown detection while preserving hash characters used in regular text.
  * Ensured converted Markdown produces valid block content and validation results.

* **Documentation**
  * Updated guidance for submitting heading-based Markdown content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->