### PR TITLE
Fix Superdav image option compatibility

### DIFF
--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiImageGenerationModel.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiImageGenerationModel.php
@@ -69,7 +69,29 @@ final class SuperdavAiImageGenerationModel extends AbstractOpenAiCompatibleImage
 	 */
 	protected function prepareGenerateImageParams( array $prompt ): array {
 		$params = parent::prepareGenerateImageParams( $prompt );
-		unset( $params['response_format'] );
+
+		// The public ability accepts common DALL-E-style hints, while the
+		// managed alias currently targets GPT Image. Drop or translate the
+		// incompatible values instead of forwarding a request that the managed
+		// gateway must reject. Unsupported options are intentionally graceful
+		// no-ops in the generate-image ability contract.
+		unset( $params['response_format'], $params['style'] );
+
+		$quality = strtolower( trim( (string) ( $params['quality'] ?? '' ) ) );
+		if ( 'hd' === $quality ) {
+			$params['quality'] = 'high';
+		} elseif ( ! in_array( $quality, array( 'low', 'medium', 'high', 'auto' ), true ) ) {
+			unset( $params['quality'] );
+		}
+
+		$size_map = array(
+			'1792x1024' => '1536x1024',
+			'1024x1792' => '1024x1536',
+		);
+		$size     = (string) ( $params['size'] ?? '' );
+		if ( isset( $size_map[ $size ] ) ) {
+			$params['size'] = $size_map[ $size ];
+		}
 
 		return $params;
 	}

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
@@ -469,6 +469,42 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Managed image requests translate DALL-E hints to GPT Image options.
+	 */
+	public function test_image_request_normalizes_managed_model_options(): void {
+		$this->skip_if_sdk_unavailable();
+
+		$model = new SuperdavAiImageGenerationModel(
+			new ModelMetadata(
+				SuperdavAiProvider::IMAGE_MODEL_ID,
+				'Superdav Image',
+				array( CapabilityEnum::imageGeneration() ),
+				array()
+			),
+			SuperdavAiProvider::metadata()
+		);
+		$config = new ModelConfig();
+		$config->setCustomOptions(
+			array(
+				'size'    => '1792x1024',
+				'style'   => 'natural',
+				'quality' => 'hd',
+			)
+		);
+		$model->setConfig( $config );
+
+		$prepare = new \ReflectionMethod( $model, 'prepareGenerateImageParams' );
+		$prepare->setAccessible( true );
+		$params = $prepare->invoke( $model, array( new UserMessage( array( new MessagePart( 'Create a beach scene.' ) ) ) ) );
+
+		$this->assertIsArray( $params );
+		$this->assertSame( '1536x1024', $params['size'] );
+		$this->assertSame( 'high', $params['quality'] );
+		$this->assertArrayNotHasKey( 'style', $params );
+		$this->assertArrayNotHasKey( 'response_format', $params );
+	}
+
+	/**
 	 * Image prompts use the OpenAI-compatible edit endpoint with a multipart upload.
 	 */
 	public function test_image_edit_request_uses_multipart_edits_endpoint(): void {


### PR DESCRIPTION
## Summary

- normalize generic image-generation hints for the bundled `superdav-image` model
- drop unsupported GPT Image `style` and response-format values
- translate legacy `hd` quality and DALL-E landscape/portrait dimensions to GPT Image equivalents

## Root cause and live verification

The chat agent correctly selected the first-party `sd-ai-agent-cloud` provider and `superdav-image` model, but supplied the ability's documented DALL-E-style defaults (`style: natural`, `quality: standard`). The managed alias currently targets `gpt-image-1`, which rejected those values and surfaced a 502.

Before this change, the full agent loop reproduced the 502 twice. With this change, the same agent-loop flow used `superdav-chat-pro` for tool orchestration, called `sd-ai-agent/generate-image`, routed image generation through `superdav-image`, and created WordPress media attachment 24.

The managed-service boundary is also hardened in https://github.com/Ultimate-Multisite/superdav-ai-service/pull/93.

## Worker self-verification
- PHPUnit: Tests: 4135, Assertions: 18680, Errors: 0, Failures: 0, Skipped: 135
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.269 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI image generation compatibility by translating supported image sizes and quality settings to compatible values.
  * Unsupported style, response format, and quality options are now omitted automatically.

* **Tests**
  * Added coverage verifying that image-generation options are normalized correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->