### PR TITLE
GH#2522: Prefix editor mutation status modifier classes

### DIFF
--- a/src/components/chat-widget/__tests__/editor-selection-status.test.js
+++ b/src/components/chat-widget/__tests__/editor-selection-status.test.js
@@ -254,6 +254,9 @@ describe( 'EditorSelectionStatus', () => {
 		const status = container.querySelector( '[role="status"]' );
 		expect( status.getAttribute( 'aria-live' ) ).toBe( 'polite' );
 		expect( status.getAttribute( 'aria-atomic' ) ).toBe( 'true' );
+		expect( status.className ).toBe(
+			'sd-ai-agent-editor-mutation-status sd-ai-agent-editor-mutation-status--warning'
+		);
 		expect( status.textContent ).toBe( 'No blocks were changed.' );
 
 		await act( async () => root.unmount() );

--- a/src/components/chat-widget/editor-selection-status.js
+++ b/src/components/chat-widget/editor-selection-status.js
@@ -360,7 +360,7 @@ export function EditorSelectionStatus( {
 			) }
 			{ mutationStatus && (
 				<div
-					className={ `sd-ai-agent-editor-mutation-status is-${ mutationStatus.kind }` }
+					className={ `sd-ai-agent-editor-mutation-status sd-ai-agent-editor-mutation-status--${ mutationStatus.kind }` }
 					role="status"
 					aria-live="polite"
 					aria-atomic="true"

--- a/src/components/chat-widget/widget-panel.css
+++ b/src/components/chat-widget/widget-panel.css
@@ -1107,11 +1107,11 @@
 	line-height: 1.35;
 }
 
-.sd-ai-agent-editor-mutation-status.is-success {
+.sd-ai-agent-editor-mutation-status--success {
 	color: #007c24;
 }
 
-.sd-ai-agent-editor-mutation-status.is-warning {
+.sd-ai-agent-editor-mutation-status--warning {
 	color: #7a5a10;
 }
 


### PR DESCRIPTION
## Summary

Replace generic mutation-state modifiers with `sd-ai-agent-`-prefixed classes and keep success and warning selectors aligned.

## Files Changed

- `src/components/chat-widget/editor-selection-status.js`
- `src/components/chat-widget/widget-panel.css`
- `src/components/chat-widget/__tests__/editor-selection-status.test.js`

## Runtime Testing

- **Risk level:** Medium
- **Verification:** Self-assessed through focused component rendering, lint, and the complete repository verification suite. The change only renames colocated DOM classes and CSS selectors; status resolution, copy, and editor behavior are unchanged.

## Worker self-verification
- PHPUnit: Tests: 4137, Assertions: 18735, Errors: 0, Failures: 0, Skipped: 135
- Lint:    PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed
- Jest:    57 suites, 553 tests, 6 snapshots passed

Resolves #2522


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.274 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 1d 11h and 68,600 tokens on this with the user in an interactive session. Overall, 12m since this issue was created.
