### PR TITLE
GH#2530: Harden Gutenberg editor reflector routes

### DIFF
--- a/src/floating-widget/reflectors/__tests__/editor-post.test.js
+++ b/src/floating-widget/reflectors/__tests__/editor-post.test.js
@@ -10,7 +10,13 @@ jest.mock( '@wordpress/api-fetch', () => jest.fn() );
  * @return {Object} Editor test state and dispatchers.
  */
 function setEditor( options = {} ) {
-	const { postId = 42, dirty = false, postType = 'page' } = options;
+	const {
+		postId = 42,
+		dirty = false,
+		postType = 'page',
+		restBase,
+		restNamespace,
+	} = options;
 	const state = { dirty };
 	const editor = {
 		getCurrentPostId: jest.fn( () => postId ),
@@ -18,12 +24,24 @@ function setEditor( options = {} ) {
 		isEditedPostDirty: jest.fn( () => state.dirty ),
 	};
 	const coreData = { receiveEntityRecords: jest.fn() };
+	const core = {
+		getPostType: jest.fn( () => ( {
+			rest_base: restBase,
+			rest_namespace: restNamespace,
+		} ) ),
+	};
 	const blockDispatcher = { resetBlocks: jest.fn() };
 	global.wp = {
 		data: {
-			select: jest.fn( ( store ) =>
-				store === 'core/editor' ? editor : {}
-			),
+			select: jest.fn( ( store ) => {
+				if ( store === 'core/editor' ) {
+					return editor;
+				}
+				if ( store === 'core' ) {
+					return core;
+				}
+				return {};
+			} ),
 			dispatch: jest.fn( ( store ) => {
 				if ( store === 'core' ) {
 					return coreData;
@@ -54,6 +72,26 @@ describe( 'editor post reflector', () => {
 	afterEach( () => {
 		apiFetch.mockReset();
 		delete global.wp;
+	} );
+
+	test( 'uses custom post type REST metadata for the editor fetch', async () => {
+		setEditor( {
+			postType: 'library_item',
+			restBase: 'books',
+			restNamespace: 'my-plugin/v1',
+		} );
+		apiFetch.mockResolvedValue( {
+			id: 42,
+			content: {
+				raw: '<!-- wp:paragraph -->Fresh<!-- /wp:paragraph -->',
+			},
+		} );
+
+		await reflectEditorPost( postEvent() );
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/my-plugin/v1/books/42?context=edit',
+		} );
 	} );
 
 	test( 'synchronizes fetched server content into a matching clean editor', async () => {

--- a/src/floating-widget/reflectors/__tests__/index.test.js
+++ b/src/floating-widget/reflectors/__tests__/index.test.js
@@ -86,4 +86,20 @@ describe( 'reflector dispatcher', () => {
 
 		expect( showFallbackToast ).toHaveBeenCalledWith( event );
 	} );
+
+	test( 'runs public reflection when the editor reflector module fails to load', async () => {
+		jest.resetModules();
+		jest.doMock( '../editor-post', () => {
+			throw new Error( 'editor chunk unavailable' );
+		} );
+		const { reflectPost: reloadedReflectPost } = require( '../post' );
+		const {
+			dispatchReflectionEvent: reloadedDispatchReflectionEvent,
+		} = require( '..' );
+		const event = makeEvent( 'post' );
+
+		await reloadedDispatchReflectionEvent( event );
+
+		expect( reloadedReflectPost ).toHaveBeenCalledWith( event );
+	} );
 } );

--- a/src/floating-widget/reflectors/editor-post.js
+++ b/src/floating-widget/reflectors/editor-post.js
@@ -36,10 +36,12 @@ function getEditorContext( postId ) {
 	try {
 		const editor = wp.data.select( 'core/editor' );
 		const blockEditor = wp.data.select( 'core/block-editor' );
+		const core = wp.data.select( 'core' );
 		const coreData = wp.data.dispatch( 'core' );
 		const blockDispatcher = wp.data.dispatch( 'core/block-editor' );
 		const currentPostId = editor?.getCurrentPostId?.();
 		const postType = editor?.getCurrentPostType?.();
+		const postTypeRecord = core?.getPostType?.( postType );
 
 		if (
 			! editor ||
@@ -55,7 +57,14 @@ function getEditorContext( postId ) {
 			return null;
 		}
 
-		return { editor, postType, coreData, blockDispatcher };
+		return {
+			editor,
+			postType,
+			restBase: postTypeRecord?.rest_base || postType,
+			restNamespace: postTypeRecord?.rest_namespace || 'wp/v2',
+			coreData,
+			blockDispatcher,
+		};
 	} catch ( _error ) {
 		return null;
 	}
@@ -87,8 +96,8 @@ export async function reflectEditorPost( event ) {
 
 	try {
 		const record = await apiFetch( {
-			path: `/wp/v2/${ encodeURIComponent(
-				context.postType
+			path: `/${ context.restNamespace }/${ encodeURIComponent(
+				context.restBase
 			) }/${ encodeURIComponent( affected.post_id ) }?context=edit`,
 		} );
 		const rawContent = record?.content?.raw;

--- a/src/floating-widget/reflectors/index.js
+++ b/src/floating-widget/reflectors/index.js
@@ -14,7 +14,9 @@ const reflectorLoaders = {
 		Promise.all( [
 			import(
 				/* webpackChunkName: "reflector-editor-post" */ './editor-post'
-			).then( ( module ) => module.reflectEditorPost ),
+			)
+				.then( ( module ) => module.reflectEditorPost )
+				.catch( () => () => undefined ),
 			import( /* webpackChunkName: "reflector-post" */ './post' ).then(
 				( module ) => module.reflectPost
 			),


### PR DESCRIPTION
## Summary

- Resolve Gutenberg editor REST paths from post-type metadata, including custom namespaces and bases.
- Preserve public post reflection when the optional editor reflector chunk fails to load.
- Add focused coverage for both fallback paths.

## Verification

- `pnpm run lint:js`
- `pnpm run test:js -- src/floating-widget/reflectors/__tests__/editor-post.test.js src/floating-widget/reflectors/__tests__/index.test.js`
- `pnpm run verify`

## Worker self-verification

- PHPUnit: Tests: 4140, Assertions: 18747, Errors: 0, Failures: 0, Skipped: 135
- Lint: PHP/JS/CSS all clean
- PHPStan: 0 errors
- Build: succeeded
- Bundle: budgets passed

Resolves #2530

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.275 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 14m and 112,348 tokens on this as a headless worker. Overall, 1h 27m since this issue was created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom post types now load editor content using their configured REST API namespace and base.
  * Public post reflection continues working even when editor-specific reflection cannot be loaded.
  * Added fallback behavior for unavailable REST metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->