### PR TITLE
GH#2520: Show truthful editor-unavailable mutation status

### DIFF
--- a/src/components/chat-widget/__tests__/editor-selection-status.test.js
+++ b/src/components/chat-widget/__tests__/editor-selection-status.test.js
@@ -114,6 +114,43 @@ describe( 'getEditorMutationStatus', () => {
 		} );
 	} );
 
+	test.each( [
+		[
+			'block_api_unavailable',
+			'sd-ai-agent-js/replace-editor-selection',
+			'The block editor API is unavailable. Wait for the editor to finish loading and try again.',
+		],
+		[
+			'editor_unavailable',
+			'sd-ai-agent-js/replace-editor-selection',
+			'The block editor is unavailable. Return to the editor and try again.',
+		],
+		[
+			'history_unavailable',
+			'sd-ai-agent-js/change-editor-history',
+			'Editor history is unavailable. Wait for the editor to finish loading and try again.',
+		],
+		[
+			'insertion_point_unavailable',
+			'sd-ai-agent-js/insert-block-markup',
+			'No valid insertion point is available. Place the cursor in the editor and try again.',
+		],
+	] )(
+		'maps %s to truthful unavailable-context copy',
+		( reason, name, text ) => {
+			expect(
+				getEditorMutationStatus( [
+					{ type: 'call', id: 'unavailable-1', name },
+					{
+						type: 'response',
+						id: 'unavailable-1',
+						response: { applied: false, reason },
+					},
+				] )
+			).toEqual( { kind: 'warning', text } );
+		}
+	);
+
 	test( 'does not claim success for an uncertain dispatch', () => {
 		expect(
 			getEditorMutationStatus( [

--- a/src/components/chat-widget/editor-selection-status.js
+++ b/src/components/chat-widget/editor-selection-status.js
@@ -18,16 +18,12 @@ const EDITOR_MUTATION_TOOLS = new Set( [
 ] );
 
 const VALIDATION_REASONS = new Set( [
-	'block_api_unavailable',
 	'block_count_exceeded',
 	'block_depth_exceeded',
 	'canonicalization_failed',
 	'disallowed_block',
-	'editor_unavailable',
 	'empty_markup',
 	'expected_selection_required',
-	'history_unavailable',
-	'insertion_point_unavailable',
 	'invalid_block',
 	'invalid_history_direction',
 	'invalid_insertion_point',
@@ -40,6 +36,39 @@ const VALIDATION_REASONS = new Set( [
 	'unsupported_block',
 	'validation_failed',
 ] );
+
+/**
+ * Return actionable copy for unavailable editor execution contexts.
+ *
+ * @param {string} reason Editor mutation result reason.
+ * @return {string|null} Localized status copy when the reason is unavailable.
+ */
+function getUnavailableCopy( reason ) {
+	switch ( reason ) {
+		case 'block_api_unavailable':
+			return __(
+				'The block editor API is unavailable. Wait for the editor to finish loading and try again.',
+				'superdav-ai-agent'
+			);
+		case 'editor_unavailable':
+			return __(
+				'The block editor is unavailable. Return to the editor and try again.',
+				'superdav-ai-agent'
+			);
+		case 'history_unavailable':
+			return __(
+				'Editor history is unavailable. Wait for the editor to finish loading and try again.',
+				'superdav-ai-agent'
+			);
+		case 'insertion_point_unavailable':
+			return __(
+				'No valid insertion point is available. Place the cursor in the editor and try again.',
+				'superdav-ai-agent'
+			);
+		default:
+			return null;
+	}
+}
 
 /**
  * Parse a possibly encoded tool result without exposing arbitrary payload data.
@@ -220,6 +249,13 @@ export function getEditorMutationStatus(
 		};
 	}
 	if ( result?.applied === false ) {
+		const unavailableCopy = getUnavailableCopy( result.reason );
+		if ( unavailableCopy ) {
+			return {
+				kind: 'warning',
+				text: unavailableCopy,
+			};
+		}
 		if ( VALIDATION_REASONS.has( result.reason ) ) {
 			return {
 				kind: 'warning',


### PR DESCRIPTION
## Summary

Map editor API, editor, history, and insertion-point unavailability to specific warning copy before generic validation handling.

## Files Changed

- `src/components/chat-widget/editor-selection-status.js`
- `src/components/chat-widget/__tests__/editor-selection-status.test.js`

## Runtime Testing

- **Risk level:** Medium
- **Verification:** Self-assessed through focused status-mapping tests and the complete repository verification suite. The change only selects warning copy from existing result reasons and does not alter mutation execution or editor state.

## Worker self-verification
- PHPUnit: Tests: 4137, Assertions: 18735, Errors: 0, Failures: 0, Skipped: 135
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed
- Jest:    57 suites, 553 tests, 6 snapshots passed

Resolves #2520

<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.274 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 1d 11h and 210,258 tokens on this with the user in an interactive session. Overall, 15m since this issue was created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added clearer, localized warning messages when editor features, history, or insertion points are unavailable.
  * Improved feedback for failed content changes by showing the most relevant warning instead of a generic message.

* **Tests**
  * Added coverage to verify the expected warning for each editor availability and mutation failure scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->