### PR TITLE
Fix stale Superdav image model discovery

### DIFF
--- a/includes/Abilities/ImageAbilities/GenerateImageAbility.php
+++ b/includes/Abilities/ImageAbilities/GenerateImageAbility.php
@@ -20,6 +20,8 @@ namespace SdAiAgent\Abilities\ImageAbilities;
 
 use SdAiAgent\Abilities\ToolCapabilities;
 use SdAiAgent\Core\Net\SafeHttpClient;
+use SdAiAgent\Core\ProviderCredentialLoader;
+use SdAiAgent\Core\ProviderModelDiscovery;
 use SdAiAgent\Core\Settings;
 use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
 use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
@@ -51,8 +53,7 @@ class GenerateImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 			return;
 		}
 
-		if ( ! function_exists( 'wp_ai_client_prompt' )
-			|| ! wp_ai_client_prompt()->is_supported_for_image_generation() ) {
+		if ( ! self::is_image_generation_supported() ) {
 			return;
 		}
 
@@ -351,8 +352,7 @@ class GenerateImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 		int $post_id,
 		array $options = []
 	): array|\WP_Error {
-		if ( ! function_exists( 'wp_ai_client_prompt' )
-			|| ! wp_ai_client_prompt()->is_supported_for_image_generation() ) {
+		if ( ! self::is_image_generation_supported() ) {
 			return new WP_Error(
 				'provider_unavailable',
 				'AI image generation is not available. Configure an image-capable provider in Settings > AI.'
@@ -398,6 +398,41 @@ class GenerateImageAbility extends \SdAiAgent\Abilities\AbstractAbility {
 			'attachment_id' => $attachment_id,
 			'url'           => $result['url'],
 		];
+	}
+
+	/**
+	 * Check image support and recover stale managed Superdav model discovery.
+	 *
+	 * The SDK converts model-directory exceptions into a false support result.
+	 * That previously made the image ability disappear when the managed site
+	 * token had expired, even though the existing provider-list path could
+	 * refresh the token. Reuse that bounded discovery recovery before treating
+	 * the configured provider as unavailable.
+	 */
+	private static function is_image_generation_supported(): bool {
+		if ( ! function_exists( 'wp_ai_client_prompt' ) ) {
+			return false;
+		}
+
+		ProviderCredentialLoader::load();
+		if ( wp_ai_client_prompt()->is_supported_for_image_generation() ) {
+			return true;
+		}
+
+		try {
+			$registry = \WordPress\AiClient\AiClient::defaultRegistry();
+			if ( ! $registry->hasProvider( SuperdavAiProvider::PROVIDER_ID )
+				|| null === $registry->getProviderRequestAuthentication( SuperdavAiProvider::PROVIDER_ID )
+			) {
+				return false;
+			}
+
+			ProviderModelDiscovery::discover( SuperdavAiProvider::PROVIDER_ID, SuperdavAiProvider::class );
+		} catch ( \Throwable ) {
+			return false;
+		}
+
+		return wp_ai_client_prompt()->is_supported_for_image_generation();
 	}
 
 	/**

--- a/tests/SdAiAgent/Abilities/AiImageAbilitiesTest.php
+++ b/tests/SdAiAgent/Abilities/AiImageAbilitiesTest.php
@@ -11,9 +11,11 @@ namespace SdAiAgent\Tests\Abilities;
 
 use SdAiAgent\Abilities\AiImageAbilities;
 use SdAiAgent\Abilities\ImageAbilities\GenerateImageAbility;
+use SdAiAgent\Bootstrap\SuperdavAiProviderHandler;
 use SdAiAgent\Core\Settings;
 use SdAiAgent\Core\ToolPermissionResolver;
 use SdAiAgent\Infrastructure\AiClient\Superdav\SuperdavAiProvider;
+use WordPress\AiClient\AiClient;
 use WordPress\AiClient\Providers\Models\DTO\ModelConfig;
 use WP_UnitTestCase;
 
@@ -158,6 +160,112 @@ class AiImageAbilitiesTest extends WP_UnitTestCase {
 		$this->assertFalse( $meta['annotations']['destructive'] );
 		$this->assertSame( 'write', ToolPermissionResolver::classify_ability( $ability ) );
 		$this->assertFalse( ToolPermissionResolver::ability_needs_confirmation( 'sd-ai-agent/generate-image', $ability, [] ) );
+	}
+
+	/**
+	 * A stale managed token should be refreshed before image support is rejected.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_generate_image_recovers_stale_superdav_model_discovery(): void {
+		if ( ! class_exists( AiClient::class ) ) {
+			$this->markTestSkipped( 'WordPress AI Client SDK is unavailable.' );
+		}
+
+		$previous_token   = get_option( SuperdavAiProvider::CREDENTIAL_OPTION, null );
+		$base_url         = 'https://image-service.example/v1';
+		$models_url       = $base_url . '/models';
+		$registration_url = $base_url . '/site/installations';
+		$model_hits        = 0;
+		$registration_hits = 0;
+
+		$base_url_filter = static fn(): string => $base_url;
+		$http_filter     = static function ( mixed $preempt, array $parsed_args, string $url ) use ( $models_url, $registration_url, &$model_hits, &$registration_hits ): mixed {
+			if ( $registration_url === $url ) {
+				++$registration_hits;
+
+				return array(
+					'response' => array(
+						'code'    => 201,
+						'message' => 'Created',
+					),
+					'body'     => wp_json_encode( array( 'site_token' => 'sdaist_refreshed_image_token' ) ),
+				);
+			}
+
+			if ( $models_url !== $url ) {
+				return $preempt;
+			}
+
+			++$model_hits;
+			$headers       = (array) ( $parsed_args['headers'] ?? array() );
+			$authorization = '';
+			foreach ( $headers as $name => $value ) {
+				if ( 'authorization' === strtolower( (string) $name ) ) {
+					$authorization = is_array( $value ) ? (string) reset( $value ) : (string) $value;
+					break;
+				}
+			}
+
+			if ( 'Bearer sdaist_refreshed_image_token' !== $authorization ) {
+				return array(
+					'response' => array(
+						'code'    => 401,
+						'message' => 'Unauthorized',
+					),
+					'body'     => wp_json_encode( array( 'error' => array( 'message' => 'Invalid site token.' ) ) ),
+				);
+			}
+
+			return array(
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'body'     => wp_json_encode(
+					array(
+						'data' => array(
+							array(
+								'id'           => SuperdavAiProvider::IMAGE_MODEL_ID,
+								'capabilities' => array( 'image_generation' ),
+							),
+						),
+					)
+				),
+			);
+		};
+
+		add_filter( 'sd_ai_agent_cloud_base_url', $base_url_filter );
+		add_filter( 'pre_http_request', $http_filter, 10, 3 );
+		update_option( SuperdavAiProvider::CREDENTIAL_OPTION, 'sdaist_stale_image_token', false );
+		( new SuperdavAiProviderHandler() )->register_provider();
+
+		$directory = SuperdavAiProvider::modelMetadataDirectory();
+		if ( method_exists( $directory, 'invalidateCaches' ) ) {
+			$directory->invalidateCaches();
+		}
+
+		try {
+			$method = new \ReflectionMethod( GenerateImageAbility::class, 'is_image_generation_supported' );
+			$method->setAccessible( true );
+
+			$this->assertTrue( $method->invoke( null ) );
+			$this->assertSame( 3, $model_hits );
+			$this->assertSame( 1, $registration_hits );
+			$this->assertSame( 'sdaist_refreshed_image_token', get_option( SuperdavAiProvider::CREDENTIAL_OPTION, '' ) );
+		} finally {
+			remove_filter( 'sd_ai_agent_cloud_base_url', $base_url_filter );
+			remove_filter( 'pre_http_request', $http_filter, 10 );
+			if ( method_exists( $directory, 'invalidateCaches' ) ) {
+				$directory->invalidateCaches();
+			}
+			if ( null === $previous_token ) {
+				delete_option( SuperdavAiProvider::CREDENTIAL_OPTION );
+			} else {
+				update_option( SuperdavAiProvider::CREDENTIAL_OPTION, $previous_token, false );
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- recover stale managed Superdav model discovery before image generation is declared unavailable
- keep the generate-image ability registered after an expired site token and add isolated regression coverage

## Verification

- Live test: a deliberately stale token was refreshed automatically and generated WordPress attachment 22 with the `superdav-image` model

## Worker self-verification
- PHPUnit: Tests: 4134, Assertions: 18675, Errors: 0, Failures: 0, Skipped: 135
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.269 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol
