### PR TITLE
GH#2533: keep Gutenberg reflections clean and ordered

### DIFF
--- a/src/floating-widget/reflectors/__tests__/editor-post.test.js
+++ b/src/floating-widget/reflectors/__tests__/editor-post.test.js
@@ -30,6 +30,7 @@ function setEditor( options = {} ) {
 			rest_namespace: restNamespace,
 		} ) ),
 	};
+	const editorDispatcher = { resetEditorBlocks: jest.fn() };
 	const blockDispatcher = { resetBlocks: jest.fn() };
 	global.wp = {
 		data: {
@@ -46,12 +47,14 @@ function setEditor( options = {} ) {
 				if ( store === 'core' ) {
 					return coreData;
 				}
-				return blockDispatcher;
+				return store === 'core/editor'
+					? editorDispatcher
+					: blockDispatcher;
 			} ),
 		},
 		blocks: { parse: jest.fn( () => [ { clientId: 'fresh' } ] ) },
 	};
-	return { state, editor, coreData, blockDispatcher };
+	return { state, editor, coreData, editorDispatcher, blockDispatcher };
 }
 
 /**
@@ -95,7 +98,7 @@ describe( 'editor post reflector', () => {
 	} );
 
 	test( 'synchronizes fetched server content into a matching clean editor', async () => {
-		const { coreData, blockDispatcher } = setEditor();
+		const { coreData, editorDispatcher, blockDispatcher } = setEditor();
 		const record = {
 			id: 42,
 			content: {
@@ -114,9 +117,11 @@ describe( 'editor post reflector', () => {
 			'page',
 			[ record ]
 		);
-		expect( blockDispatcher.resetBlocks ).toHaveBeenCalledWith( [
-			{ clientId: 'fresh' },
-		] );
+		expect( editorDispatcher.resetEditorBlocks ).toHaveBeenCalledWith(
+			[ { clientId: 'fresh' } ],
+			{ __unstableShouldCreateUndoLevel: false }
+		);
+		expect( blockDispatcher.resetBlocks ).not.toHaveBeenCalled();
 	} );
 
 	test.each( [
@@ -181,6 +186,56 @@ describe( 'editor post reflector', () => {
 
 		expect( coreData.receiveEntityRecords ).not.toHaveBeenCalled();
 		expect( blockDispatcher.resetBlocks ).not.toHaveBeenCalled();
+	} );
+
+	test( 'serializes overlapping reflections so the latest revision wins', async () => {
+		const { editorDispatcher } = setEditor();
+		let resolveFirst;
+		let resolveSecond;
+		global.wp.blocks.parse.mockImplementation( ( rawContent ) => [
+			{ clientId: rawContent },
+		] );
+		apiFetch
+			.mockReturnValueOnce(
+				new Promise( ( resolve ) => {
+					resolveFirst = resolve;
+				} )
+			)
+			.mockReturnValueOnce(
+				new Promise( ( resolve ) => {
+					resolveSecond = resolve;
+				} )
+			);
+
+		const firstReflection = reflectEditorPost( postEvent() );
+		const secondReflection = reflectEditorPost( postEvent() );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		resolveFirst( {
+			id: 42,
+			content: {
+				raw: '<!-- wp:paragraph -->Older<!-- /wp:paragraph -->',
+			},
+		} );
+		await firstReflection;
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+		resolveSecond( {
+			id: 42,
+			content: {
+				raw: '<!-- wp:paragraph -->Latest<!-- /wp:paragraph -->',
+			},
+		} );
+		await secondReflection;
+
+		expect( editorDispatcher.resetEditorBlocks ).toHaveBeenLastCalledWith(
+			[
+				{
+					clientId:
+						'<!-- wp:paragraph -->Latest<!-- /wp:paragraph -->',
+				},
+			],
+			{ __unstableShouldCreateUndoLevel: false }
+		);
 	} );
 
 	test.each( [

--- a/src/floating-widget/reflectors/editor-post.js
+++ b/src/floating-widget/reflectors/editor-post.js
@@ -7,6 +7,8 @@
 
 import apiFetch from '@wordpress/api-fetch';
 
+const reflectionQueues = new Map();
+
 /**
  * Compare post identifiers without making numeric/string REST values diverge.
  *
@@ -35,23 +37,21 @@ function getEditorContext( postId ) {
 
 	try {
 		const editor = wp.data.select( 'core/editor' );
-		const blockEditor = wp.data.select( 'core/block-editor' );
 		const core = wp.data.select( 'core' );
 		const coreData = wp.data.dispatch( 'core' );
-		const blockDispatcher = wp.data.dispatch( 'core/block-editor' );
+		const editorDispatcher = wp.data.dispatch( 'core/editor' );
 		const currentPostId = editor?.getCurrentPostId?.();
 		const postType = editor?.getCurrentPostType?.();
 		const postTypeRecord = core?.getPostType?.( postType );
 
 		if (
 			! editor ||
-			! blockEditor ||
 			! samePost( currentPostId, postId ) ||
 			editor.isEditedPostDirty?.() !== false ||
 			typeof postType !== 'string' ||
 			! postType ||
 			typeof coreData?.receiveEntityRecords !== 'function' ||
-			typeof blockDispatcher?.resetBlocks !== 'function' ||
+			typeof editorDispatcher?.resetEditorBlocks !== 'function' ||
 			typeof wp.blocks?.parse !== 'function'
 		) {
 			return null;
@@ -63,7 +63,7 @@ function getEditorContext( postId ) {
 			restBase: postTypeRecord?.rest_base || postType,
 			restNamespace: postTypeRecord?.rest_namespace || 'wp/v2',
 			coreData,
-			blockDispatcher,
+			editorDispatcher,
 		};
 	} catch ( _error ) {
 		return null;
@@ -76,7 +76,7 @@ function getEditorContext( postId ) {
  * @param {{affected?: {fields?: string[], post_id?: number|string, render_mode?: string}, result?: {preview?: Object}}} event Reflection event.
  * @return {Promise<void>} Resolves after safely applying or skipping the update.
  */
-export async function reflectEditorPost( event ) {
+async function reflectEditorPostEvent( event ) {
 	const affected = event?.affected;
 	if (
 		! Array.isArray( affected?.fields ) ||
@@ -120,9 +120,41 @@ export async function reflectEditorPost( event ) {
 		current.coreData.receiveEntityRecords( 'postType', current.postType, [
 			record,
 		] );
-		current.blockDispatcher.resetBlocks( blocks );
+		current.editorDispatcher.resetEditorBlocks( blocks, {
+			__unstableShouldCreateUndoLevel: false,
+		} );
 	} catch ( _error ) {
 		// A missing REST route, parsing failure, or unavailable editor is safe to
 		// ignore: the persisted revision remains available after a reload.
 	}
+}
+
+/**
+ * Serialize server reflections for one post so an older REST response cannot
+ * replace a newer revision after overlapping tool events.
+ *
+ * @param {Object} event Reflection event.
+ * @return {Promise<void>} Resolves after safely applying or skipping the update.
+ */
+export function reflectEditorPost( event ) {
+	const postId = event?.affected?.post_id;
+	if ( postId === undefined || postId === null ) {
+		return Promise.resolve();
+	}
+
+	const queueKey = String( postId );
+	const previous = reflectionQueues.get( queueKey );
+	const reflection = previous
+		? previous
+				.catch( () => undefined )
+				.then( () => reflectEditorPostEvent( event ) )
+		: reflectEditorPostEvent( event );
+
+	reflectionQueues.set( queueKey, reflection );
+
+	return reflection.finally( () => {
+		if ( reflectionQueues.get( queueKey ) === reflection ) {
+			reflectionQueues.delete( queueKey );
+		}
+	} );
 }

--- a/tests/e2e/client-abilities.spec.js
+++ b/tests/e2e/client-abilities.spec.js
@@ -550,6 +550,70 @@ test.describe( 'client-abilities — server post reflection', () => {
 		);
 	} );
 
+	test( 'keeps successive server mutations reflected and the editor clean', async ( {
+		page,
+	} ) => {
+		const postId = await createDraftAndOpenEditor( page );
+		const revisions = [
+			{
+				tool: 'sd-ai-agent/update-post',
+				markup:
+					'<!-- wp:heading -->\n<h2>Updated heading.</h2>\n<!-- /wp:heading -->',
+			},
+			{
+				tool: 'sd-ai-agent/edit-block-tree',
+				markup:
+					'<!-- wp:list -->\n<ul class="wp-block-list"><li>Updated nested item.</li></ul>\n<!-- /wp:list -->',
+			},
+			{
+				tool: 'sd-ai-agent/append-post-content',
+				markup:
+					'<!-- wp:paragraph -->\n<p>Appended server paragraph.</p>\n<!-- /wp:paragraph -->',
+			},
+		];
+
+		for ( const revision of revisions ) {
+			await page.evaluate(
+				async ( { currentPostId, serverMarkup, tool } ) => {
+					await wp.apiFetch( {
+						path: `/wp/v2/posts/${ currentPostId }`,
+						method: 'POST',
+						data: { content: serverMarkup },
+					} );
+					window.sdAiAgentReflection.emit( {
+						type: 'tool-applied',
+						tool,
+						affected: {
+							kind: 'post',
+							post_id: currentPostId,
+							fields: [ 'post_content' ],
+						},
+					} );
+				},
+				{
+					currentPostId: postId,
+					serverMarkup: revision.markup,
+					tool: revision.tool,
+				}
+			);
+
+			await page.waitForFunction(
+				( serverMarkup ) => {
+					const editor = wp.data.select( 'core/editor' );
+					const blocks = wp.data
+						.select( 'core/block-editor' )
+						.getBlocks();
+					return (
+						wp.blocks.serialize( blocks ) === serverMarkup &&
+						editor.isEditedPostDirty() === false
+					);
+				},
+				revision.markup,
+				{ timeout: 15_000 }
+			);
+		}
+	} );
+
 	test( 'preserves a dirty local editor after a server mutation event', async ( {
 		page,
 	} ) => {


### PR DESCRIPTION
## Summary

- Apply fetched Gutenberg block revisions through `core/editor.resetEditorBlocks()` without creating an undo level or dirty editor state.
- Serialize same-post reflection fetches so a late old response cannot replace a newer revision.
- Add unit and browser coverage for ordered reflection and three successive server mutations.

## Testing

- `pnpm run verify` — passed: PHP/JS/CSS lint, PHPStan, PHPUnit (Tests: 4140, Assertions: 18747, Errors: 0, Failures: 0, Skipped: 135), build, and bundle budgets.
- `pnpm run test:js -- src/floating-widget/reflectors/__tests__/editor-post.test.js src/floating-widget/reflectors/__tests__/index.test.js` — passed (20 tests).
- `pnpm run test:e2e:playwright -- tests/e2e/client-abilities.spec.js` — blocked locally before test execution because `localhost:8890` was unavailable; `pnpm exec wp-env start` could not resolve Docker image blobs for `wordpress:php8.2` and `wordpress:cli-php8.2`.

Resolves #2533

<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.275 plugin for [OpenCode](https://opencode.ai) v1.18.18 with gpt-5.6-terra spent 19m and 103,449 tokens on this as a headless worker. Overall, 37m since this issue was created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved synchronization between server-side post changes and the editor.
  - Prevented overlapping updates from applying out of order, ensuring the editor reflects the latest revision.
  - Applied synchronized changes without adding unnecessary undo history or marking the post as unsaved.

- **Tests**
  - Added coverage for successive server-side updates, block changes, and appended content.
  - Verified that each revision appears correctly while the editor remains clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->