### PR TITLE
GH#2490: Add safe Gutenberg editor selection bridge

### DIFF
--- a/includes/Abilities/Js/JsAbilityCatalog.php
+++ b/includes/Abilities/Js/JsAbilityCatalog.php
@@ -86,6 +86,38 @@ class JsAbilityCatalog {
 				'screens'       => array( 'all' ),
 			),
 			array(
+				'name'          => 'sd-ai-agent-js/get-editor-selection',
+				'label'         => 'Get Editor Selection',
+				'description'   => 'Return a bounded, current snapshot of explicitly selected Gutenberg blocks without changing editor state.',
+				'category'      => 'sd-ai-agent-js',
+				'input_schema'  => array(
+					'type'       => 'object',
+					'properties' => array(),
+					'required'   => array(),
+				),
+				'output_schema' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'available'     => array( 'type' => 'boolean' ),
+						'selected'      => array( 'type' => 'boolean' ),
+						'count'         => array( 'type' => 'integer' ),
+						'originalCount' => array( 'type' => 'integer' ),
+						'blocks'        => array(
+							'type'  => 'array',
+							'items' => array( 'type' => 'object' ),
+						),
+						'markup'        => array( 'type' => 'string' ),
+						'fingerprint'   => array( 'type' => 'string' ),
+						'truncated'     => array( 'type' => 'boolean' ),
+						'reason'        => array( 'type' => 'string' ),
+					),
+				),
+				'annotations'   => array(
+					'readonly' => true,
+				),
+				'screens'       => array( 'editor' ),
+			),
+			array(
 				'name'          => 'sd-ai-agent-js/insert-block',
 				'label'         => 'Insert Block',
 				'description'   => 'Insert a Gutenberg block into the active block editor. Only available on editor screens.',

--- a/src/abilities/__tests__/editor.test.js
+++ b/src/abilities/__tests__/editor.test.js
@@ -1,0 +1,176 @@
+/** Unit tests for the read-only Gutenberg editor selection ability. */
+
+/**
+ * Load an isolated editor ability module.
+ *
+ * @return {Object} Editor ability exports.
+ */
+function loadEditorModule() {
+	let mod;
+	jest.isolateModules( () => {
+		// eslint-disable-next-line global-require
+		mod = require( '../editor' );
+	} );
+	return mod;
+}
+
+/**
+ * Set a minimal Gutenberg editor environment.
+ *
+ * @param {Object}   options               Mock editor state.
+ * @param {string[]} [options.selectedIds] Selected block client IDs.
+ * @param {Object}   [options.blocks]      Blocks keyed by client ID.
+ * @param {Object}   [options.rootIds]     Parent client IDs keyed by client ID.
+ * @param {string}   [options.markup]      Serialized selected-block markup.
+ * @return {void}
+ */
+function setEditor( {
+	selectedIds = [],
+	blocks = {},
+	rootIds = {},
+	markup = '',
+} ) {
+	global.wp = {
+		data: {
+			select: jest.fn( () => ( {
+				getSelectedBlockClientIds: () => selectedIds,
+				getBlock: ( clientId ) => blocks[ clientId ],
+				getBlockRootClientId: ( clientId ) => rootIds[ clientId ] || '',
+				getBlockIndex: ( clientId ) => selectedIds.indexOf( clientId ),
+			} ) ),
+		},
+		blocks: {
+			serialize: jest.fn( () => markup ),
+		},
+	};
+}
+
+describe( 'get-editor-selection', () => {
+	afterEach( () => {
+		delete global.wp;
+	} );
+
+	test( 'returns ordered selected-only markup and parent context', async () => {
+		setEditor( {
+			selectedIds: [ 'first', 'second' ],
+			blocks: {
+				first: { clientId: 'first', name: 'core/paragraph' },
+				second: { clientId: 'second', name: 'core/image' },
+				parent: { clientId: 'parent', name: 'core/group' },
+			},
+			rootIds: { first: 'parent' },
+			markup: '<!-- wp:paragraph -->One<!-- /wp:paragraph --><!-- wp:image /-->',
+		} );
+
+		const { getEditorSelection } = loadEditorModule();
+		const result = await getEditorSelection();
+
+		expect( result ).toMatchObject( {
+			available: true,
+			selected: true,
+			count: 2,
+			originalCount: 2,
+			markup: '<!-- wp:paragraph -->One<!-- /wp:paragraph --><!-- wp:image /-->',
+			truncated: false,
+			reason: '',
+		} );
+		expect( result.blocks ).toEqual( [
+			{
+				clientId: 'first',
+				name: 'core/paragraph',
+				parent: { clientId: 'parent', name: 'core/group', position: 0 },
+			},
+			{
+				clientId: 'second',
+				name: 'core/image',
+				parent: { clientId: '', name: '', position: 1 },
+			},
+		] );
+		expect( result.fingerprint ).toMatch( /^(sha256|fallback):/ );
+	} );
+
+	test( 'returns a stable fingerprint for the same current selection', async () => {
+		setEditor( {
+			selectedIds: [ 'first' ],
+			blocks: { first: { clientId: 'first', name: 'core/paragraph' } },
+			markup: '<!-- wp:paragraph -->One<!-- /wp:paragraph -->',
+		} );
+		const { getEditorSelection } = loadEditorModule();
+
+		expect( ( await getEditorSelection() ).fingerprint ).toBe(
+			( await getEditorSelection() ).fingerprint
+		);
+	} );
+
+	test( 'returns successful structured empty states outside the editor and without a selection', async () => {
+		let { getEditorSelection } = loadEditorModule();
+		expect( await getEditorSelection() ).toMatchObject( {
+			available: false,
+			selected: false,
+			reason: 'unavailable',
+		} );
+
+		setEditor( {} );
+		( { getEditorSelection } = loadEditorModule() );
+		expect( await getEditorSelection() ).toMatchObject( {
+			available: true,
+			selected: false,
+			reason: 'no_selection',
+		} );
+	} );
+
+	test( 'reports stale selected block IDs instead of serializing another selection', async () => {
+		setEditor( {
+			selectedIds: [ 'missing' ],
+			blocks: {},
+		} );
+		const { getEditorSelection } = loadEditorModule();
+
+		expect( await getEditorSelection() ).toMatchObject( {
+			available: true,
+			selected: true,
+			truncated: true,
+			reason: 'missing_selected_block',
+			markup: '',
+			fingerprint: '',
+		} );
+	} );
+
+	test( 'caps oversized selections and markup without returning unrelated content', async () => {
+		const selectedIds = Array.from(
+			{ length: 51 },
+			( _, index ) => `block-${ index }`
+		);
+		const blocks = Object.fromEntries(
+			selectedIds.map( ( clientId ) => [
+				clientId,
+				{ clientId, name: 'core/paragraph' },
+			] )
+		);
+		setEditor( {
+			selectedIds,
+			blocks,
+			markup: '<!-- wp:paragraph -->One<!-- /wp:paragraph -->',
+		} );
+		let { getEditorSelection } = loadEditorModule();
+		expect( await getEditorSelection() ).toMatchObject( {
+			count: 50,
+			originalCount: 51,
+			truncated: true,
+			reason: 'selection_limit',
+		} );
+
+		setEditor( {
+			selectedIds: [ 'large' ],
+			blocks: { large: { clientId: 'large', name: 'core/paragraph' } },
+			markup: 'x'.repeat( 64 * 1024 + 1 ),
+		} );
+		( { getEditorSelection } = loadEditorModule() );
+		expect( await getEditorSelection() ).toMatchObject( {
+			truncated: true,
+			reason: 'markup_limit',
+			markup: '',
+			fingerprint: '',
+		} );
+	} );
+} );

--- a/src/abilities/__tests__/editor.test.js
+++ b/src/abilities/__tests__/editor.test.js
@@ -15,6 +15,23 @@ function loadEditorModule() {
 }
 
 /**
+ * Load isolated editor and registry modules from the same module instance.
+ *
+ * @return {{ editor: Object, registry: Object }} Editor and registry exports.
+ */
+function loadEditorAndRegistry() {
+	let editor;
+	let registry;
+	jest.isolateModules( () => {
+		// eslint-disable-next-line global-require
+		editor = require( '../editor' );
+		// eslint-disable-next-line global-require
+		registry = require( '../registry' );
+	} );
+	return { editor, registry };
+}
+
+/**
  * Set a minimal Gutenberg editor environment.
  *
  * @param {Object}   options               Mock editor state.
@@ -38,6 +55,7 @@ function setEditor( {
 				getBlockRootClientId: ( clientId ) => rootIds[ clientId ] || '',
 				getBlockIndex: ( clientId ) => selectedIds.indexOf( clientId ),
 			} ) ),
+			dispatch: jest.fn(),
 		},
 		blocks: {
 			serialize: jest.fn( () => markup ),
@@ -87,6 +105,24 @@ describe( 'get-editor-selection', () => {
 			},
 		] );
 		expect( result.fingerprint ).toMatch( /^(sha256|fallback):/ );
+		expect( global.wp.data.dispatch ).not.toHaveBeenCalled();
+	} );
+
+	test( 'registers the current-selection descriptor as read-only', async () => {
+		const { editor, registry } = loadEditorAndRegistry();
+		await editor.registerEditorAbility();
+		const descriptor = ( await registry.snapshotDescriptors() ).find(
+			( candidate ) =>
+				candidate.name === 'sd-ai-agent-js/get-editor-selection'
+		);
+
+		expect( descriptor ).toMatchObject( {
+			name: 'sd-ai-agent-js/get-editor-selection',
+			annotations: { readonly: true },
+		} );
+		expect( descriptor.output_schema.properties ).toHaveProperty(
+			'fingerprint'
+		);
 	} );
 
 	test( 'returns a stable fingerprint for the same current selection', async () => {

--- a/src/abilities/editor.js
+++ b/src/abilities/editor.js
@@ -10,6 +10,188 @@
 
 import { registerClientAbility } from './registry';
 
+const MAX_SELECTED_BLOCKS = 50;
+const MAX_SELECTION_MARKUP_BYTES = 64 * 1024;
+
+/**
+ * Return a deterministic non-cryptographic hash when SubtleCrypto is absent.
+ *
+ * @param {string} value Value to hash.
+ * @return {string} Stable fingerprint.
+ */
+function fallbackFingerprint( value ) {
+	let hash = 7;
+	for ( let index = 0; index < value.length; index++ ) {
+		hash = ( hash * 31 + value.charCodeAt( index ) ) % 2147483647;
+	}
+
+	return `fallback:${ hash.toString( 16 ).padStart( 8, '0' ) }`;
+}
+
+/**
+ * Calculate the UTF-8 byte length of a string in browsers without TextEncoder.
+ *
+ * @param {string} value Value to measure.
+ * @return {number} UTF-8 byte length.
+ */
+function getByteLength( value ) {
+	if ( typeof TextEncoder !== 'undefined' ) {
+		return new TextEncoder().encode( value ).byteLength;
+	}
+
+	return Array.from( value ).reduce( ( length, character ) => {
+		const codePoint = character.codePointAt( 0 );
+		if ( codePoint <= 127 ) {
+			return length + 1;
+		}
+		if ( codePoint <= 2047 ) {
+			return length + 2;
+		}
+		return length + ( codePoint <= 65535 ? 3 : 4 );
+	}, 0 );
+}
+
+/**
+ * Create a fingerprint from ordered IDs and canonical selected-only markup.
+ *
+ * @param {string[]} clientIds Ordered selected block client IDs.
+ * @param {string}   markup    Canonical serialized selected-block markup.
+ * @return {Promise<string>} Selection fingerprint.
+ */
+async function createSelectionFingerprint( clientIds, markup ) {
+	const value = `${ clientIds.join( '\n' ) }\n${ markup }`;
+	const subtle = globalThis.crypto?.subtle;
+
+	if ( subtle && typeof TextEncoder !== 'undefined' ) {
+		try {
+			const digest = await subtle.digest(
+				'SHA-256',
+				new TextEncoder().encode( value )
+			);
+			return `sha256:${ Array.from( new Uint8Array( digest ) )
+				.map( ( byte ) => byte.toString( 16 ).padStart( 2, '0' ) )
+				.join( '' ) }`;
+		} catch ( _error ) {
+			// Fall through to the deterministic browser-independent fallback.
+		}
+	}
+
+	return fallbackFingerprint( value );
+}
+
+/**
+ * Return the selected editor blocks without dispatching a state mutation.
+ *
+ * @return {Promise<Object>} Bounded current-selection snapshot.
+ */
+export async function getEditorSelection() {
+	const empty = {
+		available: false,
+		selected: false,
+		count: 0,
+		originalCount: 0,
+		blocks: [],
+		markup: '',
+		fingerprint: '',
+		truncated: false,
+		reason: 'unavailable',
+	};
+
+	if ( typeof wp === 'undefined' || ! wp.data || ! wp.blocks ) {
+		return empty;
+	}
+
+	try {
+		const editor = wp.data.select( 'core/block-editor' );
+		if ( ! editor || typeof editor.getBlock !== 'function' ) {
+			return empty;
+		}
+
+		let selectedIds = [];
+		if ( typeof editor.getSelectedBlockClientIds === 'function' ) {
+			selectedIds = editor.getSelectedBlockClientIds();
+		} else if ( typeof editor.getSelectedBlockClientId === 'function' ) {
+			selectedIds = [ editor.getSelectedBlockClientId() ];
+		}
+		const clientIds = Array.isArray( selectedIds )
+			? selectedIds.filter( Boolean )
+			: [];
+
+		if ( ! clientIds.length ) {
+			return { ...empty, available: true, reason: 'no_selection' };
+		}
+
+		const originalCount = clientIds.length;
+		const truncatedByCount = originalCount > MAX_SELECTED_BLOCKS;
+		const boundedIds = clientIds.slice( 0, MAX_SELECTED_BLOCKS );
+		const selectedBlocks = boundedIds.map( ( clientId ) =>
+			editor.getBlock( clientId )
+		);
+
+		if ( selectedBlocks.some( ( block ) => ! block ) ) {
+			return {
+				...empty,
+				available: true,
+				selected: true,
+				count: boundedIds.length,
+				originalCount,
+				truncated: true,
+				reason: 'missing_selected_block',
+			};
+		}
+
+		const markup = wp.blocks.serialize( selectedBlocks );
+		if ( getByteLength( markup ) > MAX_SELECTION_MARKUP_BYTES ) {
+			return {
+				...empty,
+				available: true,
+				selected: true,
+				count: boundedIds.length,
+				originalCount,
+				truncated: true,
+				reason: 'markup_limit',
+			};
+		}
+
+		const blocks = selectedBlocks.map( ( block, index ) => {
+			const parentId =
+				typeof editor.getBlockRootClientId === 'function'
+					? editor.getBlockRootClientId( block.clientId ) || ''
+					: '';
+			const parent = parentId ? editor.getBlock( parentId ) : null;
+			return {
+				clientId: block.clientId,
+				name: block.name,
+				parent: {
+					clientId: parentId,
+					name: parent?.name || '',
+					position:
+						typeof editor.getBlockIndex === 'function'
+							? editor.getBlockIndex(
+									block.clientId,
+									parentId || undefined
+							  )
+							: index,
+				},
+			};
+		} );
+
+		return {
+			available: true,
+			selected: true,
+			count: boundedIds.length,
+			originalCount,
+			blocks,
+			markup,
+			fingerprint: await createSelectionFingerprint( boundedIds, markup ),
+			truncated: truncatedByCount,
+			reason: truncatedByCount ? 'selection_limit' : '',
+		};
+	} catch ( _error ) {
+		return empty;
+	}
+}
+
 /**
  * Execute the insert-block ability.
  *
@@ -78,6 +260,34 @@ function executeInsertBlock( args ) {
  * @return {void}
  */
 export async function registerEditorAbility() {
+	await registerClientAbility( {
+		name: 'sd-ai-agent-js/get-editor-selection',
+		label: 'Get Editor Selection',
+		description:
+			'Return a bounded, current snapshot of explicitly selected Gutenberg blocks without changing editor state.',
+		inputSchema: {
+			type: 'object',
+			properties: {},
+			required: [],
+		},
+		outputSchema: {
+			type: 'object',
+			properties: {
+				available: { type: 'boolean' },
+				selected: { type: 'boolean' },
+				count: { type: 'integer' },
+				originalCount: { type: 'integer' },
+				blocks: { type: 'array', items: { type: 'object' } },
+				markup: { type: 'string' },
+				fingerprint: { type: 'string' },
+				truncated: { type: 'boolean' },
+				reason: { type: 'string' },
+			},
+		},
+		annotations: { readonly: true },
+		callback: getEditorSelection,
+	} );
+
 	await registerClientAbility( {
 		name: 'sd-ai-agent-js/insert-block',
 		label: 'Insert Block',

--- a/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
@@ -65,6 +65,7 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 		$names = array_column( $descriptors, 'name' );
 		$this->assertContains( 'sd-ai-agent-js/navigate-to', $names );
 		$this->assertContains( 'sd-ai-agent-js/refresh-page', $names );
+		$this->assertContains( 'sd-ai-agent-js/get-editor-selection', $names );
 		$this->assertContains( 'sd-ai-agent-js/insert-block', $names );
 		$this->assertContains( 'sd-ai-agent-js/validate-page-quality', $names );
 		$this->assertContains( 'sd-ai-agent-js/validate-theme-completion', $names );
@@ -76,6 +77,7 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 	public function test_catalog_has_method(): void {
 		$this->assertTrue( JsAbilityCatalog::has( 'sd-ai-agent-js/navigate-to' ) );
 		$this->assertTrue( JsAbilityCatalog::has( 'sd-ai-agent-js/refresh-page' ) );
+		$this->assertTrue( JsAbilityCatalog::has( 'sd-ai-agent-js/get-editor-selection' ) );
 		$this->assertTrue( JsAbilityCatalog::has( 'sd-ai-agent-js/insert-block' ) );
 		$this->assertTrue( JsAbilityCatalog::has( 'sd-ai-agent-js/validate-page-quality' ) );
 		$this->assertTrue( JsAbilityCatalog::has( 'sd-ai-agent-js/validate-theme-completion' ) );
@@ -92,6 +94,7 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 		$this->assertIsArray( $map );
 		$this->assertArrayHasKey( 'sd-ai-agent-js/navigate-to', $map );
 		$this->assertArrayHasKey( 'sd-ai-agent-js/refresh-page', $map );
+		$this->assertArrayHasKey( 'sd-ai-agent-js/get-editor-selection', $map );
 		$this->assertArrayHasKey( 'sd-ai-agent-js/insert-block', $map );
 		$this->assertArrayHasKey( 'sd-ai-agent-js/validate-page-quality', $map );
 		$this->assertArrayHasKey( 'sd-ai-agent-js/validate-theme-completion', $map );
@@ -103,6 +106,13 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 		$navigate = $map['sd-ai-agent-js/navigate-to'];
 		$this->assertSame( 'sd-ai-agent-js', $navigate['category'] );
 		$this->assertTrue( $navigate['annotations']['readonly'] );
+
+		$selection = $map['sd-ai-agent-js/get-editor-selection'];
+		$this->assertSame( 'sd-ai-agent-js', $selection['category'] );
+		$this->assertTrue( $selection['annotations']['readonly'] );
+		$this->assertSame( array( 'editor' ), $selection['screens'] );
+		$this->assertArrayHasKey( 'fingerprint', $selection['output_schema']['properties'] );
+		$this->assertArrayHasKey( 'truncated', $selection['output_schema']['properties'] );
 	}
 
 	/**
@@ -268,6 +278,24 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 		);
 
 		$this->assertFalse( $partition['client'][0]['annotations']['readonly'] );
+	}
+
+	/** Client-provided metadata cannot make the selection reader appear mutable. */
+	public function test_client_descriptors_use_canonical_selection_reader_annotations(): void {
+		$router = ClientAbilityRouter::from_raw(
+			array(
+				array(
+					'name'        => 'sd-ai-agent-js/get-editor-selection',
+					'label'       => 'Spoofed editor selection reader',
+					'input_schema' => array(),
+					'annotations' => array( 'readonly' => false ),
+				),
+			)
+		);
+		$descriptors = $router->get_descriptors();
+
+		$this->assertCount( 1, $descriptors );
+		$this->assertTrue( $descriptors[0]['annotations']['readonly'] );
 	}
 
 	// ── partition_tool_calls tests ────────────────────────────────────────


### PR DESCRIPTION
Resolves #2490

## Summary

- add the read-only `sd-ai-agent-js/get-editor-selection` browser ability
- bound selection snapshots to 50 blocks and 64 KiB serialized markup
- mirror canonical browser metadata in the PHP catalog and cover empty, stale, capped, and read-only cases

## Verification

- `pnpm run test:js -- src/abilities/__tests__/editor.test.js`
- `pnpm run lint:js`
- `pnpm run lint:php`
- `pnpm run test:php -- --filter=AgentLoopClientToolsTest`
- `pnpm run build`
- `pnpm run check:bundle`
- `pnpm run verify`

## Worker self-verification

- PHPUnit: Tests: 4136, Assertions: 18690, Errors: 0, Failures: 0, Skipped: 135, Incomplete: 4
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded
- Bundle: budgets passed

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.273 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 15m and 238,944 tokens on this as a headless worker. Overall, 38m since this issue was created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only editor selection tool for retrieving selected block information, including hierarchy, content, markup, selection counts, and availability status.
  - Provides stable fingerprints for selection snapshots and clearly reports empty, unavailable, missing, or truncated selections.
  - Applies safeguards to limit the number of selected blocks and the size of serialized markup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->