### PR TITLE
GH#2450: recover client-tool timeouts without replay

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -2485,10 +2485,7 @@ PROMPT;
 			$last_retry_after_seconds = $this->extract_retry_after_seconds( $last_error );
 			$backoff_delays[]         = $delay;
 			$this->log_provider_retry_progress( $status_code, $attempt + 1, $delay );
-
-			if ( $delay > 0 ) {
-				sleep( $delay );
-			}
+			$this->wait_for_provider_retry( $delay );
 		}
 
 		$elapsed_seconds = max( 0, (int) round( microtime( true ) - $started_at ) );
@@ -2600,6 +2597,24 @@ PROMPT;
 
 		$index = max( 0, $attempt - 1 );
 		return (int) ( $this->provider_retry_delays[ $index ] ?? 60 );
+	}
+
+	/**
+	 * Wait between transient provider attempts while keeping the active job alive.
+	 *
+	 * The managed-provider retry window can now include a 16-second delay. A
+	 * one-second heartbeat preserves the post-client-result job/checkpoint if a
+	 * stale-job monitor runs while that accepted continuation is backing off.
+	 *
+	 * @param int $delay Delay in seconds, already bounded by retry configuration.
+	 */
+	private function wait_for_provider_retry( int $delay ): void {
+		for ( $remaining = max( 0, $delay ); $remaining > 0; --$remaining ) {
+			if ( '' !== $this->active_job_id ) {
+				ActiveJobRepository::heartbeat( $this->active_job_id );
+			}
+			sleep( 1 );
+		}
 	}
 
 	/**

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -85,8 +85,14 @@ class AgentLoop {
 	/** Maximum provider-call attempts for retryable transient failures. */
 	private const PROVIDER_RETRY_MAX_ATTEMPTS = 4;
 
+	/** Longer managed-service retry budget for short edge/network outages. */
+	private const MANAGED_PROVIDER_RETRY_MAX_ATTEMPTS = 6;
+
 	/** Default exponential backoff schedule in seconds. */
 	private const PROVIDER_RETRY_DELAYS = array( 1, 2, 4 );
+
+	/** Managed-service backoff schedule: 31 seconds before the final attempt. */
+	private const MANAGED_PROVIDER_RETRY_DELAYS = array( 1, 2, 4, 8, 16 );
 
 	/** Durable checkpoint phase saved before a provider call is attempted. */
 	public const CHECKPOINT_BEFORE_PROVIDER_CALL = 'before_provider_call';
@@ -472,10 +478,17 @@ PROMPT;
 		$this->active_job_id = (string) ( $options['active_job_id'] ?? '' );
 
 		$this->checkpoint_resume_metadata = self::checkpoint_resume_metadata_from_candidate( $options['checkpoint_resume_metadata'] ?? array() );
-		// @phpstan-ignore-next-line -- Test/job callers may lower attempts or delays; production defaults remain four attempts.
-		$this->provider_retry_max_attempts = max( 1, (int) ( $options['provider_retry_max_attempts'] ?? self::PROVIDER_RETRY_MAX_ATTEMPTS ) );
+		$is_managed_provider              = SuperdavAiProvider::PROVIDER_ID === (string) $this->provider_id;
+		$default_retry_attempts           = $is_managed_provider
+			? self::MANAGED_PROVIDER_RETRY_MAX_ATTEMPTS
+			: self::PROVIDER_RETRY_MAX_ATTEMPTS;
+		$default_retry_delays             = $is_managed_provider
+			? self::MANAGED_PROVIDER_RETRY_DELAYS
+			: self::PROVIDER_RETRY_DELAYS;
+		// @phpstan-ignore-next-line -- Test/job callers may lower attempts or delays; managed production calls tolerate short outages by default.
+		$this->provider_retry_max_attempts = max( 1, (int) ( $options['provider_retry_max_attempts'] ?? $default_retry_attempts ) );
 		// @phpstan-ignore-next-line -- Values are normalised below to non-negative integer seconds.
-		$retry_delays = $options['provider_retry_delays'] ?? self::PROVIDER_RETRY_DELAYS;
+		$retry_delays = $options['provider_retry_delays'] ?? $default_retry_delays;
 		if ( is_array( $retry_delays ) ) {
 			$this->provider_retry_delays = array_map(
 				static fn( $delay ): int => max( 0, min( 60, (int) $delay ) ),

--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -605,6 +605,7 @@ Assistant: %s',
 				'completion' => 0,
 			),
 			'session_id'       => $session_id,
+			'active_job_id'    => $job_id,
 			'client_abilities' => $paused_state['client_abilities'] ?? array(),
 			'page_context'     => $paused_state['page_context'] ?? array(),
 		);

--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -636,13 +636,16 @@ Assistant: %s',
 		$result             = $loop->resume_after_client_tools( $tool_results_typed, $iterations_remaining );
 
 		if ( is_wp_error( $result ) ) {
-			// Sync the job transient/DB row to 'error' so the browser's poll
-			// loop sees a terminal state and stops re-issuing the same
-			// pending client tool call. Without this, the transient still
-			// says 'awaiting_client_tools' and the next poll cycle produces
-			// an infinite 409 loop on /chat/tool-result.
-			self::mark_job_error_after_resume(
+			// The browser results have already been validated, consumed, and
+			// appended to the resumed history. A provider failure from this point
+			// is a job-continuation failure, not a failed tool-result delivery.
+			// Return a bounded accepted response so the browser polls the terminal
+			// job and offers durable resume instead of POSTing the same results
+			// again. Returning the raw WP_Error previously leaked up to ~1 MB of
+			// recovery history and triggered two invalid result-mismatch retries.
+			return self::accepted_tool_result_failure_response(
 				$job_id,
+				$session_id,
 				$result,
 				array(
 					'last_safe_phase' => 'client_tool_resume',
@@ -650,8 +653,6 @@ Assistant: %s',
 					'model_id'        => (string) ( $options['model_id'] ?? '' ),
 				)
 			);
-
-			return $result;
 		}
 
 		/** @var array<string, mixed> $result */
@@ -842,6 +843,33 @@ Assistant: %s',
 	}
 
 	/**
+	 * Return a compact acknowledgement after client results were accepted but
+	 * the resumed provider call failed. The browser must poll/resume the job;
+	 * it must not submit the already-consumed result batch again.
+	 *
+	 * @param string               $job_id    Job UUID supplied by the browser.
+	 * @param int                  $session_id Owning session identifier.
+	 * @param WP_Error             $error     Provider/loop continuation error.
+	 * @param array<string, mixed> $context   Allowlisted diagnostic metadata.
+	 */
+	private static function accepted_tool_result_failure_response( string $job_id, int $session_id, WP_Error $error, array $context ): WP_REST_Response {
+		$recovery = self::mark_job_error_after_resume( $job_id, $error, $context, $session_id );
+
+		return new WP_REST_Response(
+			array(
+				'status'           => 'recoverable_error',
+				'results_accepted' => true,
+				'recoverable'      => $recovery['recoverable'],
+				'session_id'       => $session_id,
+				'job_id'           => $job_id,
+				'message'          => ActiveJobFailureDiagnostic::message_for( (string) $recovery['diagnostic']['reason'] ),
+				'diagnostic'       => ActiveJobFailureDiagnostic::to_rest( $recovery['diagnostic'] ),
+			),
+			202
+		);
+	}
+
+	/**
 	 * Mark a job as 'error' on both the transient and the DB row.
 	 *
 	 * Called from /chat/tool-result when resume_after_client_tools() returns
@@ -852,32 +880,37 @@ Assistant: %s',
 	 * (paused_state was already consumed before resume_after_client_tools
 	 * ran).
 	 *
-	 * @param string               $job_id  Job UUID supplied by the browser. No-op when empty.
-	 * @param WP_Error             $error   Error returned by the resumed loop.
-	 * @param array<string, mixed> $context Allowlisted diagnostic metadata.
+	 * @param string               $job_id    Job UUID supplied by the browser.
+	 * @param WP_Error             $error     Error returned by the resumed loop.
+	 * @param array<string, mixed> $context   Allowlisted diagnostic metadata.
+	 * @param int                  $session_id Owning session with durable recovery state.
+	 * @return array{diagnostic:array<string,bool|int|string>,recoverable:bool} Safe recovery result.
 	 */
-	private static function mark_job_error_after_resume( string $job_id, WP_Error $error, array $context = array() ): void {
+	private static function mark_job_error_after_resume( string $job_id, WP_Error $error, array $context = array(), int $session_id = 0 ): array {
+		$error_data  = $error->get_error_data();
+		$error_data  = is_array( $error_data ) ? $error_data : array();
+		$context     = array_merge( ActiveJobFailureDiagnostic::context_from_error_data( $error_data ), $context );
+		$reason      = ActiveJobFailureDiagnostic::reason_from_error( $error, (string) ( $context['provider_id'] ?? '' ) );
+		$diagnostic  = ActiveJobFailureDiagnostic::create( $job_id, $reason, $context );
+		$recoverable = self::session_has_recoverable_state( $session_id );
+
 		if ( '' === $job_id ) {
-			return;
+			return array(
+				'diagnostic'  => $diagnostic,
+				'recoverable' => $recoverable,
+			);
 		}
 
 		$transient_key = self::JOB_PREFIX . $job_id;
 		$job           = get_transient( $transient_key );
-		$error_data    = $error->get_error_data();
-		$error_data    = is_array( $error_data ) ? $error_data : array();
-		$context       = array_merge( ActiveJobFailureDiagnostic::context_from_error_data( $error_data ), $context );
-		$diagnostic    = ActiveJobRepository::record_failure(
-			$job_id,
-			'error',
-			ActiveJobFailureDiagnostic::reason_from_error( $error ),
-			$context
-		);
+		$diagnostic    = ActiveJobRepository::record_failure( $job_id, 'error', $reason, $context );
 
 		if ( is_array( $job ) ) {
 			unset( $job['token'], $job['tool_calls'], $job['messages'] );
-			$job['status']     = 'error';
-			$job['error']      = ActiveJobFailureDiagnostic::message_for( (string) $diagnostic['reason'] );
-			$job['diagnostic'] = ActiveJobFailureDiagnostic::to_rest( $diagnostic );
+			$job['status']      = 'error';
+			$job['error']       = ActiveJobFailureDiagnostic::message_for( (string) $diagnostic['reason'] );
+			$job['diagnostic']  = ActiveJobFailureDiagnostic::to_rest( $diagnostic );
+			$job['recoverable'] = $recoverable;
 
 			// Drop stale pending-call hints so a transient-served poll cannot
 			// re-emit 'awaiting_client_tools' for the next browser poll.
@@ -885,6 +918,29 @@ Assistant: %s',
 
 			set_transient( $transient_key, $job, self::JOB_TTL );
 		}
+
+		return array(
+			'diagnostic'  => $diagnostic,
+			'recoverable' => $recoverable,
+		);
+	}
+
+	/**
+	 * Check whether AgentLoop saved a bounded continuation for this session.
+	 */
+	private static function session_has_recoverable_state( int $session_id ): bool {
+		if ( $session_id <= 0 ) {
+			return false;
+		}
+
+		$session = Database::get_session( $session_id );
+		if ( ! $session || empty( $session->paused_state ) ) {
+			return false;
+		}
+
+		$state = json_decode( (string) $session->paused_state, true );
+
+		return is_array( $state ) && ! empty( $state['history'] ) && is_array( $state['history'] );
 	}
 
 	/**

--- a/src/components/chat-composer/__tests__/use-chat-composer.test.js
+++ b/src/components/chat-composer/__tests__/use-chat-composer.test.js
@@ -127,9 +127,11 @@ describe( 'useChatComposer', () => {
 	let root;
 	let dispatchers;
 	let pendingActionCard;
+	let pendingToolResultRetry;
 
 	beforeEach( async () => {
 		pendingActionCard = null;
+		pendingToolResultRetry = null;
 		dispatchers = {
 			sendMessage: jest.fn(),
 			stopGeneration: jest.fn(),
@@ -145,6 +147,7 @@ describe( 'useChatComposer', () => {
 			getMessageQueue: () => [],
 			getCurrentSessionId: () => 17,
 			getPendingActionCard: () => pendingActionCard,
+			getPendingToolResultRetry: () => pendingToolResultRetry,
 		};
 		useDispatch.mockReturnValue( dispatchers );
 		useSelect.mockImplementation( ( callback ) =>
@@ -172,7 +175,12 @@ describe( 'useChatComposer', () => {
 	] )(
 		'typed retry dispatches %s recovery instead of a new message',
 		async ( cardType, expectedAction ) => {
-			pendingActionCard = { type: cardType, sessionId: 17 };
+			pendingActionCard =
+				cardType === 'retry_client_tools'
+					? { type: cardType }
+					: { type: cardType, sessionId: 17 };
+			pendingToolResultRetry =
+				cardType === 'retry_client_tools' ? { sessionId: 17 } : null;
 			await act( async () => {
 				root.render( createElement( ComposerHarness ) );
 			} );
@@ -190,6 +198,25 @@ describe( 'useChatComposer', () => {
 			expect( container.querySelector( 'textarea' ).value ).toBe( '' );
 		}
 	);
+
+	test( 'typed retry ignores recovery state from another session', async () => {
+		pendingActionCard = {
+			type: 'resume_recoverable_job',
+			sessionId: 18,
+		};
+		await act( async () => {
+			root.render( createElement( ComposerHarness ) );
+		} );
+		await act( async () => {
+			setTextareaValue( container, 'retry' );
+			container
+				.querySelector( '[data-send]' )
+				.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+		} );
+
+		expect( dispatchers.resumeRecoverableJob ).not.toHaveBeenCalled();
+		expect( dispatchers.sendMessage ).toHaveBeenCalledWith( 'retry', [] );
+	} );
 
 	test( 'supports durable-plan commands identically on both surfaces', async () => {
 		await act( async () => {

--- a/src/components/chat-composer/__tests__/use-chat-composer.test.js
+++ b/src/components/chat-composer/__tests__/use-chat-composer.test.js
@@ -126,8 +126,10 @@ describe( 'useChatComposer', () => {
 	let container;
 	let root;
 	let dispatchers;
+	let pendingActionCard;
 
 	beforeEach( async () => {
+		pendingActionCard = null;
 		dispatchers = {
 			sendMessage: jest.fn(),
 			stopGeneration: jest.fn(),
@@ -135,11 +137,14 @@ describe( 'useChatComposer', () => {
 			compactConversation: jest.fn(),
 			exportSession: jest.fn(),
 			setShowShortcutsHelp: jest.fn(),
+			retryClientToolSubmission: jest.fn(),
+			resumeRecoverableJob: jest.fn(),
 		};
 		const selectors = {
 			isSending: () => false,
 			getMessageQueue: () => [],
 			getCurrentSessionId: () => 17,
+			getPendingActionCard: () => pendingActionCard,
 		};
 		useDispatch.mockReturnValue( dispatchers );
 		useSelect.mockImplementation( ( callback ) =>
@@ -160,6 +165,31 @@ describe( 'useChatComposer', () => {
 		container.remove();
 		jest.clearAllMocks();
 	} );
+
+	test.each( [
+		[ 'resume_recoverable_job', 'resumeRecoverableJob' ],
+		[ 'retry_client_tools', 'retryClientToolSubmission' ],
+	] )(
+		'typed retry dispatches %s recovery instead of a new message',
+		async ( cardType, expectedAction ) => {
+			pendingActionCard = { type: cardType, sessionId: 17 };
+			await act( async () => {
+				root.render( createElement( ComposerHarness ) );
+			} );
+			await act( async () => {
+				setTextareaValue( container, '  retry  ' );
+				container
+					.querySelector( '[data-send]' )
+					.dispatchEvent(
+						new MouseEvent( 'click', { bubbles: true } )
+					);
+			} );
+
+			expect( dispatchers[ expectedAction ] ).toHaveBeenCalledTimes( 1 );
+			expect( dispatchers.sendMessage ).not.toHaveBeenCalled();
+			expect( container.querySelector( 'textarea' ).value ).toBe( '' );
+		}
+	);
 
 	test( 'supports durable-plan commands identically on both surfaces', async () => {
 		await act( async () => {

--- a/src/components/chat-composer/use-chat-composer.js
+++ b/src/components/chat-composer/use-chat-composer.js
@@ -66,16 +66,23 @@ export default function useChatComposer( {
 		retryClientToolSubmission,
 		resumeRecoverableJob,
 	} = useDispatch( STORE_NAME );
-	const { sending, queueCount, currentSessionId, pendingActionCard } =
-		useSelect(
-			( sel ) => ( {
-				sending: sel( STORE_NAME ).isSending(),
-				queueCount: sel( STORE_NAME ).getMessageQueue().length,
-				currentSessionId: sel( STORE_NAME ).getCurrentSessionId(),
-				pendingActionCard: sel( STORE_NAME ).getPendingActionCard(),
-			} ),
-			[]
-		);
+	const {
+		sending,
+		queueCount,
+		currentSessionId,
+		pendingActionCard,
+		pendingToolResultRetry,
+	} = useSelect(
+		( sel ) => ( {
+			sending: sel( STORE_NAME ).isSending(),
+			queueCount: sel( STORE_NAME ).getMessageQueue().length,
+			currentSessionId: sel( STORE_NAME ).getCurrentSessionId(),
+			pendingActionCard: sel( STORE_NAME ).getPendingActionCard(),
+			pendingToolResultRetry:
+				sel( STORE_NAME ).getPendingToolResultRetry?.(),
+		} ),
+		[]
+	);
 
 	const [ text, setText ] = useState( '' );
 	const [ showSlash, setShowSlash ] = useState( false );
@@ -195,9 +202,13 @@ export default function useChatComposer( {
 			return;
 		}
 
+		const recoverySessionId =
+			pendingActionCard?.sessionId ||
+			( pendingActionCard?.type === 'retry_client_tools'
+				? pendingToolResultRetry?.sessionId
+				: null );
 		const cardMatchesSession =
-			! pendingActionCard?.sessionId ||
-			pendingActionCard.sessionId === currentSessionId;
+			! recoverySessionId || recoverySessionId === currentSessionId;
 		if (
 			trimmed.toLowerCase() === 'retry' &&
 			! attachments.length &&
@@ -285,6 +296,7 @@ export default function useChatComposer( {
 		clearComposer,
 		focusTextarea,
 		pendingActionCard,
+		pendingToolResultRetry,
 		currentSessionId,
 		resumeRecoverableJob,
 		retryClientToolSubmission,

--- a/src/components/chat-composer/use-chat-composer.js
+++ b/src/components/chat-composer/use-chat-composer.js
@@ -63,15 +63,19 @@ export default function useChatComposer( {
 		compactConversation,
 		exportSession,
 		setShowShortcutsHelp,
+		retryClientToolSubmission,
+		resumeRecoverableJob,
 	} = useDispatch( STORE_NAME );
-	const { sending, queueCount, currentSessionId } = useSelect(
-		( sel ) => ( {
-			sending: sel( STORE_NAME ).isSending(),
-			queueCount: sel( STORE_NAME ).getMessageQueue().length,
-			currentSessionId: sel( STORE_NAME ).getCurrentSessionId(),
-		} ),
-		[]
-	);
+	const { sending, queueCount, currentSessionId, pendingActionCard } =
+		useSelect(
+			( sel ) => ( {
+				sending: sel( STORE_NAME ).isSending(),
+				queueCount: sel( STORE_NAME ).getMessageQueue().length,
+				currentSessionId: sel( STORE_NAME ).getCurrentSessionId(),
+				pendingActionCard: sel( STORE_NAME ).getPendingActionCard(),
+			} ),
+			[]
+		);
 
 	const [ text, setText ] = useState( '' );
 	const [ showSlash, setShowSlash ] = useState( false );
@@ -191,6 +195,28 @@ export default function useChatComposer( {
 			return;
 		}
 
+		const cardMatchesSession =
+			! pendingActionCard?.sessionId ||
+			pendingActionCard.sessionId === currentSessionId;
+		if (
+			trimmed.toLowerCase() === 'retry' &&
+			! attachments.length &&
+			cardMatchesSession
+		) {
+			if ( pendingActionCard?.type === 'resume_recoverable_job' ) {
+				resumeRecoverableJob();
+				clearComposer();
+				focusTextarea();
+				return;
+			}
+			if ( pendingActionCard?.type === 'retry_client_tools' ) {
+				retryClientToolSubmission();
+				clearComposer();
+				focusTextarea();
+				return;
+			}
+		}
+
 		if ( ! isSimpleMode && trimmed.startsWith( REMEMBER_PREFIX ) ) {
 			const fact = trimmed.slice( REMEMBER_PREFIX.length ).trim();
 			if ( fact ) {
@@ -258,6 +284,10 @@ export default function useChatComposer( {
 		sendMessage,
 		clearComposer,
 		focusTextarea,
+		pendingActionCard,
+		currentSessionId,
+		resumeRecoverableJob,
+		retryClientToolSubmission,
 	] );
 
 	const handleSlashSelect = useCallback(

--- a/src/components/chat-widget/__tests__/new-chat-actions.test.js
+++ b/src/components/chat-widget/__tests__/new-chat-actions.test.js
@@ -74,6 +74,7 @@ function selectors() {
 	return {
 		getCurrentSessionId: () => 7,
 		getMessageQueue: () => [],
+		getPendingActionCard: () => null,
 		getProviders: () => [],
 		getSelectedProviderId: () => '',
 		getSelectedModelId: () => '',
@@ -95,6 +96,8 @@ function actions() {
 		exportSession: jest.fn(),
 		fetchSessions: jest.fn(),
 		openSession: jest.fn(),
+		resumeRecoverableJob: jest.fn(),
+		retryClientToolSubmission: jest.fn(),
 		sendMessage: jest.fn(),
 		setFloatingOpen: jest.fn(),
 		stopGeneration: jest.fn(),

--- a/src/components/chat-widget/__tests__/widget-message-list.test.js
+++ b/src/components/chat-widget/__tests__/widget-message-list.test.js
@@ -177,9 +177,9 @@ describe( 'WidgetMessageList recoverable-job action card', () => {
 			hasStreamError: () => true,
 			getPendingActionCard: () => ( {
 				type: 'retry_client_tools',
-				sessionId: 123,
 				toolNames: [ 'sd-ai-agent-js/screenshot-url' ],
 			} ),
+			getPendingToolResultRetry: () => ( { sessionId: 123 } ),
 			getProviders: () => [],
 		};
 		useSelect.mockImplementation( ( fn ) => fn( () => selectors ) );

--- a/src/components/chat-widget/__tests__/widget-message-list.test.js
+++ b/src/components/chat-widget/__tests__/widget-message-list.test.js
@@ -164,6 +164,117 @@ describe( 'WidgetMessageList recoverable-job action card', () => {
 			root.unmount();
 		} );
 	} );
+
+	test( 'renders preserved client-result Retry without the generic error button', async () => {
+		const retryClientToolSubmission = jest.fn();
+		const selectors = {
+			getCurrentSessionMessages: () => [],
+			isSending: () => false,
+			getCurrentSessionId: () => 123,
+			getLiveToolCalls: () => [],
+			getSessionJobs: () => ( {} ),
+			getSettings: () => ( {} ),
+			hasStreamError: () => true,
+			getPendingActionCard: () => ( {
+				type: 'retry_client_tools',
+				sessionId: 123,
+				toolNames: [ 'sd-ai-agent-js/screenshot-url' ],
+			} ),
+			getProviders: () => [],
+		};
+		useSelect.mockImplementation( ( fn ) => fn( () => selectors ) );
+		useDispatch.mockReturnValue( {
+			sendMessage: jest.fn(),
+			retryLastMessage: jest.fn(),
+			retryClientToolSubmission,
+			resumeRecoverableJob: jest.fn(),
+			compactConversation: jest.fn(),
+			setPendingActionCard: jest.fn(),
+		} );
+
+		const container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		const root = createRoot( container );
+		await act( async () => {
+			root.render( createElement( WidgetMessageList ) );
+		} );
+
+		expect(
+			container.querySelector( '.sdaa-w-retry-failed-step' )
+		).toBeNull();
+		const retryButton = container.querySelector(
+			'.sdaa-action-card--retry .sdaa-action-card-btn-confirm'
+		);
+		expect( retryButton ).not.toBeNull();
+		expect( retryButton.textContent ).toBe( 'Retry' );
+
+		await act( async () => {
+			retryButton.dispatchEvent(
+				new MouseEvent( 'click', { bubbles: true } )
+			);
+		} );
+		expect( retryClientToolSubmission ).toHaveBeenCalledTimes( 1 );
+
+		await act( async () => {
+			root.unmount();
+		} );
+	} );
+
+	test( 'renders durable Resume and dispatches resumeRecoverableJob', async () => {
+		const resumeRecoverableJob = jest.fn();
+		const selectors = {
+			getCurrentSessionMessages: () => [],
+			isSending: () => false,
+			getCurrentSessionId: () => 123,
+			getLiveToolCalls: () => [],
+			getSessionJobs: () => ( {} ),
+			getSettings: () => ( {} ),
+			hasStreamError: () => false,
+			getPendingActionCard: () => ( {
+				type: 'resume_recoverable_job',
+				sessionId: 123,
+				diagnostic: {
+					next_action: 'retry',
+					last_safe_phase: 'client_tool_resume',
+					correlation_id: 'job-abcdef123456',
+				},
+			} ),
+			getProviders: () => [],
+		};
+		useSelect.mockImplementation( ( fn ) => fn( () => selectors ) );
+		useDispatch.mockReturnValue( {
+			sendMessage: jest.fn(),
+			retryLastMessage: jest.fn(),
+			retryClientToolSubmission: jest.fn(),
+			resumeRecoverableJob,
+			compactConversation: jest.fn(),
+			setPendingActionCard: jest.fn(),
+		} );
+
+		const container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		const root = createRoot( container );
+		await act( async () => {
+			root.render( createElement( WidgetMessageList ) );
+		} );
+
+		const resumeButton = container.querySelector(
+			'.sdaa-action-card--resume .sdaa-action-card-btn-confirm'
+		);
+		expect( resumeButton ).not.toBeNull();
+		expect( resumeButton.textContent ).toBe( 'Retry failed step' );
+
+		await act( async () => {
+			resumeButton.dispatchEvent(
+				new MouseEvent( 'click', { bubbles: true } )
+			);
+		} );
+		expect( resumeRecoverableJob ).toHaveBeenCalledTimes( 1 );
+
+		await act( async () => {
+			root.unmount();
+		} );
+	} );
 } );
 
 describe( 'WidgetMessageList compact conversation action card', () => {

--- a/src/components/chat-widget/widget-message-list.js
+++ b/src/components/chat-widget/widget-message-list.js
@@ -12,6 +12,7 @@ import { __ } from '@wordpress/i18n';
 
 import STORE_NAME from '../../store';
 import CompactConversationActionCard from '../compact-conversation-action-card';
+import RecoverableJobActionCard from '../recoverable-job-action-card';
 import FeedbackConsentModal from '../feedback-consent-modal';
 import MessageRows from '../chat-messages/message-rows';
 import {
@@ -22,6 +23,68 @@ import useCompactConversationAction from '../chat-messages/use-compact-conversat
 import useMessageListScroll from '../chat-messages/use-message-list-scroll';
 import useRunningStatus from '../chat-messages/use-running-status';
 import { RunningMessage } from '../chat-redesign/message-items';
+
+/**
+ * Lightweight retry card for a browser-result POST that did not reach the
+ * server. Kept local so the floating-widget bundle does not load the much
+ * broader confirmation/proposal ActionCard component.
+ *
+ * @param {Object}   props           Component props.
+ * @param {string[]} props.toolNames Completed client tool names.
+ * @param {Function} props.onConfirm Retry callback.
+ * @param {Function} props.onCancel  Dismiss callback.
+ * @return {JSX.Element} Client-result retry action.
+ */
+function ClientToolRetryActionCard( { toolNames = [], onConfirm, onCancel } ) {
+	return (
+		<div
+			className="sdaa-action-card sdaa-action-card--retry"
+			role="region"
+			aria-label={ __(
+				'Retry client tool results',
+				'superdav-ai-agent'
+			) }
+		>
+			<div className="sdaa-action-card-header">
+				<span className="sdaa-action-card-heading">
+					{ __(
+						'Submit completed results again?',
+						'superdav-ai-agent'
+					) }
+				</span>
+			</div>
+			<div className="sdaa-action-card-body">
+				<p>
+					{ __(
+						'The browser tools already ran. Retry only resubmits their saved results.',
+						'superdav-ai-agent'
+					) }
+				</p>
+				{ toolNames.length > 0 && (
+					<p className="sdaa-action-card-tool-names">
+						{ toolNames.join( ', ' ) }
+					</p>
+				) }
+			</div>
+			<div className="sdaa-action-card-footer">
+				<button
+					type="button"
+					className="button sdaa-action-card-btn-cancel"
+					onClick={ onCancel }
+				>
+					{ __( 'Dismiss', 'superdav-ai-agent' ) }
+				</button>
+				<button
+					type="button"
+					className="button button-primary sdaa-action-card-btn-confirm"
+					onClick={ onConfirm }
+				>
+					{ __( 'Retry', 'superdav-ai-agent' ) }
+				</button>
+			</div>
+		</div>
+	);
+}
 
 /**
  * Render the floating widget's message list and surface-specific actions.
@@ -58,6 +121,8 @@ export default function WidgetMessageList() {
 	const {
 		sendMessage,
 		retryLastMessage,
+		retryClientToolSubmission,
+		resumeRecoverableJob,
 		compactConversation,
 		setPendingActionCard,
 	} = useDispatch( STORE_NAME );
@@ -86,6 +151,23 @@ export default function WidgetMessageList() {
 		liveToolCalls,
 	} );
 	const runningStatus = useRunningStatus( sending && running.isFallback );
+	const actionableCardTypes = [
+		'retry_client_tools',
+		'resume_recoverable_job',
+	];
+	const hasActionableCard =
+		actionableCardTypes.includes( pendingActionCard?.type ) &&
+		( ! pendingActionCard?.sessionId ||
+			pendingActionCard.sessionId === currentSessionId );
+	const confirmRecoveryAction = () => {
+		if ( pendingActionCard?.type === 'retry_client_tools' ) {
+			retryClientToolSubmission();
+			return;
+		}
+		if ( pendingActionCard?.type === 'resume_recoverable_job' ) {
+			resumeRecoverableJob();
+		}
+	};
 
 	return (
 		<>
@@ -114,6 +196,7 @@ export default function WidgetMessageList() {
 					{ hasStreamError &&
 						currentSessionId &&
 						! sending &&
+						! hasActionableCard &&
 						pendingActionCard?.type !== 'compact_session' && (
 							<button
 								type="button"
@@ -125,6 +208,26 @@ export default function WidgetMessageList() {
 									'superdav-ai-agent'
 								) }
 							</button>
+						) }
+
+					{ hasActionableCard &&
+						! sending &&
+						pendingActionCard.type === 'retry_client_tools' && (
+							<ClientToolRetryActionCard
+								toolNames={ pendingActionCard.toolNames }
+								onConfirm={ confirmRecoveryAction }
+								onCancel={ () => setPendingActionCard( null ) }
+							/>
+						) }
+
+					{ hasActionableCard &&
+						! sending &&
+						pendingActionCard.type === 'resume_recoverable_job' && (
+							<RecoverableJobActionCard
+								diagnostic={ pendingActionCard.diagnostic }
+								onConfirm={ confirmRecoveryAction }
+								onCancel={ () => setPendingActionCard( null ) }
+							/>
 						) }
 
 					{ pendingActionCard?.type === 'compact_session' &&

--- a/src/components/chat-widget/widget-message-list.js
+++ b/src/components/chat-widget/widget-message-list.js
@@ -100,6 +100,7 @@ export default function WidgetMessageList() {
 		sessionJobs,
 		hasStreamError,
 		pendingActionCard,
+		pendingToolResultRetry,
 		providers,
 		showToolCallDetails,
 	} = useSelect( ( sel ) => {
@@ -113,6 +114,7 @@ export default function WidgetMessageList() {
 			sessionJobs: store.getSessionJobs(),
 			hasStreamError: store.hasStreamError(),
 			pendingActionCard: store.getPendingActionCard(),
+			pendingToolResultRetry: store.getPendingToolResultRetry?.(),
 			providers: store.getProviders(),
 			showToolCallDetails: settings?.show_tool_call_details === true,
 		};
@@ -155,10 +157,14 @@ export default function WidgetMessageList() {
 		'retry_client_tools',
 		'resume_recoverable_job',
 	];
+	const actionCardSessionId =
+		pendingActionCard?.sessionId ||
+		( pendingActionCard?.type === 'retry_client_tools'
+			? pendingToolResultRetry?.sessionId
+			: null );
 	const hasActionableCard =
 		actionableCardTypes.includes( pendingActionCard?.type ) &&
-		( ! pendingActionCard?.sessionId ||
-			pendingActionCard.sessionId === currentSessionId );
+		( ! actionCardSessionId || actionCardSessionId === currentSessionId );
 	const confirmRecoveryAction = () => {
 		if ( pendingActionCard?.type === 'retry_client_tools' ) {
 			retryClientToolSubmission();

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -34,8 +34,10 @@ use SdAiAgent\Abilities\Js\JsAbilityCatalog;
 use SdAiAgent\Abilities\KnowledgeAbilities;
 use SdAiAgent\Core\ActiveJobFailureDiagnostic;
 use SdAiAgent\Core\AgentLoop;
+use SdAiAgent\Core\ClientAbilityRouter;
 use SdAiAgent\Core\ConversationSerializer;
 use SdAiAgent\Core\ConversationTrimmer;
+use SdAiAgent\Core\Database;
 use SdAiAgent\Core\ProviderCredentialLoader;
 use SdAiAgent\Core\Settings;
 use SdAiAgent\Core\SystemInstructionBuilder;
@@ -107,6 +109,11 @@ final class ScriptedAgentLoop extends AgentLoop {
 		}
 
 		$result = array_shift( $this->scriptedResults );
+		if ( $result instanceof WP_Error && 'sd_ai_agent_test_provider_timeout' === $result->get_error_code() ) {
+			$retry_error = new \ReflectionMethod( AgentLoop::class, 'build_provider_retry_failed_error' );
+
+			return $retry_error->invoke( $this, $result, 0 );
+		}
 		if ( $result instanceof GenerativeAiResult || $result instanceof WP_Error ) {
 			return $result;
 		}
@@ -966,6 +973,37 @@ class AgentLoopTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Longer retry waits heartbeat the active continuation instead of leaving
+	 * the accepted client-result job looking stale.
+	 */
+	public function test_provider_retry_wait_heartbeats_active_job(): void {
+		global $wpdb;
+
+		$job_id = '44444444-5555-6666-7777-888888888888';
+		$this->assertNotFalse( ActiveJobRepository::create( 1, $job_id, 1 ) );
+		$wpdb->update(
+			ActiveJobRepository::table_name(),
+			[ 'updated_at' => '2000-01-01 00:00:00' ],
+			[ 'job_id' => $job_id ],
+			[ '%s' ],
+			[ '%s' ]
+		);
+
+		$loop = new AgentLoop(
+			'Inspect the site.',
+			[],
+			[],
+			[ 'active_job_id' => $job_id ]
+		);
+		$wait = new \ReflectionMethod( AgentLoop::class, 'wait_for_provider_retry' );
+		$wait->invoke( $loop, 1 );
+
+		$row = ActiveJobRepository::get_by_job_id( $job_id );
+		$this->assertNotNull( $row );
+		$this->assertNotSame( '2000-01-01 00:00:00', $row->updated_at );
+	}
+
+	/**
 	 * Test run() returns WP_Error when the AI proxy returns an HTTP error.
 	 */
 	public function test_run_retries_http_error_response_then_succeeds(): void {
@@ -1052,6 +1090,96 @@ class AgentLoopTest extends WP_UnitTestCase {
 		$this->assertIsArray( $data );
 		$retry_entries = array_filter( $data['messages'], static fn( $entry ) => 'provider_retry' === ( $entry['type'] ?? '' ) );
 		$this->assertCount( 2, $retry_entries );
+	}
+
+	/**
+	 * Accepted screenshot results survive provider exhaustion and resume from
+	 * their post-results checkpoint without producing another browser-tool pause.
+	 */
+	public function test_client_results_provider_timeout_resumes_without_replay(): void {
+		$session_id = Database::create_session( [
+			'user_id' => 1,
+			'title'   => 'Client result provider recovery',
+		] );
+		$job_id     = '55555555-6666-7777-8888-999999999999';
+		$this->assertNotFalse( ActiveJobRepository::create( $session_id, $job_id, 1 ) );
+		$options = [
+			'session_id'    => $session_id,
+			'active_job_id' => $job_id,
+			'provider_id'   => 'scripted-provider',
+			'model_id'      => 'scripted-model',
+		];
+		$history = [
+			new UserMessage( [ new MessagePart( 'Review the theme code and rendered output.' ) ] ),
+			new ModelMessage(
+				[
+					new MessagePart( new FunctionCall( 'call_screen_one', 'sd-ai-agent-js/screenshot-url', [ 'url' => '/theme/' ] ) ),
+					new MessagePart( new FunctionCall( 'call_screen_two', 'sd-ai-agent-js/screenshot-url', [ 'url' => '/theme/post/' ] ) ),
+				]
+			),
+		];
+
+		$loop   = new ScriptedAgentLoop(
+			'',
+			[],
+			$history,
+			$options,
+			[ new WP_Error( 'sd_ai_agent_test_provider_timeout', 'Managed service unavailable.' ) ]
+		);
+		$accepted_results = [
+			[
+				'id'     => 'call_screen_one',
+				'name'   => 'sd-ai-agent-js/screenshot-url',
+				'result' => [ 'success' => true, 'url' => '/theme/' ],
+			],
+			[
+				'id'     => 'call_screen_two',
+				'name'   => 'sd-ai-agent-js/screenshot-url',
+				'result' => [ 'success' => true, 'url' => '/theme/post/' ],
+			],
+		];
+		$result          = $loop->resume_after_client_tools( $accepted_results, 3 );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'sd_ai_agent_provider_retry_failed', $result->get_error_code() );
+		$this->assertCount( 1, $loop->requestSizes );
+		$state = Database::load_and_clear_paused_state( $session_id );
+		$this->assertIsArray( $state );
+		$serialized = (string) wp_json_encode( $state['history'] );
+		$this->assertStringContainsString( 'Review the theme code and rendered output.', $serialized );
+		$this->assertStringContainsString( 'call_screen_one', $serialized );
+		$this->assertStringContainsString( 'call_screen_two', $serialized );
+		$this->assertArrayNotHasKey( 'pending_client_tool_calls', $state );
+		$this->assertFalse(
+			ClientAbilityRouter::matches_pending_results(
+				$state['pending_client_tool_calls'] ?? [],
+				$accepted_results
+			),
+			'Accepted screenshot results must be invalid for replay against the post-results checkpoint.'
+		);
+
+		$job = ActiveJobRepository::get_by_job_id( $job_id );
+		$this->assertNotNull( $job );
+		$this->assertSame( AgentLoop::CHECKPOINT_BEFORE_PROVIDER_CALL, $job->checkpoint_phase );
+		$this->assertStringContainsString( 'call_screen_one', $job->checkpoint );
+		$this->assertStringContainsString( 'call_screen_two', $job->checkpoint );
+
+		$resumed_loop = new ScriptedAgentLoop(
+			'',
+			[],
+			ConversationSerializer::deserialize( $state['history'] ),
+			[
+				'provider_id' => 'scripted-provider',
+				'model_id'    => 'scripted-model',
+			],
+			[ $this->create_scripted_result( 'Theme review continued from accepted screenshots.' ) ]
+		);
+		$resumed = $resumed_loop->resume_from_checkpoint( (int) ( $state['iterations_remaining'] ?? 1 ) );
+
+		$this->assertIsArray( $resumed );
+		$this->assertSame( 'Theme review continued from accepted screenshots.', $resumed['reply'] );
+		$this->assertArrayNotHasKey( 'pending_client_tool_calls', $resumed );
+		$this->assertCount( 1, $resumed_loop->requestSizes );
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/AgentLoopTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopTest.php
@@ -919,6 +919,53 @@ class AgentLoopTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Managed Superdav calls tolerate a short edge outage while other providers
+	 * retain the existing retry budget. Explicit per-run overrides still win.
+	 */
+	public function test_managed_provider_uses_longer_default_retry_policy(): void {
+		$attempts = new \ReflectionProperty( AgentLoop::class, 'provider_retry_max_attempts' );
+		$delays   = new \ReflectionProperty( AgentLoop::class, 'provider_retry_delays' );
+
+		$managed = new AgentLoop(
+			'Inspect the site.',
+			[],
+			[],
+			[
+				'provider_id' => 'sd-ai-agent-cloud',
+				'model_id'    => 'superdav-chat-pro',
+			]
+		);
+		$this->assertSame( 6, $attempts->getValue( $managed ) );
+		$this->assertSame( [ 1, 2, 4, 8, 16 ], $delays->getValue( $managed ) );
+
+		$other = new AgentLoop(
+			'Inspect the site.',
+			[],
+			[],
+			[
+				'provider_id' => 'another-provider',
+				'model_id'    => 'another-model',
+			]
+		);
+		$this->assertSame( 4, $attempts->getValue( $other ) );
+		$this->assertSame( [ 1, 2, 4 ], $delays->getValue( $other ) );
+
+		$overridden = new AgentLoop(
+			'Inspect the site.',
+			[],
+			[],
+			[
+				'provider_id'                => 'sd-ai-agent-cloud',
+				'model_id'                   => 'superdav-chat-pro',
+				'provider_retry_max_attempts' => 2,
+				'provider_retry_delays'       => [ 0 ],
+			]
+		);
+		$this->assertSame( 2, $attempts->getValue( $overridden ) );
+		$this->assertSame( [ 0 ], $delays->getValue( $overridden ) );
+	}
+
+	/**
 	 * Test run() returns WP_Error when the AI proxy returns an HTTP error.
 	 */
 	public function test_run_retries_http_error_response_then_succeeds(): void {

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -2484,6 +2484,100 @@ class RestControllerTest extends WP_UnitTestCase {
 	// ─── /chat/tool-result regression: 409 loop fix (sd-ai-9ip) ──────────────
 
 	/**
+	 * A provider failure after browser results were accepted returns a bounded
+	 * acknowledgement and leaves the exact continuation available for resume.
+	 */
+	public function test_tool_result_provider_failure_is_bounded_and_recoverable(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$session_id = Database::create_session( [
+			'user_id' => $this->admin_id,
+			'title'   => 'Accepted client results recovery',
+		] );
+		$history    = [
+			[
+				'role'  => 'user',
+				'parts' => [ [ 'text' => 'Inspect the theme code and rendered output.' ] ],
+			],
+		];
+		Database::save_paused_state(
+			$session_id,
+			[
+				'history'              => $history,
+				'tool_call_log'        => [],
+				'message_log'          => [],
+				'iterations_remaining' => 90,
+				'provider_id'          => 'sd-ai-agent-cloud',
+				'model_id'             => 'superdav-chat-pro',
+			]
+		);
+
+		$job_id = '33333333-4444-5555-6666-777777777777';
+		ActiveJobRepository::create( $session_id, $job_id, $this->admin_id, 'awaiting_client_tools' );
+		set_transient(
+			RestController::JOB_PREFIX . $job_id,
+			[
+				'status'                    => 'awaiting_client_tools',
+				'params'                    => [ 'session_id' => $session_id ],
+				'pending_client_tool_calls' => [
+					[ 'id' => 'call-screenshot', 'name' => 'sd-ai-agent-js/screenshot-url' ],
+				],
+				'tool_calls'                => [ [ 'type' => 'call', 'id' => 'call-screenshot' ] ],
+				'messages'                  => [],
+			],
+			RestController::JOB_TTL
+		);
+
+		$error = new \WP_Error(
+			'sd_ai_agent_provider_retry_failed',
+			'The provider response included unsafe detail that must not escape.',
+			[
+				'history'     => [ [ 'private' => str_repeat( 'x', 900000 ) ] ],
+				'tool_calls'  => [ [ 'private' => 'MUST_NOT_ESCAPE' ] ],
+				'provider_id' => 'sd-ai-agent-cloud',
+				'model_id'    => 'superdav-chat-pro',
+			]
+		);
+
+		$method   = new \ReflectionMethod( RestController::class, 'accepted_tool_result_failure_response' );
+		$response = $method->invoke(
+			null,
+			$job_id,
+			$session_id,
+			$error,
+			[
+				'last_safe_phase' => 'client_tool_resume',
+				'provider_id'     => 'sd-ai-agent-cloud',
+				'model_id'        => 'superdav-chat-pro',
+			]
+		);
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertSame( 202, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertTrue( $data['results_accepted'] );
+		$this->assertTrue( $data['recoverable'] );
+		$this->assertSame( 'recoverable_error', $data['status'] );
+		$this->assertSame( 'provider_timeout', $data['diagnostic']['reason'] );
+		$this->assertSame( 'client_tool_resume', $data['diagnostic']['last_safe_phase'] );
+		$this->assertLessThan( 4096, strlen( (string) wp_json_encode( $data ) ) );
+		$this->assertStringNotContainsString( 'MUST_NOT_ESCAPE', (string) wp_json_encode( $data ) );
+		$this->assertArrayNotHasKey( 'history', $data );
+		$this->assertArrayNotHasKey( 'tool_calls', $data );
+
+		$job = get_transient( RestController::JOB_PREFIX . $job_id );
+		$this->assertIsArray( $job );
+		$this->assertSame( 'error', $job['status'] );
+		$this->assertTrue( $job['recoverable'] );
+		$this->assertArrayNotHasKey( 'pending_client_tool_calls', $job );
+
+		$session = Database::get_session( $session_id );
+		$this->assertNotNull( $session );
+		$saved_state = json_decode( (string) $session->paused_state, true );
+		$this->assertSame( $history, $saved_state['history'] );
+	}
+
+	/**
 	 * Invalid browser batches are rejected before resume and preserve the paused
 	 * state so the exact pending calls can still be submitted.
 	 */


### PR DESCRIPTION
## Summary

- treat provider failures after `/chat/tool-result` consumption as accepted, recoverable continuation failures and return a bounded HTTP 202 response
- preserve the post-browser-result checkpoint, expose safe diagnostics through job polling, and prevent consumed browser results from being replayed
- increase managed Superdav provider defaults to six attempts with `1, 2, 4, 8, 16` second backoff while preserving explicit overrides and existing defaults for other providers
- carry the active job through client-result continuation and heartbeat it during longer backoff waits so accepted-result checkpoints cannot look stale
- render retry/resume controls in the floating widget as well as the main chat, and make a standalone `retry` composer command invoke the saved recovery action instead of starting a new run
- add a deterministic two-screenshot integration regression proving the original intent and accepted results survive provider exhaustion, stale results cannot be replayed, and checkpoint resume continues without another client-tool pause

This is the verified replacement for closed, unmerged PR #2439. Issue #2437 was closed as superseded by the consolidated specification in #2450.

Closes #2450

## Worker self-verification
- PHPUnit: Tests: 4111, Assertions: 18451, Errors: 0, Failures: 0, Skipped: 136
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

## Additional verification
- JavaScript: 47 suites, 478 tests, 6 snapshots passed
- Focused accepted-result recovery tests: 4 tests, 44 assertions, 0 failures
- Existing Playwright E2E CI shards passed on the first PR revision; the pushed hardening revision restarted CI
- Local WordPress admin responds at `http://superdave-main.localhost:18080/wp-admin/`
