### PR TITLE
GH#2506: fix: recover tool call status chips

### DIFF
--- a/src/components/chat-redesign/__tests__/message-helpers.test.js
+++ b/src/components/chat-redesign/__tests__/message-helpers.test.js
@@ -343,6 +343,8 @@ describe( 'friendly tool progress summaries', () => {
 		expect( summary.totalCount ).toBe( 3 );
 		expect( summary.completedCount ).toBe( 1 );
 		expect( summary.failedCount ).toBe( 1 );
+		expect( summary.recoveredCount ).toBe( 0 );
+		expect( summary.attentionCount ).toBe( 1 );
 		expect( summary.runningCount ).toBe( 1 );
 		expect( summary.currentLabel ).toBe( 'Generating an image' );
 		expect( summary.latestThought ).not.toContain( 'sd-ai-agent/' );
@@ -358,6 +360,27 @@ describe( 'friendly tool progress summaries', () => {
 				'sd-ai-agent/generate-image',
 			]
 		);
+	} );
+
+	test( 'marks failures followed by a successful tool call as recovered', () => {
+		const summary = buildToolProgressSummary( [
+			{ type: 'call', id: 'first', name: 'sd-ai-agent/get-post' },
+			{
+				type: 'response',
+				id: 'first',
+				response: { error: 'The first request timed out.' },
+			},
+			{ type: 'call', id: 'retry', name: 'sd-ai-agent/get-post' },
+			{
+				type: 'response',
+				id: 'retry',
+				response: { success: true },
+			},
+		] );
+
+		expect( summary.failedCount ).toBe( 1 );
+		expect( summary.recoveredCount ).toBe( 1 );
+		expect( summary.attentionCount ).toBe( 0 );
 	} );
 } );
 

--- a/src/components/chat-redesign/__tests__/message-items.test.js
+++ b/src/components/chat-redesign/__tests__/message-items.test.js
@@ -43,7 +43,7 @@ jest.mock( '../icons', () => ( {
 
 jest.mock( '../ToolCard', () => ( {
 	__esModule: true,
-	default: ( { call } ) => `Tool card: ${ call.name }`,
+	default: ( { call } ) => `Tool card: ${ call.name } (${ call.id })`,
 	ToolResultHighlights: () => null,
 } ) );
 
@@ -170,15 +170,18 @@ describe( 'AssistantMessage progress summary', () => {
 
 		await act( async () => {
 			container
-				.querySelector( '.sdaa-cr-progress-stat.is-recovered' )
+				.querySelector( '.sd-ai-agent-progress-stat--recovered' )
 				.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
 		} );
 
 		expect(
-			container.querySelector( '.sdaa-cr-progress-details' )
+			container.querySelector( '.sd-ai-agent-progress-details' )
 		).not.toBeNull();
 		expect( container.textContent ).toContain(
-			'Tool card: sd-ai-agent/get-post'
+			'Tool card: sd-ai-agent/get-post (first)'
+		);
+		expect( container.textContent ).toContain(
+			'Tool card: sd-ai-agent/get-post (retry)'
 		);
 
 		await act( async () => {

--- a/src/components/chat-redesign/__tests__/message-items.test.js
+++ b/src/components/chat-redesign/__tests__/message-items.test.js
@@ -43,7 +43,7 @@ jest.mock( '../icons', () => ( {
 
 jest.mock( '../ToolCard', () => ( {
 	__esModule: true,
-	default: () => null,
+	default: ( { call } ) => `Tool card: ${ call.name }`,
 	ToolResultHighlights: () => null,
 } ) );
 
@@ -53,10 +53,15 @@ jest.mock( '../ToolCard', () => ( {
  * @param {Object}  root0                Options.
  * @param {boolean} root0.hasStreamError Whether the active session has a send error.
  * @param {string}  root0.text           Assistant message text.
+ * @param {Array}   root0.toolCalls      Logged tool calls for the message.
  * @return {Promise<{container: HTMLElement, root: import('react-dom/client').Root}>}
  *   Rendered container and root.
  */
-async function renderAssistantMessage( { hasStreamError, text = '' } ) {
+async function renderAssistantMessage( {
+	hasStreamError,
+	text = '',
+	toolCalls,
+} ) {
 	const selectors = {
 		getMessageTokens: () => [],
 		getSettings: () => ( { show_tool_call_details: false } ),
@@ -73,7 +78,7 @@ async function renderAssistantMessage( { hasStreamError, text = '' } ) {
 				msg: {
 					role: 'model',
 					parts: [ { text } ],
-					toolCalls: [
+					toolCalls: toolCalls || [
 						{
 							type: 'call',
 							id: 'theme',
@@ -133,6 +138,48 @@ describe( 'AssistantMessage progress summary', () => {
 		expect( summary.classList.contains( 'is-error' ) ).toBe( true );
 		expect( summary.textContent ).toContain( 'Work paused' );
 		expect( summary.textContent ).not.toContain( 'Work completed' );
+
+		await act( async () => {
+			root.unmount();
+		} );
+	} );
+
+	test( 'keeps recovered failures inspectable without showing an attention warning', async () => {
+		const { container, root } = await renderAssistantMessage( {
+			hasStreamError: false,
+			text: 'I found the page and completed the update.',
+			toolCalls: [
+				{ type: 'call', id: 'first', name: 'sd-ai-agent/get-post' },
+				{
+					type: 'response',
+					id: 'first',
+					response: { error: 'The first request timed out.' },
+				},
+				{ type: 'call', id: 'retry', name: 'sd-ai-agent/get-post' },
+				{
+					type: 'response',
+					id: 'retry',
+					response: { success: true },
+				},
+			],
+		} );
+
+		expect( container.textContent ).toContain( 'Work completed' );
+		expect( container.textContent ).toContain( '1 recovered' );
+		expect( container.textContent ).not.toContain( 'need attention' );
+
+		await act( async () => {
+			container
+				.querySelector( '.sdaa-cr-progress-stat.is-recovered' )
+				.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
+		} );
+
+		expect(
+			container.querySelector( '.sdaa-cr-progress-details' )
+		).not.toBeNull();
+		expect( container.textContent ).toContain(
+			'Tool card: sd-ai-agent/get-post'
+		);
 
 		await act( async () => {
 			root.unmount();

--- a/src/components/chat-redesign/chat-redesign.css
+++ b/src/components/chat-redesign/chat-redesign.css
@@ -1247,18 +1247,18 @@ input[type="text"].sdaa-cr-search-input {
 	background: var(--sdaa-error-surface);
 }
 
-.sdaa-cr-progress-stat.is-recovered {
+.sd-ai-agent-progress-stat--recovered {
 	border-color: #d8eddb;
 	color: var(--sdaa-success);
 }
 
-.sdaa-cr-progress-details {
+.sd-ai-agent-progress-details {
 	display: grid;
 	gap: 8px;
 	padding-top: 2px;
 }
 
-.sdaa-cr-progress-details-label {
+.sd-ai-agent-progress-details-label {
 	color: var(--sdaa-text-secondary);
 	font-size: 12px;
 	font-weight: 600;

--- a/src/components/chat-redesign/chat-redesign.css
+++ b/src/components/chat-redesign/chat-redesign.css
@@ -1215,9 +1215,20 @@ input[type="text"].sdaa-cr-search-input {
 	border: 1px solid var(--sdaa-border-subtle);
 	border-radius: var(--sdaa-radius-pill);
 	padding: 2px 8px;
+	font-family: inherit;
 	font-size: 11.5px;
 	color: var(--sdaa-text-secondary);
 	background: #fff;
+	cursor: pointer;
+}
+
+.sdaa-cr-progress-stat:hover {
+	filter: brightness(0.98);
+}
+
+.sdaa-cr-progress-stat:focus-visible {
+	outline: 2px solid var(--sdaa-primary);
+	outline-offset: 2px;
 }
 
 .sdaa-cr-progress-stat.is-complete {
@@ -1234,6 +1245,23 @@ input[type="text"].sdaa-cr-search-input {
 	border-color: #f1b0b7;
 	color: var(--sdaa-error);
 	background: var(--sdaa-error-surface);
+}
+
+.sdaa-cr-progress-stat.is-recovered {
+	border-color: #d8eddb;
+	color: var(--sdaa-success);
+}
+
+.sdaa-cr-progress-details {
+	display: grid;
+	gap: 8px;
+	padding-top: 2px;
+}
+
+.sdaa-cr-progress-details-label {
+	color: var(--sdaa-text-secondary);
+	font-size: 12px;
+	font-weight: 600;
 }
 
 .sdaa-cr-progress-steps {

--- a/src/components/chat-redesign/message-helpers.js
+++ b/src/components/chat-redesign/message-helpers.js
@@ -299,6 +299,8 @@ export function buildToolProgressSummary( toolCalls ) {
 			finishedCount: 0,
 			completedCount: 0,
 			failedCount: 0,
+			recoveredCount: 0,
+			attentionCount: 0,
 			runningCount: 0,
 			currentLabel: '',
 			latestThought: '',
@@ -344,6 +346,18 @@ export function buildToolProgressSummary( toolCalls ) {
 	const failedCount = steps.filter(
 		( step ) => step.status === 'error'
 	).length;
+	let recoveredCount = 0;
+	let hasSuccessfulRecovery = false;
+	for ( let index = steps.length - 1; index >= 0; index-- ) {
+		if ( steps[ index ].status === 'done' ) {
+			hasSuccessfulRecovery = true;
+		} else if (
+			steps[ index ].status === 'error' &&
+			hasSuccessfulRecovery
+		) {
+			recoveredCount++;
+		}
+	}
 	const runningCount = steps.filter(
 		( step ) => step.status === 'running'
 	).length;
@@ -361,6 +375,8 @@ export function buildToolProgressSummary( toolCalls ) {
 		finishedCount,
 		completedCount,
 		failedCount,
+		recoveredCount,
+		attentionCount: failedCount - recoveredCount,
 		runningCount,
 		currentLabel: currentStep?.label || '',
 		latestThought: truncateProgressText(

--- a/src/components/chat-redesign/message-items.js
+++ b/src/components/chat-redesign/message-items.js
@@ -331,7 +331,7 @@ function ToolProgressSummary( {
 					{ recoveredCount > 0 && (
 						<button
 							type="button"
-							className="sdaa-cr-progress-stat is-recovered"
+							className="sdaa-cr-progress-stat sd-ai-agent-progress-stat--recovered"
 							onClick={ toggleDetails }
 							aria-expanded={ showDetails }
 						>
@@ -353,8 +353,8 @@ function ToolProgressSummary( {
 				</div>
 			) }
 			{ showDetails && items.length > 0 && (
-				<div className="sdaa-cr-progress-details">
-					<div className="sdaa-cr-progress-details-label">
+				<div className="sd-ai-agent-progress-details">
+					<div className="sd-ai-agent-progress-details-label">
 						{ __( 'Tool call details', 'superdav-ai-agent' ) }
 					</div>
 					{ items.map( ( item ) => (

--- a/src/components/chat-redesign/message-items.js
+++ b/src/components/chat-redesign/message-items.js
@@ -214,7 +214,7 @@ function getProgressSummaryTitle( summary, mode, fallbackStep ) {
 		return __( 'Work paused', 'superdav-ai-agent' );
 	}
 
-	if ( summary.failedCount > 0 ) {
+	if ( summary.attentionCount > 0 ) {
 		return __( 'Some steps need attention', 'superdav-ai-agent' );
 	}
 
@@ -247,14 +247,19 @@ function getProgressStepStatusLabel( status ) {
  * @param {Object} root0.summary      Progress summary.
  * @param {string} root0.mode         Either 'running', 'complete', or 'error'.
  * @param {string} root0.fallbackStep Fallback running text.
+ * @param {Array}  root0.items        Paired tool calls available for inspection.
  */
 function ToolProgressSummary( {
 	summary,
 	mode = 'running',
 	fallbackStep = '',
+	items = [],
 } ) {
+	const [ showDetails, setShowDetails ] = useState( false );
 	const isRunning = mode === 'running';
 	const isError = mode === 'error';
+	const attentionCount = summary.attentionCount;
+	const recoveredCount = summary.recoveredCount;
 	let statusClass = 'is-complete';
 	if ( isRunning ) {
 		statusClass = 'is-running';
@@ -282,6 +287,7 @@ function ToolProgressSummary( {
 			);
 		}
 	}
+	const toggleDetails = () => setShowDetails( ( visible ) => ! visible );
 
 	return (
 		<div className={ `sdaa-cr-progress-summary ${ statusClass }` }>
@@ -301,23 +307,66 @@ function ToolProgressSummary( {
 			{ summary.totalCount > 0 && (
 				<div className="sdaa-cr-progress-stats">
 					{ summary.completedCount > 0 && (
-						<span className="sdaa-cr-progress-stat is-complete">
+						<button
+							type="button"
+							className="sdaa-cr-progress-stat is-complete"
+							onClick={ toggleDetails }
+							aria-expanded={ showDetails }
+						>
 							{ summary.completedCount }{ ' ' }
 							{ __( 'completed', 'superdav-ai-agent' ) }
-						</span>
+						</button>
 					) }
 					{ summary.runningCount > 0 && (
-						<span className="sdaa-cr-progress-stat is-running">
+						<button
+							type="button"
+							className="sdaa-cr-progress-stat is-running"
+							onClick={ toggleDetails }
+							aria-expanded={ showDetails }
+						>
 							{ summary.runningCount }{ ' ' }
 							{ __( 'in progress', 'superdav-ai-agent' ) }
-						</span>
+						</button>
 					) }
-					{ summary.failedCount > 0 && (
-						<span className="sdaa-cr-progress-stat is-error">
-							{ summary.failedCount }{ ' ' }
+					{ recoveredCount > 0 && (
+						<button
+							type="button"
+							className="sdaa-cr-progress-stat is-recovered"
+							onClick={ toggleDetails }
+							aria-expanded={ showDetails }
+						>
+							{ recoveredCount }{ ' ' }
+							{ __( 'recovered', 'superdav-ai-agent' ) }
+						</button>
+					) }
+					{ attentionCount > 0 && (
+						<button
+							type="button"
+							className="sdaa-cr-progress-stat is-error"
+							onClick={ toggleDetails }
+							aria-expanded={ showDetails }
+						>
+							{ attentionCount }{ ' ' }
 							{ __( 'need attention', 'superdav-ai-agent' ) }
-						</span>
+						</button>
 					) }
+				</div>
+			) }
+			{ showDetails && items.length > 0 && (
+				<div className="sdaa-cr-progress-details">
+					<div className="sdaa-cr-progress-details-label">
+						{ __( 'Tool call details', 'superdav-ai-agent' ) }
+					</div>
+					{ items.map( ( item ) => (
+						<ToolCard
+							key={ `${ item.key }-details` }
+							call={ item.call }
+							response={ item.response }
+							defaultOpen={ Boolean(
+								item.response?.response?.error
+							) }
+						/>
+					) ) }
 				</div>
 			) }
 
@@ -625,6 +674,7 @@ export function AssistantMessage( {
 					<ToolProgressSummary
 						summary={ progressSummary }
 						mode={ showInterruptedProgress ? 'error' : 'complete' }
+						items={ items }
 					/>
 				) }
 				{ showToolCallDetails &&
@@ -736,6 +786,7 @@ export function RunningMessage( {
 					summary={ progressSummary }
 					mode="running"
 					fallbackStep={ step }
+					items={ items.filter( ( item ) => item.kind === 'pair' ) }
 				/>
 				{ showToolCallDetails &&
 					items.map( ( item ) => {


### PR DESCRIPTION
## Summary

Classify failed tool calls followed by successful calls as recovered and make progress status chips reveal the complete tool-call log.

## Files Changed

src/components/chat-redesign/__tests__/message-helpers.test.js, src/components/chat-redesign/__tests__/message-items.test.js, src/components/chat-redesign/chat-redesign.css, src/components/chat-redesign/message-helpers.js, src/components/chat-redesign/message-items.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — pnpm run verify (PHPUnit: 4136 tests, 18706 assertions, 135 skipped, 4 incomplete; lint, PHPStan, JS tests, build, and bundle budgets passed)

Resolves #2506


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.273 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 13m and 103,610 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive progress counters for completed, running, recovered, and attention-needed tool activity.
  * Users can expand progress details to inspect individual tool calls, including failures that later recovered successfully.
  * Added clearer visual states and keyboard focus indicators for progress controls.

* **Bug Fixes**
  * Recovered tool failures no longer trigger an unnecessary attention warning.
  * Progress summaries now distinguish between recovered and unresolved failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->