### PR TITLE
GH#2526: feat: sync clean Gutenberg editor content

### DIFF
--- a/src/floating-widget/reflectors/__tests__/editor-post.test.js
+++ b/src/floating-widget/reflectors/__tests__/editor-post.test.js
@@ -1,0 +1,172 @@
+import apiFetch from '@wordpress/api-fetch';
+import { reflectEditorPost } from '../editor-post';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+/**
+ * Create a minimal clean or dirty Gutenberg editor state.
+ *
+ * @param {Object} options Editor options.
+ * @return {Object} Editor test state and dispatchers.
+ */
+function setEditor( options = {} ) {
+	const { postId = 42, dirty = false, postType = 'page' } = options;
+	const state = { dirty };
+	const editor = {
+		getCurrentPostId: jest.fn( () => postId ),
+		getCurrentPostType: jest.fn( () => postType ),
+		isEditedPostDirty: jest.fn( () => state.dirty ),
+	};
+	const coreData = { receiveEntityRecords: jest.fn() };
+	const blockDispatcher = { resetBlocks: jest.fn() };
+	global.wp = {
+		data: {
+			select: jest.fn( ( store ) =>
+				store === 'core/editor' ? editor : {}
+			),
+			dispatch: jest.fn( ( store ) => {
+				if ( store === 'core' ) {
+					return coreData;
+				}
+				return blockDispatcher;
+			} ),
+		},
+		blocks: { parse: jest.fn( () => [ { clientId: 'fresh' } ] ) },
+	};
+	return { state, editor, coreData, blockDispatcher };
+}
+
+/**
+ * Build a successful server-side post mutation event.
+ *
+ * @param {Object} overrides Event properties to override.
+ * @return {Object} Reflection event.
+ */
+function postEvent( overrides = {} ) {
+	return {
+		type: 'tool-applied',
+		affected: { kind: 'post', post_id: 42, fields: [ 'post_content' ] },
+		...overrides,
+	};
+}
+
+describe( 'editor post reflector', () => {
+	afterEach( () => {
+		apiFetch.mockReset();
+		delete global.wp;
+	} );
+
+	test( 'synchronizes fetched server content into a matching clean editor', async () => {
+		const { coreData, blockDispatcher } = setEditor();
+		const record = {
+			id: 42,
+			content: {
+				raw: '<!-- wp:paragraph -->Fresh<!-- /wp:paragraph -->',
+			},
+		};
+		apiFetch.mockResolvedValue( record );
+
+		await reflectEditorPost( postEvent() );
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/wp/v2/page/42?context=edit',
+		} );
+		expect( coreData.receiveEntityRecords ).toHaveBeenCalledWith(
+			'postType',
+			'page',
+			[ record ]
+		);
+		expect( blockDispatcher.resetBlocks ).toHaveBeenCalledWith( [
+			{ clientId: 'fresh' },
+		] );
+	} );
+
+	test.each( [
+		[
+			'a mismatched post',
+			postEvent( {
+				affected: { post_id: 7, fields: [ 'post_content' ] },
+			} ),
+		],
+		[
+			'a preview mutation',
+			postEvent( {
+				affected: {
+					post_id: 42,
+					fields: [ 'post_content' ],
+					render_mode: 'preview',
+				},
+			} ),
+		],
+		[
+			'a mutation without post content',
+			postEvent( {
+				affected: { post_id: 42, fields: [ 'post_title' ] },
+			} ),
+		],
+	] )( 'skips %s', async ( _name, event ) => {
+		const { blockDispatcher } = setEditor();
+
+		await reflectEditorPost( event );
+
+		expect( apiFetch ).not.toHaveBeenCalled();
+		expect( blockDispatcher.resetBlocks ).not.toHaveBeenCalled();
+	} );
+
+	test( 'does not fetch or replace a dirty editor', async () => {
+		const { blockDispatcher } = setEditor( { dirty: true } );
+
+		await reflectEditorPost( postEvent() );
+
+		expect( apiFetch ).not.toHaveBeenCalled();
+		expect( blockDispatcher.resetBlocks ).not.toHaveBeenCalled();
+	} );
+
+	test( 'preserves local edits made while fetching', async () => {
+		const { state, coreData, blockDispatcher } = setEditor();
+		let resolveFetch;
+		apiFetch.mockReturnValue(
+			new Promise( ( resolve ) => {
+				resolveFetch = resolve;
+			} )
+		);
+
+		const reflection = reflectEditorPost( postEvent() );
+		state.dirty = true;
+		resolveFetch( {
+			id: 42,
+			content: {
+				raw: '<!-- wp:paragraph -->Fresh<!-- /wp:paragraph -->',
+			},
+		} );
+		await reflection;
+
+		expect( coreData.receiveEntityRecords ).not.toHaveBeenCalled();
+		expect( blockDispatcher.resetBlocks ).not.toHaveBeenCalled();
+	} );
+
+	test.each( [
+		[ 'malformed REST content', { id: 42, content: {} } ],
+		[ 'a fetch failure', new Error( 'offline' ) ],
+	] )( 'fails safely for %s', async ( _name, response ) => {
+		const { blockDispatcher } = setEditor();
+		if ( response instanceof Error ) {
+			apiFetch.mockRejectedValue( response );
+		} else {
+			apiFetch.mockResolvedValue( response );
+		}
+
+		await reflectEditorPost( postEvent() );
+
+		expect( blockDispatcher.resetBlocks ).not.toHaveBeenCalled();
+	} );
+
+	test( 'fails safely when Gutenberg APIs are unavailable or parsing fails', async () => {
+		setEditor();
+		delete global.wp.blocks;
+
+		await reflectEditorPost( postEvent() );
+
+		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
+} );

--- a/src/floating-widget/reflectors/__tests__/editor-post.test.js
+++ b/src/floating-widget/reflectors/__tests__/editor-post.test.js
@@ -161,12 +161,27 @@ describe( 'editor post reflector', () => {
 		expect( blockDispatcher.resetBlocks ).not.toHaveBeenCalled();
 	} );
 
-	test( 'fails safely when Gutenberg APIs are unavailable or parsing fails', async () => {
+	test( 'fails safely when Gutenberg APIs are unavailable', async () => {
 		setEditor();
 		delete global.wp.blocks;
 
 		await reflectEditorPost( postEvent() );
 
 		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
+
+	test( 'fails safely when parsing fetched content throws', async () => {
+		const { blockDispatcher } = setEditor();
+		global.wp.blocks.parse.mockImplementation( () => {
+			throw new Error( 'Malformed block markup' );
+		} );
+		apiFetch.mockResolvedValue( {
+			id: 42,
+			content: { raw: '<!-- wp:broken -->' },
+		} );
+
+		await reflectEditorPost( postEvent() );
+
+		expect( blockDispatcher.resetBlocks ).not.toHaveBeenCalled();
 	} );
 } );

--- a/src/floating-widget/reflectors/__tests__/index.test.js
+++ b/src/floating-widget/reflectors/__tests__/index.test.js
@@ -14,11 +14,15 @@ jest.mock( '../menu', () => ( {
 jest.mock( '../post', () => ( {
 	reflectPost: jest.fn(),
 } ) );
+jest.mock( '../editor-post', () => ( {
+	reflectEditorPost: jest.fn(),
+} ) );
 
 import { showFallbackToast } from '../fallback-toast';
 import { reflectGlobalStyles } from '../global-styles';
 import { reflectMenu } from '../menu';
 import { reflectPost } from '../post';
+import { reflectEditorPost } from '../editor-post';
 import bus from '../../../store/reflection-bus';
 import { dispatchReflectionEvent } from '..';
 
@@ -33,6 +37,7 @@ describe( 'reflector dispatcher', () => {
 		reflectGlobalStyles.mockClear();
 		reflectMenu.mockClear();
 		reflectPost.mockClear();
+		reflectEditorPost.mockClear();
 	} );
 
 	test( 'subscribes the deferred dispatcher to the reflection bus', () => {
@@ -50,6 +55,19 @@ describe( 'reflector dispatcher', () => {
 
 		expect( reflector ).toHaveBeenCalledWith( event );
 		expect( showFallbackToast ).not.toHaveBeenCalled();
+	} );
+
+	test( 'runs the editor post reflector before public post reflection', async () => {
+		const event = makeEvent( 'post' );
+		const callOrder = [];
+		reflectEditorPost.mockImplementation( () =>
+			callOrder.push( 'editor' )
+		);
+		reflectPost.mockImplementation( () => callOrder.push( 'public' ) );
+
+		await dispatchReflectionEvent( event );
+
+		expect( callOrder ).toEqual( [ 'editor', 'public' ] );
 	} );
 
 	test( 'uses the fallback for an unknown affected kind', () => {

--- a/src/floating-widget/reflectors/editor-post.js
+++ b/src/floating-widget/reflectors/editor-post.js
@@ -1,0 +1,119 @@
+/**
+ * Gutenberg editor post-content reflector.
+ *
+ * Synchronizes persisted server-side post mutations into the currently open,
+ * clean editor without replaying tool arguments or triggering a save.
+ */
+
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Compare post identifiers without making numeric/string REST values diverge.
+ *
+ * @param {number|string} first  First post ID.
+ * @param {number|string} second Second post ID.
+ * @return {boolean} Whether both values identify the same post.
+ */
+function samePost( first, second ) {
+	return String( first ) === String( second );
+}
+
+/**
+ * Return the active editor APIs when they can safely synchronize a post.
+ *
+ * @param {number|string} postId Affected post ID.
+ * @return {Object|null} Current editor APIs and post type, or null.
+ */
+function getEditorContext( postId ) {
+	if (
+		typeof wp === 'undefined' ||
+		! wp.data?.select ||
+		! wp.data?.dispatch
+	) {
+		return null;
+	}
+
+	try {
+		const editor = wp.data.select( 'core/editor' );
+		const blockEditor = wp.data.select( 'core/block-editor' );
+		const coreData = wp.data.dispatch( 'core' );
+		const blockDispatcher = wp.data.dispatch( 'core/block-editor' );
+		const currentPostId = editor?.getCurrentPostId?.();
+		const postType = editor?.getCurrentPostType?.();
+
+		if (
+			! editor ||
+			! blockEditor ||
+			! samePost( currentPostId, postId ) ||
+			editor.isEditedPostDirty?.() !== false ||
+			typeof postType !== 'string' ||
+			! postType ||
+			typeof coreData?.receiveEntityRecords !== 'function' ||
+			typeof blockDispatcher?.resetBlocks !== 'function' ||
+			typeof wp.blocks?.parse !== 'function'
+		) {
+			return null;
+		}
+
+		return { editor, postType, coreData, blockDispatcher };
+	} catch ( _error ) {
+		return null;
+	}
+}
+
+/**
+ * Synchronize a server-side post-content mutation into a clean open editor.
+ *
+ * @param {{affected?: {fields?: string[], post_id?: number|string, render_mode?: string}, result?: {preview?: Object}}} event Reflection event.
+ * @return {Promise<void>} Resolves after safely applying or skipping the update.
+ */
+export async function reflectEditorPost( event ) {
+	const affected = event?.affected;
+	if (
+		! Array.isArray( affected?.fields ) ||
+		! affected.fields.includes( 'post_content' ) ||
+		affected.render_mode === 'preview' ||
+		event?.result?.preview ||
+		affected.post_id === undefined ||
+		affected.post_id === null
+	) {
+		return;
+	}
+
+	const context = getEditorContext( affected.post_id );
+	if ( ! context ) {
+		return;
+	}
+
+	try {
+		const record = await apiFetch( {
+			path: `/wp/v2/${ encodeURIComponent(
+				context.postType
+			) }/${ encodeURIComponent( affected.post_id ) }?context=edit`,
+		} );
+		const rawContent = record?.content?.raw;
+		if ( typeof rawContent !== 'string' ) {
+			return;
+		}
+
+		const blocks = wp.blocks.parse( rawContent );
+		if ( ! Array.isArray( blocks ) ) {
+			return;
+		}
+
+		// Re-read immediately before writing so a local edit or navigation that
+		// occurred during the fetch is never overwritten.
+		const current = getEditorContext( affected.post_id );
+		if ( ! current || current.editor.isEditedPostDirty() ) {
+			return;
+		}
+
+		current.coreData.receiveEntityRecords( 'postType', current.postType, [
+			record,
+		] );
+		current.blockDispatcher.resetBlocks( blocks );
+	} catch ( _error ) {
+		// A missing REST route, parsing failure, or unavailable editor is safe to
+		// ignore: the persisted revision remains available after a reload.
+	}
+}

--- a/src/floating-widget/reflectors/index.js
+++ b/src/floating-widget/reflectors/index.js
@@ -11,9 +11,21 @@ import { showFallbackToast } from './fallback-toast';
 
 const reflectorLoaders = {
 	post: () =>
-		import( /* webpackChunkName: "reflector-post" */ './post' ).then(
-			( module ) => module.reflectPost
-		),
+		Promise.all( [
+			import(
+				/* webpackChunkName: "reflector-editor-post" */ './editor-post'
+			).then( ( module ) => module.reflectEditorPost ),
+			import( /* webpackChunkName: "reflector-post" */ './post' ).then(
+				( module ) => module.reflectPost
+			),
+		] ).then( ( [ reflectEditorPost, reflectPost ] ) => async ( event ) => {
+			try {
+				await reflectEditorPost( event );
+			} catch ( _error ) {
+				// The public-page reflector remains useful if editor APIs fail.
+			}
+			return reflectPost( event );
+		} ),
 	global_styles: () =>
 		import(
 			/* webpackChunkName: "reflector-global-styles" */ './global-styles'

--- a/tests/e2e/client-abilities.spec.js
+++ b/tests/e2e/client-abilities.spec.js
@@ -156,7 +156,9 @@ async function waitForAbilitiesRegistered( page, timeout = 45_000 ) {
 					// attach a side-effect that sets a flag when resolved.
 					if ( ! window.__sdAbilitiesResolved ) {
 						result.then( ( abilities ) => {
-							window.__sdAbilitiesResolved = Array.isArray( abilities )
+							window.__sdAbilitiesResolved = Array.isArray(
+								abilities
+							)
 								? abilities.filter( ( a ) =>
 										a?.name?.startsWith( 'sd-ai-agent-js/' )
 								  ).length >= 2
@@ -185,7 +187,7 @@ async function waitForAbilitiesRegistered( page, timeout = 45_000 ) {
  * Collect console errors and page errors during a test.
  *
  * @param {import('@playwright/test').Page} page
- * @return {{ consoleErrors: string[], pageErrors: string[] }}
+ * @return {{ consoleErrors: string[], pageErrors: string[] }} Captured errors.
  */
 function collectErrors( page ) {
 	const consoleErrors = [];
@@ -202,6 +204,42 @@ function collectErrors( page ) {
 	} );
 
 	return { consoleErrors, pageErrors };
+}
+
+/**
+ * Create a draft through the authenticated REST client and open it in Gutenberg.
+ *
+ * @param {import('@playwright/test').Page} page Browser page.
+ * @return {Promise<number>} Draft post ID.
+ */
+async function createDraftAndOpenEditor( page ) {
+	await page.goto( '/wp-admin/index.php' );
+	await page.waitForLoadState( 'domcontentloaded' );
+	const postId = await page.evaluate( async () => {
+		const post = await wp.apiFetch( {
+			path: '/wp/v2/posts',
+			method: 'POST',
+			data: {
+				status: 'draft',
+				title: 'SD AI Agent reflector test',
+			},
+		} );
+		return post.id;
+	} );
+
+	await page.goto( `/wp-admin/post.php?post=${ postId }&action=edit` );
+	await page.waitForLoadState( 'domcontentloaded' );
+	await page
+		.locator( '.block-editor-writing-flow, .editor-styles-wrapper' )
+		.first()
+		.waitFor( { state: 'visible', timeout: 60_000 } );
+	await page.waitForFunction(
+		() => typeof window.sdAiAgentReflection?.emit === 'function',
+		null,
+		{ timeout: 30_000 }
+	);
+
+	return postId;
 }
 
 // ---------------------------------------------------------------------------
@@ -461,7 +499,108 @@ test.describe( 'client-abilities — insert-block on editor screen', () => {
 } );
 
 // ---------------------------------------------------------------------------
-// Test suite 5: insert-block no-op on non-editor screen
+// Test suite 5: server-side post reflection in the block editor
+// ---------------------------------------------------------------------------
+
+test.describe( 'client-abilities — server post reflection', () => {
+	test.beforeEach( async ( { page } ) => {
+		await loginToWordPress( page );
+	} );
+
+	test( 'synchronizes a server mutation into a clean editor without making it dirty', async ( {
+		page,
+	} ) => {
+		const postId = await createDraftAndOpenEditor( page );
+
+		const markup =
+			'<!-- wp:paragraph -->\n<p>Reflected server revision.</p>\n<!-- /wp:paragraph -->';
+		await page.evaluate(
+			async ( { serverMarkup, currentPostId } ) => {
+				await wp.apiFetch( {
+					path: `/wp/v2/posts/${ currentPostId }`,
+					method: 'POST',
+					data: { content: serverMarkup },
+				} );
+				window.sdAiAgentReflection.emit( {
+					type: 'tool-applied',
+					tool: 'sd-ai-agent/update-post',
+					affected: {
+						kind: 'post',
+						post_id: currentPostId,
+						fields: [ 'post_content' ],
+					},
+				} );
+			},
+			{ serverMarkup: markup, currentPostId: postId }
+		);
+
+		await page.waitForFunction(
+			( serverMarkup ) => {
+				const editor = wp.data.select( 'core/editor' );
+				const blocks = wp.data
+					.select( 'core/block-editor' )
+					.getBlocks();
+				return (
+					wp.blocks.serialize( blocks ) === serverMarkup &&
+					editor.isEditedPostDirty() === false
+				);
+			},
+			markup,
+			{ timeout: 15_000 }
+		);
+	} );
+
+	test( 'preserves a dirty local editor after a server mutation event', async ( {
+		page,
+	} ) => {
+		const postId = await createDraftAndOpenEditor( page );
+
+		const localMarkup =
+			'<!-- wp:paragraph -->\n<p>Local unsaved revision.</p>\n<!-- /wp:paragraph -->';
+		const serverMarkup =
+			'<!-- wp:paragraph -->\n<p>Server revision.</p>\n<!-- /wp:paragraph -->';
+		await page.evaluate(
+			async ( { localContent, serverContent, currentPostId } ) => {
+				wp.data.dispatch( 'core/editor' ).editPost( {
+					content: localContent,
+				} );
+				await wp.apiFetch( {
+					path: `/wp/v2/posts/${ currentPostId }`,
+					method: 'POST',
+					data: { content: serverContent },
+				} );
+				window.sdAiAgentReflection.emit( {
+					type: 'tool-applied',
+					tool: 'sd-ai-agent/edit-block-tree',
+					affected: {
+						kind: 'post',
+						post_id: currentPostId,
+						fields: [ 'post_content' ],
+					},
+				} );
+			},
+			{
+				localContent: localMarkup,
+				serverContent: serverMarkup,
+				currentPostId: postId,
+			}
+		);
+
+		await page.waitForTimeout( 500 );
+		const state = await page.evaluate( () => ( {
+			content: wp.blocks.serialize(
+				wp.data.select( 'core/block-editor' ).getBlocks()
+			),
+			dirty: wp.data.select( 'core/editor' ).isEditedPostDirty(),
+		} ) );
+
+		expect( state.content ).toBe( localMarkup );
+		expect( state.dirty ).toBe( true );
+	} );
+} );
+
+// ---------------------------------------------------------------------------
+// Test suite 6: insert-block no-op on non-editor screen
 // ---------------------------------------------------------------------------
 
 test.describe( 'client-abilities — insert-block no-op on non-editor screen', () => {
@@ -505,7 +644,7 @@ test.describe( 'client-abilities — insert-block no-op on non-editor screen', (
 } );
 
 // ---------------------------------------------------------------------------
-// Test suite 6: snapshotDescriptors
+// Test suite 7: snapshotDescriptors
 // ---------------------------------------------------------------------------
 
 test.describe( 'client-abilities — snapshotDescriptors', () => {
@@ -531,7 +670,8 @@ test.describe( 'client-abilities — snapshotDescriptors', () => {
 				return [];
 			}
 			try {
-				const allAbilities = ( await wp.abilities.getAbilities() ) || [];
+				const allAbilities =
+					( await wp.abilities.getAbilities() ) || [];
 				return allAbilities
 					.filter(
 						( ability ) =>
@@ -578,7 +718,7 @@ test.describe( 'client-abilities — snapshotDescriptors', () => {
 } );
 
 // ---------------------------------------------------------------------------
-// Test suite 7: No relevant console errors
+// Test suite 8: No relevant console errors
 // ---------------------------------------------------------------------------
 
 test.describe( 'client-abilities — no relevant console errors', () => {


### PR DESCRIPTION
## Summary

Adds a clean-editor post reflector that fetches persisted edit-context content, updates the entity baseline, and resets native Gutenberg blocks before public reflection.

## Files Changed

src/floating-widget/reflectors/__tests__/editor-post.test.js, src/floating-widget/reflectors/__tests__/index.test.js, src/floating-widget/reflectors/editor-post.js, src/floating-widget/reflectors/index.js

## Runtime Testing

- **Risk level:** Medium
- **Verification:** self-assessed — pnpm run lint:js; pnpm run test:js -- src/floating-widget/reflectors/__tests__/editor-post.test.js src/floating-widget/reflectors/__tests__/index.test.js

Resolves #2526


<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.274 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 9m and 105,365 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added synchronization for post content changes in the Gutenberg editor.
  - Updates are applied only to the relevant, clean editor and preserve edits made while content is loading.
  - Public-page reflection continues after editor synchronization, even if editor updates cannot be applied.

- **Bug Fixes**
  - Safely handles previews, invalid posts, unavailable editor APIs, failed requests, malformed responses, and parsing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->