### PR TITLE
auto-recover: orphaned worker branch for #2533

### DIFF
--- a/src/floating-widget/reflectors/__tests__/editor-post.test.js
+++ b/src/floating-widget/reflectors/__tests__/editor-post.test.js
@@ -30,6 +30,7 @@ function setEditor( options = {} ) {
 			rest_namespace: restNamespace,
 		} ) ),
 	};
+	const editorDispatcher = { resetEditorBlocks: jest.fn() };
 	const blockDispatcher = { resetBlocks: jest.fn() };
 	global.wp = {
 		data: {
@@ -46,12 +47,14 @@ function setEditor( options = {} ) {
 				if ( store === 'core' ) {
 					return coreData;
 				}
-				return blockDispatcher;
+				return store === 'core/editor'
+					? editorDispatcher
+					: blockDispatcher;
 			} ),
 		},
 		blocks: { parse: jest.fn( () => [ { clientId: 'fresh' } ] ) },
 	};
-	return { state, editor, coreData, blockDispatcher };
+	return { state, editor, coreData, editorDispatcher, blockDispatcher };
 }
 
 /**
@@ -95,7 +98,7 @@ describe( 'editor post reflector', () => {
 	} );
 
 	test( 'synchronizes fetched server content into a matching clean editor', async () => {
-		const { coreData, blockDispatcher } = setEditor();
+		const { coreData, editorDispatcher, blockDispatcher } = setEditor();
 		const record = {
 			id: 42,
 			content: {
@@ -114,9 +117,11 @@ describe( 'editor post reflector', () => {
 			'page',
 			[ record ]
 		);
-		expect( blockDispatcher.resetBlocks ).toHaveBeenCalledWith( [
-			{ clientId: 'fresh' },
-		] );
+		expect( editorDispatcher.resetEditorBlocks ).toHaveBeenCalledWith(
+			[ { clientId: 'fresh' } ],
+			{ __unstableShouldCreateUndoLevel: false }
+		);
+		expect( blockDispatcher.resetBlocks ).not.toHaveBeenCalled();
 	} );
 
 	test.each( [
@@ -181,6 +186,56 @@ describe( 'editor post reflector', () => {
 
 		expect( coreData.receiveEntityRecords ).not.toHaveBeenCalled();
 		expect( blockDispatcher.resetBlocks ).not.toHaveBeenCalled();
+	} );
+
+	test( 'serializes overlapping reflections so the latest revision wins', async () => {
+		const { editorDispatcher } = setEditor();
+		let resolveFirst;
+		let resolveSecond;
+		global.wp.blocks.parse.mockImplementation( ( rawContent ) => [
+			{ clientId: rawContent },
+		] );
+		apiFetch
+			.mockReturnValueOnce(
+				new Promise( ( resolve ) => {
+					resolveFirst = resolve;
+				} )
+			)
+			.mockReturnValueOnce(
+				new Promise( ( resolve ) => {
+					resolveSecond = resolve;
+				} )
+			);
+
+		const firstReflection = reflectEditorPost( postEvent() );
+		const secondReflection = reflectEditorPost( postEvent() );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		resolveFirst( {
+			id: 42,
+			content: {
+				raw: '<!-- wp:paragraph -->Older<!-- /wp:paragraph -->',
+			},
+		} );
+		await firstReflection;
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+		resolveSecond( {
+			id: 42,
+			content: {
+				raw: '<!-- wp:paragraph -->Latest<!-- /wp:paragraph -->',
+			},
+		} );
+		await secondReflection;
+
+		expect( editorDispatcher.resetEditorBlocks ).toHaveBeenLastCalledWith(
+			[
+				{
+					clientId:
+						'<!-- wp:paragraph -->Latest<!-- /wp:paragraph -->',
+				},
+			],
+			{ __unstableShouldCreateUndoLevel: false }
+		);
 	} );
 
 	test.each( [

--- a/src/floating-widget/reflectors/editor-post.js
+++ b/src/floating-widget/reflectors/editor-post.js
@@ -7,6 +7,8 @@
 
 import apiFetch from '@wordpress/api-fetch';
 
+const reflectionQueues = new Map();
+
 /**
  * Compare post identifiers without making numeric/string REST values diverge.
  *
@@ -35,23 +37,21 @@ function getEditorContext( postId ) {
 
 	try {
 		const editor = wp.data.select( 'core/editor' );
-		const blockEditor = wp.data.select( 'core/block-editor' );
 		const core = wp.data.select( 'core' );
 		const coreData = wp.data.dispatch( 'core' );
-		const blockDispatcher = wp.data.dispatch( 'core/block-editor' );
+		const editorDispatcher = wp.data.dispatch( 'core/editor' );
 		const currentPostId = editor?.getCurrentPostId?.();
 		const postType = editor?.getCurrentPostType?.();
 		const postTypeRecord = core?.getPostType?.( postType );
 
 		if (
 			! editor ||
-			! blockEditor ||
 			! samePost( currentPostId, postId ) ||
 			editor.isEditedPostDirty?.() !== false ||
 			typeof postType !== 'string' ||
 			! postType ||
 			typeof coreData?.receiveEntityRecords !== 'function' ||
-			typeof blockDispatcher?.resetBlocks !== 'function' ||
+			typeof editorDispatcher?.resetEditorBlocks !== 'function' ||
 			typeof wp.blocks?.parse !== 'function'
 		) {
 			return null;
@@ -63,7 +63,7 @@ function getEditorContext( postId ) {
 			restBase: postTypeRecord?.rest_base || postType,
 			restNamespace: postTypeRecord?.rest_namespace || 'wp/v2',
 			coreData,
-			blockDispatcher,
+			editorDispatcher,
 		};
 	} catch ( _error ) {
 		return null;
@@ -76,7 +76,7 @@ function getEditorContext( postId ) {
  * @param {{affected?: {fields?: string[], post_id?: number|string, render_mode?: string}, result?: {preview?: Object}}} event Reflection event.
  * @return {Promise<void>} Resolves after safely applying or skipping the update.
  */
-export async function reflectEditorPost( event ) {
+async function reflectEditorPostEvent( event ) {
 	const affected = event?.affected;
 	if (
 		! Array.isArray( affected?.fields ) ||
@@ -120,9 +120,41 @@ export async function reflectEditorPost( event ) {
 		current.coreData.receiveEntityRecords( 'postType', current.postType, [
 			record,
 		] );
-		current.blockDispatcher.resetBlocks( blocks );
+		current.editorDispatcher.resetEditorBlocks( blocks, {
+			__unstableShouldCreateUndoLevel: false,
+		} );
 	} catch ( _error ) {
 		// A missing REST route, parsing failure, or unavailable editor is safe to
 		// ignore: the persisted revision remains available after a reload.
 	}
+}
+
+/**
+ * Serialize server reflections for one post so an older REST response cannot
+ * replace a newer revision after overlapping tool events.
+ *
+ * @param {Object} event Reflection event.
+ * @return {Promise<void>} Resolves after safely applying or skipping the update.
+ */
+export function reflectEditorPost( event ) {
+	const postId = event?.affected?.post_id;
+	if ( postId === undefined || postId === null ) {
+		return Promise.resolve();
+	}
+
+	const queueKey = String( postId );
+	const previous = reflectionQueues.get( queueKey );
+	const reflection = previous
+		? previous
+				.catch( () => undefined )
+				.then( () => reflectEditorPostEvent( event ) )
+		: reflectEditorPostEvent( event );
+
+	reflectionQueues.set( queueKey, reflection );
+
+	return reflection.finally( () => {
+		if ( reflectionQueues.get( queueKey ) === reflection ) {
+			reflectionQueues.delete( queueKey );
+		}
+	} );
 }

--- a/tests/e2e/client-abilities.spec.js
+++ b/tests/e2e/client-abilities.spec.js
@@ -550,6 +550,70 @@ test.describe( 'client-abilities — server post reflection', () => {
 		);
 	} );
 
+	test( 'keeps successive server mutations reflected and the editor clean', async ( {
+		page,
+	} ) => {
+		const postId = await createDraftAndOpenEditor( page );
+		const revisions = [
+			{
+				tool: 'sd-ai-agent/update-post',
+				markup:
+					'<!-- wp:heading -->\n<h2>Updated heading.</h2>\n<!-- /wp:heading -->',
+			},
+			{
+				tool: 'sd-ai-agent/edit-block-tree',
+				markup:
+					'<!-- wp:list -->\n<ul class="wp-block-list"><li>Updated nested item.</li></ul>\n<!-- /wp:list -->',
+			},
+			{
+				tool: 'sd-ai-agent/append-post-content',
+				markup:
+					'<!-- wp:paragraph -->\n<p>Appended server paragraph.</p>\n<!-- /wp:paragraph -->',
+			},
+		];
+
+		for ( const revision of revisions ) {
+			await page.evaluate(
+				async ( { currentPostId, serverMarkup, tool } ) => {
+					await wp.apiFetch( {
+						path: `/wp/v2/posts/${ currentPostId }`,
+						method: 'POST',
+						data: { content: serverMarkup },
+					} );
+					window.sdAiAgentReflection.emit( {
+						type: 'tool-applied',
+						tool,
+						affected: {
+							kind: 'post',
+							post_id: currentPostId,
+							fields: [ 'post_content' ],
+						},
+					} );
+				},
+				{
+					currentPostId: postId,
+					serverMarkup: revision.markup,
+					tool: revision.tool,
+				}
+			);
+
+			await page.waitForFunction(
+				( serverMarkup ) => {
+					const editor = wp.data.select( 'core/editor' );
+					const blocks = wp.data
+						.select( 'core/block-editor' )
+						.getBlocks();
+					return (
+						wp.blocks.serialize( blocks ) === serverMarkup &&
+						editor.isEditedPostDirty() === false
+					);
+				},
+				revision.markup,
+				{ timeout: 15_000 }
+			);
+		}
+	} );
+
 	test( 'preserves a dirty local editor after a server mutation event', async ( {
 		page,
 	} ) => {


### PR DESCRIPTION
Local branch recovery PR — worker committed locally but exited before pushing or opening a PR.

Branch `feature/auto-20260819-235234-gh2533` had local commits from headless worker session `issue-2533` and was published by the recovery path before this PR was created (GH#25374).

Resolves #2533

<!-- aidevops:orphan-recovery worker_local_branch_unpushed session=issue-2533 -->
<!-- aidevops:origin:worker -->
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.276 automated scan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization when multiple post updates occur in quick succession, ensuring the editor applies only the latest content.
  * Preserved clean editor state during automatic content updates without adding unnecessary undo history.
  * Added coverage for successive server-side changes and overlapping updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->