### PR TITLE
GH#2486: fix(ci): avoid Playwright dependency install stalls

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -116,10 +116,11 @@ jobs:
             if (!patched) console.log('No files needed patching');
           "
 
-      - name: Install Playwright browser dependencies
-        run: |
-          pnpm exec playwright install-deps chromium
-          google-chrome --version
+      # Playwright launches the preinstalled Chrome channel below. Avoid
+      # `playwright install-deps`, which runs apt and can stall on a runner
+      # mirror before the E2E suite starts.
+      - name: Verify system Chrome availability
+        run: google-chrome --version
 
       - name: Build plugin assets
         run: pnpm run build


### PR DESCRIPTION
## Summary

- replace the apt-backed Playwright dependency installer with a Google Chrome availability check
- prevent runner mirror stalls from consuming the E2E job timeout before tests begin

## Files Changed

- `.github/workflows/e2e.yml`

## Verification

- `pnpm exec playwright --version`
- `git diff --check`

Resolves #2486

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.272 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 50m and 276,029 tokens on this as a headless worker. Overall, 1h since this issue was created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated end-to-end test setup to use the runner’s preinstalled Chrome.
  * Added a verification step to report the installed Chrome version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->