### PR TITLE
GH#2433: require post-mutation render evidence

### DIFF
--- a/includes/Abilities/FileAbilities.php
+++ b/includes/Abilities/FileAbilities.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Abilities;
 
+use SdAiAgent\Core\AgentEventLog;
 use SdAiAgent\Core\Filesystem\PathCanonicalizer;
 use SdAiAgent\Core\Settings;
 use SdAiAgent\Core\WordPressPaths;
@@ -284,6 +285,11 @@ abstract class AbstractFileAbility extends AbstractAbility {
 		$wp_content_path = WordPressPaths::content_dir();
 		$full_path       = $wp_content_path . '/' . $relative_path;
 
+		// Long-lived PHP workers can retain stale stat and realpath entries after
+		// another request creates a file or updates a symlinked content root.
+		// Resolve each request against the current filesystem state.
+		clearstatcache( true, $full_path );
+
 		// Resolve real path for security check.
 		$real_path = realpath( dirname( $full_path ) );
 		if ( false === $real_path ) {
@@ -300,7 +306,12 @@ abstract class AbstractFileAbility extends AbstractAbility {
 		if ( false === $real_path || false === $wp_content_real ) {
 			return new WP_Error(
 				'sd_ai_agent_path_resolve_failed',
-				__( 'Cannot resolve path.', 'superdav-ai-agent' )
+				__( 'Cannot resolve path.', 'superdav-ai-agent' ),
+				[
+					'content_root_resolved' => false !== $wp_content_real,
+					'parent_resolved'       => false !== $real_path,
+					'reason'                => false === $wp_content_real ? 'unresolved_content_root' : 'unresolved_parent',
+				]
 			);
 		}
 
@@ -317,6 +328,46 @@ abstract class AbstractFileAbility extends AbstractAbility {
 		}
 
 		return $canonical;
+	}
+
+	/**
+	 * Build and record a path-safe missing-file diagnostic.
+	 *
+	 * The returned data deliberately contains no absolute path or file contents.
+	 * It lets callers distinguish a missing leaf from a parent/root resolution
+	 * failure while the event log retains only a hash of the caller input.
+	 *
+	 * @param string $relative_path Requested wp-content-relative path.
+	 * @param string $full_path Canonical path returned by resolve_path().
+	 * @return WP_Error
+	 */
+	protected function file_not_found_error( string $relative_path, string $full_path ): WP_Error {
+		$parent_path = dirname( $full_path );
+		clearstatcache( true, $full_path );
+
+		$diagnostics = [
+			'content_root_resolved' => false !== realpath( WordPressPaths::content_dir() ),
+			'parent_exists'         => is_dir( $parent_path ),
+			'parent_resolved'       => false !== realpath( $parent_path ),
+			'reason'                => 'missing_leaf',
+		];
+
+		AgentEventLog::log(
+			'file_read_not_found',
+			AgentEventLog::SEVERITY_WARNING,
+			[
+				'ability'   => $this->name,
+				'code'      => 'sd_ai_agent_file_not_found',
+				'reason'    => 'missing_leaf',
+				'args_hash' => AgentEventLog::payload_hash( [ 'path' => $relative_path ] ),
+			]
+		);
+
+		return new WP_Error(
+			'sd_ai_agent_file_not_found',
+			sprintf( 'File not found: %s', $relative_path ),
+			$diagnostics
+		);
 	}
 
 	/**
@@ -533,9 +584,9 @@ class FileReadAbility extends AbstractFileAbility {
 			return $full_path;
 		}
 
+		clearstatcache( true, $full_path );
 		if ( ! file_exists( $full_path ) ) {
-			// @phpstan-ignore-next-line
-			return new WP_Error( 'sd_ai_agent_file_not_found', sprintf( 'File not found: %s', $path ) );
+			return $this->file_not_found_error( $path, $full_path );
 		}
 
 		if ( ! is_readable( $full_path ) ) {

--- a/includes/Abilities/Js/JsAbilityCatalog.php
+++ b/includes/Abilities/Js/JsAbilityCatalog.php
@@ -66,7 +66,7 @@ class JsAbilityCatalog {
 			array(
 				'name'          => 'sd-ai-agent-js/refresh-page',
 				'label'         => 'Refresh Current Page',
-				'description'   => 'Refresh the current browser page while preserving the open AI Agent widget and current session. Use after site changes that did not return an affected descriptor for live preview.',
+				'description'   => 'Schedule a refresh of the current browser page while preserving the open AI Agent widget and current session. Use after site changes that did not return an affected descriptor for live preview. This is navigation only, not rendered-output validation; capture or inspect the refreshed page before claiming visual verification.',
 				'category'      => 'sd-ai-agent-js',
 				'input_schema'  => array(
 					'type'       => 'object',

--- a/includes/Abilities/PostAbilities.php
+++ b/includes/Abilities/PostAbilities.php
@@ -124,7 +124,7 @@ class PostAbilities {
 						],
 						'content'           => [
 							'type'        => 'string',
-							'description' => 'The post content. Write in markdown (headings with ##, lists with -, bold with **) or HTML — markdown is automatically converted to Gutenberg blocks.',
+							'description' => 'The post content. Write in markdown (headings with ##, lists with -, bold with **) or HTML — markdown is automatically converted to Gutenberg blocks. A single Markdown heading with plain paragraphs is supported.',
 						],
 						'excerpt'           => [
 							'type'        => 'string',
@@ -216,7 +216,7 @@ class PostAbilities {
 						],
 						'content'               => [
 							'type'        => 'string',
-							'description' => 'New post content.',
+							'description' => 'New post content. Markdown, including a single heading with plain paragraphs, is automatically converted to Gutenberg blocks.',
 						],
 						'excerpt'               => [
 							'type'        => 'string',
@@ -2179,7 +2179,7 @@ class PostAbilities {
 		// Check for markdown signals.
 		$markdown_signals = self::count_markdown_signals( $content );
 
-		if ( $markdown_signals < 2 ) {
+		if ( $markdown_signals < 2 && ! self::has_atx_heading( $content ) ) {
 			return $content;
 		}
 
@@ -2195,7 +2195,7 @@ class PostAbilities {
 	private static function count_markdown_signals( string $text ): int {
 		$signals = 0;
 
-		if ( preg_match( '/^#{1,6}\s+\S/m', $text ) ) {
+		if ( self::has_atx_heading( $text ) ) {
 			++$signals;
 		}
 		if ( preg_match( '/\*{1,2}[^*\n]+\*{1,2}/', $text ) || preg_match( '/_{1,2}[^_\n]+_{1,2}/', $text ) ) {
@@ -2215,6 +2215,16 @@ class PostAbilities {
 		}
 
 		return $signals;
+	}
+
+	/**
+	 * Determine whether text contains an ATX heading at the start of a line.
+	 *
+	 * @param string $text Text to check for a Markdown heading.
+	 * @return bool Whether the text contains an ATX heading.
+	 */
+	private static function has_atx_heading( string $text ): bool {
+		return 1 === preg_match( '/^#{1,6}\s+\S/m', $text );
 	}
 
 	/**

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -339,6 +339,9 @@ PROMPT;
 	/** @var PageCompletionGate Tracks rendered quality evidence for published page mutations. */
 	private PageCompletionGate $page_completion_gate;
 
+	/** @var RenderedOutputEvidenceGate Tracks post-file-mutation browser evidence for rendered claims. */
+	private RenderedOutputEvidenceGate $rendered_output_evidence_gate;
+
 	/**
 	 * @param string               $user_message     The user's prompt.
 	 * @param string[]             $abilities         Ability names to enable (empty = all).
@@ -547,6 +550,10 @@ PROMPT;
 			$this->client_router->get_names()
 		);
 		$this->page_completion_gate->replay_tool_call_log( $this->tool_call_log );
+		$this->rendered_output_evidence_gate = new RenderedOutputEvidenceGate(
+			$this->client_router->get_names()
+		);
+		$this->rendered_output_evidence_gate->replay_tool_call_log( $this->tool_call_log );
 
 		// Build or lock the initial system instruction.
 		if ( $this->durable_plan_mode ) {
@@ -957,6 +964,7 @@ PROMPT;
 				$client_result = $result['result'] ?? array( 'error' => $result['error'] ?? '' );
 				$this->generated_theme_completion_gate->record_tool_response( $name, $client_result );
 				$this->page_completion_gate->record_tool_response( $name, $client_result );
+				$this->rendered_output_evidence_gate->record_tool_response( $name, $client_result );
 			}
 
 			// Fire progress so the UI reflects the client tool responses
@@ -990,6 +998,9 @@ PROMPT;
 		}
 		if ( $this->page_completion_gate->is_required() ) {
 			$payload['page_quality_completion'] = $this->page_completion_gate->get_status();
+		}
+		if ( $this->rendered_output_evidence_gate->get_status()['required'] ) {
+			$payload['rendered_output_evidence'] = $this->rendered_output_evidence_gate->get_status();
 		}
 		return $payload;
 	}
@@ -1031,6 +1042,9 @@ PROMPT;
 		}
 		if ( $this->page_completion_gate->is_required() ) {
 			$payload['page_quality_completion'] = $this->page_completion_gate->get_status();
+		}
+		if ( $this->rendered_output_evidence_gate->get_status()['required'] ) {
+			$payload['rendered_output_evidence'] = $this->rendered_output_evidence_gate->get_status();
 		}
 		return $payload;
 	}
@@ -1713,6 +1727,7 @@ PROMPT;
 				$reply = $this->inject_real_permalinks( $reply );
 				$reply = $this->append_generated_theme_completion_notice( $reply );
 				$reply = $this->append_page_completion_notice( $reply );
+				$reply = $this->append_rendered_output_evidence_notice( $reply );
 
 				return $this->inject_inability_data(
 					$this->with_result_logs(
@@ -1990,6 +2005,7 @@ PROMPT;
 			$reply = $this->inject_real_permalinks( $reply );
 			$reply = $this->append_generated_theme_completion_notice( $reply );
 			$reply = $this->append_page_completion_notice( $reply );
+			$reply = $this->append_rendered_output_evidence_notice( $reply );
 
 			return $this->inject_inability_data(
 				$this->with_result_logs(
@@ -4147,6 +4163,7 @@ PROMPT;
 				$normalized_args = self::normalize_function_call_args( $call->getArgs() );
 				$this->generated_theme_completion_gate->record_tool_call( $name, $normalized_args );
 				$this->page_completion_gate->record_tool_call( $name, $normalized_args );
+				$this->rendered_output_evidence_gate->record_tool_call( $name, $normalized_args );
 			}
 		}
 
@@ -4445,6 +4462,7 @@ PROMPT;
 				$this->track_block_validation_response( $name, $response->getResponse() );
 				$this->generated_theme_completion_gate->record_tool_response( $name, $response->getResponse() );
 				$this->page_completion_gate->record_tool_response( $name, $response->getResponse() );
+				$this->rendered_output_evidence_gate->record_tool_response( $name, $response->getResponse() );
 
 				$this->tool_call_log[] = array(
 					'type'     => 'response',
@@ -4771,6 +4789,15 @@ PROMPT;
 			$this->discard_unpublished_page_previews();
 		}
 		return '' === $notice ? $reply : $notice;
+	}
+
+	/** Prevent unsupported rendered-success claims after a successful file mutation. */
+	private function append_rendered_output_evidence_notice( string $reply ): string {
+		if ( ! $this->rendered_output_evidence_gate->blocks_rendered_claim( $reply ) ) {
+			return $reply;
+		}
+
+		return $this->rendered_output_evidence_gate->get_terminal_notice();
 	}
 
 	/** Discard only gate-owned autosaves; the published parents are untouched. */

--- a/includes/Core/RenderedOutputEvidenceGate.php
+++ b/includes/Core/RenderedOutputEvidenceGate.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Tracks browser evidence collected after a site-file mutation.
+ *
+ * @package SdAiAgent
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Core;
+
+/**
+ * Prevents rendered-output claims when the current mutation has no later browser evidence.
+ */
+final class RenderedOutputEvidenceGate {
+
+	/** @var array<string,list<array<string,mixed>>> */
+	private array $pending_calls = array();
+
+	private bool $mutation_requires_evidence = false;
+
+	private bool $has_post_mutation_evidence = false;
+
+	private bool $browser_evidence_available;
+
+	private string $last_failure = '';
+
+	/**
+	 * @param array<string> $client_ability_names Browser abilities available in this run.
+	 */
+	public function __construct( array $client_ability_names = array() ) {
+		$this->browser_evidence_available = ! empty(
+			array_intersect(
+				$client_ability_names,
+				array(
+					'sd-ai-agent-js/capture-screenshot',
+					'sd-ai-agent-js/screenshot-url',
+					PageCompletionGate::CLIENT_ABILITY,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Rebuild state from persisted tool activity after a paused client-tool run.
+	 *
+	 * @param list<array<string,mixed>> $tool_call_log Ordered activity log.
+	 */
+	public function replay_tool_call_log( array $tool_call_log ): void {
+		foreach ( $tool_call_log as $entry ) {
+			if ( 'call' === ( $entry['type'] ?? '' ) ) {
+				$args = $entry['args'] ?? array();
+				$this->record_tool_call( (string) ( $entry['name'] ?? '' ), is_array( $args ) ? $args : array() );
+				continue;
+			}
+
+			if ( 'response' === ( $entry['type'] ?? '' ) ) {
+				$this->record_tool_response( (string) ( $entry['name'] ?? '' ), $entry['response'] ?? array() );
+			}
+		}
+	}
+
+	/**
+	 * Record a dispatched call before its response is available.
+	 *
+	 * @param string              $tool_name Ability name as sent to the provider.
+	 * @param array<string,mixed> $args      Normalized tool arguments.
+	 */
+	public function record_tool_call( string $tool_name, array $args ): void {
+		$name = self::normalize_tool_name( $tool_name );
+		if ( '' !== $name ) {
+			$this->pending_calls[ $name ][] = $args;
+		}
+	}
+
+	/**
+	 * Record a response and establish whether it supports the current rendered output.
+	 *
+	 * @param string $tool_name Ability name as returned by the provider/client.
+	 * @param mixed  $response  Raw response payload.
+	 */
+	public function record_tool_response( string $tool_name, $response ): void {
+		$name      = self::normalize_tool_name( $tool_name );
+		$call_args = $this->consume_pending_call( $name );
+		$payload   = self::normalize_response( $response );
+		if ( '' === $name || ! self::is_successful_response( $payload ) ) {
+			return;
+		}
+
+		if ( self::is_file_mutation( $name ) ) {
+			$this->mutation_requires_evidence = true;
+			$this->has_post_mutation_evidence = false;
+			$this->last_failure               = 'The successful file mutation has no later browser screenshot, DOM inspection, or page-quality result.';
+			return;
+		}
+
+		// A scheduled refresh is navigation only. It deliberately cannot satisfy
+		// rendered-output evidence because no post-refresh document was inspected.
+		if ( 'sd-ai-agent-js/refresh-page' === $name ) {
+			return;
+		}
+
+		if ( $this->mutation_requires_evidence && self::is_browser_evidence( $name, $payload, $call_args ) ) {
+			$this->has_post_mutation_evidence = true;
+			$this->last_failure               = '';
+		}
+	}
+
+	/** Whether the reply claims visual/rendered success without current evidence. */
+	public function blocks_rendered_claim( string $reply ): bool {
+		return $this->mutation_requires_evidence
+			&& ! $this->has_post_mutation_evidence
+			&& self::contains_rendered_claim( $reply );
+	}
+
+	/** Return an honest replacement for an unsupported rendered-success claim. */
+	public function get_terminal_notice(): string {
+		if ( ! $this->mutation_requires_evidence || $this->has_post_mutation_evidence ) {
+			return '';
+		}
+
+		$availability = $this->browser_evidence_available
+			? 'No post-mutation browser evidence was captured.'
+			: 'Browser verification was unavailable in this client.';
+		return 'The file change was saved, but its rendered result remains unverified. ' . $availability . ' I cannot claim that the rendered page was checked or visually verified.';
+	}
+
+	/** @return array<string,mixed> */
+	public function get_status(): array {
+		return array(
+			'required'                   => $this->mutation_requires_evidence,
+			'has_post_mutation_evidence' => $this->has_post_mutation_evidence,
+			'browser_evidence_available' => $this->browser_evidence_available,
+			'last_failure'               => $this->last_failure,
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private function consume_pending_call( string $name ): array {
+		if ( '' === $name || empty( $this->pending_calls[ $name ] ) ) {
+			return array();
+		}
+
+		$args = array_shift( $this->pending_calls[ $name ] );
+		if ( empty( $this->pending_calls[ $name ] ) ) {
+			unset( $this->pending_calls[ $name ] );
+		}
+
+		return is_array( $args ) ? $args : array();
+	}
+
+	private static function is_file_mutation( string $name ): bool {
+		return in_array( $name, array( 'sd-ai-agent/file-write', 'sd-ai-agent/file-edit', 'sd-ai-agent/file-delete' ), true );
+	}
+
+	/**
+	 * @param string              $name      Normalized ability name.
+	 * @param array<string,mixed> $payload   Normalized response.
+	 * @param array<string,mixed> $call_args Original call arguments.
+	 */
+	private static function is_browser_evidence( string $name, array $payload, array $call_args ): bool {
+		if ( in_array( $name, array( 'sd-ai-agent-js/capture-screenshot', 'sd-ai-agent-js/screenshot-url' ), true ) ) {
+			return true === ( $payload['success'] ?? false )
+				&& ( is_string( $payload['image'] ?? null ) || true === ( $payload['attached_to_model'] ?? false ) );
+		}
+
+		if ( PageCompletionGate::CLIENT_ABILITY === $name ) {
+			return true === ( $payload['success'] ?? false )
+				&& true === ( $payload['complete'] ?? false )
+				&& true === ( $payload['passed'] ?? false )
+				&& ! empty( $call_args );
+		}
+
+		return false;
+	}
+
+	private static function contains_rendered_claim( string $reply ): bool {
+		return 1 === preg_match(
+			'/\b(?:checked|check|verified|verify|validated|validate|inspected|inspect)\b[^.]{0,80}\b(?:rendered|visual(?:ly)?|page|output|site)\b|\b(?:rendered|visual(?:ly)?|page|output|site)\b[^.]{0,80}\b(?:checked|verified|validated|inspected)\b/i',
+			$reply
+		);
+	}
+
+	private static function normalize_tool_name( string $tool_name ): string {
+		if ( str_starts_with( $tool_name, 'wpab__sd-ai-agent__' ) ) {
+			return 'sd-ai-agent/' . substr( $tool_name, strlen( 'wpab__sd-ai-agent__' ) );
+		}
+		if ( str_starts_with( $tool_name, 'wpab__sd-ai-agent-js__' ) ) {
+			return 'sd-ai-agent-js/' . substr( $tool_name, strlen( 'wpab__sd-ai-agent-js__' ) );
+		}
+		return $tool_name;
+	}
+
+	/** @param mixed $response */
+	private static function normalize_response( $response ): array {
+		if ( is_string( $response ) && '' !== $response ) {
+			$decoded  = json_decode( $response, true );
+			$response = is_array( $decoded ) ? $decoded : array( 'error' => $response );
+		}
+		if ( ! is_array( $response ) ) {
+			return array();
+		}
+
+		return $response;
+	}
+
+	/** @param array<string,mixed> $response */
+	private static function is_successful_response( array $response ): bool {
+		return ! empty( $response )
+			&& empty( $response['error'] ?? '' )
+			&& false !== ( $response['success'] ?? true )
+			&& 'proposal_pending' !== (string) ( $response['status'] ?? '' );
+	}
+}

--- a/includes/Core/SystemInstructionBuilder.php
+++ b/includes/Core/SystemInstructionBuilder.php
@@ -94,7 +94,7 @@ class SystemInstructionBuilder {
 			. 'When you mutate that visible page, inspect each tool result for an `affected` descriptor. '
 			. "If the result includes `affected.render_mode: preview`, the change exists only in a private WordPress autosave and the reflector deliberately leaves the public DOM unchanged; do not tell the user it is live. Otherwise, when the result includes `affected.kind: post`, a matching `post_id`/URL, and `fields` containing `post_content`, the widget's live-preview reflector will attempt to update the visible page automatically. "
 			. 'If a mutating tool result does not include an `affected` descriptor for the visible page, the browser cannot know what changed and the user must refresh to see it. In that case, call `sd-ai-agent-js/refresh-page` after your server-side write completes; it refreshes the current page while preserving the open widget and current session. '
-			. 'Do not call the refresh tool after a dry run or after read-only inspection. If you are unsure whether live reflection succeeded, use a screenshot/inspection tool or explain that a refresh may be required.';
+			. 'Do not call the refresh tool after a dry run or after read-only inspection. A refresh acknowledgement only schedules navigation; it is not evidence that the changed output rendered. Before claiming that a rendered page, template, or theme change was checked or visually verified, capture a screenshot, inspect the refreshed DOM, or receive a passing page-quality result after the mutation. If browser verification is unavailable, preserve the successful change and disclose that its rendered result remains unverified.';
 	}
 
 	/**

--- a/includes/Core/WordPressPaths.php
+++ b/includes/Core/WordPressPaths.php
@@ -44,13 +44,18 @@ final class WordPressPaths {
 	/**
 	 * Resolve the content directory.
 	 *
-	 * WordPress exposes helpers for theme and upload directories rather than a
-	 * content-root path helper. The theme root is the most stable public location
-	 * for deriving the surrounding content directory; uploads are the fallback.
+	 * WP_CONTENT_DIR is WordPress' authoritative content root. It remains stable
+	 * when a theme or this plugin is loaded through a symlink, whereas deriving
+	 * the root from get_theme_root() can resolve a different physical directory.
+	 * The helper fallbacks retain compatibility with incomplete test bootstraps.
 	 *
 	 * @return string Absolute directory path without a trailing slash.
 	 */
 	public static function content_dir(): string {
+		if ( defined( 'WP_CONTENT_DIR' ) && '' !== (string) constant( 'WP_CONTENT_DIR' ) ) {
+			return untrailingslashit( (string) constant( 'WP_CONTENT_DIR' ) );
+		}
+
 		$theme_root = get_theme_root();
 		if ( '' !== $theme_root ) {
 			return untrailingslashit( dirname( $theme_root ) );

--- a/includes/Models/skills/gutenberg-blocks.md
+++ b/includes/Models/skills/gutenberg-blocks.md
@@ -12,6 +12,11 @@ Content passed to `sd-ai-agent/create-post` or `sd-ai-agent/update-post` must be
 
 **NEVER mix raw markdown with block markup.** Mixed content renders incorrectly.
 
+An ATX heading at the start of a line (for example, `## Section heading`) is
+enough to identify Markdown content. Pass heading-only outlines and a single
+heading followed by plain paragraphs directly to the post abilities; they are
+converted to `core/heading` and `core/paragraph` blocks.
+
 ## Quick diagnostic — symptom → fix
 
 | Symptom or error | Fix |

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -69,6 +69,17 @@ final class SessionController {
 	/** Public anonymous chat HMAC purpose string. */
 	private const PUBLIC_CHAT_TOKEN_PURPOSE = 'public_chat_session_v1';
 
+	/**
+	 * Per-message transport attribution that does not alter conversation meaning.
+	 *
+	 * Recovery payloads can be serialized before or after turn attribution is
+	 * added. Keep this list deliberately narrow: roles, ordered parts, function
+	 * IDs, and their payloads must remain part of message identity.
+	 *
+	 * @var list<string>
+	 */
+	private const RECOVERY_TRANSPORT_METADATA = array( 'provider_id', 'model_id' );
+
 	/** @var Database Injected database dependency. */
 	private Database $database;
 
@@ -2727,14 +2738,19 @@ final class SessionController {
 		if ( ! is_array( $existing_messages ) ) {
 			$existing_messages = array();
 		}
+		$existing_tool_calls = json_decode( (string) $session->tool_calls, true );
+		if ( ! is_array( $existing_tool_calls ) ) {
+			$existing_tool_calls = array();
+		}
 
-		$append_offset = $this->get_history_append_offset( $full_history, $existing_messages );
-		$appended      = array_slice( $full_history, $append_offset );
-		if ( empty( $appended ) && empty( $tool_calls ) ) {
+		$append_offset  = $this->get_history_append_offset( $full_history, $existing_messages );
+		$appended       = array_slice( $full_history, $append_offset );
+		$new_tool_calls = $this->get_unpersisted_recovery_rows( $tool_calls, $existing_tool_calls );
+		if ( empty( $appended ) && empty( $new_tool_calls ) ) {
 			return true;
 		}
 
-		return $this->database->append_to_session( $session_id, array_values( $appended ), $tool_calls );
+		return $this->database->append_to_session( $session_id, array_values( $appended ), $new_tool_calls );
 	}
 
 	/**
@@ -2754,7 +2770,7 @@ final class SessionController {
 	private function get_history_append_offset( array $full_history, array $existing_messages ): int {
 		$common_prefix = 0;
 		foreach ( $full_history as $index => $row ) {
-			if ( ! isset( $existing_messages[ $index ] ) || $existing_messages[ $index ] !== $row ) {
+			if ( ! isset( $existing_messages[ $index ] ) || ! is_array( $existing_messages[ $index ] ) || ! $this->recovery_rows_are_semantically_equal( $existing_messages[ $index ], $row ) ) {
 				break;
 			}
 
@@ -2766,12 +2782,104 @@ final class SessionController {
 		}
 
 		foreach ( $full_history as $index => $row ) {
-			if ( ! in_array( $row, $existing_messages, true ) ) {
+			if ( ! $this->recovery_row_exists( $row, $existing_messages ) ) {
 				return $index;
 			}
 		}
 
 		return count( $full_history );
+	}
+
+	/**
+	 * Return recovery rows that have not already been persisted.
+	 *
+	 * Tool-call entries are a separate append-only log from history. Filtering
+	 * against the persisted log makes a replay of the same recovery payload
+	 * idempotent without globally deduplicating conversation messages.
+	 *
+	 * @param list<array<string, mixed>> $recovery_rows Recovery rows to append.
+	 * @param array<mixed>               $persisted_rows Existing stored rows.
+	 * @return list<array<string, mixed>>
+	 */
+	private function get_unpersisted_recovery_rows( array $recovery_rows, array $persisted_rows ): array {
+		$unpersisted = array();
+		foreach ( $recovery_rows as $row ) {
+			if ( ! $this->recovery_row_exists( $row, $persisted_rows ) ) {
+				$unpersisted[] = $row;
+			}
+		}
+
+		return $unpersisted;
+	}
+
+	/**
+	 * Check whether a canonical recovery row exists in a list of persisted rows.
+	 *
+	 * @param array<string, mixed> $needle Candidate row.
+	 * @param array<mixed>         $haystack Persisted rows.
+	 * @return bool
+	 */
+	private function recovery_row_exists( array $needle, array $haystack ): bool {
+		foreach ( $haystack as $row ) {
+			if ( is_array( $row ) && $this->recovery_rows_are_semantically_equal( $needle, $row ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Compare serialized recovery rows by conversation semantics.
+	 *
+	 * Only provider/model attribution is transport metadata. All other fields,
+	 * including role, ordered parts, function-call/result IDs, and payloads,
+	 * remain part of the canonical value.
+	 *
+	 * @param array<string, mixed> $left First serialized row.
+	 * @param array<string, mixed> $right Second serialized row.
+	 * @return bool
+	 */
+	private function recovery_rows_are_semantically_equal( array $left, array $right ): bool {
+		return $this->canonicalize_recovery_row( $left ) === $this->canonicalize_recovery_row( $right );
+	}
+
+	/**
+	 * Remove documented transport metadata and normalize associative-key order.
+	 *
+	 * @param array<string, mixed> $row Serialized message or tool-call row.
+	 * @return array<string, mixed>
+	 */
+	private function canonicalize_recovery_row( array $row ): array {
+		foreach ( self::RECOVERY_TRANSPORT_METADATA as $metadata_key ) {
+			unset( $row[ $metadata_key ] );
+		}
+
+		/** @var array<string, mixed> $canonical */
+		$canonical = $this->canonicalize_recovery_value( $row );
+		return $canonical;
+	}
+
+	/**
+	 * Canonicalize array keys without changing ordered conversation lists.
+	 *
+	 * @param mixed $value Serialized field value.
+	 * @return mixed
+	 */
+	private function canonicalize_recovery_value( mixed $value ): mixed {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		foreach ( $value as $key => $entry ) {
+			$value[ $key ] = $this->canonicalize_recovery_value( $entry );
+		}
+
+		if ( ! array_is_list( $value ) ) {
+			ksort( $value );
+		}
+
+		return $value;
 	}
 
 	/**

--- a/src/abilities/refresh-page.js
+++ b/src/abilities/refresh-page.js
@@ -1,7 +1,7 @@
 /**
  * Client-side refresh-page ability.
  *
- * Reloads the current browser page after the tool result has been posted back
+ * Schedules a reload of the current browser page after the tool result has been posted back.
  * to the server. The job poller performs the actual reload so the in-flight
  * tool-result POST is not aborted. It also stores the active session/widget
  * state so the floating widget reopens to the same conversation after reload.
@@ -12,7 +12,7 @@ import { registerClientAbility } from './registry';
 /**
  * Execute the refresh-page ability.
  *
- * @return {{ refresh_scheduled: boolean, url: string }} Refresh scheduling result.
+ * @return {{ refresh_scheduled: boolean, url: string }} Refresh scheduling result, not render evidence.
  */
 function executeRefreshPage() {
 	const url = window.location.href;
@@ -34,7 +34,7 @@ export async function registerRefreshPageAbility() {
 		name: 'sd-ai-agent-js/refresh-page',
 		label: 'Refresh Current Page',
 		description:
-			'Refresh the current browser page while preserving the open AI Agent widget and current session. Use after site changes that did not return an affected descriptor for live preview.',
+			'Schedule a refresh of the current browser page while preserving the open AI Agent widget and current session. Use after site changes that did not return an affected descriptor for live preview. This only schedules navigation and does not validate rendered output.',
 		inputSchema: {
 			type: 'object',
 			properties: {},

--- a/src/abilities/refresh-page.js
+++ b/src/abilities/refresh-page.js
@@ -1,8 +1,8 @@
 /**
  * Client-side refresh-page ability.
  *
- * Schedules a reload of the current browser page after the tool result has been posted back.
- * to the server. The job poller performs the actual reload so the in-flight
+ * Schedules a reload after the tool result has been posted back to the server.
+ * The job poller performs the actual reload so the in-flight
  * tool-result POST is not aborted. It also stores the active session/widget
  * state so the floating widget reopens to the same conversation after reload.
  */
@@ -34,7 +34,7 @@ export async function registerRefreshPageAbility() {
 		name: 'sd-ai-agent-js/refresh-page',
 		label: 'Refresh Current Page',
 		description:
-			'Schedule a refresh of the current browser page while preserving the open AI Agent widget and current session. Use after site changes that did not return an affected descriptor for live preview. This only schedules navigation and does not validate rendered output.',
+			'Refresh the current browser page while preserving the open AI Agent widget and current session. Navigation only; it does not validate rendered output.',
 		inputSchema: {
 			type: 'object',
 			properties: {},

--- a/tests/SdAiAgent/Abilities/FileAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/FileAbilitiesTest.php
@@ -10,6 +10,8 @@
 namespace SdAiAgent\Tests\Abilities;
 
 use SdAiAgent\Abilities\FileAbilities;
+use SdAiAgent\Core\AgentEventLog;
+use SdAiAgent\Core\WordPressPaths;
 use WP_UnitTestCase;
 
 /**
@@ -173,12 +175,80 @@ class FileAbilitiesTest extends WP_UnitTestCase {
 	 * Test handle_read_file returns WP_Error for non-existent file.
 	 */
 	public function test_handle_read_file_not_found() {
+		$events   = [];
+		$listener = static function ( string $event, string $severity, array $context ) use ( &$events ): void {
+			$events[] = compact( 'event', 'severity', 'context' );
+		};
+		add_action( 'sd_ai_agent_event_logged', $listener, 10, 3 );
+
 		$result = FileAbilities::handle_read_file( [
 			'path' => 'uploads/nonexistent-file-xyz.txt',
 		] );
+		remove_action( 'sd_ai_agent_event_logged', $listener, 10 );
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'sd_ai_agent_file_not_found', $result->get_error_code() );
+		$this->assertSame(
+			[
+				'content_root_resolved' => true,
+				'parent_exists'         => true,
+				'parent_resolved'       => true,
+				'reason'                => 'missing_leaf',
+			],
+			$result->get_error_data()
+		);
+		$this->assertCount( 1, $events );
+		$this->assertSame( 'file_read_not_found', $events[0]['event'] );
+		$this->assertSame( AgentEventLog::SEVERITY_WARNING, $events[0]['severity'] );
+		$this->assertSame( 'missing_leaf', $events[0]['context']['reason'] );
+		$this->assertArrayHasKey( 'args_hash', $events[0]['context'] );
+		$this->assertArrayNotHasKey( 'path', $events[0]['context'] );
+	}
+
+	/**
+	 * An existing sibling must remain correlated to its own result when the
+	 * caller dispatches a missing and an existing read in the same batch.
+	 */
+	public function test_handle_read_file_keeps_sibling_batch_results_distinct() {
+		file_put_contents( $this->test_file_full, 'Existing sibling content' );
+
+		$requests = [
+			'call_missing_sibling'  => [ 'path' => 'uploads/sd-ai-agent-missing-sibling.txt' ],
+			'call_existing_sibling' => [ 'path' => $this->test_file ],
+		];
+		$results  = [];
+		foreach ( $requests as $call_id => $request ) {
+			$results[ $call_id ] = FileAbilities::handle_read_file( $request );
+		}
+
+		$this->assertInstanceOf( \WP_Error::class, $results['call_missing_sibling'] );
+		$this->assertSame( 'sd_ai_agent_file_not_found', $results['call_missing_sibling']->get_error_code() );
+		$this->assertIsArray( $results['call_existing_sibling'] );
+		$this->assertSame( $this->test_file, $results['call_existing_sibling']['path'] );
+		$this->assertSame( 'Existing sibling content', $results['call_existing_sibling']['content'] );
+	}
+
+	/**
+	 * Repeated and resumed reads must resolve the same unchanged canonical path.
+	 */
+	public function test_handle_read_file_repeated_requests_bypass_stale_filesystem_cache() {
+		file_put_contents( $this->test_file_full, 'Stable repeated read content' );
+
+		for ( $request = 0; $request < 3; $request++ ) {
+			$result = FileAbilities::handle_read_file( [ 'path' => $this->test_file ] );
+
+			$this->assertIsArray( $result );
+			$this->assertSame( $this->test_file, $result['path'] );
+			$this->assertSame( 'Stable repeated read content', $result['content'] );
+		}
+	}
+
+	/**
+	 * File abilities must anchor their allowed root to WordPress' content root,
+	 * not to a theme path that may be symlinked elsewhere.
+	 */
+	public function test_file_abilities_use_the_wordpress_content_root() {
+		$this->assertSame( untrailingslashit( WP_CONTENT_DIR ), WordPressPaths::content_dir() );
 	}
 
 	/**

--- a/tests/SdAiAgent/Abilities/PostAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/PostAbilitiesTest.php
@@ -477,6 +477,26 @@ class PostAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Heading-only Markdown must be converted when updating post content.
+	 */
+	public function test_handle_update_post_converts_heading_only_markdown(): void {
+		$post_id = $this->factory->post->create( [ 'post_status' => 'draft' ] );
+		$content = "## Updated section\n\nUpdated paragraph.";
+
+		$result = PostAbilities::handle_update_post(
+			[
+				'post_id' => $post_id,
+				'content' => $content,
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['block_validation']['isValid'] );
+		$this->assertStringContainsString( '<!-- wp:heading', get_post( $post_id )->post_content );
+		$this->assertStringNotContainsString( '## Updated section', get_post( $post_id )->post_content );
+	}
+
+	/**
 	 * Provider-filled empty optional fields must not erase a published page.
 	 */
 	public function test_handle_update_post_blocks_empty_published_page_replacement(): void {
@@ -807,17 +827,17 @@ class PostAbilitiesTest extends WP_UnitTestCase {
 	// ─── block_validation save-time gate (GH#1584 follow-up) ────────
 
 	/**
-	 * Content without block markup should omit the block_validation key — the
-	 * helper short-circuits when `<!-- wp:` is not present.
+	 * A single heading with plain paragraphs is converted and validated as blocks.
 	 */
-	public function test_handle_create_post_omits_block_validation_for_markdown() {
+	public function test_handle_create_post_validates_single_heading_markdown() {
 		$result = PostAbilities::handle_create_post( [
 			'title'   => 'Markdown post',
 			'content' => "## Heading\n\nParagraph.",
 		] );
 
 		$this->assertIsArray( $result );
-		$this->assertArrayNotHasKey( 'block_validation', $result );
+		$this->assertArrayHasKey( 'block_validation', $result );
+		$this->assertTrue( $result['block_validation']['isValid'] );
 	}
 
 	/**
@@ -1499,6 +1519,50 @@ class PostAbilitiesTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '<!-- wp:', $result );
 		// Must not contain the raw markdown heading.
 		$this->assertStringNotContainsString( '## Introduction', $result );
+	}
+
+	/**
+	 * Test that headings are converted without a second Markdown construct.
+	 */
+	public function test_maybe_convert_markdown_heading_only_converted() {
+		$markdown = "Intro paragraph.\n\n## First section\n\nBody.\n\n### Second section\n\nMore body.";
+		$result   = $this->call_maybe_convert_markdown( $markdown );
+
+		$this->assertStringContainsString( '<!-- wp:heading', $result );
+		$this->assertStringContainsString( '<!-- wp:paragraph', $result );
+		$this->assertStringNotContainsString( '## First section', $result );
+		$this->assertStringNotContainsString( '### Second section', $result );
+	}
+
+	/**
+	 * Test that prose using hash characters is not mistaken for an ATX heading.
+	 */
+	public function test_maybe_convert_markdown_ignores_non_heading_hash_characters() {
+		$prose  = "#not a heading\nC# is a programming language.";
+		$result = $this->call_maybe_convert_markdown( $prose );
+
+		$this->assertSame( $prose, $result );
+	}
+
+	/**
+	 * Create-post saves heading-only Markdown as valid Gutenberg blocks.
+	 */
+	public function test_handle_create_post_converts_heading_only_markdown_to_valid_blocks(): void {
+		$result = PostAbilities::handle_create_post(
+			[
+				'title'   => 'Heading-only markdown',
+				'content' => "Intro paragraph.\n\n## First section\n\nBody.\n\n## Second section\n\nMore body.",
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertTrue( $result['block_validation']['isValid'] );
+
+		$saved_content = get_post( $result['post_id'] )->post_content;
+		$this->assertStringContainsString( '<!-- wp:heading', $saved_content );
+		$this->assertStringContainsString( '<!-- wp:paragraph', $saved_content );
+		$this->assertStringNotContainsString( '## First section', $saved_content );
+		$this->assertStringNotContainsString( '## Second section', $saved_content );
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
@@ -624,6 +624,60 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 		$this->assertStringNotContainsString( 'DONE', $reply );
 	}
 
+	/** A refresh acknowledgement cannot support a rendered-success claim after a file write. */
+	public function test_file_write_then_refresh_replaces_unsupported_rendered_success_claim(): void {
+		$loop = new AgentLoop(
+			'test',
+			array(),
+			array(),
+			array(
+				'client_abilities' => array(
+					array( 'name' => 'sd-ai-agent-js/refresh-page' ),
+				),
+			)
+		);
+		$gate = $this->get_rendered_output_evidence_gate( $loop );
+		$gate->record_tool_call( 'sd-ai-agent/file-write', array( 'path' => 'themes/example/templates/single.html' ) );
+		$gate->record_tool_response( 'sd-ai-agent/file-write', array( 'success' => true ) );
+		$gate->record_tool_call( 'sd-ai-agent-js/refresh-page', array() );
+		$gate->record_tool_response( 'sd-ai-agent-js/refresh-page', array( 'refresh_scheduled' => true ) );
+
+		$method = ( new \ReflectionClass( $loop ) )->getMethod( 'append_rendered_output_evidence_notice' );
+		$method->setAccessible( true );
+		$reply = (string) $method->invoke( $loop, 'I checked the rendered page and the complete article is visible.' );
+
+		$this->assertStringContainsString( 'remains unverified', $reply );
+		$this->assertStringNotContainsString( 'complete article is visible', $reply );
+	}
+
+	/** A screenshot returned after a file write supports the later rendered-success claim. */
+	public function test_file_write_then_refresh_then_screenshot_preserves_rendered_success_claim(): void {
+		$loop = new AgentLoop(
+			'test',
+			array(),
+			array(),
+			array(
+				'client_abilities' => array(
+					array( 'name' => 'sd-ai-agent-js/refresh-page' ),
+					array( 'name' => 'sd-ai-agent-js/capture-screenshot' ),
+				),
+			)
+		);
+		$gate = $this->get_rendered_output_evidence_gate( $loop );
+		$gate->record_tool_call( 'sd-ai-agent/file-write', array( 'path' => 'themes/example/templates/single.html' ) );
+		$gate->record_tool_response( 'sd-ai-agent/file-write', array( 'success' => true ) );
+		$gate->record_tool_call( 'sd-ai-agent-js/refresh-page', array() );
+		$gate->record_tool_response( 'sd-ai-agent-js/refresh-page', array( 'refresh_scheduled' => true ) );
+		$gate->record_tool_call( 'sd-ai-agent-js/capture-screenshot', array() );
+		$gate->record_tool_response( 'sd-ai-agent-js/capture-screenshot', array( 'success' => true, 'image' => 'data:image/jpeg;base64,abc' ) );
+
+		$method = ( new \ReflectionClass( $loop ) )->getMethod( 'append_rendered_output_evidence_notice' );
+		$method->setAccessible( true );
+		$reply = 'I checked the rendered page and the complete article is visible.';
+
+		$this->assertSame( $reply, $method->invoke( $loop, $reply ) );
+	}
+
 	/** Server-directed page validation uses exact gate-owned preview arguments. */
 	public function test_page_quality_dispatch_does_not_depend_on_model_arguments(): void {
 		$loop = new AgentLoop(
@@ -700,6 +754,13 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 		$part->method( 'getFunctionCall' )->willReturn( $call );
 
 		return $part;
+	}
+
+	/** Return the focused rendered-output gate from an AgentLoop instance. */
+	private function get_rendered_output_evidence_gate( AgentLoop $loop ): object {
+		$property = ( new \ReflectionClass( $loop ) )->getProperty( 'rendered_output_evidence_gate' );
+		$property->setAccessible( true );
+		return $property->getValue( $loop );
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
@@ -647,6 +647,7 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 		$reply = (string) $method->invoke( $loop, 'I checked the rendered page and the complete article is visible.' );
 
 		$this->assertStringContainsString( 'remains unverified', $reply );
+		$this->assertStringContainsString( 'Browser verification was unavailable', $reply );
 		$this->assertStringNotContainsString( 'complete article is visible', $reply );
 	}
 

--- a/tests/SdAiAgent/Core/SystemInstructionBuilderTest.php
+++ b/tests/SdAiAgent/Core/SystemInstructionBuilderTest.php
@@ -128,6 +128,8 @@ class SystemInstructionBuilderTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( '`affected` descriptor', $instruction );
 		$this->assertStringContainsString( 'sd-ai-agent-js/refresh-page', $instruction );
 		$this->assertStringContainsString( 'preserving the open widget and current session', $instruction );
+		$this->assertStringContainsString( 'not evidence that the changed output rendered', $instruction );
+		$this->assertStringContainsString( 'rendered result remains unverified', $instruction );
 	}
 
 	/**

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -1804,6 +1804,83 @@ class RestControllerTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A full recovery replay ignores turn attribution but preserves ordered tool history.
+	 */
+	public function test_error_recovery_replay_ignores_transport_metadata_and_is_idempotent(): void {
+		$session_id = Database::create_session( [
+			'user_id' => $this->admin_id,
+			'title'   => 'Recover metadata replay',
+		] );
+
+		$recovery_history = [
+			[ 'role' => 'user', 'parts' => [ [ 'text' => 'Do anything.' ] ] ],
+			[ 'role' => 'model', 'parts' => [ [ 'function_call' => [ 'id' => 'create-post', 'name' => 'create_post', 'args' => [ 'title' => 'Recovery test' ] ] ] ] ],
+			[ 'role' => 'user', 'parts' => [ [ 'function_response' => [ 'id' => 'create-post', 'name' => 'create_post', 'response' => [ 'id' => 123 ] ] ] ] ],
+			[ 'role' => 'model', 'parts' => [ [ 'text' => 'The post was created.' ] ] ],
+			[ 'role' => 'user', 'parts' => [ [ 'text' => 'Follow up on the post.' ] ] ],
+			[ 'role' => 'model', 'parts' => [ [ 'function_call' => [ 'id' => 'inspect-post', 'name' => 'get_post', 'args' => [ 'id' => 123 ] ] ] ] ],
+			[ 'role' => 'user', 'parts' => [ [ 'function_response' => [ 'id' => 'inspect-post', 'name' => 'get_post', 'response' => [ 'status' => 'publish' ] ] ] ] ],
+			[ 'role' => 'model', 'parts' => [ [ 'text' => 'The post is published.' ] ] ],
+			[ 'role' => 'user', 'parts' => [ [ 'text' => "But I don't, check it yourself." ] ] ],
+			[ 'role' => 'model', 'parts' => [ [ 'text' => 'I verified the published post.' ] ] ],
+		];
+		$persisted_history = array_map(
+			static function ( array $message ): array {
+				$message['provider_id'] = 'recovery-provider';
+				$message['model_id']    = 'recovery-model';
+				return $message;
+			},
+			$recovery_history
+		);
+		$tool_calls        = [
+			[ 'id' => 'create-post', 'name' => 'create_post' ],
+			[ 'id' => 'inspect-post', 'name' => 'get_post' ],
+		];
+		Database::append_to_session( $session_id, $persisted_history, $tool_calls );
+
+		// A second identical user turn is a legitimate new turn, not a replay.
+		$recovery_history[] = [ 'role' => 'user', 'parts' => [ [ 'text' => "But I don't, check it yourself." ] ] ];
+		$error              = new \WP_Error(
+			'prompt_invalid_argument',
+			'The provider rejected the prompt.',
+			[
+				'history'    => $recovery_history,
+				'tool_calls' => $tool_calls,
+				'messages'   => [],
+				'token_usage' => [ 'prompt' => 1, 'completion' => 0 ],
+			]
+		);
+
+		$controller = new \SdAiAgent\REST\SessionController( new Database() );
+		$method     = new \ReflectionMethod( \SdAiAgent\REST\SessionController::class, 'persist_error_recovery_to_session' );
+		$method->setAccessible( true );
+		$params     = [ 'message' => "But I don't, check it yourself.", 'session_id' => $session_id ];
+		$options    = [];
+		$error_data = $error->get_error_data();
+		$this->assertIsArray( $error_data );
+
+		$job = [ 'status' => 'error', 'error' => $error->get_error_message(), 'params' => $params ];
+		$method->invokeArgs( $controller, [ $session_id, $error, $error_data, $params, $options, &$job ] );
+		$job = [ 'status' => 'error', 'error' => $error->get_error_message(), 'params' => $params ];
+		$method->invokeArgs( $controller, [ $session_id, $error, $error_data, $params, $options, &$job ] );
+
+		$session       = Database::get_session( $session_id );
+		$messages      = json_decode( (string) $session->messages, true );
+		$stored_calls  = json_decode( (string) $session->tool_calls, true );
+		$this->assertIsArray( $messages );
+		$this->assertSame( $persisted_history, array_slice( $messages, 0, 10 ) );
+		$this->assertCount( 11, $messages );
+		$this->assertSame( $recovery_history[10], $messages[10] );
+		$this->assertSame( 'create-post', $messages[1]['parts'][0]['function_call']['id'] );
+		$this->assertSame( 'create-post', $messages[2]['parts'][0]['function_response']['id'] );
+		$this->assertSame( 'inspect-post', $messages[5]['parts'][0]['function_call']['id'] );
+		$this->assertSame( 'inspect-post', $messages[6]['parts'][0]['function_response']['id'] );
+		$this->assertSame( $tool_calls, $stored_calls );
+		$this->assertSame( $session_id, $job['session_id'] );
+		$this->assertTrue( $job['recoverable'] );
+	}
+
+	/**
 	 * Test recovery persistence appends a suffix payload instead of dropping it by count.
 	 */
 	public function test_persist_error_recovery_appends_shorter_failed_turn_suffix(): void {


### PR DESCRIPTION
## Summary

- Track successful file mutations separately from browser evidence.
- Treat `refresh-page` as navigation scheduling rather than rendered-output validation.
- Prevent unsupported rendered-success claims while retaining successful mutations.

## Verification in progress

- PHP syntax checks passed.
- Targeted PHPUnit checks passed: 49 tests, 178 assertions, 1 skipped.
- PHPCS passed.
- PHPStan passed.

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.264 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 13m and 143,230 tokens on this as a headless worker.
