### PR TITLE
GH#2516: fix(ci): bound Subversion setup

### DIFF
--- a/.github/scripts/ensure-subversion.sh
+++ b/.github/scripts/ensure-subversion.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if command -v svn >/dev/null 2>&1; then
+	svn --version --quiet
+	exit 0
+fi
+
+timeout_seconds="${SUBVERSION_INSTALL_TIMEOUT_SECONDS:-120}"
+kill_after_seconds="${SUBVERSION_INSTALL_KILL_AFTER_SECONDS:-30}"
+
+if [[ ! "${timeout_seconds}" =~ ^[1-9][0-9]*$ ]] || [[ ! "${kill_after_seconds}" =~ ^[1-9][0-9]*$ ]]; then
+	printf 'Subversion installation timeouts must be positive integers.\n' >&2
+	exit 2
+fi
+
+sudo timeout --signal=TERM --kill-after="${kill_after_seconds}s" "${timeout_seconds}s" apt-get update || {
+	status=$?
+	printf 'Subversion setup failed during apt-get update (exit %d).\n' "${status}" >&2
+	exit "${status}"
+}
+sudo timeout --signal=TERM --kill-after="${kill_after_seconds}s" "${timeout_seconds}s" apt-get install --yes --no-install-recommends subversion || {
+	status=$?
+	printf 'Subversion setup failed during apt-get install (exit %d).\n' "${status}" >&2
+	exit "${status}"
+}
+
+svn --version --quiet

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,7 +189,7 @@ jobs:
           test ! -e wporg-package/superdav-ai-agent/advanced-plugin
 
       - name: Install SVN
-        run: sudo apt-get update && sudo apt-get install -y subversion
+        run: bash .github/scripts/ensure-subversion.sh
 
       - name: Deploy trunk to WordPress.org SVN
         env:

--- a/.github/workflows/stress.yml
+++ b/.github/workflows/stress.yml
@@ -61,7 +61,7 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Install subversion
-        run: sudo apt-get update && sudo apt-get install -y subversion
+        run: bash .github/scripts/ensure-subversion.sh
 
       - name: Install WordPress test suite
         run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 trunk true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Install subversion
-        run: sudo apt-get update && sudo apt-get install -y subversion
+        run: bash .github/scripts/ensure-subversion.sh
 
       - name: Install WordPress test suite
         run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 trunk true
@@ -157,7 +157,7 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Install subversion
-        run: sudo apt-get update && sudo apt-get install -y subversion
+        run: bash .github/scripts/ensure-subversion.sh
 
       - name: Install WordPress test suite
         run: bash bin/install-wp-tests.sh wordpress_test root root 127.0.0.1 trunk true


### PR DESCRIPTION
## Summary

- Reuse the runner's existing `svn` binary instead of always invoking apt.
- Bound fallback `apt-get update` and install operations with configurable TERM/KILL timeouts and attributable errors.
- Use the shared setup helper in PHPUnit, coverage, stress, and WordPress.org release workflows.

Resolves #2516

## Worker self-verification
- PHPUnit: Tests: 4136, Assertions: 18706, Errors: 0, Failures: 0, Skipped: 135, Incomplete: 4
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed
- ShellCheck: `.github/scripts/ensure-subversion.sh` clean
- Workflow YAML: parsed successfully
- Helper smoke test: existing SVN path returned `1.14.3`

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.274 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 1d 2h and 1,896,080 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automated release, stress, and test workflows to reliably detect and install Subversion when needed.
  - Added timeout validation and clearer failure reporting during Subversion setup.
  - Workflows now confirm the installed Subversion version after setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->