### PR TITLE
GH#2524: Skip unnecessary apt update during Subversion setup

### DIFF
--- a/.github/scripts/ensure-subversion.sh
+++ b/.github/scripts/ensure-subversion.sh
@@ -15,14 +15,22 @@ if [[ ! "${timeout_seconds}" =~ ^[1-9][0-9]*$ ]] || [[ ! "${kill_after_seconds}"
 	exit 2
 fi
 
+if sudo timeout --signal=TERM --kill-after="${kill_after_seconds}s" "${timeout_seconds}s" apt-get install --yes --no-install-recommends subversion; then
+	svn --version --quiet
+	exit 0
+else
+	status=$?
+	printf 'Initial Subversion install failed (exit %d); refreshing package indexes before one retry.\n' "${status}" >&2
+fi
+
 sudo timeout --signal=TERM --kill-after="${kill_after_seconds}s" "${timeout_seconds}s" apt-get update || {
 	status=$?
-	printf 'Subversion setup failed during apt-get update (exit %d).\n' "${status}" >&2
+	printf 'Subversion setup failed during apt-get update fallback (exit %d).\n' "${status}" >&2
 	exit "${status}"
 }
 sudo timeout --signal=TERM --kill-after="${kill_after_seconds}s" "${timeout_seconds}s" apt-get install --yes --no-install-recommends subversion || {
 	status=$?
-	printf 'Subversion setup failed during apt-get install (exit %d).\n' "${status}" >&2
+	printf 'Subversion setup failed during apt-get install retry (exit %d).\n' "${status}" >&2
 	exit "${status}"
 }
 


### PR DESCRIPTION
## Summary

Try the bounded Subversion install against GitHub runner package indexes before running a bounded `apt-get update` fallback and one install retry.

## Files Changed

- `.github/scripts/ensure-subversion.sh`

## Runtime Testing

- **Risk level:** Low
- **Verification:** Shell syntax and ShellCheck passed; the local installed-SVN fast path returned Subversion 1.14.3. The PR's PHPUnit workflow provides the GitHub-hosted runner proof for the install-first path.

## Worker self-verification
- PHPUnit: Tests: 4137, Assertions: 18735, Errors: 0, Failures: 0, Skipped: 135
- Lint:    PHP/JS/CSS and ShellCheck all clean
- PHPStan: 0 errors
- Build:   succeeded
- Bundle:  budgets passed

Resolves #2524
Blocks #2523


<!-- aidevops:origin:interactive -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.274 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-sol spent 1d 13h and 405,589 tokens on this with the user in an interactive session. Overall, 1h 33m since this issue was created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Subversion installation reliability by retrying after refreshing package information when the initial installation fails.
  * Added clearer error reporting for update and installation failures.
  * Confirmed successful installation by reporting the installed Subversion version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->