### PR TITLE
GH#2493: Safely parse, canonicalize, and apply Gutenberg markup

### DIFF
--- a/includes/Abilities/Js/JsAbilityCatalog.php
+++ b/includes/Abilities/Js/JsAbilityCatalog.php
@@ -149,8 +149,14 @@ class JsAbilityCatalog {
 					'type'       => 'object',
 					'properties' => array(
 						'markup'       => array( 'type' => 'string' ),
-						'rootClientId' => array( 'type' => 'string' ),
-						'index'        => array( 'type' => 'integer' ),
+						'rootClientId' => array(
+							'type'        => 'string',
+							'description' => 'Supply rootClientId and index together; omit both to use the current insertion point.',
+						),
+						'index'        => array(
+							'type'        => 'integer',
+							'description' => 'Supply rootClientId and index together; omit both to use the current insertion point.',
+						),
 					),
 					'required'   => array( 'markup' ),
 				),
@@ -178,7 +184,7 @@ class JsAbilityCatalog {
 				'output_schema' => array(
 					'type'       => 'object',
 					'properties' => array(
-						'applied'   => array( 'type' => 'boolean' ),
+						'applied'   => array( 'type' => array( 'boolean', 'string' ) ),
 						'direction' => array( 'type' => 'string' ),
 						'reason'    => array( 'type' => 'string' ),
 					),

--- a/includes/Abilities/Js/JsAbilityCatalog.php
+++ b/includes/Abilities/Js/JsAbilityCatalog.php
@@ -118,6 +118,77 @@ class JsAbilityCatalog {
 				'screens'       => array( 'editor' ),
 			),
 			array(
+				'name'          => 'sd-ai-agent-js/replace-editor-selection',
+				'label'         => 'Replace Editor Selection',
+				'description'   => 'Replace exactly the selected Gutenberg blocks only when the supplied ordered IDs and fingerprint still match.',
+				'category'      => 'sd-ai-agent-js',
+				'input_schema'  => array(
+					'type'       => 'object',
+					'properties' => array(
+						'markup'              => array( 'type' => 'string' ),
+						'expectedFingerprint' => array( 'type' => 'string' ),
+						'expectedClientIds'   => array(
+							'type'  => 'array',
+							'items' => array( 'type' => 'string' ),
+						),
+					),
+					'required'   => array( 'markup', 'expectedFingerprint', 'expectedClientIds' ),
+				),
+				'output_schema' => self::editor_mutation_output_schema(),
+				'annotations'   => array(
+					'readonly' => false,
+				),
+				'screens'       => array( 'editor' ),
+			),
+			array(
+				'name'          => 'sd-ai-agent-js/insert-block-markup',
+				'label'         => 'Insert Block Markup',
+				'description'   => 'Insert validated canonical Gutenberg markup once at an explicit editor location or the current insertion point.',
+				'category'      => 'sd-ai-agent-js',
+				'input_schema'  => array(
+					'type'       => 'object',
+					'properties' => array(
+						'markup'       => array( 'type' => 'string' ),
+						'rootClientId' => array( 'type' => 'string' ),
+						'index'        => array( 'type' => 'integer' ),
+					),
+					'required'   => array( 'markup' ),
+				),
+				'output_schema' => self::editor_mutation_output_schema(),
+				'annotations'   => array(
+					'readonly' => false,
+				),
+				'screens'       => array( 'editor' ),
+			),
+			array(
+				'name'          => 'sd-ai-agent-js/change-editor-history',
+				'label'         => 'Change Editor History',
+				'description'   => 'Request one native Gutenberg editor undo or redo operation.',
+				'category'      => 'sd-ai-agent-js',
+				'input_schema'  => array(
+					'type'       => 'object',
+					'properties' => array(
+						'direction' => array(
+							'type' => 'string',
+							'enum' => array( 'undo', 'redo' ),
+						),
+					),
+					'required'   => array( 'direction' ),
+				),
+				'output_schema' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'applied'   => array( 'type' => 'boolean' ),
+						'direction' => array( 'type' => 'string' ),
+						'reason'    => array( 'type' => 'string' ),
+					),
+				),
+				'annotations'   => array(
+					'readonly' => false,
+				),
+				'screens'       => array( 'editor' ),
+			),
+			array(
 				'name'          => 'sd-ai-agent-js/get-editor-capabilities',
 				'label'         => 'Get Editor Capabilities',
 				'description'   => 'Return a bounded, current manifest of installed Gutenberg blocks and active editor/theme capabilities without changing editor state.',
@@ -459,6 +530,27 @@ class JsAbilityCatalog {
 					'readonly' => true,
 				),
 				'screens'       => array( 'all' ),
+			),
+		);
+	}
+
+	/** @return array<string,mixed> */
+	private static function editor_mutation_output_schema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'applied'     => array( 'type' => array( 'boolean', 'string' ) ),
+				'reason'      => array( 'type' => 'string' ),
+				'markup'      => array( 'type' => 'string' ),
+				'clientIds'   => array(
+					'type'  => 'array',
+					'items' => array( 'type' => 'string' ),
+				),
+				'fingerprint' => array( 'type' => 'string' ),
+				'errors'      => array(
+					'type'  => 'array',
+					'items' => array( 'type' => 'object' ),
+				),
 			),
 		);
 	}

--- a/src/abilities/__tests__/editor-mutations.test.js
+++ b/src/abilities/__tests__/editor-mutations.test.js
@@ -49,6 +49,8 @@ function setEditor() {
 			}
 			state.selectedIds = blocks.map( ( block ) => block.clientId );
 		} ),
+	};
+	const historyDispatcher = {
 		undo: jest.fn(),
 		redo: jest.fn(),
 	};
@@ -72,7 +74,9 @@ function setEditor() {
 	global.wp = {
 		data: {
 			select: jest.fn( () => selector ),
-			dispatch: jest.fn( () => dispatcher ),
+			dispatch: jest.fn( ( storeName ) =>
+				storeName === 'core/editor' ? historyDispatcher : dispatcher
+			),
 		},
 		blocks: {
 			parse,
@@ -85,7 +89,7 @@ function setEditor() {
 			validateBlock: jest.fn( () => [ true, [] ] ),
 		},
 	};
-	return { state, selector, dispatcher, parse };
+	return { state, selector, dispatcher, historyDispatcher, parse };
 }
 
 describe( 'editor markup mutations', () => {
@@ -187,6 +191,11 @@ describe( 'editor markup mutations', () => {
 		const result = await insertBlockMarkup( { markup: 'valid' } );
 
 		expect( dispatcher.insertBlocks ).toHaveBeenCalledTimes( 1 );
+		expect( dispatcher.insertBlocks ).toHaveBeenCalledWith(
+			expect.any( Array ),
+			1,
+			undefined
+		);
 		expect( result ).toMatchObject( {
 			applied: true,
 			clientIds: [ 'new' ],
@@ -194,14 +203,84 @@ describe( 'editor markup mutations', () => {
 	} );
 
 	test( 'runs one native history operation and reports whether it changed blocks', () => {
-		const { dispatcher } = setEditor();
+		const { historyDispatcher } = setEditor();
 		const { changeEditorHistory } = loadModule();
 
 		expect( changeEditorHistory( { direction: 'undo' } ) ).toEqual( {
 			applied: false,
 			direction: 'undo',
 		} );
-		expect( dispatcher.undo ).toHaveBeenCalledTimes( 1 );
-		expect( dispatcher.redo ).not.toHaveBeenCalled();
+		expect( historyDispatcher.undo ).toHaveBeenCalledTimes( 1 );
+		expect( historyDispatcher.redo ).not.toHaveBeenCalled();
+		expect( global.wp.data.dispatch ).toHaveBeenCalledWith( 'core/editor' );
+	} );
+
+	test( 'reports a history change and rejects an invalid direction', () => {
+		const { state, historyDispatcher } = setEditor();
+		historyDispatcher.undo.mockImplementation( () => {
+			state.blocks.changed = {
+				clientId: 'changed',
+				name: 'core/paragraph',
+				markup: '<!-- wp:paragraph -->Changed<!-- /wp:paragraph -->',
+				attributes: {},
+				innerBlocks: [],
+			};
+		} );
+		const { changeEditorHistory } = loadModule();
+
+		expect( changeEditorHistory( { direction: 'undo' } ) ).toEqual( {
+			applied: true,
+			direction: 'undo',
+		} );
+		expect(
+			changeEditorHistory( { direction: 'sideways' } )
+		).toMatchObject( {
+			applied: false,
+			reason: 'invalid_history_direction',
+		} );
+		expect( historyDispatcher.undo ).toHaveBeenCalledTimes( 1 );
+		expect( historyDispatcher.redo ).not.toHaveBeenCalled();
+	} );
+
+	test( 'returns an uncertain result when an editor dispatch throws', async () => {
+		const { dispatcher, historyDispatcher } = setEditor();
+		const { getEditorSelection } = require( '../editor' );
+		const snapshot = await getEditorSelection();
+		const {
+			changeEditorHistory,
+			insertBlockMarkup,
+			replaceEditorSelection,
+		} = loadModule();
+		dispatcher.replaceBlocks.mockImplementation( () => {
+			throw new Error( 'replace failed' );
+		} );
+		dispatcher.insertBlocks.mockImplementation( () => {
+			throw new Error( 'insert failed' );
+		} );
+		historyDispatcher.undo.mockImplementation( () => {
+			throw new Error( 'undo failed' );
+		} );
+
+		await expect(
+			replaceEditorSelection( {
+				markup: 'valid',
+				expectedFingerprint: snapshot.fingerprint,
+				expectedClientIds: [ 'old' ],
+			} )
+		).resolves.toMatchObject( {
+			applied: 'unknown',
+			reason: 'dispatch_failed',
+		} );
+		await expect(
+			insertBlockMarkup( { markup: 'valid' } )
+		).resolves.toMatchObject( {
+			applied: 'unknown',
+			reason: 'dispatch_failed',
+		} );
+		expect( changeEditorHistory( { direction: 'undo' } ) ).toMatchObject( {
+			applied: 'unknown',
+			direction: 'undo',
+			reason: 'dispatch_failed',
+		} );
 	} );
 } );

--- a/src/abilities/__tests__/editor-mutations.test.js
+++ b/src/abilities/__tests__/editor-mutations.test.js
@@ -1,0 +1,207 @@
+/** Unit tests for safe editor markup mutation abilities. */
+
+/** Load the mutations module without sharing registry state between tests. */
+function loadModule() {
+	let mod;
+	jest.isolateModules( () => {
+		// eslint-disable-next-line global-require
+		mod = require( '../editor-mutations' );
+	} );
+	return mod;
+}
+
+/** Create a minimal block-editor runtime with one replaceable block. */
+function setEditor() {
+	const state = {
+		selectedIds: [ 'old' ],
+		blocks: {
+			old: {
+				clientId: 'old',
+				name: 'core/paragraph',
+				markup: '<!-- wp:paragraph -->Old<!-- /wp:paragraph -->',
+				attributes: {},
+				innerBlocks: [],
+			},
+		},
+	};
+	const selector = {
+		getSelectedBlockClientIds: () => state.selectedIds,
+		getBlock: ( clientId ) => state.blocks[ clientId ],
+		getBlockRootClientId: () => '',
+		getBlockIndex: ( clientId ) => state.selectedIds.indexOf( clientId ),
+		getBlockParents: () => [],
+		getBlockListSettings: () => ( {} ),
+		getBlockInsertionPoint: () => ( { rootClientId: '', index: 1 } ),
+		getSettings: () => ( { allowedBlockTypes: true } ),
+		canInsertBlockType: () => true,
+		getBlocks: () => Object.values( state.blocks ),
+	};
+	const dispatcher = {
+		replaceBlocks: jest.fn( ( _ids, blocks ) => {
+			state.blocks = Object.fromEntries(
+				blocks.map( ( block ) => [ block.clientId, block ] )
+			);
+			state.selectedIds = blocks.map( ( block ) => block.clientId );
+		} ),
+		insertBlocks: jest.fn( ( blocks ) => {
+			for ( const block of blocks ) {
+				state.blocks[ block.clientId ] = block;
+			}
+			state.selectedIds = blocks.map( ( block ) => block.clientId );
+		} ),
+		undo: jest.fn(),
+		redo: jest.fn(),
+	};
+	const parse = jest.fn( ( markup ) => {
+		if (
+			markup === 'valid' ||
+			markup === '<!-- wp:paragraph -->New<!-- /wp:paragraph -->'
+		) {
+			return [
+				{
+					clientId: 'new',
+					name: 'core/paragraph',
+					markup: '<!-- wp:paragraph -->New<!-- /wp:paragraph -->',
+					attributes: {},
+					innerBlocks: [],
+				},
+			];
+		}
+		return [];
+	} );
+	global.wp = {
+		data: {
+			select: jest.fn( () => selector ),
+			dispatch: jest.fn( () => dispatcher ),
+		},
+		blocks: {
+			parse,
+			serialize: jest.fn( ( blocks ) =>
+				blocks.map( ( block ) => block.markup ).join( '' )
+			),
+			getBlockType: jest.fn( ( name ) =>
+				name === 'core/paragraph' ? { name } : null
+			),
+			validateBlock: jest.fn( () => [ true, [] ] ),
+		},
+	};
+	return { state, selector, dispatcher, parse };
+}
+
+describe( 'editor markup mutations', () => {
+	afterEach( () => {
+		delete global.wp;
+	} );
+
+	test( 'rejects a stale replacement before dispatching', async () => {
+		const { dispatcher } = setEditor();
+		const { replaceEditorSelection } = loadModule();
+		const result = await replaceEditorSelection( {
+			markup: 'valid',
+			expectedFingerprint: 'stale',
+			expectedClientIds: [ 'old' ],
+		} );
+
+		expect( result ).toMatchObject( {
+			applied: false,
+			reason: 'stale_selection',
+		} );
+		expect( dispatcher.replaceBlocks ).not.toHaveBeenCalled();
+	} );
+
+	test( 'replaces a current selection once and returns canonical evidence', async () => {
+		const { dispatcher } = setEditor();
+		const { getEditorSelection } = require( '../editor' );
+		const snapshot = await getEditorSelection();
+		const { replaceEditorSelection } = loadModule();
+		const result = await replaceEditorSelection( {
+			markup: 'valid',
+			expectedFingerprint: snapshot.fingerprint,
+			expectedClientIds: [ 'old' ],
+		} );
+
+		expect( dispatcher.replaceBlocks ).toHaveBeenCalledTimes( 1 );
+		expect( result ).toMatchObject( {
+			applied: true,
+			markup: '<!-- wp:paragraph -->New<!-- /wp:paragraph -->',
+			clientIds: [ 'new' ],
+		} );
+		expect( result.fingerprint ).toMatch( /^(sha256|fallback):/ );
+	} );
+
+	test( 'rejects protected selections and malformed markup before writing', async () => {
+		const { state, dispatcher } = setEditor();
+		const { getEditorSelection } = require( '../editor' );
+		const snapshot = await getEditorSelection();
+		state.blocks.old.attributes = {
+			metadata: { bindings: { content: {} } },
+		};
+		const { replaceEditorSelection, insertBlockMarkup } = loadModule();
+		await expect(
+			replaceEditorSelection( {
+				markup: 'valid',
+				expectedFingerprint: snapshot.fingerprint,
+				expectedClientIds: [ 'old' ],
+			} )
+		).resolves.toMatchObject( {
+			applied: false,
+			reason: 'protected_selection',
+		} );
+		await expect(
+			insertBlockMarkup( { markup: 'not block markup' } )
+		).resolves.toMatchObject( {
+			applied: false,
+			reason: 'parse_failed',
+		} );
+		expect( dispatcher.replaceBlocks ).not.toHaveBeenCalled();
+		expect( dispatcher.insertBlocks ).not.toHaveBeenCalled();
+	} );
+
+	test( 'rejects a selection that would remove a protected descendant or lock', async () => {
+		const { state, dispatcher } = setEditor();
+		const { getEditorSelection } = require( '../editor' );
+		const snapshot = await getEditorSelection();
+		state.blocks.old.innerBlocks = [
+			{
+				attributes: { lock: { remove: true } },
+				innerBlocks: [],
+			},
+		];
+		const { replaceEditorSelection } = loadModule();
+		const result = await replaceEditorSelection( {
+			markup: 'valid',
+			expectedFingerprint: snapshot.fingerprint,
+			expectedClientIds: [ 'old' ],
+		} );
+
+		expect( result ).toMatchObject( {
+			applied: false,
+			reason: 'protected_selection',
+		} );
+		expect( dispatcher.replaceBlocks ).not.toHaveBeenCalled();
+	} );
+
+	test( 'inserts canonical markup once and makes no retry', async () => {
+		const { dispatcher } = setEditor();
+		const { insertBlockMarkup } = loadModule();
+		const result = await insertBlockMarkup( { markup: 'valid' } );
+
+		expect( dispatcher.insertBlocks ).toHaveBeenCalledTimes( 1 );
+		expect( result ).toMatchObject( {
+			applied: true,
+			clientIds: [ 'new' ],
+		} );
+	} );
+
+	test( 'runs one native history operation and reports whether it changed blocks', () => {
+		const { dispatcher } = setEditor();
+		const { changeEditorHistory } = loadModule();
+
+		expect( changeEditorHistory( { direction: 'undo' } ) ).toEqual( {
+			applied: false,
+			direction: 'undo',
+		} );
+		expect( dispatcher.undo ).toHaveBeenCalledTimes( 1 );
+		expect( dispatcher.redo ).not.toHaveBeenCalled();
+	} );
+} );

--- a/src/abilities/__tests__/editor-mutations.test.js
+++ b/src/abilities/__tests__/editor-mutations.test.js
@@ -14,6 +14,7 @@ function loadModule() {
 function setEditor() {
 	const state = {
 		selectedIds: [ 'old' ],
+		onSerialize: null,
 		blocks: {
 			old: {
 				clientId: 'old',
@@ -80,9 +81,10 @@ function setEditor() {
 		},
 		blocks: {
 			parse,
-			serialize: jest.fn( ( blocks ) =>
-				blocks.map( ( block ) => block.markup ).join( '' )
-			),
+			serialize: jest.fn( ( blocks ) => {
+				state.onSerialize?.( blocks );
+				return blocks.map( ( block ) => block.markup ).join( '' );
+			} ),
 			getBlockType: jest.fn( ( name ) =>
 				name === 'core/paragraph' ? { name } : null
 			),
@@ -179,6 +181,34 @@ describe( 'editor markup mutations', () => {
 		} );
 
 		expect( result ).toMatchObject( {
+			applied: false,
+			reason: 'protected_selection',
+		} );
+		expect( dispatcher.replaceBlocks ).not.toHaveBeenCalled();
+	} );
+
+	test( 'rechecks protected state immediately before replacement', async () => {
+		const { state, dispatcher } = setEditor();
+		const { getEditorSelection } = require( '../editor' );
+		const snapshot = await getEditorSelection();
+		let selectionSerializations = 0;
+		state.onSerialize = ( blocks ) => {
+			if (
+				blocks[ 0 ]?.clientId === 'old' &&
+				++selectionSerializations === 2
+			) {
+				state.blocks.old.attributes.lock = { remove: true };
+			}
+		};
+		const { replaceEditorSelection } = loadModule();
+
+		await expect(
+			replaceEditorSelection( {
+				markup: 'valid',
+				expectedFingerprint: snapshot.fingerprint,
+				expectedClientIds: [ 'old' ],
+			} )
+		).resolves.toMatchObject( {
 			applied: false,
 			reason: 'protected_selection',
 		} );

--- a/src/abilities/editor-mutations.js
+++ b/src/abilities/editor-mutations.js
@@ -1,0 +1,517 @@
+/**
+ * Safe Gutenberg markup mutation abilities.
+ *
+ * Raw model markup is parsed, validated, canonicalized, and constrained before
+ * a single block-editor transaction is dispatched. These callbacks never use
+ * DOM mutation or attempt a retry after a write is uncertain.
+ */
+
+import { getEditorSelection, getEditorSelectionForIds } from './editor';
+import { registerClientAbility } from './registry';
+
+export const MAX_MARKUP_BYTES = 64 * 1024;
+export const MAX_TOP_LEVEL_BLOCKS = 50;
+export const MAX_TOTAL_BLOCKS = 200;
+export const MAX_BLOCK_DEPTH = 20;
+
+const UNSUPPORTED_BLOCKS = new Set( [ 'core/freeform', 'core/missing' ] );
+
+/**
+ * Return the UTF-8 size of a string.
+ *
+ * @param {string} value Value to measure.
+ * @return {number} UTF-8 byte count.
+ */
+function getByteLength( value ) {
+	if ( typeof TextEncoder !== 'undefined' ) {
+		return new TextEncoder().encode( value ).byteLength;
+	}
+	return unescape( encodeURIComponent( value ) ).length;
+}
+
+/**
+ * Normalize WordPress validation return values.
+ *
+ * @param {*} result Gutenberg validation response.
+ * @return {boolean} Whether the block is valid.
+ */
+function isValidBlock( result ) {
+	if ( typeof result === 'boolean' ) {
+		return result;
+	}
+	if ( Array.isArray( result ) ) {
+		return result[ 0 ] === true;
+	}
+	return result?.isValid === true;
+}
+
+/**
+ * Return a structured rejection without exposing unbounded markup.
+ *
+ * @param {string}   reason Rejection code.
+ * @param {Object[]} errors Bounded per-block errors.
+ * @return {Object} Safe mutation rejection.
+ */
+function rejected( reason, errors = [] ) {
+	return { applied: false, reason, errors: errors.slice( 0, 20 ) };
+}
+
+/**
+ * Determine whether a registered block is permitted in this editor root.
+ *
+ * @param {Object} editor       Block editor selector.
+ * @param {Object} settings     Editor settings.
+ * @param {string} name         Block name.
+ * @param {string} rootClientId Target root client ID.
+ * @return {boolean} Whether insertion is allowed.
+ */
+function isAllowedBlock( editor, settings, name, rootClientId ) {
+	try {
+		if ( typeof editor?.canInsertBlockType === 'function' ) {
+			return editor.canInsertBlockType( name, rootClientId || undefined );
+		}
+	} catch ( _error ) {
+		return false;
+	}
+	if ( Array.isArray( settings?.allowedBlockTypes ) ) {
+		return settings.allowedBlockTypes.includes( name );
+	}
+	return settings?.allowedBlockTypes === true;
+}
+
+/**
+ * Count and validate one parsed block tree.
+ *
+ * @param {Object}   api          Gutenberg blocks API.
+ * @param {Object}   editor       Block editor selector.
+ * @param {Object}   settings     Editor settings.
+ * @param {Object[]} blocks       Parsed blocks.
+ * @param {string}   rootClientId Target root client ID.
+ * @return {Object[]} Structured validation errors.
+ */
+function validateTree( api, editor, settings, blocks, rootClientId ) {
+	let count = 0;
+	const errors = [];
+	const walk = ( block, depth ) => {
+		count++;
+		if ( depth > MAX_BLOCK_DEPTH ) {
+			errors.push( {
+				code: 'block_depth_exceeded',
+				block: block?.name || '',
+			} );
+			return;
+		}
+		if ( count > MAX_TOTAL_BLOCKS ) {
+			errors.push( { code: 'block_count_exceeded' } );
+			return;
+		}
+		if ( ! block?.name || UNSUPPORTED_BLOCKS.has( block.name ) ) {
+			errors.push( {
+				code: 'unsupported_block',
+				block: block?.name || '',
+			} );
+			return;
+		}
+		const type = api.getBlockType( block.name );
+		if ( ! type ) {
+			errors.push( { code: 'unregistered_block', block: block.name } );
+			return;
+		}
+		if ( ! isAllowedBlock( editor, settings, block.name, rootClientId ) ) {
+			errors.push( { code: 'disallowed_block', block: block.name } );
+			return;
+		}
+		try {
+			if ( ! isValidBlock( api.validateBlock( block, type ) ) ) {
+				errors.push( { code: 'invalid_block', block: block.name } );
+			}
+		} catch ( _error ) {
+			errors.push( { code: 'invalid_block', block: block.name } );
+		}
+		for ( const child of block.innerBlocks || [] ) {
+			walk( child, depth + 1 );
+		}
+	};
+	for ( const block of blocks ) {
+		walk( block, 1 );
+	}
+	return errors;
+}
+
+/**
+ * Parse and canonically validate model-provided block markup without writing.
+ *
+ * @param {string} markup       Markup to validate.
+ * @param {Object} editor       Block editor selector.
+ * @param {string} rootClientId Target root client ID.
+ * @return {{blocks?: Object[], markup?: string, errors?: Object[], reason?: string}} Validated canonical result.
+ */
+export function parseCanonicalMarkup( markup, editor, rootClientId = '' ) {
+	if ( typeof markup !== 'string' || ! markup.trim() ) {
+		return { reason: 'empty_markup' };
+	}
+	if ( getByteLength( markup ) > MAX_MARKUP_BYTES ) {
+		return { reason: 'markup_limit' };
+	}
+	const api = typeof wp !== 'undefined' ? wp.blocks : null;
+	if (
+		! api ||
+		typeof api.parse !== 'function' ||
+		typeof api.serialize !== 'function' ||
+		typeof api.getBlockType !== 'function' ||
+		typeof api.validateBlock !== 'function'
+	) {
+		return { reason: 'block_api_unavailable' };
+	}
+	let parsed;
+	try {
+		parsed = api.parse( markup );
+	} catch ( _error ) {
+		return { reason: 'parse_failed' };
+	}
+	if ( ! Array.isArray( parsed ) || ! parsed.length ) {
+		return { reason: 'parse_failed' };
+	}
+	if ( parsed.length > MAX_TOP_LEVEL_BLOCKS ) {
+		return { reason: 'top_level_block_limit' };
+	}
+	const settings = editor?.getSettings?.() || null;
+	const errors = validateTree( api, editor, settings, parsed, rootClientId );
+	if ( errors.length ) {
+		return { reason: 'validation_failed', errors };
+	}
+	let canonical;
+	let reparsed;
+	let stable;
+	try {
+		canonical = api.serialize( parsed );
+		reparsed = api.parse( canonical );
+		stable = api.serialize( reparsed );
+	} catch ( _error ) {
+		return { reason: 'canonicalization_failed' };
+	}
+	if (
+		! canonical ||
+		canonical !== stable ||
+		getByteLength( canonical ) > MAX_MARKUP_BYTES ||
+		! Array.isArray( reparsed ) ||
+		reparsed.length !== parsed.length
+	) {
+		return { reason: 'unstable_markup' };
+	}
+	const canonicalErrors = validateTree(
+		api,
+		editor,
+		settings,
+		reparsed,
+		rootClientId
+	);
+	return canonicalErrors.length
+		? { reason: 'validation_failed', errors: canonicalErrors }
+		: { blocks: reparsed, markup: canonical };
+}
+
+/**
+ * Return true when a block tree contains bindings or structural locks.
+ *
+ * @param {Object} block Editor block.
+ * @return {boolean} Whether this block tree is protected.
+ */
+function blockHasProtectedState( block ) {
+	const attrs = block?.attributes || {};
+	if (
+		Object.keys( attrs?.metadata?.bindings || {} ).length ||
+		Object.keys( attrs?.lock || block?.lock || {} ).length ||
+		attrs?.templateLock ||
+		block?.templateLock
+	) {
+		return true;
+	}
+
+	return ( block?.innerBlocks || [] ).some( blockHasProtectedState );
+}
+
+/**
+ * Return true when a selected block or its ancestors have protected state.
+ *
+ * @param {Object}   editor    Block editor selector.
+ * @param {string[]} clientIds Selected block client IDs.
+ * @return {boolean} Whether a binding or lock prevents replacement.
+ */
+function hasProtectedSelectionState( editor, clientIds ) {
+	for ( const clientId of clientIds ) {
+		const block = editor.getBlock?.( clientId );
+		if ( blockHasProtectedState( block ) ) {
+			return true;
+		}
+		const parentIds = editor.getBlockParents?.( clientId ) || [];
+		for ( const parentId of parentIds ) {
+			const parent = editor.getBlock?.( parentId );
+			if ( parent?.attributes?.templateLock || parent?.templateLock ) {
+				return true;
+			}
+		}
+		const rootId = editor.getBlockRootClientId?.( clientId ) || '';
+		const listSettings = editor.getBlockListSettings?.( rootId );
+		if ( listSettings?.templateLock ) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * Read the exact, ordered selection expected by a replacement request.
+ *
+ * @param {Object} args Replacement arguments.
+ * @return {Promise<Object>} Current selection or a rejection.
+ */
+async function currentReplacementSelection( args ) {
+	const expectedIds = args?.expectedClientIds;
+	if (
+		! Array.isArray( expectedIds ) ||
+		! expectedIds.length ||
+		! args?.expectedFingerprint
+	) {
+		return { error: rejected( 'expected_selection_required' ) };
+	}
+	const snapshot = await getEditorSelection();
+	const currentIds = snapshot.blocks.map( ( block ) => block.clientId );
+	if (
+		! snapshot.available ||
+		! snapshot.selected ||
+		snapshot.truncated ||
+		snapshot.fingerprint !== args.expectedFingerprint ||
+		currentIds.length !== expectedIds.length ||
+		currentIds.some( ( id, index ) => id !== expectedIds[ index ] )
+	) {
+		return { error: rejected( 'stale_selection' ) };
+	}
+	return { snapshot, clientIds: currentIds };
+}
+
+/**
+ * Replace an exact current selection with validated canonical markup.
+ *
+ * @param {Object} args Replacement arguments.
+ * @return {Promise<Object>} Mutation result.
+ */
+export async function replaceEditorSelection( args = {} ) {
+	if (
+		typeof wp === 'undefined' ||
+		! wp.data?.select ||
+		! wp.data?.dispatch
+	) {
+		return rejected( 'editor_unavailable' );
+	}
+	const editor = wp.data.select( 'core/block-editor' );
+	const dispatcher = wp.data.dispatch( 'core/block-editor' );
+	if ( ! editor || typeof dispatcher?.replaceBlocks !== 'function' ) {
+		return rejected( 'editor_unavailable' );
+	}
+	const selection = await currentReplacementSelection( args );
+	if ( selection.error ) {
+		return selection.error;
+	}
+	if ( hasProtectedSelectionState( editor, selection.clientIds ) ) {
+		return rejected( 'protected_selection' );
+	}
+	const rootClientId =
+		editor.getBlockRootClientId?.( selection.clientIds[ 0 ] ) || '';
+	const parsed = parseCanonicalMarkup( args.markup, editor, rootClientId );
+	if ( ! parsed.blocks ) {
+		return rejected( parsed.reason, parsed.errors );
+	}
+	// Compare immediately before the sole write; never validate one selection and write another.
+	const current = await currentReplacementSelection( args );
+	if ( current.error ) {
+		return current.error;
+	}
+	dispatcher.replaceBlocks( current.clientIds, parsed.blocks );
+	const resultIds = parsed.blocks
+		.map( ( block ) => block.clientId )
+		.filter( Boolean );
+	const applied = await getEditorSelectionForIds( resultIds );
+	if (
+		! resultIds.length ||
+		applied.count !== resultIds.length ||
+		applied.truncated
+	) {
+		return { applied: 'unknown', reason: 'post_dispatch_unverified' };
+	}
+	return {
+		applied: true,
+		markup: parsed.markup,
+		clientIds: resultIds,
+		fingerprint: applied.fingerprint,
+	};
+}
+
+/**
+ * Insert canonical markup at an explicit or current editor insertion point.
+ *
+ * @param {Object} args Insertion arguments.
+ * @return {Promise<Object>} Mutation result.
+ */
+export async function insertBlockMarkup( args = {} ) {
+	if (
+		typeof wp === 'undefined' ||
+		! wp.data?.select ||
+		! wp.data?.dispatch
+	) {
+		return rejected( 'editor_unavailable' );
+	}
+	const editor = wp.data.select( 'core/block-editor' );
+	const dispatcher = wp.data.dispatch( 'core/block-editor' );
+	if ( ! editor || typeof dispatcher?.insertBlocks !== 'function' ) {
+		return rejected( 'editor_unavailable' );
+	}
+	const insertion = editor.getBlockInsertionPoint?.() || {};
+	const explicitRoot = args.rootClientId;
+	const explicitIndex = args.index;
+	if (
+		( explicitRoot !== undefined || explicitIndex !== undefined ) &&
+		( typeof explicitRoot !== 'string' ||
+			! Number.isInteger( explicitIndex ) ||
+			explicitIndex < 0 )
+	) {
+		return rejected( 'invalid_insertion_point' );
+	}
+	const rootClientId =
+		explicitRoot === undefined
+			? insertion.rootClientId || ''
+			: explicitRoot;
+	const index = explicitIndex === undefined ? insertion.index : explicitIndex;
+	if ( ! Number.isInteger( index ) || index < 0 ) {
+		return rejected( 'insertion_point_unavailable' );
+	}
+	const parsed = parseCanonicalMarkup( args.markup, editor, rootClientId );
+	if ( ! parsed.blocks ) {
+		return rejected( parsed.reason, parsed.errors );
+	}
+	dispatcher.insertBlocks( parsed.blocks, index, rootClientId || undefined );
+	const resultIds = parsed.blocks
+		.map( ( block ) => block.clientId )
+		.filter( Boolean );
+	const applied = await getEditorSelectionForIds( resultIds );
+	if (
+		! resultIds.length ||
+		applied.count !== resultIds.length ||
+		applied.truncated
+	) {
+		return { applied: 'unknown', reason: 'post_dispatch_unverified' };
+	}
+	return {
+		applied: true,
+		markup: parsed.markup,
+		clientIds: resultIds,
+		fingerprint: applied.fingerprint,
+	};
+}
+
+/**
+ * Request precisely one native editor undo or redo action.
+ *
+ * @param {Object} args History arguments.
+ * @return {Object} History mutation result.
+ */
+export function changeEditorHistory( args = {} ) {
+	if (
+		typeof wp === 'undefined' ||
+		! wp.data?.select ||
+		! wp.data?.dispatch
+	) {
+		return rejected( 'editor_unavailable' );
+	}
+	const direction = args.direction;
+	if ( direction !== 'undo' && direction !== 'redo' ) {
+		return rejected( 'invalid_history_direction' );
+	}
+	const editor = wp.data.select( 'core/block-editor' );
+	const dispatcher = wp.data.dispatch( 'core/block-editor' );
+	if ( ! editor || typeof dispatcher?.[ direction ] !== 'function' ) {
+		return rejected( 'history_unavailable' );
+	}
+	const before = wp.blocks?.serialize?.( editor.getBlocks?.() || [] ) || '';
+	dispatcher[ direction ]();
+	const after = wp.blocks?.serialize?.( editor.getBlocks?.() || [] ) || '';
+	return { applied: before !== after, direction };
+}
+
+/**
+ * Register all markup mutation abilities after the client category exists.
+ *
+ * @return {Promise<void>} Registration completion.
+ */
+export async function registerEditorMutationAbilities() {
+	const commonOutput = {
+		type: 'object',
+		properties: {
+			applied: { type: [ 'boolean', 'string' ] },
+			reason: { type: 'string' },
+			markup: { type: 'string' },
+			clientIds: { type: 'array', items: { type: 'string' } },
+			fingerprint: { type: 'string' },
+			errors: { type: 'array', items: { type: 'object' } },
+		},
+	};
+	await registerClientAbility( {
+		name: 'sd-ai-agent-js/replace-editor-selection',
+		label: 'Replace Editor Selection',
+		description:
+			'Replace exactly the selected Gutenberg blocks only when the supplied ordered IDs and fingerprint still match.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				markup: { type: 'string' },
+				expectedFingerprint: { type: 'string' },
+				expectedClientIds: { type: 'array', items: { type: 'string' } },
+			},
+			required: [ 'markup', 'expectedFingerprint', 'expectedClientIds' ],
+		},
+		outputSchema: commonOutput,
+		annotations: { readonly: false },
+		callback: replaceEditorSelection,
+	} );
+	await registerClientAbility( {
+		name: 'sd-ai-agent-js/insert-block-markup',
+		label: 'Insert Block Markup',
+		description:
+			'Insert validated canonical Gutenberg markup once at an explicit editor location or the current insertion point.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				markup: { type: 'string' },
+				rootClientId: { type: 'string' },
+				index: { type: 'integer' },
+			},
+			required: [ 'markup' ],
+		},
+		outputSchema: commonOutput,
+		annotations: { readonly: false },
+		callback: insertBlockMarkup,
+	} );
+	await registerClientAbility( {
+		name: 'sd-ai-agent-js/change-editor-history',
+		label: 'Change Editor History',
+		description:
+			'Request one native Gutenberg editor undo or redo operation.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				direction: { type: 'string', enum: [ 'undo', 'redo' ] },
+			},
+			required: [ 'direction' ],
+		},
+		outputSchema: {
+			type: 'object',
+			properties: {
+				applied: { type: 'boolean' },
+				direction: { type: 'string' },
+				reason: { type: 'string' },
+			},
+		},
+		annotations: { readonly: false },
+		callback: changeEditorHistory,
+	} );
+}

--- a/src/abilities/editor-mutations.js
+++ b/src/abilities/editor-mutations.js
@@ -6,7 +6,11 @@
  * DOM mutation or attempt a retry after a write is uncertain.
  */
 
-import { getEditorSelection, getEditorSelectionForIds } from './editor';
+import {
+	getByteLength,
+	getEditorSelection,
+	getEditorSelectionForIds,
+} from './editor';
 import { registerClientAbility } from './registry';
 
 export const MAX_MARKUP_BYTES = 64 * 1024;
@@ -15,19 +19,6 @@ export const MAX_TOTAL_BLOCKS = 200;
 export const MAX_BLOCK_DEPTH = 20;
 
 const UNSUPPORTED_BLOCKS = new Set( [ 'core/freeform', 'core/missing' ] );
-
-/**
- * Return the UTF-8 size of a string.
- *
- * @param {string} value Value to measure.
- * @return {number} UTF-8 byte count.
- */
-function getByteLength( value ) {
-	if ( typeof TextEncoder !== 'undefined' ) {
-		return new TextEncoder().encode( value ).byteLength;
-	}
-	return unescape( encodeURIComponent( value ) ).length;
-}
 
 /**
  * Normalize WordPress validation return values.
@@ -327,7 +318,11 @@ export async function replaceEditorSelection( args = {} ) {
 	if ( current.error ) {
 		return current.error;
 	}
-	dispatcher.replaceBlocks( current.clientIds, parsed.blocks );
+	try {
+		dispatcher.replaceBlocks( current.clientIds, parsed.blocks );
+	} catch ( _error ) {
+		return { applied: 'unknown', reason: 'dispatch_failed' };
+	}
 	const resultIds = parsed.blocks
 		.map( ( block ) => block.clientId )
 		.filter( Boolean );
@@ -389,7 +384,15 @@ export async function insertBlockMarkup( args = {} ) {
 	if ( ! parsed.blocks ) {
 		return rejected( parsed.reason, parsed.errors );
 	}
-	dispatcher.insertBlocks( parsed.blocks, index, rootClientId || undefined );
+	try {
+		dispatcher.insertBlocks(
+			parsed.blocks,
+			index,
+			rootClientId || undefined
+		);
+	} catch ( _error ) {
+		return { applied: 'unknown', reason: 'dispatch_failed' };
+	}
 	const resultIds = parsed.blocks
 		.map( ( block ) => block.clientId )
 		.filter( Boolean );
@@ -428,12 +431,20 @@ export function changeEditorHistory( args = {} ) {
 		return rejected( 'invalid_history_direction' );
 	}
 	const editor = wp.data.select( 'core/block-editor' );
-	const dispatcher = wp.data.dispatch( 'core/block-editor' );
+	const dispatcher = wp.data.dispatch( 'core/editor' );
 	if ( ! editor || typeof dispatcher?.[ direction ] !== 'function' ) {
 		return rejected( 'history_unavailable' );
 	}
 	const before = wp.blocks?.serialize?.( editor.getBlocks?.() || [] ) || '';
-	dispatcher[ direction ]();
+	try {
+		dispatcher[ direction ]();
+	} catch ( _error ) {
+		return {
+			applied: 'unknown',
+			direction,
+			reason: 'dispatch_failed',
+		};
+	}
 	const after = wp.blocks?.serialize?.( editor.getBlocks?.() || [] ) || '';
 	return { applied: before !== after, direction };
 }
@@ -482,8 +493,16 @@ export async function registerEditorMutationAbilities() {
 			type: 'object',
 			properties: {
 				markup: { type: 'string' },
-				rootClientId: { type: 'string' },
-				index: { type: 'integer' },
+				rootClientId: {
+					type: 'string',
+					description:
+						'Supply rootClientId and index together; omit both to use the current insertion point.',
+				},
+				index: {
+					type: 'integer',
+					description:
+						'Supply rootClientId and index together; omit both to use the current insertion point.',
+				},
 			},
 			required: [ 'markup' ],
 		},
@@ -506,7 +525,7 @@ export async function registerEditorMutationAbilities() {
 		outputSchema: {
 			type: 'object',
 			properties: {
-				applied: { type: 'boolean' },
+				applied: { type: [ 'boolean', 'string' ] },
 				direction: { type: 'string' },
 				reason: { type: 'string' },
 			},

--- a/src/abilities/editor-mutations.js
+++ b/src/abilities/editor-mutations.js
@@ -318,6 +318,9 @@ export async function replaceEditorSelection( args = {} ) {
 	if ( current.error ) {
 		return current.error;
 	}
+	if ( hasProtectedSelectionState( editor, current.clientIds ) ) {
+		return rejected( 'protected_selection' );
+	}
 	try {
 		dispatcher.replaceBlocks( current.clientIds, parsed.blocks );
 	} catch ( _error ) {

--- a/src/abilities/editor.js
+++ b/src/abilities/editor.js
@@ -85,6 +85,20 @@ async function createSelectionFingerprint( clientIds, markup ) {
  * @return {Promise<Object>} Bounded current-selection snapshot.
  */
 export async function getEditorSelection() {
+	return getEditorSelectionForIds();
+}
+
+/**
+ * Return a bounded snapshot for either the current selection or exact IDs.
+ *
+ * Mutation abilities use the explicit-ID form after a transaction so their
+ * response is bound to the blocks that were actually written, not to a UI
+ * selection that may have changed as a side effect of the transaction.
+ *
+ * @param {string[]} [requestedIds] Ordered block IDs to snapshot.
+ * @return {Promise<Object>} Bounded current-selection snapshot.
+ */
+export async function getEditorSelectionForIds( requestedIds ) {
 	const empty = {
 		available: false,
 		selected: false,
@@ -107,10 +121,16 @@ export async function getEditorSelection() {
 			return empty;
 		}
 
-		let selectedIds = [];
-		if ( typeof editor.getSelectedBlockClientIds === 'function' ) {
+		let selectedIds = Array.isArray( requestedIds ) ? requestedIds : [];
+		if (
+			! selectedIds.length &&
+			typeof editor.getSelectedBlockClientIds === 'function'
+		) {
 			selectedIds = editor.getSelectedBlockClientIds();
-		} else if ( typeof editor.getSelectedBlockClientId === 'function' ) {
+		} else if (
+			! selectedIds.length &&
+			typeof editor.getSelectedBlockClientId === 'function'
+		) {
 			selectedIds = [ editor.getSelectedBlockClientId() ];
 		}
 		const clientIds = Array.isArray( selectedIds )

--- a/src/abilities/editor.js
+++ b/src/abilities/editor.js
@@ -34,7 +34,7 @@ function fallbackFingerprint( value ) {
  * @param {string} value Value to measure.
  * @return {number} UTF-8 byte length.
  */
-function getByteLength( value ) {
+export function getByteLength( value ) {
 	if ( typeof TextEncoder !== 'undefined' ) {
 		return new TextEncoder().encode( value ).byteLength;
 	}

--- a/src/abilities/index.js
+++ b/src/abilities/index.js
@@ -37,7 +37,6 @@ import { registerCategory } from './registry';
 import { registerNavigationAbility } from './navigation';
 import { registerRefreshPageAbility } from './refresh-page';
 import { registerEditorAbility } from './editor';
-import { registerEditorMutationAbilities } from './editor-mutations';
 import { registerEditorCapabilitiesAbility } from './editor-capabilities';
 import {
 	registerCaptureScreenshotAbility,
@@ -110,7 +109,9 @@ export function ensureRegistered() {
 		await registerNavigationAbility();
 		await registerRefreshPageAbility();
 		await registerEditorAbility();
-		await registerEditorMutationAbilities();
+		await (
+			await import( './editor-mutations' )
+		).registerEditorMutationAbilities();
 		await registerEditorCapabilitiesAbility();
 		await (
 			await import( './block-examples' )

--- a/src/abilities/index.js
+++ b/src/abilities/index.js
@@ -37,6 +37,7 @@ import { registerCategory } from './registry';
 import { registerNavigationAbility } from './navigation';
 import { registerRefreshPageAbility } from './refresh-page';
 import { registerEditorAbility } from './editor';
+import { registerEditorMutationAbilities } from './editor-mutations';
 import { registerEditorCapabilitiesAbility } from './editor-capabilities';
 import {
 	registerCaptureScreenshotAbility,
@@ -109,6 +110,7 @@ export function ensureRegistered() {
 		await registerNavigationAbility();
 		await registerRefreshPageAbility();
 		await registerEditorAbility();
+		await registerEditorMutationAbilities();
 		await registerEditorCapabilitiesAbility();
 		await (
 			await import( './block-examples' )

--- a/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
@@ -69,6 +69,9 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 		$this->assertContains( 'sd-ai-agent-js/get-editor-capabilities', $names );
 		$this->assertContains( 'sd-ai-agent-js/get-canonical-block-examples', $names );
 		$this->assertContains( 'sd-ai-agent-js/insert-block', $names );
+		$this->assertContains( 'sd-ai-agent-js/replace-editor-selection', $names );
+		$this->assertContains( 'sd-ai-agent-js/insert-block-markup', $names );
+		$this->assertContains( 'sd-ai-agent-js/change-editor-history', $names );
 		$this->assertContains( 'sd-ai-agent-js/validate-page-quality', $names );
 		$this->assertContains( 'sd-ai-agent-js/validate-theme-completion', $names );
 	}
@@ -83,6 +86,9 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 		$this->assertTrue( JsAbilityCatalog::has( 'sd-ai-agent-js/get-editor-capabilities' ) );
 		$this->assertTrue( JsAbilityCatalog::has( 'sd-ai-agent-js/get-canonical-block-examples' ) );
 		$this->assertTrue( JsAbilityCatalog::has( 'sd-ai-agent-js/insert-block' ) );
+		$this->assertTrue( JsAbilityCatalog::has( 'sd-ai-agent-js/replace-editor-selection' ) );
+		$this->assertTrue( JsAbilityCatalog::has( 'sd-ai-agent-js/insert-block-markup' ) );
+		$this->assertTrue( JsAbilityCatalog::has( 'sd-ai-agent-js/change-editor-history' ) );
 		$this->assertTrue( JsAbilityCatalog::has( 'sd-ai-agent-js/validate-page-quality' ) );
 		$this->assertTrue( JsAbilityCatalog::has( 'sd-ai-agent-js/validate-theme-completion' ) );
 		$this->assertFalse( JsAbilityCatalog::has( 'sd-ai-agent-js/unknown-ability' ) );
@@ -102,6 +108,9 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'sd-ai-agent-js/get-editor-capabilities', $map );
 		$this->assertArrayHasKey( 'sd-ai-agent-js/get-canonical-block-examples', $map );
 		$this->assertArrayHasKey( 'sd-ai-agent-js/insert-block', $map );
+		$this->assertArrayHasKey( 'sd-ai-agent-js/replace-editor-selection', $map );
+		$this->assertArrayHasKey( 'sd-ai-agent-js/insert-block-markup', $map );
+		$this->assertArrayHasKey( 'sd-ai-agent-js/change-editor-history', $map );
 		$this->assertArrayHasKey( 'sd-ai-agent-js/validate-page-quality', $map );
 		$this->assertArrayHasKey( 'sd-ai-agent-js/validate-theme-completion', $map );
 
@@ -133,6 +142,12 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 		$this->assertSame( array( 'editor' ), $examples['screens'] );
 		$this->assertSame( array( 'blockNames' ), $examples['input_schema']['required'] );
 		$this->assertArrayHasKey( 'examples', $examples['output_schema']['properties'] );
+
+		foreach ( array( 'sd-ai-agent-js/replace-editor-selection', 'sd-ai-agent-js/insert-block-markup', 'sd-ai-agent-js/change-editor-history' ) as $name ) {
+			$this->assertSame( 'sd-ai-agent-js', $map[ $name ]['category'] );
+			$this->assertFalse( $map[ $name ]['annotations']['readonly'] );
+			$this->assertSame( array( 'editor' ), $map[ $name ]['screens'] );
+		}
 	}
 
 	/**
@@ -298,6 +313,30 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 		);
 
 		$this->assertFalse( $partition['client'][0]['annotations']['readonly'] );
+	}
+
+	/** Client metadata cannot downgrade any editor markup mutation. */
+	public function test_client_descriptors_keep_editor_markup_mutations_mutating(): void {
+		$router = ClientAbilityRouter::from_raw(
+			array(
+				array(
+					'name'        => 'sd-ai-agent-js/replace-editor-selection',
+					'annotations' => array( 'readonly' => true ),
+				),
+				array(
+					'name'        => 'sd-ai-agent-js/insert-block-markup',
+					'annotations' => array( 'readonly' => true ),
+				),
+				array(
+					'name'        => 'sd-ai-agent-js/change-editor-history',
+					'annotations' => array( 'readonly' => true ),
+				),
+			)
+		);
+
+		foreach ( $router->get_descriptors() as $descriptor ) {
+			$this->assertFalse( $descriptor['annotations']['readonly'] );
+		}
 	}
 
 	/** Client-provided metadata cannot make the selection reader appear mutable. */

--- a/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
+++ b/tests/SdAiAgent/Core/AgentLoopClientToolsTest.php
@@ -148,6 +148,14 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 			$this->assertFalse( $map[ $name ]['annotations']['readonly'] );
 			$this->assertSame( array( 'editor' ), $map[ $name ]['screens'] );
 		}
+
+		$this->assertSame(
+			$map['sd-ai-agent-js/replace-editor-selection']['output_schema'],
+			$map['sd-ai-agent-js/insert-block-markup']['output_schema']
+		);
+		foreach ( array( 'applied', 'reason', 'markup', 'clientIds', 'fingerprint', 'errors' ) as $property ) {
+			$this->assertArrayHasKey( $property, $map['sd-ai-agent-js/insert-block-markup']['output_schema']['properties'] );
+		}
 	}
 
 	/**
@@ -334,7 +342,10 @@ class AgentLoopClientToolsTest extends WP_UnitTestCase {
 			)
 		);
 
-		foreach ( $router->get_descriptors() as $descriptor ) {
+		$descriptors = $router->get_descriptors();
+		$this->assertCount( 3, $descriptors );
+
+		foreach ( $descriptors as $descriptor ) {
 			$this->assertFalse( $descriptor['annotations']['readonly'] );
 		}
 	}


### PR DESCRIPTION
## Summary

- Add guarded browser abilities for atomic editor selection replacement, canonical markup insertion, and one-step undo/redo.
- Parse, validate, canonicalize, constrain, and post-verify Gutenberg markup before one editor transaction; reject stale selections, protected bindings/locks, invalid blocks, and unsafe insertion points.
- Recheck protected selection state immediately before replacement and report uncertain dispatch outcomes without retrying mutations.
- Keep catalog descriptors canonically mutating and defer the mutation bundle to preserve the floating-widget budget.

Resolves #2493

## Worker self-verification
- PHPUnit: Tests: 4137, Assertions: 18735, Errors: 0, Failures: 0, Skipped: 135, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.273 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 43m and 195,519 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added editor tools to replace selected blocks, insert block markup, and perform a single undo or redo action.
  * Added support for targeting explicitly selected blocks and specifying insertion locations.
  * Added validation and safety checks for stale, protected, malformed, or overly complex block changes.

* **Bug Fixes**
  * Improved editor mutation feedback with clear statuses, reasons, and validation errors.
  * Added confirmation of resulting editor state after changes, with uncertain outcomes reported when completion cannot be confirmed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
