### PR TITLE
GH#2435: harden file-read path resolution

### DIFF
--- a/includes/Abilities/FileAbilities.php
+++ b/includes/Abilities/FileAbilities.php
@@ -15,6 +15,7 @@ declare(strict_types=1);
 
 namespace SdAiAgent\Abilities;
 
+use SdAiAgent\Core\AgentEventLog;
 use SdAiAgent\Core\Filesystem\PathCanonicalizer;
 use SdAiAgent\Core\Settings;
 use SdAiAgent\Core\WordPressPaths;
@@ -284,6 +285,11 @@ abstract class AbstractFileAbility extends AbstractAbility {
 		$wp_content_path = WordPressPaths::content_dir();
 		$full_path       = $wp_content_path . '/' . $relative_path;
 
+		// Long-lived PHP workers can retain stale stat and realpath entries after
+		// another request creates a file or updates a symlinked content root.
+		// Resolve each request against the current filesystem state.
+		clearstatcache( true, $full_path );
+
 		// Resolve real path for security check.
 		$real_path = realpath( dirname( $full_path ) );
 		if ( false === $real_path ) {
@@ -300,7 +306,12 @@ abstract class AbstractFileAbility extends AbstractAbility {
 		if ( false === $real_path || false === $wp_content_real ) {
 			return new WP_Error(
 				'sd_ai_agent_path_resolve_failed',
-				__( 'Cannot resolve path.', 'superdav-ai-agent' )
+				__( 'Cannot resolve path.', 'superdav-ai-agent' ),
+				[
+					'content_root_resolved' => false !== $wp_content_real,
+					'parent_resolved'       => false !== $real_path,
+					'reason'                => false === $wp_content_real ? 'unresolved_content_root' : 'unresolved_parent',
+				]
 			);
 		}
 
@@ -317,6 +328,46 @@ abstract class AbstractFileAbility extends AbstractAbility {
 		}
 
 		return $canonical;
+	}
+
+	/**
+	 * Build and record a path-safe missing-file diagnostic.
+	 *
+	 * The returned data deliberately contains no absolute path or file contents.
+	 * It lets callers distinguish a missing leaf from a parent/root resolution
+	 * failure while the event log retains only a hash of the caller input.
+	 *
+	 * @param string $relative_path Requested wp-content-relative path.
+	 * @param string $full_path Canonical path returned by resolve_path().
+	 * @return WP_Error
+	 */
+	protected function file_not_found_error( string $relative_path, string $full_path ): WP_Error {
+		$parent_path = dirname( $full_path );
+		clearstatcache( true, $full_path );
+
+		$diagnostics = [
+			'content_root_resolved' => false !== realpath( WordPressPaths::content_dir() ),
+			'parent_exists'         => is_dir( $parent_path ),
+			'parent_resolved'       => false !== realpath( $parent_path ),
+			'reason'                => 'missing_leaf',
+		];
+
+		AgentEventLog::log(
+			'file_read_not_found',
+			AgentEventLog::SEVERITY_WARNING,
+			[
+				'ability'   => $this->name,
+				'code'      => 'sd_ai_agent_file_not_found',
+				'reason'    => 'missing_leaf',
+				'args_hash' => AgentEventLog::payload_hash( [ 'path' => $relative_path ] ),
+			]
+		);
+
+		return new WP_Error(
+			'sd_ai_agent_file_not_found',
+			sprintf( 'File not found: %s', $relative_path ),
+			$diagnostics
+		);
 	}
 
 	/**
@@ -533,9 +584,9 @@ class FileReadAbility extends AbstractFileAbility {
 			return $full_path;
 		}
 
+		clearstatcache( true, $full_path );
 		if ( ! file_exists( $full_path ) ) {
-			// @phpstan-ignore-next-line
-			return new WP_Error( 'sd_ai_agent_file_not_found', sprintf( 'File not found: %s', $path ) );
+			return $this->file_not_found_error( $path, $full_path );
 		}
 
 		if ( ! is_readable( $full_path ) ) {

--- a/includes/Core/WordPressPaths.php
+++ b/includes/Core/WordPressPaths.php
@@ -44,13 +44,18 @@ final class WordPressPaths {
 	/**
 	 * Resolve the content directory.
 	 *
-	 * WordPress exposes helpers for theme and upload directories rather than a
-	 * content-root path helper. The theme root is the most stable public location
-	 * for deriving the surrounding content directory; uploads are the fallback.
+	 * WP_CONTENT_DIR is WordPress' authoritative content root. It remains stable
+	 * when a theme or this plugin is loaded through a symlink, whereas deriving
+	 * the root from get_theme_root() can resolve a different physical directory.
+	 * The helper fallbacks retain compatibility with incomplete test bootstraps.
 	 *
 	 * @return string Absolute directory path without a trailing slash.
 	 */
 	public static function content_dir(): string {
+		if ( defined( 'WP_CONTENT_DIR' ) && '' !== (string) constant( 'WP_CONTENT_DIR' ) ) {
+			return untrailingslashit( (string) constant( 'WP_CONTENT_DIR' ) );
+		}
+
 		$theme_root = get_theme_root();
 		if ( '' !== $theme_root ) {
 			return untrailingslashit( dirname( $theme_root ) );

--- a/tests/SdAiAgent/Abilities/FileAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/FileAbilitiesTest.php
@@ -10,6 +10,8 @@
 namespace SdAiAgent\Tests\Abilities;
 
 use SdAiAgent\Abilities\FileAbilities;
+use SdAiAgent\Core\AgentEventLog;
+use SdAiAgent\Core\WordPressPaths;
 use WP_UnitTestCase;
 
 /**
@@ -173,12 +175,80 @@ class FileAbilitiesTest extends WP_UnitTestCase {
 	 * Test handle_read_file returns WP_Error for non-existent file.
 	 */
 	public function test_handle_read_file_not_found() {
+		$events   = [];
+		$listener = static function ( string $event, string $severity, array $context ) use ( &$events ): void {
+			$events[] = compact( 'event', 'severity', 'context' );
+		};
+		add_action( 'sd_ai_agent_event_logged', $listener, 10, 3 );
+
 		$result = FileAbilities::handle_read_file( [
 			'path' => 'uploads/nonexistent-file-xyz.txt',
 		] );
+		remove_action( 'sd_ai_agent_event_logged', $listener, 10 );
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'sd_ai_agent_file_not_found', $result->get_error_code() );
+		$this->assertSame(
+			[
+				'content_root_resolved' => true,
+				'parent_exists'         => true,
+				'parent_resolved'       => true,
+				'reason'                => 'missing_leaf',
+			],
+			$result->get_error_data()
+		);
+		$this->assertCount( 1, $events );
+		$this->assertSame( 'file_read_not_found', $events[0]['event'] );
+		$this->assertSame( AgentEventLog::SEVERITY_WARNING, $events[0]['severity'] );
+		$this->assertSame( 'missing_leaf', $events[0]['context']['reason'] );
+		$this->assertArrayHasKey( 'args_hash', $events[0]['context'] );
+		$this->assertArrayNotHasKey( 'path', $events[0]['context'] );
+	}
+
+	/**
+	 * An existing sibling must remain correlated to its own result when the
+	 * caller dispatches a missing and an existing read in the same batch.
+	 */
+	public function test_handle_read_file_keeps_sibling_batch_results_distinct() {
+		file_put_contents( $this->test_file_full, 'Existing sibling content' );
+
+		$requests = [
+			'call_missing_sibling'  => [ 'path' => 'uploads/sd-ai-agent-missing-sibling.txt' ],
+			'call_existing_sibling' => [ 'path' => $this->test_file ],
+		];
+		$results  = [];
+		foreach ( $requests as $call_id => $request ) {
+			$results[ $call_id ] = FileAbilities::handle_read_file( $request );
+		}
+
+		$this->assertInstanceOf( \WP_Error::class, $results['call_missing_sibling'] );
+		$this->assertSame( 'sd_ai_agent_file_not_found', $results['call_missing_sibling']->get_error_code() );
+		$this->assertIsArray( $results['call_existing_sibling'] );
+		$this->assertSame( $this->test_file, $results['call_existing_sibling']['path'] );
+		$this->assertSame( 'Existing sibling content', $results['call_existing_sibling']['content'] );
+	}
+
+	/**
+	 * Repeated and resumed reads must resolve the same unchanged canonical path.
+	 */
+	public function test_handle_read_file_repeated_requests_bypass_stale_filesystem_cache() {
+		file_put_contents( $this->test_file_full, 'Stable repeated read content' );
+
+		for ( $request = 0; $request < 3; $request++ ) {
+			$result = FileAbilities::handle_read_file( [ 'path' => $this->test_file ] );
+
+			$this->assertIsArray( $result );
+			$this->assertSame( $this->test_file, $result['path'] );
+			$this->assertSame( 'Stable repeated read content', $result['content'] );
+		}
+	}
+
+	/**
+	 * File abilities must anchor their allowed root to WordPress' content root,
+	 * not to a theme path that may be symlinked elsewhere.
+	 */
+	public function test_file_abilities_use_the_wordpress_content_root() {
+		$this->assertSame( untrailingslashit( WP_CONTENT_DIR ), WordPressPaths::content_dir() );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Clear stale stat and realpath caches before resolving and reading files.
- Anchor file abilities to WordPress' `WP_CONTENT_DIR`, including symlinked installs.
- Return and log path-safe diagnostics for missing files, without absolute paths or file contents.
- Cover sibling batch, repeated-read, and content-root regression cases.

## Testing

- `pnpm run lint:php`
- `php bin/run-wp-phpunit.php --filter=FileAbilitiesTest`
- `composer phpstan`

Resolves #2435

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.264 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 12m and 144,589 tokens on this as a headless worker. Overall, 1h 6m since this issue was created.
