### PR TITLE
GH#2469: surface featured images in post listings

### DIFF
--- a/includes/Abilities/PostAbilities.php
+++ b/includes/Abilities/PostAbilities.php
@@ -376,7 +376,7 @@ class PostAbilities {
 			'sd-ai-agent/list-posts',
 			[
 				'label'               => __( 'List Posts', 'superdav-ai-agent' ),
-				'description'         => __( 'Query and list WordPress posts or pages. Filter by post_type, post_status (single string or array), search term, category, tag, date range (date_after/date_before), author, tax_query, and meta_query. Returns id, title, excerpt, status, post_type, date, permalink, featured_image_url, and query_args for each match. Default: 10 most recent published posts.', 'superdav-ai-agent' ),
+				'description'         => __( 'Query and list WordPress posts or pages. Filter by post_type, post_status (single string or array), search term, category, tag, date range (date_after/date_before), author, tax_query, and meta_query. Returns id, title, excerpt, status, post_type, date, permalink, featured-image state (has_featured_image, ID, alt text, and thumbnail URL when the current user can access the attachment), and query_args for each match. Default: 10 most recent published posts.', 'superdav-ai-agent' ),
 				'category'            => 'sd-ai-agent',
 				'input_schema'        => [
 					'type'       => 'object',
@@ -508,6 +508,9 @@ class PostAbilities {
 									'date'               => [ 'type' => 'string' ],
 									'modified'           => [ 'type' => 'string' ],
 									'permalink'          => [ 'type' => 'string' ],
+									'has_featured_image' => [ 'type' => 'boolean' ],
+									'featured_image_id'  => [ 'type' => 'integer' ],
+									'featured_image_alt' => [ 'type' => 'string' ],
 									'featured_image_url' => [ 'type' => 'string' ],
 									'categories'         => [ 'type' => 'array' ],
 									'tags'               => [ 'type' => 'array' ],
@@ -802,12 +805,7 @@ class PostAbilities {
 				continue;
 			}
 
-			$thumbnail_url = '';
-			$thumbnail_id  = get_post_thumbnail_id( $post->ID );
-			if ( $thumbnail_id ) {
-				$image_src     = wp_get_attachment_image_src( $thumbnail_id, 'medium' );
-				$thumbnail_url = $image_src ? $image_src[0] : '';
-			}
+			$featured_image = self::get_listed_featured_image_context( $post->ID );
 
 			$categories = wp_get_post_categories( $post->ID, [ 'fields' => 'names' ] );
 			$tags       = wp_get_post_tags( $post->ID, [ 'fields' => 'names' ] );
@@ -826,7 +824,10 @@ class PostAbilities {
 				'date'               => $post->post_date,
 				'modified'           => $post->post_modified,
 				'permalink'          => get_permalink( $post->ID ) ?: '',
-				'featured_image_url' => $thumbnail_url,
+				'has_featured_image' => $featured_image['has_featured_image'],
+				'featured_image_id'  => $featured_image['featured_image_id'],
+				'featured_image_alt' => $featured_image['featured_image_alt'],
+				'featured_image_url' => $featured_image['featured_image_url'],
 				'categories'         => is_wp_error( $categories ) ? [] : $categories,
 				'tags'               => is_wp_error( $tags ) ? [] : $tags,
 			];
@@ -844,6 +845,40 @@ class PostAbilities {
 			'per_page'   => $per_page,
 			'query_args' => $sanitized,
 		];
+	}
+
+	/**
+	 * Return featured-image context safe to expose from list-posts.
+	 *
+	 * The existence state is useful when auditing site content. Attachment
+	 * metadata and URLs are returned only to users who can edit that attachment,
+	 * so a post's thumbnail cannot expose private media from another user.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return array{has_featured_image: bool, featured_image_id: int, featured_image_alt: string, featured_image_url: string}
+	 */
+	private static function get_listed_featured_image_context( int $post_id ): array {
+		$thumbnail_id = (int) get_post_thumbnail_id( $post_id );
+		$has_image    = $thumbnail_id > 0 && wp_attachment_is_image( $thumbnail_id );
+
+		$context = [
+			'has_featured_image' => $has_image,
+			'featured_image_id'  => 0,
+			'featured_image_alt' => '',
+			'featured_image_url' => '',
+		];
+
+		if ( ! $has_image || ! current_user_can( 'edit_post', $thumbnail_id ) ) {
+			return $context;
+		}
+
+		$image_src = wp_get_attachment_image_src( $thumbnail_id, 'medium' );
+
+		$context['featured_image_id']  = $thumbnail_id;
+		$context['featured_image_alt'] = sanitize_text_field( (string) get_post_meta( $thumbnail_id, '_wp_attachment_image_alt', true ) );
+		$context['featured_image_url'] = $image_src ? $image_src[0] : '';
+
+		return $context;
 	}
 
 	/**

--- a/tests/SdAiAgent/Abilities/PostAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/PostAbilitiesTest.php
@@ -1254,6 +1254,70 @@ class PostAbilitiesTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Listed posts expose featured-image state and safe attachment context.
+	 */
+	public function test_handle_list_posts_includes_featured_image_context() {
+		$post_id = $this->factory->post->create( [ 'post_status' => 'publish' ] );
+		$thumb   = $this->factory->attachment->create_upload_object(
+			DIR_TESTDATA . '/images/canola.jpg',
+			$post_id
+		);
+
+		update_post_meta( $thumb, '_wp_attachment_image_alt', 'Canola field' );
+		set_post_thumbnail( $post_id, $thumb );
+
+		$result = PostAbilities::handle_list_posts( [
+			'post_status' => 'publish',
+			'per_page'    => 50,
+		] );
+
+		$this->assertIsArray( $result );
+		$posts = array_column( $result['posts'], null, 'id' );
+		$this->assertArrayHasKey( $post_id, $posts );
+		$this->assertTrue( $posts[ $post_id ]['has_featured_image'] );
+		$this->assertSame( $thumb, $posts[ $post_id ]['featured_image_id'] );
+		$this->assertSame( 'Canola field', $posts[ $post_id ]['featured_image_alt'] );
+		$this->assertNotSame( '', $posts[ $post_id ]['featured_image_url'] );
+	}
+
+	/**
+	 * Listed posts report image existence without exposing inaccessible media.
+	 */
+	public function test_handle_list_posts_hides_inaccessible_featured_image_metadata() {
+		$post_author_id  = self::factory()->user->create( [ 'role' => 'author' ] );
+		$media_author_id = self::factory()->user->create( [ 'role' => 'author' ] );
+		$post_id         = $this->factory->post->create( [
+			'post_author' => $post_author_id,
+			'post_status' => 'publish',
+		] );
+		$thumb           = $this->factory->attachment->create_upload_object(
+			DIR_TESTDATA . '/images/canola.jpg',
+			$post_id
+		);
+
+		wp_update_post( [
+			'ID'          => $thumb,
+			'post_author' => $media_author_id,
+		] );
+		update_post_meta( $thumb, '_wp_attachment_image_alt', 'Private attachment context' );
+		set_post_thumbnail( $post_id, $thumb );
+		wp_set_current_user( $post_author_id );
+
+		$result = PostAbilities::handle_list_posts( [
+			'post_status' => 'publish',
+			'per_page'    => 50,
+		] );
+
+		$this->assertIsArray( $result );
+		$posts = array_column( $result['posts'], null, 'id' );
+		$this->assertArrayHasKey( $post_id, $posts );
+		$this->assertTrue( $posts[ $post_id ]['has_featured_image'] );
+		$this->assertSame( 0, $posts[ $post_id ]['featured_image_id'] );
+		$this->assertSame( '', $posts[ $post_id ]['featured_image_alt'] );
+		$this->assertSame( '', $posts[ $post_id ]['featured_image_url'] );
+	}
+
+	/**
 	 * Multi-type array: page + post searches should work instead of producing a
 	 * schema validation retry loop when the agent is locating an unknown target.
 	 */


### PR DESCRIPTION
## Summary

- Add featured-image state, attachment ID, alt text, and thumbnail URL to `sd-ai-agent/list-posts` results.
- Restrict attachment metadata and URLs to media the current user can edit.
- Cover permitted and inaccessible featured-media contexts in `PostAbilitiesTest`.

Resolves #2469

## Runtime Testing

Self-assessed: this read-only ability change is covered by WordPress PHPUnit tests.

## Worker self-verification
- PHPUnit: Tests: 4129, Assertions: 18648, Errors: 0, Failures: 0, Skipped: 135, Incomplete: 4
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded
- Bundle: budgets passed

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.269 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 15m and 125,466 tokens on this as a headless worker. Overall, 26m since this issue was created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Post listings now indicate whether a featured image exists.
  * When permitted, listings include the featured image ID, URL, and sanitized alt text.
  * Image metadata is hidden when access is restricted, while image existence remains visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->