### PR TITLE
Clarify account connection state

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -207,9 +207,11 @@ System notices:
 ### SD AI Account Card
 
 - Show the verified linked user's display name, masked email, and a concise “Email verified” status above wallet details.
+- When no verified user is linked, label the primary linking intent **Connect account to site**; reserve **Link a different user** for an existing linked identity.
 - Use **Link a different user** as a secondary action. Relinking must open the managed confirmation flow rather than accepting identity details in WordPress.
 - **Open account portal**, **Manage payment methods**, and **Add credits** are buttons that request a fresh one-time URL when clicked; do not render, inspect, or persist action tickets in the settings page.
 - Open account actions in a separate tab when the browser permits, clear `window.opener`, and show one neutral retry notice if URL minting fails.
+- Keep the account tab and each account card padded on every viewport: use the 2xl spacing token on desktop, the xl token on compact screens, and never let card content touch the settings panel edge.
 
 ### Tooltips
 

--- a/src/settings-page/__tests__/superdav-account-manager.test.js
+++ b/src/settings-page/__tests__/superdav-account-manager.test.js
@@ -359,6 +359,24 @@ describe( 'SuperdavAccountManager', () => {
 		);
 	} );
 
+	test( 'offers to connect the site when no verified user is linked', async () => {
+		apiFetch.mockResolvedValue( {
+			configured: true,
+			link_account_available: true,
+			linked_user: null,
+		} );
+
+		await act( async () => {
+			root.render( createElement( SuperdavAccountManager, {} ) );
+		} );
+		await act( async () => {
+			await Promise.resolve();
+		} );
+
+		expect( findButton( 'Connect account to site' ) ).toBeDefined();
+		expect( findButton( 'Link a different user' ) ).toBeUndefined();
+	} );
+
 	test( 'redeems a coupon, disables submission while pending, and updates the balance', async () => {
 		let resolveRedemption;
 		apiFetch

--- a/src/settings-page/style.css
+++ b/src/settings-page/style.css
@@ -1,6 +1,7 @@
 /* Settings Page */
 
 .sdaa-settings {
+	box-sizing: border-box;
 	max-width: 800px;
 	margin-top: 16px;
 	background: #fff;
@@ -113,7 +114,7 @@
 }
 
 .sdaa-settings-section {
-	padding: 20px 24px;
+	padding: 24px clamp(20px, 3vw, 32px);
 	display: flex;
 	flex-direction: column;
 	gap: 16px;
@@ -527,7 +528,8 @@
 .sd-ai-agent-superdav-account {
 	display: flex;
 	flex-direction: column;
-	gap: 24px;
+	gap: 28px;
+	width: 100%;
 }
 
 .sd-ai-agent-superdav-account-loading {
@@ -555,7 +557,8 @@
 .sd-ai-agent-superdav-linked-user,
 .sd-ai-agent-superdav-session-usage,
 .sd-ai-agent-superdav-credit-activity {
-	padding: 24px;
+	box-sizing: border-box;
+	padding: clamp(20px, 3vw, 28px);
 	border: 1px solid #dcdcde;
 	border-radius: 8px;
 	background: #fff;

--- a/src/settings-page/superdav-account-manager.js
+++ b/src/settings-page/superdav-account-manager.js
@@ -803,10 +803,15 @@ export default function SuperdavAccountManager() {
 									isBusy={ openingAction === 'link_account' }
 									disabled={ !! openingAction }
 								>
-									{ __(
-										'Link a different user',
-										'superdav-ai-agent'
-									) }
+									{ linkedUser
+										? __(
+												'Link a different user',
+												'superdav-ai-agent'
+										  )
+										: __(
+												'Connect account to site',
+												'superdav-ai-agent'
+										  ) }
 								</Button>
 							) }
 						</section>


### PR DESCRIPTION
## Summary
- show **Connect account to site** when no verified user is linked while retaining **Link a different user** for linked accounts
- increase responsive settings and account-card padding
- record the connection-state and spacing rules in `DESIGN.md`

## Worker self-verification
- PHPUnit: Tests: 4127, Assertions: 18636, Errors: 0, Failures: 0, Skipped: 135, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

## Targeted verification
- `pnpm run test:js -- src/settings-page/__tests__/superdav-account-manager.test.js --runInBand` — 12 tests passed

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.266 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer account actions: connect an account to a site when none is linked, or link a different user when one is already connected.
  * Improved responsive spacing and layout for settings sections, account tabs, and account cards.

* **Bug Fixes**
  * Corrected account-management actions for configured sites without a linked verified user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->