### PR TITLE
fix: normalize Superdav image quality options

### DIFF
--- a/includes/Infrastructure/AiClient/Superdav/SuperdavAiImageGenerationModel.php
+++ b/includes/Infrastructure/AiClient/Superdav/SuperdavAiImageGenerationModel.php
@@ -79,8 +79,11 @@ final class SuperdavAiImageGenerationModel extends AbstractOpenAiCompatibleImage
 
 		$quality = strtolower( trim( (string) ( $params['quality'] ?? '' ) ) );
 		if ( 'hd' === $quality ) {
-			$params['quality'] = 'high';
-		} elseif ( ! in_array( $quality, array( 'low', 'medium', 'high', 'auto' ), true ) ) {
+			$quality = 'high';
+		}
+		if ( in_array( $quality, array( 'low', 'medium', 'high', 'auto' ), true ) ) {
+			$params['quality'] = $quality;
+		} else {
 			unset( $params['quality'] );
 		}
 

--- a/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
+++ b/tests/SdAiAgent/Infrastructure/AiClient/Superdav/SuperdavAiProviderTest.php
@@ -488,7 +488,7 @@ final class SuperdavAiProviderTest extends WP_UnitTestCase {
 			array(
 				'size'    => '1792x1024',
 				'style'   => 'natural',
-				'quality' => 'hd',
+				'quality' => ' HIGH ',
 			)
 		);
 		$model->setConfig( $config );


### PR DESCRIPTION
## Summary

- Normalize supported Superdav image quality values before forwarding them.
- Cover whitespace-padded quality input in the provider test.

## Testing

- `pnpm run verify`

## Worker self-verification

- PHPUnit: Tests: 4135, Assertions: 18680, Errors: 0, Failures: 0, Skipped: 135, Incomplete: 4
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded
- Bundle: budgets passed

Resolves #2481

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.269 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra
