### PR TITLE
GH#2470: show exact tool calls

### DIFF
--- a/src/components/chat-redesign/__tests__/message-helpers.test.js
+++ b/src/components/chat-redesign/__tests__/message-helpers.test.js
@@ -291,6 +291,13 @@ describe( 'friendly tool progress summaries', () => {
 			'Checking colour contrast',
 			'Generating an image',
 		] );
+		expect( summary.recentSteps.map( ( step ) => step.toolName ) ).toEqual(
+			[
+				'sd-ai-agent/compile-design-tokens',
+				'sd-ai-agent/validate-palette-contrast',
+				'sd-ai-agent/generate-image',
+			]
+		);
 	} );
 } );
 

--- a/src/components/chat-redesign/__tests__/message-items.test.js
+++ b/src/components/chat-redesign/__tests__/message-items.test.js
@@ -7,7 +7,7 @@ import { useSelect } from '@wordpress/data';
 import { createRoot } from 'react-dom/client';
 import { act } from 'react';
 
-import { AssistantMessage } from '../message-items';
+import { AssistantMessage, RunningMessage } from '../message-items';
 
 global.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -137,5 +137,38 @@ describe( 'AssistantMessage progress summary', () => {
 		await act( async () => {
 			root.unmount();
 		} );
+	} );
+} );
+
+describe( 'RunningMessage progress summary', () => {
+	test( 'shows the exact canonical ability name while a tool runs', async () => {
+		const container = document.createElement( 'div' );
+		document.body.appendChild( container );
+		const root = createRoot( container );
+
+		await act( async () => {
+			root.render(
+				createElement( RunningMessage, {
+					step: 'Checking options…',
+					liveToolCalls: [
+						{
+							type: 'call',
+							id: 'options',
+							name: 'wpab__sd-ai-agent__list-options',
+						},
+					],
+				} )
+			);
+		} );
+
+		expect( container.textContent ).toContain( 'sd-ai-agent/list-options' );
+		expect( container.textContent ).not.toContain(
+			'wpab__sd-ai-agent__list-options'
+		);
+
+		await act( async () => {
+			root.unmount();
+		} );
+		document.body.removeChild( container );
 	} );
 } );

--- a/src/components/chat-redesign/message-helpers.js
+++ b/src/components/chat-redesign/message-helpers.js
@@ -294,6 +294,7 @@ export function buildToolProgressSummary( toolCalls ) {
 		return {
 			id: call.id || call.name || '',
 			label: getFriendlyToolLabel( call.name ),
+			toolName: normalizeToolName( call.name ),
 			status: deriveProgressStatus( response ),
 		};
 	} );

--- a/src/components/chat-redesign/message-items.js
+++ b/src/components/chat-redesign/message-items.js
@@ -335,6 +335,11 @@ function ToolProgressSummary( {
 							<span className="sdaa-cr-progress-step-label">
 								{ step.label }
 							</span>
+							{ step.toolName && (
+								<code className="sdaa-cr-progress-step-tool-name">
+									{ step.toolName }
+								</code>
+							) }
 							<span className="sdaa-cr-progress-step-status">
 								{ getProgressStepStatusLabel( step.status ) }
 							</span>


### PR DESCRIPTION
## Summary

- Show each running chat progress step's exact canonical ability name alongside its friendly label.
- Preserve bridge-name normalization so internal `sd-ai-agent/*` identifiers remain canonical.
- Cover the normalized summary data and rendered running-state UI.

Resolves #2470

## Runtime Testing

Self-assessed: the focused React rendering test verifies the default running chat view displays `sd-ai-agent/list-options`. Existing `src/abilities/__tests__/navigation.test.js` covers the supported same-site browser navigation path and external-URL rejection.

## Worker self-verification
- PHPUnit: Tests: 4127, Assertions: 18636, Errors: 0, Failures: 0, Skipped: 135, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

Additional focused JS tests:

- `pnpm run test:js -- --runInBand src/components/chat-redesign/__tests__/message-helpers.test.js src/components/chat-redesign/__tests__/message-items.test.js`

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.269 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 20m and 234,343 tokens on this as a headless worker. Overall, 32m since this issue was created.
