### PR TITLE
GH#2455: defer optional frontend bundles

### DIFF
--- a/scripts/check-bundle-size.js
+++ b/scripts/check-bundle-size.js
@@ -1,11 +1,21 @@
 #!/usr/bin/env node
 /* eslint-env node */
+/* eslint-disable no-console */
 
 const fs = require( 'fs' );
 const path = require( 'path' );
 const zlib = require( 'zlib' );
 
 const KIB = 1024;
+const BUILD_DIR = 'build';
+const ENTRYPOINT_JAVASCRIPT = new Set( [
+	'admin-page.js',
+	'block-validator.js',
+	'embed-widget.js',
+	'floating-widget.js',
+	'superdav-connector-card.js',
+	'unified-admin.js',
+] );
 const BUDGETS = [
 	{
 		name: 'floating-widget',
@@ -16,15 +26,30 @@ const BUDGETS = [
 	{
 		name: 'widget-panel',
 		file: 'build/widget-panel.js',
-		minifiedBudgetKiB: 220,
-		gzipBudgetKiB: 70,
+		minifiedBudgetKiB: 100,
+		gzipBudgetKiB: 28,
 	},
 ];
+const DEFERRED_JAVASCRIPT_BUDGET = {
+	name: 'deferred-javascript',
+	minifiedBudgetKiB: 1700,
+	gzipBudgetKiB: 525,
+	largestMinifiedBudgetKiB: 270,
+	largestGzipBudgetKiB: 90,
+};
 
+/**
+ * @param {number} bytes Byte count.
+ * @return {string} Kibibytes formatted to one decimal place.
+ */
 function formatKiB( bytes ) {
 	return ( bytes / KIB ).toFixed( 1 );
 }
 
+/**
+ * @param {Object} budget Named entrypoint budget.
+ * @return {Object} Measured bundle and failures.
+ */
 function checkBundle( budget ) {
 	const filePath = path.resolve( process.cwd(), budget.file );
 
@@ -39,13 +64,21 @@ function checkBundle( budget ) {
 
 	if ( minifiedKiB > budget.minifiedBudgetKiB ) {
 		failures.push(
-			`minified ${ formatKiB( source.length ) } KiB exceeds ${ budget.minifiedBudgetKiB } KiB`
+			[
+				'minified',
+				`${ formatKiB( source.length ) } KiB exceeds`,
+				`${ budget.minifiedBudgetKiB } KiB`,
+			].join( ' ' )
 		);
 	}
 
 	if ( gzipKiB > budget.gzipBudgetKiB ) {
 		failures.push(
-			`gzip ${ gzipKiB.toFixed( 1 ) } KiB exceeds ${ budget.gzipBudgetKiB } KiB`
+			[
+				'gzip',
+				`${ gzipKiB.toFixed( 1 ) } KiB exceeds`,
+				`${ budget.gzipBudgetKiB } KiB`,
+			].join( ' ' )
 		);
 	}
 
@@ -57,21 +90,167 @@ function checkBundle( budget ) {
 	};
 }
 
+/**
+ * Guard the complete deferred JavaScript graph, including numeric webpack
+ * chunks whose filenames are not stable across dependency changes.
+ *
+ * Aggregate gzip is the sum of individually compressed assets because browsers
+ * download chunks as separate responses. Largest minified and gzip assets are
+ * tracked independently because they need not be the same file.
+ *
+ * @param {Object} budget Deferred graph budget.
+ * @return {Object} Measured deferred graph and failures.
+ */
+function checkDeferredJavaScript( budget ) {
+	const buildPath = path.resolve( process.cwd(), BUILD_DIR );
+	if ( ! fs.existsSync( buildPath ) ) {
+		throw new Error( `${ budget.name }: missing build directory` );
+	}
+
+	const files = fs
+		.readdirSync( buildPath )
+		.filter(
+			( file ) =>
+				file.endsWith( '.js' ) && ! ENTRYPOINT_JAVASCRIPT.has( file )
+		)
+		.sort();
+	if ( files.length === 0 ) {
+		throw new Error(
+			`${ budget.name }: no deferred JavaScript assets found`
+		);
+	}
+
+	const assets = files.map( ( file ) => {
+		const source = fs.readFileSync( path.join( buildPath, file ) );
+		return {
+			file,
+			minifiedBytes: source.length,
+			gzipBytes: zlib.gzipSync( source ).length,
+		};
+	} );
+	const minifiedBytes = assets.reduce(
+		( total, asset ) => total + asset.minifiedBytes,
+		0
+	);
+	const gzipBytes = assets.reduce(
+		( total, asset ) => total + asset.gzipBytes,
+		0
+	);
+	const largestMinified = assets.reduce( ( largest, asset ) =>
+		asset.minifiedBytes > largest.minifiedBytes ? asset : largest
+	);
+	const largestGzip = assets.reduce( ( largest, asset ) =>
+		asset.gzipBytes > largest.gzipBytes ? asset : largest
+	);
+	const failures = [];
+
+	if ( minifiedBytes / KIB > budget.minifiedBudgetKiB ) {
+		failures.push(
+			[
+				'aggregate minified',
+				`${ formatKiB( minifiedBytes ) } KiB exceeds`,
+				`${ budget.minifiedBudgetKiB } KiB`,
+			].join( ' ' )
+		);
+	}
+	if ( gzipBytes / KIB > budget.gzipBudgetKiB ) {
+		failures.push(
+			[
+				'aggregate gzip',
+				`${ formatKiB( gzipBytes ) } KiB exceeds`,
+				`${ budget.gzipBudgetKiB } KiB`,
+			].join( ' ' )
+		);
+	}
+	if (
+		largestMinified.minifiedBytes / KIB >
+		budget.largestMinifiedBudgetKiB
+	) {
+		failures.push(
+			[
+				`largest minified asset ${ largestMinified.file } is`,
+				`${ formatKiB(
+					largestMinified.minifiedBytes
+				) } KiB, exceeding`,
+				`${ budget.largestMinifiedBudgetKiB } KiB`,
+			].join( ' ' )
+		);
+	}
+	if ( largestGzip.gzipBytes / KIB > budget.largestGzipBudgetKiB ) {
+		failures.push(
+			[
+				`largest gzip asset ${ largestGzip.file } is`,
+				`${ formatKiB( largestGzip.gzipBytes ) } KiB, exceeding`,
+				`${ budget.largestGzipBudgetKiB } KiB`,
+			].join( ' ' )
+		);
+	}
+
+	return {
+		...budget,
+		assetCount: assets.length,
+		minifiedKiB: minifiedBytes / KIB,
+		gzipKiB: gzipBytes / KIB,
+		largestMinified,
+		largestGzip,
+		failures,
+	};
+}
+
+/**
+ * Print all bundle measurements and set a failing process exit code when a
+ * budget is exceeded.
+ */
 function main() {
 	const results = BUDGETS.map( checkBundle );
+	const deferredResult = checkDeferredJavaScript(
+		DEFERRED_JAVASCRIPT_BUDGET
+	);
 	let failed = false;
 
 	for ( const result of results ) {
 		const status = result.failures.length > 0 ? 'FAIL' : 'OK';
-		console.log(
-			`${ status } ${ result.name }: ${ result.minifiedKiB.toFixed( 1 ) } KiB minified (budget ${ result.minifiedBudgetKiB } KiB), ${ result.gzipKiB.toFixed( 1 ) } KiB gzip (budget ${ result.gzipBudgetKiB } KiB)`
-		);
+		const summary = [
+			`${ status } ${ result.name }:`,
+			`${ result.minifiedKiB.toFixed( 1 ) } KiB minified`,
+			`(budget ${ result.minifiedBudgetKiB } KiB),`,
+			`${ result.gzipKiB.toFixed( 1 ) } KiB gzip`,
+			`(budget ${ result.gzipBudgetKiB } KiB)`,
+		].join( ' ' );
+		console.log( summary );
 
 		if ( result.failures.length > 0 ) {
 			failed = true;
 			for ( const failure of result.failures ) {
 				console.error( `  - ${ failure }` );
 			}
+		}
+	}
+
+	const deferredStatus = deferredResult.failures.length > 0 ? 'FAIL' : 'OK';
+	const deferredSummary = [
+		`${ deferredStatus } ${ deferredResult.name }:`,
+		`${ deferredResult.assetCount } assets,`,
+		`${ deferredResult.minifiedKiB.toFixed( 1 ) } KiB aggregate minified`,
+		`(budget ${ deferredResult.minifiedBudgetKiB } KiB),`,
+		`${ deferredResult.gzipKiB.toFixed( 1 ) } KiB aggregate gzip`,
+		`(budget ${ deferredResult.gzipBudgetKiB } KiB)`,
+	].join( ' ' );
+	const largestSummary = [
+		`  largest minified: ${ deferredResult.largestMinified.file }`,
+		`${ formatKiB(
+			deferredResult.largestMinified.minifiedBytes
+		) } KiB (budget ${ deferredResult.largestMinifiedBudgetKiB } KiB);`,
+		`largest gzip: ${ deferredResult.largestGzip.file }`,
+		`${ formatKiB( deferredResult.largestGzip.gzipBytes ) } KiB`,
+		`(budget ${ deferredResult.largestGzipBudgetKiB } KiB)`,
+	].join( ' ' );
+	console.log( deferredSummary );
+	console.log( largestSummary );
+	if ( deferredResult.failures.length > 0 ) {
+		failed = true;
+		for ( const failure of deferredResult.failures ) {
+			console.error( `  - ${ failure }` );
 		}
 	}
 

--- a/src/components/__tests__/code-block.test.js
+++ b/src/components/__tests__/code-block.test.js
@@ -1,0 +1,37 @@
+jest.mock( '@codemirror/lang-javascript', () => ( {
+	javascript: jest.fn( ( options ) => ( {
+		language: 'javascript',
+		options,
+	} ) ),
+} ) );
+
+import { javascript } from '@codemirror/lang-javascript';
+import { getLanguageExtension } from '../code-block';
+
+describe( 'CodeBlock language loading', () => {
+	beforeEach( () => {
+		javascript.mockClear();
+	} );
+
+	test( 'does not load a parser for an unknown language', async () => {
+		await expect( getLanguageExtension( 'plaintext' ) ).resolves.toBeNull();
+		expect( javascript ).not.toHaveBeenCalled();
+	} );
+
+	test( 'loads a canonical parser only when requested', async () => {
+		await expect( getLanguageExtension( 'js' ) ).resolves.toEqual( {
+			language: 'javascript',
+			options: undefined,
+		} );
+		expect( javascript ).toHaveBeenCalledWith();
+	} );
+
+	test( 'passes alias options to the deferred parser factory', async () => {
+		await getLanguageExtension( ' TSX ' );
+
+		expect( javascript ).toHaveBeenCalledWith( {
+			jsx: true,
+			typescript: true,
+		} );
+	} );
+} );

--- a/src/components/chat-redesign/chat-redesign.css
+++ b/src/components/chat-redesign/chat-redesign.css
@@ -717,6 +717,10 @@ input[type="text"].sdaa-cr-search-input {
 	color: var(--sdaa-text-primary);
 }
 
+.sdaa-cr-markdown-fallback {
+	white-space: pre-wrap;
+}
+
 .sdaa-cr-msg-body p {
 	margin: 0 0 8px;
 }

--- a/src/components/chat-redesign/message-items.js
+++ b/src/components/chat-redesign/message-items.js
@@ -13,7 +13,14 @@
  * (assistant) or model · time (user), sourced from store.messageTokens.
  */
 
-import { useState, useRef, useEffect, useCallback } from '@wordpress/element';
+import {
+	useState,
+	useRef,
+	useEffect,
+	useCallback,
+	lazy,
+	Suspense,
+} from '@wordpress/element';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import {
@@ -25,7 +32,6 @@ import {
 } from '@wordpress/icons';
 
 import STORE_NAME from '../../store';
-import MarkdownMessage from '../markdown-message';
 import { AiIcon } from './icons';
 import ToolCard, { ToolResultHighlights } from './ToolCard';
 import {
@@ -36,6 +42,29 @@ import {
 } from './message-helpers';
 import { linkifyText } from '../../utils/linkify';
 import { copyToClipboard } from '../../utils/clipboard';
+
+const MarkdownMessage = lazy( () =>
+	import( /* webpackChunkName: "markdown-message" */ '../markdown-message' )
+);
+
+/**
+ * Keep message text visible while the Markdown renderer downloads.
+ *
+ * @param {Object} root0
+ * @param {string} root0.content Markdown source.
+ * @return {JSX.Element} Deferred Markdown output with a plain-text fallback.
+ */
+function DeferredMarkdownMessage( { content } ) {
+	return (
+		<Suspense
+			fallback={
+				<span className="sdaa-cr-markdown-fallback">{ content }</span>
+			}
+		>
+			<MarkdownMessage content={ content } />
+		</Suspense>
+	);
+}
 
 /**
  *
@@ -585,7 +614,9 @@ export function AssistantMessage( {
 							response={ item.response }
 						/>
 					) ) }
-				{ cleanText && <MarkdownMessage content={ cleanText } /> }
+				{ cleanText && (
+					<DeferredMarkdownMessage content={ cleanText } />
+				) }
 				{ isLastModel && suggestions.length > 0 && (
 					<div className="sdaa-cr-suggestions">
 						{ suggestions.map( ( s, i ) => (
@@ -682,7 +713,9 @@ export function RunningMessage( {
 									key={ item.key }
 									className="sdaa-cr-running-preamble"
 								>
-									<MarkdownMessage content={ item.text } />
+									<DeferredMarkdownMessage
+										content={ item.text }
+									/>
 								</div>
 							);
 						}

--- a/src/components/chat-widget/index.js
+++ b/src/components/chat-widget/index.js
@@ -10,9 +10,8 @@
  * in a separate async chunk.  The browser downloads that chunk only the
  * first time the user opens the widget.
  *
- * webpackPrefetch causes the browser to fetch the chunk in the background
- * during idle time after the main page loads, so when the user clicks the
- * FAB the chunk is already cached — no visible delay on first open.
+ * The browser fetches the panel chunk only after the user opens the widget,
+ * avoiding speculative work on pages where the launcher is never used.
  */
 
 import { lazy, Suspense } from '@wordpress/element';
@@ -21,17 +20,12 @@ import { useSelect } from '@wordpress/data';
 import STORE_NAME from '../../store';
 import { getChatUiMode } from '../../utils/chat-ui-mode';
 import WidgetLauncher from './widget-launcher';
-// widget.css contains the launcher (FAB) styles and is required in the
-// initial bundle so the FAB is styled immediately on every page load.
-// chat-redesign.css is imported inside widget-panel.js so it lands in
-// the async chunk and is only fetched when the panel first opens.
-import './widget.css';
+// Only the launcher (FAB) styles are required in the initial bundle.
+// Panel and chat-redesign styles are imported inside widget-panel.js.
+import './widget-launcher.css';
 
 const WidgetPanel = lazy( () =>
-	import(
-		/* webpackChunkName: "widget-panel", webpackPrefetch: true */
-		'./widget-panel'
-	)
+	import( /* webpackChunkName: "widget-panel" */ './widget-panel' )
 );
 
 /**
@@ -50,7 +44,7 @@ export default function ChatWidget( { frontendOnboardingMode = null } ) {
 	}
 
 	// Suspense renders nothing while the panel chunk is downloading.
-	// On a cache hit (prefetch or repeat visit) this is imperceptible.
+	// On a repeat visit this is normally served from the browser cache.
 	return (
 		<Suspense fallback={ null }>
 			<WidgetPanel

--- a/src/components/chat-widget/widget-launcher.css
+++ b/src/components/chat-widget/widget-launcher.css
@@ -1,0 +1,132 @@
+/*
+ * Floating chat widget launcher styles and tokens used by the deferred panel.
+ * Kept deliberately small because this stylesheet loads on every page.
+ */
+
+:root {
+	--sdaa-w-primary: var(--wp-admin-theme-color, #2271b1);
+	--sdaa-w-primary-dark: var(--wp-admin-theme-color-darker-10, #135e96);
+	--sdaa-w-text-primary: #1d2327;
+	--sdaa-w-text-secondary: #50575e;
+	--sdaa-w-text-muted: #787c82;
+	--sdaa-w-text-muted-contrast: #71767b;
+	--sdaa-w-border-strong: #c3c4c7;
+	--sdaa-w-border-subtle: #dcdcde;
+	--sdaa-w-bubble-user-border: #c5d9ed;
+	--sdaa-w-surface: #f6f7f7;
+	--sdaa-w-surface-hover: #f0f0f1;
+	--sdaa-w-surface-active: #f0f6fc;
+	--sdaa-w-success: #00a32a;
+	--sdaa-w-warning: #dba617;
+	--sdaa-w-error: #d63638;
+	--sdaa-w-radius-xs: 4px;
+	--sdaa-w-radius-sm: 6px;
+	--sdaa-w-radius-md: 8px;
+	--sdaa-w-radius-lg: 12px;
+	--sdaa-w-radius-pill: 9999px;
+	--sdaa-w-duration: 150ms;
+	--sdaa-w-shadow-overlay: 0 8px 32px rgb(0 0 0 / 20%);
+	--sdaa-w-shadow-elevated: 0 4px 16px rgb(0 0 0 / 14%);
+	--sdaa-w-font-ui:
+		-apple-system, blinkmacsystemfont, "Segoe UI", Roboto, Oxygen-Sans,
+		Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	--sdaa-w-font-mono:
+		ui-monospace, sfmono-regular, "SF Mono", Menlo, Consolas, monospace;
+}
+
+.sdaa-w-launcher {
+	position: fixed;
+	right: 36px;
+	bottom: 28px;
+	z-index: 99999;
+	display: inline-flex;
+	width: 52px;
+	height: 52px;
+	align-items: center;
+	justify-content: center;
+	border: 0;
+	border-radius: 50%;
+	background: var(--sdaa-w-primary);
+	color: #fff;
+	box-shadow:
+		0 4px 16px rgb(0 0 0 / 18%),
+		0 2px 4px rgb(0 0 0 / 10%);
+	cursor: pointer;
+	transition: transform var(--sdaa-w-duration), background var(--sdaa-w-duration);
+}
+
+.sdaa-w-launcher:hover {
+	background: var(--sdaa-w-primary-dark);
+	transform: translateY(-1px);
+}
+
+.sdaa-w-launcher svg {
+	width: 24px;
+	height: 24px;
+	fill: currentcolor;
+}
+
+.sdaa-w-launcher-logo {
+	width: 26px;
+	height: 26px;
+	border-radius: 3px;
+	object-fit: contain;
+}
+
+.sdaa-w-launcher-pulse {
+	position: absolute;
+	top: -2px;
+	right: -2px;
+	width: 10px;
+	height: 10px;
+	border: 2px solid #fff;
+	border-radius: 50%;
+	background: var(--sdaa-w-success);
+	animation: sdaa-w-pulse 1.5s ease-in-out infinite;
+}
+
+.sdaa-w-launcher-badge {
+	position: absolute;
+	top: -4px;
+	right: -4px;
+	display: inline-flex;
+	min-width: 18px;
+	height: 18px;
+	align-items: center;
+	justify-content: center;
+	padding: 0 4px;
+	border: 2px solid #fff;
+	border-radius: 9px;
+	background: var(--sdaa-w-error);
+	color: #fff;
+	font-size: 10px;
+	font-weight: 700;
+	line-height: 1;
+	box-sizing: border-box;
+	pointer-events: none;
+}
+
+@keyframes sdaa-w-pulse {
+	0%,
+	100% {
+		opacity: 1;
+	}
+
+	50% {
+		opacity: 0.4;
+	}
+}
+
+@media (max-width: 500px) {
+	.sdaa-w-launcher {
+		right: 16px;
+		bottom: 16px;
+		width: 44px;
+		height: 44px;
+	}
+
+	.sdaa-w-launcher svg {
+		width: 20px;
+		height: 20px;
+	}
+}

--- a/src/components/chat-widget/widget-panel.css
+++ b/src/components/chat-widget/widget-panel.css
@@ -1,117 +1,8 @@
 /*
- * Floating chat widget — redesign styles.
- * Scoped under .sdaa-w-* so nothing leaks into the surrounding wp-admin.
- * All colour tokens resolve against the chat-redesign variables when
- * chat-redesign.css has loaded on the page; for admin pages that only
- * load the widget bundle, we re-declare the subset we need below.
+ * Floating chat widget panel styles.
+ * Loaded with the deferred panel chunk; launcher styles and shared tokens live
+ * in widget-launcher.css so the closed widget remains cheap and styled.
  */
-
-:root {
-	--sdaa-w-primary: var(--wp-admin-theme-color, #2271b1);
-	--sdaa-w-primary-dark: var(--wp-admin-theme-color-darker-10, #135e96);
-	--sdaa-w-text-primary: #1d2327;
-	--sdaa-w-text-secondary: #50575e;
-	--sdaa-w-text-muted: #787c82;
-	--sdaa-w-text-muted-contrast: #71767b;
-	--sdaa-w-border-strong: #c3c4c7;
-	--sdaa-w-border-subtle: #dcdcde;
-	--sdaa-w-bubble-user-border: #c5d9ed;
-	--sdaa-w-surface: #f6f7f7;
-	--sdaa-w-surface-hover: #f0f0f1;
-	--sdaa-w-surface-active: #f0f6fc;
-	--sdaa-w-success: #00a32a;
-	--sdaa-w-warning: #dba617;
-	--sdaa-w-error: #d63638;
-	--sdaa-w-radius-xs: 4px;
-	--sdaa-w-radius-sm: 6px;
-	--sdaa-w-radius-md: 8px;
-	--sdaa-w-radius-lg: 12px;
-	--sdaa-w-radius-pill: 9999px;
-	--sdaa-w-duration: 150ms;
-	--sdaa-w-shadow-overlay: 0 8px 32px rgb(0 0 0 / 20%);
-	--sdaa-w-shadow-elevated: 0 4px 16px rgb(0 0 0 / 14%);
-	--sdaa-w-font-ui:
-		-apple-system, blinkmacsystemfont, "Segoe UI", Roboto, Oxygen-Sans,
-		Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	--sdaa-w-font-mono:
-		ui-monospace, sfmono-regular, "SF Mono", Menlo, Consolas, monospace;
-}
-
-/* =================================================================
-   Launcher (FAB)
-   ================================================================= */
-
-.sdaa-w-launcher {
-	position: fixed;
-	right: 36px;
-	bottom: 28px;
-	z-index: 99999;
-	display: inline-flex;
-	width: 52px;
-	height: 52px;
-	align-items: center;
-	justify-content: center;
-	border: 0;
-	border-radius: 50%;
-	background: var(--sdaa-w-primary);
-	color: #fff;
-	box-shadow:
-		0 4px 16px rgb(0 0 0 / 18%),
-		0 2px 4px rgb(0 0 0 / 10%);
-	cursor: pointer;
-	transition: transform var(--sdaa-w-duration), background var(--sdaa-w-duration);
-}
-
-.sdaa-w-launcher:hover {
-	background: var(--sdaa-w-primary-dark);
-	transform: translateY(-1px);
-}
-
-.sdaa-w-launcher svg {
-	width: 24px;
-	height: 24px;
-	fill: currentcolor;
-}
-
-.sdaa-w-launcher-logo {
-	width: 26px;
-	height: 26px;
-	border-radius: 3px;
-	object-fit: contain;
-}
-
-.sdaa-w-launcher-pulse {
-	position: absolute;
-	top: -2px;
-	right: -2px;
-	width: 10px;
-	height: 10px;
-	border: 2px solid #fff;
-	border-radius: 50%;
-	background: var(--sdaa-w-success);
-	animation: sdaa-w-pulse 1.5s ease-in-out infinite;
-}
-
-.sdaa-w-launcher-badge {
-	position: absolute;
-	top: -4px;
-	right: -4px;
-	display: inline-flex;
-	min-width: 18px;
-	height: 18px;
-	align-items: center;
-	justify-content: center;
-	padding: 0 4px;
-	border: 2px solid #fff;
-	border-radius: 9px;
-	background: var(--sdaa-w-error);
-	color: #fff;
-	font-size: 10px;
-	font-weight: 700;
-	line-height: 1;
-	box-sizing: border-box;
-	pointer-events: none;
-}
 
 /* =================================================================
    Panel shell
@@ -1373,17 +1264,6 @@
 		height: auto;
 	}
 
-	.sdaa-w-launcher {
-		right: 16px;
-		bottom: 16px;
-		width: 44px;
-		height: 44px;
-	}
-
-	.sdaa-w-launcher svg {
-		width: 20px;
-		height: 20px;
-	}
 }
 
 /* =================================================================

--- a/src/components/chat-widget/widget-panel.js
+++ b/src/components/chat-widget/widget-panel.js
@@ -20,6 +20,7 @@ import { isCustomerSimpleMode } from '../../utils/chat-ui-mode';
 // sub-components, so the import lives here rather than in index.js.
 // This keeps the CSS in the async panel chunk and out of the initial bundle.
 import '../chat-redesign/chat-redesign.css';
+import './widget-panel.css';
 import WidgetHeader from './widget-header';
 import WidgetEmpty from './widget-empty';
 import WidgetMessageList from './widget-message-list';

--- a/src/components/code-block.js
+++ b/src/components/code-block.js
@@ -16,87 +16,100 @@ import { EditorView, lineNumbers } from '@codemirror/view';
 import { EditorState } from '@codemirror/state';
 import { oneDark } from '@codemirror/theme-one-dark';
 
-/**
- * CodeMirror language support — imported statically so webpack can tree-shake
- * unused parsers. Only languages commonly returned by AI chat responses are
- * included here to keep the bundle lean.
- */
-import { javascript } from '@codemirror/lang-javascript';
-import { php } from '@codemirror/lang-php';
-import { css } from '@codemirror/lang-css';
-import { html } from '@codemirror/lang-html';
-import { sql } from '@codemirror/lang-sql';
-import { python } from '@codemirror/lang-python';
-import { json } from '@codemirror/lang-json';
-import { yaml } from '@codemirror/lang-yaml';
-import { markdown } from '@codemirror/lang-markdown';
-import { rust } from '@codemirror/lang-rust';
+const languageLoaders = {
+	javascript: () =>
+		import(
+			/* webpackChunkName: "codemirror-lang-javascript" */ '@codemirror/lang-javascript'
+		).then( ( module ) => module.javascript ),
+	php: () =>
+		import(
+			/* webpackChunkName: "codemirror-lang-php" */ '@codemirror/lang-php'
+		).then( ( module ) => module.php ),
+	css: () =>
+		import(
+			/* webpackChunkName: "codemirror-lang-css" */ '@codemirror/lang-css'
+		).then( ( module ) => module.css ),
+	html: () =>
+		import(
+			/* webpackChunkName: "codemirror-lang-html" */ '@codemirror/lang-html'
+		).then( ( module ) => module.html ),
+	sql: () =>
+		import(
+			/* webpackChunkName: "codemirror-lang-sql" */ '@codemirror/lang-sql'
+		).then( ( module ) => module.sql ),
+	python: () =>
+		import(
+			/* webpackChunkName: "codemirror-lang-python" */ '@codemirror/lang-python'
+		).then( ( module ) => module.python ),
+	json: () =>
+		import(
+			/* webpackChunkName: "codemirror-lang-json" */ '@codemirror/lang-json'
+		).then( ( module ) => module.json ),
+	yaml: () =>
+		import(
+			/* webpackChunkName: "codemirror-lang-yaml" */ '@codemirror/lang-yaml'
+		).then( ( module ) => module.yaml ),
+	markdown: () =>
+		import(
+			/* webpackChunkName: "codemirror-lang-markdown" */ '@codemirror/lang-markdown'
+		).then( ( module ) => module.markdown ),
+	rust: () =>
+		import(
+			/* webpackChunkName: "codemirror-lang-rust" */ '@codemirror/lang-rust'
+		).then( ( module ) => module.rust ),
+};
+
+const languageAliases = {
+	javascript: [ 'javascript' ],
+	js: [ 'javascript' ],
+	jsx: [ 'javascript', { jsx: true } ],
+	typescript: [ 'javascript', { typescript: true } ],
+	ts: [ 'javascript', { typescript: true } ],
+	tsx: [ 'javascript', { jsx: true, typescript: true } ],
+	php: [ 'php' ],
+	css: [ 'css' ],
+	scss: [ 'css' ],
+	sass: [ 'css' ],
+	html: [ 'html' ],
+	xml: [ 'html' ],
+	svg: [ 'html' ],
+	sql: [ 'sql' ],
+	mysql: [ 'sql' ],
+	postgresql: [ 'sql' ],
+	sqlite: [ 'sql' ],
+	python: [ 'python' ],
+	py: [ 'python' ],
+	json: [ 'json' ],
+	jsonc: [ 'json' ],
+	yaml: [ 'yaml' ],
+	yml: [ 'yaml' ],
+	markdown: [ 'markdown' ],
+	md: [ 'markdown' ],
+	rust: [ 'rust' ],
+	rs: [ 'rust' ],
+};
 
 /**
  * Map raw language identifiers (from fenced code blocks) to a CodeMirror
- * language extension factory. Aliases are normalised to a canonical key.
+ * language extension factory. Each parser remains in its own async chunk.
  *
  * @param {string|undefined} lang Raw language string from the markdown fence.
- * @return {import('@codemirror/state').Extension|null} Language extension or null.
+ * @return {Promise<import('@codemirror/state').Extension|null>} Language extension or null.
  */
-function getLanguageExtension( lang ) {
+export async function getLanguageExtension( lang ) {
 	if ( ! lang ) {
 		return null;
 	}
 
 	const normalised = lang.toLowerCase().trim();
+	const descriptor = languageAliases[ normalised ];
+	if ( ! descriptor ) {
+		return null;
+	}
 
-	const map = {
-		// JavaScript / TypeScript
-		javascript: () => javascript(),
-		js: () => javascript(),
-		jsx: () => javascript( { jsx: true } ),
-		typescript: () => javascript( { typescript: true } ),
-		ts: () => javascript( { typescript: true } ),
-		tsx: () => javascript( { jsx: true, typescript: true } ),
-
-		// PHP
-		php: () => php(),
-
-		// CSS / SCSS
-		css: () => css(),
-		scss: () => css(),
-		sass: () => css(),
-
-		// HTML / XML
-		html: () => html(),
-		xml: () => html(),
-		svg: () => html(),
-
-		// SQL
-		sql: () => sql(),
-		mysql: () => sql(),
-		postgresql: () => sql(),
-		sqlite: () => sql(),
-
-		// Python
-		python: () => python(),
-		py: () => python(),
-
-		// JSON
-		json: () => json(),
-		jsonc: () => json(),
-
-		// YAML
-		yaml: () => yaml(),
-		yml: () => yaml(),
-
-		// Markdown
-		markdown: () => markdown(),
-		md: () => markdown(),
-
-		// Rust
-		rust: () => rust(),
-		rs: () => rust(),
-	};
-
-	const factory = map[ normalised ];
-	return factory ? factory() : null;
+	const [ canonical, options ] = descriptor;
+	const factory = await languageLoaders[ canonical ]();
+	return options ? factory( options ) : factory();
 }
 
 /**
@@ -174,23 +187,36 @@ export default function CodeBlock( { language, children } ) {
 			viewRef.current = null;
 		}
 
-		const langExtension = getLanguageExtension( language );
-		const extensions = [
-			...BASE_EXTENSIONS,
-			lineNumbers(),
-			...( langExtension ? [ langExtension ] : [] ),
-		];
+		let active = true;
+		const createView = ( langExtension = null ) =>
+			new EditorView( {
+				state: EditorState.create( {
+					doc: code,
+					extensions: [
+						...BASE_EXTENSIONS,
+						lineNumbers(),
+						...( langExtension ? [ langExtension ] : [] ),
+					],
+				} ),
+				parent: containerRef.current,
+			} );
 
-		viewRef.current = new EditorView( {
-			state: EditorState.create( {
-				doc: code,
-				extensions,
-			} ),
-			parent: containerRef.current,
-		} );
+		// Render readable, unhighlighted code immediately, then replace the view
+		// once the requested language parser arrives.
+		viewRef.current = createView();
+		getLanguageExtension( language )
+			.then( ( langExtension ) => {
+				if ( ! active || ! langExtension ) {
+					return;
+				}
+				viewRef.current?.destroy();
+				viewRef.current = createView( langExtension );
+			} )
+			.catch( () => undefined );
 
 		// Cleanup: destroy the view when the effect re-runs or the component unmounts.
 		return () => {
+			active = false;
 			if ( viewRef.current ) {
 				viewRef.current.destroy();
 				viewRef.current = null;

--- a/src/components/markdown-message.js
+++ b/src/components/markdown-message.js
@@ -16,24 +16,15 @@ import DataTable from './data-table';
 import FilePathLink from './FilePathLink';
 
 /**
- * CodeBlock and ChartBlock are lazy-loaded so their heavy dependencies
- * (CodeMirror ~800 KB, Chart.js ~220 KB) are bundled into separate async
- * chunks that are only downloaded the first time the AI returns a fenced
- * code block. webpackPrefetch causes the browser to fetch the chunks in
- * the background during idle time so the download is usually already
- * complete by the time a code block first appears.
+ * CodeBlock and ChartBlock are lazy-loaded so their heavy dependencies are
+ * downloaded only when the AI returns the matching fenced block. Do not
+ * prefetch these chunks: most conversations never need either dependency.
  */
 const CodeBlock = lazy( () =>
-	import(
-		/* webpackChunkName: "code-block", webpackPrefetch: true */
-		'./code-block'
-	)
+	import( /* webpackChunkName: "code-block" */ './code-block' )
 );
 const ChartBlock = lazy( () =>
-	import(
-		/* webpackChunkName: "chart-block", webpackPrefetch: true */
-		'./chart-block'
-	)
+	import( /* webpackChunkName: "chart-block" */ './chart-block' )
 );
 
 /**

--- a/src/floating-widget/reflectors/__tests__/index.test.js
+++ b/src/floating-widget/reflectors/__tests__/index.test.js
@@ -1,0 +1,71 @@
+jest.mock( '../../../store/reflection-bus', () => ( {
+	__esModule: true,
+	default: { on: jest.fn() },
+} ) );
+jest.mock( '../fallback-toast', () => ( {
+	showFallbackToast: jest.fn(),
+} ) );
+jest.mock( '../global-styles', () => ( {
+	reflectGlobalStyles: jest.fn(),
+} ) );
+jest.mock( '../menu', () => ( {
+	reflectMenu: jest.fn(),
+} ) );
+jest.mock( '../post', () => ( {
+	reflectPost: jest.fn(),
+} ) );
+
+import { showFallbackToast } from '../fallback-toast';
+import { reflectGlobalStyles } from '../global-styles';
+import { reflectMenu } from '../menu';
+import { reflectPost } from '../post';
+import bus from '../../../store/reflection-bus';
+import { dispatchReflectionEvent } from '..';
+
+const makeEvent = ( kind ) => ( {
+	type: 'tool-applied',
+	affected: { kind },
+} );
+
+describe( 'reflector dispatcher', () => {
+	beforeEach( () => {
+		showFallbackToast.mockClear();
+		reflectGlobalStyles.mockClear();
+		reflectMenu.mockClear();
+		reflectPost.mockClear();
+	} );
+
+	test( 'subscribes the deferred dispatcher to the reflection bus', () => {
+		expect( bus.on ).toHaveBeenCalledWith( dispatchReflectionEvent );
+	} );
+
+	test.each( [
+		[ 'post', reflectPost ],
+		[ 'global_styles', reflectGlobalStyles ],
+		[ 'menu', reflectMenu ],
+	] )( 'loads and runs the %s reflector', async ( kind, reflector ) => {
+		const event = makeEvent( kind );
+
+		await dispatchReflectionEvent( event );
+
+		expect( reflector ).toHaveBeenCalledWith( event );
+		expect( showFallbackToast ).not.toHaveBeenCalled();
+	} );
+
+	test( 'uses the fallback for an unknown affected kind', () => {
+		const event = makeEvent( 'unknown' );
+
+		dispatchReflectionEvent( event );
+
+		expect( showFallbackToast ).toHaveBeenCalledWith( event );
+	} );
+
+	test( 'uses the fallback when a deferred reflector rejects', async () => {
+		const event = makeEvent( 'post' );
+		reflectPost.mockRejectedValueOnce( new Error( 'reflection failed' ) );
+
+		await dispatchReflectionEvent( event );
+
+		expect( showFallbackToast ).toHaveBeenCalledWith( event );
+	} );
+} );

--- a/src/floating-widget/reflectors/index.js
+++ b/src/floating-widget/reflectors/index.js
@@ -8,27 +8,42 @@
 
 import bus from '../../store/reflection-bus';
 import { showFallbackToast } from './fallback-toast';
-import { reflectGlobalStyles } from './global-styles';
-import { reflectMenu } from './menu';
-import { reflectPost } from './post';
 
-bus.on( ( event ) => {
+const reflectorLoaders = {
+	post: () =>
+		import( /* webpackChunkName: "reflector-post" */ './post' ).then(
+			( module ) => module.reflectPost
+		),
+	global_styles: () =>
+		import(
+			/* webpackChunkName: "reflector-global-styles" */ './global-styles'
+		).then( ( module ) => module.reflectGlobalStyles ),
+	menu: () =>
+		import( /* webpackChunkName: "reflector-menu" */ './menu' ).then(
+			( module ) => module.reflectMenu
+		),
+};
+
+/**
+ * Dispatch a reflection event without loading unused DOM strategies up front.
+ *
+ * @param {Object} event Reflection bus event.
+ * @return {Promise<void>|void} Resolves after the selected reflector runs.
+ */
+export function dispatchReflectionEvent( event ) {
 	if ( event.type !== 'tool-applied' || ! event.affected?.kind ) {
 		return;
 	}
 
-	switch ( event.affected.kind ) {
-		case 'post':
-			reflectPost( event );
-			break;
-		case 'global_styles':
-			reflectGlobalStyles( event );
-			break;
-		case 'menu':
-			reflectMenu( event );
-			break;
-		default:
-			showFallbackToast( event );
-			break;
+	const loadReflector = reflectorLoaders[ event.affected.kind ];
+	if ( ! loadReflector ) {
+		showFallbackToast( event );
+		return;
 	}
-} );
+
+	return loadReflector()
+		.then( ( reflect ) => reflect( event ) )
+		.catch( () => showFallbackToast( event ) );
+}
+
+bus.on( dispatchReflectionEvent );

--- a/src/unified-admin/router.js
+++ b/src/unified-admin/router.js
@@ -13,25 +13,16 @@ import ChatRoute from './routes/chat';
 
 // All non-default routes are lazy-loaded so their code (SettingsApp and its
 // 12 managers, AbilitiesExplorer, ChangesPage, …) is only downloaded when
-// the user first navigates to that section.  webpackPrefetch fetches the
-// chunks in the background during idle time so transitions feel instant.
+// the user first navigates to that section. Avoid prefetching every route for
+// chat-only visits, especially the much larger settings dependency graph.
 const AbilitiesRoute = lazy( () =>
-	import(
-		/* webpackChunkName: "route-abilities", webpackPrefetch: true */
-		'./routes/abilities'
-	)
+	import( /* webpackChunkName: "route-abilities" */ './routes/abilities' )
 );
 const ChangesRoute = lazy( () =>
-	import(
-		/* webpackChunkName: "route-changes", webpackPrefetch: true */
-		'./routes/changes'
-	)
+	import( /* webpackChunkName: "route-changes" */ './routes/changes' )
 );
 const SettingsRoute = lazy( () =>
-	import(
-		/* webpackChunkName: "route-settings", webpackPrefetch: true */
-		'./routes/settings'
-	)
+	import( /* webpackChunkName: "route-settings" */ './routes/settings' )
 );
 
 /**


### PR DESCRIPTION
## Summary

- defer frontend reflection strategies so `morphdom` loads only after a matching tool result
- split launcher and panel CSS, and load the panel styles with the panel chunk
- defer Markdown, CodeMirror language parsers, charts, and non-default admin routes until requested
- expand bundle checks to cover aggregate and largest deferred JavaScript assets

## Bundle impact

- `floating-widget.js`: 78.3 KiB minified / 23.6 KiB gzip, down from 87.0 / 26.4 KiB
- `widget-panel.js`: 86.4 KiB minified / 23.2 KiB gzip
- largest deferred asset: 262.4 KiB minified / 84.5 KiB gzip, down from the previous approximately 709 / 244 KiB CodeMirror chunk
- existing floating-widget limits remain 87 / 28 KiB; the panel limit is tightened to 100 / 28 KiB

## Worker self-verification

- PHPUnit: Tests: 4126, Assertions: 18629, Errors: 0, Failures: 0, Skipped: 135
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

Additional JavaScript evidence: 49 suites, 488 tests, and 6 snapshots passed. PHPUnit also reported the same 4 pre-existing incomplete tests seen on the base revision; the suite exited successfully.

Resolves #2455

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.265 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 1h 16m and 769,087 tokens on this with the user in an interactive session.