### PR TITLE
docs(release): note frontend bundle optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Page creation and editing now use preview-first publication, rendered quality checks, and stronger post-mutation evidence requirements.
 - Read-only file inspections can be reused, path resolution and heading-only Markdown handling are more robust, and development package management now uses pnpm.
+- Initial frontend payloads are smaller: widget panel styles, live-preview strategies, Markdown, charts, syntax parsers, and non-default admin routes now load only when needed, with expanded deferred-bundle budgets guarding regressions.
 
 ### Fixed
 

--- a/readme.txt
+++ b/readme.txt
@@ -169,6 +169,7 @@ SD AI Agent uses the native WordPress AI Client SDK and Abilities API. These API
 = 1.22.0 - Released on 2026-08-15 =
 * New: Use verified SD account sign-in and account actions, apply account coupons, and review credit usage for each chat session.
 * Improved: Preview-first page changes, clearer agent activity, and stronger clarification and rendered-evidence safeguards.
+* Improved: Reduced initial frontend downloads by loading widget panel styles, live-preview strategies, Markdown, charts, syntax parsers, and non-default admin routes only when needed.
 * Fixed: Client-tool timeout recovery without replay, plus floating-widget state, navigation, image fallback, attachment, and provider-retry issues.
 
 = 1.21.0 - Released on 2026-07-30 =
@@ -284,4 +285,4 @@ SD AI Agent uses the native WordPress AI Client SDK and Abilities API. These API
 == Upgrade Notice ==
 
 = 1.22.0 =
-Improves client-tool recovery, page-change safeguards, SD account actions, credit visibility, and floating-widget reliability. Requires WordPress 7.0+ and PHP 8.2+.
+Improves client-tool recovery, page-change safeguards, SD account actions, credit visibility, floating-widget reliability, and frontend loading performance. Requires WordPress 7.0+ and PHP 8.2+.


### PR DESCRIPTION
## Summary

- document the frontend payload reduction merged in PR #2456 in the `1.22.0` changelog
- update the WordPress.org changelog and upgrade notice to mention deferred frontend loading

## Worker self-verification

- PHPUnit: Tests: 4126, Assertions: 18629, Errors: 0, Failures: 0, Skipped: 135
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

Ref #2455 and #2456

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.265 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 6h 29m and 2,315,349 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduced initial frontend downloads by loading widget styles, preview tools, Markdown support, charts, syntax parsers, and non-default administrative routes only when needed.
  * Improved loading performance for the application, especially on initial page access.
* **Documentation**
  * Updated the changelog and upgrade notes with details about the frontend loading improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->