### PR TITLE
feat: reuse repeated readonly file inspections

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -330,6 +330,9 @@ PROMPT;
 	/** @var SpinDetector Tracks consecutive identical tool-call rounds. */
 	private SpinDetector $spin_detector;
 
+	/** @var RunLocalReadonlyToolCache Reuses safe local readonly calls within this run. */
+	private RunLocalReadonlyToolCache $readonly_tool_cache;
+
 	/** @var ClientAbilityRouter Partitions tool calls to PHP or JS handlers. */
 	private ClientAbilityRouter $client_router;
 
@@ -519,7 +522,8 @@ PROMPT;
 		);
 
 		// SpinDetector tracks consecutive identical tool-call rounds.
-		$this->spin_detector = new SpinDetector();
+		$this->spin_detector       = new SpinDetector();
+		$this->readonly_tool_cache = new RunLocalReadonlyToolCache();
 
 		// ClientAbilityRouter validates and routes client-side ability calls.
 		// @phpstan-ignore-next-line
@@ -984,7 +988,11 @@ PROMPT;
 	 * @return array<string, mixed>
 	 */
 	private function with_result_logs( array $payload ): array {
-		$payload['messages'] = $this->message_log;
+		$payload['messages']        = $this->message_log;
+		$payload['run_diagnostics'] = array_merge(
+			$this->readonly_tool_cache->get_diagnostics(),
+			array( 'cumulative_prompt_tokens' => (int) ( $this->token_usage['prompt'] ?? 0 ) )
+		);
 		if ( $this->generated_theme_completion_gate->is_required() ) {
 			$payload['generated_theme_completion'] = $this->generated_theme_completion_gate->get_status();
 		}
@@ -1024,8 +1032,12 @@ PROMPT;
 	 * @return array<string, mixed>
 	 */
 	private function with_paused_logs( array $payload ): array {
-		$payload['message_log'] = $this->message_log;
-		$payload['messages']    = $this->message_log;
+		$payload['message_log']     = $this->message_log;
+		$payload['messages']        = $this->message_log;
+		$payload['run_diagnostics'] = array_merge(
+			$this->readonly_tool_cache->get_diagnostics(),
+			array( 'cumulative_prompt_tokens' => (int) ( $this->token_usage['prompt'] ?? 0 ) )
+		);
 		if ( $this->generated_theme_completion_gate->is_required() ) {
 			$payload['generated_theme_completion'] = $this->generated_theme_completion_gate->get_status();
 		}
@@ -1609,12 +1621,15 @@ PROMPT;
 				continue;
 			}
 
+			$history_message = $assistant_message;
+			$reuse_plan      = $this->readonly_tool_cache->reuse( $assistant_message );
+
 			// Split multi-part assistant messages so each function_call lives
 			// in its own ModelMessage. The OpenAI Responses API rejects
 			// "function_call + other part" shapes (see
 			// ConversationSerializer::append_assistant_message for the full
 			// rationale and provider-side validator reference).
-			$this->append_assistant_message_to_history( $assistant_message );
+			$this->append_assistant_message_to_history( $history_message );
 			$this->save_active_job_checkpoint( self::CHECKPOINT_PROVIDER_RESPONSE_RECORDED, $iterations );
 
 			// Check if the model wants to call tools.
@@ -1731,7 +1746,22 @@ PROMPT;
 			$last_was_tool_call = true;
 
 			// Log tool calls and check for confirmation requirement.
-			$this->log_tool_calls( $assistant_message );
+			$this->log_tool_calls( $history_message );
+			if ( null !== $reuse_plan['reused'] ) {
+				$this->append_tool_response_to_history( $reuse_plan['reused'] );
+				$this->log_tool_responses( $reuse_plan['reused'] );
+				$this->message_log[] = array(
+					'type'     => 'event',
+					'reason'   => 'repeated_readonly_tool_calls_reused',
+					'count'    => $reuse_plan['count'],
+					'sequence' => $this->next_activity_sequence(),
+				);
+				$this->history[]     = new UserMessage(
+					array( new MessagePart( __( 'Do not repeat unchanged local file inspections. Synthesize the results already in this conversation or name the specific missing information needed to continue.', 'superdav-ai-agent' ) ) )
+				);
+			}
+
+			$assistant_message = $reuse_plan['execute'];
 
 			$empty_global_styles_guard = $this->build_empty_global_styles_guard_response( $assistant_message );
 			if ( null !== $empty_global_styles_guard ) {
@@ -1739,6 +1769,11 @@ PROMPT;
 				$this->log_tool_responses( $empty_global_styles_guard );
 				$this->inject_empty_global_styles_update_guidance();
 				$this->last_loop_phase = 'empty_global_styles_update_guarded';
+				continue;
+			}
+
+			if ( ! $this->message_has_function_calls( $assistant_message ) ) {
+				$this->last_loop_phase = 'reused_readonly_tool_results';
 				continue;
 			}
 
@@ -1888,6 +1923,7 @@ PROMPT;
 			$truncated_message = self::truncate_tool_results( $response_message );
 			$this->append_tool_response_to_history( $truncated_message );
 			$this->log_tool_responses( $truncated_message );
+			$this->readonly_tool_cache->record( $history_message, $truncated_message );
 			$this->last_loop_phase = 'tool_response_recorded';
 			$this->save_active_job_checkpoint( self::CHECKPOINT_TOOL_RESPONSE_RECORDED, $iterations );
 

--- a/includes/Core/RunLocalReadonlyToolCache.php
+++ b/includes/Core/RunLocalReadonlyToolCache.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * Reuses safe, local read results within one agent-loop run.
+ *
+ * @package SdAiAgent\Core
+ * @license GPL-2.0-or-later
+ */
+
+namespace SdAiAgent\Core;
+
+use WordPress\AiClient\Messages\DTO\Message;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\DTO\ModelMessage;
+use WordPress\AiClient\Messages\DTO\UserMessage;
+use WordPress\AiClient\Tools\DTO\FunctionCall;
+use WordPress\AiClient\Tools\DTO\FunctionResponse;
+
+/**
+ * Keeps a deliberately narrow cache of immutable local file reads.
+ *
+ * Browser and network tools are volatile by definition. Other readonly
+ * abilities can also depend on mutable WordPress state, so they remain opt-in
+ * until they declare a stronger cache contract. This prevents accidental
+ * caching from changing the behaviour of an existing ability.
+ */
+class RunLocalReadonlyToolCache {
+
+	/** @var array<string, true> Fingerprints executed in this run. */
+	private array $executed = array();
+
+	/** @var int Number of calls replaced by prior-result references. */
+	private int $reused_calls = 0;
+
+	/** @var int Number of batches which repeated a prior inspection. */
+	private int $repeated_call_warnings = 0;
+
+	/**
+	 * Split a model tool-call message into calls that must execute and concise
+	 * responses for safe calls that already executed in this run.
+	 *
+	 * @param Message $message Assistant tool-call message.
+	 * @return array{execute:Message,reused:?Message,count:int}
+	 */
+	public function reuse( Message $message ): array {
+		$execute_parts  = array();
+		$response_parts = array();
+		$reused         = 0;
+
+		if ( $this->message_has_mutation( $message ) ) {
+			$this->executed = array();
+		}
+
+		foreach ( $message->getParts() as $part ) {
+			$call = $part->getFunctionCall();
+			if ( ! $call ) {
+				$execute_parts[] = $part;
+				continue;
+			}
+
+			$key = $this->fingerprint( $call );
+			if (
+				'' === $key
+				|| ! $this->is_cacheable_local_read( $call )
+				|| ! isset( $this->executed[ $key ] )
+			) {
+				$execute_parts[] = $part;
+				continue;
+			}
+
+			++$reused;
+			$response_parts[] = new MessagePart(
+				new FunctionResponse(
+					(string) $call->getId(),
+					(string) $call->getName(),
+					array(
+						'reused'  => true,
+						'message' => 'This unchanged local file was already read earlier in this run. Use the prior result in the conversation rather than reading it again.',
+					)
+				)
+			);
+		}
+
+		if ( $reused > 0 ) {
+			$this->reused_calls += $reused;
+			++$this->repeated_call_warnings;
+		}
+
+		return array(
+			'execute' => new ModelMessage( $execute_parts ),
+			'reused'  => empty( $response_parts ) ? null : new UserMessage( $response_parts ),
+			'count'   => $reused,
+		);
+	}
+
+	/**
+	 * Record safe local reads which completed successfully.
+	 *
+	 * @param Message      $message   Assistant tool-call message.
+	 * @param Message|null $responses Tool responses, when available.
+	 */
+	public function record( Message $message, ?Message $responses = null ): void {
+		foreach ( $message->getParts() as $part ) {
+			$call = $part->getFunctionCall();
+			if (
+				! $call
+				|| ! $this->is_cacheable_local_read( $call )
+				|| ( null !== $responses && ! $this->has_successful_response( $call, $responses ) )
+			) {
+				continue;
+			}
+
+			$key = $this->fingerprint( $call );
+			if ( '' !== $key ) {
+				$this->executed[ $key ] = true;
+			}
+		}
+	}
+
+	/**
+	 * @param FunctionCall $call      File read that completed.
+	 * @param Message      $responses Tool response message.
+	 * @return bool True when the matching response did not report an error.
+	 */
+	private function has_successful_response( FunctionCall $call, Message $responses ): bool {
+		foreach ( $responses->getParts() as $part ) {
+			$response = $part->getFunctionResponse();
+			if ( ! $response || (string) $response->getId() !== (string) $call->getId() ) {
+				continue;
+			}
+
+			$result = $response->getResponse();
+			return ! $result instanceof \WP_Error
+				&& ( ! is_array( $result ) || ! array_key_exists( 'error', $result ) );
+		}
+
+		return false;
+	}
+
+	/**
+	 * Return lightweight per-run diagnostics for result payloads and logs.
+	 *
+	 * @return array{unique_readonly_calls:int,reused_readonly_calls:int,repeated_call_warnings:int}
+	 */
+	public function get_diagnostics(): array {
+		return array(
+			'unique_readonly_calls'  => count( $this->executed ),
+			'reused_readonly_calls'  => $this->reused_calls,
+			'repeated_call_warnings' => $this->repeated_call_warnings,
+		);
+	}
+
+	/**
+	 * @param Message $message Assistant tool-call message.
+	 * @return bool True when the batch contains a potentially invalidating call.
+	 */
+	private function message_has_mutation( Message $message ): bool {
+		foreach ( $message->getParts() as $part ) {
+			$call = $part->getFunctionCall();
+			if ( $call && ! $this->is_cacheable_local_read( $call ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * @param FunctionCall $call Function call to evaluate.
+	 * @return bool True when the call is a safe local file read.
+	 */
+	private function is_cacheable_local_read( FunctionCall $call ): bool {
+		$name = self::canonical_name( (string) $call->getName() );
+		if ( 'sd-ai-agent/file-read' !== $name ) {
+			return false;
+		}
+
+		$args = $call->getArgs();
+		return is_array( $args )
+			&& isset( $args['path'] )
+			&& is_string( $args['path'] )
+			&& '' !== $args['path'];
+	}
+
+	/**
+	 * @param FunctionCall $call Function call to fingerprint.
+	 * @return string Stable call fingerprint, or an empty string when unavailable.
+	 */
+	private function fingerprint( FunctionCall $call ): string {
+		$name = self::canonical_name( (string) $call->getName() );
+		if ( '' === $name ) {
+			return '';
+		}
+
+		$args = wp_json_encode( self::canonicalize_args( $call->getArgs() ) );
+		return is_string( $args ) ? hash( 'sha256', $name . "\n" . $args ) : '';
+	}
+
+	/**
+	 * @param mixed $value Raw function arguments.
+	 * @return mixed Canonical arguments.
+	 */
+	private static function canonicalize_args( $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+
+		if ( ! array_is_list( $value ) ) {
+			ksort( $value );
+		}
+
+		foreach ( $value as $key => $item ) {
+			$value[ $key ] = self::canonicalize_args( $item );
+		}
+
+		return $value;
+	}
+
+	private static function canonical_name( string $name ): string {
+		if ( str_starts_with( $name, 'wpab__sd-ai-agent__' ) ) {
+			return 'sd-ai-agent/' . substr( $name, strlen( 'wpab__sd-ai-agent__' ) );
+		}
+
+		return $name;
+	}
+}

--- a/tests/SdAiAgent/Core/RunLocalReadonlyToolCacheTest.php
+++ b/tests/SdAiAgent/Core/RunLocalReadonlyToolCacheTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SdAiAgent\Tests\Core;
+
+use SdAiAgent\Core\RunLocalReadonlyToolCache;
+use WordPress\AiClient\Messages\DTO\MessagePart;
+use WordPress\AiClient\Messages\DTO\ModelMessage;
+use WordPress\AiClient\Tools\DTO\FunctionCall;
+use WP_UnitTestCase;
+
+/** @group agent-loop */
+class RunLocalReadonlyToolCacheTest extends WP_UnitTestCase {
+
+	public function test_reuses_normalized_file_read_arguments_within_one_run(): void {
+		if ( ! class_exists( ModelMessage::class ) ) {
+			$this->markTestSkipped( 'WP AI Client message classes are not available.' );
+		}
+
+		$cache = new RunLocalReadonlyToolCache();
+		$first = new ModelMessage(
+			array(
+				new MessagePart(
+					new FunctionCall(
+						'first',
+						'wpab__sd-ai-agent__file-read',
+						array( 'path' => 'theme/style.css', 'options' => array( 'b' => 2, 'a' => 1 ) )
+					)
+				),
+			)
+		);
+		$cache->record( $first );
+
+		$second = new ModelMessage(
+			array(
+				new MessagePart(
+					new FunctionCall(
+						'second',
+						'wpab__sd-ai-agent__file-read',
+						array( 'options' => array( 'a' => 1, 'b' => 2 ), 'path' => 'theme/style.css' )
+					)
+				),
+			)
+		);
+		$plan = $cache->reuse( $second );
+
+		$this->assertSame( 1, $plan['count'] );
+		$this->assertNotNull( $plan['reused'] );
+		$this->assertCount( 0, $plan['execute']->getParts() );
+		$this->assertSame( 1, $cache->get_diagnostics()['reused_readonly_calls'] );
+	}
+
+	public function test_mutation_invalidates_cached_file_read(): void {
+		if ( ! class_exists( ModelMessage::class ) ) {
+			$this->markTestSkipped( 'WP AI Client message classes are not available.' );
+		}
+
+		$cache = new RunLocalReadonlyToolCache();
+		$read  = new ModelMessage(
+			array( new MessagePart( new FunctionCall( 'read', 'wpab__sd-ai-agent__file-read', array( 'path' => 'theme/style.css' ) ) ) )
+		);
+		$cache->record( $read );
+		$write = new ModelMessage(
+			array( new MessagePart( new FunctionCall( 'write', 'wpab__sd-ai-agent__file-write', array( 'path' => 'theme/style.css', 'content' => 'changed' ) ) ) )
+		);
+		$cache->reuse( $write );
+
+		$plan = $cache->reuse( $read );
+		$this->assertSame( 0, $plan['count'] );
+		$this->assertCount( 1, $plan['execute']->getParts() );
+	}
+
+	public function test_reuses_overlapping_readonly_batch_when_one_call_changes(): void {
+		if ( ! class_exists( ModelMessage::class ) ) {
+			$this->markTestSkipped( 'WP AI Client message classes are not available.' );
+		}
+
+		$cache = new RunLocalReadonlyToolCache();
+		$first = new ModelMessage(
+			array(
+				new MessagePart( new FunctionCall( 'first-a', 'wpab__sd-ai-agent__file-read', array( 'path' => 'theme/a.css' ) ) ),
+				new MessagePart( new FunctionCall( 'first-b', 'wpab__sd-ai-agent__file-read', array( 'path' => 'theme/b.css' ) ) ),
+			)
+		);
+		$cache->record( $first );
+
+		$second = new ModelMessage(
+			array(
+				new MessagePart( new FunctionCall( 'second-a', 'wpab__sd-ai-agent__file-read', array( 'path' => 'theme/a.css' ) ) ),
+				new MessagePart( new FunctionCall( 'second-c', 'wpab__sd-ai-agent__file-read', array( 'path' => 'theme/c.css' ) ) ),
+			)
+		);
+		$plan = $cache->reuse( $second );
+
+		$this->assertSame( 1, $plan['count'] );
+		$this->assertCount( 1, $plan['execute']->getParts() );
+	}
+
+	public function test_does_not_cache_volatile_client_tool(): void {
+		if ( ! class_exists( ModelMessage::class ) ) {
+			$this->markTestSkipped( 'WP AI Client message classes are not available.' );
+		}
+
+		$cache      = new RunLocalReadonlyToolCache();
+		$screenshot = new ModelMessage(
+			array( new MessagePart( new FunctionCall( 'shot', 'wpab__sd-ai-agent-js__capture-screenshot', array( 'url' => '/' ) ) ) )
+		);
+		$cache->record( $screenshot );
+		$plan = $cache->reuse( $screenshot );
+
+		$this->assertSame( 0, $plan['count'] );
+		$this->assertCount( 1, $plan['execute']->getParts() );
+	}
+}


### PR DESCRIPTION
## Summary
- reuse repeated `sd-ai-agent/file-read` calls during one agent run
- invalidate cached read fingerprints on any other tool call
- log reuse warnings and expose run diagnostics

## Verification
- `pnpm run lint:php`
- `php bin/run-wp-phpunit.php --filter='RunLocalReadonlyToolCacheTest|AgentLoopTest|SpinDetector|ToolResultTruncatorTest'`

Resolves #2436

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.264 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra
