### PR TITLE
GH#2461: Redeem coupons with site tokens

### DIFF
--- a/includes/Core/SuperdavSiteConnectionService.php
+++ b/includes/Core/SuperdavSiteConnectionService.php
@@ -30,8 +30,7 @@ final class SuperdavSiteConnectionService {
 	private const REVOCATION_ENDPOINT_PATH                = 'site/token/revoke';
 	private const ACCOUNT_STATUS_ENDPOINT_PATH            = 'site/account';
 	private const ACCOUNT_ACTION_ENDPOINT_PATH            = 'site/account/action';
-	private const ACCOUNT_COUPON_REDEMPTION_ENDPOINT_PATH = 'portal/account/redeem-coupon';
-	private const ACCOUNT_COUPON_REDEMPTION_PATH          = '/v1/portal/account/redeem-coupon';
+	private const ACCOUNT_COUPON_REDEMPTION_ENDPOINT_PATH = 'site/account/redeem-coupon';
 
 	/**
 	 * Maximum number of newest-first credit activity rows retained for display.
@@ -298,22 +297,14 @@ final class SuperdavSiteConnectionService {
 		if ( ! is_string( $body ) ) {
 			return new WP_Error( 'sd_ai_agent_coupon_redemption_unavailable', __( 'Coupon redemption is temporarily unavailable.', 'superdav-ai-agent' ), array( 'status' => 502 ) );
 		}
-		$path      = wp_parse_url( $endpoint, PHP_URL_PATH );
-		$signature = $this->get_account_coupon_redemption_signature( $body, is_string( $path ) && '' !== $path ? $path : self::ACCOUNT_COUPON_REDEMPTION_PATH );
-		if ( null === $signature ) {
-			return new WP_Error( 'sd_ai_agent_coupon_redemption_unavailable', __( 'Coupon redemption is temporarily unavailable.', 'superdav-ai-agent' ), array( 'status' => 503 ) );
-		}
-
 		$response = wp_remote_post(
 			$endpoint,
 			array(
 				'timeout'     => 15,
 				'redirection' => 0,
 				'headers'     => array(
-					'Authorization'        => 'Bearer ' . $token,
-					'Content-Type'         => 'application/json',
-					'X-Superdav-Timestamp' => $signature['timestamp'],
-					'X-Superdav-Signature' => $signature['value'],
+					'Authorization' => 'Bearer ' . $token,
+					'Content-Type'  => 'application/json',
 				),
 				'body'        => $body,
 			)
@@ -525,42 +516,6 @@ final class SuperdavSiteConnectionService {
 		$endpoint = apply_filters( 'sd_ai_agent_cloud_account_coupon_redemption_endpoint', $endpoint );
 
 		return $this->sanitize_account_url( $endpoint );
-	}
-
-	/**
-	 * Create the HMAC headers required by the managed portal redemption contract.
-	 *
-	 * The shared secret is deployment configuration only; it is never stored in
-	 * WordPress options, sent to the browser, or included in a REST response.
-	 *
-	 * @param string $body Exact JSON body that the service verifies.
-	 * @param string $path Request path resolved from the endpoint URL.
-	 * @return array{timestamp: string, value: string}|null Signature headers, or null when unconfigured.
-	 */
-	private function get_account_coupon_redemption_signature( string $body, string $path ): ?array {
-		$secret = defined( 'SD_AI_AGENT_CLOUD_PORTAL_SIGNING_SECRET' ) && is_string( SD_AI_AGENT_CLOUD_PORTAL_SIGNING_SECRET )
-			? SD_AI_AGENT_CLOUD_PORTAL_SIGNING_SECRET
-			: '';
-
-		/**
-		 * Filters the deployment-only secret used to sign coupon redemptions.
-		 *
-		 * The service verifies HMAC-SHA256 over timestamp, method, path, and the
-		 * exact JSON request body. Return an empty string to disable redemption.
-		 *
-		 * @param string $secret Portal signing secret.
-		 */
-		$secret = apply_filters( 'sd_ai_agent_cloud_portal_signing_secret', $secret );
-		if ( ! is_string( $secret ) || '' === $secret ) {
-			return null;
-		}
-
-		$timestamp = gmdate( 'c' );
-
-		return array(
-			'timestamp' => $timestamp,
-			'value'     => hash_hmac( 'sha256', $timestamp . '.POST.' . $path . '.' . $body, $secret ),
-		);
 	}
 
 	/**

--- a/tests/SdAiAgent/REST/SettingsControllerTest.php
+++ b/tests/SdAiAgent/REST/SettingsControllerTest.php
@@ -45,7 +45,6 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		delete_option( SuperdavSiteConnectionService::INSTALLATION_ID_OPTION );
 		delete_option( SuperdavSiteConnectionService::TOKEN_METADATA_OPTION );
 		remove_all_filters( 'sd_ai_agent_cloud_base_url' );
-		remove_all_filters( 'sd_ai_agent_cloud_portal_signing_secret' );
 		remove_all_filters( 'sd_ai_agent_cloud_account_action_endpoint' );
 		remove_all_filters( 'sd_ai_agent_cloud_account_coupon_redemption_endpoint' );
 		remove_all_filters( 'sd_ai_agent_options_read_blocklist' );
@@ -531,33 +530,28 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		}
 	}
 
-	/** Coupon redemption signs the documented request and returns only safe refreshed metadata. */
+	/** Coupon redemption uses the scoped site bearer token and returns only safe refreshed metadata. */
 	public function test_handle_redeem_superdav_coupon_returns_safe_refreshed_wallet(): void {
 		$base_url    = 'https://service.example/v1';
-		$redeem_url  = 'https://service.example/custom/portal/redeem-coupon';
+		$redeem_url  = 'https://service.example/custom/site/redeem-coupon';
 		$token       = 'sdaist_coupon_redemption_token';
 		$coupon_code = 'test-coupon-code';
-		$secret      = 'test-portal-signing-secret';
 
 		add_filter( 'sd_ai_agent_cloud_base_url', static fn(): string => $base_url );
 		add_filter( 'sd_ai_agent_cloud_account_coupon_redemption_endpoint', static fn(): string => $redeem_url );
-		add_filter( 'sd_ai_agent_cloud_portal_signing_secret', static fn(): string => $secret );
 		add_filter(
 			'pre_http_request',
-			static function ( mixed $preempt, array $parsed_args, string $url ) use ( $redeem_url, $token, $coupon_code, $secret ): mixed {
+			static function ( mixed $preempt, array $parsed_args, string $url ) use ( $redeem_url, $token, $coupon_code ): mixed {
 				if ( $redeem_url !== $url ) {
 					return $preempt;
 				}
 
-				$body      = (string) ( $parsed_args['body'] ?? '' );
-				$timestamp = (string) ( $parsed_args['headers']['X-Superdav-Timestamp'] ?? '' );
+				$body = (string) ( $parsed_args['body'] ?? '' );
 				self::assertSame( 'Bearer ' . $token, self::authorization_header_from_args( $parsed_args ) );
 				self::assertSame( 0, $parsed_args['redirection'] ?? null );
 				self::assertSame( $coupon_code, json_decode( $body, true )['coupon_code'] ?? '' );
-				self::assertSame(
-					hash_hmac( 'sha256', $timestamp . '.POST./custom/portal/redeem-coupon.' . $body, $secret ),
-					$parsed_args['headers']['X-Superdav-Signature'] ?? ''
-				);
+				self::assertArrayNotHasKey( 'X-Superdav-Timestamp', $parsed_args['headers'] );
+				self::assertArrayNotHasKey( 'X-Superdav-Signature', $parsed_args['headers'] );
 
 				return array(
 					'response' => array( 'code' => 200, 'message' => 'OK' ),
@@ -600,7 +594,7 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 	/** Redemption preserves documented coupon errors and safely collapses unknown failures. */
 	public function test_handle_redeem_superdav_coupon_handles_service_errors_without_disclosure(): void {
 		$base_url   = 'https://service.example/v1';
-		$redeem_url = $base_url . '/portal/account/redeem-coupon';
+		$redeem_url = $base_url . '/site/account/redeem-coupon';
 		$responses  = array(
 			array( 'code' => 302, 'error' => 'redirect', 'expected' => 'sd_ai_agent_coupon_redemption_unavailable' ),
 			array( 'code' => 404, 'error' => 'coupon_invalid', 'expected' => 'sd_ai_agent_coupon_invalid' ),
@@ -612,7 +606,6 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 		$response_index = 0;
 
 		add_filter( 'sd_ai_agent_cloud_base_url', static fn(): string => $base_url );
-		add_filter( 'sd_ai_agent_cloud_portal_signing_secret', static fn(): string => 'test-portal-signing-secret' );
 		add_filter(
 			'pre_http_request',
 			static function ( mixed $preempt, array $parsed_args, string $url ) use ( $redeem_url, $responses, &$response_index ): mixed {
@@ -655,13 +648,12 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 	/** Coupon redemption never sends its bearer token to unsafe filtered endpoints. */
 	public function test_handle_redeem_superdav_coupon_rejects_unsafe_endpoint_overrides(): void {
 		$endpoints = array(
-			'http://service.example/portal/account/redeem-coupon',
-			'https://coupon-user:coupon-password@service.example/portal/account/redeem-coupon',
-			'https://service.example/portal/account/redeem-coupon?access_token=must-not-be-sent',
+			'http://service.example/site/account/redeem-coupon',
+			'https://coupon-user:coupon-password@service.example/site/account/redeem-coupon',
+			'https://service.example/site/account/redeem-coupon?access_token=must-not-be-sent',
 		);
 
 		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, 'sdaist_coupon_endpoint_token', false );
-		add_filter( 'sd_ai_agent_cloud_portal_signing_secret', static fn(): string => 'test-portal-signing-secret' );
 		add_filter(
 			'pre_http_request',
 			static function (): void {
@@ -685,13 +677,12 @@ final class SettingsControllerTest extends WP_UnitTestCase {
 
 	/** A consumed coupon reports a non-retryable refresh error when metadata cannot persist. */
 	public function test_handle_redeem_superdav_coupon_reports_metadata_persistence_failure(): void {
-		$redeem_url = 'https://service.example/portal/account/redeem-coupon';
+		$redeem_url = 'https://service.example/site/account/redeem-coupon';
 		$metadata   = array( 'connected_at' => '2026-07-16T00:00:00+00:00' );
 
 		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, 'sdaist_coupon_persistence_token', false );
 		update_option( SuperdavSiteConnectionService::TOKEN_METADATA_OPTION, $metadata, false );
 		add_filter( 'sd_ai_agent_cloud_account_coupon_redemption_endpoint', static fn(): string => $redeem_url );
-		add_filter( 'sd_ai_agent_cloud_portal_signing_secret', static fn(): string => 'test-portal-signing-secret' );
 		add_filter(
 			'pre_http_request',
 			static function ( mixed $preempt, array $parsed_args, string $url ) use ( $redeem_url ): mixed {


### PR DESCRIPTION
## Summary

- redeem coupons through the canonical site endpoint with the stored site bearer token
- remove the customer-site dependency on the deployment-only portal HMAC secret
- preserve endpoint validation, no-redirect requests, safe wallet persistence, and normalized coupon errors
- assert canonical endpoint selection and absence of portal-signature headers

Resolves #2461

## Worker self-verification
- PHPUnit: Tests: 4126, Assertions: 18633, Errors: 0, Failures: 0, Skipped: 135, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.265 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated coupon redemption to use the current account endpoint.
  * Coupon redemption now authenticates with bearer credentials and no longer requires legacy signature headers.
  * Improved handling of unsafe requests and persistence failures for coupon redemption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->