### PR TITLE
Show nested abilities and make client-tool retries idempotent

### DIFF
--- a/advanced-plugin/includes/Models/GitTracker.php
+++ b/advanced-plugin/includes/Models/GitTracker.php
@@ -550,6 +550,11 @@ class GitTracker {
 		$original_hash = hash( 'sha256', $original_content );
 		$now           = current_time( 'mysql', true );
 
+		// A second request can race the is_tracked() check. Keep an expected
+		// unique-key race (or a damaged legacy schema) from printing SQL text into
+		// a REST response; the package-scoped follow-up lookup distinguishes an
+		// idempotent insert from a real storage failure.
+		$previous_suppression = $wpdb->suppress_errors();
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Custom table insert.
 		$result = $wpdb->insert(
 			$table,
@@ -566,6 +571,11 @@ class GitTracker {
 			],
 			[ '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', null ]
 		);
+		$wpdb->suppress_errors( $previous_suppression );
+
+		if ( false === $result && $this->is_tracked( $relative_path ) ) {
+			return true;
+		}
 
 		if ( false === $result ) {
 			return new WP_Error(

--- a/includes/Core/ClientAbilityRouter.php
+++ b/includes/Core/ClientAbilityRouter.php
@@ -288,30 +288,117 @@ final class ClientAbilityRouter {
 			$expected_by_id[ $id ] = $name;
 		}
 
-		$seen_ids = array();
+		$submitted_by_id = self::validated_result_names_by_id( $tool_results );
+		if ( null === $submitted_by_id ) {
+			return false;
+		}
+
+		return self::result_name_maps_match( $submitted_by_id, $expected_by_id );
+	}
+
+	/**
+	 * Return whether a submitted result batch was already consumed earlier in
+	 * the resumed loop represented by an activity log.
+	 *
+	 * A successful /chat/tool-result request can continue synchronously until it
+	 * reaches another browser-tool pause. If the original HTTP response is then
+	 * lost or cannot be parsed, retrying the old batch sees that newer paused
+	 * state. The old opaque IDs are no longer the current pending IDs, but their
+	 * contiguous client-response batch is present in tool_call_log. Recognising
+	 * that exact historical ID/name set makes submission idempotent without
+	 * consuming or replacing the newer pause.
+	 *
+	 * Result payload values are deliberately not compared. Screenshot results
+	 * are stripped of image data before entering the activity log, so their
+	 * persisted representation differs from a legitimate browser retry. The
+	 * historical opaque ID/name batch is sufficient because this check never
+	 * replays the payload or mutates loop state.
+	 *
+	 * @param array<mixed,mixed> $tool_call_log Persisted ordered activity log.
+	 * @param array<mixed,mixed> $tool_results  Browser-submitted results.
+	 */
+	public static function matches_processed_results( array $tool_call_log, array $tool_results ): bool {
+		$submitted_by_id = self::validated_result_names_by_id( $tool_results );
+		if ( null === $submitted_by_id ) {
+			return false;
+		}
+
+		$processed_batch = array();
+		foreach ( $tool_call_log as $entry ) {
+			$is_client_response = is_array( $entry )
+				&& 'response' === ( $entry['type'] ?? '' )
+				&& 'client' === ( $entry['source'] ?? '' );
+
+			if ( ! $is_client_response ) {
+				if ( self::processed_batch_matches( $processed_batch, $submitted_by_id ) ) {
+					return true;
+				}
+				$processed_batch = array();
+				continue;
+			}
+
+			$id   = (string) ( $entry['id'] ?? '' );
+			$name = (string) ( $entry['name'] ?? '' );
+			if ( '' === $id || '' === $name || isset( $processed_batch[ $id ] ) ) {
+				$processed_batch = array();
+				continue;
+			}
+			$processed_batch[ $id ] = $name;
+		}
+
+		return self::processed_batch_matches( $processed_batch, $submitted_by_id );
+	}
+
+	/**
+	 * Validate one browser result batch and key its ability names by opaque ID.
+	 *
+	 * @param array<mixed,mixed> $tool_results Browser-submitted results.
+	 * @return array<string,string>|null Validated ID/name map, or null.
+	 */
+	private static function validated_result_names_by_id( array $tool_results ): ?array {
+		if ( empty( $tool_results ) ) {
+			return null;
+		}
+
+		$names_by_id = array();
 		foreach ( $tool_results as $result ) {
 			if ( ! is_array( $result ) ) {
-				return false;
+				return null;
 			}
 
 			$id         = (string) ( $result['id'] ?? '' );
 			$name       = (string) ( $result['name'] ?? '' );
 			$has_result = array_key_exists( 'result', $result );
 			$has_error  = array_key_exists( 'error', $result );
-			if (
-				'' === $id
-				|| ! isset( $expected_by_id[ $id ] )
-				|| $expected_by_id[ $id ] !== $name
-				|| isset( $seen_ids[ $id ] )
-				|| $has_result === $has_error
-			) {
-				return false;
+			if ( '' === $id || '' === $name || isset( $names_by_id[ $id ] ) || $has_result === $has_error ) {
+				return null;
 			}
 
-			$seen_ids[ $id ] = true;
+			$names_by_id[ $id ] = $name;
 		}
 
-		return count( $seen_ids ) === count( $expected_by_id );
+		return $names_by_id;
+	}
+
+	/**
+	 * Compare one contiguous historical client-response batch with a retry.
+	 *
+	 * @param array<string,string> $processed_batch Historical ID/name map.
+	 * @param array<string,string> $submitted_by_id Submitted ID/name map.
+	 */
+	private static function processed_batch_matches( array $processed_batch, array $submitted_by_id ): bool {
+		return self::result_name_maps_match( $processed_batch, $submitted_by_id );
+	}
+
+	/**
+	 * Compare two validated ID/name maps without depending on batch order.
+	 *
+	 * @param array<string,string> $left  First ID/name map.
+	 * @param array<string,string> $right Second ID/name map.
+	 */
+	private static function result_name_maps_match( array $left, array $right ): bool {
+		return count( $left ) === count( $right )
+			&& empty( array_diff_assoc( $left, $right ) );
 	}
 
 	/**

--- a/includes/Core/Database.php
+++ b/includes/Core/Database.php
@@ -36,7 +36,7 @@ use SdAiAgent\Tools\CustomTools;
 class Database {
 
 	const DB_VERSION_OPTION = 'sd_ai_agent_db_version';
-	const DB_VERSION        = '19.9.1';
+	const DB_VERSION        = '19.9.2';
 
 	// ─── Table Name Registry ──────────────────────────────────────────────────
 
@@ -565,7 +565,7 @@ class Database {
 			tracked_at datetime NOT NULL,
 			modified_at datetime DEFAULT NULL,
 			PRIMARY KEY  (id),
-			UNIQUE KEY file_path (file_path(255)),
+			UNIQUE KEY package_file (package_slug(191), file_path(255)),
 			KEY package_slug (package_slug),
 			KEY file_type (file_type),
 			KEY status (status)
@@ -902,6 +902,8 @@ class Database {
 
 		self::ensure_calendar_reminder_dedupe_index( $calendar_reminders_table );
 
+		self::ensure_git_tracked_files_package_index( $git_tracked_files_table );
+
 		// Add FULLTEXT index on memories table if not present.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Custom table query; table name from internal method.
 		$ft_exists = $wpdb->get_var( "SHOW INDEX FROM {$memories_table} WHERE Key_name = 'ft_content'" );
@@ -944,6 +946,40 @@ class Database {
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, PluginCheck.Security.DirectDB.UnescapedDBParameter -- Required schema repair for the calendar reminder dedupe index.
 		$wpdb->query( "ALTER TABLE {$table} ADD UNIQUE KEY reminder_dedupe (calendar_id, event_id, attendee_email, reminder_date)" );
+	}
+
+	/**
+	 * Scope tracked relative paths to their owning plugin or theme package.
+	 *
+	 * The legacy file_path-only key made ordinary names such as style.css collide
+	 * across every theme. Besides losing snapshots, wpdb printed those duplicate
+	 * errors into REST responses in debug mode and corrupted client-tool result
+	 * acknowledgements. dbDelta adds the replacement key but does not reliably
+	 * remove obsolete indexes, so repair both sides explicitly.
+	 */
+	private static function ensure_git_tracked_files_package_index( string $table ): bool {
+		global $wpdb;
+		/** @var \wpdb $wpdb */
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Internal schema introspection during a versioned upgrade.
+		$legacy_index = $wpdb->get_var( "SHOW INDEX FROM {$table} WHERE Key_name = 'file_path'" );
+		if ( null !== $legacy_index ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Removes the globally-scoped legacy uniqueness constraint.
+			if ( false === $wpdb->query( "ALTER TABLE {$table} DROP INDEX file_path" ) ) {
+				return false;
+			}
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Internal schema introspection during a versioned upgrade.
+		$package_index = $wpdb->get_var( "SHOW INDEX FROM {$table} WHERE Key_name = 'package_file' AND Non_unique = 0" );
+		if ( null !== $package_index ) {
+			return true;
+		}
+
+		// Prefix lengths remain below InnoDB's utf8mb4 index-byte limit while
+		// retaining enough package/path identity for WordPress-managed files.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.SchemaChange, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Adds the package-scoped uniqueness constraint required by GitTracker.
+		return false !== $wpdb->query( "ALTER TABLE {$table} ADD UNIQUE KEY package_file (package_slug(191), file_path(255))" );
 	}
 
 	/**

--- a/includes/REST/RestController.php
+++ b/includes/REST/RestController.php
@@ -532,6 +532,41 @@ Assistant: %s',
 		$pending_client_tool_calls = array_values( $pending_client_tool_calls );
 		$tool_results              = array_values( $tool_results );
 		if ( ! ClientAbilityRouter::matches_pending_results( $pending_client_tool_calls, $tool_results ) ) {
+			$tool_call_log = $paused_state['tool_call_log'] ?? array();
+			if (
+				is_array( $tool_call_log )
+				&& ClientAbilityRouter::matches_processed_results( $tool_call_log, $tool_results )
+			) {
+				// The prior POST was processed far enough to reach this newer
+				// browser-tool pause, but its HTTP response was lost or rejected by
+				// the client. Preserve the newer pause and acknowledge the old batch
+				// idempotently; never replay its already-consumed result payload.
+				Database::save_paused_state( $session_id, $paused_state );
+
+				AgentEventLog::log(
+					'client_tools_duplicate_result_accepted',
+					AgentEventLog::SEVERITY_INFO,
+					array(
+						'session_id'          => $session_id,
+						'job_id'              => $job_id,
+						'phase'               => 'tool_result_validation',
+						'reason'              => 'result_batch_already_processed',
+						'pending_state_found' => true,
+						'client_tool_count'   => count( $tool_results ),
+					)
+				);
+
+				return new WP_REST_Response(
+					array(
+						'status'           => 'already_processed',
+						'results_accepted' => true,
+						'session_id'       => $session_id,
+						'job_id'           => $job_id,
+					),
+					202
+				);
+			}
+
 			Database::save_paused_state( $session_id, $paused_state );
 
 			AgentEventLog::log(

--- a/src/components/chat-messages/__tests__/message-presentation.test.js
+++ b/src/components/chat-messages/__tests__/message-presentation.test.js
@@ -104,6 +104,25 @@ describe( 'shared chat message presentation', () => {
 		expect( getRunningStatusMessage( 100 ) ).toBe( 'Thinking…' );
 	} );
 
+	test( 'names the nested ability instead of the ability-call dispatcher', () => {
+		expect(
+			getRunningJobPresentation( {
+				currentSessionId: 7,
+				sessionJobs: {},
+				liveToolCalls: [
+					{
+						type: 'call',
+						name: 'wpab__sd-ai-agent__ability-call',
+						args: { ability: 'sd-ai-agent/update-post' },
+					},
+				],
+			} )
+		).toMatchObject( {
+			isFallback: false,
+			step: 'Updating content…',
+		} );
+	} );
+
 	test( 'keeps a concrete tool status instead of rotating fallback copy', () => {
 		expect(
 			getRunningJobPresentation( {

--- a/src/components/chat-redesign/ToolCard.js
+++ b/src/components/chat-redesign/ToolCard.js
@@ -104,7 +104,7 @@ function deriveStatus( call, response ) {
 	if ( ! response ) {
 		return 'running';
 	}
-	const r = response.response;
+	const r = getAbilityResponse( call, response );
 	if ( r && typeof r === 'object' ) {
 		if ( r.success === false || r.error ) {
 			return 'error';

--- a/src/components/chat-redesign/ToolCard.js
+++ b/src/components/chat-redesign/ToolCard.js
@@ -10,18 +10,7 @@ import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, check, chevronDown, undo, caution } from '@wordpress/icons';
 import DesignPreviewGallery from '../design-preview-gallery';
-
-/**
- *
- * @param {*} name
- */
-function formatName( name ) {
-	let display = name || '';
-	if ( display.startsWith( 'wpab__' ) ) {
-		display = display.substring( 6 );
-	}
-	return display.replace( /__/g, '/' );
-}
+import { getToolCallDisplayName, normalizeToolName } from './message-helpers';
 
 /**
  *
@@ -39,6 +28,29 @@ function formatValue( value ) {
 	} catch {
 		return String( value );
 	}
+}
+
+/**
+ * Return the result produced by the displayed ability.
+ *
+ * The ability-call dispatcher wraps successful target output in `result`.
+ * Direct abilities return that same payload at the top level.
+ *
+ * @param {*} call     Tool call.
+ * @param {*} response Tool response.
+ * @return {*} Displayed ability response payload.
+ */
+function getAbilityResponse( call, response ) {
+	const result = response?.response;
+	if (
+		getToolCallDisplayName( call ) !== normalizeToolName( call?.name ) &&
+		result?.success === true &&
+		result.result &&
+		typeof result.result === 'object'
+	) {
+		return result.result;
+	}
+	return result;
 }
 
 /**
@@ -113,7 +125,7 @@ function deriveSummary( call, response ) {
 	if ( ! response ) {
 		return '';
 	}
-	const r = response.response;
+	const r = getAbilityResponse( call, response );
 	if ( r && typeof r === 'object' ) {
 		if ( r.summary ) {
 			return formatValue( r.summary );
@@ -142,16 +154,15 @@ function deriveSummary( call, response ) {
  * @return {Array|null} Array of design preview objects, or null if not a preview tool call.
  */
 function extractDesignPreviews( call, response ) {
-	const rawName = ( call.name || '' ).toLowerCase();
+	const displayName = getToolCallDisplayName( call ).toLowerCase();
 	const isPreviewTool =
-		rawName === 'sd-ai-agent/render-design-previews' ||
-		rawName.includes( 'render-design-previews' ) ||
-		rawName.includes( 'render__design__previews' );
+		displayName === 'sd-ai-agent/render-design-previews' ||
+		displayName.endsWith( '/render-design-previews' );
 
 	if ( ! isPreviewTool ) {
 		return null;
 	}
-	const r = response && response.response;
+	const r = getAbilityResponse( call, response );
 	if (
 		r &&
 		Array.isArray( r.design_previews ) &&
@@ -172,8 +183,9 @@ function extractDesignPreviews( call, response ) {
  */
 export function ToolResultHighlights( { call, response } ) {
 	const designPreviews = extractDesignPreviews( call, response );
-	const previewMessage = response?.response?.message
-		? formatValue( response.response.message )
+	const abilityResponse = getAbilityResponse( call, response );
+	const previewMessage = abilityResponse?.message
+		? formatValue( abilityResponse.message )
 		: null;
 
 	if ( ! designPreviews ) {
@@ -191,11 +203,12 @@ export function ToolResultHighlights( { call, response } ) {
 /**
  * Return itemized update-blocks errors from a structured tool response.
  *
+ * @param {*} call     Tool call entry.
  * @param {*} response Tool response pair entry.
  * @return {Array} Itemized validation errors.
  */
-function extractItemizedErrors( response ) {
-	const result = response?.response;
+function extractItemizedErrors( call, response ) {
+	const result = getAbilityResponse( call, response );
 	const errors = result?.errors || result?.details?.errors;
 	return Array.isArray( errors ) ? errors : [];
 }
@@ -207,9 +220,9 @@ function extractItemizedErrors( response ) {
 function isMutating( call ) {
 	// Heuristic: any tool whose name hints at creating/updating/deleting
 	// is considered mutating. The store doesn't carry this flag natively.
-	const n = ( call.name || '' ).toLowerCase();
+	const name = getToolCallDisplayName( call ).toLowerCase();
 	return /create|update|delete|install|activate|deactivate|switch|set|move|publish|draft|revert|bulk|import/.test(
-		n
+		name
 	);
 }
 
@@ -230,7 +243,7 @@ export default function ToolCard( {
 	const status = deriveStatus( call, response );
 	const [ open, setOpen ] = useState( defaultOpen );
 
-	const name = formatName( call.name );
+	const name = getToolCallDisplayName( call );
 	const summary = deriveSummary( call, response );
 	const args = formatValue( call.args );
 	const result = response ? formatValue( response.response ) : '';
@@ -238,10 +251,11 @@ export default function ToolCard( {
 
 	// Extract design previews when this is a render-design-previews tool call.
 	const designPreviews = extractDesignPreviews( call, response );
-	const itemizedErrors = extractItemizedErrors( response );
+	const abilityResponse = getAbilityResponse( call, response );
+	const itemizedErrors = extractItemizedErrors( call, response );
 	const recoveryHints =
-		response?.response?.recovery_hints ||
-		response?.response?.details?.recovery_hints;
+		abilityResponse?.recovery_hints ||
+		abilityResponse?.details?.recovery_hints;
 	const hasRecoveryHints =
 		Array.isArray( recoveryHints ) && recoveryHints.length > 0;
 	const hasValidationFeedback = itemizedErrors.length > 0 || hasRecoveryHints;

--- a/src/components/chat-redesign/__tests__/ToolCard.test.js
+++ b/src/components/chat-redesign/__tests__/ToolCard.test.js
@@ -27,6 +27,25 @@ jest.mock(
 );
 
 describe( 'ToolCard', () => {
+	test( 'shows the nested ability instead of the ability-call dispatcher', () => {
+		const html = renderToStaticMarkup(
+			createElement( ToolCard, {
+				call: {
+					id: 'tool-dispatch',
+					name: 'wpab__sd-ai-agent__ability-call',
+					args: {
+						ability: 'sd-ai-agent/update-post',
+						arguments: { post_id: 42 },
+					},
+				},
+				response: null,
+			} )
+		);
+
+		expect( html ).toContain( 'sd-ai-agent/update-post' );
+		expect( html ).not.toContain( 'sd-ai-agent/ability-call</code>' );
+	} );
+
 	test( 'stringifies object-shaped response summaries before rendering', () => {
 		const html = renderToStaticMarkup(
 			createElement( ToolCard, {
@@ -117,6 +136,38 @@ describe( 'ToolCard', () => {
 			'Re-run get-page-blocks with the current revision.'
 		);
 		expect( html ).not.toContain( 'Validation errors' );
+	} );
+
+	test( 'recognizes design previews invoked through ability-call', () => {
+		const html = renderToStaticMarkup(
+			createElement( ToolResultHighlights, {
+				call: {
+					id: 'tool-dispatch-preview',
+					name: 'sd-ai-agent/ability-call',
+					args: {
+						ability: 'sd-ai-agent/render-design-previews',
+					},
+				},
+				response: {
+					id: 'tool-dispatch-preview',
+					response: {
+						ability: 'sd-ai-agent/render-design-previews',
+						success: true,
+						result: {
+							design_previews: [
+								{
+									name: 'Design 1',
+									html_url:
+										'https://example.test/design-1.html',
+								},
+							],
+						},
+					},
+				},
+			} )
+		);
+
+		expect( html ).toContain( 'Design preview gallery' );
 	} );
 
 	test( 'renders design previews as standalone result highlights', () => {

--- a/src/components/chat-redesign/__tests__/ToolCard.test.js
+++ b/src/components/chat-redesign/__tests__/ToolCard.test.js
@@ -46,6 +46,28 @@ describe( 'ToolCard', () => {
 		expect( html ).not.toContain( 'sd-ai-agent/ability-call</code>' );
 	} );
 
+	test( 'shows an error status when a nested ability response fails', () => {
+		const html = renderToStaticMarkup(
+			createElement( ToolCard, {
+				call: {
+					id: 'tool-dispatch-error',
+					name: 'wpab__sd-ai-agent__ability-call',
+					args: { ability: 'sd-ai-agent/update-post' },
+				},
+				response: {
+					id: 'tool-dispatch-error',
+					response: {
+						success: true,
+						result: { success: false, error: 'Validation failed.' },
+					},
+				},
+			} )
+		);
+
+		expect( html ).toContain( 'sdaa-cr-tool-status is-error' );
+		expect( html ).not.toContain( 'sdaa-cr-tool-status is-ok' );
+	} );
+
 	test( 'stringifies object-shaped response summaries before rendering', () => {
 		const html = renderToStaticMarkup(
 			createElement( ToolCard, {

--- a/src/components/chat-redesign/__tests__/message-helpers.test.js
+++ b/src/components/chat-redesign/__tests__/message-helpers.test.js
@@ -22,6 +22,7 @@ import {
 	extractText,
 	getFriendlyToolLabel,
 	getRunningToolName,
+	getToolCallDisplayName,
 	pairToolCalls,
 	parseSuggestions,
 	sanitizeProgressText,
@@ -195,6 +196,37 @@ describe( 'buildRunningItems', () => {
 	} );
 } );
 
+describe( 'tool call display names', () => {
+	test( 'uses the nested target for ability-call dispatches', () => {
+		expect(
+			getToolCallDisplayName( {
+				name: 'wpab__sd-ai-agent__ability-call',
+				args: { ability: 'sd-ai-agent/update-post' },
+			} )
+		).toBe( 'sd-ai-agent/update-post' );
+	} );
+
+	test( 'reads nested targets from JSON-encoded dispatcher arguments', () => {
+		expect(
+			getToolCallDisplayName( {
+				name: 'sd-ai-agent/ability-call',
+				args: '{"ability":"sd-ai-agent/get-theme-json"}',
+			} )
+		).toBe( 'sd-ai-agent/get-theme-json' );
+	} );
+
+	test( 'keeps direct abilities and incomplete dispatches identifiable', () => {
+		expect(
+			getToolCallDisplayName( {
+				name: 'wpab__sd-ai-agent__memory-list',
+			} )
+		).toBe( 'sd-ai-agent/memory-list' );
+		expect(
+			getToolCallDisplayName( { name: 'sd-ai-agent/ability-call' } )
+		).toBe( 'sd-ai-agent/ability-call' );
+	} );
+} );
+
 describe( 'getRunningToolName', () => {
 	test( 'returns null when no calls are present', () => {
 		expect( getRunningToolName( [] ) ).toBeNull();
@@ -209,6 +241,18 @@ describe( 'getRunningToolName', () => {
 			{ type: 'call', id: 'a', name: 'wpab__sd-ai-agent__memory-list' },
 		];
 		expect( getRunningToolName( log ) ).toBe( 'sd-ai-agent/memory-list' );
+	} );
+
+	test( 'returns the nested ability while a dispatcher call is running', () => {
+		const log = [
+			{
+				type: 'call',
+				id: 'a',
+				name: 'wpab__sd-ai-agent__ability-call',
+				args: { ability: 'sd-ai-agent/update-post' },
+			},
+		];
+		expect( getRunningToolName( log ) ).toBe( 'sd-ai-agent/update-post' );
 	} );
 
 	test( 'returns null when every call has a response', () => {
@@ -244,6 +288,22 @@ describe( 'friendly tool progress summaries', () => {
 		expect(
 			sanitizeProgressText( '<thinking>Planning templates</thinking>' )
 		).toBe( 'Planning templates' );
+	} );
+
+	test( 'shows the nested ability and action for dispatcher calls', () => {
+		const summary = buildToolProgressSummary( [
+			{
+				type: 'call',
+				id: 'update',
+				name: 'wpab__sd-ai-agent__ability-call',
+				args: { ability: 'sd-ai-agent/update-post' },
+			},
+		] );
+
+		expect( summary.currentLabel ).toBe( 'Updating content' );
+		expect( summary.recentSteps[ 0 ].toolName ).toBe(
+			'sd-ai-agent/update-post'
+		);
 	} );
 
 	test( 'summarizes completed, failed, and running steps', () => {

--- a/src/components/chat-redesign/__tests__/message-items.test.js
+++ b/src/components/chat-redesign/__tests__/message-items.test.js
@@ -141,7 +141,7 @@ describe( 'AssistantMessage progress summary', () => {
 } );
 
 describe( 'RunningMessage progress summary', () => {
-	test( 'shows the exact canonical ability name while a tool runs', async () => {
+	test( 'shows the exact nested ability instead of its dispatcher', async () => {
 		const container = document.createElement( 'div' );
 		document.body.appendChild( container );
 		const root = createRoot( container );
@@ -154,16 +154,20 @@ describe( 'RunningMessage progress summary', () => {
 						{
 							type: 'call',
 							id: 'options',
-							name: 'wpab__sd-ai-agent__list-options',
+							name: 'wpab__sd-ai-agent__ability-call',
+							args: {
+								ability: 'sd-ai-agent/list-options',
+							},
 						},
 					],
 				} )
 			);
 		} );
 
+		expect( container.textContent ).toContain( 'Checking options' );
 		expect( container.textContent ).toContain( 'sd-ai-agent/list-options' );
 		expect( container.textContent ).not.toContain(
-			'wpab__sd-ai-agent__list-options'
+			'sd-ai-agent/ability-call'
 		);
 
 		await act( async () => {

--- a/src/components/chat-redesign/chat-redesign.css
+++ b/src/components/chat-redesign/chat-redesign.css
@@ -1273,10 +1273,25 @@ input[type="text"].sdaa-cr-search-input {
 	background: var(--sdaa-warning);
 }
 
+.sdaa-cr-progress-step-details {
+	display: flex;
+	align-items: baseline;
+	gap: 7px;
+	min-width: 0;
+}
+
 .sdaa-cr-progress-step-label {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.sdaa-cr-progress-step-tool-name {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	color: var(--sdaa-text-muted);
+	font-size: 11px;
 }
 
 .sdaa-cr-progress-step-status {

--- a/src/components/chat-redesign/chat-redesign.css
+++ b/src/components/chat-redesign/chat-redesign.css
@@ -1273,7 +1273,7 @@ input[type="text"].sdaa-cr-search-input {
 	background: var(--sdaa-warning);
 }
 
-.sdaa-cr-progress-step-details {
+.sd-ai-agent-progress-step-details {
 	display: flex;
 	align-items: baseline;
 	gap: 7px;
@@ -1286,7 +1286,7 @@ input[type="text"].sdaa-cr-search-input {
 	white-space: nowrap;
 }
 
-.sdaa-cr-progress-step-tool-name {
+.sd-ai-agent-progress-step-tool-name {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;

--- a/src/components/chat-redesign/message-helpers.js
+++ b/src/components/chat-redesign/message-helpers.js
@@ -70,6 +70,44 @@ export function normalizeToolName( name ) {
 }
 
 /**
+ * Return the actual ability represented by a tool-call entry.
+ *
+ * Tier-2 abilities are invoked through the `sd-ai-agent/ability-call`
+ * dispatcher. Showing only that outer dispatcher hides the capability that is
+ * really running, so prefer its nested `ability` argument when available.
+ *
+ * @param {Object} call Tool-call entry.
+ * @return {string} Canonical ability name for display.
+ */
+export function getToolCallDisplayName( call ) {
+	const outerName = normalizeToolName( call?.name );
+	if (
+		outerName !== 'sd-ai-agent/ability-call' &&
+		outerName !== 'ability-call'
+	) {
+		return outerName;
+	}
+
+	let args = call?.args ?? call?.arguments;
+	if ( typeof args === 'string' ) {
+		try {
+			args = JSON.parse( args );
+		} catch {
+			args = null;
+		}
+	}
+
+	if ( args && typeof args === 'object' && ! Array.isArray( args ) ) {
+		const targetName = normalizeToolName( args.ability );
+		if ( targetName ) {
+			return targetName;
+		}
+	}
+
+	return outerName;
+}
+
+/**
  * Return the ability slug after the namespace.
  *
  * @param {string} name Raw or normalized tool/function name.
@@ -291,10 +329,11 @@ export function buildToolProgressSummary( toolCalls ) {
 
 	const steps = calls.map( ( call ) => {
 		const response = call.id ? responses[ call.id ] || null : null;
+		const toolName = getToolCallDisplayName( call );
 		return {
 			id: call.id || call.name || '',
-			label: getFriendlyToolLabel( call.name ),
-			toolName: normalizeToolName( call.name ),
+			label: getFriendlyToolLabel( toolName ),
+			toolName,
 			status: deriveProgressStatus( response ),
 		};
 	} );
@@ -476,9 +515,7 @@ export function getRunningToolName( toolCalls ) {
 		) || [];
 	const lastCall = calls[ calls.length - 1 ];
 	if ( responses.length < calls.length && lastCall ) {
-		return ( lastCall.name || '' )
-			.replace( /^wpab__/, '' )
-			.replace( /__/g, '/' );
+		return getToolCallDisplayName( lastCall );
 	}
 	return null;
 }

--- a/src/components/chat-redesign/message-items.js
+++ b/src/components/chat-redesign/message-items.js
@@ -332,12 +332,12 @@ function ToolProgressSummary( {
 								className="sdaa-cr-progress-step-dot"
 								aria-hidden="true"
 							/>
-							<span className="sdaa-cr-progress-step-details">
+							<span className="sd-ai-agent-progress-step-details">
 								<span className="sdaa-cr-progress-step-label">
 									{ step.label }
 								</span>
 								{ step.toolName && (
-									<code className="sdaa-cr-progress-step-tool-name">
+									<code className="sd-ai-agent-progress-step-tool-name">
 										{ step.toolName }
 									</code>
 								) }

--- a/src/components/chat-redesign/message-items.js
+++ b/src/components/chat-redesign/message-items.js
@@ -332,14 +332,16 @@ function ToolProgressSummary( {
 								className="sdaa-cr-progress-step-dot"
 								aria-hidden="true"
 							/>
-							<span className="sdaa-cr-progress-step-label">
-								{ step.label }
+							<span className="sdaa-cr-progress-step-details">
+								<span className="sdaa-cr-progress-step-label">
+									{ step.label }
+								</span>
+								{ step.toolName && (
+									<code className="sdaa-cr-progress-step-tool-name">
+										{ step.toolName }
+									</code>
+								) }
 							</span>
-							{ step.toolName && (
-								<code className="sdaa-cr-progress-step-tool-name">
-									{ step.toolName }
-								</code>
-							) }
 							<span className="sdaa-cr-progress-step-status">
 								{ getProgressStepStatusLabel( step.status ) }
 							</span>

--- a/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
@@ -426,10 +426,34 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 		);
 
 		$this->assertTrue( ClientAbilityRouter::matches_pending_results( $expected, $valid ) );
+		$this->assertTrue( ClientAbilityRouter::matches_pending_results( $expected, array_reverse( $valid ) ) );
 		$this->assertFalse( ClientAbilityRouter::matches_pending_results( $expected, array( array( 'id' => 'call-one', 'name' => 'sd-ai-agent-js/refresh-page', 'result' => array() ), array( 'id' => 'call-two', 'name' => 'sd-ai-agent-js/navigate-to', 'error' => 'Denied.' ) ) ) );
 		$this->assertFalse( ClientAbilityRouter::matches_pending_results( $expected, array( array( 'id' => 'unknown', 'name' => 'sd-ai-agent-js/navigate-to', 'result' => array() ), $valid[1] ) ) );
 		$this->assertFalse( ClientAbilityRouter::matches_pending_results( $expected, array( $valid[0], $valid[0] ) ) );
 		$this->assertFalse( ClientAbilityRouter::matches_pending_results( $expected, array( $valid[0] ) ) );
+	}
+
+	/**
+	 * Retries of a consumed client batch match its contiguous activity-log
+	 * response group, even when persisted payloads were transformed.
+	 */
+	public function test_processed_client_result_matcher_recognizes_only_the_complete_historical_batch(): void {
+		$activity = array(
+			array( 'type' => 'call', 'id' => 'old-one', 'name' => 'wpab__sd-ai-agent-js__screenshot-url' ),
+			array( 'type' => 'call', 'id' => 'old-two', 'name' => 'wpab__sd-ai-agent-js__validate-theme-completion' ),
+			array( 'type' => 'response', 'id' => 'old-one', 'name' => 'sd-ai-agent-js/screenshot-url', 'response' => array( 'attached_to_model' => true ), 'source' => 'client' ),
+			array( 'type' => 'response', 'id' => 'old-two', 'name' => 'sd-ai-agent-js/validate-theme-completion', 'response' => array( 'passed' => false ), 'source' => 'client' ),
+			array( 'type' => 'call', 'id' => 'current', 'name' => 'wpab__sd-ai-agent-js__validate-theme-completion' ),
+		);
+		$retry = array(
+			array( 'id' => 'old-two', 'name' => 'sd-ai-agent-js/validate-theme-completion', 'result' => array( 'passed' => false, 'violations' => array() ) ),
+			array( 'id' => 'old-one', 'name' => 'sd-ai-agent-js/screenshot-url', 'result' => array( 'image' => 'data:image/jpeg;base64,old-browser-payload' ) ),
+		);
+
+		$this->assertTrue( ClientAbilityRouter::matches_processed_results( $activity, $retry ) );
+		$this->assertFalse( ClientAbilityRouter::matches_processed_results( $activity, array( $retry[0] ) ) );
+		$this->assertFalse( ClientAbilityRouter::matches_processed_results( $activity, array( array( 'id' => 'old-one', 'name' => 'sd-ai-agent-js/validate-theme-completion', 'result' => array() ), $retry[0] ) ) );
+		$this->assertFalse( ClientAbilityRouter::matches_processed_results( $activity, array( array( 'id' => 'current', 'name' => 'sd-ai-agent-js/validate-theme-completion', 'result' => array() ) ) ) );
 	}
 
 	/**

--- a/tests/SdAiAgent/Core/DatabaseSchemaTest.php
+++ b/tests/SdAiAgent/Core/DatabaseSchemaTest.php
@@ -185,6 +185,30 @@ class DatabaseSchemaTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Git tracking scopes common relative paths (such as style.css) to the
+	 * owning plugin or theme rather than enforcing site-wide uniqueness.
+	 */
+	public function test_git_tracked_files_uses_package_scoped_unique_index(): void {
+		global $wpdb;
+
+		Database::install();
+
+		$table = Database::git_tracked_files_table_name();
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test-only schema introspection.
+		$package_index = $wpdb->get_results( "SHOW INDEX FROM {$table} WHERE Key_name = 'package_file' AND Non_unique = 0", ARRAY_A );
+		usort(
+			$package_index,
+			static fn( array $left, array $right ): int => (int) $left['Seq_in_index'] <=> (int) $right['Seq_in_index']
+		);
+
+		$this->assertSame( [ 'package_slug', 'file_path' ], array_column( $package_index, 'Column_name' ) );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- Test-only schema introspection.
+		$legacy_index = $wpdb->get_var( "SHOW INDEX FROM {$table} WHERE Key_name = 'file_path'" );
+		$this->assertNull( $legacy_index, 'The legacy globally unique file_path index must be removed.' );
+	}
+
+	/**
 	 * Skill usage telemetry table has the required columns and indexes.
 	 */
 	public function test_skill_usage_table_has_required_columns_and_indexes(): void {

--- a/tests/SdAiAgent/Models/GitTrackerManagerTest.php
+++ b/tests/SdAiAgent/Models/GitTrackerManagerTest.php
@@ -219,6 +219,25 @@ class GitTrackerManagerTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Different packages may track the same ordinary relative file path.
+	 */
+	public function test_snapshot_scopes_relative_file_paths_to_their_package(): void {
+		$plugin_style = $this->plugin_dir . '/style.css';
+		$theme_style  = $this->theme_dir . '/style.css';
+		file_put_contents( $plugin_style, '/* Plugin styles. */' );
+
+		$this->assertTrue( GitTrackerManager::snapshot_before_modify( $plugin_style ) );
+		$this->assertTrue( GitTrackerManager::snapshot_before_modify( $theme_style ) );
+
+		$plugin_tracker = GitTrackerManager::for_plugin( $this->plugin_slug );
+		$theme_tracker  = GitTrackerManager::for_theme( $this->theme_slug );
+		$this->assertInstanceOf( GitTracker::class, $plugin_tracker );
+		$this->assertInstanceOf( GitTracker::class, $theme_tracker );
+		$this->assertTrue( $plugin_tracker->is_tracked( 'style.css' ) );
+		$this->assertTrue( $theme_tracker->is_tracked( 'style.css' ) );
+	}
+
+	/**
 	 * snapshot_before_modify() silently succeeds (returns true) for files outside packages.
 	 */
 	public function test_snapshot_before_modify_silently_succeeds_outside_packages(): void {

--- a/tests/SdAiAgent/REST/RestControllerTest.php
+++ b/tests/SdAiAgent/REST/RestControllerTest.php
@@ -2624,6 +2624,89 @@ class RestControllerTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A retry of an already-consumed batch must acknowledge success while
+	 * preserving the newer client-tool pause reached by the original POST.
+	 */
+	public function test_tool_result_retry_accepts_processed_batch_without_consuming_newer_pause(): void {
+		wp_set_current_user( $this->admin_id );
+
+		$session_id = Database::create_session( [
+			'user_id' => $this->admin_id,
+			'title'   => 'Idempotent client result retry',
+		] );
+		$old_call   = [
+			'id'   => 'call-old-completion',
+			'name' => 'sd-ai-agent-js/validate-theme-completion',
+		];
+		$new_call   = [
+			'id'          => 'call-current-completion',
+			'name'        => 'sd-ai-agent-js/validate-theme-completion',
+			'args'        => [ 'stylesheet' => 'generated-current' ],
+			'annotations' => [ 'readonly' => true ],
+		];
+		$paused_state = [
+			'history'                   => [],
+			'iterations_remaining'      => 3,
+			'pending_client_tool_calls' => [ $new_call ],
+			'tool_call_log'             => [
+				[ 'type' => 'call', 'id' => $old_call['id'], 'name' => 'wpab__sd-ai-agent-js__validate-theme-completion', 'sequence' => 1 ],
+				[ 'type' => 'response', 'id' => $old_call['id'], 'name' => $old_call['name'], 'response' => [ 'passed' => false ], 'source' => 'client', 'sequence' => 2 ],
+				[ 'type' => 'call', 'id' => $new_call['id'], 'name' => 'wpab__sd-ai-agent-js__validate-theme-completion', 'sequence' => 3 ],
+			],
+		];
+		Database::save_paused_state( $session_id, $paused_state );
+
+		$job_id = '44444444-5555-6666-7777-888888888888';
+		ActiveJobRepository::create( $session_id, $job_id, $this->admin_id, 'awaiting_client_tools' );
+		ActiveJobRepository::update_status(
+			$job_id,
+			'awaiting_client_tools',
+			[ 'pending_tools' => wp_json_encode( [ $new_call ] ) ]
+		);
+		set_transient(
+			RestController::JOB_PREFIX . $job_id,
+			[
+				'status'                    => 'awaiting_client_tools',
+				'pending_client_tool_calls' => [ $new_call ],
+			],
+			RestController::JOB_TTL
+		);
+
+		$request = new WP_REST_Request( 'POST', '/sd-ai-agent/v1/chat/tool-result' );
+		$request->set_body( wp_json_encode( [
+			'session_id'   => $session_id,
+			'job_id'       => $job_id,
+			'tool_results' => [
+				[
+					'id'     => $old_call['id'],
+					'name'   => $old_call['name'],
+					'result' => [ 'passed' => false, 'violations' => [ [ 'code' => 'focus' ] ] ],
+				],
+			],
+		] ) );
+		$request->set_header( 'Content-Type', 'application/json' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertStatus( 202, $response );
+		$data = $response->get_data();
+		$this->assertSame( 'already_processed', $data['status'] );
+		$this->assertTrue( $data['results_accepted'] );
+
+		$session_after = Database::get_session( $session_id );
+		$this->assertNotNull( $session_after );
+		$this->assertSame( $paused_state, json_decode( (string) $session_after->paused_state, true ) );
+
+		$transient_after = get_transient( RestController::JOB_PREFIX . $job_id );
+		$this->assertIsArray( $transient_after );
+		$this->assertSame( [ $new_call ], $transient_after['pending_client_tool_calls'] );
+
+		$db_row = ActiveJobRepository::get_by_job_id( $job_id );
+		$this->assertNotNull( $db_row );
+		$this->assertSame( 'awaiting_client_tools', $db_row->status );
+		$this->assertSame( [ $new_call ], json_decode( $db_row->pending_tools, true ) );
+	}
+
+	/**
 	 * Test POST /chat/tool-result cannot consume another user's paused state.
 	 *
 	 * The permission callback must verify access to the supplied session_id before


### PR DESCRIPTION
Follow-up to #2470.

## Summary
- resolve the target nested inside `sd-ai-agent/ability-call` for live and persisted progress updates
- show the target's friendly action and canonical ability ID instead of the generic dispatcher
- apply the same target resolution to detailed tool cards, wrapped design-preview results, and nested failures
- make `/chat/tool-result` retries idempotent when an earlier result was accepted and the loop has already reached a newer browser-tool pause
- scope Git-tracked relative paths to their owning plugin or theme, migrate the legacy global `file_path` key, and prevent expected insert races from corrupting REST JSON
- preserve direct tool calls and incomplete dispatcher calls for backward compatibility

## Root-cause evidence
- the original client-tool POST completed and advanced the paused loop, but a duplicate Git-tracking key printed SQL diagnostics before the REST JSON
- the browser therefore retried the already-consumed result against the newer pending call and received `sd_ai_agent_invalid_client_tool_results`
- the new package-scoped key removes the response corruption, while processed-batch recognition safely acknowledges stale delivery retries without replaying results or consuming the newer pause

## Testing
- `pnpm run verify`
- live database migration verified `package_file (package_slug, file_path)` replaced the legacy global `file_path` unique key
- live retry replay returned HTTP 202 with `results_accepted: true` while preserving the newer pending client call

## Worker self-verification
- PHPUnit: Tests: 4133, Assertions: 18662, Errors: 0, Failures: 0, Skipped: 137
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

PHPUnit also reported 4 existing incomplete tests.
