### PR TITLE
GH#2527: Prevent reasoning leaks in chat

### DIFF
--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -4450,26 +4450,17 @@ PROMPT;
 	}
 
 	/**
-	 * Log real tool calls and separate any assistant preamble text.
+	 * Log real tool calls for display and execution tracking.
 	 *
-	 * Some models emit short narration in the same assistant message as a tool
-	 * call. The narration belongs in the message log, not `tool_calls`, so
-	 * usage dashboards and run summaries can count only real tool activity while
-	 * the live UI can still merge both streams by sequence.
+	 * Some providers emit planning narration in the same assistant message as a
+	 * tool call. Do not project that untrusted prose into the live activity log:
+	 * deterministic tool status is the only safe running-job display. The full
+	 * provider message remains in the internal conversation history.
 	 *
 	 * @param Message $message Assistant message to inspect.
 	 */
 	private function log_tool_calls( Message $message ): void {
 		foreach ( $message->getParts() as $part ) {
-			$text = $this->visible_content_text( $part );
-			if ( '' !== $text ) {
-				$this->message_log[] = array(
-					'type'     => 'preamble',
-					'text'     => $text,
-					'sequence' => $this->next_activity_sequence(),
-				);
-			}
-
 			$call = $part->getFunctionCall();
 			if ( $call ) {
 				$name = (string) $call->getName();

--- a/includes/Core/AgentLoop.php
+++ b/includes/Core/AgentLoop.php
@@ -4450,17 +4450,26 @@ PROMPT;
 	}
 
 	/**
-	 * Log real tool calls for display and execution tracking.
+	 * Log real tool calls and separate any assistant preamble text.
 	 *
-	 * Some providers emit planning narration in the same assistant message as a
-	 * tool call. Do not project that untrusted prose into the live activity log:
-	 * deterministic tool status is the only safe running-job display. The full
-	 * provider message remains in the internal conversation history.
+	 * Some models emit short narration in the same assistant message as a tool
+	 * call. The narration belongs in the message log, not `tool_calls`, so
+	 * usage dashboards and run summaries can count only real tool activity while
+	 * the live UI can still merge both streams by sequence.
 	 *
 	 * @param Message $message Assistant message to inspect.
 	 */
 	private function log_tool_calls( Message $message ): void {
 		foreach ( $message->getParts() as $part ) {
+			$text = $this->visible_content_text( $part );
+			if ( '' !== $text ) {
+				$this->message_log[] = array(
+					'type'     => 'preamble',
+					'text'     => $text,
+					'sequence' => $this->next_activity_sequence(),
+				);
+			}
+
 			$call = $part->getFunctionCall();
 			if ( $call ) {
 				$name = (string) $call->getName();

--- a/includes/Core/ConversationDisplaySanitizer.php
+++ b/includes/Core/ConversationDisplaySanitizer.php
@@ -17,6 +17,57 @@ namespace SdAiAgent\Core;
 
 class ConversationDisplaySanitizer {
 
+	/** Complete textual reasoning wrappers emitted in otherwise-content parts. */
+	private const THINKING_BLOCK_PATTERN = '/<thinking\b[^>]*>.*?<\/thinking\s*>/is';
+
+	/** An unfinished textual reasoning wrapper and the remainder of its content. */
+	private const UNTERMINATED_THINKING_PATTERN = '/<thinking\b[^>]*>.*/is';
+
+	/**
+	 * Remove provider textual reasoning wrappers from browser-facing text.
+	 *
+	 * Structured thought-channel parts remain in the persisted conversation so
+	 * providers that require reasoning round trips retain their continuation
+	 * context. This method is deliberately for display projections only.
+	 *
+	 * @param string $text Provider-generated display text.
+	 * @return string Text without complete or unfinished thinking blocks.
+	 */
+	public static function sanitize_display_text( string $text ): string {
+		$text = preg_replace( self::THINKING_BLOCK_PATTERN, '', $text ) ?? '';
+
+		return preg_replace( self::UNTERMINATED_THINKING_PATTERN, '', $text ) ?? '';
+	}
+
+	/**
+	 * Sanitize textual activity messages returned with live job progress.
+	 *
+	 * @param array<mixed> $messages Job activity entries.
+	 * @return list<array<string, mixed>> Display-safe activity entries.
+	 */
+	public static function sanitize_activity_messages( array $messages ): array {
+		$sanitized = array();
+
+		foreach ( $messages as $message ) {
+			if ( ! is_array( $message ) ) {
+				continue;
+			}
+
+			$sanitized_message = array();
+			foreach ( $message as $key => $value ) {
+				if ( is_string( $key ) ) {
+					$sanitized_message[ $key ] = 'text' === $key && is_string( $value )
+						? self::sanitize_display_text( $value )
+						: $value;
+				}
+			}
+
+			$sanitized[] = $sanitized_message;
+		}
+
+		return $sanitized;
+	}
+
 	/**
 	 * Strip hidden/non-content message parts from a list of serialized messages.
 	 *
@@ -98,6 +149,10 @@ class ConversationDisplaySanitizer {
 
 			if ( ! self::is_content_channel( $sanitized_part['channel'] ?? null ) ) {
 				continue;
+			}
+
+			if ( is_string( $sanitized_part['text'] ?? null ) ) {
+				$sanitized_part['text'] = self::sanitize_display_text( $sanitized_part['text'] );
 			}
 
 			$sanitized[] = $sanitized_part;

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -1413,7 +1413,7 @@ final class SessionController {
 			$response['tool_calls'] = $job['tool_calls'];
 		}
 		if ( ! empty( $job['messages'] ) ) {
-			$response['messages'] = $job['messages'];
+			$response['messages'] = ConversationDisplaySanitizer::sanitize_activity_messages( $job['messages'] );
 		}
 
 		if ( 'awaiting_confirmation' === $job['status'] && isset( $job['pending_tools'] ) ) {
@@ -1430,14 +1430,14 @@ final class SessionController {
 
 		if ( 'complete' === $job['status'] && isset( $job['result'] ) ) {
 			// @phpstan-ignore-next-line
-			$response['reply'] = $job['result']['reply'] ?? '';
+			$response['reply'] = ConversationDisplaySanitizer::sanitize_display_text( (string) ( $job['result']['reply'] ?? '' ) );
 			// @phpstan-ignore-next-line
 			$history             = $job['result']['history'] ?? array();
 			$response['history'] = is_array( $history ) ? ConversationDisplaySanitizer::sanitize_messages( $history ) : array();
 			// @phpstan-ignore-next-line
 			$response['tool_calls'] = $job['result']['tool_calls'] ?? array();
 			// @phpstan-ignore-next-line
-			$response['messages'] = $job['result']['messages'] ?? array();
+			$response['messages'] = ConversationDisplaySanitizer::sanitize_activity_messages( (array) ( $job['result']['messages'] ?? array() ) );
 			// @phpstan-ignore-next-line
 			$response['session_id'] = $job['result']['session_id'] ?? null;
 			// @phpstan-ignore-next-line
@@ -2511,11 +2511,11 @@ final class SessionController {
 			$response['tool_calls'] = $job['tool_calls'];
 		}
 		if ( ! empty( $job['messages'] ) ) {
-			$response['messages'] = $job['messages'];
+			$response['messages'] = ConversationDisplaySanitizer::sanitize_activity_messages( $job['messages'] );
 		}
 
 		if ( 'complete' === ( $job['status'] ?? '' ) && isset( $job['result'] ) && is_array( $job['result'] ) ) {
-			$response['reply']           = $job['result']['reply'] ?? '';
+			$response['reply']           = ConversationDisplaySanitizer::sanitize_display_text( (string) ( $job['result']['reply'] ?? '' ) );
 			$response['history']         = isset( $job['result']['history'] ) && is_array( $job['result']['history'] ) ? ConversationDisplaySanitizer::sanitize_messages( $job['result']['history'] ) : array();
 			$response['tool_calls']      = $job['result']['tool_calls'] ?? array();
 			$response['iterations_used'] = $job['result']['iterations_used'] ?? 0;

--- a/includes/REST/SessionController.php
+++ b/includes/REST/SessionController.php
@@ -1413,7 +1413,9 @@ final class SessionController {
 			$response['tool_calls'] = $job['tool_calls'];
 		}
 		if ( ! empty( $job['messages'] ) ) {
-			$response['messages'] = ConversationDisplaySanitizer::sanitize_activity_messages( $job['messages'] );
+			$response['messages'] = is_array( $job['messages'] )
+				? ConversationDisplaySanitizer::sanitize_activity_messages( $job['messages'] )
+				: array();
 		}
 
 		if ( 'awaiting_confirmation' === $job['status'] && isset( $job['pending_tools'] ) ) {
@@ -2511,7 +2513,9 @@ final class SessionController {
 			$response['tool_calls'] = $job['tool_calls'];
 		}
 		if ( ! empty( $job['messages'] ) ) {
-			$response['messages'] = ConversationDisplaySanitizer::sanitize_activity_messages( $job['messages'] );
+			$response['messages'] = is_array( $job['messages'] )
+				? ConversationDisplaySanitizer::sanitize_activity_messages( $job['messages'] )
+				: array();
 		}
 
 		if ( 'complete' === ( $job['status'] ?? '' ) && isset( $job['result'] ) && is_array( $job['result'] ) ) {

--- a/src/components/chat-redesign/__tests__/message-helpers.test.js
+++ b/src/components/chat-redesign/__tests__/message-helpers.test.js
@@ -5,8 +5,8 @@
  * - pairToolCalls() pairs calls with responses by id and ignores preamble entries.
  * - pairToolCalls() falls back to one item per entry when no call types exist,
  *   while still skipping preamble entries.
- * - buildRunningItems() preserves original emission order across preamble and
- *   call entries, suppresses whitespace-only preambles, and assigns stable keys.
+ * - buildRunningItems() exposes deterministic tool entries while excluding
+ *   provider-generated preamble text.
  * - getRunningToolName() ignores preamble entries when deciding what is in
  *   flight.
  * - extractText() concatenates only text parts.
@@ -126,7 +126,7 @@ describe( 'buildRunningItems', () => {
 		expect( buildRunningItems( [] ) ).toEqual( [] );
 	} );
 
-	test( 'preserves emission order across preamble and call entries', () => {
+	test( 'renders tool cards while excluding model preambles', () => {
 		const log = [
 			{ type: 'preamble', text: 'First, let me look that up.' },
 			{ type: 'call', id: 'a', name: 'tool_a', args: {} },
@@ -135,21 +135,20 @@ describe( 'buildRunningItems', () => {
 			{ type: 'call', id: 'b', name: 'tool_b', args: {} },
 		];
 		const items = buildRunningItems( log );
-		expect( items.map( ( i ) => i.kind ) ).toEqual( [
-			'preamble',
-			'pair',
-			'preamble',
-			'pair',
-		] );
-		expect( items[ 0 ].text ).toBe( 'First, let me look that up.' );
-		expect( items[ 1 ].call.id ).toBe( 'a' );
-		expect( items[ 1 ].response.response ).toEqual( { ok: true } );
-		expect( items[ 2 ].text ).toBe( 'Now updating the page.' );
-		expect( items[ 3 ].call.id ).toBe( 'b' );
-		expect( items[ 3 ].response ).toBeNull();
+		expect( items.map( ( i ) => i.kind ) ).toEqual( [ 'pair', 'pair' ] );
+		expect( items[ 0 ].call.id ).toBe( 'a' );
+		expect( items[ 0 ].response.response ).toEqual( { ok: true } );
+		expect( items[ 1 ].call.id ).toBe( 'b' );
+		expect( items[ 1 ].response ).toBeNull();
+		expect( JSON.stringify( items ) ).not.toContain(
+			'First, let me look that up.'
+		);
+		expect( JSON.stringify( items ) ).not.toContain(
+			'Now updating the page.'
+		);
 	} );
 
-	test( 'strips thinking tags from preamble narration', () => {
+	test( 'excludes thinking preambles entirely', () => {
 		const items = buildRunningItems( [
 			{
 				type: 'preamble',
@@ -157,11 +156,10 @@ describe( 'buildRunningItems', () => {
 			},
 		] );
 
-		expect( items ).toHaveLength( 1 );
-		expect( items[ 0 ].text ).toBe( 'Planning templates' );
+		expect( items ).toEqual( [] );
 	} );
 
-	test( 'suppresses whitespace-only preambles', () => {
+	test( 'suppresses preambles while keeping tool cards', () => {
 		const log = [
 			{ type: 'preamble', text: '  \n  ' },
 			{ type: 'preamble', text: '' },
@@ -172,14 +170,14 @@ describe( 'buildRunningItems', () => {
 		expect( items[ 0 ].kind ).toBe( 'pair' );
 	} );
 
-	test( 'assigns stable keys derived from call ids', () => {
+	test( 'assigns stable keys derived from call ids without preambles', () => {
 		const log = [
 			{ type: 'preamble', text: 'A' },
 			{ type: 'call', id: 'call-xyz', name: 'tool_a', args: {} },
 		];
 		const items = buildRunningItems( log );
-		expect( items[ 0 ].key ).toBe( 'preamble-0' );
-		expect( items[ 1 ].key ).toBe( 'call-xyz' );
+		expect( items ).toHaveLength( 1 );
+		expect( items[ 0 ].key ).toBe( 'call-xyz' );
 	} );
 
 	test( 'still works when responses arrive out of order', () => {
@@ -284,10 +282,15 @@ describe( 'friendly tool progress summaries', () => {
 		expect( text ).toContain( 'checking colour contrast' );
 	} );
 
-	test( 'strips reasoning tags while keeping their visible narration', () => {
+	test( 'removes complete and unfinished reasoning blocks', () => {
 		expect(
-			sanitizeProgressText( '<thinking>Planning templates</thinking>' )
-		).toBe( 'Planning templates' );
+			sanitizeProgressText(
+				'Visible<thinking>Planning templates</thinking> text'
+			)
+		).toBe( 'Visible text' );
+		expect( sanitizeProgressText( 'Visible<thinking>Private plan' ) ).toBe(
+			'Visible'
+		);
 	} );
 
 	test( 'shows the nested ability and action for dispatcher calls', () => {
@@ -347,7 +350,7 @@ describe( 'friendly tool progress summaries', () => {
 		expect( summary.attentionCount ).toBe( 1 );
 		expect( summary.runningCount ).toBe( 1 );
 		expect( summary.currentLabel ).toBe( 'Generating an image' );
-		expect( summary.latestThought ).not.toContain( 'sd-ai-agent/' );
+		expect( summary.latestThought ).toBe( '' );
 		expect( summary.recentSteps.map( ( step ) => step.label ) ).toEqual( [
 			'Preparing design tokens',
 			'Checking colour contrast',

--- a/src/components/chat-redesign/__tests__/message-items.test.js
+++ b/src/components/chat-redesign/__tests__/message-items.test.js
@@ -191,7 +191,7 @@ describe( 'AssistantMessage progress summary', () => {
 } );
 
 describe( 'RunningMessage progress summary', () => {
-	test( 'shows the exact nested ability instead of its dispatcher', async () => {
+	test( 'hides planning preambles while showing the exact nested ability', async () => {
 		const container = document.createElement( 'div' );
 		document.body.appendChild( container );
 		const root = createRoot( container );
@@ -201,6 +201,10 @@ describe( 'RunningMessage progress summary', () => {
 				createElement( RunningMessage, {
 					step: 'Checking options…',
 					liveToolCalls: [
+						{
+							type: 'preamble',
+							text: 'Need append content before checking options.',
+						},
 						{
 							type: 'call',
 							id: 'options',
@@ -218,6 +222,9 @@ describe( 'RunningMessage progress summary', () => {
 		expect( container.textContent ).toContain( 'sd-ai-agent/list-options' );
 		expect( container.textContent ).not.toContain(
 			'sd-ai-agent/ability-call'
+		);
+		expect( container.textContent ).not.toContain(
+			'Need append content before checking options.'
 		);
 
 		await act( async () => {

--- a/src/components/chat-redesign/message-helpers.js
+++ b/src/components/chat-redesign/message-helpers.js
@@ -52,7 +52,8 @@ const FRIENDLY_TOOL_LABELS = {
 
 const PROGRESS_TOOL_PATTERN =
 	/`?(?:wpab__)?(?:sd-ai-agent|sd-ai-agent-js)(?:__|\/)[a-z0-9][a-z0-9-]*`?/gi;
-const THINKING_TAG_PATTERN = /<\/?thinking\b[^>]*>/gi;
+const THINKING_BLOCK_PATTERN = /<thinking\b[^>]*>[\s\S]*?<\/thinking\s*>/gi;
+const UNTERMINATED_THINKING_PATTERN = /<thinking\b[^>]*>[\s\S]*$/gi;
 
 /**
  * Normalize provider/native ability bridge names into canonical ability IDs.
@@ -241,26 +242,13 @@ export function getFriendlyToolLabel( name ) {
  */
 export function sanitizeProgressText( text ) {
 	return String( text || '' )
-		.replace( THINKING_TAG_PATTERN, '' )
+		.replace( THINKING_BLOCK_PATTERN, '' )
+		.replace( UNTERMINATED_THINKING_PATTERN, '' )
 		.replace( PROGRESS_TOOL_PATTERN, ( match ) =>
 			getFriendlyToolLabel( match ).toLowerCase()
 		)
 		.replace( /\s+/g, ' ' )
 		.trim();
-}
-
-/**
- * Keep live progress narration compact in the chat timeline.
- *
- * @param {string} text Text to truncate.
- * @return {string} Truncated text.
- */
-function truncateProgressText( text ) {
-	const maxLength = 180;
-	if ( text.length <= maxLength ) {
-		return text;
-	}
-	return `${ text.substring( 0, maxLength - 1 ).trimEnd() }…`;
 }
 
 /**
@@ -310,7 +298,6 @@ export function buildToolProgressSummary( toolCalls ) {
 
 	const responses = {};
 	const calls = [];
-	const thoughts = [];
 	for ( const entry of toolCalls ) {
 		if (
 			( entry.type === 'response' || entry.type === 'result' ) &&
@@ -320,12 +307,6 @@ export function buildToolProgressSummary( toolCalls ) {
 		}
 		if ( entry.type === 'call' ) {
 			calls.push( entry );
-		}
-		if ( entry.type === 'preamble' && typeof entry.text === 'string' ) {
-			const text = sanitizeProgressText( entry.text );
-			if ( text ) {
-				thoughts.push( text );
-			}
 		}
 	}
 
@@ -370,7 +351,7 @@ export function buildToolProgressSummary( toolCalls ) {
 		null;
 
 	return {
-		hasActivity: steps.length > 0 || thoughts.length > 0,
+		hasActivity: steps.length > 0,
 		totalCount: steps.length,
 		finishedCount,
 		completedCount,
@@ -379,9 +360,7 @@ export function buildToolProgressSummary( toolCalls ) {
 		attentionCount: failedCount - recoveredCount,
 		runningCount,
 		currentLabel: currentStep?.label || '',
-		latestThought: truncateProgressText(
-			thoughts[ thoughts.length - 1 ] || ''
-		),
+		latestThought: '',
 		recentSteps: steps.slice( -3 ),
 	};
 }
@@ -434,18 +413,15 @@ export function pairToolCalls( toolCalls ) {
 }
 
 /**
- * Build the ordered list of items to render inside a model message body,
- * preserving the original emission order of preamble text blocks and tool
- * call pairs.
+ * Build the ordered list of deterministic tool-call items to render inside a
+ * model message body.
  *
  * Returns a heterogeneous list of items shaped as either:
- *   { kind: 'preamble', text: string, key: string }
  *   { kind: 'pair', call: ToolCall, response: ToolResponse|null, key: string }
  *
  * The polling frontend uses this for the live RunningMessage so the user
- * can see narration like "Looking that up first…" immediately above the
- * tool card it precedes. Finalised assistant messages also use it so live
- * and persisted views share the same layout pipeline.
+ * can see deterministic tool progress during a running job. Provider narration
+ * is intentionally excluded because it can contain internal reasoning.
  *
  * @param {Array} toolCalls Flat tool-call log entries.
  * @return {Array} Ordered render items.
@@ -461,20 +437,8 @@ export function buildRunningItems( toolCalls ) {
 		}
 	}
 	const items = [];
-	let preambleSeq = 0;
 	let pairSeq = 0;
 	for ( const t of toolCalls ) {
-		if ( t.type === 'preamble' && typeof t.text === 'string' ) {
-			const text = sanitizeProgressText( t.text );
-			if ( text !== '' ) {
-				items.push( {
-					kind: 'preamble',
-					text,
-					key: `preamble-${ preambleSeq++ }`,
-				} );
-			}
-			continue;
-		}
 		if ( t.type === 'call' ) {
 			items.push( {
 				kind: 'pair',

--- a/src/store/slices/jobSlice.js
+++ b/src/store/slices/jobSlice.js
@@ -20,10 +20,9 @@ import { emitReflectionEvents } from '../reflection-emitter';
 /**
  * Merge real tool calls with assistant channel messages for live rendering.
  *
- * Backend `tool_calls` now contains only real tool invocations/results. Text
- * preambles, retry notices, and guardrail messages arrive separately in
- * `messages`; the live running UI still needs both streams interleaved by the
- * monotonic `sequence` field.
+ * Backend `tool_calls` contains real tool invocations/results. Model preambles
+ * must never be rendered as progress because providers can emit reasoning as
+ * ordinary content text. Deterministic tool activity remains visible.
  *
  * @param {Array} toolCalls Tool call/result entries.
  * @param {Array} messages  Assistant channel or event entries.
@@ -31,7 +30,9 @@ import { emitReflectionEvents } from '../reflection-emitter';
  */
 function mergeActivityForDisplay( toolCalls, messages ) {
 	const callEntries = Array.isArray( toolCalls ) ? toolCalls : [];
-	const messageEntries = Array.isArray( messages ) ? messages : [];
+	const messageEntries = Array.isArray( messages )
+		? messages.filter( ( entry ) => entry?.type !== 'preamble' )
+		: [];
 
 	if ( ! messageEntries.length ) {
 		return callEntries;

--- a/tests/SdAiAgent/Core/ConversationDisplaySanitizerTest.php
+++ b/tests/SdAiAgent/Core/ConversationDisplaySanitizerTest.php
@@ -114,4 +114,33 @@ class ConversationDisplaySanitizerTest extends WP_UnitTestCase {
 
 		$this->assertSame( 'Visible legacy.', ConversationDisplaySanitizer::extract_text( $message ) );
 	}
+
+	/** Textual thinking blocks are removed from content-channel display text. */
+	public function test_sanitize_messages_removes_complete_multiline_thinking_blocks(): void {
+		$messages = [
+			[
+				'role'  => 'assistant',
+				'parts' => [
+					[
+						'channel' => 'content',
+						'text'    => "Visible before.<THINKING provider=\"example\">\nPrivate plan.\n</ThInKiNg>Visible after.",
+					],
+				],
+			],
+		];
+
+		$sanitized = ConversationDisplaySanitizer::sanitize_messages( $messages );
+
+		$this->assertSame( 'Visible before.Visible after.', $sanitized[0]['parts'][0]['text'] );
+		$this->assertStringNotContainsString( 'Private plan', (string) wp_json_encode( $sanitized ) );
+	}
+
+	/** An unfinished textual thinking block fails closed for display projections. */
+	public function test_sanitize_display_text_removes_unterminated_thinking_block(): void {
+		$text = ConversationDisplaySanitizer::sanitize_display_text(
+			'Visible answer.<thinking>Private reasoning that must not be shown.'
+		);
+
+		$this->assertSame( 'Visible answer.', $text );
+	}
 }

--- a/tests/SdAiAgent/REST/SessionControllerTest.php
+++ b/tests/SdAiAgent/REST/SessionControllerTest.php
@@ -485,6 +485,47 @@ class SessionControllerTest extends WP_UnitTestCase {
 		}
 	}
 
+	/** Completed job and persisted-session display projections hide textual reasoning. */
+	public function test_job_and_session_display_responses_scrub_textual_thinking(): void {
+		$session_id = $this->create_session();
+		$messages   = [
+			[
+				'role'  => 'assistant',
+				'parts' => [
+					[ 'text' => 'Saved answer.<thinking>Persisted private reasoning.</thinking>' ],
+				],
+			],
+		];
+		$this->assertTrue( Database::append_to_session( $session_id, $messages ) );
+
+		$session_response = $this->dispatch( 'GET', "/sd-ai-agent/v1/sessions/{$session_id}" );
+		$this->assert_status( 200, $session_response );
+		$this->assertSame( 'Saved answer.', $session_response->get_data()['messages'][0]['parts'][0]['text'] );
+
+		$job_id = '00000000-0000-4000-8000-000000000103';
+		$this->assertNotFalse( ActiveJobRepository::create( $session_id, $job_id, $this->admin_id, 'processing' ) );
+		set_transient(
+			RestController::JOB_PREFIX . $job_id,
+			[
+				'status'   => 'complete',
+				'user_id'  => $this->admin_id,
+				'result'   => [
+					'reply'      => "Completed answer.<thinking>\nDo not expose this.\n</thinking>",
+					'history'    => $messages,
+					'messages'   => [ [ 'type' => 'preamble', 'text' => '<thinking>Live private reasoning.</thinking>' ] ],
+					'tool_calls' => [],
+				],
+			],
+			RestController::JOB_TTL
+		);
+
+		$job_response = $this->dispatch( 'GET', "/sd-ai-agent/v1/job/{$job_id}" );
+		$this->assert_status( 200, $job_response );
+		$this->assertSame( 'Completed answer.', $job_response->get_data()['reply'] );
+		$this->assertSame( 'Saved answer.', $job_response->get_data()['history'][0]['parts'][0]['text'] );
+		$this->assertSame( '', $job_response->get_data()['messages'][0]['text'] );
+	}
+
 	/**
 	 * @return \WP_REST_Response|\WP_Error
 	 */


### PR DESCRIPTION
Resolves #2527

## Draft implementation

Suppresses model preambles from running-job activity and removes textual `<thinking>` blocks from browser-facing chat projections while preserving provider history.

Verification in progress: targeted PHP and JavaScript test suites pass.

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.274 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 9m and 157,326 tokens on this as a headless worker. Overall, 29m since this issue was created.
